### PR TITLE
feat(trace-items): Add context to Sentry-defined attributes

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -47,6 +47,20 @@ class ResolverSettings(TypedDict):
 
 
 @dataclass(frozen=True, kw_only=True)
+class AttributeContext:
+    """User-facing context for a Sentry-defined (non-convention) attribute.
+
+    Mirrors the subset of the ``/attributes`` endpoint's ``expand=context``
+    response that a definition can supply on its own (``brief`` and ``examples``);
+    the endpoint combines this with ``isConvention``/deprecation at serialization
+    time. Conventions get their context from ``sentry_conventions`` instead.
+    """
+
+    brief: str
+    examples: Sequence[str] | None = None
+
+
+@dataclass(frozen=True, kw_only=True)
 class ResolvedColumn:
     # The alias for this column
     public_alias: (
@@ -139,6 +153,11 @@ class ResolvedAttribute(ResolvedColumn):
     private: bool = False
     replacement: str | None = field(default=None)
     deprecation_status: str | None = field(default=None)
+    # User-facing context for this Sentry-defined attribute. Only set for
+    # attributes that aren't sentry-conventions (those get their context from
+    # `sentry_conventions`); briefs/examples sourced from Seer's
+    # `attributes_reference.py`.
+    context: AttributeContext | None = field(default=None)
 
     @property
     def proto_definition(self) -> AttributeKey:
@@ -717,6 +736,7 @@ class ConditionalTraceMetricFormulaDefinition(TraceMetricFormulaDefinition):
 def simple_sentry_field(
     field: str,
     search_type: constants.SearchType = "string",
+    context: AttributeContext | None = None,
 ) -> ResolvedAttribute:
     """For a good number of fields, the public alias matches the internal alias
     without the `sentry.` suffix. This helper functions makes defining them easier"""
@@ -724,6 +744,7 @@ def simple_sentry_field(
         public_alias=field,
         internal_name=f"sentry.{field}",
         search_type=search_type,
+        context=context,
     )
 
 
@@ -731,6 +752,7 @@ def simple_measurements_field(
     field: str,
     search_type: constants.SearchType = "number",
     secondary_alias: bool = False,
+    context: AttributeContext | None = None,
 ) -> ResolvedAttribute:
     """For a good number of fields, the public alias matches the internal alias
     with the `measurements.` prefix. This helper functions makes defining them easier"""
@@ -739,6 +761,7 @@ def simple_measurements_field(
         internal_name=field,
         search_type=search_type,
         secondary_alias=secondary_alias,
+        context=context,
     )
 
 

--- a/src/sentry/search/eap/common_columns.py
+++ b/src/sentry/search/eap/common_columns.py
@@ -1,5 +1,6 @@
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
+    AttributeContext,
     ResolvedAttribute,
     VirtualColumnDefinition,
     datetime_processor,
@@ -36,11 +37,13 @@ COMMON_COLUMNS = [
         internal_name="sentry.project_id",
         internal_type=constants.INT,
         search_type="string",
+        context=AttributeContext(brief="The id of the project."),
     ),
     ResolvedAttribute(
         public_alias="project_id",
         internal_name="sentry.project_id",
         search_type="integer",
+        context=AttributeContext(brief="The id of the project."),
     ),
     ResolvedAttribute(
         public_alias="sentry.item_type",
@@ -60,5 +63,6 @@ COMMON_COLUMNS = [
         internal_type=constants.DOUBLE,
         search_type="string",
         processor=datetime_processor,
+        context=AttributeContext(brief="The timestamp of the item."),
     ),
 ]

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
+    AttributeContext,
     ResolvedAttribute,
     simple_sentry_field,
 )
@@ -24,16 +25,27 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             public_alias="severity_number",
             internal_name="sentry.severity_number",
             search_type="integer",
+            context=AttributeContext(
+                brief="Numeric severity level of a log entry (higher values indicate more severe events)."
+            ),
         ),
         ResolvedAttribute(
             public_alias="severity",
             internal_name="sentry.severity_text",
             search_type="string",
+            context=AttributeContext(
+                brief=(
+                    "The severity level assigned to the log, indicating its impact. "
+                    "Higher severity indicates more critical issues that need attention."
+                ),
+                examples=["error", "warn", "info"],
+            ),
         ),
         ResolvedAttribute(
             public_alias="message",
             internal_name="sentry.body",
             search_type="string",
+            context=AttributeContext(brief="The full log message body."),
         ),
         ResolvedAttribute(
             public_alias=constants.TRACE_ALIAS,
@@ -41,6 +53,13 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
             validator=validate_event_id,
             normalizer=normalize_event_id_strict,
+            context=AttributeContext(
+                brief=(
+                    "A trace represents the record of the entire operation you want to "
+                    "measure or track — like page load, searched using the UUID generated "
+                    "by Sentry's SDK."
+                )
+            ),
         ),
         ResolvedAttribute(
             public_alias=constants.TIMESTAMP_PRECISE_ALIAS,

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -12,6 +12,7 @@ from sentry_protos.snuba.v1.trace_item_attribute_pb2 import VirtualColumnContext
 from sentry.insights.models import InsightsStarredSegment
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
+    AttributeContext,
     ResolvedAttribute,
     VirtualColumnDefinition,
     simple_measurements_field,
@@ -70,6 +71,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="span.description",
             internal_name="sentry.raw_description",
             search_type="string",
+            context=AttributeContext(brief="Description of the span's operation."),
         ),
         ResolvedAttribute(
             public_alias="description",
@@ -88,6 +90,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.raw_description",
             search_type="string",
             secondary_alias=True,
+            context=AttributeContext(brief="Description of the span's operation."),
         ),
         ResolvedAttribute(
             public_alias="span.domain",
@@ -113,16 +116,23 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="span.self_time",
             internal_name="sentry.exclusive_time_ms",
             search_type="millisecond",
+            context=AttributeContext(
+                brief="The duration of the span excluding the duration of its child spans."
+            ),
         ),
         ResolvedAttribute(
             public_alias="span.duration",
             internal_name="sentry.duration_ms",
             search_type="millisecond",
+            context=AttributeContext(brief="The total time taken by the span."),
         ),
         ResolvedAttribute(
             public_alias="span.status",
             internal_name="sentry.status",
             search_type="string",
+            context=AttributeContext(
+                brief="Span status. Indicates whether the operation was successful."
+            ),
         ),
         ResolvedAttribute(
             public_alias="span.status_code",
@@ -140,6 +150,13 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
             validator=validate_event_id,
             normalizer=normalize_event_id_strict,
+            context=AttributeContext(
+                brief=(
+                    "A trace represents the record of the entire operation you want to "
+                    "measure or track — like page load, searched using the UUID generated "
+                    "by Sentry's SDK."
+                )
+            ),
         ),
         ResolvedAttribute(
             public_alias="transaction",
@@ -150,6 +167,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="is_transaction",
             internal_name="sentry.is_segment",
             search_type="boolean",
+            context=AttributeContext(brief="The span is also a transaction."),
         ),
         ResolvedAttribute(
             public_alias="transaction.span_id",
@@ -368,26 +386,41 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             public_alias="spans.browser",
             internal_name="span_ops.ops.browser",
             search_type="millisecond",
+            context=AttributeContext(
+                brief="Cumulative browser time for a transaction, based on the span operations."
+            ),
         ),
         ResolvedAttribute(
             public_alias="spans.db",
             internal_name="span_ops.ops.db",
             search_type="millisecond",
+            context=AttributeContext(
+                brief="Cumulative db time for a transaction, based on span operations."
+            ),
         ),
         ResolvedAttribute(
             public_alias="spans.http",
             internal_name="span_ops.ops.http",
             search_type="millisecond",
+            context=AttributeContext(
+                brief="Cumulative http time for a transaction, based on span operations."
+            ),
         ),
         ResolvedAttribute(
             public_alias="spans.resource",
             internal_name="span_ops.ops.resource",
             search_type="millisecond",
+            context=AttributeContext(
+                brief="Cumulative resource time for a transaction, based on span operations."
+            ),
         ),
         ResolvedAttribute(
             public_alias="spans.ui",
             internal_name="span_ops.ops.ui",
             search_type="millisecond",
+            context=AttributeContext(
+                brief="Cumulative UI time for a transaction, based on span operations."
+            ),
         ),
         ResolvedAttribute(
             public_alias="span.system",
@@ -411,9 +444,12 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="number",
         ),
         simple_sentry_field("browser.name"),
-        simple_sentry_field("file_extension"),
+        simple_sentry_field(
+            "file_extension",
+            context=AttributeContext(brief="The file extension of a resource span."),
+        ),
         simple_sentry_field("device.family"),
-        simple_sentry_field("device.arch"),
+        simple_sentry_field("device.arch", context=AttributeContext(brief="CPU architecture.")),
         simple_sentry_field("device.battery_level"),
         simple_sentry_field("device.brand"),
         simple_sentry_field("device.charging"),
@@ -456,9 +492,18 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.item_id",
             search_type="string",
         ),
-        simple_sentry_field("trace.status"),
-        simple_sentry_field("transaction.method"),
-        simple_sentry_field("transaction.op"),
+        simple_sentry_field(
+            "trace.status",
+            context=AttributeContext(brief="The span trace's success or failure status."),
+        ),
+        simple_sentry_field(
+            "transaction.method",
+            context=AttributeContext(brief="HTTP method of the containing transaction."),
+        ),
+        simple_sentry_field(
+            "transaction.op",
+            context=AttributeContext(brief="Operation of the containing transaction."),
+        ),
         simple_sentry_field("user"),
         simple_sentry_field("user.email"),
         simple_sentry_field("user.geo.city"),
@@ -474,25 +519,63 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
         simple_sentry_field("ttid"),
         simple_measurements_field("app_start_cold", "millisecond"),
         simple_measurements_field("app_start_warm", "millisecond"),
-        simple_measurements_field("frames_frozen"),
+        simple_measurements_field(
+            "frames_frozen",
+            context=AttributeContext(
+                brief="Slow and frozen frames measure the responsiveness of your app."
+            ),
+        ),
         simple_measurements_field("frames_frozen_rate", "percentage"),
-        simple_measurements_field("frames_slow"),
+        simple_measurements_field(
+            "frames_slow",
+            context=AttributeContext(
+                brief="Slow and frozen frames measure the responsiveness of your app."
+            ),
+        ),
         simple_measurements_field("frames_slow_rate", "percentage"),
-        simple_measurements_field("frames_total"),
+        simple_measurements_field(
+            "frames_total",
+            context=AttributeContext(
+                brief="Returns results with a matching total number of frames."
+            ),
+        ),
         simple_measurements_field("time_to_initial_display", "millisecond"),
         simple_measurements_field("time_to_full_display", "millisecond"),
-        simple_measurements_field("stall_count"),
+        simple_measurements_field(
+            "stall_count",
+            context=AttributeContext(
+                brief=(
+                    "A stall is when the JavaScript event loop takes longer than expected "
+                    "to complete. Only applies to React Native."
+                )
+            ),
+        ),
         simple_measurements_field("stall_percentage", "percentage"),
         simple_measurements_field("stall_stall_longest_time"),
         simple_measurements_field("stall_stall_total_time"),
         simple_measurements_field("cls"),
         simple_measurements_field("fcp", "millisecond"),
-        simple_measurements_field("fid", "millisecond"),
+        simple_measurements_field(
+            "fid",
+            "millisecond",
+            context=AttributeContext(
+                brief=(
+                    "First Input Delay (FID) measures the response time when the user "
+                    "tries to interact with the viewport."
+                )
+            ),
+        ),
         simple_measurements_field("fp", "millisecond"),
         simple_measurements_field("inp", "millisecond"),
         simple_measurements_field("lcp", "millisecond"),
         simple_measurements_field("ttfb", "millisecond"),
-        simple_measurements_field("ttfb.requesttime", "millisecond"),
+        simple_measurements_field(
+            "ttfb.requesttime",
+            "millisecond",
+            context=AttributeContext(
+                brief="The time between start of the request and start of the response (see diagram)."
+            ),
+        ),
         simple_measurements_field("score.cls"),
         simple_measurements_field("score.fcp"),
         simple_measurements_field("score.fid"),

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from sentry.search.eap import constants
 from sentry.search.eap.columns import (
+    AttributeContext,
     ResolvedAttribute,
     simple_sentry_field,
 )
@@ -26,6 +27,13 @@ TRACE_METRICS_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
             validator=validate_event_id,
             normalizer=normalize_event_id_strict,
+            context=AttributeContext(
+                brief=(
+                    "A trace represents the record of the entire operation you want to "
+                    "measure or track — like page load, searched using the UUID generated "
+                    "by Sentry's SDK."
+                )
+            ),
         ),
         ResolvedAttribute(
             public_alias=constants.TIMESTAMP_PRECISE_ALIAS,


### PR DESCRIPTION
## Summary

Adds an `AttributeContext` — a required `brief` plus optional `examples` — to `ResolvedAttribute` and populates it for the Sentry defined (non-convention) attributes surfaced by the `/trace-items` attributes endpoint, for **spans, logs, and trace metrics**.

The shape deliberately mirrors the subset of the attributes endpoint's `expand=context` response that a definition can supply on its own (`brief` / `examples`). A **follow-up** will wire this into the endpoint, building the response directly from the definition and combining it with `isConvention` / deprecation at serialization time. This PR only adds the data.

Co-locating context on the definition keeps `search_type` the single source of truth for the attribute's type (no parallel type declaration that can drift).

## Scope

- **In:** attributes that are (1) described in Seer's `attributes_reference.py`, (2) **not** in `sentry-conventions` (conventions carry their own context), and (3) already a hardcoded `ResolvedAttribute`.
- Item types: **spans (traces) 26 / logs 7 / trace metrics 4** (incl. shared `project.id`, `project_id`, `timestamp` in `common_columns.py`).
- **Out (intentionally deferred):** `project` (a mapping-only alias, no `ResolvedAttribute`) and the `occurrences` / errors item types.

## Brief sourcing

Briefs come verbatim from Seer's `attributes_reference.py` with the trailing `Type: …` hint stripped, with deliberate adjustments where Seer's flattened map is misleading:

- **`timestamp`** (shared column): Seer only has transaction-centric text and never describes it for logs/metrics → neutral `"The timestamp of the item."`
- **`message`**: logs → `"The full log message body."`; spans → mirrors `span.description`.
- **`device.uuid`**: skipped — Seer's text is just `"Deprecated."`
- **`severity`** (logs): the brief's enumerated values move into `examples=["error", "warn", "info"]`.

## Testing

- `tests/sentry/search/eap/` — 139 passed.
- Verified the exact set with context matches scope and that `severity` carries the expected examples.
