### PR TITLE
fix(dev): Symbolicator mode now depends on objectstore

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -199,7 +199,7 @@ x-sentry-service-config:
       [snuba, postgres, relay, taskbroker, spotlight, taskworker, taskworker-scheduler]
     backend-ci:
       [snuba, postgres, redis, bigtable, redis-cluster, symbolicator, objectstore]
-    symbolicator: [postgres, snuba, symbolicator, spotlight]
+    symbolicator: [postgres, snuba, symbolicator, spotlight, objectstore]
     memcached: [postgres, snuba, memcached, spotlight]
     tracing:
       [

--- a/src/sentry/testutils/pytest/relay.py
+++ b/src/sentry/testutils/pytest/relay.py
@@ -145,8 +145,8 @@ def relay_server(relay_server_setup, settings):
     # minidump/unreal endpoints resolve the project config synchronously before queueing.
     # The test project's config is never warm in Relay, so that fetch times out and Relay
     # rejects the upload with a 503 (ProjectUnavailable) -- the cause of the minidump test
-    # flakiness. These tests cover the ingestion pipeline, not the endpoint-fetch path
-    # (which also needs an objectstore the symbolicator mode doesn't run), so turn it off.
+    # flakiness. These tests cover the ingestion pipeline, not the endpoint-fetch path,
+    # so turn it off.
     # It is served to the test Relay via the upstream global config, hence the override
     # must wrap Relay startup.
     with override_options({"relay.endpoint-fetch-config.enabled": False}):


### PR DESCRIPTION
E2E Sentry Tests are now failing in the Relay Repo, probably also Symbolicator:

```
==================================== ERRORS ====================================
_____ ERROR at setup of BasicResolvingIntegrationTest.test_basic_resolving _____
src/sentry/testutils/skips.py:52: in _requires_objectstore
    pytest.fail(service_message)
E   Failed: requires 'objectstore' server running
E   	💡 Hint: run `devservices up --mode=objectstore`
_ ERROR at setup of BasicResolvingIntegrationTest.test_basic_resolving_objectstore _
src/sentry/testutils/skips.py:52: in _requires_objectstore
    pytest.fail(service_message)
E   Failed: requires 'objectstore' server running
E   	💡 Hint: run `devservices up --mode=objectstore`
___ ERROR at setup of BasicResolvingIntegrationTest.test_basic_source_lookup ___
src/sentry/testutils/skips.py:52: in _requires_objectstore
    pytest.fail(service_message)
```

This fixes the problem introduced in #118145.