### PR TITLE
feat(integrations): type referrer on integration analytics events

### DIFF
--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -34,6 +34,7 @@ type SingleIntegrationEventParams = {
   integration_status?: SentryAppStatus;
   integration_tab?: 'configurations' | 'overview' | 'features';
   plan?: string;
+  referrer?: string;
 } & IntegrationView;
 
 // Required on install events so the data team can filter SCM connections


### PR DESCRIPTION
clean up of #118740, SingleIntegrationEventParams was missing the referrer field and we should really add them to fully type the analytics event