### PR TITLE
ref(api): type group level as a Literal

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -123,7 +123,7 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     culprit: str | None
     permalink: str
     logger: str | None
-    level: str
+    level: GroupLevelStr
     status: GroupStatusStr
     statusDetails: GroupStatusDetailsResponseOptional
     substatus: GroupSubStatusStr | None
@@ -229,7 +229,18 @@ def _get_substatus_label(group: Group) -> GroupSubStatusStr | None:
     return SUBSTATUS_TO_STR[group.substatus] if group.substatus else None
 
 
-def _get_level_label(group: Group):
+GroupLevelStr = Literal[
+    "sample",
+    "debug",
+    "info",
+    "warning",
+    "error",
+    "fatal",
+    "unknown",
+]
+
+
+def _get_level_label(group: Group) -> GroupLevelStr:
     return LOG_LEVELS.get(group.level, "unknown")
 
 
@@ -1185,7 +1196,7 @@ class SimpleGroupSerializerResponse(TypedDict):
     title: str
     culprit: str | None
     shortId: str | None
-    level: str
+    level: GroupLevelStr
     status: GroupStatusStr
     substatus: GroupSubStatusStr | None
     platform: str | None

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -15,6 +15,7 @@ from sentry.api.serializers.models.actor import ActorSerializerResponse
 from sentry.api.serializers.models.group import (
     BaseGroupSerializerResponse,
     GroupAnnotation,
+    GroupLevelStr,
     GroupProjectResponse,
     GroupSerializer,
     GroupSerializerSnuba,
@@ -252,7 +253,7 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     culprit: NotRequired[str | None]
     permalink: NotRequired[str]
     logger: NotRequired[str | None]
-    level: NotRequired[str]
+    level: NotRequired[GroupLevelStr]
     status: NotRequired[GroupStatusStr]
     statusDetails: NotRequired[GroupStatusDetailsResponseOptional]
     substatus: NotRequired[GroupSubStatusStr | None]

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -8,8 +8,8 @@ import os.path
 from collections import namedtuple
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
-from enum import Enum
-from typing import cast
+from enum import Enum, IntEnum
+from typing import Literal, cast
 
 import sentry_relay.consts
 import sentry_relay.processing
@@ -245,7 +245,19 @@ RESERVED_PROJECT_SLUGS = frozenset(
     )
 )
 
-LOG_LEVELS = {
+
+class LogLevel(IntEnum):
+    SAMPLE = logging.NOTSET
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    FATAL = logging.FATAL
+
+
+LogLevelStr = Literal["sample", "debug", "info", "warning", "error", "fatal"]
+
+LOG_LEVELS: dict[int, LogLevelStr] = {
     logging.NOTSET: "sample",
     logging.DEBUG: "debug",
     logging.INFO: "info",
@@ -255,7 +267,14 @@ LOG_LEVELS = {
 }
 DEFAULT_LOG_LEVEL = "error"
 DEFAULT_LOGGER_NAME = ""
-LOG_LEVELS_MAP = {v: k for k, v in LOG_LEVELS.items()}
+LOG_LEVELS_MAP: dict[str, LogLevel] = {level.name.lower(): level for level in LogLevel}
+
+
+def parse_log_level(level: str | None) -> LogLevel | None:
+    if level is None:
+        return None
+    return LOG_LEVELS_MAP.get(level)
+
 
 PLACEHOLDER_EVENT_TITLES = frozenset(["<untitled>", "<unknown>", "<unlabeled event>", "Error"])
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -40,12 +40,12 @@ from sentry.analytics.events.event_processing_error_recorded import EventProcess
 from sentry.attachments import CachedAttachment, MissingAttachmentChunks
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
-    LOG_LEVELS_MAP,
     MAX_TAG_VALUE_LENGTH,
     PLACEHOLDER_EVENT_TITLES,
     VALID_PLATFORMS,
     DataCategory,
     InsightModules,
+    parse_log_level,
 )
 from sentry.culprit import generate_culprit
 from sentry.dynamic_sampling import record_latest_release
@@ -876,7 +876,7 @@ def _get_group_processing_kwargs(job: Job) -> dict[str, Any]:
         "platform": job["platform"],
         "message": job["event"].search_message,
         "logger": job["logger_name"],
-        "level": LOG_LEVELS_MAP.get(job["level"]),
+        "level": parse_log_level(job["level"]),
         "last_seen": job["event"].datetime,
         "first_seen": job["event"].datetime,
         "active_at": job["event"].datetime,
@@ -2151,10 +2151,10 @@ def update_severity_error_count(reset=False) -> None:
 
 def _get_severity_score(event: Event) -> tuple[float, str]:
     # Short circuit the severity value if we know the event is fatal or info/debug
-    level = str(event.data.get("level", "error"))
-    if LOG_LEVELS_MAP[level] == logging.FATAL:
+    level_value = parse_log_level(str(event.data.get("level", "error")))
+    if level_value == logging.FATAL:
         return 1.0, "log_level_fatal"
-    if LOG_LEVELS_MAP[level] <= logging.INFO:
+    if level_value is not None and level_value <= logging.INFO:
         return 0.0, "log_level_info"
 
     op = "event_manager._get_severity_score"

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import router, transaction
 
 from sentry import eventstream
-from sentry.constants import LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH
+from sentry.constants import MAX_CULPRIT_LENGTH, parse_log_level
 from sentry.event_manager import (
     GroupInfo,
     _get_or_create_group_environment,
@@ -134,7 +134,7 @@ def _create_issue_kwargs(
         # TODO: Figure out what message should be. Or maybe we just implement a platform event and
         # define it in `search_message` there.
         "message": event.search_message,
-        "level": LOG_LEVELS_MAP.get(occurrence.level),
+        "level": parse_log_level(occurrence.level),
         "culprit": truncatechars(occurrence.culprit, MAX_CULPRIT_LENGTH),
         "last_seen": event.datetime,
         "first_seen": event.datetime,

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from django import forms
 
-from sentry.constants import LOG_LEVELS, LOG_LEVELS_MAP
+from sentry.constants import LOG_LEVELS, parse_log_level
 from sentry.rules import LEVEL_MATCH_CHOICES as MATCH_CHOICES
 from sentry.rules import EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
@@ -42,9 +42,8 @@ class LevelCondition(EventCondition):
         desired_level = int(desired_level_raw)
         # Fetch the event level from the tags since event.level is
         # event.group.level which may have changed
-        try:
-            level: int = LOG_LEVELS_MAP[level_name]
-        except KeyError:
+        level = parse_log_level(level_name)
+        if level is None:
             return False
 
         if desired_match == MatchType.EQUAL:

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -11,7 +11,7 @@ from django.db import router, transaction
 from django.db.models.base import Model
 
 from sentry import similarity, tsdb
-from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
+from sentry.constants import DEFAULT_LOGGER_NAME, parse_log_level
 from sentry.culprit import generate_culprit
 from sentry.killswitches import killswitch_matches_context
 from sentry.models.activity import Activity
@@ -88,6 +88,11 @@ def merge_mappings(values: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     return result
 
 
+def _initial_level(event: GroupEvent, group: Group) -> int:
+    level = parse_log_level(event.get_tag("level"))
+    return logging.ERROR if level is None else level
+
+
 initial_fields = {
     "culprit": lambda event, group: generate_culprit(event.data),
     "data": lambda event, group: {
@@ -96,7 +101,7 @@ initial_fields = {
         "metadata": event.data["metadata"],
     },
     "last_seen": lambda event, group: event.datetime,
-    "level": lambda event, group: LOG_LEVELS_MAP.get(event.get_tag("level"), logging.ERROR),
+    "level": _initial_level,
     "message": lambda event, group: event.search_message,
     "times_seen": lambda event, group: 0,
     "status": lambda event, group: group.status,

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable
 
-from sentry.constants import LOG_LEVELS, LOG_LEVELS_MAP
+from sentry.constants import LOG_LEVELS, LogLevel, parse_log_level
 from sentry.rules import LEVEL_MATCH_CHOICES, MatchType
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
@@ -20,7 +20,7 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     comparison_json_schema = {
         "type": "object",
         "properties": {
-            "level": {"type": "integer", "enum": list(LOG_LEVELS_MAP.values())},
+            "level": {"type": "integer", "enum": [level.value for level in LogLevel]},
             "match": {"type": "string", "enum": [*MatchType]},
         },
         "required": ["level", "match"],
@@ -35,19 +35,14 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
             # This condition is only applicable to GroupEvent
             return False
 
-        level_name = event.get_tag("level")
-        if level_name is None:
+        # Fetch the event level from the tags since event.level is
+        # event.group.level which may have changed
+        level = parse_log_level(event.get_tag("level"))
+        if level is None:
             return False
 
         desired_level = int(comparison.get("level"))
         desired_match = comparison.get("match")
-
-        # Fetch the event level from the tags since event.level is
-        # event.group.level which may have changed
-        try:
-            level: int = LOG_LEVELS_MAP[level_name]
-        except KeyError:
-            return False
 
         if desired_match == MatchType.EQUAL:
             return level == desired_level

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from django.utils import timezone
 
 from sentry.api.helpers.group_index.update import handle_priority
-from sentry.constants import LOG_LEVELS_MAP, MAX_CULPRIT_LENGTH
+from sentry.constants import MAX_CULPRIT_LENGTH, parse_log_level
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue, MetricIssueDetectorHandler
 from sentry.incidents.utils.types import AnomalyDetectionUpdate, ProcessedSubscriptionUpdate
@@ -383,7 +383,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
             group = group_info.group
             assert group.title == occurrence.issue_title
             assert group.platform == event.platform
-            assert group.level == LOG_LEVELS_MAP.get(occurrence.level)
+            assert group.level == parse_log_level(occurrence.level)
             assert group.last_seen == event.datetime
             assert group.first_seen == event.datetime
             assert group.active_at == event.datetime
@@ -807,7 +807,7 @@ class CreateIssueKwargsTest(OccurrenceTestMixin, TestCase):
         assert _create_issue_kwargs(occurrence, event, None) == {
             "platform": event.platform,
             "message": event.search_message,
-            "level": LOG_LEVELS_MAP.get(occurrence.level),
+            "level": parse_log_level(occurrence.level),
             # Should truncate the culprit to max allowable length
             "culprit": f"{culprit[: MAX_CULPRIT_LENGTH - 3]}...",
             "last_seen": event.datetime,


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/118668. Type GroupLevel and LogLevel strings as literals, so they flow to the API docs. Move LOG_LEVEL to an `IntEnum` as a part of this.