### PR TITLE
feat(explore): add trace-items by-id point-lookup endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_items_by_id.py
+++ b/src/sentry/api/endpoints/organization_trace_items_by_id.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 import uuid
@@ -19,7 +20,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.endpoints.project_trace_item_details import (
     convert_rpc_attribute_to_json,
     serialize_item_id,
@@ -60,20 +61,14 @@ class _TraceItemsByIdSerializer(serializers.Serializer[Never]):
     referrer = serializers.CharField(required=False)
 
 
-class OrganizationTraceItemsByIdPermission(OrganizationPermission):
-    # POST here is a read; only org:read is required, not the default org:write.
-    scope_map = {"POST": ["org:read", "org:write", "org:admin"]}
-
-
 @cell_silo_endpoint
 class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
     owner = ApiOwner.DATA_BROWSING
-    permission_classes = (OrganizationTraceItemsByIdPermission,)
     publish_status = {
-        "POST": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def post(self, request: Request, organization: Organization) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         """Fetch specific trace items by id as exact point lookups.
 
         Unlike a filtered table query, each id is resolved directly so a result
@@ -81,8 +76,25 @@ class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
         returned in `notFoundIds`, and ids whose lookup errored are returned in
         `errorIds`, rather than omitted silently. A single failed lookup never
         fails the whole batch.
+
+        The `items` list is passed as a JSON-encoded query parameter since it
+        holds objects that don't flatten cleanly into a query string.
         """
-        serializer = _TraceItemsByIdSerializer(data=request.data)
+        try:
+            items = json.loads(request.GET.get("items", "null"))
+        except ValueError:
+            return Response({"detail": "items must be a JSON-encoded array"}, status=400)
+
+        serializer_data = {
+            "itemType": request.GET.get("itemType"),
+            "columns": request.GET.getlist("columns"),
+            "items": items,
+        }
+        referrer = request.GET.get("referrer")
+        if referrer is not None:
+            serializer_data["referrer"] = referrer
+
+        serializer = _TraceItemsByIdSerializer(data=serializer_data)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
@@ -225,5 +237,7 @@ class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
             include_arrays=include_arrays,
         )
         values_by_name = {attribute["name"]: attribute["value"] for attribute in attributes}
-        values_by_name.setdefault("id", serialize_item_id(response["itemId"], item_type))
+        item_id = response.get("itemId")
+        if item_id is not None:
+            values_by_name.setdefault("id", serialize_item_id(item_id, item_type))
         return {field: values_by_name.get(field) for field in fields}

--- a/src/sentry/api/endpoints/organization_trace_items_by_id.py
+++ b/src/sentry/api/endpoints/organization_trace_items_by_id.py
@@ -1,0 +1,206 @@
+import logging
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import timedelta
+from typing import Any, Literal, Never
+
+import sentry_sdk
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp as ProtoTimestamp
+from rest_framework import serializers
+from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
+from rest_framework.response import Response
+from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import TraceItemDetailsRequest
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.endpoints.project_trace_item_details import (
+    convert_rpc_attribute_to_json,
+    serialize_item_id,
+)
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.search.eap import constants
+from sentry.search.eap.types import SupportedTraceItemType
+from sentry.snuba.referrer import Referrer
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+from sentry.utils.snuba_rpc import trace_item_details_rpc
+
+logger = logging.getLogger(__name__)
+
+# Generous window around the supplied timestamp to absorb clock skew and ingestion
+# lag. The lookup is keyed by item id, so a wide window only affects scan cost.
+_TIMESTAMP_BUFFER = timedelta(days=1)
+_MAX_ITEMS = 100
+
+_ItemStatus = Literal["found", "not_found", "error"]
+_ItemOutcome = tuple[_ItemStatus, dict[str, Any] | Exception | None]
+
+
+class _TraceItemSerializer(serializers.Serializer[Never]):
+    id = serializers.CharField(required=True)
+    traceId = serializers.UUIDField(format="hex", required=True)
+    projectId = serializers.IntegerField(required=True)
+    timestamp = serializers.DateTimeField(required=False)
+
+
+class _TraceItemsByIdSerializer(serializers.Serializer[Never]):
+    itemType = serializers.ChoiceField([e.value for e in SupportedTraceItemType], required=True)
+    columns = serializers.ListField(child=serializers.CharField(), required=True, allow_empty=False)
+    items = _TraceItemSerializer(many=True, required=True, allow_empty=False)
+    referrer = serializers.CharField(required=False)
+
+
+@cell_silo_endpoint
+class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.DATA_BROWSING
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+
+    def post(self, request: Request, organization: Organization) -> Response:
+        """Fetch specific trace items by id as exact point lookups.
+
+        Unlike a filtered table query, each id is resolved directly so a result
+        is never dropped by storage downsampling. Ids that don't resolve are
+        returned in `notFoundIds`, and ids whose lookup errored are returned in
+        `errorIds`, rather than omitted silently. A single failed lookup never
+        fails the whole batch.
+        """
+        serializer = _TraceItemsByIdSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        data = serializer.validated_data
+        item_type = SupportedTraceItemType(data["itemType"])
+        trace_item_type = constants.SUPPORTED_TRACE_ITEM_TYPE_MAP[item_type]
+        columns = data["columns"]
+        items = data["items"]
+        if len(items) > _MAX_ITEMS:
+            return Response(
+                {"detail": f"Cannot request more than {_MAX_ITEMS} items at once"}, status=400
+            )
+        referrer = data.get("referrer", Referrer.API_ORGANIZATION_TRACE_ITEMS_BY_ID.value)
+
+        project_ids = {item["projectId"] for item in items}
+        projects_by_id = {
+            project.id: project
+            for project in self.get_projects(request, organization, project_ids=project_ids)
+        }
+
+        include_internal = is_active_superuser(request) or is_active_staff(request)
+        include_arrays = features.has(
+            "organizations:trace-item-details-array-fields", organization, actor=request.user
+        )
+
+        requests_by_id = {
+            item["id"]: self._build_request(
+                organization, projects_by_id[item["projectId"]], trace_item_type, item, referrer
+            )
+            for item in items
+        }
+
+        outcomes = self._fetch(requests_by_id)
+
+        rows = []
+        not_found_ids = []
+        error_ids = []
+        sample_error: Exception | None = None
+        for item_id, (status, payload) in outcomes.items():
+            if status == "found" and isinstance(payload, dict):
+                rows.append(
+                    self._serialize_row(
+                        payload, item_type, columns, include_internal, include_arrays
+                    )
+                )
+            elif status == "not_found":
+                not_found_ids.append(item_id)
+            else:
+                error_ids.append(item_id)
+                if isinstance(payload, Exception):
+                    sample_error = payload
+
+        if error_ids:
+            logger.warning(
+                "trace_items_by_id.partial_failure",
+                extra={"errored_item_count": len(error_ids), "organization_id": organization.id},
+            )
+            if sample_error is not None:
+                sentry_sdk.capture_exception(sample_error)
+
+        return Response({"data": rows, "notFoundIds": not_found_ids, "errorIds": error_ids})
+
+    def _build_request(
+        self,
+        organization: Organization,
+        project: Project,
+        trace_item_type: TraceItemType.ValueType,
+        item: Mapping[str, Any],
+        referrer: str,
+    ) -> TraceItemDetailsRequest:
+        start = ProtoTimestamp()
+        end = ProtoTimestamp()
+        timestamp = item.get("timestamp")
+        if timestamp is not None:
+            start.FromDatetime(timestamp - _TIMESTAMP_BUFFER)
+            end.FromDatetime(timestamp + _TIMESTAMP_BUFFER)
+        else:
+            start.FromSeconds(0)
+            end.FromSeconds(int(time.time()) + 60 * 60 * 24 * 7)
+
+        return TraceItemDetailsRequest(
+            item_id=item["id"],
+            trace_id=item["traceId"].hex,
+            meta=RequestMeta(
+                organization_id=organization.id,
+                cogs_category="events_analytics_platform",
+                referrer=referrer,
+                project_ids=[project.id],
+                start_timestamp=start,
+                end_timestamp=end,
+                trace_item_type=trace_item_type,
+                request_id=str(uuid.uuid4()),
+            ),
+        )
+
+    def _fetch(
+        self, requests_by_id: Mapping[str, TraceItemDetailsRequest]
+    ) -> dict[str, _ItemOutcome]:
+        def run(req: TraceItemDetailsRequest) -> _ItemOutcome:
+            try:
+                return ("found", MessageToDict(trace_item_details_rpc(req)))
+            except NotFound:
+                return ("not_found", None)
+            except Exception as error:
+                return ("error", error)
+
+        item_ids = list(requests_by_id.keys())
+        with ContextPropagatingThreadPoolExecutor(max_workers=10) as pool:
+            results = pool.map(run, (requests_by_id[item_id] for item_id in item_ids))
+        return dict(zip(item_ids, results))
+
+    def _serialize_row(
+        self,
+        response: Mapping[str, Any],
+        item_type: SupportedTraceItemType,
+        fields: Sequence[str],
+        include_internal: bool,
+        include_arrays: bool,
+    ) -> dict[str, Any]:
+        attributes = convert_rpc_attribute_to_json(
+            response.get("attributes", []),
+            item_type,
+            include_internal=include_internal,
+            include_arrays=include_arrays,
+        )
+        values_by_name = {attribute["name"]: attribute["value"] for attribute in attributes}
+        values_by_name.setdefault("id", serialize_item_id(response["itemId"], item_type))
+        return {field: values_by_name.get(field) for field in fields}

--- a/src/sentry/api/endpoints/organization_trace_items_by_id.py
+++ b/src/sentry/api/endpoints/organization_trace_items_by_id.py
@@ -108,7 +108,13 @@ class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
             for item in items
         }
 
-        outcomes = self._fetch(requests_by_id)
+        outcomes = self._fetch(
+            requests_by_id,
+            item_type=item_type,
+            columns=columns,
+            include_internal=include_internal,
+            include_arrays=include_arrays,
+        )
 
         rows = []
         not_found_ids = []
@@ -116,11 +122,7 @@ class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
         sample_error: Exception | None = None
         for item_id, (status, payload) in outcomes.items():
             if status == "found" and isinstance(payload, dict):
-                rows.append(
-                    self._serialize_row(
-                        payload, item_type, columns, include_internal, include_arrays
-                    )
-                )
+                rows.append(payload)
             elif status == "not_found":
                 not_found_ids.append(item_id)
             else:
@@ -172,11 +174,23 @@ class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
         )
 
     def _fetch(
-        self, requests_by_id: Mapping[str, TraceItemDetailsRequest]
+        self,
+        requests_by_id: Mapping[str, TraceItemDetailsRequest],
+        *,
+        item_type: SupportedTraceItemType,
+        columns: Sequence[str],
+        include_internal: bool,
+        include_arrays: bool,
     ) -> dict[str, _ItemOutcome]:
         def run(req: TraceItemDetailsRequest) -> _ItemOutcome:
             try:
-                return ("found", MessageToDict(trace_item_details_rpc(req)))
+                response = MessageToDict(trace_item_details_rpc(req))
+                return (
+                    "found",
+                    self._serialize_row(
+                        response, item_type, columns, include_internal, include_arrays
+                    ),
+                )
             except NotFound:
                 return ("not_found", None)
             except Exception as error:

--- a/src/sentry/api/endpoints/organization_trace_items_by_id.py
+++ b/src/sentry/api/endpoints/organization_trace_items_by_id.py
@@ -19,11 +19,12 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.endpoints.project_trace_item_details import (
     convert_rpc_attribute_to_json,
     serialize_item_id,
 )
+from sentry.api.exceptions import BadRequest
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
 from sentry.models.organization import Organization
@@ -59,9 +60,15 @@ class _TraceItemsByIdSerializer(serializers.Serializer[Never]):
     referrer = serializers.CharField(required=False)
 
 
+class OrganizationTraceItemsByIdPermission(OrganizationPermission):
+    # POST here is a read; only org:read is required, not the default org:write.
+    scope_map = {"POST": ["org:read", "org:write", "org:admin"]}
+
+
 @cell_silo_endpoint
 class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
     owner = ApiOwner.DATA_BROWSING
+    permission_classes = (OrganizationTraceItemsByIdPermission,)
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
@@ -81,7 +88,9 @@ class OrganizationTraceItemsByIdEndpoint(OrganizationEndpoint):
 
         data = serializer.validated_data
         item_type = SupportedTraceItemType(data["itemType"])
-        trace_item_type = constants.SUPPORTED_TRACE_ITEM_TYPE_MAP[item_type]
+        trace_item_type = constants.SUPPORTED_TRACE_ITEM_TYPE_MAP.get(item_type)
+        if trace_item_type is None:
+            raise BadRequest(detail=f"Unsupported trace item type: {item_type.value}")
         columns = data["columns"]
         items = data["items"]
         if len(items) > _MAX_ITEMS:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -50,6 +50,9 @@ from sentry.api.endpoints.organization_trace_item_attributes_ranked import (
     OrganizationTraceItemsAttributesRankedEndpoint,
 )
 from sentry.api.endpoints.organization_trace_item_stats import OrganizationTraceItemsStatsEndpoint
+from sentry.api.endpoints.organization_trace_items_by_id import (
+    OrganizationTraceItemsByIdEndpoint,
+)
 from sentry.api.endpoints.organization_unsubscribe import (
     OrganizationUnsubscribeIssue,
     OrganizationUnsubscribeProject,
@@ -1736,6 +1739,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/stats/$",
         OrganizationTraceItemsStatsEndpoint.as_view(),
         name="sentry-api-0-organization-trace-item-stats",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/trace-items/by-id/$",
+        OrganizationTraceItemsByIdEndpoint.as_view(),
+        name="sentry-api-0-organization-trace-items-by-id",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/spans/fields/$",

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -437,6 +437,7 @@ class Referrer(StrEnum):
     API_METRICS_SERIES_SECOND_QUERY = "api.metrics.series.second_query"
 
     API_ORGANIZATION_TRACE_ITEM_DETAILS = "api.organization-trace-item-details"
+    API_ORGANIZATION_TRACE_ITEMS_BY_ID = "api.organization-trace-items-by-id"
     API_ORGANIZATION_EVENT_STATS_FIND_TOPN = "api.organization-event-stats.find-topn"
     API_ORGANIZATION_EVENT_STATS_METRICS_ENHANCED = "api.organization-event-stats.metrics-enhanced"
     API_ORGANIZATION_EVENT_STATS = "api.organization-event-stats"

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -380,6 +380,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/'
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/ranked/'
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/validate/'
+  | '/organizations/$organizationIdOrSlug/trace-items/by-id/'
   | '/organizations/$organizationIdOrSlug/trace-items/stats/'
   | '/organizations/$organizationIdOrSlug/trace-logs/'
   | '/organizations/$organizationIdOrSlug/trace-meta/$traceId/'

--- a/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
@@ -161,6 +161,25 @@ class OrganizationTraceItemsByIdEndpointTest(APITestCase, SnubaTestCase, OurLogT
         assert response.data["notFoundIds"] == []
         assert response.data["errorIds"] == [bad_id]
 
+    @mock.patch(
+        "sentry.api.endpoints.organization_trace_items_by_id.convert_rpc_attribute_to_json",
+        side_effect=Exception("malformed attribute"),
+    )
+    def test_routes_serialization_failures_to_error_ids(self, _mock: mock.MagicMock) -> None:
+        item_id = self.store_log("foo")
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message"],
+                "items": [self.item(item_id)],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+        assert response.data["errorIds"] == [item_id]
+
     def test_rejects_project_the_user_cannot_access(self) -> None:
         other_organization = self.create_organization()
         other_project = self.create_project(organization=other_organization)

--- a/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
@@ -180,6 +180,25 @@ class OrganizationTraceItemsByIdEndpointTest(APITestCase, SnubaTestCase, OurLogT
         assert response.data["data"] == []
         assert response.data["errorIds"] == [item_id]
 
+    def test_allows_org_read_member_since_post_is_a_read(self) -> None:
+        member = self.create_user()
+        self.create_member(
+            user=member, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(user=member)
+        item_id = self.store_log("foo")
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message"],
+                "items": [self.item(item_id)],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"id": item_id, "message": "foo"}]
+
     def test_rejects_project_the_user_cannot_access(self) -> None:
         other_organization = self.create_organization()
         other_project = self.create_project(organization=other_organization)
@@ -193,6 +212,17 @@ class OrganizationTraceItemsByIdEndpointTest(APITestCase, SnubaTestCase, OurLogT
         )
 
         assert response.status_code == 403, response.content
+
+    def test_rejects_item_type_without_a_supported_mapping(self) -> None:
+        response = self.do_request(
+            {
+                "itemType": "replays",
+                "columns": ["id"],
+                "items": [self.item(uuid.uuid4().hex)],
+            }
+        )
+
+        assert response.status_code == 400, response.content
 
     def test_rejects_request_with_no_items(self) -> None:
         response = self.do_request({"itemType": "logs", "columns": ["id"], "items": []})

--- a/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from unittest import mock
 
@@ -40,8 +41,9 @@ class OrganizationTraceItemsByIdEndpointTest(APITestCase, SnubaTestCase, OurLogT
         return result
 
     def do_request(self, data: dict):
+        query = {**data, "items": json.dumps(data["items"])}
         with self.feature({"organizations:discover-basic": True}):
-            return self.client.post(self.url, data, format="json")
+            return self.client.get(self.url, query)
 
     def test_returns_requested_columns_when_id_resolves(self) -> None:
         item_id = self.store_log("foo")
@@ -180,7 +182,7 @@ class OrganizationTraceItemsByIdEndpointTest(APITestCase, SnubaTestCase, OurLogT
         assert response.data["data"] == []
         assert response.data["errorIds"] == [item_id]
 
-    def test_allows_org_read_member_since_post_is_a_read(self) -> None:
+    def test_allows_org_read_member_since_get_is_a_read(self) -> None:
         member = self.create_user()
         self.create_member(
             user=member, organization=self.organization, role="member", teams=[self.team]

--- a/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_items_by_id.py
@@ -1,0 +1,188 @@
+import uuid
+from unittest import mock
+
+from django.urls import reverse
+
+from sentry.models.project import Project
+from sentry.testutils.cases import APITestCase, OurLogTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.snuba_rpc import trace_item_details_rpc
+
+
+class OrganizationTraceItemsByIdEndpointTest(APITestCase, SnubaTestCase, OurLogTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.one_min_ago = before_now(minutes=1)
+        self.trace_uuid = str(uuid.uuid4()).replace("-", "")
+        self.url = reverse(
+            "sentry-api-0-organization-trace-items-by-id",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    def store_log(self, body: str, project: Project | None = None) -> str:
+        log = self.create_ourlog(
+            {"body": body, "trace_id": self.trace_uuid},
+            project=project or self.project,
+            timestamp=self.one_min_ago,
+        )
+        self.store_eap_items([log])
+        return log.item_id.hex()
+
+    def item(self, item_id: str, project: Project | None = None, with_timestamp: bool = True):
+        result = {
+            "id": item_id,
+            "traceId": self.trace_uuid,
+            "projectId": (project or self.project).id,
+        }
+        if with_timestamp:
+            result["timestamp"] = self.one_min_ago.isoformat()
+        return result
+
+    def do_request(self, data: dict):
+        with self.feature({"organizations:discover-basic": True}):
+            return self.client.post(self.url, data, format="json")
+
+    def test_returns_requested_columns_when_id_resolves(self) -> None:
+        item_id = self.store_log("foo")
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message", "trace"],
+                "items": [self.item(item_id)],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["notFoundIds"] == []
+        assert response.data["errorIds"] == []
+        assert response.data["data"] == [
+            {"id": item_id, "message": "foo", "trace": self.trace_uuid}
+        ]
+
+    def test_resolves_logs_across_multiple_projects(self) -> None:
+        other_project = self.create_project(organization=self.organization)
+        item_id = self.store_log("foo")
+        other_item_id = self.store_log("bar", project=other_project)
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message"],
+                "items": [
+                    self.item(item_id),
+                    self.item(other_item_id, project=other_project),
+                ],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["notFoundIds"] == []
+        assert sorted(response.data["data"], key=lambda row: row["message"]) == [
+            {"id": other_item_id, "message": "bar"},
+            {"id": item_id, "message": "foo"},
+        ]
+
+    def test_resolves_without_timestamp_using_wide_window(self) -> None:
+        item_id = self.store_log("foo")
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message"],
+                "items": [self.item(item_id, with_timestamp=False)],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"id": item_id, "message": "foo"}]
+
+    def test_returns_unresolved_ids_in_not_found_when_id_is_missing(self) -> None:
+        item_id = self.store_log("foo")
+        missing_id = uuid.uuid4().hex
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message"],
+                "items": [self.item(item_id), self.item(missing_id)],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["notFoundIds"] == [missing_id]
+        assert response.data["errorIds"] == []
+        assert response.data["data"] == [{"id": item_id, "message": "foo"}]
+
+    @mock.patch(
+        "sentry.api.endpoints.organization_trace_items_by_id.trace_item_details_rpc",
+        side_effect=Exception("snuba is down"),
+    )
+    def test_returns_errored_ids_when_lookup_fails(self, _mock_rpc: mock.MagicMock) -> None:
+        item_id = self.store_log("foo")
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id", "message"],
+                "items": [self.item(item_id)],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == []
+        assert response.data["notFoundIds"] == []
+        assert response.data["errorIds"] == [item_id]
+
+    def test_returns_found_and_errored_ids_in_the_same_batch(self) -> None:
+        good_id = self.store_log("foo")
+        bad_id = self.store_log("bar")
+
+        def side_effect(req, *args, **kwargs):
+            if req.item_id == bad_id:
+                raise Exception("snuba is down")
+            return trace_item_details_rpc(req, *args, **kwargs)
+
+        with mock.patch(
+            "sentry.api.endpoints.organization_trace_items_by_id.trace_item_details_rpc",
+            side_effect=side_effect,
+        ):
+            response = self.do_request(
+                {
+                    "itemType": "logs",
+                    "columns": ["id", "message"],
+                    "items": [self.item(good_id), self.item(bad_id)],
+                }
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [{"id": good_id, "message": "foo"}]
+        assert response.data["notFoundIds"] == []
+        assert response.data["errorIds"] == [bad_id]
+
+    def test_rejects_project_the_user_cannot_access(self) -> None:
+        other_organization = self.create_organization()
+        other_project = self.create_project(organization=other_organization)
+
+        response = self.do_request(
+            {
+                "itemType": "logs",
+                "columns": ["id"],
+                "items": [self.item(uuid.uuid4().hex, project=other_project)],
+            }
+        )
+
+        assert response.status_code == 403, response.content
+
+    def test_rejects_request_with_no_items(self) -> None:
+        response = self.do_request({"itemType": "logs", "columns": ["id"], "items": []})
+
+        assert response.status_code == 400, response.content
+
+    def test_rejects_request_with_too_many_items(self) -> None:
+        items = [self.item(uuid.uuid4().hex) for _ in range(101)]
+
+        response = self.do_request({"itemType": "logs", "columns": ["id"], "items": items})
+
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
Adds `OrganizationTraceItemsByIdEndpoint` -> a POST `/organizations/{org}/trace-items/by-id/` that resolves specific trace items (logs, spans, etc.) by id. This is a general-purpose endpoint but really only has one use that I know of at the moment: finding specific pinned logs. 📌 

The motivation: fetching a known set of items through a filtered table query (`EndpointTraceItemTable`, e.g. `query=id:[...]`) is a sampled scan over a time window, so for high-volume orgs it can return a partial scan that silently drops rows that actually exist. A point lookup resolves each id directly and is never subject to downsampling, so it reliably returns the requested items with the selected columns.

Closes LOGS-904.