### PR TITLE
ref(issues): Remove linked pull request frontend flag

### DIFF
--- a/static/app/components/group/externalIssuesList/index.spec.tsx
+++ b/static/app/components/group/externalIssuesList/index.spec.tsx
@@ -101,7 +101,7 @@ describe('ExternalIssueList', () => {
       organization,
     });
     expect(
-      await screen.findByRole('button', {name: 'Test-Sentry/github-test#13'})
+      await screen.findByRole('link', {name: 'Test-Sentry/github-test#13'})
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Jira'})).toBeInTheDocument();
   });

--- a/static/app/components/group/externalIssuesList/index.tsx
+++ b/static/app/components/group/externalIssuesList/index.tsx
@@ -1,11 +1,7 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
 import {AlertLink} from '@sentry/scraps/alert';
-import {Button, LinkButton} from '@sentry/scraps/button';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import type {GroupIntegrationIssueResult} from 'sentry/components/group/externalIssuesList/hooks/types';
 import {useGroupExternalIssues} from 'sentry/components/group/externalIssuesList/hooks/useGroupExternalIssues';
 import {InlineIssueTrackerActions} from 'sentry/components/group/externalIssuesList/issueTrackerActions';
@@ -48,13 +44,9 @@ export function ExternalIssueListContent({
   showInlineIssueTrackerActions,
 }: ExternalIssueListContentProps) {
   const organization = useOrganization();
-  const hasLinkedPullRequestsFeature = organization.features.includes(
-    'issue-details-linked-pull-requests'
-  );
-  const loadingPlaceholderHeight = hasLinkedPullRequestsFeature ? '34px' : '25px';
 
   if (isLoading) {
-    return <Placeholder height={loadingPlaceholderHeight} />;
+    return <Placeholder height="34px" />;
   }
 
   const hasLinkedIssuesOrIntegrations = integrations.length || linkedIssues.length;
@@ -70,110 +62,14 @@ export function ExternalIssueListContent({
   }
 
   const showIssueTrackerActions =
-    (showInlineIssueTrackerActions ?? !hasLinkedPullRequestsFeature) &&
-    integrations.length > 0;
+    Boolean(showInlineIssueTrackerActions) && integrations.length > 0;
 
   return (
     <Fragment>
-      {linkedIssues.length > 0 &&
-        (hasLinkedPullRequestsFeature ? (
-          <LinkedIssueRows linkedIssues={linkedIssues} />
-        ) : (
-          <LinkedIssuesList linkedIssues={linkedIssues} />
-        ))}
+      {linkedIssues.length > 0 && <LinkedIssueRows linkedIssues={linkedIssues} />}
       {showIssueTrackerActions && (
         <InlineIssueTrackerActions integrations={integrations} />
       )}
     </Fragment>
   );
 }
-
-function LinkedIssuesList({
-  linkedIssues,
-}: {
-  linkedIssues: GroupIntegrationIssueResult['linkedIssues'];
-}) {
-  return (
-    <IssueActionWrapper>
-      {linkedIssues.map(linkedIssue => (
-        <ErrorBoundary key={linkedIssue.key} mini>
-          <Tooltip
-            overlayStyle={{maxWidth: '400px'}}
-            position="bottom"
-            title={
-              <LinkedIssueTooltipWrapper>
-                <LinkedIssueName>{linkedIssue.title}</LinkedIssueName>
-                <HorizontalSeparator />
-                <UnlinkButton variant="link" size="zero" onClick={linkedIssue.onUnlink}>
-                  {t('Unlink issue')}
-                </UnlinkButton>
-              </LinkedIssueTooltipWrapper>
-            }
-            isHoverable
-          >
-            <LinkedIssue
-              href={linkedIssue.url}
-              external
-              size="zero"
-              icon={linkedIssue.displayIcon}
-            >
-              <IssueActionName>{linkedIssue.displayName}</IssueActionName>
-            </LinkedIssue>
-          </Tooltip>
-        </ErrorBoundary>
-      ))}
-    </IssueActionWrapper>
-  );
-}
-
-const IssueActionWrapper = styled('span')`
-  display: flex;
-  flex-wrap: wrap;
-  gap: ${p => p.theme.space.md};
-  line-height: 1.2;
-`;
-
-const LinkedIssue = styled(LinkButton)`
-  display: flex;
-  align-items: center;
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.sm};
-  border: none;
-  border-radius: ${p => p.theme.radius.md};
-  font-weight: normal;
-`;
-
-const IssueActionName = styled('div')`
-  display: block;
-  width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 200px;
-`;
-
-const LinkedIssueTooltipWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  white-space: nowrap;
-`;
-
-const LinkedIssueName = styled('div')`
-  display: block;
-  width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-right: ${p => p.theme.space['2xs']};
-`;
-
-const HorizontalSeparator = styled('div')`
-  width: 1px;
-  height: 14px;
-  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-  background: ${p => p.theme.tokens.border.primary};
-`;
-
-const UnlinkButton = styled(Button)`
-  color: ${p => p.theme.tokens.content.secondary};
-`;

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -9,23 +9,20 @@ import {GroupActivityType} from 'sentry/types/group';
 
 import {getLinkedPullRequestActivityIds, LinkedPullRequests} from './linkedPullRequests';
 
-const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
 const REPOSITORY_NAME = 'example/widget-app';
 
 describe('LinkedPullRequests', () => {
   const group = GroupFixture();
-  const organizationWithFeature = OrganizationFixture({
-    features: [LINKED_PULL_REQUESTS_FEATURE],
-  });
+  const organization = OrganizationFixture();
   const repository = RepositoryFixture({
     id: '42',
     name: REPOSITORY_NAME,
     provider: {id: 'integrations:github', name: 'GitHub'},
   });
 
-  it('renders linked pull requests when the feature is enabled', async () => {
+  it('renders linked pull requests', async () => {
     const pullRequestsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organizationWithFeature.slug}/issues/${group.id}/pull-requests/`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
       body: {
         pullRequests: [
           {
@@ -59,7 +56,7 @@ describe('LinkedPullRequests', () => {
     });
 
     render(<LinkedPullRequests group={group} />, {
-      organization: organizationWithFeature,
+      organization,
     });
 
     const list = await screen.findByRole('list', {name: 'Linked pull requests'});

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import {skipToken, useQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
 import {Avatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
@@ -34,8 +34,6 @@ import {
   getPullRequestStatusLabel,
   PullRequestStatusBadge,
 } from './pullRequestStatusBadge';
-
-const LINKED_PULL_REQUESTS_FEATURE = 'issue-details-linked-pull-requests';
 
 const PULL_REQUEST_ACTIVITY_TYPES = new Set([
   GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
@@ -225,15 +223,12 @@ function SeerAttributionAvatar() {
 
 export function useLinkedPullRequests({group}: {group: Group}) {
   const organization = useOrganization();
-  const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
 
   return useQuery(
     apiOptions.as<LinkedPullRequestsResponse>()(
       '/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/',
       {
-        path: hasFeature
-          ? {organizationIdOrSlug: organization.slug, issueId: group.id}
-          : skipToken,
+        path: {organizationIdOrSlug: organization.slug, issueId: group.id},
         staleTime: 30_000,
       }
     )
@@ -241,12 +236,10 @@ export function useLinkedPullRequests({group}: {group: Group}) {
 }
 
 export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsProps) {
-  const organization = useOrganization();
-  const hasFeature = organization.features.includes(LINKED_PULL_REQUESTS_FEATURE);
   const {data, isError, isPending} = useLinkedPullRequests({group});
   const activityPullRequestIds = getLinkedPullRequestActivityIds(group);
 
-  if (!hasFeature || isError) {
+  if (isError) {
     return null;
   }
 

--- a/static/app/views/issueDetails/groupDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupDetails.spec.tsx
@@ -192,6 +192,10 @@ describe('groupDetails', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${defaultInit.organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${defaultInit.organization.slug}/repos/`,
       body: {},
     });

--- a/static/app/views/issueDetails/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/groupDetailsLayout.spec.tsx
@@ -73,6 +73,10 @@ describe('GroupDetailsLayout', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-stats/`,
       body: {'count()': EventsStatsFixture(), 'count_unique(user)': EventsStatsFixture()},
     });

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.spec.tsx
@@ -24,17 +24,10 @@ import {ExternalIssueSidebarList} from './externalIssueSidebarList';
 
 describe('ExternalIssueSidebarList', () => {
   const organization = OrganizationFixture();
-  const organizationWithLinkedPullRequestsFeature = OrganizationFixture({
-    features: ['issue-details-linked-pull-requests'],
-  });
   const event = EventFixture();
   const group = GroupFixture();
 
-  function mockLinkedPullRequestsFeatureRequests(integrations: GroupIntegration[]) {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
-      body: {pullRequests: []},
-    });
+  function mockExternalLinkRequests(integrations: GroupIntegration[]) {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: integrations,
@@ -47,6 +40,10 @@ describe('ExternalIssueSidebarList', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/integrations/`,
       body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/external-issues/`,
@@ -87,8 +84,7 @@ describe('ExternalIssueSidebarList', () => {
 
     render(<ExternalIssueSidebarList event={event} group={group} />);
 
-    expect(await screen.findByRole('button', {name: issueKey})).toBeInTheDocument();
-    await userEvent.hover(screen.getByRole('button', {name: issueKey}));
+    expect(await screen.findByRole('link', {name: issueKey})).toBeInTheDocument();
 
     // Integrations are refetched, remove the external issue from the object
     const refetchMock = MockApiClient.addMockResponse({
@@ -101,10 +97,12 @@ describe('ExternalIssueSidebarList', () => {
       ],
     });
 
-    await userEvent.click(await screen.findByRole('button', {name: 'Unlink issue'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: `Unlink ${issueKey}`})
+    );
 
     await waitFor(() => {
-      expect(screen.queryByRole('button', {name: issueKey})).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', {name: issueKey})).not.toBeInTheDocument();
     });
     expect(unlinkMock).toHaveBeenCalledTimes(1);
     expect(refetchMock).toHaveBeenCalledTimes(1);
@@ -150,14 +148,15 @@ describe('ExternalIssueSidebarList', () => {
     render(<ExternalIssueSidebarList event={event} group={group} />);
 
     expect(
-      await screen.findByRole('button', {name: 'ClickUp: hello#1'})
+      await screen.findByRole('link', {name: 'ClickUp: hello#1'})
     ).toBeInTheDocument();
-    await userEvent.hover(screen.getByRole('button', {name: 'ClickUp: hello#1'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Unlink issue'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Unlink ClickUp: hello#1'})
+    );
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('button', {name: 'ClickUp: hello#1'})
+        screen.queryByRole('link', {name: 'ClickUp: hello#1'})
       ).not.toBeInTheDocument();
     });
     expect(unlinkMock).toHaveBeenCalledTimes(1);
@@ -188,8 +187,8 @@ describe('ExternalIssueSidebarList', () => {
 
     render(<ExternalIssueSidebarList event={event} group={group} />);
 
-    expect(await screen.findByRole('button', {name: 'GitHub'})).toBeInTheDocument();
-    await userEvent.click(await screen.findByRole('button', {name: 'GitHub'}));
+    expect(await screen.findByRole('button', {name: 'Link issue'})).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', {name: 'Link issue'}));
 
     // Both items are listed inside the dropdown
     expect(
@@ -214,7 +213,7 @@ describe('ExternalIssueSidebarList', () => {
         app: asanaComponent.sentryApp,
       }),
     ]);
-    mockLinkedPullRequestsFeatureRequests([
+    mockExternalLinkRequests([
       GitHubIntegrationFixture({
         status: 'active',
         externalIssues: [],
@@ -229,9 +228,7 @@ describe('ExternalIssueSidebarList', () => {
       }),
     ]);
 
-    render(<ExternalIssueSidebarList event={event} group={group} />, {
-      organization: organizationWithLinkedPullRequestsFeature,
-    });
+    render(<ExternalIssueSidebarList event={event} group={group} />);
 
     expect(await screen.findByText('External Links')).toBeInTheDocument();
     expect(screen.queryByText('Issue Tracking')).not.toBeInTheDocument();
@@ -254,7 +251,7 @@ describe('ExternalIssueSidebarList', () => {
   });
 
   it('should open the integration modal directly when there is one issue tracker action', async () => {
-    mockLinkedPullRequestsFeatureRequests([
+    mockExternalLinkRequests([
       GitHubIntegrationFixture({
         id: '1',
         status: 'active',
@@ -268,10 +265,8 @@ describe('ExternalIssueSidebarList', () => {
       body: {createIssueConfig: [], linkIssueConfig: []},
     });
 
-    render(<ExternalIssueSidebarList event={event} group={group} />, {
-      organization: organizationWithLinkedPullRequestsFeature,
-    });
-    renderGlobalModal({organization: organizationWithLinkedPullRequestsFeature});
+    render(<ExternalIssueSidebarList event={event} group={group} />);
+    renderGlobalModal({organization});
 
     await userEvent.click(await screen.findByRole('button', {name: 'Link issue'}));
 
@@ -293,7 +288,7 @@ describe('ExternalIssueSidebarList', () => {
       url: 'https://linear.app/example/issue/DE-1275',
     };
     const linkedIssues = [issue, prefixedIssue];
-    mockLinkedPullRequestsFeatureRequests(
+    mockExternalLinkRequests(
       linkedIssues.map((linkedIssue, index) =>
         GitHubIntegrationFixture({
           id: String(index + 1),
@@ -312,9 +307,7 @@ describe('ExternalIssueSidebarList', () => {
       )
     );
 
-    render(<ExternalIssueSidebarList event={event} group={group} />, {
-      organization: organizationWithLinkedPullRequestsFeature,
-    });
+    render(<ExternalIssueSidebarList event={event} group={group} />);
 
     const linkedIssueList = await screen.findByRole('list', {name: 'Linked issues'});
     expect(within(linkedIssueList).getByRole('link', {name: issue.key})).toHaveAttribute(
@@ -335,7 +328,7 @@ describe('ExternalIssueSidebarList', () => {
   });
 
   it('should render an external links empty state', async () => {
-    mockLinkedPullRequestsFeatureRequests([
+    mockExternalLinkRequests([
       GitHubIntegrationFixture({
         status: 'active',
         externalIssues: [],
@@ -343,9 +336,7 @@ describe('ExternalIssueSidebarList', () => {
       }),
     ]);
 
-    render(<ExternalIssueSidebarList event={event} group={group} />, {
-      organization: organizationWithLinkedPullRequestsFeature,
-    });
+    render(<ExternalIssueSidebarList event={event} group={group} />);
 
     expect(await screen.findByRole('button', {name: 'Link issue'})).toBeInTheDocument();
     expect(
@@ -367,9 +358,7 @@ describe('ExternalIssueSidebarList', () => {
       body: [],
     });
 
-    render(<ExternalIssueSidebarList event={event} group={group} />, {
-      organization: organizationWithLinkedPullRequestsFeature,
-    });
+    render(<ExternalIssueSidebarList event={event} group={group} />);
 
     expect(
       await screen.findByText('Track this issue in Jira, GitHub, etc.')
@@ -407,8 +396,8 @@ describe('ExternalIssueSidebarList', () => {
 
     render(<ExternalIssueSidebarList event={event} group={group} />);
 
-    expect(await screen.findByRole('button', {name: 'Jira'})).toBeInTheDocument();
-    await userEvent.click(await screen.findByRole('button', {name: 'Jira'}));
+    expect(await screen.findByRole('button', {name: 'Link issue'})).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', {name: 'Link issue'}));
 
     // Item with different name and subtext should show both
     const menuItem = await screen.findByRole('menuitemradio', {

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -13,7 +13,6 @@ import {
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {SidebarFoldSection} from 'sentry/views/issueDetails/foldSection';
 
@@ -23,16 +22,11 @@ interface Props {
 }
 
 export function ExternalIssueSidebarList({event, group}: Props) {
-  const organization = useOrganization();
-  const hasLinkedPullRequestsFeature = organization.features.includes(
-    'issue-details-linked-pull-requests'
-  );
   const externalIssueData = useGroupExternalIssues({group, event});
   const {data: linkedPullRequestsData, isPending: isLinkedPullRequestsLoading} =
     useLinkedPullRequests({group});
   const hasLinkedPullRequestActivity = getLinkedPullRequestActivityIds(group).size > 0;
   const showEmptyIssueTrackerAction =
-    hasLinkedPullRequestsFeature &&
     !externalIssueData.isLoading &&
     !(hasLinkedPullRequestActivity && isLinkedPullRequestsLoading) &&
     externalIssueData.integrations.length > 0 &&
@@ -44,16 +38,16 @@ export function ExternalIssueSidebarList({event, group}: Props) {
       dataTestId="linked-issues"
       title={
         <Heading as="h3" size="md">
-          {hasLinkedPullRequestsFeature ? t('External Links') : t('Issue Tracking')}
+          {t('External Links')}
         </Heading>
       }
       actions={
-        hasLinkedPullRequestsFeature && !showEmptyIssueTrackerAction ? (
+        showEmptyIssueTrackerAction ? undefined : (
           <IssueTrackerActionDropdown
             integrations={externalIssueData.integrations}
             isLoading={externalIssueData.isLoading}
           />
-        ) : undefined
+        )
       }
       sectionKey={SectionKey.EXTERNAL_ISSUES}
     >
@@ -67,7 +61,6 @@ export function ExternalIssueSidebarList({event, group}: Props) {
           <LinkedPullRequests
             group={group}
             showEmptyState={
-              hasLinkedPullRequestsFeature &&
               !showEmptyIssueTrackerAction &&
               !externalIssueData.isLoading &&
               externalIssueData.integrations.length > 0 &&

--- a/static/app/views/issueDetails/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/sidebar.spec.tsx
@@ -86,6 +86,10 @@ describe('IssueDetailsSidebar', () => {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/tags/`,
       body: [],
     });
@@ -131,10 +135,8 @@ describe('IssueDetailsSidebar', () => {
     expect(screen.getByText('Last seen')).toBeInTheDocument();
     expect(mockFirstLastRelease).toHaveBeenCalled();
 
-    expect(await screen.findByText('Issue Tracking')).toBeInTheDocument();
-    expect(
-      await screen.findByRole('button', {name: issueTrackingKey})
-    ).toBeInTheDocument();
+    expect(await screen.findByText('External Links')).toBeInTheDocument();
+    expect(await screen.findByRole('link', {name: issueTrackingKey})).toBeInTheDocument();
     expect(mockExternalIssues).toHaveBeenCalled();
 
     expect(screen.getByRole('heading', {name: 'Activity'})).toBeInTheDocument();


### PR DESCRIPTION
always show the linked pull request UI now that the backend endpoint is ga.

this keeps the issue sidebar on the external links layout and drops the old compact linked issue path.