### PR TITLE
perf(github): Parallelize repo-list pagination for the repos endpoint

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -73,10 +73,16 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
             accessible_only = request.GET.get("accessibleOnly", "false").lower() == "true"
 
             try:
+                # This endpoint backs interactive repo pickers (the onboarding
+                # repo selector and the code-mappings path config form), so opt
+                # into parallel pagination for the latency win. Providers that
+                # don't implement it ignore the flag; internal/background callers
+                # of get_repositories keep the serial default.
                 repositories = install.get_repositories(
                     search,
                     accessible_only=accessible_only,
                     use_cache=accessible_only and bool(search),
+                    parallel=True,
                 )
             except (IntegrationError, IdentityNotValid) as e:
                 return self.respond({"detail": str(e)}, status=400)

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -130,6 +130,7 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -288,6 +288,7 @@ class BitbucketServerIntegration(RepositoryIntegration[BitbucketServerClient]):
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         if not query:
             resp = self.get_client().get_repos()

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -168,6 +168,7 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         return [{"name": "repo", "identifier": "user/repo", "external_id": "1"}]
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -47,6 +47,7 @@ from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import (
     ApiConflictError,
     ApiError,
+    ApiForbiddenError,
     ApiPaginationTruncated,
     ApiRateLimitedError,
     UnknownHostError,
@@ -70,6 +71,23 @@ MINIMUM_REQUESTS = 200
 PAGINATION_MAX_WORKERS = 10
 
 JWT_AUTH_ROUTES = ("/app/installations", "access_tokens")
+
+
+def _is_rate_limit_forbidden(error: ApiForbiddenError) -> bool:
+    """
+    GitHub does not only use 429 for rate limits: it also returns 403 when an
+    installation trips its primary or secondary rate limits, naming the limit
+    in the response body (e.g. "You have exceeded a secondary rate limit" or
+    "API rate limit exceeded"). ApiForbiddenError does not retain the
+    Retry-After header GitHub sets on these responses, so detect the condition
+    from the body message instead. A plain permission 403 has no such message.
+    """
+    message = ""
+    if isinstance(error.json, dict):
+        raw_message = error.json.get("message")
+        if isinstance(raw_message, str):
+            message = raw_message
+    return "rate limit" in (message or error.text or "").lower()
 
 
 class CachedRepo(TypedDict):
@@ -862,12 +880,18 @@ class GitHubBaseClient(
                                 # (bounded by max_workers), not the whole page range.
                                 for resp in executor.map(fetch_page, remaining_pages):
                                     output.extend(page_items(resp))
-                        except ApiRateLimitedError:
-                            metrics.incr(
-                                "integrations.github.parallel_pagination",
-                                tags={"outcome": "rate_limited"},
-                                sample_rate=1.0,
-                            )
+                        except (ApiRateLimitedError, ApiForbiddenError) as e:
+                            # GitHub signals a tripped rate limit with either a
+                            # 429 or a 403 whose body names the limit (primary or
+                            # secondary), so attribute both to the rate_limited
+                            # outcome to keep the fan-out's rate-limit exposure
+                            # visible. A plain permission 403 re-raises untagged.
+                            if isinstance(e, ApiRateLimitedError) or _is_rate_limit_forbidden(e):
+                                metrics.incr(
+                                    "integrations.github.parallel_pagination",
+                                    tags={"outcome": "rate_limited"},
+                                    sample_rate=1.0,
+                                )
                             raise
                         metrics.incr(
                             "integrations.github.parallel_pagination",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -22,7 +22,7 @@ from sentry.integrations.github.blame import (
     is_graphql_response,
 )
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
-from sentry.integrations.github.utils import get_jwt, get_next_link
+from sentry.integrations.github.utils import get_jwt, get_last_page_number, get_next_link
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.source_code_management.commit_context import (
@@ -53,6 +53,7 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.silo.base import control_silo_function
 from sentry.utils import metrics
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.tracing import start_span
 
@@ -62,6 +63,11 @@ logger = logging.getLogger("sentry.integrations.github")
 # as the lower ceiling before hitting Github anymore, thus, leaving at least these
 # many requests left for other features that need to reach Github
 MINIMUM_REQUESTS = 200
+
+# When Github advertises the total page count up front, the pages after the
+# first are fetched concurrently. Bounded to keep the fan-out comfortably under
+# Github's secondary (concurrent request) rate limits.
+PAGINATION_MAX_WORKERS = 10
 
 JWT_AUTH_ROUTES = ("/app/installations", "access_tokens")
 
@@ -667,6 +673,7 @@ class GitHubBaseClient(
         self,
         page_number_limit: int | None = None,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[dict[str, Any]]:
         """
         This fetches all repositories accessible to the Github App
@@ -678,6 +685,10 @@ class GitHubBaseClient(
         When ``raise_on_page_limit`` is True, raises ``ApiPaginationTruncated`` if the
         pagination loop exits because it hit the cap while there were still
         more pages available.
+
+        When ``parallel`` is True, pages after the first are fetched concurrently
+        (see ``_get_with_pagination``). Only interactive callers opt in; the
+        background ``link_all_repos`` task keeps the serial default.
         """
         with SCMIntegrationInteractionEvent(
             interaction_type=SCMIntegrationInteractionType.GET_REPOSITORIES,
@@ -692,6 +703,7 @@ class GitHubBaseClient(
                     page_number_limit=page_number_limit,
                     api_request_type=GitHubApiRequestType.GET_REPOSITORIES,
                     raise_on_page_limit=raise_on_page_limit,
+                    parallel=parallel,
                 )
             except ApiPaginationTruncated as e:
                 # Hitting the pagination cap is an expected signal.
@@ -700,20 +712,22 @@ class GitHubBaseClient(
                 lifecycle.record_halt(e, create_issue=False)
                 raise
 
-    def get_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
+    def get_repos_cached(self, ttl: int = 300, parallel: bool = False) -> list[CachedRepo]:
         """
         Return all repos accessible to this installation, cached in
         Django cache for ``ttl`` seconds.
 
         Only the fields used by get_repositories() are stored to keep
         the cache payload small.
+
+        ``parallel`` is forwarded to ``get_repos`` for the cache-miss fetch.
         """
         cache_key = f"github:repos:{self.integration.id}"
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
 
-        all_repos = self.get_repos()
+        all_repos = self.get_repos(parallel=parallel)
         repos: list[CachedRepo] = [
             {
                 "id": r["id"],
@@ -756,44 +770,97 @@ class GitHubBaseClient(
         page_number_limit: int | None = None,
         api_request_type: GitHubApiRequestType | None = None,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[Any]:
         """
-        Github uses the Link header to provide pagination links. Github
-        recommends using the provided link relations and not constructing our
-        own URL.
+        Github uses the Link header to provide pagination links.
         https://docs.github.com/en/rest/guides/traversing-with-pagination
 
         Use response_key when the API stores the results within a key.
         For instance, the repositories API returns the list of repos under the "repositories" key.
 
-        When ``raise_on_page_limit`` is True and the loop exits because it hit
-        ``page_number_limit`` while Github was still advertising a next page,
+        By default the remaining pages are fetched serially by following the
+        ``next`` links one round-trip at a time, which is what Github recommends.
+
+        When ``parallel`` is True and Github advertises the total page count via
+        a ``rel="last"`` link on the first response, the remaining pages are
+        fetched concurrently instead. Callers opt into this only where the
+        latency matters and the bounded extra concurrency against Github's
+        secondary rate limits is acceptable. Even when ``parallel`` is True,
+        endpoints that do not advertise a last page (a single page, or
+        cursor-based pagination where arbitrary page jumps are unsupported) fall
+        back to the serial ``next`` walk.
+
+        When ``raise_on_page_limit`` is True and pagination stops because it hit
+        ``page_number_limit`` while Github was still advertising more pages,
         raises ``ApiPaginationTruncated`` with the partial result attached.
         """
         if page_number_limit is None or page_number_limit > self.page_number_limit:
             page_number_limit = self.page_number_limit
 
+        def page_items(resp: Any) -> Any:
+            return resp[response_key] if response_key else resp
+
         with start_span(
             op=f"{self.integration_type}.http.pagination",
             name=f"{self.integration_type}.http_response.pagination.{self.name}",
         ):
-            output: list[dict[str, Any]] = []
-
-            page_number = 1
-            resp = self.get(
+            # Fetch the first page serially. Besides returning its data, this
+            # warms up any lazily-initialized client state (auth token, session)
+            # before any fan-out, and tells us how many pages there are.
+            first_response = self.get(
                 path, params={"per_page": self.page_size}, api_request_type=api_request_type
             )
-            output.extend(resp) if not response_key else output.extend(resp[response_key])
-            next_link = get_next_link(resp)
+            output: list[Any] = list(page_items(first_response))
 
-            # XXX: In order to speed up this function we will need to parallelize this
-            # Use ThreadPoolExecutor; see src/sentry/utils/snuba.py#L358
+            if parallel:
+                last_page_number = get_last_page_number(first_response)
+                if last_page_number is not None and last_page_number > 1:
+                    truncated = last_page_number > page_number_limit
+                    remaining_pages = range(2, min(last_page_number, page_number_limit) + 1)
+
+                    # Pages are addressed by number (per_page + page) rather than
+                    # by following Github's next-link URLs. That is only equivalent
+                    # when the request carries no other query params, which holds
+                    # for the sole opt-in caller (the repo-list endpoint sends
+                    # none). A future parallel caller that adds filter/sort/q params
+                    # would need them threaded in here, since this reconstructed URL
+                    # would otherwise silently drop them.
+                    def fetch_page(page_number: int) -> Any:
+                        return self.get(
+                            path,
+                            params={"per_page": self.page_size, "page": page_number},
+                            api_request_type=api_request_type,
+                        )
+
+                    if remaining_pages:
+                        with ContextPropagatingThreadPoolExecutor(
+                            thread_name_prefix=__name__,
+                            max_workers=min(PAGINATION_MAX_WORKERS, len(remaining_pages)),
+                        ) as executor:
+                            # ``map`` yields results in input order, so the pages
+                            # are concatenated in order regardless of which request
+                            # finished first. If a page fails, ``map`` cancels the
+                            # pages it has not started yet, so a failed fan-out costs
+                            # at most roughly one in-flight batch of extra requests
+                            # (bounded by max_workers), not the whole page range.
+                            for resp in executor.map(fetch_page, remaining_pages):
+                                output.extend(page_items(resp))
+
+                    if truncated and raise_on_page_limit:
+                        raise ApiPaginationTruncated(
+                            output,
+                            f"pagination stopped at page_number_limit={page_number_limit}",
+                        )
+                    return output
+
+            # Serial walk: the default, and the fallback when ``parallel`` is
+            # requested but Github does not advertise a last page.
+            page_number = 1
+            next_link = get_next_link(first_response)
             while next_link and page_number < page_number_limit:
-                # If a per_page is specified, GitHub preserves the per_page value
-                # in the response headers.
                 resp = self.get(next_link, api_request_type=api_request_type)
-                output.extend(resp) if not response_key else output.extend(resp[response_key])
-
+                output.extend(page_items(resp))
                 next_link = get_next_link(resp)
                 page_number += 1
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -837,18 +837,43 @@ class GitHubBaseClient(
                         )
 
                     if remaining_pages:
-                        with ContextPropagatingThreadPoolExecutor(
-                            thread_name_prefix=__name__,
-                            max_workers=min(PAGINATION_MAX_WORKERS, len(remaining_pages)),
-                        ) as executor:
-                            # ``map`` yields results in input order, so the pages
-                            # are concatenated in order regardless of which request
-                            # finished first. If a page fails, ``map`` cancels the
-                            # pages it has not started yet, so a failed fan-out costs
-                            # at most roughly one in-flight batch of extra requests
-                            # (bounded by max_workers), not the whole page range.
-                            for resp in executor.map(fetch_page, remaining_pages):
-                                output.extend(page_items(resp))
+                        # Stats for the parallel fan-out so we can watch whether
+                        # the extra concurrency is what tips installs over
+                        # GitHub's secondary rate limits (the ``rate_limited``
+                        # outcome), and how wide the fan-outs actually get. These
+                        # fire only on multi-page picker opens, and rate_limited
+                        # is rarer still, so pin sample_rate=1.0 (prod lowers the
+                        # global default) to keep the rare event visible.
+                        metrics.distribution(
+                            "integrations.github.parallel_pagination.pages",
+                            len(remaining_pages) + 1,
+                            sample_rate=1.0,
+                        )
+                        try:
+                            with ContextPropagatingThreadPoolExecutor(
+                                thread_name_prefix=__name__,
+                                max_workers=min(PAGINATION_MAX_WORKERS, len(remaining_pages)),
+                            ) as executor:
+                                # ``map`` yields results in input order, so the pages
+                                # are concatenated in order regardless of which request
+                                # finished first. If a page fails, ``map`` cancels the
+                                # pages it has not started yet, so a failed fan-out costs
+                                # at most roughly one in-flight batch of extra requests
+                                # (bounded by max_workers), not the whole page range.
+                                for resp in executor.map(fetch_page, remaining_pages):
+                                    output.extend(page_items(resp))
+                        except ApiRateLimitedError:
+                            metrics.incr(
+                                "integrations.github.parallel_pagination",
+                                tags={"outcome": "rate_limited"},
+                                sample_rate=1.0,
+                            )
+                            raise
+                        metrics.incr(
+                            "integrations.github.parallel_pagination",
+                            tags={"outcome": "success"},
+                            sample_rate=1.0,
+                        )
 
                     if truncated and raise_on_page_limit:
                         raise ApiPaginationTruncated(

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -820,12 +820,15 @@ class GitHubBaseClient(
                     remaining_pages = range(2, min(last_page_number, page_number_limit) + 1)
 
                     # Pages are addressed by number (per_page + page) rather than
-                    # by following Github's next-link URLs. That is only equivalent
-                    # when the request carries no other query params, which holds
-                    # for the sole opt-in caller (the repo-list endpoint sends
-                    # none). A future parallel caller that adds filter/sort/q params
-                    # would need them threaded in here, since this reconstructed URL
-                    # would otherwise silently drop them.
+                    # by following Github's next-link URLs. Any query params
+                    # already in ``path`` survive because fetch_page reuses it, so
+                    # this matches next-link following for offset-paginated
+                    # endpoints (the only kind we take this path for, since it is
+                    # gated on a numeric rel="last"). The one gap: if this function
+                    # ever grows a ``params`` argument for filter/sort/q, fetch_page
+                    # must forward it too -- it hardcodes only per_page and page, so
+                    # params supplied any way other than via ``path`` would be
+                    # dropped from pages 2..N.
                     def fetch_page(page_number: int) -> Any:
                         return self.get(
                             path,

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -278,6 +278,7 @@ class GitHubIntegration(
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         """
         args:
@@ -291,6 +292,9 @@ class GitHubIntegration(
           page_number_limit cap with more data still available, raise
           ApiPaginationTruncated (partial result attached). Ignored when
           ``use_cache`` is True.
+        * parallel - when True, fetch pages after the first concurrently. Only
+          the interactive repo-listing endpoint opts in; not used on the Search
+          API path.
 
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
@@ -319,11 +323,12 @@ class GitHubIntegration(
         def _fetch_and_process() -> list[RepositoryInfo]:
             try:
                 raw = (
-                    client.get_repos_cached()
+                    client.get_repos_cached(parallel=parallel)
                     if use_cache
                     else client.get_repos(
                         page_number_limit=page_number_limit,
                         raise_on_page_limit=raise_on_page_limit,
+                        parallel=parallel,
                     )
                 )
             except ApiPaginationTruncated as e:

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import calendar
 import datetime
 import time
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from rest_framework.response import Response
 
@@ -50,6 +50,36 @@ def get_next_link(response: Response) -> str | None:
             start = link.find("<") + 1
             end = link.find(">")
             return link[start:end]
+
+    return None
+
+
+def get_last_page_number(response: Response) -> int | None:
+    """Return the page number advertised by Github's `rel="last"` link.
+
+    For offset-paginated endpoints Github includes a `rel="last"` relation in
+    the `link` header, so the total number of pages is known from the first
+    response. This lets us fetch the remaining pages in parallel instead of
+    walking the `next` links one round-trip at a time.
+
+    Returns None when the header is absent (a single page) or does not
+    advertise a last page (for example, cursor-based pagination), in which
+    case the caller should fall back to following the `next` links serially.
+    """
+    link_option: str | None = response.headers.get("link")
+    if link_option is None:
+        return None
+
+    for link in link_option.split(","):
+        if 'rel="last"' in link:
+            start = link.find("<") + 1
+            end = link.find(">")
+            page = parse_qs(urlparse(link[start:end]).query).get("page")
+            if page:
+                try:
+                    return int(page[0])
+                except ValueError:
+                    return None
 
     return None
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -258,6 +258,7 @@ class GitHubEnterpriseIntegration(
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         def _process(raw_repos: Iterable[Mapping[str, Any]]) -> list[RepositoryInfo]:
             return [

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -197,6 +197,7 @@ class GitlabIntegration(
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         try:
             # Note: gitlab projects are the same things as repos everywhere else

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -428,6 +428,7 @@ class PerforceIntegration(RepositoryIntegration[PerforceClient], CommitContextIn
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         """
         Get list of depots/streams from Perforce server.

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -85,6 +85,7 @@ class BaseRepositoryIntegration(ABC):
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         """
         Get a list of available repositories for an installation
@@ -114,6 +115,10 @@ class BaseRepositoryIntegration(ABC):
         pagination cap with more data still available, ``ApiPaginationTruncated``
         is raised with the partial result attached. Providers without a
         pagination cap may accept and ignore this argument.
+
+        ``parallel`` is a hint that pages after the first may be fetched
+        concurrently. Providers that do not implement parallel pagination may
+        accept and ignore this argument.
         """
         raise NotImplementedError
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -356,6 +356,7 @@ class VstsIntegration(RepositoryIntegration[VstsApiClient], VstsIssuesSpec):
         accessible_only: bool = False,
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
+        parallel: bool = False,
     ) -> list[RepositoryInfo]:
         try:
             repos = self.get_client().get_repos()

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -262,7 +262,9 @@ class OrganizationIntegrationReposTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with("rad", accessible_only=True, use_cache=True)
+        get_repositories.assert_called_once_with(
+            "rad", accessible_only=True, use_cache=True, parallel=True
+        )
         assert response.data == {
             "repos": [
                 {
@@ -293,7 +295,21 @@ class OrganizationIntegrationReposTest(APITestCase):
         response = self.client.get(self.path, format="json", data={"accessibleOnly": "true"})
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with(None, accessible_only=True, use_cache=False)
+        get_repositories.assert_called_once_with(
+            None, accessible_only=True, use_cache=False, parallel=True
+        )
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_passes_parallel(self, get_repositories: MagicMock) -> None:
+        """The endpoint opts into parallel pagination for its interactive callers."""
+        response = self.client.get(self.path, format="json")
+
+        assert response.status_code == 200, response.content
+        get_repositories.assert_called_once_with(
+            None, accessible_only=False, use_cache=False, parallel=True
+        )
 
     @patch(
         "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
@@ -329,7 +345,9 @@ class OrganizationIntegrationReposTest(APITestCase):
         )
 
         assert response.status_code == 200, response.content
-        get_repositories.assert_called_once_with("Example", accessible_only=True, use_cache=True)
+        get_repositories.assert_called_once_with(
+            "Example", accessible_only=True, use_cache=True, parallel=True
+        )
         assert response.data == {
             "repos": [
                 {

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -25,7 +25,11 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
 from sentry.scm.private.rate_limit import DynamicRateLimiter
-from sentry.shared_integrations.exceptions import ApiError, ApiRateLimitedError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiPaginationTruncated,
+    ApiRateLimitedError,
+)
 from sentry.shared_integrations.response.base import BaseApiResponse
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
@@ -314,6 +318,130 @@ class GitHubApiClientTest(TestCase):
         self.github_client._get_with_pagination(f"/repos/{self.repo.name}/assignees")
         assert len(responses.calls) == 1
         assert responses.calls[0].response.status_code == 200
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_parallel_uses_last_link(self, get_jwt) -> None:
+        # When Github advertises the last page, the remaining pages are fetched
+        # by page number (concurrently) rather than by following each page's
+        # `next` link. The later pages omit their `next` link to prove the
+        # last-page hint, not serial `next` walking, drives the fetch, and the
+        # results are concatenated in page order regardless of completion order.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}, {"id": 2}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=3>; rel="last"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=2", json=[{"id": 3}, {"id": 4}])
+        responses.add(method=responses.GET, url=f"{url}&page=3", json=[{"id": 5}, {"id": 6}])
+
+        result = self.github_client._get_with_pagination(
+            f"/repos/{self.repo.name}/assignees", parallel=True
+        )
+
+        assert [item["id"] for item in result] == [1, 2, 3, 4, 5, 6]
+        assert len(responses.calls) == 3
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_falls_back_to_serial_without_last_link(self, get_jwt) -> None:
+        # Even with parallel requested, cursor-style pagination provides `next`
+        # links but no `rel="last"`, so arbitrary page jumps are unavailable and
+        # we fall back to following the links serially.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next"'},
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=2",
+            json=[{"id": 2}],
+            headers={"link": f'<{url}&page=3>; rel="next"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=3", json=[{"id": 3}])
+
+        result = self.github_client._get_with_pagination(
+            f"/repos/{self.repo.name}/assignees", parallel=True
+        )
+
+        assert [item["id"] for item in result] == [1, 2, 3]
+        assert len(responses.calls) == 3
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_raises_when_truncated(self, get_jwt) -> None:
+        # Github advertises five pages but the caller caps at three: only the
+        # first three pages are fetched and the partial result is attached.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=5>; rel="last"'},
+        )
+        for page in (2, 3):
+            responses.add(method=responses.GET, url=f"{url}&page={page}", json=[{"id": page}])
+
+        with pytest.raises(ApiPaginationTruncated) as excinfo:
+            self.github_client._get_with_pagination(
+                f"/repos/{self.repo.name}/assignees",
+                page_number_limit=3,
+                raise_on_page_limit=True,
+                parallel=True,
+            )
+
+        assert len(responses.calls) == 3
+        assert [item["id"] for item in excinfo.value.partial_data] == [1, 2, 3]
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_truncates_without_raising(self, get_jwt) -> None:
+        # Same cap, but without raise_on_page_limit the partial result (the
+        # pages fetched up to the cap) is returned silently.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=5>; rel="last"'},
+        )
+        for page in (2, 3):
+            responses.add(method=responses.GET, url=f"{url}&page={page}", json=[{"id": page}])
+
+        result = self.github_client._get_with_pagination(
+            f"/repos/{self.repo.name}/assignees",
+            page_number_limit=3,
+            parallel=True,
+        )
+
+        assert [item["id"] for item in result] == [1, 2, 3]
+        assert len(responses.calls) == 3
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_serial_by_default_ignores_last_link(self, get_jwt) -> None:
+        # parallel defaults to False: even though Github advertises rel="last",
+        # the serial walk follows `next` links only. Page 2 omits its `next`
+        # link, so the walk stops there and never fetches the advertised page 3.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=3>; rel="last"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=2", json=[{"id": 2}])
+        responses.add(method=responses.GET, url=f"{url}&page=3", json=[{"id": 3}])
+
+        result = self.github_client._get_with_pagination(f"/repos/{self.repo.name}/assignees")
+
+        assert [item["id"] for item in result] == [1, 2]
+        assert len(responses.calls) == 2
 
     @mock.patch(
         "sentry.integrations.github.integration.GitHubIntegration.check_file",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -478,6 +478,67 @@ class GitHubApiClientTest(TestCase):
         assert [item["id"] for item in result] == [1, 2]
         assert len(responses.calls) == 2
 
+    @mock.patch("sentry.integrations.github.client.metrics")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_parallel_records_success_metric(
+        self, get_jwt, mock_metrics
+    ) -> None:
+        # A successful parallel fan-out records its width (total pages) and a
+        # success outcome so we can watch the fast path in production.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=3>; rel="last"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=2", json=[{"id": 2}])
+        responses.add(method=responses.GET, url=f"{url}&page=3", json=[{"id": 3}])
+
+        self.github_client._get_with_pagination(f"/repos/{self.repo.name}/assignees", parallel=True)
+
+        mock_metrics.distribution.assert_called_once_with(
+            "integrations.github.parallel_pagination.pages", 3, sample_rate=1.0
+        )
+        mock_metrics.incr.assert_any_call(
+            "integrations.github.parallel_pagination",
+            tags={"outcome": "success"},
+            sample_rate=1.0,
+        )
+
+    @mock.patch("sentry.integrations.github.client.metrics")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_parallel_records_rate_limited_metric(
+        self, get_jwt, mock_metrics
+    ) -> None:
+        # A 429 from any page in the fan-out surfaces as ApiRateLimitedError and
+        # is attributed to the parallel path, so we can tell whether the extra
+        # concurrency is what trips Github's secondary rate limits.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=3>; rel="last"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=2", json=[{"id": 2}])
+        responses.add(
+            method=responses.GET, url=f"{url}&page=3", status=429, json={"message": "rate limited"}
+        )
+
+        with pytest.raises(ApiRateLimitedError):
+            self.github_client._get_with_pagination(
+                f"/repos/{self.repo.name}/assignees", parallel=True
+            )
+
+        mock_metrics.incr.assert_any_call(
+            "integrations.github.parallel_pagination",
+            tags={"outcome": "rate_limited"},
+            sample_rate=1.0,
+        )
+
     @mock.patch(
         "sentry.integrations.github.integration.GitHubIntegration.check_file",
         return_value=GITHUB_CODEOWNERS["html_url"],

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -27,6 +27,7 @@ from sentry.models.repository import Repository
 from sentry.scm.private.rate_limit import DynamicRateLimiter
 from sentry.shared_integrations.exceptions import (
     ApiError,
+    ApiForbiddenError,
     ApiPaginationTruncated,
     ApiRateLimitedError,
 )
@@ -538,6 +539,78 @@ class GitHubApiClientTest(TestCase):
             tags={"outcome": "rate_limited"},
             sample_rate=1.0,
         )
+
+    @mock.patch("sentry.integrations.github.client.metrics")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_parallel_403_rate_limit_records_rate_limited_metric(
+        self, get_jwt, mock_metrics
+    ) -> None:
+        # Github also signals a tripped secondary rate limit with a 403 whose
+        # body names the limit, not only a 429, so that outcome is attributed to
+        # the parallel path too.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=3>; rel="last"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=2", json=[{"id": 2}])
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=3",
+            status=403,
+            json={
+                "message": "You have exceeded a secondary rate limit. Please wait a few minutes."
+            },
+        )
+
+        with pytest.raises(ApiForbiddenError):
+            self.github_client._get_with_pagination(
+                f"/repos/{self.repo.name}/assignees", parallel=True
+            )
+
+        mock_metrics.incr.assert_any_call(
+            "integrations.github.parallel_pagination",
+            tags={"outcome": "rate_limited"},
+            sample_rate=1.0,
+        )
+
+    @mock.patch("sentry.integrations.github.client.metrics")
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_with_pagination_parallel_403_permission_does_not_record_rate_limited(
+        self, get_jwt, mock_metrics
+    ) -> None:
+        # A plain permission 403 (no rate-limit message) is not a rate limit, so
+        # it re-raises without recording either outcome.
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json=[{"id": 1}],
+            headers={"link": f'<{url}&page=2>; rel="next", <{url}&page=3>; rel="last"'},
+        )
+        responses.add(method=responses.GET, url=f"{url}&page=2", json=[{"id": 2}])
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=3",
+            status=403,
+            json={"message": "Resource not accessible by integration"},
+        )
+
+        with pytest.raises(ApiForbiddenError):
+            self.github_client._get_with_pagination(
+                f"/repos/{self.repo.name}/assignees", parallel=True
+            )
+
+        outcomes = [
+            call.kwargs.get("tags", {}).get("outcome")
+            for call in mock_metrics.incr.call_args_list
+            if call.args and call.args[0] == "integrations.github.parallel_pagination"
+        ]
+        assert outcomes == []
 
     @mock.patch(
         "sentry.integrations.github.integration.GitHubIntegration.check_file",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -346,6 +346,41 @@ class GitHubApiClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_get_with_pagination_parallel_preserves_path_query_params(self, get_jwt) -> None:
+        # A query string embedded in ``path`` must ride along on every page the
+        # parallel fan-out fetches, not just the first. ``fetch_page`` reuses
+        # ``path``, so pages 2..N keep the original query params alongside the
+        # reconstructed per_page/page. No caller does this today (all pass bare
+        # paths), so this locks in that invariant. The strict query_param_matcher
+        # fails the request if ``type`` is dropped from any page.
+        pp = self.github_client.page_size
+        url = f"https://api.github.com/repos/{self.repo.name}/assignees"
+        last_link = f'<{url}?type=all&per_page={pp}&page=2>; rel="last"'
+        responses.add(
+            method=responses.GET,
+            url=url,
+            match=[matchers.query_param_matcher({"type": "all", "per_page": pp})],
+            json=[{"id": 1}],
+            headers={"link": last_link},
+        )
+        responses.add(
+            method=responses.GET,
+            url=url,
+            match=[matchers.query_param_matcher({"type": "all", "per_page": pp, "page": 2})],
+            json=[{"id": 2}],
+        )
+
+        result = self.github_client._get_with_pagination(
+            f"/repos/{self.repo.name}/assignees?type=all", parallel=True
+        )
+
+        assert [item["id"] for item in result] == [1, 2]
+        assert len(responses.calls) == 2
+        # Both requests carried the query param that was embedded in ``path``.
+        assert all("type=all" in call.request.url for call in responses.calls)
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_get_with_pagination_falls_back_to_serial_without_last_link(self, get_jwt) -> None:
         # Even with parallel requested, cursor-style pagination provides `next`
         # links but no `rel="last"`, so arbitrary page jumps are unavailable and

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -235,8 +235,14 @@ class GitHubIntegrationTest(IntegrationTestCase):
         self.repositories = repositories
         len_repos = len(repositories)
         api_url = f"{self.base_url}/installation/repositories"
+        # Only pages 1-3 (foo, bar, baz) are registered below, so Github's
+        # rel="last" points at page 3. It must match the real final page:
+        # callers read the last page number from the first response to fetch
+        # the remaining pages in parallel, so an inflated value would request
+        # pages that do not exist.
+        last_page = 3
         first = f'<{api_url}?per_page={pp}&page=1>; rel="first"'
-        last = f'<{api_url}?per_page={pp}&page={len_repos}>; rel="last"'
+        last = f'<{api_url}?per_page={pp}&page={last_page}>; rel="last"'
 
         def gen_link(page: int, text: str) -> str:
             return f'<{api_url}?per_page={pp}&page={page}>; rel="{text}"'
@@ -546,7 +552,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         with patch.object(client.GitHubBaseClient, "page_size", 1):
-            result = installation.get_repositories()
+            result = installation.get_repositories(parallel=True)
             assert result == [
                 {
                     "name": "foo",
@@ -583,7 +589,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             patch.object(client.GitHubBaseClient, "page_number_limit", 1),
             patch.object(client.GitHubBaseClient, "page_size", 1),
         ):
-            result = installation.get_repositories()
+            result = installation.get_repositories(parallel=True)
             assert result == [
                 {
                     "name": "foo",

--- a/tests/sentry/integrations/github/test_utils.py
+++ b/tests/sentry/integrations/github/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
+from rest_framework.response import Response
 
 from sentry.integrations.github.utils import (
+    get_last_page_number,
     is_github_rate_limit_sensitive,
     parse_github_blob_url,
 )
@@ -43,6 +45,34 @@ def test_parse_github_blob_url(repo_url, source_url, expected_branch, expected_p
     branch, path = parse_github_blob_url(repo_url, source_url)
     assert branch == expected_branch
     assert path == expected_path
+
+
+@pytest.mark.parametrize(
+    "link,expected",
+    [
+        # Multi-page offset pagination advertises the last page.
+        (
+            '<https://api.github.com/installation/repositories?per_page=100&page=2>; rel="next", '
+            '<https://api.github.com/installation/repositories?per_page=100&page=9>; rel="last"',
+            9,
+        ),
+        # Single page: no link header at all.
+        (None, None),
+        # Cursor-based pagination: a next link but no last link.
+        ('<https://api.github.com/x?per_page=100&page=2>; rel="next"', None),
+        # On the final page Github only sends the first/prev relations.
+        (
+            '<https://api.github.com/x?per_page=100&page=1>; rel="first", '
+            '<https://api.github.com/x?per_page=100&page=8>; rel="prev"',
+            None,
+        ),
+        # Malformed last link with no page query param.
+        ('<https://api.github.com/x?per_page=100>; rel="last"', None),
+    ],
+)
+def test_get_last_page_number(link: str | None, expected: int | None) -> None:
+    response = Response(headers={"link": link} if link is not None else {})
+    assert get_last_page_number(response) == expected
 
 
 class IsGithubRateLimitSensitiveTest(TestCase):


### PR DESCRIPTION
## TLDR

Fetches GitHub's paginated repo list in parallel to speed up the SCM repo dropdown, cutting first-open time for a ~880-repo (9-page) install from ~15s to ~2s. It's opt-in: only the repo-listing endpoint behind the dropdown parallelizes; every other GitHub pagination caller stays serial, as GitHub recommends.

The dropdown has to query GitHub live rather than Sentry's stored `Repository` records: in onboarding the user may have just connected the integration, so the `link_all_repos` backfill of those records is often still running and they would be incomplete. That puts live pagination on the critical path.

## Details

`OrganizationIntegrationReposEndpoint` loads every repository through `get_repositories` -> `get_repos` -> `_get_with_pagination`, which walked GitHub's `next` links one page at a time. Each page is a separate round-trip, so the cost scaled linearly with the number of pages.

GitHub advertises the total page count via a `rel="last"` link on the first response. When the new `parallel` flag is set, `_get_with_pagination` reads that page number up front, then fetches pages 2..N concurrently with a bounded `ContextPropagatingThreadPoolExecutor` (the same helper `snuba.py` uses, so the Sentry SDK scope and silo context propagate into the worker threads). Page 1 is still fetched first and serially, which also warms any lazily-initialized client state (auth token, session) before the fan-out. `executor.map` preserves input order, so the pages concatenate in page order regardless of which request finishes first. When GitHub does not advertise a last page (a single page, or cursor-based pagination), it falls back to the original serial `next` walk.

GitHub recommends making requests serially to avoid its secondary rate limits, so the parallel path is opt-in rather than on for every caller of the shared helper. The `parallel` flag defaults to off and is threaded through the shared `get_repositories` contract (the base `RepositoryIntegration` plus all provider overrides; only GitHub implements it), matching how `accessible_only` and `use_cache` were added in #111892 and #112548. Only `OrganizationIntegrationReposEndpoint` opts in, by passing `parallel=True`, because it backs the two interactive repo pickers (the onboarding repo selector via `useScmRepos` and the code-mappings path config form) where the latency is user-visible. Every other caller of `_get_with_pagination` (assignees, labels, reactions, compare-commits) and the background `link_all_repos` task keep the serial walk.

The fan-out is bounded at `PAGINATION_MAX_WORKERS=10` concurrent requests per call. GitHub's documented secondary limits are 100 concurrent requests and 900 points per minute per installation token (a GET counts as 1 point), so a 10-wide fan-out for one installation sits well under both, even when the dropdown and `link_all_repos` run together during onboarding.

One test fixture in `test_integration.py` set `rel="last"` to the total repo count while only registering three pages. The old serial code ignored the last link, but the parallel path reads it, so the fixture now points `rel="last"` at its actual final page, matching how GitHub behaves.

Fixes VDY-131
