### PR TITLE
ref(dynamic-sampling): Tighten sampling table types

### DIFF
--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -49,7 +49,6 @@ interface Props {
   period: ProjectionSamplePeriod;
   rateHeader: React.ReactNode;
   canEdit?: boolean;
-  inputTooltip?: string;
   onChange?: (projectId: string, value: string) => void;
 }
 
@@ -58,7 +57,6 @@ const MAX_SCROLL_HEIGHT = 400;
 
 export function ProjectsTable({
   items,
-  inputTooltip,
   canEdit,
   rateHeader,
   onChange,
@@ -170,7 +168,6 @@ export function ProjectsTable({
                   <TableRow
                     canEdit={canEdit}
                     onChange={onChange}
-                    inputTooltip={inputTooltip}
                     toggleExpanded={handleToggleItemExpanded}
                     hasAccess={hasAccess}
                     {...item}
@@ -293,7 +290,6 @@ const TableRow = memo(function TableRow({
   toggleExpanded,
   subProjects,
   error,
-  inputTooltip: inputTooltipProp,
   onChange,
 }: {
   count: number;
@@ -307,7 +303,6 @@ const TableRow = memo(function TableRow({
   toggleExpanded: (id: string) => void;
   canEdit?: boolean;
   error?: string;
-  inputTooltip?: string;
   onChange?: (projectId: string, value: string) => void;
 }) {
   const organization = useOrganization();
@@ -318,10 +313,9 @@ const TableRow = memo(function TableRow({
   const subProjectContent = getSubProjectContent(project.slug, subProjects, isExpanded);
   const subSpansContent = getSubSpansContent(ownCount, subProjects, isExpanded);
 
-  let inputTooltip = inputTooltipProp;
-  if (!hasAccess) {
-    inputTooltip = t('You do not have permission to change the sample rate.');
-  }
+  const permissionTooltip = hasAccess
+    ? undefined
+    : t('You do not have permission to change the sample rate.');
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -387,7 +381,7 @@ const TableRow = memo(function TableRow({
       </Cell>
       <Flex direction="column" padding="xl xl md xl" gap="xs" style={{minWidth: 0}}>
         <FirstCellLine align="center" height="32px">
-          <Tooltip disabled={!inputTooltip} title={inputTooltip}>
+          <Tooltip disabled={!permissionTooltip} title={permissionTooltip}>
             <PercentInput
               type="number"
               disabled={!canEdit || !hasAccess}

--- a/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingBreakdown.tsx
@@ -1,4 +1,3 @@
-import type React from 'react';
 import {Fragment} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -17,7 +16,7 @@ import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatP
 import type {ProjectSampleCount} from 'sentry/views/settings/dynamicSampling/utils/useProjectSampleCounts';
 
 const ITEMS_TO_SHOW = 5;
-interface Props extends React.ComponentProps<typeof StyledPanel> {
+interface Props {
   sampleCounts: ProjectSampleCount[];
   sampleRates: Record<string, number>;
   isLoading?: boolean;
@@ -45,12 +44,7 @@ function OthersBadge() {
   );
 }
 
-export function SamplingBreakdown({
-  sampleCounts,
-  sampleRates,
-  isLoading,
-  ...props
-}: Props) {
+export function SamplingBreakdown({sampleCounts, sampleRates, isLoading}: Props) {
   const theme = useTheme();
   const spansWithSampleRates = sampleCounts
     ?.map(item => {
@@ -61,7 +55,7 @@ export function SamplingBreakdown({
         sampledSpans,
       };
     })
-    .toSorted((a: any, b: any) => b.sampledSpans - a.sampledSpans);
+    .toSorted((a, b) => b.sampledSpans - a.sampledSpans);
 
   const hasOthers = spansWithSampleRates.length > ITEMS_TO_SHOW;
 
@@ -70,18 +64,15 @@ export function SamplingBreakdown({
     : spansWithSampleRates.slice(0, ITEMS_TO_SHOW);
   const otherSpanCount = spansWithSampleRates
     .slice(ITEMS_TO_SHOW - 1)
-    .reduce((acc: any, item: any) => acc + item.sampledSpans, 0);
-  const total = spansWithSampleRates.reduce(
-    (acc: any, item: any) => acc + item.sampledSpans,
-    0
-  );
+    .reduce((acc, item) => acc + item.sampledSpans, 0);
+  const total = spansWithSampleRates.reduce((acc, item) => acc + item.sampledSpans, 0);
 
-  const getSpanRate = (spanCount: any) => (total === 0 ? 0 : spanCount / total);
+  const getSpanRate = (spanCount: number) => (total === 0 ? 0 : spanCount / total);
   const otherRate = getSpanRate(otherSpanCount);
   const palette = theme.chart.getColorPalette(ITEMS_TO_SHOW);
 
   return (
-    <StyledPanel {...props}>
+    <StyledPanel>
       <Heading>{t('Distribution of stored spans')}</Heading>
       {isLoading ? (
         <LoadingIndicator
@@ -93,7 +84,7 @@ export function SamplingBreakdown({
       ) : sampleCounts.length > 0 ? (
         <Fragment>
           <Breakdown>
-            {topItems.map((item: any, index: any) => {
+            {topItems.map((item, index) => {
               const itemPercent = getSpanRate(item.sampledSpans);
               return (
                 <Tooltip
@@ -140,7 +131,7 @@ export function SamplingBreakdown({
           </Breakdown>
           <Flex align="start" gap="xl">
             <Legend>
-              {topItems.map((item: any) => {
+              {topItems.map(item => {
                 const itemPercent = getSpanRate(item.sampledSpans);
                 return (
                   <Flex align="center" gap="sm" key={item.project.id}>

--- a/static/app/views/settings/dynamicSampling/utils/rebalancing.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/rebalancing.tsx
@@ -34,7 +34,7 @@ export function balanceSampleRate<T extends BalancingItem>({
   usedBudget: number;
 } {
   // Sort the items ascending by count, so the available budget is distributed to the items with the lowest count first
-  const sortedItems = items.toSorted((a: any, b: any) => a.count - b.count);
+  const sortedItems = items.toSorted((a, b) => a.count - b.count);
   const total = items.reduce((acc, item) => acc + item.count, 0);
 
   let numItems = items.length;

--- a/static/app/views/settings/dynamicSampling/utils/scaleSampleRates.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/scaleSampleRates.tsx
@@ -48,7 +48,7 @@ export function scaleSampleRates<T extends ScalingItem>({
   let remainingSampleCount = newSampled;
   let remainingOldSampleCount = totalSpans * oldSampleRate;
 
-  const sortedItems = items.toSorted((a: any, b: any) => a.count - b.count);
+  const sortedItems = items.toSorted((a, b) => a.count - b.count);
 
   const scaledItems: T[] = [];
   for (const item of sortedItems) {

--- a/static/app/views/settings/dynamicSampling/utils/useProjectSampleCounts.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/useProjectSampleCounts.tsx
@@ -114,7 +114,7 @@ export function useProjectSampleCounts({period}: {period: ProjectionSamplePeriod
     return Array.from(map.values()).map<ProjectSampleCount>(value => {
       return {
         ...value,
-        subProjects: value.subProjects.toSorted((a: any, b: any) => b.count - a.count),
+        subProjects: value.subProjects.toSorted((a, b) => b.count - a.count),
       };
     });
   }, [projectById, projectBySlug, queryResult]);


### PR DESCRIPTION
fixes a few loose dynamic sampling table types and removes unused prop passthroughs.