### PR TITLE
feat(assisted-query):  Support org-level flags in the assisted query agent by patching via Sentry Request

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -507,4 +507,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-generate-billing-outcome", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("organizations:claude-code-vault-reuse", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
+    # seer feature flags for assisted query agent org scoped
+    manager.add("organizations:assisted-query-cross-event-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:assisted-query-project-expansion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
     # fmt: on

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -67,7 +67,7 @@ def send_search_agent_start_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
-    extra_feature_flags: dict[str, Any] | None = None,
+    extra_feature_flags: dict[str, bool] | None = None,
 ) -> SeerRun:
     """Create the SeerRun mirror and enqueue the outbox that starts the agent in Seer."""
     body = SearchAgentStartRequest(
@@ -178,7 +178,9 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         user_org_context = collect_user_org_context(request.user, organization)
         user_email = user_org_context.get("user_email")
         timezone = user_org_context.get("user_timezone")
-        extra_feature_flags = get_extra_seer_feature_flags()
+        extra_feature_flags = get_extra_seer_feature_flags(
+            organization=organization, user=request.user
+        )
 
         try:
             viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -16,6 +16,7 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_utils import collect_user_org_context, enqueue_seer_run
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
+from sentry.seer.endpoints.utils import get_extra_seer_feature_flags
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRun, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
@@ -66,6 +67,7 @@ def send_search_agent_start_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
+    extra_feature_flags: dict[str, Any] | None = None,
 ) -> SeerRun:
     """Create the SeerRun mirror and enqueue the outbox that starts the agent in Seer."""
     body = SearchAgentStartRequest(
@@ -85,8 +87,9 @@ def send_search_agent_start_request(
         options["model_name"] = model_name
     if metric_context is not None:
         options["metric_context"] = metric_context
-    if options:
-        body["options"] = options
+    extra_feature_flags = extra_feature_flags or {}
+    options["extra_feature_flags"] = extra_feature_flags
+    body["options"] = options
 
     return enqueue_seer_run(
         organization=organization,
@@ -175,6 +178,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         user_org_context = collect_user_org_context(request.user, organization)
         user_email = user_org_context.get("user_email")
         timezone = user_org_context.get("user_timezone")
+        extra_feature_flags = get_extra_seer_feature_flags()
 
         try:
             viewer_context = SeerViewerContext(
@@ -191,6 +195,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 model_name=model_name,
                 metric_context=metric_context,
                 viewer_context=viewer_context,
+                extra_feature_flags=extra_feature_flags,
             )
             return Response(
                 {

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -67,7 +67,7 @@ def send_translate_agentic_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
-    extra_seer_feature_flags: dict[str, bool] | None = None,
+    extra_feature_flags: dict[str, bool] | None = None,
 ) -> Any:
     """
     Sends a request to seer to translate a natural language query using the agentic search API.
@@ -84,8 +84,8 @@ def send_translate_agentic_request(
         options["model_name"] = model_name
     if metric_context is not None:
         options["metric_context"] = metric_context
-    extra_seer_feature_flags = extra_seer_feature_flags or {}
-    options["extra_seer_feature_flags"] = extra_seer_feature_flags
+    extra_feature_flags = extra_feature_flags or {}
+    options["extra_feature_flags"] = extra_feature_flags
     body["options"] = options
 
     response = make_translate_agentic_request(body, timeout=10, viewer_context=viewer_context)
@@ -147,7 +147,9 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
             )
 
         viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
-        extra_feature_flags = get_extra_seer_feature_flags()
+        extra_feature_flags = get_extra_seer_feature_flags(
+            organization=organization, user=request.user
+        )
         data = send_translate_agentic_request(
             organization.id,
             organization.slug,

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -15,6 +15,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
+from sentry.seer.endpoints.utils import get_extra_seer_feature_flags
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
@@ -66,6 +67,7 @@ def send_translate_agentic_request(
     model_name: str | None = None,
     metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
+    extra_seer_feature_flags: dict[str, bool] | None = None,
 ) -> Any:
     """
     Sends a request to seer to translate a natural language query using the agentic search API.
@@ -82,8 +84,9 @@ def send_translate_agentic_request(
         options["model_name"] = model_name
     if metric_context is not None:
         options["metric_context"] = metric_context
-    if options:
-        body["options"] = options
+    extra_seer_feature_flags = extra_seer_feature_flags or {}
+    options["extra_seer_feature_flags"] = extra_seer_feature_flags
+    body["options"] = options
 
     response = make_translate_agentic_request(body, timeout=10, viewer_context=viewer_context)
     if response.status >= 400:
@@ -144,6 +147,7 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
             )
 
         viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
+        extra_feature_flags = get_extra_seer_feature_flags()
         data = send_translate_agentic_request(
             organization.id,
             organization.slug,
@@ -153,5 +157,6 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
             model_name=model_name,
             metric_context=metric_context,
             viewer_context=viewer_context,
+            extra_feature_flags=extra_feature_flags,
         )
         return Response(data)

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -110,13 +110,13 @@ def accept_organization_id_param(func: Callable[..., _RpcReturn]) -> Callable[..
     return wrapper
 
 
-def get_extra_seer_feature_flags() -> dict[str, Any] | None:
+def get_extra_seer_feature_flags(organization: Organization, user: Any) -> dict[str, bool]:
     feature_flag_options = {}
     feature_flags = [
         "assisted-query.cross-event-explorer-endpoint-enabled",
         "assisted-query.project-expansion-enabled",
     ]
     for ff in feature_flags:
-        if features.has(ff):
+        if features.has(ff, organization, actor=user):
             feature_flag_options[ff] = True
     return feature_flag_options

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -12,7 +12,11 @@ from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus
 from sentry.utils.numbers import validate_bigint
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
+
     from sentry.models.organization import Organization
+    from sentry.users.models.user import User
+    from sentry.users.services.user import RpcUser
 
 
 class ResolvedSeerRun(NamedTuple):
@@ -110,13 +114,17 @@ def accept_organization_id_param(func: Callable[..., _RpcReturn]) -> Callable[..
     return wrapper
 
 
-def get_extra_seer_feature_flags(organization: Organization, user: Any) -> dict[str, bool]:
-    feature_flag_options = {}
-    feature_flags = [
-        "assisted-query.cross-event-explorer-endpoint-enabled",
-        "assisted-query.project-expansion-enabled",
-    ]
-    for ff in feature_flags:
-        if features.has(ff, organization, actor=user):
-            feature_flag_options[ff] = True
-    return feature_flag_options
+_SEER_FORWARDED_FLAGS = {
+    "organizations:assisted-query-cross-event-explorer": "assisted-query.cross-event-explorer-endpoint-enabled",
+    "organizations:assisted-query-project-expansion": "assisted-query.project-expansion-enabled",
+}
+
+
+def get_extra_seer_feature_flags(
+    organization: Organization, user: User | RpcUser | AnonymousUser
+) -> dict[str, bool]:
+    return {
+        seer_key: True
+        for ff, seer_key in _SEER_FORWARDED_FLAGS.items()
+        if features.has(ff, organization, actor=user)
+    }

--- a/src/sentry/seer/endpoints/utils.py
+++ b/src/sentry/seer/endpoints/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 from rest_framework import status
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus
 from sentry.utils.numbers import validate_bigint
 
@@ -107,3 +108,15 @@ def accept_organization_id_param(func: Callable[..., _RpcReturn]) -> Callable[..
         return func(**kwargs)
 
     return wrapper
+
+
+def get_extra_seer_feature_flags() -> dict[str, Any] | None:
+    feature_flag_options = {}
+    feature_flags = [
+        "assisted-query.cross-event-explorer-endpoint-enabled",
+        "assisted-query.project-expansion-enabled",
+    ]
+    for ff in feature_flags:
+        if features.has(ff):
+            feature_flag_options[ff] = True
+    return feature_flag_options

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
@@ -57,6 +57,7 @@ class SearchAgentTranslateEndpointTest(APITestCase):
                 "organization_id": self.organization.id,
                 "user_id": self.user.id,
             },
+            extra_feature_flags={},
         )
 
     @patch(


### PR DESCRIPTION
Seer doesn't support org level feature flags, its either on or off. Rolling out feature gradually is not possible. We can pass feature flags along with request when they are proxied from sentry layer. 