### PR TITLE
chore(cells) Remove rollout options and logic for api_gateway_address

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -5,7 +5,6 @@ Utilities related to proxying a request to a cell
 from __future__ import annotations
 
 import logging
-import random
 from collections.abc import Callable, Generator
 from http.cookiejar import Cookie
 from threading import local
@@ -130,12 +129,7 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     """Take a django request object and proxy it to a cell silo"""
 
     host = cell.address
-    rollout_option = options.get("apigateway.proxy.cell-rollout")
-    if (
-        cell.api_gateway_address
-        and isinstance(rollout_option, dict)
-        and random.random() < rollout_option.get(cell.name, 0.0)
-    ):
+    if cell.api_gateway_address:
         host = cell.api_gateway_address
 
     metric_tags = {

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import random
 from collections.abc import AsyncGenerator, AsyncIterator
 from urllib.parse import urljoin
 
@@ -16,7 +15,6 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.http.response import HttpResponseBase
 
-from sentry import options
 from sentry.objectstore.endpoints.organization import get_raw_body_async
 from sentry.silo.util import (
     PRESERVE_CONTENT_ENCODING_URL_NAMES,
@@ -120,12 +118,7 @@ async def proxy_cell_request(
 ) -> HttpResponseBase:
     """Take a django request object and proxy it to a cell silo"""
     host = cell.address
-    rollout_option = await sync_to_async(options.get)("apigateway.proxy.cell-rollout")
-    if (
-        cell.api_gateway_address
-        and isinstance(rollout_option, dict)
-        and random.random() < rollout_option.get(cell.name, 0.0)
-    ):
+    if cell.api_gateway_address:
         host = cell.api_gateway_address
 
     metric_tags = {

--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -208,14 +208,3 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "apigateway.proxy.cell-rollout",
-    type=Dict,
-    default={
-        "us": 1.0,
-        "de": 0.0,
-        "us2": 0.0,
-        "s4s2": 0.0,
-    },
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ipaddress
 import logging
-import random
 import socket
 from collections.abc import Mapping
 from hashlib import sha256
@@ -122,12 +121,7 @@ class CellSiloClient(BaseApiClient):
         self.cell = get_cell_by_name(cell.name)
         self.base_url = self.cell.address
 
-        gateway_rollout = options.get("apigateway.proxy.cell-rollout")
-        if (
-            self.cell.api_gateway_address
-            and isinstance(gateway_rollout, dict)
-            and random.random() < gateway_rollout.get(cell.name, 0.0)
-        ):
+        if self.cell.api_gateway_address:
             self.base_url = self.cell.api_gateway_address
         self.retry = retry
 

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -493,48 +493,11 @@ api_gateway_address_cell = Cell(
 @control_silo_test(cells=[api_gateway_address_cell], include_monolith_run=True)
 class ApiGatewayAddressProxyTestCase(ApiGatewayTestCase):
     @responses.activate
-    @override_options({"apigateway.proxy.cell-rollout": {"us": 1.0}})
     def test_sync_post(self) -> None:
         responses.add(
             responses.POST,
             "http://sentry-api-gateway-rpc:8999/post",
             body=json.dumps({"test": "header"}),
-        )
-        request = RequestFactory().post(
-            "http://sentry.io/post", data={"test": "header"}, content_type="application/json"
-        )
-        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
-        resp_json = json.loads(close_streaming_response(resp))
-
-        assert resp.status_code == 200
-        assert resp_json["test"]
-        assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-
-    @responses.activate
-    @override_options({"apigateway.proxy.cell-rollout": "lol"})
-    def test_sync_post_corrupt_rollout_option(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://sentry-rpc:8999/post",
-            body=json.dumps({"test": "value"}),
-        )
-        request = RequestFactory().post(
-            "http://sentry.io/post", data={"test": "header"}, content_type="application/json"
-        )
-        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
-        resp_json = json.loads(close_streaming_response(resp))
-
-        assert resp.status_code == 200
-        assert resp_json["test"]
-        assert resp.has_header(PROXY_DIRECT_LOCATION_HEADER)
-
-    @responses.activate
-    @override_options({"apigateway.proxy.cell-rollout": {"nope": 1.0}})
-    def test_sync_post_undefined_cell_in_option(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://sentry-rpc:8999/post",
-            body=json.dumps({"test": "value"}),
         )
         request = RequestFactory().post(
             "http://sentry.io/post", data={"test": "header"}, content_type="application/json"

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -576,7 +576,6 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_cells(cell_config_with_gateway)
-    @override_options({"apigateway.proxy.cell-rollout": {"us": 1.0}})
     def test_drain_success_api_gateway_address(self) -> None:
         responses.add(
             responses.POST,

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -22,7 +22,6 @@ from sentry.silo.client import (
 from sentry.silo.util import PROXY_DIRECT_LOCATION_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.cell import override_cells
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import override_allowed_cell_silo_ip_addresses
 from sentry.types.cell import Cell, CellResolutionError
 from sentry.utils import json
@@ -351,7 +350,6 @@ class SiloClientTest(TestCase):
         assert err.args == ("Disallowed Cell Silo IP address: 172.31.255.31",)
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"apigateway.proxy.cell-rollout": {"us": 1.0}})
     @responses.activate
     def test_cell_gateway_address_is_allowed(self) -> None:
         cell = Cell(
@@ -383,74 +381,6 @@ class SiloClientTest(TestCase):
             )
             res = client.proxy_request(request)
             assert res.content == b'{"ok": "66"}'
-
-            assert mock_capture_exception.call_count == 0
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"apigateway.proxy.cell-rollout": {"nope": 1.0}})
-    @responses.activate
-    def test_cell_gateway_address_option_key_undefined(self) -> None:
-        cell = Cell(
-            name="us",
-            snowflake_id=1,
-            address="http://10.2.0.88:9000",
-            api_gateway_address="http://10.2.0.66:9000",
-        )
-
-        responses.add(
-            responses.GET,
-            "http://10.2.0.88:9000/api/0/imaginary-public-endpoint/",
-            json={"ok": "88"},
-            headers={"X-Some-Header": "Some-Value", PROXY_SIGNATURE_HEADER: "123"},
-        )
-
-        # We're not mocking allowed_cell_silo_ip_addresses, so the cell attributes
-        # above are used.
-        with (
-            override_cells((cell,)),
-            patch("sentry_sdk.capture_exception") as mock_capture_exception,
-        ):
-            client = CellSiloClient(cell)
-            assert client.base_url == "http://10.2.0.88:9000"
-            request = self.factory.get(
-                "/api/0/imaginary-public-endpoint/", HTTP_HOST="http://control.sentry.io"
-            )
-            res = client.proxy_request(request)
-            assert res.content == b'{"ok": "88"}'
-
-            assert mock_capture_exception.call_count == 0
-
-    @override_settings(SILO_MODE=SiloMode.CONTROL)
-    @override_options({"apigateway.proxy.cell-rollout": "oops"})
-    @responses.activate
-    def test_cell_gateway_address_corrupt_option(self) -> None:
-        cell = Cell(
-            name="us",
-            snowflake_id=1,
-            address="http://10.2.0.88:9000",
-            api_gateway_address="http://10.2.0.66:9000",
-        )
-
-        responses.add(
-            responses.GET,
-            "http://10.2.0.88:9000/api/0/imaginary-public-endpoint/",
-            json={"ok": "88"},
-            headers={"X-Some-Header": "Some-Value", PROXY_SIGNATURE_HEADER: "123"},
-        )
-
-        # We're not mocking allowed_cell_silo_ip_addresses, so the cell attributes
-        # above are used.
-        with (
-            override_cells((cell,)),
-            patch("sentry_sdk.capture_exception") as mock_capture_exception,
-        ):
-            client = CellSiloClient(cell)
-            assert client.base_url == "http://10.2.0.88:9000"
-            request = self.factory.get(
-                "/api/0/imaginary-public-endpoint/", HTTP_HOST="http://control.sentry.io"
-            )
-            res = client.proxy_request(request)
-            assert res.content == b'{"ok": "88"}'
 
             assert mock_capture_exception.call_count == 0
 


### PR DESCRIPTION
Usage of `api_gateway_address` is complete, and this rollout option & supporting code can be removed.

Refs INC-2198