### PR TITLE
fix(issue-details): Remove misleading author from PR closed activity

### DIFF
--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -507,17 +507,14 @@ export function getGroupActivityItem(
         const {pullRequest} = data;
         return {
           title: t('Pull Request Closed'),
-          message: tct(' by [author]: [pullRequest]', {
-            author,
-            pullRequest: pullRequest ? (
-              <PullRequestLink
-                pullRequest={pullRequest}
-                repository={pullRequest.repository}
-              />
-            ) : (
-              t('PR not available')
-            ),
-          }),
+          message: pullRequest ? (
+            <PullRequestLink
+              pullRequest={pullRequest}
+              repository={pullRequest.repository}
+            />
+          ) : (
+            t('PR not available')
+          ),
         };
       }
       case GroupActivityType.SET_UNRESOLVED: {


### PR DESCRIPTION
The `pull_request_closed` activity was showing "by author" but the author displayed was the PR author, not the person who actually closed the PR. This is misleading since it implies attribution to the closing actor. This removes the "By author" text and just displays the PR.

<img width="691" height="74" alt="CleanShot 2026-06-30 at 10 55 24" src="https://github.com/user-attachments/assets/0f10b703-b661-4208-97f4-02956a775d64" />
