### PR TITLE
feat(seer): Add organization Seer runs list endpoint

### DIFF
--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -9,18 +9,15 @@ from sentry.seer.models.run import SeerAgentRun, SeerRun
 
 class SeerRunResponse(TypedDict):
     id: str
-    seerRunId: str | None
     type: str
     userId: str | None
     lastTriggeredAt: str
     dateCreated: str
-    extras: dict[str, Any]
     # Agent fields, null when the run has no SeerAgentRun row.
     title: str | None
     source: str | None
     projectId: str | None
     groupId: str | None
-    agentExtras: dict[str, Any] | None
 
 
 @register(SeerRun)
@@ -41,12 +38,10 @@ class SeerRunSerializer(Serializer):
         agent: SeerAgentRun | None = attrs.get("agent")
         return {
             "id": str(obj.uuid),
-            "seerRunId": str(obj.seer_run_state_id) if obj.seer_run_state_id is not None else None,
             "type": obj.type,
             "userId": str(obj.user_id) if obj.user_id is not None else None,
             "lastTriggeredAt": obj.last_triggered_at.isoformat(),
             "dateCreated": obj.date_added.isoformat(),
-            "extras": obj.extras or {},
             "title": agent.title if agent is not None else None,
             "source": agent.source if agent is not None else None,
             "projectId": str(agent.project_id)
@@ -55,5 +50,4 @@ class SeerRunSerializer(Serializer):
             "groupId": str(agent.group_id)
             if agent is not None and agent.group_id is not None
             else None,
-            "agentExtras": (agent.extras or {}) if agent is not None else None,
         }

--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, TypedDict
+
+from sentry.api.serializers import Serializer, register
+from sentry.seer.models.run import SeerAgentRun, SeerRun
+
+
+class SeerRunResponse(TypedDict):
+    id: str
+    seerRunId: str | None
+    type: str
+    userId: str | None
+    lastTriggeredAt: str
+    dateCreated: str
+    extras: dict[str, Any]
+    # Agent fields, null when the run has no SeerAgentRun row.
+    title: str | None
+    source: str | None
+    projectId: str | None
+    groupId: str | None
+    agentExtras: dict[str, Any] | None
+
+
+@register(SeerRun)
+class SeerRunSerializer(Serializer):
+    def get_attrs(
+        self, item_list: Sequence[SeerRun], user: Any, **kwargs: Any
+    ) -> dict[SeerRun, dict[str, Any]]:
+        # The reverse one-to-one accessor (``run.agent``) raises DoesNotExist when
+        # absent, so map the agent rows explicitly rather than dereferencing it.
+        agent_by_run_id = {
+            agent.run_id: agent for agent in SeerAgentRun.objects.filter(run__in=item_list)
+        }
+        return {run: {"agent": agent_by_run_id.get(run.id)} for run in item_list}
+
+    def serialize(
+        self, obj: SeerRun, attrs: Mapping[str, Any], user: Any, **kwargs: Any
+    ) -> SeerRunResponse:
+        agent: SeerAgentRun | None = attrs.get("agent")
+        return {
+            "id": str(obj.uuid),
+            "seerRunId": str(obj.seer_run_state_id) if obj.seer_run_state_id is not None else None,
+            "type": obj.type,
+            "userId": str(obj.user_id) if obj.user_id is not None else None,
+            "lastTriggeredAt": obj.last_triggered_at.isoformat(),
+            "dateCreated": obj.date_added.isoformat(),
+            "extras": obj.extras or {},
+            "title": agent.title if agent is not None else None,
+            "source": agent.source if agent is not None else None,
+            "projectId": str(agent.project_id)
+            if agent is not None and agent.project_id is not None
+            else None,
+            "groupId": str(agent.group_id)
+            if agent is not None and agent.group_id is not None
+            else None,
+            "agentExtras": (agent.extras or {}) if agent is not None else None,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -526,6 +526,7 @@ from sentry.seer.endpoints.organization_seer_agent_update import (
 )
 from sentry.seer.endpoints.organization_seer_onboarding_check import OrganizationSeerOnboardingCheck
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
+from sentry.seer.endpoints.organization_seer_runs import OrganizationSeerRunsEndpoint
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheckEndpoint
 from sentry.seer.endpoints.organization_seer_workflows import OrganizationSeerWorkflowsEndpoint
 from sentry.seer.endpoints.project_seer_night_shift import ProjectSeerNightShiftEndpoint
@@ -2358,6 +2359,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/seer/explorer-runs/$",
         OrganizationSeerAgentRunsEndpoint.as_view(),
         name="sentry-api-0-organization-seer-explorer-runs",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/runs/$",
+        OrganizationSeerRunsEndpoint.as_view(),
+        name="sentry-api-0-organization-seer-runs",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/workflows/$",

--- a/src/sentry/seer/endpoints/organization_seer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_runs.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.seer_run import SeerRunSerializer
+from sentry.api.utils import get_date_range_from_params
+from sentry.exceptions import InvalidSearchQuery
+from sentry.models.organization import Organization
+from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
+from sentry.seer.runs_query import filtered_runs_queryset
+
+
+class OrganizationSeerRunsPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read"],
+    }
+
+
+@cell_silo_endpoint
+class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    permission_classes = (OrganizationSeerRunsPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        List Seer runs for the organization, served from the Sentry-side mirror
+        tables (``SeerRun``/``SeerAgentRun``).
+
+        Returns all runs for the organization the caller can access by default
+        (runs tied to projects the caller cannot access are excluded). Use
+        ``is:mine`` in the query to scope results to the requesting user's runs.
+
+        Query Parameters:
+            query: Optional structured search string. Supports ``source``, ``type``,
+                ``project``, ``is:agent``/``!is:agent``, ``is:mine``/``!is:mine``,
+                and free-text title search.
+        """
+        has_access, error = has_seer_agent_access_with_detail(organization, request.user)
+        if not has_access:
+            raise PermissionDenied(error)
+
+        query = request.GET.get("query", "").strip()
+        accessible_project_ids = [
+            p.id for p in self.get_projects(request, organization, include_all_accessible=True)
+        ]
+
+        # get_date_range_from_params raises InvalidParams (a DRF ParseError) on
+        # bad date params, which DRF renders as a 400 on its own.
+        start, end = get_date_range_from_params(request.GET, optional=True)
+
+        try:
+            queryset = filtered_runs_queryset(
+                organization=organization,
+                query=query,
+                user_id=request.user.id,
+                accessible_project_ids=accessible_project_ids,
+                start=start,
+                end=end,
+            )
+        except InvalidSearchQuery as e:
+            # CodeQL complains about str(e) below but ~all handlers
+            # of InvalidSearchQuery do the same as this.
+            return Response({"detail": str(e)}, status=400)
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="-last_triggered_at",
+            on_results=lambda runs: serialize(runs, request.user, SeerRunSerializer()),
+            paginator_cls=OffsetPaginator,
+            default_per_page=100,
+            max_per_page=100,
+        )

--- a/src/sentry/seer/runs_query.py
+++ b/src/sentry/seer/runs_query.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from datetime import datetime
+
+from django.db.models import Q, QuerySet
+
+from sentry.models.organization import Organization
+from sentry.seer.models.run import SeerRun
+from sentry.seer.runs_search import queryset_for_query
+
+
+def filtered_runs_queryset(
+    *,
+    organization: Organization,
+    query: str,
+    user_id: int | None,
+    accessible_project_ids: Collection[int],
+    start: datetime | None,
+    end: datetime | None,
+) -> QuerySet[SeerRun]:
+    """Build the ``SeerRun`` queryset for the runs list endpoint.
+
+    Applies the structured search query (including the ``is:mine`` owner filter,
+    scoped to ``user_id``), organization scope, project-access scoping, and an
+    optional ``last_triggered_at`` date range. Callers are responsible for adding
+    their own ``select_related`` and ordering on top of the returned queryset.
+
+    Runs tied to a project the caller cannot access are excluded so we don't leak
+    project/group identifiers; runs with no associated project (including those
+    with no ``SeerAgentRun`` row) are always kept.
+
+    Raises:
+        InvalidSearchQuery: if the query string is invalid.
+    """
+    queryset = queryset_for_query(query, organization, user_id)
+
+    queryset = queryset.filter(
+        Q(agent__project_id__isnull=True) | Q(agent__project_id__in=accessible_project_ids)
+    )
+
+    if start:
+        queryset = queryset.filter(last_triggered_at__gte=start)
+    if end:
+        queryset = queryset.filter(last_triggered_at__lte=end)
+
+    return queryset

--- a/src/sentry/seer/runs_search.py
+++ b/src/sentry/seer/runs_search.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from django.db.models import Q, QuerySet
+
+from sentry.api.event_search import (
+    AggregateFilter,
+    ParenExpression,
+    QueryToken,
+    SearchConfig,
+    SearchFilter,
+    parse_search_query,
+)
+from sentry.exceptions import InvalidSearchQuery
+from sentry.models.organization import Organization
+from sentry.seer.models.run import SeerRun, SeerRunType
+
+search_config = SearchConfig.create_from(
+    SearchConfig(),
+    # Keys we allow text operators (e.g. ``~``) to be used on.
+    text_operator_keys={"source", "type"},
+    # ``is:agent`` / ``!is:agent`` selects runs that do (or do not) have a
+    # SeerAgentRun row. ``is:mine`` / ``!is:mine`` selects runs owned (or not
+    # owned) by the requesting user.
+    boolean_keys={"agent", "mine"},
+    is_filter_translation={
+        "agent": ("agent", True),
+        "mine": ("mine", True),
+    },
+    allowed_keys={
+        "agent",
+        "has",
+        "is",
+        "mine",
+        "project",
+        "source",
+        "type",
+    },
+    free_text_key="text",
+)
+
+# Search keys that don't map 1:1 to a ``SeerRun`` field name.
+FIELD_MAPPINGS: dict[str, str] = {
+    "source": "agent__source",
+}
+
+_SEER_RUN_TYPES = frozenset(member.value for member in SeerRunType)
+
+
+def _validate_type(value: object) -> str:
+    raw = str(value)
+    if raw not in _SEER_RUN_TYPES:
+        raise InvalidSearchQuery(
+            f"Invalid type value: {value}. Valid values: {', '.join(sorted(_SEER_RUN_TYPES))}"
+        )
+    return raw
+
+
+def _validate_project_id(value: object) -> int:
+    # ``project`` maps to the integer ``agent__project_id`` column. Validate up
+    # front so a non-numeric value raises InvalidSearchQuery (a 400) rather than
+    # a ValueError during lazy SQL compilation (a 500).
+    raw = str(value)
+    if not raw.isdigit():
+        raise InvalidSearchQuery(f"Invalid project value: {value}. Expected a numeric project ID.")
+    return int(raw)
+
+
+def queryset_for_query(
+    query: str, organization: Organization, user_id: int | None
+) -> QuerySet[SeerRun]:
+    """
+    Build a ``SeerRun`` queryset for ``organization`` filtered by ``query``.
+
+    All runs for the organization are listed by default; ``is:agent`` /
+    ``!is:agent`` opts in/out of runs that have a ``SeerAgentRun`` row, and
+    ``is:mine`` / ``!is:mine`` opts in/out of runs owned by ``user_id``.
+
+    Raises:
+        InvalidSearchQuery: if the query string is invalid.
+    """
+    search_filters = parse_search_query(query, config=search_config)
+    queryset = SeerRun.objects.filter(organization=organization)
+    return apply_filters(queryset, search_filters, user_id)
+
+
+def apply_filters(
+    queryset: QuerySet[SeerRun],
+    filters: Sequence[QueryToken],
+    user_id: int | None,
+) -> QuerySet[SeerRun]:
+    for token in filters:
+        if isinstance(token, str):  # "AND" / "OR" literals
+            raise InvalidSearchQuery(f"Boolean operators are not supported: {token}")
+        if isinstance(token, ParenExpression):
+            raise InvalidSearchQuery("Parenthetical expressions are not supported")
+        if isinstance(token, AggregateFilter):
+            raise InvalidSearchQuery("Aggregate filters are not supported")
+
+        assert isinstance(token, SearchFilter)
+
+        name = token.key.name
+
+        if name == "text":
+            search_term = str(token.value.value).strip()
+            if not search_term:
+                continue
+            queryset = queryset.filter(agent__title__icontains=search_term)
+            continue
+
+        if name == "agent":
+            # ``is:agent`` arrives as operator "=", ``!is:agent`` as "!=".
+            want_agent = token.operator == "="
+            queryset = queryset.filter(agent__isnull=not want_agent)
+            continue
+
+        if name == "mine":
+            # ``is:mine`` arrives as operator "=", ``!is:mine`` as "!=". An
+            # anonymous actor (no user_id) can never own a run.
+            want_mine = token.operator == "="
+            if user_id is None:
+                queryset = queryset.none() if want_mine else queryset
+            elif want_mine:
+                queryset = queryset.filter(user_id=user_id)
+            else:
+                queryset = queryset.exclude(user_id=user_id)
+            continue
+
+        if name == "type":
+            values = token.value.value if token.is_in_filter else [token.value.value]
+            q = Q(type__in=[_validate_type(v) for v in values])
+            queryset = queryset.exclude(q) if token.is_negation else queryset.filter(q)
+            continue
+
+        if name == "project":
+            values = token.value.value if token.is_in_filter else [token.value.value]
+            q = Q(agent__project_id__in=[_validate_project_id(v) for v in values])
+            queryset = queryset.exclude(q) if token.is_negation else queryset.filter(q)
+            continue
+
+        db_field = FIELD_MAPPINGS.get(name, name)
+
+        if token.value.is_wildcard():
+            # Check wildcard before the IN branch: a bracketed list containing a
+            # wildcard (e.g. ``source:[foo*, bar*]``) collapses ``value`` into a
+            # single combined regex string, not a list, so it must use __regex.
+            # Passing that string to __in would make Django iterate its chars.
+            q = Q(**{f"{db_field}__regex": token.value.value})
+        elif token.is_in_filter:
+            q = Q(**{f"{db_field}__in": token.value.value})
+        elif token.operator == "~":
+            q = Q(**{f"{db_field}__icontains": token.value.value})
+        elif token.operator in ("=", "!=") and token.value.value == "":
+            # has: / !has: filter
+            q = Q(**{f"{db_field}__isnull": False})
+        elif token.operator in ("=", "!="):
+            q = Q(**{f"{db_field}__exact": token.value.value})
+        else:
+            raise InvalidSearchQuery(f"Unsupported operator {token.operator} for {name}.")
+
+        if token.is_negation or token.operator == "!~":
+            q = ~q
+        queryset = queryset.filter(q)
+
+    return queryset.distinct()

--- a/src/sentry/seer/runs_search.py
+++ b/src/sentry/seer/runs_search.py
@@ -110,15 +110,18 @@ def apply_filters(
             continue
 
         if name == "agent":
-            # ``is:agent`` arrives as operator "=", ``!is:agent`` as "!=".
-            want_agent = token.operator == "="
-            queryset = queryset.filter(agent__isnull=not want_agent)
+            # ``is:agent`` / ``has:agent`` select runs that have a SeerAgentRun
+            # row; the negated forms select runs without one. ``is_negation``
+            # normalizes the differing ``is:`` (``=``/``!=``) and ``has:``
+            # (``!=``/``=``) operator conventions into a single flag.
+            queryset = queryset.filter(agent__isnull=token.is_negation)
             continue
 
         if name == "mine":
-            # ``is:mine`` arrives as operator "=", ``!is:mine`` as "!=". An
-            # anonymous actor (no user_id) can never own a run.
-            want_mine = token.operator == "="
+            # ``is:mine`` selects runs owned by the requesting user; ``!is:mine``
+            # selects everyone else's. An anonymous actor (no user_id) can never
+            # own a run. ``has:``/``!has:`` map onto the same semantics.
+            want_mine = not token.is_negation
             if user_id is None:
                 queryset = queryset.none() if want_mine else queryset
             elif want_mine:
@@ -134,12 +137,18 @@ def apply_filters(
             continue
 
         if name == "project":
-            values = token.value.value if token.is_in_filter else [token.value.value]
-            q = Q(agent__project_id__in=[_validate_project_id(v) for v in values])
+            if token.is_in_filter or token.value.value != "":
+                values = token.value.value if token.is_in_filter else [token.value.value]
+                q = Q(agent__project_id__in=[_validate_project_id(v) for v in values])
+            else:
+                # ``has:project`` / ``!has:project`` — filter on whether a
+                # project is set rather than parsing the (empty) value as an ID.
+                q = Q(agent__project_id__isnull=False)
             queryset = queryset.exclude(q) if token.is_negation else queryset.filter(q)
             continue
 
         db_field = FIELD_MAPPINGS.get(name, name)
+        is_has_filter = token.operator in ("=", "!=") and token.value.value == ""
 
         if token.value.is_wildcard():
             # Check wildcard before the IN branch: a bracketed list containing a
@@ -151,7 +160,7 @@ def apply_filters(
             q = Q(**{f"{db_field}__in": token.value.value})
         elif token.operator == "~":
             q = Q(**{f"{db_field}__icontains": token.value.value})
-        elif token.operator in ("=", "!=") and token.value.value == "":
+        elif is_has_filter:
             # has: / !has: filter
             q = Q(**{f"{db_field}__isnull": False})
         elif token.operator in ("=", "!="):
@@ -161,6 +170,12 @@ def apply_filters(
 
         if token.is_negation or token.operator == "!~":
             q = ~q
+            if not is_has_filter:
+                # A negated match across the nullable ``agent`` join would
+                # otherwise also return rows where the field is NULL (e.g. runs
+                # with no SeerAgentRun row). Standard Sentry search excludes
+                # NULLs from negated filters; ``!has:`` selects them explicitly.
+                q &= Q(**{f"{db_field}__isnull": False})
         queryset = queryset.filter(q)
 
     return queryset.distinct()

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -149,7 +149,7 @@ from sentry.preprod.models import (
     PreprodSnapshotMetrics,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
-from sentry.seer.models.run import SeerRun, SeerRunType
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.sentry_apps.installations import (
     SentryAppInstallationCreator,
     SentryAppInstallationTokenCreator,
@@ -2988,3 +2988,9 @@ class Factories:
     def create_seer_run(organization, type: str = SeerRunType.EXPLORER, **kwargs) -> SeerRun:
         kwargs.setdefault("last_triggered_at", timezone.now())
         return SeerRun.objects.create(organization=organization, type=type, **kwargs)
+
+    @staticmethod
+    def create_seer_agent_run(
+        run: SeerRun, title: str = "Test run", source: str = "chat", **kwargs
+    ) -> SeerAgentRun:
+        return SeerAgentRun.objects.create(run=run, title=title, source=source, **kwargs)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1237,6 +1237,9 @@ class Fixtures:
             organization = self.organization
         return Factories.create_seer_run(organization=organization, **kwargs)
 
+    def create_seer_agent_run(self, run, **kwargs):
+        return Factories.create_seer_agent_run(run=run, **kwargs)
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot: InstaSnapshotter) -> None:
         self.insta_snapshot = insta_snapshot

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -353,6 +353,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/seer/explorer-update/$runId/'
   | '/organizations/$organizationIdOrSlug/seer/onboarding-check/'
   | '/organizations/$organizationIdOrSlug/seer/projects/'
+  | '/organizations/$organizationIdOrSlug/seer/runs/'
   | '/organizations/$organizationIdOrSlug/seer/setup-check/'
   | '/organizations/$organizationIdOrSlug/seer/supergroups/$supergroupId/'
   | '/organizations/$organizationIdOrSlug/seer/supergroups/by-group/'

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -1,0 +1,282 @@
+from sentry.seer.models.run import SeerRunType
+from sentry.seer.runs_query import filtered_runs_queryset
+from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
+
+
+@with_feature("organizations:seer-explorer")
+@with_feature("organizations:gen-ai-features")
+@with_feature("organizations:gen-ai-consent-flow-removal")
+class OrganizationSeerRunsEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-seer-runs"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+        self.login_as(user=self.user)
+
+    def test_lists_runs_ordered_by_last_triggered(self) -> None:
+        older = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            seer_run_state_id=1,
+            last_triggered_at=before_now(minutes=10),
+        )
+        newer = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            seer_run_state_id=2,
+            last_triggered_at=before_now(minutes=1),
+        )
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert [r["id"] for r in response.data] == [str(newer.uuid), str(older.uuid)]
+        assert response.data[0]["seerRunId"] == "2"
+        assert response.data[1]["seerRunId"] == "1"
+
+    def test_scopes_to_organization(self) -> None:
+        run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        other_org = self.create_organization(owner=self.user)
+        self.create_seer_run(organization=other_org, user_id=self.user.id)
+
+        response = self.get_success_response(self.organization.slug)
+
+        assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_is_mine_filter(self) -> None:
+        mine = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        other_user = self.create_user()
+        theirs = self.create_seer_run(organization=self.organization, user_id=other_user.id)
+
+        # No filter returns runs regardless of owner.
+        response = self.get_success_response(self.organization.slug)
+        assert {r["id"] for r in response.data} == {str(mine.uuid), str(theirs.uuid)}
+
+        # is:mine returns only the requesting user's runs.
+        response = self.get_success_response(self.organization.slug, qs_params={"query": "is:mine"})
+        assert [r["id"] for r in response.data] == [str(mine.uuid)]
+
+        # !is:mine returns everyone else's runs.
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "!is:mine"}
+        )
+        assert [r["id"] for r in response.data] == [str(theirs.uuid)]
+
+    def test_agent_fields_present_and_null(self) -> None:
+        with_agent = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            last_triggered_at=before_now(minutes=1),
+        )
+        project = self.create_project(organization=self.organization)
+        group = self.create_group(project=project)
+        self.create_seer_agent_run(
+            run=with_agent,
+            title="Fix login bug",
+            source="chat",
+            project=project,
+            group=group,
+            extras={"thread_ts": "123"},
+        )
+        without_agent = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            last_triggered_at=before_now(minutes=10),
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        by_id = {r["id"]: r for r in response.data}
+
+        agent_row = by_id[str(with_agent.uuid)]
+        assert agent_row["title"] == "Fix login bug"
+        assert agent_row["source"] == "chat"
+        assert agent_row["projectId"] == str(project.id)
+        assert agent_row["groupId"] == str(group.id)
+        assert agent_row["agentExtras"] == {"thread_ts": "123"}
+
+        plain_row = by_id[str(without_agent.uuid)]
+        assert plain_row["title"] is None
+        assert plain_row["source"] is None
+        assert plain_row["projectId"] is None
+        assert plain_row["groupId"] is None
+        assert plain_row["agentExtras"] is None
+
+    def test_is_agent_filter(self) -> None:
+        with_agent = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=with_agent)
+        without_agent = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "is:agent"}
+        )
+        assert [r["id"] for r in response.data] == [str(with_agent.uuid)]
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "!is:agent"}
+        )
+        assert [r["id"] for r in response.data] == [str(without_agent.uuid)]
+
+    def test_type_filter(self) -> None:
+        explorer = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, type=SeerRunType.EXPLORER
+        )
+        self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, type=SeerRunType.PR_REVIEW
+        )
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "type:explorer"}
+        )
+        assert [r["id"] for r in response.data] == [str(explorer.uuid)]
+
+    def test_source_filter(self) -> None:
+        run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=run, source="night_shift")
+        other = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=other, source="chat")
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "source:night_shift"}
+        )
+        assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_source_in_filter(self) -> None:
+        night_shift = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=night_shift, source="night_shift")
+        chat = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=chat, source="chat")
+        slack = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=slack, source="slack_thread")
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "source:[night_shift, chat]"}
+        )
+        assert {r["id"] for r in response.data} == {str(night_shift.uuid), str(chat.uuid)}
+
+    def test_source_wildcard_in_filter(self) -> None:
+        # A bracketed list with wildcards collapses to a regex string; it must
+        # match via __regex rather than being iterated char-by-char by __in.
+        slack = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=slack, source="slack_thread")
+        night_shift = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=night_shift, source="night_shift")
+        chat = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=chat, source="chat")
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "source:[slack*, night*]"}
+        )
+        assert {r["id"] for r in response.data} == {str(slack.uuid), str(night_shift.uuid)}
+
+    def test_project_filter(self) -> None:
+        project = self.create_project(organization=self.organization)
+        run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=run, project=project)
+        other = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=other)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"project:{project.id}"}
+        )
+        assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_free_text_query_matches_title(self) -> None:
+        run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=run, title="Fix login bug")
+        other = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=other, title="Refactor billing")
+
+        response = self.get_success_response(self.organization.slug, qs_params={"query": "login"})
+        assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_invalid_query_returns_400(self) -> None:
+        self.get_error_response(
+            self.organization.slug, qs_params={"query": "unknownkey:foo"}, status_code=400
+        )
+
+    def test_invalid_type_returns_400(self) -> None:
+        self.get_error_response(
+            self.organization.slug, qs_params={"query": "type:bogus"}, status_code=400
+        )
+
+    def test_non_numeric_project_returns_400(self) -> None:
+        # A non-integer project value must 400, not 500 during SQL compilation.
+        self.get_error_response(
+            self.organization.slug, qs_params={"query": "project:abc"}, status_code=400
+        )
+
+    def test_pagination(self) -> None:
+        runs = [
+            self.create_seer_run(
+                organization=self.organization,
+                user_id=self.user.id,
+                last_triggered_at=before_now(minutes=i),
+            )
+            for i in range(1, 4)
+        ]
+        # Newest first.
+        expected = [str(runs[0].uuid), str(runs[1].uuid)]
+
+        response = self.get_success_response(self.organization.slug, qs_params={"per_page": "2"})
+        assert [r["id"] for r in response.data] == expected
+        assert 'rel="next"; results="true"' in response.headers["Link"]
+
+    def test_ids_serialized_as_strings(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=42
+        )
+
+        response = self.get_success_response(self.organization.slug)
+        data = response.data[0]
+        assert data["id"] == str(run.uuid)
+        assert data["seerRunId"] == "42"
+        assert data["userId"] == str(self.user.id)
+
+
+class OrganizationSeerRunsEndpointAccessTest(APITestCase):
+    endpoint = "sentry-api-0-organization-seer-runs"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+    def test_missing_features_returns_403(self) -> None:
+        with self.feature({"organizations:seer-explorer": True}):
+            self.get_error_response(self.organization.slug, status_code=403)
+
+
+class FilteredRunsQuerysetTest(TestCase):
+    def test_scopes_to_accessible_projects(self) -> None:
+        accessible = self.create_project(organization=self.organization)
+        hidden = self.create_project(organization=self.organization)
+
+        run_accessible = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run=run_accessible, project=accessible)
+        run_hidden = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run=run_hidden, project=hidden)
+        # No project (agent row with null project) and no agent row at all are
+        # both kept regardless of project access.
+        run_null_project = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run=run_null_project, project=None)
+        run_no_agent = self.create_seer_run(organization=self.organization)
+
+        queryset = filtered_runs_queryset(
+            organization=self.organization,
+            query="",
+            user_id=None,
+            accessible_project_ids={accessible.id},
+            start=None,
+            end=None,
+        )
+
+        assert {r.id for r in queryset} == {
+            run_accessible.id,
+            run_null_project.id,
+            run_no_agent.id,
+        }
+        assert run_hidden.id not in {r.id for r in queryset}

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -35,8 +35,6 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         response = self.get_success_response(self.organization.slug)
 
         assert [r["id"] for r in response.data] == [str(newer.uuid), str(older.uuid)]
-        assert response.data[0]["seerRunId"] == "2"
-        assert response.data[1]["seerRunId"] == "1"
 
     def test_scopes_to_organization(self) -> None:
         run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
@@ -80,7 +78,6 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             source="chat",
             project=project,
             group=group,
-            extras={"thread_ts": "123"},
         )
         without_agent = self.create_seer_run(
             organization=self.organization,
@@ -96,14 +93,12 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         assert agent_row["source"] == "chat"
         assert agent_row["projectId"] == str(project.id)
         assert agent_row["groupId"] == str(group.id)
-        assert agent_row["agentExtras"] == {"thread_ts": "123"}
 
         plain_row = by_id[str(without_agent.uuid)]
         assert plain_row["title"] is None
         assert plain_row["source"] is None
         assert plain_row["projectId"] is None
         assert plain_row["groupId"] is None
-        assert plain_row["agentExtras"] is None
 
     def test_is_agent_filter(self) -> None:
         with_agent = self.create_seer_run(organization=self.organization, user_id=self.user.id)
@@ -117,6 +112,23 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
 
         response = self.get_success_response(
             self.organization.slug, qs_params={"query": "!is:agent"}
+        )
+        assert [r["id"] for r in response.data] == [str(without_agent.uuid)]
+
+    def test_has_agent_filter(self) -> None:
+        # has:agent must match is:agent semantics (runs *with* an agent), not the
+        # inverse from the differing has: operator convention.
+        with_agent = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=with_agent)
+        without_agent = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "has:agent"}
+        )
+        assert [r["id"] for r in response.data] == [str(with_agent.uuid)]
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "!has:agent"}
         )
         assert [r["id"] for r in response.data] == [str(without_agent.uuid)]
 
@@ -143,6 +155,21 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             self.organization.slug, qs_params={"query": "source:night_shift"}
         )
         assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_negated_source_excludes_null(self) -> None:
+        # A negated match must not return rows where the field is NULL (runs with
+        # no agent row); !has: is the way to select those.
+        autofix = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=autofix, source="autofix")
+        chat = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=chat, source="chat")
+        # No agent row -> agent__source is NULL.
+        self.create_seer_run(organization=self.organization, user_id=self.user.id)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "!source:autofix"}
+        )
+        assert [r["id"] for r in response.data] == [str(chat.uuid)]
 
     def test_source_in_filter(self) -> None:
         night_shift = self.create_seer_run(organization=self.organization, user_id=self.user.id)
@@ -183,6 +210,25 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             self.organization.slug, qs_params={"query": f"project:{project.id}"}
         )
         assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_has_project_filter(self) -> None:
+        # has:project / !has:project filter on whether a project is set rather
+        # than 400ing on the empty (non-numeric) value.
+        project = self.create_project(organization=self.organization)
+        with_project = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=with_project, project=project)
+        without_project = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=without_project, project=None)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "has:project"}
+        )
+        assert [r["id"] for r in response.data] == [str(with_project.uuid)]
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "!has:project"}
+        )
+        assert [r["id"] for r in response.data] == [str(without_project.uuid)]
 
     def test_free_text_query_matches_title(self) -> None:
         run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
@@ -233,7 +279,6 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         response = self.get_success_response(self.organization.slug)
         data = response.data[0]
         assert data["id"] == str(run.uuid)
-        assert data["seerRunId"] == "42"
         assert data["userId"] == str(self.user.id)
 
 


### PR DESCRIPTION
Adds `GET /api/0/organizations/{org}/seer/runs/` to list Seer runs directly from the Sentry-side mirror tables (`SeerRun`/`SeerAgentRun`) rather than proxying to Seer over RPC.

This is intended to eventually replace `OrganizationSeerAgentRunsEndpoint` (`seer/explorer-runs/`), which is left in place until the frontend migrates.

```
$ curl -sS --get "http://dev.getsentry.net:8000/api/0/organizations/1/seer/runs/" \
        --data-urlencode "query=ZeroDivisionError" \
        -H "Authorization: Bearer $SENTRY_AUTH_TOKEN_DEV" | jq
[
  {
    "id": "c234e405-664d-4cb6-8f3b-51cf89eb5aaf",
    "seerRunId": "119",
    "type": "explorer",
    "userId": null,
    "lastTriggeredAt": "2026-06-25T10:39:53.547835+00:00",
    "dateCreated": "2026-06-25T09:58:59.271882+00:00",
    "extras": {},
    "title": "Analyze issue SEER-TEST-SANDBOX-PYTHON-5D: \"ZeroDivisionError: float division by zero\" (culprit: src.report_service in compute_velocity)\n\nYour task is to find the ROOT CAUSE of this issue. Do not propose fixes - only identify why the error is happening.\n\n…",
    "source": "autofix",
    "projectId": "9",
    "groupId": "289",
    "agentExtras": {
      "category_value": "289"
    }
  }
]
```