### PR TITLE
feat(pr-metrics): Constrain PullRequestActivity table size and fix activity tracking gates

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -1023,8 +1023,11 @@ class PullRequestEventWebhook(GitHubWebhook):
         pr_metrics_handle_attribution,
         # Persist counters before emission reads them off the PullRequestMetrics row.
         pr_metrics_handle_metrics,
-        pr_metrics_handle_emission,
+        # Activity must be written before emission so the verdict check in
+        # handle_activity sees no verdict yet on the open/sync events, and so the
+        # SYNCHRONIZED rows are present when select_verdict runs on the close event.
         pr_metrics_handle_activity,
+        pr_metrics_handle_emission,
     )
 
     def _handle(

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -274,4 +274,8 @@ def emit_pr_metrics_row(
             "close_action": close_action,
         },
     )
+    # Imported here to avoid a circular import: tasks → judge → emit.
+    from sentry.pr_metrics.tasks import cleanup_pr_activity_task
+
+    cleanup_pr_activity_task.delay(pull_request_id=pull_request.id)
     return True

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -7,7 +7,7 @@ import logging
 from taskbroker_client.retry import Retry
 from urllib3.exceptions import HTTPError
 
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestActivity
 from sentry.models.repository import Repository
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge
 from sentry.silo.base import SiloMode
@@ -68,3 +68,22 @@ def forward_pr_to_seer_task(
         return
 
     forward_pr_to_seer_judge(pull_request, repository)
+
+
+@instrumented_task(
+    name="sentry.pr_metrics.tasks.cleanup_pr_activity",
+    namespace=seer_code_review_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def cleanup_pr_activity_task(*, pull_request_id: int) -> None:
+    """Delete PullRequestActivity rows for a PR whose scm.pr.closed event has been emitted.
+
+    Enqueued by ``emit_pr_metrics_row`` once emission succeeds. The rows are no
+    longer needed: the judge path has consumed what it needed, and the activity
+    table is not reread after a terminal event. A failure here is safe to drop —
+    the existing 30-day age-based cleanup in the cleanup command will sweep any
+    rows that survive.
+    """
+    logger.info("pr_metrics.cleanup_activity", extra={"pull_request_id": pull_request_id})
+    deleted, _ = PullRequestActivity.objects.filter(pull_request_id=pull_request_id).delete()
+    metrics.incr("pr_metrics.cleanup_activity.deleted", amount=deleted)

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -16,6 +16,7 @@ from sentry.models.pullrequest import (
     PullRequestActivity,
     PullRequestActivityType,
     PullRequestAttribution,
+    PullRequestLifecycleState,
     PullRequestMetrics,
 )
 
@@ -28,13 +29,16 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
     Gated on the feature flag rollout only — Seer access is not required,
     since activity is collected for all attribution types including MCP.
 
-    When ``pr`` is supplied, two additional per-PR checks apply:
+    When ``pr`` is supplied, three additional per-PR checks apply in order:
 
-    1. If the PR already has a terminal verdict (or the ``JUDGE_IN_PROGRESS``
+    1. If the PR's ``state`` is already ``CLOSED`` or ``MERGED``, no further
+       activity is needed — this short-circuits without any extra DB queries.
+
+    2. If the PR already has a terminal verdict (or the ``JUDGE_IN_PROGRESS``
        sentinel) on its ``PullRequestMetrics`` row, the ``scm.pr.closed`` event
        has already been emitted and activity rows are no longer needed.
 
-    2. A time-based buffer gate applies after the verdict check:
+    3. A time-based buffer gate applies after the verdict check:
        - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (30 h) of ``pr.date_added``,
          activity is always collected regardless of attribution state.
        - After that window, activity is only collected when the PR has at least
@@ -45,13 +49,11 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
     if not features.has("organizations:pr-metrics-activity", organization):
         return False
 
-    if (
-        pr is not None
-        and PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=False).exists()
-    ):
-        return False
-
     if pr is not None:
+        if pr.state in (PullRequestLifecycleState.CLOSED, PullRequestLifecycleState.MERGED):
+            return False
+        if PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=False).exists():
+            return False
         if timezone.now() - pr.date_added <= _PR_ACTIVITY_ATTRIBUTION_BUFFER:
             return True
         return PullRequestAttribution.objects.filter(pull_request=pr, is_valid=True).exists()

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -16,24 +16,20 @@ from sentry.models.pullrequest import (
     PullRequestActivityType,
     PullRequestMetrics,
 )
-from sentry.seer.seer_setup import has_seer_access
 
 
 def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | None = None) -> bool:
     """Whether PR activity rows should be written for this organization (and PR).
 
-    Both the feature flag rollout and Seer access are required: activity data
-    feeds the judge path which is only meaningful for Seer-enabled orgs.
+    Gated on the feature flag rollout only — Seer access is not required,
+    since activity is collected for all attribution types including MCP.
 
     When ``pr`` is supplied, an additional per-PR check applies: if the PR
     already has a terminal verdict (or the ``JUDGE_IN_PROGRESS`` sentinel) on
     its ``PullRequestMetrics`` row, the ``scm.pr.closed`` event has already
     been emitted and activity rows are no longer needed.
     """
-    if not (
-        features.has("organizations:pr-metrics-activity", organization)
-        and has_seer_access(organization)
-    ):
+    if not features.has("organizations:pr-metrics-activity", organization):
         return False
 
     if (

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -17,6 +17,7 @@ from sentry.models.pullrequest import (
     PullRequestActivityType,
     PullRequestAttribution,
     PullRequestLifecycleState,
+    PullRequestMetrics,
 )
 
 _PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=30)
@@ -34,15 +35,15 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
        ``SUPERSEDED``), no further activity is needed — this short-circuits
        without any extra DB queries.
 
-    2. A time-based buffer gate applies next:
+    2. A verdict check runs next: if ``PullRequestMetrics`` exists with a
+       non-null verdict (terminal emit or ``JUDGE_IN_PROGRESS`` claim), no
+       further activity is needed.
+
+    3. A time-based buffer gate applies last:
        - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (30 h) of ``pr.date_added``,
-         activity is always collected regardless of attribution state.
-       - After that window, a single query checks both conditions together:
-         activity is collected only when the PR has at least one valid
-         ``PullRequestAttribution`` row (``is_valid=True``) *and* its
-         ``PullRequestMetrics`` row has no verdict yet (``verdict IS NULL``
-         or no metrics row). This prevents activity writes after the
-         ``scm.pr.closed`` event has already been emitted.
+         activity is always collected — no attribution row is required yet.
+       - After that window, activity is collected only when the PR has at
+         least one valid ``PullRequestAttribution`` row (``is_valid=True``).
     """
     if not features.has("organizations:pr-metrics-activity", organization):
         return False
@@ -54,12 +55,17 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
             PullRequestLifecycleState.SUPERSEDED,
         ):
             return False
+        verdict_claimed = PullRequestMetrics.objects.filter(
+            pull_request=pr,
+            verdict__isnull=False,
+        ).exists()
+        if verdict_claimed:
+            return False
         if timezone.now() - pr.date_added <= _PR_ACTIVITY_ATTRIBUTION_BUFFER:
             return True
         return PullRequestAttribution.objects.filter(
             pull_request=pr,
             is_valid=True,
-            pull_request__metrics__verdict__isnull=True,
         ).exists()
 
     return True

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -17,7 +17,6 @@ from sentry.models.pullrequest import (
     PullRequestActivityType,
     PullRequestAttribution,
     PullRequestLifecycleState,
-    PullRequestMetrics,
 )
 
 _PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=30)
@@ -29,34 +28,39 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
     Gated on the feature flag rollout only — Seer access is not required,
     since activity is collected for all attribution types including MCP.
 
-    When ``pr`` is supplied, three additional per-PR checks apply in order:
+    When ``pr`` is supplied, two additional per-PR checks apply in order:
 
-    1. If the PR's ``state`` is already ``CLOSED`` or ``MERGED``, no further
-       activity is needed — this short-circuits without any extra DB queries.
+    1. If the PR's ``state`` is already terminal (``CLOSED``, ``MERGED``, or
+       ``SUPERSEDED``), no further activity is needed — this short-circuits
+       without any extra DB queries.
 
-    2. If the PR already has a terminal verdict (or the ``JUDGE_IN_PROGRESS``
-       sentinel) on its ``PullRequestMetrics`` row, the ``scm.pr.closed`` event
-       has already been emitted and activity rows are no longer needed.
-
-    3. A time-based buffer gate applies after the verdict check:
+    2. A time-based buffer gate applies next:
        - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (30 h) of ``pr.date_added``,
          activity is always collected regardless of attribution state.
-       - After that window, activity is only collected when the PR has at least
-         one valid ``PullRequestAttribution`` row (``is_valid=True``); if no
-         such row exists the PR is not attributed and further activity is
-         not useful.
+       - After that window, a single query checks both conditions together:
+         activity is collected only when the PR has at least one valid
+         ``PullRequestAttribution`` row (``is_valid=True``) *and* its
+         ``PullRequestMetrics`` row has no verdict yet (``verdict IS NULL``
+         or no metrics row). This prevents activity writes after the
+         ``scm.pr.closed`` event has already been emitted.
     """
     if not features.has("organizations:pr-metrics-activity", organization):
         return False
 
     if pr is not None:
-        if pr.state in (PullRequestLifecycleState.CLOSED, PullRequestLifecycleState.MERGED):
-            return False
-        if PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=False).exists():
+        if pr.state in (
+            PullRequestLifecycleState.CLOSED,
+            PullRequestLifecycleState.MERGED,
+            PullRequestLifecycleState.SUPERSEDED,
+        ):
             return False
         if timezone.now() - pr.date_added <= _PR_ACTIVITY_ATTRIBUTION_BUFFER:
             return True
-        return PullRequestAttribution.objects.filter(pull_request=pr, is_valid=True).exists()
+        return PullRequestAttribution.objects.filter(
+            pull_request=pr,
+            is_valid=True,
+            pull_request__metrics__verdict__isnull=True,
+        ).exists()
 
     return True
 

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.db.models import Q
+from django.utils import timezone
 
 from sentry import features
 from sentry.models.commit import Commit
@@ -14,8 +15,11 @@ from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
     PullRequestActivityType,
+    PullRequestAttribution,
     PullRequestMetrics,
 )
+
+_PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=4)
 
 
 def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | None = None) -> bool:
@@ -24,10 +28,19 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
     Gated on the feature flag rollout only — Seer access is not required,
     since activity is collected for all attribution types including MCP.
 
-    When ``pr`` is supplied, an additional per-PR check applies: if the PR
-    already has a terminal verdict (or the ``JUDGE_IN_PROGRESS`` sentinel) on
-    its ``PullRequestMetrics`` row, the ``scm.pr.closed`` event has already
-    been emitted and activity rows are no longer needed.
+    When ``pr`` is supplied, two additional per-PR checks apply:
+
+    1. If the PR already has a terminal verdict (or the ``JUDGE_IN_PROGRESS``
+       sentinel) on its ``PullRequestMetrics`` row, the ``scm.pr.closed`` event
+       has already been emitted and activity rows are no longer needed.
+
+    2. A time-based buffer gate applies after the verdict check:
+       - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (4 h) of ``pr.date_added``,
+         activity is always collected regardless of attribution state.
+       - After that window, activity is only collected when the PR has at least
+         one valid ``PullRequestAttribution`` row (``is_valid=True``); if no
+         such row exists the PR is not attributed and further activity is
+         not useful.
     """
     if not features.has("organizations:pr-metrics-activity", organization):
         return False
@@ -37,6 +50,11 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
         and PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=False).exists()
     ):
         return False
+
+    if pr is not None:
+        if timezone.now() - pr.date_added <= _PR_ACTIVITY_ATTRIBUTION_BUFFER:
+            return True
+        return PullRequestAttribution.objects.filter(pull_request=pr, is_valid=True).exists()
 
     return True
 

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -19,7 +19,7 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
 )
 
-_PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=4)
+_PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=30)
 
 
 def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | None = None) -> bool:
@@ -35,7 +35,7 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
        has already been emitted and activity rows are no longer needed.
 
     2. A time-based buffer gate applies after the verdict check:
-       - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (4 h) of ``pr.date_added``,
+       - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (30 h) of ``pr.date_added``,
          activity is always collected regardless of attribution state.
        - After that window, activity is only collected when the PR has at least
          one valid ``PullRequestAttribution`` row (``is_valid=True``); if no

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -10,19 +10,39 @@ from sentry import features
 from sentry.models.commit import Commit
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
-from sentry.models.pullrequest import PullRequest, PullRequestActivity, PullRequestActivityType
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestActivity,
+    PullRequestActivityType,
+    PullRequestMetrics,
+)
 from sentry.seer.seer_setup import has_seer_access
 
 
-def is_activity_tracking_enabled(organization: Organization) -> bool:
-    """Whether PR activity rows should be written for this organization.
+def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | None = None) -> bool:
+    """Whether PR activity rows should be written for this organization (and PR).
 
     Both the feature flag rollout and Seer access are required: activity data
     feeds the judge path which is only meaningful for Seer-enabled orgs.
+
+    When ``pr`` is supplied, an additional per-PR check applies: if the PR
+    already has a terminal verdict (or the ``JUDGE_IN_PROGRESS`` sentinel) on
+    its ``PullRequestMetrics`` row, the ``scm.pr.closed`` event has already
+    been emitted and activity rows are no longer needed.
     """
-    return features.has("organizations:pr-metrics-activity", organization) and has_seer_access(
-        organization
-    )
+    if not (
+        features.has("organizations:pr-metrics-activity", organization)
+        and has_seer_access(organization)
+    ):
+        return False
+
+    if (
+        pr is not None
+        and PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=False).exists()
+    ):
+        return False
+
+    return True
 
 
 def iso_or_none(value: datetime | None) -> str | None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -2,7 +2,7 @@
 
 Multiple independent processors serve several webhook event types:
 - ``PullRequestEventWebhook``: ``handle_attribution``, ``handle_metrics``,
-  ``handle_emission``, ``handle_activity``
+  ``handle_activity``, ``handle_emission``
 - ``IssueCommentEventWebhook``: ``handle_comment``
 - ``PullRequestReviewEventWebhook``: ``handle_review``
 - ``PullRequestReviewCommentEventWebhook``: ``handle_review_comment``
@@ -425,7 +425,7 @@ def handle_activity(
     if pr is None:
         return
 
-    if not is_activity_tracking_enabled(organization):
+    if not is_activity_tracking_enabled(organization, pr):
         return
 
     webhook_id: str | None = kwargs.get("github_delivery_id")
@@ -469,6 +469,9 @@ def handle_comment(
         github_event=github_event,
     )
     if pr is None:
+        return
+
+    if not is_activity_tracking_enabled(organization, pr):
         return
 
     sender = event.get("sender") or {}
@@ -518,6 +521,9 @@ def handle_review(
         github_event=github_event,
     )
     if pr is None:
+        return
+
+    if not is_activity_tracking_enabled(organization, pr):
         return
 
     review = event.get("review") or {}
@@ -576,6 +582,9 @@ def handle_review_comment(
     if pr is None:
         return
 
+    if not is_activity_tracking_enabled(organization, pr):
+        return
+
     comment = event.get("comment") or {}
     sender = event.get("sender") or {}
 
@@ -620,6 +629,9 @@ def handle_review_thread(
         github_event=github_event,
     )
     if pr is None:
+        return
+
+    if not is_activity_tracking_enabled(organization, pr):
         return
 
     thread = event.get("thread") or {}
@@ -687,7 +699,10 @@ def handle_check_suite(
     )
 
     for pr in _prs_from_check_payload(organization, repo, check_suite, webhook_id, github_event):
-        _write_activity_row(pr, webhook_id, PullRequestActivityType.CHECK_SUITE_COMPLETED, payload)
+        if is_activity_tracking_enabled(organization, pr):
+            _write_activity_row(
+                pr, webhook_id, PullRequestActivityType.CHECK_SUITE_COMPLETED, payload
+            )
 
 
 def handle_check_run(
@@ -730,7 +745,10 @@ def handle_check_run(
     )
 
     for pr in _prs_from_check_payload(organization, repo, check_run, webhook_id, github_event):
-        _write_activity_row(pr, webhook_id, PullRequestActivityType.CHECK_RUN_COMPLETED, payload)
+        if is_activity_tracking_enabled(organization, pr):
+            _write_activity_row(
+                pr, webhook_id, PullRequestActivityType.CHECK_RUN_COMPLETED, payload
+            )
 
 
 def _prs_from_check_payload(

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -664,3 +664,20 @@ class PrMetricsEmissionTest(TestCase):
         self._sync_activity(after_sha="a" * 40, before_sha="b" * 40, webhook_id="s1")
         emit_pr_metrics_row(pull_request=self.pull_request)
         assert mock_record.call_args[0][0].group_ids == [group_id]
+
+    @patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task")
+    @patch("sentry.analytics.record")
+    def test_emit_enqueues_cleanup_task(self, mock_record: Any, mock_cleanup: Any) -> None:
+        self._track()
+        emit_pr_metrics_row(pull_request=self.pull_request)
+        mock_cleanup.delay.assert_called_once_with(pull_request_id=self.pull_request.id)
+
+    @patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task")
+    @patch("sentry.analytics.record")
+    def test_untracked_pr_does_not_enqueue_cleanup(
+        self, mock_record: Any, mock_cleanup: Any
+    ) -> None:
+        # No attribution → emit returns False and must not enqueue cleanup.
+        result = emit_pr_metrics_row(pull_request=self.pull_request)
+        assert result is False
+        mock_cleanup.delay.assert_not_called()

--- a/tests/sentry/pr_metrics/test_tasks.py
+++ b/tests/sentry/pr_metrics/test_tasks.py
@@ -47,3 +47,63 @@ class ForwardPrToSeerTaskTest(TestCase):
         # resolves no PR and nothing is forwarded.
         self._run(repository_id=self.repo.id + 1000)
         assert mock_forward.call_count == 0
+
+
+@cell_silo_test
+class CleanupPrActivityTaskTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+
+    def _create_activity(self, webhook_id: str) -> None:
+        from sentry.models.pullrequest import PullRequestActivity, PullRequestActivityType
+
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.OPENED,
+            payload={},
+        )
+
+    def test_deletes_activity_rows_for_pr(self) -> None:
+        from sentry.models.pullrequest import PullRequestActivity
+        from sentry.pr_metrics.tasks import cleanup_pr_activity_task
+
+        self._create_activity("delivery-1")
+        self._create_activity("delivery-2")
+
+        cleanup_pr_activity_task(pull_request_id=self.pull_request.id)
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pull_request).exists()
+
+    def test_no_op_when_no_rows_exist(self) -> None:
+        from sentry.models.pullrequest import PullRequestActivity
+        from sentry.pr_metrics.tasks import cleanup_pr_activity_task
+
+        cleanup_pr_activity_task(pull_request_id=self.pull_request.id)
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pull_request).exists()
+
+    def test_does_not_delete_rows_for_other_prs(self) -> None:
+        from sentry.models.pullrequest import PullRequestActivity, PullRequestActivityType
+        from sentry.pr_metrics.tasks import cleanup_pr_activity_task
+
+        other_pr = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="99"
+        )
+        PullRequestActivity.objects.create(
+            pull_request=other_pr,
+            webhook_id="delivery-other",
+            event_type=PullRequestActivityType.OPENED,
+            payload={},
+        )
+        self._create_activity("delivery-1")
+
+        cleanup_pr_activity_task(pull_request_id=self.pull_request.id)
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pull_request).exists()
+        assert PullRequestActivity.objects.filter(pull_request=other_pr).exists()

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -7,6 +7,7 @@ from sentry.models.pullrequest import (
     PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
+    PullRequestLifecycleState,
 )
 from sentry.pr_metrics.utils import is_activity_tracking_enabled
 from sentry.testutils.cases import TestCase
@@ -88,3 +89,26 @@ class IsActivityTrackingEnabledTest(TestCase):
         )
         with self.feature("organizations:pr-metrics-activity"):
             assert not is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_closed_pr_returns_false_without_db_queries(self) -> None:
+        pr = self._make_pr()
+        pr.state = PullRequestLifecycleState.CLOSED
+        pr.save()
+        with self.feature("organizations:pr-metrics-activity"):
+            assert not is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_merged_pr_returns_false_without_db_queries(self) -> None:
+        pr = self._make_pr()
+        pr.state = PullRequestLifecycleState.MERGED
+        pr.save()
+        with self.feature("organizations:pr-metrics-activity"):
+            assert not is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_open_pr_within_buffer_not_blocked_by_state_check(self) -> None:
+        now = timezone.now()
+        with freeze_time(now):
+            pr = self._make_pr()
+            pr.state = PullRequestLifecycleState.OPEN
+            pr.save()
+            with self.feature("organizations:pr-metrics-activity"):
+                assert is_activity_tracking_enabled(self.organization, pr=pr)

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -54,7 +54,7 @@ class IsActivityTrackingEnabledTest(TestCase):
                 assert is_activity_tracking_enabled(self.organization, pr=pr)
 
     def test_after_buffer_no_attribution_returns_false(self) -> None:
-        past = timezone.now() - timedelta(hours=5)
+        past = timezone.now() - timedelta(hours=31)
         with freeze_time(past):
             pr = self._make_pr()
 
@@ -62,7 +62,7 @@ class IsActivityTrackingEnabledTest(TestCase):
             assert not is_activity_tracking_enabled(self.organization, pr=pr)
 
     def test_after_buffer_with_valid_attribution_returns_true(self) -> None:
-        past = timezone.now() - timedelta(hours=5)
+        past = timezone.now() - timedelta(hours=31)
         with freeze_time(past):
             pr = self._make_pr()
 
@@ -76,7 +76,7 @@ class IsActivityTrackingEnabledTest(TestCase):
             assert is_activity_tracking_enabled(self.organization, pr=pr)
 
     def test_after_buffer_only_invalid_attribution_returns_false(self) -> None:
-        past = timezone.now() - timedelta(hours=5)
+        past = timezone.now() - timedelta(hours=31)
         with freeze_time(past):
             pr = self._make_pr()
 

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.utils import timezone
 
 from sentry.models.pullrequest import (
+    PullRequest,
     PullRequestAttribution,
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
@@ -18,7 +19,7 @@ class IsActivityTrackingEnabledTest(TestCase):
             self.project, name="getsentry/sentry", provider="integrations:github"
         )
 
-    def _make_pr(self):
+    def _make_pr(self) -> "PullRequest":
         return self.create_pull_request(
             organization_id=self.organization.id,
             repository_id=self.repo.id,

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -1,0 +1,89 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.models.pullrequest import (
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
+from sentry.pr_metrics.utils import is_activity_tracking_enabled
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
+
+
+class IsActivityTrackingEnabledTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+
+    def _make_pr(self):
+        return self.create_pull_request(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+        )
+
+    def test_feature_flag_disabled_returns_false(self) -> None:
+        pr = self._make_pr()
+        assert not is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_no_pr_returns_true_when_flag_enabled(self) -> None:
+        with self.feature("organizations:pr-metrics-activity"):
+            assert is_activity_tracking_enabled(self.organization)
+
+    def test_within_buffer_no_attribution_returns_true(self) -> None:
+        now = timezone.now()
+        with freeze_time(now):
+            pr = self._make_pr()
+            with self.feature("organizations:pr-metrics-activity"):
+                assert is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_within_buffer_with_attribution_returns_true(self) -> None:
+        now = timezone.now()
+        with freeze_time(now):
+            pr = self._make_pr()
+            PullRequestAttribution.objects.create(
+                pull_request=pr,
+                signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+                source=PullRequestAttributionSource.WEBHOOK_DATA,
+                is_valid=True,
+            )
+            with self.feature("organizations:pr-metrics-activity"):
+                assert is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_after_buffer_no_attribution_returns_false(self) -> None:
+        past = timezone.now() - timedelta(hours=5)
+        with freeze_time(past):
+            pr = self._make_pr()
+
+        with self.feature("organizations:pr-metrics-activity"):
+            assert not is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_after_buffer_with_valid_attribution_returns_true(self) -> None:
+        past = timezone.now() - timedelta(hours=5)
+        with freeze_time(past):
+            pr = self._make_pr()
+
+        PullRequestAttribution.objects.create(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        with self.feature("organizations:pr-metrics-activity"):
+            assert is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_after_buffer_only_invalid_attribution_returns_false(self) -> None:
+        past = timezone.now() - timedelta(hours=5)
+        with freeze_time(past):
+            pr = self._make_pr()
+
+        PullRequestAttribution.objects.create(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=False,
+        )
+        with self.feature("organizations:pr-metrics-activity"):
+            assert not is_activity_tracking_enabled(self.organization, pr=pr)

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -8,6 +8,8 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
     PullRequestLifecycleState,
+    PullRequestMetrics,
+    PullRequestVerdict,
 )
 from sentry.pr_metrics.utils import is_activity_tracking_enabled
 from sentry.testutils.cases import TestCase
@@ -101,6 +103,24 @@ class IsActivityTrackingEnabledTest(TestCase):
         pr = self._make_pr()
         pr.state = PullRequestLifecycleState.MERGED
         pr.save()
+        with self.feature("organizations:pr-metrics-activity"):
+            assert not is_activity_tracking_enabled(self.organization, pr=pr)
+
+    def test_after_buffer_valid_attribution_but_verdict_set_returns_false(self) -> None:
+        past = timezone.now() - timedelta(hours=31)
+        with freeze_time(past):
+            pr = self._make_pr()
+
+        PullRequestAttribution.objects.create(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        PullRequestMetrics.objects.create(
+            pull_request=pr,
+            verdict=PullRequestVerdict.MERGED_UNCHANGED,
+        )
         with self.feature("organizations:pr-metrics-activity"):
             assert not is_activity_tracking_enabled(self.organization, pr=pr)
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -389,13 +389,17 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
 
     @patch("sentry.analytics.record")
-    def test_skips_emit_when_no_seer_access(self, mock_record: MagicMock) -> None:
-        # Without Seer access, activity rows are not written, so the commits-after-open
-        # signal is absent and select_verdict must defer — same invariant as flag-off.
+    def test_emits_without_seer_access(self, mock_record: MagicMock) -> None:
+        # Seer access is no longer required for activity tracking, so the
+        # commits-after-open signal is present regardless — a clean merge can
+        # still resolve to merged_unchanged without Seer access.
         with self.feature({"organizations:gen-ai-features": False}):
             self._call(merged=True)
-        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
-        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert (
+            PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict
+            == "merged_unchanged"
+        )
 
     @patch("sentry.analytics.record")
     def test_skips_untracked_pr(self, mock_record: MagicMock) -> None:
@@ -551,7 +555,7 @@ class HandleWebhookForPrMetricsCountersTest(TestCase):
         assert PullRequestMetrics.objects.count() == 0
 
 
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature("organizations:pr-metrics-activity")
 @cell_silo_test
 class HandleWebhookForPrMetricsActivityTest(TestCase):
     def setUp(self) -> None:
@@ -933,11 +937,11 @@ class HandleWebhookForPrMetricsActivityTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
-    def test_no_seer_access_skips_activity(self) -> None:
+    def test_activity_written_without_seer_access(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call(action="opened")
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_verdict_claimed_skips_activity(self) -> None:
         PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
@@ -954,7 +958,7 @@ class HandleWebhookForPrMetricsActivityTest(TestCase):
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
 
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature("organizations:pr-metrics-activity")
 @cell_silo_test
 class HandleCommentForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1087,11 +1091,11 @@ class HandleCommentForPrMetricsTest(TestCase):
         activity = PullRequestActivity.objects.get(pull_request=self.pr)
         assert activity.payload["is_review"] is False
 
-    def test_no_seer_access_skips_comment(self) -> None:
+    def test_comment_written_without_seer_access(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call()
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_recent_missing_pr_creates_stub_and_writes_activity(self) -> None:
         # A comment can be delivered before the PR's `opened` webhook writes the
@@ -1159,7 +1163,7 @@ class HandleCommentForPrMetricsTest(TestCase):
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
 
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature("organizations:pr-metrics-activity")
 @cell_silo_test
 class HandleReviewForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1267,11 +1271,11 @@ class HandleReviewForPrMetricsTest(TestCase):
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
-    def test_no_seer_access_skips_review(self) -> None:
+    def test_review_written_without_seer_access(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call()
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_verdict_claimed_skips_review(self) -> None:
         PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
@@ -1281,7 +1285,7 @@ class HandleReviewForPrMetricsTest(TestCase):
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
 
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature("organizations:pr-metrics-activity")
 @cell_silo_test
 class HandleReviewCommentForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1379,11 +1383,11 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
-    def test_no_seer_access_skips_review_comment(self) -> None:
+    def test_review_comment_written_without_seer_access(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call()
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_verdict_claimed_skips_review_comment(self) -> None:
         PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
@@ -1393,7 +1397,7 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
 
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature("organizations:pr-metrics-activity")
 @cell_silo_test
 class HandleReviewThreadForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1486,11 +1490,11 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
         )
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
-    def test_no_seer_access_skips_thread_event(self) -> None:
+    def test_thread_event_written_without_seer_access(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call()
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     def test_verdict_claimed_skips_thread_event(self) -> None:
         PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
@@ -1500,7 +1504,7 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
 
-@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@with_feature("organizations:pr-metrics-activity")
 @cell_silo_test
 class HandleCheckEventsForPrMetricsTest(TestCase):
     def setUp(self) -> None:
@@ -1678,11 +1682,11 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
-    def test_check_suite_no_seer_access_skips(self) -> None:
+    def test_check_suite_written_without_seer_access(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call_suite()
 
-        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
     # --- check_run ---
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -939,6 +939,20 @@ class HandleWebhookForPrMetricsActivityTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_verdict_claimed_skips_activity(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
+
+        self._call(action="opened")
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_judge_in_progress_verdict_skips_activity(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="judge_in_progress")
+
+        self._call(action="synchronize", before="abc", after="def")
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
 
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
@@ -1137,6 +1151,13 @@ class HandleCommentForPrMetricsTest(TestCase):
         assert not PullRequest.objects.filter(repository_id=self.repo.id, key="9999").exists()
         assert mock_logger.info.call_args.kwargs["extra"]["reason"] == "predates_ingestion"
 
+    def test_verdict_claimed_skips_comment(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
+
+        self._call()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
 
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
@@ -1252,6 +1273,13 @@ class HandleReviewForPrMetricsTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_verdict_claimed_skips_review(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
+
+        self._call()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
 
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
@@ -1357,6 +1385,13 @@ class HandleReviewCommentForPrMetricsTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_verdict_claimed_skips_review_comment(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
+
+        self._call()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
 
 @with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
 @cell_silo_test
@@ -1454,6 +1489,13 @@ class HandleReviewThreadForPrMetricsTest(TestCase):
     def test_no_seer_access_skips_thread_event(self) -> None:
         with self.feature({"organizations:gen-ai-features": False}):
             self._call()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_verdict_claimed_skips_thread_event(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="merged_unchanged")
+
+        self._call()
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
@@ -1673,6 +1715,20 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
     def test_check_run_flag_off_skips(self) -> None:
         with self.feature({"organizations:pr-metrics-activity": False}):
             self._call_run()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_verdict_claimed_skips(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="closed_unmerged")
+
+        self._call_suite()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_run_verdict_claimed_skips(self) -> None:
+        PullRequestMetrics.objects.create(pull_request=self.pr, verdict="closed_unmerged")
+
+        self._call_run()
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 


### PR DESCRIPTION
## Summary

- Enqueues a cleanup task after `scm.pr.closed` is emitted to delete `PullRequestActivity` rows for the PR — once emitted the rows are never reread, so they can be freed immediately
- Gates activity writes on the PR verdict: if a terminal verdict (or `JUDGE_IN_PROGRESS`) already exists on `PullRequestMetrics`, the closed event has already fired and no new rows are needed
- Ensures the `handle_activity` webhook processor runs before `handle_emission` so SYNCHRONIZED rows are present when `select_verdict` runs
- Drops the Seer access requirement from `is_activity_tracking_enabled` — MCP attribution doesn't require Seer, so gating on it was incorrect
- Adds a time-based buffer to the activity gate: activity is always collected for the first 30 hours after the `PullRequest` row is created, then only if the PR has at least one valid attribution row. This bounds data collection for unattributed PRs while absorbing attribution timing variability

Refs CORE-258
Refs CORE-259