### PR TITLE
fix(o11y): Restore max_value_length

### DIFF
--- a/src/sentry/conf/types/sdk_config.py
+++ b/src/sentry/conf/types/sdk_config.py
@@ -17,6 +17,7 @@ class SdkConfig(TypedDict):
     keep_alive: NotRequired[bool]
     spotlight: NotRequired[str | bool | None]
     add_full_stack: NotRequired[bool]
+    max_value_length: NotRequired[int]
     send_client_reports: NotRequired[bool]
     traces_sampler: NotRequired[Callable[[dict[str, Any]], float]]
     before_send: NotRequired[Callable[[Event, Hint], Event | None]]

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -319,6 +319,7 @@ class Dsns(NamedTuple):
 def _get_sdk_options() -> tuple[SdkConfig, Dsns]:
     sdk_options = settings.SENTRY_SDK_CONFIG.copy()
     sdk_options["add_full_stack"] = True
+    sdk_options["max_value_length"] = 100_000
     sdk_options["traces_sampler"] = traces_sampler
     sdk_options["before_send"] = before_send
     sdk_options["before_send_transaction"] = before_send_transaction


### PR DESCRIPTION
<img width="818" height="254" alt="image" src="https://github.com/user-attachments/assets/996a35cd-5ba7-401c-9d33-20b2633cbb0f" />

The SDK bump in #117807 let do a big increase in too large transaction outcomes. Setting the value to the pervious value in the SDK. https://github.com/getsentry/sentry-python/releases/tag/2.61.0