### PR TITLE
test(billing): update AM3 replay fixtures for 5,000 included + $0.0045 PAYG

### DIFF
--- a/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/overrides/useScmFeatureMeta.spec.tsx
@@ -33,7 +33,7 @@ describe('useScmFeatureMeta', () => {
       '10M spans / mo'
     );
     expect(result.current.meta[ProductSolution.SESSION_REPLAY].volume).toBe(
-      '50 replays / mo'
+      '5,000 replays / mo'
     );
     expect(result.current.meta[ProductSolution.LOGS].volume).toBe('5 GB logs / mo');
     // PROFILING is intentionally absent from DYNAMIC_FORMATS, so the static

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -273,8 +273,13 @@ describe('Default Tier Checkout', () => {
       )
     ).toBeInTheDocument();
 
-    // 500 replays from sponsored plan becomes 50 on am3
-    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('50');
+    // The old paid replay reservation (5,000 @ $15) is now included at $0, so the
+    // sponsored sub carries no paid reserved volume and the sliders start collapsed.
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Show reserved volume sliders'})
+    );
+    // 500 replays from the sponsored plan becomes the 5,000 am3 minimum
+    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('5,000');
   });
 
   it('renders for self-serve partners', async () => {
@@ -485,7 +490,7 @@ describe('Default Tier Checkout', () => {
     expect(screen.getByTestId('spans-volume-item')).toHaveTextContent('20M');
 
     // other categories use defaults
-    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('50');
+    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('5,000');
 
     expect(screen.getByTestId('product-option-seer')).toBeChecked();
   });
@@ -538,7 +543,7 @@ describe('Default Tier Checkout', () => {
     expect(screen.getByTestId('spans-volume-item')).toHaveTextContent('20M');
 
     // other categories use defaults
-    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('50');
+    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('5,000');
 
     expect(screen.getByTestId('product-option-seer')).not.toBeChecked();
   });
@@ -605,8 +610,8 @@ describe('Default Tier Checkout', () => {
     );
     // Check that missing 'Errors' category defaults to 50,000 errors
     expect(screen.getByTestId('errors-volume-item')).toHaveTextContent('50K');
-    // For 'Replays', should be set to 50 as per the subscription
-    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('50');
+    // For 'Replays', should be set to 5,000 as per the subscription
+    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('5,000');
     // Check that missing 'Attachments' category defaults to 1 GB
     expect(screen.getByTestId('attachments-volume-item')).toHaveTextContent('1 GB');
   });
@@ -751,6 +756,6 @@ describe('Default Tier Checkout', () => {
     expect(screen.getByTestId('errors-volume-item')).toHaveTextContent('50K');
     expect(screen.getByTestId('attachments-volume-item')).toHaveTextContent('1 GB');
     expect(screen.getByTestId('spans-volume-item')).toHaveTextContent('10M');
-    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('50');
+    expect(screen.getByTestId('replays-volume-item')).toHaveTextContent('5,000');
   });
 });

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -268,8 +268,8 @@ describe('ReserveAdditionalVolume', () => {
           billingInterval: MONTHLY,
           category: 'replays',
           max: '10M',
-          min: '50',
-          selectedTier: '50',
+          min: '5,000',
+          selectedTier: '5,000',
         },
         {
           billingInterval: MONTHLY,

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -571,22 +571,16 @@ export const AM3_PLANS = {
       ],
       replays: [
         {
-          events: 50,
+          events: 5000,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
         },
         {
-          events: 5000,
-          unitPrice: 0.3,
-          price: 1500,
-          onDemandPrice: 0.375,
-        },
-        {
           events: 10000,
           unitPrice: 0.285,
           price: 2900,
-          onDemandPrice: 0.3563,
+          onDemandPrice: 0.45,
         },
         {
           events: 25000,
@@ -1080,22 +1074,16 @@ export const AM3_PLANS = {
       ],
       replays: [
         {
-          events: 50,
+          events: 5000,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
         },
         {
-          events: 5000,
-          unitPrice: 0.3,
-          price: 16200,
-          onDemandPrice: 0.375,
-        },
-        {
           events: 10000,
           unitPrice: 0.285,
           price: 31300,
-          onDemandPrice: 0.3563,
+          onDemandPrice: 0.45,
         },
         {
           events: 25000,
@@ -1719,7 +1707,7 @@ export const AM3_PLANS = {
       ],
       replays: [
         {
-          events: 50,
+          events: 5000,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
@@ -2029,22 +2017,16 @@ export const AM3_PLANS = {
       ],
       replays: [
         {
-          events: 50,
+          events: 5000,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
         },
         {
-          events: 5000,
-          unitPrice: 0.3,
-          price: 1500,
-          onDemandPrice: 0.375,
-        },
-        {
           events: 10000,
           unitPrice: 0.285,
           price: 2900,
-          onDemandPrice: 0.3563,
+          onDemandPrice: 0.45,
         },
         {
           events: 25000,
@@ -2540,22 +2522,16 @@ export const AM3_PLANS = {
       ],
       replays: [
         {
-          events: 50,
+          events: 5000,
           unitPrice: 0,
           price: 0,
           onDemandPrice: 0,
         },
         {
-          events: 5000,
-          unitPrice: 0.3,
-          price: 16200,
-          onDemandPrice: 0.375,
-        },
-        {
           events: 10000,
           unitPrice: 0.285,
           price: 31300,
-          onDemandPrice: 0.3563,
+          onDemandPrice: 0.45,
         },
         {
           events: 25000,

--- a/tests/js/getsentry-test/fixtures/billingConfig.ts
+++ b/tests/js/getsentry-test/fixtures/billingConfig.ts
@@ -47,7 +47,7 @@ export function BillingConfigFixture(tier: PlanTier): BillingConfig {
       defaultReserved: {
         errors: 50_000,
         attachments: 1,
-        replays: 50,
+        replays: 5000,
         monitorSeats: 1,
         spans: 10_000_000,
         uptime: 1,
@@ -66,7 +66,7 @@ export function BillingConfigFixture(tier: PlanTier): BillingConfig {
       defaultReserved: {
         errors: 50_000,
         attachments: 1,
-        replays: 50,
+        replays: 5000,
         monitorSeats: 1,
         spans: 10_000_000,
         uptime: 1,


### PR DESCRIPTION
## What

Updates the frontend billing test fixtures to mirror the AM3 replays pricing change (REVENG-264) implemented on the backend in getsentry#20871:

- **Included replays 50 → 5,000** for AM3 self-serve plans (Developer / Team / Business).
- The old first **paid reserved tier (5,000 @ $15/mo, $162/yr) is removed** — folded into the now-free included tier (`5,000 @ $0`).
- The replay **PAYG entry rate moves to $0.0045** (the `10,000` on-demand band; `onDemandPrice 0.3563 → 0.45`). Higher tiers are unchanged. This is intentionally non-monotonic (entry `0.45` > next band `0.3563`), matching the backend.

Enterprise AM3 (`*_ent*`) and am1/am2 are untouched — they keep the existing `50` structure.

## Files

| File | Change |
|---|---|
| `tests/js/getsentry-test/fixtures/am3Plans.ts` | 5 self-serve replay arrays (Developer/Team/Business × monthly/annual): drop `events:50`, fold `5000@$15` into included `5000@$0`, raise `10000` PAYG to `0.45`. |
| `tests/js/getsentry-test/fixtures/billingConfig.ts` | AM3 `defaultReserved.replays` `50 → 5000` (now the included minimum; am1/am2 stay `500`). |
| `static/gsApp/overrides/useScmFeatureMeta.spec.tsx` | `'50 replays / mo'` → `'5,000 replays / mo'`. |
| `static/gsApp/views/amCheckout/index.spec.tsx` | Prefill assertions `50` → `5,000`; the sponsored-partner migration now starts with the reserved-volume sliders collapsed (no paid replay reservation survives), so the test expands them before asserting. |
| `static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx` | Modern Plans replays slider `min`/`selectedTier` `50` → `5,000`. |

## Behavior note

With the paid replay tier removed, a sponsored AM2 customer migrating to AM3 no longer carries any `price > 0` reservation, so the checkout's "Reserve additional volume" sliders now start **collapsed** by default (correct — there is nothing reserved beyond the included amount). The affected test expands the section before reading the replays value.

## Testing

All affected/adjacent JS suites pass: amCheckout (13 suites / 94 tests), plus `useScmFeatureMeta`, `pendingChanges`, `reserveAdditionalVolume`, and the billing/subscription/product candidate specs (178 tests).

Backend counterpart: getsentry#20871.