### PR TITLE
fix(sdk): Inherit parent sampling decision instead of overriding it

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -137,9 +137,9 @@ export function initializeSdk(config: Config) {
     tracesSampler: context => {
       const op = context.attributes?.[Sentry.SEMANTIC_ATTRIBUTE_SENTRY_OP] || '';
       if (op.startsWith('ui.action')) {
-        return tracesSampleRate / 100;
+        return context.inheritOrSampleWith(tracesSampleRate / 100);
       }
-      return tracesSampleRate;
+      return context.inheritOrSampleWith(tracesSampleRate);
     },
     ignoreSpans: IGNORED_SPAN_NAMES,
 


### PR DESCRIPTION
Fixes an SDK misconfiguration where we'd hard-return the frontend's sample rate in `tracesSampler`. This overwrote the parent SDK's sampling decision that the SDK should pick up via `<meta>` tags. 

This led to incomplete traces ending up in Sentry: The backend sampled its initial page rendering transaction negtively, correctly wrote a `-0` sampling decision into the `<meta>` tag but the frontend's `tracesSampler` overwrote this decision. 

The solution is to use the `inheritOrSampleWith` helper on the context, which should be used to avoid this very edge case.