### PR TITLE
ref(migrations): Replace cross-migration __import__ with sentry.new_migrations.operations.to_jsonb

### DIFF
--- a/src/sentry/discover/migrations/0003_discover_json_field.py
+++ b/src/sentry/discover/migrations/0003_discover_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_discoversavedquery", "query")],
+            database_operations=[to_jsonb("sentry_discoversavedquery", "query")],
             state_operations=[
                 migrations.AlterField(
                     model_name="discoversavedquery",

--- a/src/sentry/explore/migrations/0005_explore_django_json_field.py
+++ b/src/sentry/explore/migrations/0005_explore_django_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("explore_exploresavedquery", "query")],
+            database_operations=[to_jsonb("explore_exploresavedquery", "query")],
             state_operations=[
                 migrations.AlterField(
                     model_name="exploresavedquery",

--- a/src/sentry/migrations/0940_auditlog_json_field.py
+++ b/src/sentry/migrations/0940_auditlog_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_auditlogentry", "data")],
+            database_operations=[to_jsonb("sentry_auditlogentry", "data")],
             state_operations=[
                 migrations.AlterField(
                     model_name="auditlogentry",

--- a/src/sentry/migrations/0954_user_option_json_field.py
+++ b/src/sentry/migrations/0954_user_option_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_useroption", "value")],
+            database_operations=[to_jsonb("sentry_useroption", "value")],
             state_operations=[
                 migrations.AlterField(
                     model_name="useroption",

--- a/src/sentry/migrations/0955_org_option_json_field.py
+++ b/src/sentry/migrations/0955_org_option_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_organizationoptions", "value")],
+            database_operations=[to_jsonb("sentry_organizationoptions", "value")],
             state_operations=[
                 migrations.AlterField(
                     model_name="organizationoption",

--- a/src/sentry/migrations/0957_projecttemplateoption_json.py
+++ b/src/sentry/migrations/0957_projecttemplateoption_json.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_projecttemplateoption", "value")],
+            database_operations=[to_jsonb("sentry_projecttemplateoption", "value")],
             state_operations=[
                 migrations.AlterField(
                     model_name="projecttemplateoption",

--- a/src/sentry/migrations/0958_base_option_json_field.py
+++ b/src/sentry/migrations/0958_base_option_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,8 +29,8 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_option", "value"),
-                mod.to_jsonb("sentry_controloption", "value"),
+                to_jsonb("sentry_option", "value"),
+                to_jsonb("sentry_controloption", "value"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0960_project_option_json_field.py
+++ b/src/sentry/migrations/0960_project_option_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_projectoptions", "value")],
+            database_operations=[to_jsonb("sentry_projectoptions", "value")],
             state_operations=[
                 migrations.AlterField(
                     model_name="projectoption",

--- a/src/sentry/migrations/0961_identity_json_field.py
+++ b/src/sentry/migrations/0961_identity_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,8 +29,8 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_identity", "data"),
-                mod.to_jsonb("sentry_identityprovider", "config"),
+                to_jsonb("sentry_identity", "data"),
+                to_jsonb("sentry_identityprovider", "config"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0963_scheduleddeletion_json_field.py
+++ b/src/sentry/migrations/0963_scheduleddeletion_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,8 +29,8 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_regionscheduleddeletion", "data"),
-                mod.to_jsonb("sentry_scheduleddeletion", "data"),
+                to_jsonb("sentry_regionscheduleddeletion", "data"),
+                to_jsonb("sentry_scheduleddeletion", "data"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0974_hc_json_field.py
+++ b/src/sentry/migrations/0974_hc_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,8 +29,8 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_controloutbox", "payload"),
-                mod.to_jsonb("sentry_regionoutbox", "payload"),
+                to_jsonb("sentry_controloutbox", "payload"),
+                to_jsonb("sentry_regionoutbox", "payload"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0975_grouplink_json_field.py
+++ b/src/sentry/migrations/0975_grouplink_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_grouplink", "data")],
+            database_operations=[to_jsonb("sentry_grouplink", "data")],
             state_operations=[
                 migrations.AlterField(
                     model_name="grouplink",

--- a/src/sentry/migrations/0976_sentry_app_json_field.py
+++ b/src/sentry/migrations/0976_sentry_app_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,9 +29,9 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_sentryapp", "metadata"),
-                mod.to_jsonb("sentry_sentryapp", "schema"),
-                mod.to_jsonb("sentry_sentryappcomponent", "schema"),
+                to_jsonb("sentry_sentryapp", "metadata"),
+                to_jsonb("sentry_sentryapp", "schema"),
+                to_jsonb("sentry_sentryappcomponent", "schema"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0980_integrations_json_field.py
+++ b/src/sentry/migrations/0980_integrations_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,9 +29,9 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_docintegration", "metadata"),
-                mod.to_jsonb("sentry_integration", "metadata"),
-                mod.to_jsonb("sentry_organizationintegration", "config"),
+                to_jsonb("sentry_docintegration", "metadata"),
+                to_jsonb("sentry_integration", "metadata"),
+                to_jsonb("sentry_organizationintegration", "config"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0984_authprovider_json_field.py
+++ b/src/sentry/migrations/0984_authprovider_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,8 +29,8 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_authprovider", "config"),
-                mod.to_jsonb("sentry_authproviderreplica", "config"),
+                to_jsonb("sentry_authprovider", "config"),
+                to_jsonb("sentry_authproviderreplica", "config"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0987_authidentity_json_field.py
+++ b/src/sentry/migrations/0987_authidentity_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,8 +29,8 @@ class Migration(CheckedMigration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                mod.to_jsonb("sentry_authidentity", "data"),
-                mod.to_jsonb("sentry_authidentityreplica", "data"),
+                to_jsonb("sentry_authidentity", "data"),
+                to_jsonb("sentry_authidentityreplica", "data"),
             ],
             state_operations=[
                 migrations.AlterField(

--- a/src/sentry/migrations/0991_projectownership_json_field.py
+++ b/src/sentry/migrations/0991_projectownership_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_projectownership", "schema")],
+            database_operations=[to_jsonb("sentry_projectownership", "schema")],
             state_operations=[
                 migrations.AlterField(
                     model_name="projectownership",

--- a/src/sentry/monitors/migrations/0007_monitors_json_field.py
+++ b/src/sentry/monitors/migrations/0007_monitors_json_field.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import sentry.db.models.fields.jsonfield
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -29,7 +29,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("sentry_monitor", "config")],
+            database_operations=[to_jsonb("sentry_monitor", "config")],
             state_operations=[
                 migrations.AlterField(
                     model_name="monitor",

--- a/src/social_auth/migrations/0003_social_auth_json_field.py
+++ b/src/social_auth/migrations/0003_social_auth_json_field.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 
 from sentry.new_migrations.migrations import CheckedMigration
 
-mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
+from sentry.new_migrations.operations import to_jsonb
 
 
 class Migration(CheckedMigration):
@@ -28,7 +28,7 @@ class Migration(CheckedMigration):
 
     operations = [
         migrations.SeparateDatabaseAndState(
-            database_operations=[mod.to_jsonb("social_auth_usersocialauth", "extra_data")],
+            database_operations=[to_jsonb("social_auth_usersocialauth", "extra_data")],
             state_operations=[
                 migrations.AlterField(
                     model_name="usersocialauth",


### PR DESCRIPTION
19 migration files imported `to_jsonb` at module level via:

```python
mod = __import__("sentry.migrations.0929_no_pickle_authenticator", fromlist=["_trash"])
```

This breaks the migration drift CI check in PRs that squash sentry migrations. The squash tool deletes all files in `src/sentry/migrations/` before running `makemigrations`, so any other app whose original migration files are still on disk (e.g. `discover`, `monitors`, `social_auth`) immediately fails to import because `0929_no_pickle_authenticator.py` no longer exists.

`to_jsonb` is already exported from `sentry.new_migrations.operations` — replace all `__import__` calls with a direct import from there.