### PR TITLE
Remove method start logging in service.py

### DIFF
--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -97,10 +97,6 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
             extras["contract_id"] = contract_id
 
         try:
-            logger.info(
-                "billing.service.method.start",
-                extra=extras,
-            )
 
             with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
                 for k, v in extras.items():

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -97,7 +97,6 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
             extras["contract_id"] = contract_id
 
         try:
-
             with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
                 for k, v in extras.items():
                     set_span_data(cur_span, k, v)

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -79,7 +79,7 @@ class TestBillingService:
         mock_metrics.timing.assert_called()
 
         # Verify logging
-        assert mock_logger.info.call_count == 1 
+        assert mock_logger.info.call_count == 1
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
     def test_service_method_error_handling(self, mock_metrics):

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -79,7 +79,7 @@ class TestBillingService:
         mock_metrics.timing.assert_called()
 
         # Verify logging
-        assert mock_logger.info.call_count == 2  # start and success
+        assert mock_logger.info.call_count == 1 
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
     def test_service_method_error_handling(self, mock_metrics):


### PR DESCRIPTION
Remove logging of method start in billing service.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
