### PR TITLE
feat(explore): Increase resolution of heat map widgets

### DIFF
--- a/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
+++ b/static/app/views/dashboards/widgets/heatMapWidget/settings.ts
@@ -32,9 +32,10 @@ export const HEATMAP_COLORS = [
 /**
  * Target size, in pixels, of a single heat map bucket along each axis. Both the
  * X-axis (time) interval and the Y-axis bucket count are chosen so that cells
- * are roughly this size, keeping them approximately square.
+ * are roughly this size, keeping them approximately square. A smaller value
+ * yields denser buckets, which makes modality in the data easier to resolve.
  */
-export const PIXELS_PER_BUCKET = 15;
+export const PIXELS_PER_BUCKET = 5;
 
 /**
  * How long, in milliseconds, to debounce the measured chart dimensions before

--- a/static/app/views/dashboards/widgets/heatMapWidget/utils/calculateHeatMapBucketDimensions.spec.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/utils/calculateHeatMapBucketDimensions.spec.tsx
@@ -337,9 +337,11 @@ describe('calculateHeatMapBucketDimensions()', () => {
         AVAILABLE_INTERVALS
       );
 
-      // The coarsest interval should be selected for such a long window.
+      // One of the coarsest intervals should be selected for such a long
+      // window. With a 5px target over 90d / 800px the bucket target is ~13.5h,
+      // which snaps to '12h' rather than the absolute coarsest '1d'.
       expect(result).not.toBeNull();
-      expect(result!.interval).toBe('1d');
+      expect(result!.interval).toBe('12h');
     });
 
     it('handles absolute date ranges', () => {


### PR DESCRIPTION
Lowers `PIXELS_PER_BUCKET` from `15` to `5` for heat map widgets. This snaps to finer intervals and Y-axis bucket counts. The difference in the visualization is stark, take a look at these before/afters:

**24h**
<img width="566" height="285" alt="Screenshot 2026-06-30 at 11 44 02 AM" src="https://github.com/user-attachments/assets/ee5a6f38-f6eb-4f4a-ac34-ed00af1c15eb" />
<img width="560" height="308" alt="Screenshot 2026-06-30 at 11 44 06 AM" src="https://github.com/user-attachments/assets/cea0a6d6-a5ef-41ad-8419-80bbf2f43d57" />

**7d**
<img width="531" height="285" alt="Screenshot 2026-06-30 at 11 44 21 AM" src="https://github.com/user-attachments/assets/90c10094-116e-4461-9be5-2e083cd805d7" />
<img width="493" height="280" alt="Screenshot 2026-06-30 at 11 44 42 AM" src="https://github.com/user-attachments/assets/6ea6595c-5c17-40a5-b7df-9cf5ce834093" />

**30d**
<img width="512" height="294" alt="Screenshot 2026-06-30 at 11 45 06 AM" src="https://github.com/user-attachments/assets/8cf2c5cd-d88e-4889-8715-198f1e3c31ee" />
<img width="499" height="291" alt="Screenshot 2026-06-30 at 11 45 10 AM" src="https://github.com/user-attachments/assets/c274ab2d-37f3-4b23-82d9-8e346bb16798" />

The increased resolution reveals much finer details. The downside is _much_ longer load time, to the point where we might overshoot the 30s timeout in many cases. We'll need to track metrics for this. Our escape hatch is split loading: making 2-3 requests instead of one, and chunking the load.

Closes DAIN-1742.