### PR TITLE
feat(integrations): track referrer on auto-opened install modal

### DIFF
--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -26,6 +26,7 @@ export interface AddIntegrationParams {
       | 'seer_onboarding_code_review'
       | 'test_analytics_onboarding'
       | 'test_analytics_org_selector';
+    referrer?: string;
   };
   /**
    * Overrides for the install modal's copy. Passed straight through to

--- a/static/app/utils/integrations/useAutoOpenInstallModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenInstallModal.tsx
@@ -60,6 +60,7 @@ export function useAutoOpenInstallModal({
       organization,
       integration: provider.key,
       integration_type: 'first_party',
+      ...analyticsParams,
     });
 
     // NOTE: The `?showInstallModal=1` entry point is currently only used by the


### PR DESCRIPTION
let's add the referrer for slack nudge to update the slack installation so we can track how many people are updating the app via clicking the slack nudge