### PR TITLE
feat(trace-items): Serve context for Sentry-defined attributes

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -310,15 +310,9 @@ _CONVENTION_TYPE_TO_SEARCH_TYPE: dict[str, str] = {
 }
 
 
-# Sentry-defined attributes the `/attributes` endpoint force-includes in its
-# response even when the attribute-names RPC pages them out past its key limit.
-# Kept deliberately narrow (it widens every no-substring response, including the
-# frontend's), so it only covers attributes with a demonstrated paging problem
-# rather than every described attribute. Each must be a public alias of a
-# definition carrying an `AttributeContext`.
 SENTRY_ALWAYS_INCLUDED_ATTRIBUTES: dict[SupportedTraceItemType, frozenset[str]] = {
     SupportedTraceItemType.SPANS: frozenset({"span.description"}),
-    SupportedTraceItemType.LOGS: frozenset(),
+    SupportedTraceItemType.LOGS: frozenset({"message"}),
     SupportedTraceItemType.TRACEMETRICS: frozenset(),
 }
 
@@ -402,17 +396,9 @@ def build_sentry_attribute_context(
     item_type: SupportedTraceItemType,
 ) -> TraceItemAttributeContext | None:
     """
-    Build context for a Sentry-defined attribute that isn't a sentry convention
-    (e.g. ``span.description``), sourced from the attribute definition's
-    ``context`` (see ``ResolvedAttribute.context``). These resolve with
-    ``isConvention=False``; clients distinguish them from conventions via
-    ``source_type == sentry``.
-
-    The expected type is taken from the definition's ``search_type`` -- the same
-    object the context lives on -- so it can't drift. When ``attribute_type`` is
-    provided the context only attaches if it matches, so a user attribute that
-    merely shares a public alias (e.g. a string tag named ``span.duration``) isn't
-    mislabeled with the definition's context.
+    Build context for a Sentry-defined (non-convention) attribute from its
+    definition's ``context``. When ``attribute_type`` is given, context only
+    attaches if it matches, so a user tag sharing a public alias isn't mislabeled.
     """
     column = get_column_definitions(item_type).columns.get(public_name)
     context = getattr(column, "context", None)

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -310,6 +310,28 @@ _CONVENTION_TYPE_TO_SEARCH_TYPE: dict[str, str] = {
 }
 
 
+# Sentry-defined attributes the `/attributes` endpoint force-includes in its
+# response even when the attribute-names RPC pages them out past its key limit.
+# Kept deliberately narrow (it widens every no-substring response, including the
+# frontend's), so it only covers attributes with a demonstrated paging problem
+# rather than every described attribute. Each must be a public alias of a
+# definition carrying an `AttributeContext`.
+SENTRY_ALWAYS_INCLUDED_ATTRIBUTES: dict[SupportedTraceItemType, frozenset[str]] = {
+    SupportedTraceItemType.SPANS: frozenset({"span.description"}),
+    SupportedTraceItemType.LOGS: frozenset(),
+    SupportedTraceItemType.TRACEMETRICS: frozenset(),
+}
+
+
+def _search_type_to_context_type(search_type: str) -> Literal["string", "number", "boolean"]:
+    """Collapse an EAP search type to the coarse type used for context matching."""
+    if search_type == "string":
+        return "string"
+    if search_type == "boolean":
+        return "boolean"
+    return "number"
+
+
 def build_sentry_convention_context(
     public_name: str,
     internal_name: str,
@@ -374,6 +396,47 @@ def build_sentry_convention_context(
     return context
 
 
+def build_sentry_attribute_context(
+    public_name: str,
+    attribute_type: Literal["string", "number", "boolean"] | None,
+    item_type: SupportedTraceItemType,
+) -> TraceItemAttributeContext | None:
+    """
+    Build context for a Sentry-defined attribute that isn't a sentry convention
+    (e.g. ``span.description``), sourced from the attribute definition's
+    ``context`` (see ``ResolvedAttribute.context``). These resolve with
+    ``isConvention=False``; clients distinguish them from conventions via
+    ``source_type == sentry``.
+
+    The expected type is taken from the definition's ``search_type`` -- the same
+    object the context lives on -- so it can't drift. When ``attribute_type`` is
+    provided the context only attaches if it matches, so a user attribute that
+    merely shares a public alias (e.g. a string tag named ``span.duration``) isn't
+    mislabeled with the definition's context.
+    """
+    column = get_column_definitions(item_type).columns.get(public_name)
+    context = getattr(column, "context", None)
+    if column is None or context is None:
+        return None
+
+    if (
+        attribute_type is not None
+        and _search_type_to_context_type(column.search_type) != attribute_type
+    ):
+        return None
+
+    result: TraceItemAttributeContext = {
+        "isConvention": False,
+        "brief": context.brief,
+        "isDeprecated": bool(column.deprecation_status or column.replacement),
+    }
+    if context.examples:
+        result["examples"] = list(context.examples)
+    if column.replacement:
+        result["replacementAttribute"] = column.replacement
+    return result
+
+
 def as_attribute_key(
     name: str,
     attr_type: Literal["string", "number", "boolean"],
@@ -432,10 +495,13 @@ def as_attribute_key(
         # need an alias (a public name distinct from their internal name), so a
         # convention whose name is already the same internally -- e.g.
         # `http.route` -- is missing from it and resolves as a `user` source
-        # attribute. Anything without a matching convention gets an empty context
-        # for now; serving custom attribute context is planned.
-        context = build_sentry_convention_context(public_name, name, attr_type) or {}
-        attribute_key["context"] = context
+        # attribute. A Sentry-defined attribute that isn't a convention (e.g.
+        # `span.description`) instead carries its context on the definition. User
+        # attributes with no match get an empty context.
+        context = build_sentry_convention_context(
+            public_name, name, attr_type
+        ) or build_sentry_attribute_context(public_name, attr_type, item_type)
+        attribute_key["context"] = context or {}
 
     return attribute_key
 
@@ -650,6 +716,21 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
                                 )
                             )
                 else:
+                    # Always include curated Sentry-defined attributes (e.g.
+                    # span.description) so they aren't paged out past the RPC's
+                    # attribute-name limit. They carry context and
+                    # source_type=sentry.
+                    for public_alias in SENTRY_ALWAYS_INCLUDED_ATTRIBUTES.get(
+                        trace_item_type, frozenset()
+                    ):
+                        always_include_column = column_definitions.columns.get(public_alias)
+                        if (
+                            always_include_column is not None
+                            and always_include_column.proto_type == attr_type
+                            and not always_include_column.secondary_alias
+                            and not always_include_column.private
+                        ):
+                            all_aliased_attributes.append(always_include_column)
                     for (
                         public_label,
                         virtual_context,

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -402,7 +402,7 @@ def build_sentry_attribute_context(
     """
     column = get_column_definitions(item_type).columns.get(public_name)
     context = getattr(column, "context", None)
-    if column is None or context is None:
+    if column is None or context is None or column.secondary_alias:
         return None
 
     if (

--- a/src/sentry/seer/assisted_query/traces_tools.py
+++ b/src/sentry/seer/assisted_query/traces_tools.py
@@ -161,6 +161,9 @@ def get_attribute_names(
     # Maps an attribute name to its type ("string"/"number"), so context-bearing
     # attributes that aren't hardcoded built-ins can still be emitted as fields.
     type_by_name: dict[str, str] = {}
+    # Maps an attribute name to its source ("sentry"/"user"), used to decide which
+    # context-bearing attributes to surface as built-in fields.
+    source_by_name: dict[str, str] = {}
 
     # Fetch both string and number attributes from the public API
     for attr_type in ["string", "number"]:
@@ -196,20 +199,24 @@ def get_attribute_names(
             if item.get("context"):
                 context_by_name[item["name"]] = item["context"]
                 type_by_name[item["name"]] = attr_type
+                source_by_name[item["name"]] = item.get("attributeSource", {}).get("source_type")
 
     hardcoded_fields = _get_built_in_fields(item_type)
     built_in_fields = [
         BuiltInField(**f, context=context_by_name.get(f["key"])) for f in hardcoded_fields
     ]
 
-    # Convention-backed attributes (e.g. http.route) aren't in the hardcoded
-    # list, so their context would otherwise be dropped. Surface them through
-    # built_in_fields too, since that's where Seer reads attribute context from.
-    # Only conventions are promoted (isConvention=True); user-authored custom
-    # context is intentionally left out.
+    # Context-bearing attributes that aren't hardcoded built-ins (e.g. the
+    # convention http.route, or Sentry-defined fields like span.description) would
+    # otherwise be dropped. Surface them through built_in_fields too, since that's
+    # where Seer reads attribute context from. We promote conventions
+    # (isConvention=True) and Sentry-defined attributes (source=sentry);
+    # user-authored custom context is intentionally left out.
     hardcoded_keys = {f["key"] for f in hardcoded_fields}
     for name, context in context_by_name.items():
-        if name in hardcoded_keys or not context.get("isConvention"):
+        if name in hardcoded_keys:
+            continue
+        if not (context.get("isConvention") or source_by_name.get(name) == "sentry"):
             continue
         built_in_fields.append(BuiltInField(key=name, type=type_by_name[name], context=context))
 

--- a/tests/sentry/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/sentry/api/endpoints/test_organization_trace_item_attributes.py
@@ -1,0 +1,52 @@
+from sentry.api.endpoints.organization_trace_item_attributes import (
+    build_sentry_attribute_context,
+)
+from sentry.search.eap.types import SupportedTraceItemType
+
+
+def test_build_sentry_attribute_context_brief() -> None:
+    # `span.description` is a Sentry-defined attribute (not a convention); its
+    # context comes from the definition and is marked isConvention=False.
+    context = build_sentry_attribute_context(
+        "span.description", "string", SupportedTraceItemType.SPANS
+    )
+    assert context is not None
+    assert context["isConvention"] is False
+    assert context["brief"] == "Description of the span's operation."
+    assert context["isDeprecated"] is False
+    assert "examples" not in context
+
+
+def test_build_sentry_attribute_context_examples() -> None:
+    # Enumerated values carried on the definition surface as `examples`.
+    context = build_sentry_attribute_context("severity", "string", SupportedTraceItemType.LOGS)
+    assert context is not None
+    assert context["examples"] == ["error", "warn", "info"]
+
+
+def test_build_sentry_attribute_context_project_id_string_type() -> None:
+    # `project.id`'s EAP column is string-typed; its context must still resolve
+    # when requested with attributeType=string. Guards against type drift between
+    # the context and the definition's search_type (they share one source now).
+    context = build_sentry_attribute_context("project.id", "string", SupportedTraceItemType.SPANS)
+    assert context is not None
+    assert context["brief"] == "The id of the project."
+
+
+def test_build_sentry_attribute_context_type_mismatch_returns_none() -> None:
+    # A request whose type doesn't match the definition (e.g. a string tag that
+    # merely shares the `span.duration` alias) must not be labeled with the
+    # definition's context.
+    assert (
+        build_sentry_attribute_context("span.duration", "string", SupportedTraceItemType.SPANS)
+        is None
+    )
+
+
+def test_build_sentry_attribute_context_unknown_returns_none() -> None:
+    assert (
+        build_sentry_attribute_context(
+            "definitely.not.an.attribute", "string", SupportedTraceItemType.SPANS
+        )
+        is None
+    )

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -588,6 +588,29 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert attributes["span.description"]["context"]["isConvention"] is False
         assert attributes["span.description"]["context"]["brief"]
 
+    def test_expand_context_user_attribute_matching_secondary_alias(self) -> None:
+        # `message` is a secondary alias of `span.description` on spans and carries
+        # a definition context. A user tag that happens to share that name must not
+        # be mislabeled with the Sentry context; it should resolve to an empty one.
+        self.store_segment(
+            self.project.id,
+            uuid4().hex,
+            uuid4().hex,
+            organization_id=self.organization.id,
+            timestamp=before_now(days=0, minutes=10).replace(microsecond=0),
+            tags={"message": "hello"},
+        )
+
+        response = self.do_request(
+            query={"attributeType": "string", "expand": "context"},
+        )
+        assert response.status_code == 200, response.data
+
+        attributes = {item["key"]: item for item in response.data}
+        message = attributes["tags[message,string]"]
+        assert message["name"] == "message"
+        assert message["context"] == {}
+
     def test_expand_context_without_feature_flag(self) -> None:
         self._store_basic_segment()
 

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -580,6 +580,13 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
             "examples": ["/users/:id"],
             "isDeprecated": False,
         }
+        # `span.description` is a Sentry-defined attribute that isn't a sentry
+        # convention. It's always included (this segment sets no description) and
+        # carries context from its definition (`ResolvedAttribute.context`), marked
+        # isConvention=False with a `sentry` source.
+        assert attributes["span.description"]["attributeSource"]["source_type"] == "sentry"
+        assert attributes["span.description"]["context"]["isConvention"] is False
+        assert attributes["span.description"]["context"]["brief"]
 
     def test_expand_context_without_feature_flag(self) -> None:
         self._store_basic_segment()
@@ -804,13 +811,10 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         )
         assert response.status_code == 200, response.data
 
+        # `span.description` is now always included (a curated Sentry-defined
+        # attribute), so it occupies a slot on the first page and pushes `bar`
+        # to a later page.
         expected: list[TraceItemAttributeKey] = [
-            {
-                "key": "bar",
-                "name": "bar",
-                "attributeType": "string",
-                "attributeSource": {"source_type": "user"},
-            },
             {
                 "key": "device.class",
                 "name": "device.class",
@@ -818,14 +822,21 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "attributeSource": {"source_type": "sentry"},
             },
             {
-                "key": "span.module",
-                "name": "span.module",
+                "key": "project",
+                "name": "project",
                 "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
             {
-                "key": "project",
-                "name": "project",
+                "key": "span.description",
+                "name": "span.description",
+                "attributeType": "string",
+                "attributeSource": {"source_type": "sentry"},
+                "secondaryAliases": ["description", "message"],
+            },
+            {
+                "key": "span.module",
+                "name": "span.module",
                 "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
             },
@@ -872,11 +883,10 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "attributeSource": {"source_type": "user"},
             },
             {
-                "key": "span.description",
-                "name": "span.description",
+                "key": "project",
+                "name": "project",
                 "attributeType": "string",
                 "attributeSource": {"source_type": "sentry"},
-                "secondaryAliases": ["description", "message"],
             },
         ]
         assert sorted(
@@ -902,11 +912,10 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
 
         expected_3: list[TraceItemAttributeKey] = [
             {
-                "key": "span.description",
-                "name": "span.description",
+                "key": "foo",
+                "name": "foo",
                 "attributeType": "string",
-                "attributeSource": {"source_type": "sentry"},
-                "secondaryAliases": ["description", "message"],
+                "attributeSource": {"source_type": "user"},
             },
             {
                 "key": "transaction",

--- a/tests/snuba/api/endpoints/test_seer_attributes.py
+++ b/tests/snuba/api/endpoints/test_seer_attributes.py
@@ -43,8 +43,8 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert result.dict() == {
             "fields": {
                 "string": [
-                    "span.description",
                     "transaction",
+                    "span.description",
                     "device.class",
                     "span.module",
                     "project",
@@ -120,6 +120,13 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
         assert device_class_context is not None
         assert device_class_context["isConvention"] is True
         assert device_class_context["brief"]
+
+        # Sentry-defined attributes that aren't conventions (e.g. span.description)
+        # carry context too, marked isConvention=False.
+        span_description_context = built_in_by_key["span.description"].context
+        assert span_description_context is not None
+        assert span_description_context["isConvention"] is False
+        assert span_description_context["brief"]
 
         # Context is either None or populated, never an empty dict (the endpoint
         # attaches an empty context to attributes without convention metadata).


### PR DESCRIPTION
## Summary

Follow-up to #118739 (which added `AttributeContext` to `ResolvedAttribute`). This wires that context into the `/trace-items/attributes` endpoint's `expand=context` response, so Sentry-defined (non-convention) attributes like `span.description` now serve their `brief`/`examples` to clients.

## What changed

- **`build_sentry_attribute_context`** (new): looks up the `ResolvedAttribute` for a resolved public alias and serializes its `context` (`brief` + optional `examples`) as a `TraceItemAttributeContext` with `isConvention=False`. `as_attribute_key` falls back to it when the sentry-convention lookup misses.
- **Type-drift safe:** the expected type for the compatibility check is read from the definition's `search_type` — the same object the context lives on — so it can't drift from the declared type. (This is the class of bug that silently dropped `project.id`'s context in the earlier approach, where the type was declared separately.)
- **Force-include:** `SENTRY_ALWAYS_INCLUDED_ATTRIBUTES` (currently `{spans: span.description}`) keeps curated Sentry-defined attributes from being paged out past the attribute-names RPC limit.
- **Seer assisted query:** `traces_tools` now promotes `source=sentry` attributes (not just conventions) into its `built_in_fields`, so Seer sees their context.

Clients distinguish these from conventions via `source_type == sentry` (`isConvention=False`).

## Out of scope (deferred)

- `project` (a mapping-only alias, no `ResolvedAttribute`) and the `occurrences`/errors item types — consistent with #118739.

## Testing

- `tests/sentry/api/endpoints/test_organization_trace_item_attributes.py` (new unit tests): `build_sentry_attribute_context` brief/examples, the `project.id` string-type resolution (regression for the drift bug), the type-mismatch guard, and unknown-attribute.
- Updated snuba tests: `test_expand_context` (asserts `span.description` context), `test_pagination` (reflects `span.description` now force-included on page 1), and `test_seer_attributes` (span.description promoted with `isConvention=False`).
- Full `tests/snuba/api/endpoints/test_organization_trace_item_attributes.py` (89) + `test_seer_attributes.py` (5) + new unit tests (5) pass; lint + mypy clean.

## Notes for review

- Opened as **draft** — wanted eyes on (1) `SENTRY_ALWAYS_INCLUDED_ATTRIBUTES` living in the endpoint module vs. becoming an `always_include` flag on the definition, and (2) whether `message` (a `secondary_alias`) should carry context at all.
