### PR TITLE
feat(pr-metrics): Add typed signal_details to SENTRY_APP attribution

### DIFF
--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -43,6 +43,18 @@ SIGNAL_TYPE_CONFIDENCE: dict[str, int] = {
 }
 
 
+class SentryAppSignalDetails(BaseModel):
+    """Typed signal_details for SENTRY_APP attribution signals.
+
+    Populated by both the GitHub webhook path and the Seer pr_created event.
+    Fields that are unavailable at a given source are left at their defaults.
+    """
+
+    pr_url: str
+    group_ids: list[int] = []
+    run_id: int | None = None
+
+
 class DelegatedAgentSignalDetails(BaseModel):
     """Typed signal_details for SEER_DELEGATED_* attribution signals."""
 
@@ -237,7 +249,11 @@ def attribute_seer_created_pull_requests(
             pr_number=pr_number,
             signal_type=PullRequestAttributionSignalType.SENTRY_APP,
             source=PullRequestAttributionSource.SEER_DATA,
-            signal_details={"run_id": run_id, "group_id": group_id, "pr_url": pr_url},
+            signal_details=SentryAppSignalDetails(
+                pr_url=pr_url or "",
+                group_ids=[int(group_id)] if group_id is not None else [],
+                run_id=int(run_id) if run_id is not None else None,
+            ).dict(),
             log_context=log_context,
         )
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -69,7 +69,11 @@ from sentry.pr_metrics.activity_types import (
     UnassignedPayload,
     UnlabeledPayload,
 )
-from sentry.pr_metrics.attribution import JUDGE_ELIGIBLE_SIGNAL_TYPES, record_attribution_signal
+from sentry.pr_metrics.attribution import (
+    JUDGE_ELIGIBLE_SIGNAL_TYPES,
+    SentryAppSignalDetails,
+    record_attribution_signal,
+)
 from sentry.pr_metrics.emit import (
     emit_pr_metrics_row,
     is_pr_tracked,
@@ -166,7 +170,8 @@ def handle_attribution(
         return
 
     if action == "opened":
-        _write_author_attribution(pr, github_user)
+        pr_url = (pull_request or {}).get("html_url") or None
+        _write_author_attribution(pr, github_user, pr_url=pr_url, group_ids=resolved_group_ids(pr))
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
     if action == "opened" and pull_request is not None and has_seer_access(organization):
@@ -946,17 +951,29 @@ def _detect_app_signal(github_user_id: int) -> PullRequestAttributionSignalType 
     return None
 
 
-def _write_author_attribution(pr: PullRequest, github_user: dict[str, Any]) -> None:
+def _write_author_attribution(
+    pr: PullRequest,
+    github_user: dict[str, Any],
+    pr_url: str | None = None,
+    group_ids: list[int] | None = None,
+) -> None:
     user_id = github_user.get("id")
     if user_id is None:
         return
     signal_type = _detect_app_signal(user_id)
     if signal_type is None:
         return
+    signal_details: SentryAppSignalDetails | None = None
+    if pr_url:
+        signal_details = SentryAppSignalDetails(
+            pr_url=pr_url,
+            group_ids=group_ids or [],
+        )
     record_attribution_signal(
         pull_request=pr,
         signal_type=signal_type,
         source=PullRequestAttributionSource.WEBHOOK_DATA,
+        signal_details=signal_details.dict() if signal_details is not None else None,
     )
 
 

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -63,7 +63,7 @@ class AttributeSeerCreatedPullRequestsTest(TestCase):
         assert attribution.is_valid is True
         assert attribution.signal_details == {
             "run_id": 123,
-            "group_id": self.group.id,
+            "group_ids": [self.group.id],
             "pr_url": "https://github.com/getsentry/sentry/pull/42",
         }
 
@@ -325,10 +325,10 @@ class RecordAttributionSignalTest(TestCase):
 
     def test_updates_details_on_redelivery(self) -> None:
         first = self._record_seer_signal(
-            signal_details={"run_id": 1, "group_id": 2, "pr_url": "https://x/1"}
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
         )
         second = self._record_seer_signal(
-            signal_details={"run_id": 1, "group_id": 2, "pr_url": "https://x/2"}
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/2"}
         )
 
         assert first.id == second.id


### PR DESCRIPTION
Previously the GitHub webhook path wrote `SENTRY_APP` attribution rows with `signal_details=None`, while the Seer `pr_created` path stored `run_id`, `group_id`, and `pr_url` as an untyped plain dict. This meant the two sources for the same signal type had inconsistent schemas, and webhook-sourced rows carried no diagnostic context at all.

This PR closes the gap by introducing `SentryAppSignalDetails` — a pydantic `BaseModel` mirroring the existing `DelegatedAgentSignalDetails` pattern — and wiring both paths through it:

- **`pr_url`** — populated by both paths (`html_url` from the webhook payload; the existing `pr_url` field from the Seer event).
- **`group_ids`** — list of GroupLink-resolved group IDs. The webhook path calls `resolved_group_ids(pr)` (already used elsewhere in the module). The Seer path normalises the incoming singular `group_id` into `[group_id]`.
- **`run_id`** — optional; present only from the Seer path, absent (None) on the webhook path.

The old `group_id` key in the Seer path's plain dict is replaced by `group_ids` across both sources to maintain a single consistent shape.