### PR TITLE
ref(billing): Derive checkout categories on the frontend

### DIFF
--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -145,9 +145,20 @@ describe('ChangePlanAction', () => {
     await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '100,000');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Replays'}), '50');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Spans'}), '10,000,000');
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Uptime monitors'}), '1');
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Attachments (GB)'}),
       '1'
+    );
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Size analysis builds'}),
+      '100'
+    );
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Build distribution installs'}),
+      '-1'
     );
 
     expect(screen.getByText('Available Products')).toBeInTheDocument(); // will always show if any product is launched and available for an org
@@ -175,9 +186,20 @@ describe('ChangePlanAction', () => {
     await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '100,000');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Replays'}), '50');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Spans'}), '10,000,000');
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Uptime monitors'}), '1');
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Attachments (GB)'}),
       '1'
+    );
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Size analysis builds'}),
+      '100'
+    );
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Build distribution installs'}),
+      '-1'
     );
 
     // XXX: irl we would not have both versions of Seer available, but doing this for testing multiple addons
@@ -300,9 +322,23 @@ describe('ChangePlanAction', () => {
         screen.getByRole('textbox', {name: 'Spans'}),
         '10,000,000'
       );
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Uptime monitors'}),
+        '1'
+      );
       await selectEvent.select(
         screen.getByRole('textbox', {name: 'Attachments (GB)'}),
         '1'
+      );
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Size analysis builds'}),
+        '100'
+      );
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Build distribution installs'}),
+        '-1'
       );
 
       // Submit the form
@@ -341,9 +377,23 @@ describe('ChangePlanAction', () => {
         screen.getByRole('textbox', {name: 'Spans'}),
         '10,000,000'
       );
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Uptime monitors'}),
+        '1'
+      );
       await selectEvent.select(
         screen.getByRole('textbox', {name: 'Attachments (GB)'}),
         '1'
+      );
+      await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Size analysis builds'}),
+        '100'
+      );
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Build distribution installs'}),
+        '-1'
       );
 
       // Submit the form

--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -145,20 +145,9 @@ describe('ChangePlanAction', () => {
     await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '100,000');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Replays'}), '50');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Spans'}), '10,000,000');
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Uptime monitors'}), '1');
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Attachments (GB)'}),
       '1'
-    );
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
-    await selectEvent.select(
-      screen.getByRole('textbox', {name: 'Size analysis builds'}),
-      '100'
-    );
-    await selectEvent.select(
-      screen.getByRole('textbox', {name: 'Build distribution installs'}),
-      '-1'
     );
 
     expect(screen.getByText('Available Products')).toBeInTheDocument(); // will always show if any product is launched and available for an org
@@ -186,20 +175,9 @@ describe('ChangePlanAction', () => {
     await selectEvent.select(screen.getByRole('textbox', {name: 'Errors'}), '100,000');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Replays'}), '50');
     await selectEvent.select(screen.getByRole('textbox', {name: 'Spans'}), '10,000,000');
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Uptime monitors'}), '1');
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Attachments (GB)'}),
       '1'
-    );
-    await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
-    await selectEvent.select(
-      screen.getByRole('textbox', {name: 'Size analysis builds'}),
-      '100'
-    );
-    await selectEvent.select(
-      screen.getByRole('textbox', {name: 'Build distribution installs'}),
-      '-1'
     );
 
     // XXX: irl we would not have both versions of Seer available, but doing this for testing multiple addons
@@ -322,23 +300,9 @@ describe('ChangePlanAction', () => {
         screen.getByRole('textbox', {name: 'Spans'}),
         '10,000,000'
       );
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Uptime monitors'}),
-        '1'
-      );
       await selectEvent.select(
         screen.getByRole('textbox', {name: 'Attachments (GB)'}),
         '1'
-      );
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Size analysis builds'}),
-        '100'
-      );
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Build distribution installs'}),
-        '-1'
       );
 
       // Submit the form
@@ -377,23 +341,9 @@ describe('ChangePlanAction', () => {
         screen.getByRole('textbox', {name: 'Spans'}),
         '10,000,000'
       );
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Cron monitors'}), '1');
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Uptime monitors'}),
-        '1'
-      );
       await selectEvent.select(
         screen.getByRole('textbox', {name: 'Attachments (GB)'}),
         '1'
-      );
-      await selectEvent.select(screen.getByRole('textbox', {name: 'Logs (GB)'}), '5');
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Size analysis builds'}),
-        '100'
-      );
-      await selectEvent.select(
-        screen.getByRole('textbox', {name: 'Build distribution installs'}),
-        '-1'
       );
 
       // Submit the form

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -21,6 +21,7 @@ import {useApi} from 'sentry/utils/useApi';
 import {PlanList} from 'admin/components/planList';
 import {ANNUAL, BillingConfigTier, MONTHLY} from 'getsentry/constants';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
+import {isReservedBudgetCategory} from 'getsentry/utils/dataCategory';
 
 type Props = {
   onSuccess: () => void;
@@ -133,7 +134,8 @@ function ChangePlanAction({
     Object.entries(subscription.categories).forEach(([category, metricHistory]) => {
       if (
         metricHistory.reserved &&
-        plan.checkoutCategories.includes(category as DataCategory)
+        (plan.planCategories[category as DataCategory]?.length ?? 0) > 1 &&
+        !isReservedBudgetCategory(category as DataCategory, plan)
       ) {
         const closestTier = findClosestTier(
           plan,

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -21,7 +21,7 @@ import {useApi} from 'sentry/utils/useApi';
 import {PlanList} from 'admin/components/planList';
 import {ANNUAL, BillingConfigTier, MONTHLY} from 'getsentry/constants';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
-import {isReservedBudgetCategory} from 'getsentry/utils/dataCategory';
+import {isCheckoutCategory} from 'getsentry/utils/dataCategory';
 
 type Props = {
   onSuccess: () => void;
@@ -132,11 +132,7 @@ function ChangePlanAction({
     }
 
     Object.entries(subscription.categories).forEach(([category, metricHistory]) => {
-      if (
-        metricHistory.reserved &&
-        (plan.planCategories[category as DataCategory]?.length ?? 0) > 1 &&
-        !isReservedBudgetCategory(category as DataCategory, plan)
-      ) {
+      if (metricHistory.reserved && isCheckoutCategory(category as DataCategory, plan)) {
         const closestTier = findClosestTier(
           plan,
           category as DataCategory,

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -24,7 +24,7 @@ import {
 import {
   getPlanCategoryName,
   isByteCategory,
-  isReservedBudgetCategory,
+  isCheckoutCategory,
 } from 'getsentry/utils/dataCategory';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
@@ -140,11 +140,7 @@ export function PlanList({
           <StyledFormSection>
             <h4>Reserved Volumes</h4>
             {activePlan.categories
-              .filter(
-                category =>
-                  (activePlan.planCategories[category]?.length ?? 0) > 1 &&
-                  !isReservedBudgetCategory(category, activePlan)
-              )
+              .filter(category => isCheckoutCategory(category, activePlan))
               .map(category => {
                 const titleCategory = getPlanCategoryName({
                   plan: activePlan,

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -21,7 +21,11 @@ import {
   type Plan,
   type Subscription,
 } from 'getsentry/types';
-import {getPlanCategoryName, isByteCategory} from 'getsentry/utils/dataCategory';
+import {
+  getPlanCategoryName,
+  isByteCategory,
+  isReservedBudgetCategory,
+} from 'getsentry/utils/dataCategory';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
 type Props = {
@@ -135,39 +139,45 @@ export function PlanList({
         ).length > 1 && (
           <StyledFormSection>
             <h4>Reserved Volumes</h4>
-            {activePlan.checkoutCategories.map(category => {
-              const titleCategory = getPlanCategoryName({
-                plan: activePlan,
-                category,
-              });
-              const reservedKey = `reserved${toTitleCase(category, {
-                allowInnerUpperCase: true,
-              })}`;
-              const label = isByteCategory(category)
-                ? `${titleCategory} (GB)`
-                : titleCategory;
-              const fieldValue = formModel.getValue(reservedKey);
-              const currentValueDisplay = getCurrentValueDisplay(category);
-              return (
-                <Container position="relative" key={`test-${category}`}>
-                  <SelectField
-                    inline={false}
-                    stacked
-                    name={reservedKey}
-                    label={label}
-                    value={fieldValue}
-                    options={(activePlan.planCategories[category] || []).map(
-                      (level: {events: {toLocaleString: () => any}}) => ({
-                        label: level.events.toLocaleString(),
-                        value: level.events,
-                      })
-                    )}
-                    required
-                  />
-                  {currentValueDisplay}
-                </Container>
-              );
-            })}
+            {activePlan.categories
+              .filter(
+                category =>
+                  (activePlan.planCategories[category]?.length ?? 0) > 1 &&
+                  !isReservedBudgetCategory(category, activePlan)
+              )
+              .map(category => {
+                const titleCategory = getPlanCategoryName({
+                  plan: activePlan,
+                  category,
+                });
+                const reservedKey = `reserved${toTitleCase(category, {
+                  allowInnerUpperCase: true,
+                })}`;
+                const label = isByteCategory(category)
+                  ? `${titleCategory} (GB)`
+                  : titleCategory;
+                const fieldValue = formModel.getValue(reservedKey);
+                const currentValueDisplay = getCurrentValueDisplay(category);
+                return (
+                  <Container position="relative" key={`test-${category}`}>
+                    <SelectField
+                      inline={false}
+                      stacked
+                      name={reservedKey}
+                      label={label}
+                      value={fieldValue}
+                      options={(activePlan.planCategories[category] || []).map(
+                        (level: {events: {toLocaleString: () => any}}) => ({
+                          label: level.events.toLocaleString(),
+                          value: level.events,
+                        })
+                      )}
+                      required
+                    />
+                    {currentValueDisplay}
+                  </Container>
+                );
+              })}
           </StyledFormSection>
         )}
       {availableAddOns.length > 0 && (

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -3258,13 +3258,6 @@ describe('Gift Categories Availability', () => {
     organization,
     planDetails: {
       ...SubscriptionFixture({organization}).planDetails,
-      checkoutCategories: [
-        DataCategory.ERRORS,
-        DataCategory.REPLAYS,
-        DataCategory.SPANS,
-        DataCategory.SEER_AUTOFIX,
-        DataCategory.SEER_SCANNER,
-      ],
       onDemandCategories: [
         DataCategory.ERRORS,
         DataCategory.PROFILE_DURATION,

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -236,8 +236,8 @@ export function CustomerDetails() {
     if (!subscription?.planDetails) {
       return {};
     }
-    // We display all categories that are in either checkoutCategories or onDemandCategories,
-    // then disable the button if the category cannot be gifted to on this particular subscription (ie. unlimited quota).
+    // We display all plan categories that are giftable (have a freeEventsMultiple),
+    // then disable the button if the category cannot be gifted on this particular subscription (ie. unlimited quota).
     // Categories that are not giftable in any state for the subscription are excluded (ie. plan does not include category).
     return Object.fromEntries(
       subscription.planDetails.categories

--- a/static/gsApp/__fixtures__/plan.tsx
+++ b/static/gsApp/__fixtures__/plan.tsx
@@ -7,7 +7,6 @@ export function PlanFixture(fields: Partial<Plan>): Plan {
     basePrice: 0,
     billingInterval: 'monthly',
     categories: [],
-    checkoutCategories: [],
     availableReservedBudgetTypes: {},
     dashboardLimit: 10,
     metricDetectorLimit: 20,

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -158,7 +158,6 @@ export type Plan = {
    * Data categories on the plan (errors, transactions, etc.)
    */
   categories: DataCategory[];
-  checkoutCategories: DataCategory[];
   dashboardLimit: number;
   features: string[];
 

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -149,6 +149,21 @@ export function isReservedBudgetCategory(category: DataCategory, plan: Plan): bo
 }
 
 /**
+ * Whether a category is reservable in checkout — i.e. it has a real reserved
+ * tier (its first reserved bucket is a non-zero or unlimited amount, rather than
+ * a PAYG-only 0) and isn't billed through a reserved budget. Mirrors the
+ * server's is_checkout_category, and is the set shown in the admin reserved
+ * volume controls. Categories whose only reserved option is 0 (e.g. continuous
+ * profiling, Seer users) are excluded.
+ */
+export function isCheckoutCategory(category: DataCategory, plan: Plan): boolean {
+  return (
+    (plan.planCategories[category]?.[0]?.events ?? 0) !== 0 &&
+    !isReservedBudgetCategory(category, plan)
+  );
+}
+
+/**
  * Convert a list of reserved budget categories to a display name for the budget
  */
 export function getReservedBudgetDisplayName({

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -137,6 +137,18 @@ export function isPartOfReservedBudget(
 }
 
 /**
+ * Whether a category belongs to a reserved budget available on the plan (e.g.
+ * Seer's seerAutofix/seerScanner). Such categories are configured through their
+ * reserved budget rather than a per-category reserved-volume slider, so they are
+ * excluded from the checkout volume sliders.
+ */
+export function isReservedBudgetCategory(category: DataCategory, plan: Plan): boolean {
+  return Object.values(plan?.availableReservedBudgetTypes ?? {}).some(budgetInfo =>
+    budgetInfo.dataCategories.includes(category)
+  );
+}
+
+/**
  * Convert a list of reserved budget categories to a display name for the budget
  */
 export function getReservedBudgetDisplayName({

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -18,6 +18,7 @@ import {
   getPlanCategoryName,
   getSingularCategoryName,
   isByteCategory,
+  isReservedBudgetCategory,
 } from 'getsentry/utils/dataCategory';
 import {UnitTypeItem} from 'getsentry/views/amCheckout/components/unitTypeItem';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
@@ -78,10 +79,14 @@ export function VolumeSliders({
 
   return (
     <SlidersContainer>
-      {activePlan.checkoutCategories
+      {activePlan.categories
         .filter(
-          // only show sliders for checkout categories with more than 1 bucket
-          category => (activePlan.planCategories[category]?.length ?? 0) > 1
+          // Show sliders for categories with a multi-bucket reserved-volume
+          // schedule, excluding those configured via a reserved budget (e.g.
+          // Seer), which are set through the budget rather than a volume slider.
+          category =>
+            (activePlan.planCategories[category]?.length ?? 0) > 1 &&
+            !isReservedBudgetCategory(category, activePlan)
         )
         .map(category => {
           const allowedValues = activePlan.planCategories[category]?.map(

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import type {DataCategory} from 'sentry/types/core';
 
 import {isDeveloperPlan} from 'getsentry/utils/billing';
+import {isReservedBudgetCategory} from 'getsentry/utils/dataCategory';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 import {VolumeSliders} from 'getsentry/views/amCheckout/components/volumeSliders';
 import type {StepProps} from 'getsentry/views/amCheckout/types';
@@ -32,8 +33,8 @@ export function ReserveAdditionalVolume({
       : Object.values(subscription.categories ?? {})
           .filter(
             ({category}) =>
-              activePlan.checkoutCategories.includes(category) &&
-              category in activePlan.planCategories
+              (activePlan.planCategories[category]?.length ?? 0) > 1 &&
+              !isReservedBudgetCategory(category, activePlan)
           )
           .some(
             ({category, reserved}) =>

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -35,7 +35,7 @@ import {
   isBizPlanFamily,
   isTeamPlanFamily,
 } from 'getsentry/utils/billing';
-import {isReservedBudgetCategory} from 'getsentry/utils/dataCategory';
+import {isCheckoutCategory} from 'getsentry/utils/dataCategory';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
 import type {State as CheckoutState} from 'getsentry/views/amCheckout/';
@@ -349,9 +349,7 @@ function recordAnalytics(
   // Parse previous data and populate both flat and nested structures
   Object.entries(subscription.categories).forEach(([category, metricHistory]) => {
     if (
-      (subscription.planDetails.planCategories[category as DataCategory]?.length ?? 0) >
-        1 &&
-      !isReservedBudgetCategory(category as DataCategory, subscription.planDetails) &&
+      isCheckoutCategory(category as DataCategory, subscription.planDetails) &&
       metricHistory.reserved !== null &&
       metricHistory.reserved !== undefined
     ) {

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -35,6 +35,7 @@ import {
   isBizPlanFamily,
   isTeamPlanFamily,
 } from 'getsentry/utils/billing';
+import {isReservedBudgetCategory} from 'getsentry/utils/dataCategory';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
 import type {State as CheckoutState} from 'getsentry/views/amCheckout/';
@@ -348,7 +349,9 @@ function recordAnalytics(
   // Parse previous data and populate both flat and nested structures
   Object.entries(subscription.categories).forEach(([category, metricHistory]) => {
     if (
-      subscription.planDetails.checkoutCategories.includes(category as DataCategory) &&
+      (subscription.planDetails.planCategories[category as DataCategory]?.length ?? 0) >
+        1 &&
+      !isReservedBudgetCategory(category as DataCategory, subscription.planDetails) &&
       metricHistory.reserved !== null &&
       metricHistory.reserved !== undefined
     ) {

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -112,7 +112,6 @@ const commonFields = {
   addOnCategories: AM1_ADD_ON_CATEGORIES,
   categories: AM1_CATEGORIES,
   categoryDisplayNames: AM1_CATEGORY_DISPLAY_NAMES,
-  checkoutCategories: AM1_CHECKOUT_CATEGORIES,
   onDemandCategories: AM1_ONDEMAND_CATEGORIES,
   hasOnDemandModes: true,
   budgetTerm: BUDGET_TERM as 'on-demand',

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -122,7 +122,6 @@ const commonFields = {
   addOnCategories: AM2_ADD_ON_CATEGORIES,
   categories: AM2_CATEGORIES,
   categoryDisplayNames: AM2_CATEGORY_DISPLAY_NAMES,
-  checkoutCategories: AM2_CHECKOUT_CATEGORIES,
   onDemandCategories: AM2_ONDEMAND_CATEGORIES,
   hasOnDemandModes: true,
   budgetTerm: BUDGET_TERM as 'on-demand',

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -230,7 +230,6 @@ const commonFields = {
   addOnCategories: AM3_ADD_ON_CATEGORIES,
   categories: AM3_CATEGORIES,
   categoryDisplayNames: AM3_CATEGORY_DISPLAY_NAMES,
-  checkoutCategories: AM3_CHECKOUT_CATEGORIES,
   onDemandCategories: AM3_ONDEMAND_CATEGORIES,
   availableReservedBudgetTypes: AM3_AVAILABLE_RESERVED_BUDGET_TYPES, // TODO(isabella): default budgets for sponsored plans is different
   hasOnDemandModes: false,

--- a/tests/js/getsentry-test/fixtures/mm1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm1Plans.ts
@@ -14,7 +14,6 @@ const commonFields = {
   addOnCategories: {},
   categories: MM1_CATEGORIES,
   categoryDisplayNames: MM1_CATEGORY_DISPLAY_NAMES,
-  checkoutCategories: MM1_CATEGORIES,
   onDemandCategories: MM1_CATEGORIES,
   hasOnDemandModes: false,
   budgetTerm: BUDGET_TERM as 'on-demand',

--- a/tests/js/getsentry-test/fixtures/mm2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm2Plans.ts
@@ -17,7 +17,6 @@ const commonFields = {
   addOnCategories: {},
   categories: MM2_CATEGORIES,
   categoryDisplayNames: MM2_CATEGORY_DISPLAY_NAMES,
-  checkoutCategories: MM2_CATEGORIES,
   onDemandCategories: MM2_CATEGORIES,
   hasOnDemandModes: false,
   budgetTerm: BUDGET_TERM as 'on-demand',


### PR DESCRIPTION
The checkout and admin billing UI read planDetails.checkoutCategories to decide which categories expose a reserved-volume control. That list is intrinsic per-category information the client can derive itself, so the server field is redundant.

Derive the reservable-volume set from plan.categories, keeping only categories with a multi-bucket reserved schedule (planCategories length > 1) and excluding reserved-budget categories via a new
isReservedBudgetCategory helper (which reads availableReservedBudgetTypes). This drops the dependency on checkoutCategories in the volume sliders, the reserve-additional-volume step, checkout analytics, and the admin plan-change form.

Single-tier seat/byte categories, which only ever had one selectable reserved value, no longer appear in the admin reserved-volume controls or analytics; Seer stays excluded as a reserved budget.
