### PR TITLE
ref(spans): Separate legacy and span-first detectors for segments

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -299,6 +299,10 @@ def _create_models(
 def _detect_performance_problems(
     segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
 ) -> None:
+    # Killswitch for all segment-based issue detection
+    if not options.get("spans.process-segments.detect-performance-problems.enable"):
+        return
+
     try:
         # Run the legacy detectors and, if the `_performance_issues_spans` flag is set on the
         # segment span, produce occurrences from the results

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -28,7 +28,6 @@ from sentry.issue_detection.detectors.span_first.span_first_utils import (
 )
 from sentry.issue_detection.performance_detection import detect_performance_problems
 from sentry.issue_detection.performance_problem import PerformanceProblem
-from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.killswitches import killswitch_matches_context
@@ -344,11 +343,6 @@ def _run_legacy_detectors(
         event_data["timestamp"] = event_data["datetime"]
 
         for problem in detected_problems:
-            problem.type = PerformanceStreamedSpansGroupTypeExperimental
-            problem.fingerprint = (
-                f"{problem.fingerprint}-{PerformanceStreamedSpansGroupTypeExperimental.type_id}"
-            )
-
             occurrence = IssueOccurrence(
                 id=uuid.uuid4().hex,
                 resource_id=None,

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -308,33 +308,12 @@ def _detect_performance_problems(
         # If the legacy detectors error out, there's no point in running the experiment, so bail now
         return
 
-    if not options.get(SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION):
-        return
-
-    sampled_grouptypes = [
-        grouptype_slug
-        for grouptype_slug in SPAN_FIRST_DETECTORS_BY_GROUPTYPE
-        if SpanFirstDetectorsRolloutController.should_check_experiment(grouptype_slug)
-    ]
-    if not sampled_grouptypes:
-        return
-
     # Run the new span-first detectors and compare their results to those of the legacy detectors.
     # Note: Not all legacy detectors have span-first analogs yet. Results from those that don't are
     # just ignored in the comparison.
-    try:
-        span_first_problems_by_grouptype = run_span_first_detectors(
-            sampled_grouptypes, segment_span, spans, project
-        )
-        compare_span_first_problems_to_control_data(
-            span_first_problems_by_grouptype,
-            all_control_problems,
-            get_source_of_truth=lambda _: (
-                "control" if segment_span.get("_performance_issues_spans") else "neither"
-            ),
-        )
-    except Exception:
-        logger.exception("span_first_detector_test.error")
+    _maybe_run_span_first_detector_parity_check(
+        segment_span, spans, project, legacy_detected_problems
+    )
 
 
 def _run_legacy_detectors(
@@ -390,6 +369,39 @@ def _run_legacy_detectors(
             )
 
     return detected_problems
+
+
+def _maybe_run_span_first_detector_parity_check(
+    segment_span: CompatibleSpan,
+    segment: list[CompatibleSpan],
+    project: Project,
+    all_control_problems: list[PerformanceProblem],
+) -> None:
+    if not options.get(SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION):
+        return
+
+    sampled_grouptypes = [
+        grouptype_slug
+        for grouptype_slug in SPAN_FIRST_DETECTORS_BY_GROUPTYPE
+        if SpanFirstDetectorsRolloutController.should_check_experiment(grouptype_slug)
+    ]
+    if not sampled_grouptypes:
+        return
+
+    try:
+        span_first_problems_by_grouptype = run_span_first_detectors(
+            sampled_grouptypes, segment_span, segment, project
+        )
+
+        compare_span_first_problems_to_control_data(
+            span_first_problems_by_grouptype,
+            all_control_problems,
+            get_source_of_truth=lambda _: (
+                "control" if segment_span.get("_performance_issues_spans") else "neither"
+            ),
+        )
+    except Exception:
+        logger.exception("span_first_detector_test.error")
 
 
 @metrics.wraps("spans.consumers.process_segments.record_signals")

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -299,28 +299,24 @@ def _create_models(
 def _detect_performance_problems(
     segment_span: CompatibleSpan, spans: list[CompatibleSpan], project: Project
 ) -> None:
+    try:
+        # Run the legacy detectors and, if the `_performance_issues_spans` flag is set on the
+        # segment span, produce occurrences from the results
+        legacy_detected_problems = _run_legacy_detectors(segment_span, spans, project)
+    except Exception:
+        logger.exception("segment_consumer_legacy_issue_detectors.error")
+        # If the legacy detectors error out, there's no point in running the experiment, so bail now
+        return
+
     if not options.get(SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION):
         return
 
-    # Sample once per segment, up front: if no grouptypes are selected, neither the existing nor the
-    # span-first detectors will run.pipeline runs. Since for now the existing detection is only
-    # being run for the sake of comparison testing, gating it together with the experimental side
-    # avoids paying its cost on segments we won't compare.
     sampled_grouptypes = [
         grouptype_slug
         for grouptype_slug in SPAN_FIRST_DETECTORS_BY_GROUPTYPE
         if SpanFirstDetectorsRolloutController.should_check_experiment(grouptype_slug)
     ]
     if not sampled_grouptypes:
-        return
-
-    try:
-        # Run the legacy detectors and, if the `_performance_issues_spans` flag is set on the
-        # segment span, produce occurrences from the results
-        all_control_problems = _run_legacy_detectors(segment_span, spans, project)
-    except Exception:
-        logger.exception("segment_consumer_legacy_issue_detectors.error")
-        # If the legacy detectors error out, there's no point in running the experiment, so bail now
         return
 
     # Run the new span-first detectors and compare their results to those of the legacy detectors.

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -27,6 +27,7 @@ from sentry.issue_detection.detectors.span_first.span_first_utils import (
     SpanFirstDetectorsRolloutController,
 )
 from sentry.issue_detection.performance_detection import detect_performance_problems
+from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
@@ -314,13 +315,21 @@ def _detect_performance_problems(
         return
 
     try:
-        event_data = build_shim_event_data(segment_span, spans)
-        all_control_problems = detect_performance_problems(event_data, project, standalone=True)
+        # Run the legacy detectors and, if the `_performance_issues_spans` flag is set on the
+        # segment span, produce occurrences from the results
+        all_control_problems = _run_legacy_detectors(segment_span, spans, project)
+    except Exception:
+        logger.exception("segment_consumer_legacy_issue_detectors.error")
+        # If the legacy detectors error out, there's no point in running the experiment, so bail now
+        return
 
+    # Run the new span-first detectors and compare their results to those of the legacy detectors.
+    # Note: Not all legacy detectors have span-first analogs yet. Results from those that don't are
+    # just ignored in the comparison.
+    try:
         span_first_problems_by_grouptype = run_span_first_detectors(
             sampled_grouptypes, segment_span, spans, project
         )
-
         compare_span_first_problems_to_control_data(
             span_first_problems_by_grouptype,
             all_control_problems,
@@ -330,47 +339,61 @@ def _detect_performance_problems(
         )
     except Exception:
         logger.exception("span_first_detector_test.error")
-        return
 
-    # This flag is set in Relay (though at the moment it's not turned on)
-    if not segment_span.get("_performance_issues_spans"):
-        return
 
-    # Prepare a slimmer event payload for the occurrence consumer. This event
-    # will be persisted by the consumer. Once issue detectors can run on
-    # standalone spans, we should directly build a minimal occurrence event
-    # payload here, instead.
-    event_data["spans"] = []
-    event_data["timestamp"] = event_data["datetime"]
+def _run_legacy_detectors(
+    segment_span: CompatibleSpan, segment: list[CompatibleSpan], project: Project
+) -> list[PerformanceProblem]:
+    """
+    Run legacy issue detectors on segment data by first creating a fake transaction event. If the
+    `_performance_issues_spans` flag is set, also create occurrences from the results.
+    """
+    # Create a fake transaction event out of the segment data, to match what the legacy detectors
+    # are expecting
+    event_data = build_shim_event_data(segment_span, segment)
+    detected_problems = detect_performance_problems(event_data, project, standalone=True)
 
-    for problem in all_control_problems:
-        problem.type = PerformanceStreamedSpansGroupTypeExperimental
-        problem.fingerprint = (
-            f"{problem.fingerprint}-{PerformanceStreamedSpansGroupTypeExperimental.type_id}"
-        )
+    # This flag is set in Relay, and here enables producing occurrences from the legacy detector
+    # results. For segments derived from transactions, it additionally suppresses the running of
+    # legacy detectors in `save_transaction_events`, thus preventing duplicate occurrences from
+    # being created.
+    if segment_span.get("_performance_issues_spans"):
+        # Prepare a slimmer event payload for the occurrence consumer. This event will be persisted
+        # by the consumer. Once issue detectors can run on standalone spans, we should directly
+        # build a minimal occurrence event payload here, instead.
+        event_data["spans"] = []
+        event_data["timestamp"] = event_data["datetime"]
 
-        occurrence = IssueOccurrence(
-            id=uuid.uuid4().hex,
-            resource_id=None,
-            project_id=project.id,
-            event_id=event_data["event_id"],
-            fingerprint=[problem.fingerprint],
-            type=problem.type,
-            issue_title=problem.title,
-            subtitle=problem.desc,
-            culprit=event_data["transaction"],
-            evidence_data=problem.evidence_data or {},
-            evidence_display=problem.evidence_display,
-            detection_time=to_datetime(segment_span["end_timestamp"]),
-            level="info",
-        )
+        for problem in detected_problems:
+            problem.type = PerformanceStreamedSpansGroupTypeExperimental
+            problem.fingerprint = (
+                f"{problem.fingerprint}-{PerformanceStreamedSpansGroupTypeExperimental.type_id}"
+            )
 
-        produce_occurrence_to_kafka(
-            payload_type=PayloadType.OCCURRENCE,
-            occurrence=occurrence,
-            event_data=event_data,
-            is_buffered_spans=True,
-        )
+            occurrence = IssueOccurrence(
+                id=uuid.uuid4().hex,
+                resource_id=None,
+                project_id=project.id,
+                event_id=event_data["event_id"],
+                fingerprint=[problem.fingerprint],
+                type=problem.type,
+                issue_title=problem.title,
+                subtitle=problem.desc,
+                culprit=event_data["transaction"],
+                evidence_data=problem.evidence_data or {},
+                evidence_display=problem.evidence_display,
+                detection_time=to_datetime(segment_span["end_timestamp"]),
+                level="info",
+            )
+
+            produce_occurrence_to_kafka(
+                payload_type=PayloadType.OCCURRENCE,
+                occurrence=occurrence,
+                event_data=event_data,
+                is_buffered_spans=True,
+            )
+
+    return detected_problems
 
 
 @metrics.wraps("spans.consumers.process_segments.record_signals")

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -5,11 +5,7 @@ from unittest import mock
 
 import pytest
 
-from sentry.issue_detection.detectors.span_first.span_first_utils import (
-    SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION,
-    SpanFirstDetectorsRolloutController,
-)
-from sentry.issues.grouptype import PerformanceStreamedSpansGroupTypeExperimental
+from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
 from sentry.spans.consumers.process_segments import message as message_module
@@ -157,19 +153,11 @@ class TestSpansTask(TestCase):
             name="a" * 64,
         )
 
-    @override_options({SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True})
+    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     def test_n_plus_one_issue_detection(self, mock_eventstream: mock.MagicMock) -> None:
         spans = self.generate_n_plus_one_spans()
-        with (
-            mock.patch(
-                "sentry.issues.grouptype.PerformanceStreamedSpansGroupTypeExperimental.released",
-                return_value=True,
-            ),
-            mock.patch.object(
-                SpanFirstDetectorsRolloutController, "should_check_experiment", return_value=True
-            ),
-        ):
+        with mock.patch("sentry.issues.ingest.should_create_group", return_value=True):
             process_segment(spans)
 
         mock_eventstream.assert_called_once()
@@ -177,12 +165,12 @@ class TestSpansTask(TestCase):
         performance_problem = mock_eventstream.call_args[0][1]
         assert performance_problem.fingerprint == [
             md5(
-                b"1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67-1019"
+                b"1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67"
             ).hexdigest()
         ]
-        assert performance_problem.type == PerformanceStreamedSpansGroupTypeExperimental
+        assert performance_problem.type == PerformanceNPlusOneGroupType
 
-    @override_options({SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION: True})
+    @override_options({"spans.process-segments.detect-performance-problems.enable": True})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")
     @pytest.mark.xfail(reason="batches without segment spans are not supported yet")
     def test_n_plus_one_issue_detection_without_segment_span(
@@ -225,24 +213,16 @@ class TestSpansTask(TestCase):
         repeating_spans = [repeating_span() for _ in range(7)]
         spans = [segment_span, child_span, cause_span] + repeating_spans
 
-        with (
-            mock.patch(
-                "sentry.issues.grouptype.PerformanceStreamedSpansGroupTypeExperimental.released",
-                return_value=True,
-            ),
-            mock.patch.object(
-                SpanFirstDetectorsRolloutController, "should_check_experiment", return_value=True
-            ),
-        ):
+        with mock.patch("sentry.issues.ingest.should_create_group", return_value=True):
             process_segment(spans)
 
         performance_problem = mock_eventstream.call_args[0][1]
         assert performance_problem.fingerprint == [
             md5(
-                b"1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67-1019"
+                b"1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-f906d576ffde8f005fd741f7b9c8a35062361e67"
             ).hexdigest()
         ]
-        assert performance_problem.type == PerformanceStreamedSpansGroupTypeExperimental
+        assert performance_problem.type == PerformanceNPlusOneGroupType
 
     @mock.patch("sentry.spans.consumers.process_segments.message.track_outcome")
     @pytest.mark.skip("temporarily disabled")


### PR DESCRIPTION
As a step towards enabling the legacy issue detector shim in production (to make legacy detectors able to run on segments), this makes a few changes to our segment consumer issue detection logic.

- Because the original plan was only to run the shim as part of the parity check with the new span-first detectors, https://github.com/getsentry/sentry/pull/117631 removed the `spans.process-segments.detect-performance-problems.enable` flag, and tied the running of both legacy and span-first detectors to `SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION`. Now that we want to be able to run the legacy detectors with the shim for real, this PR reverses that, reviving the original flag as a killswitch for both sets of detectors, and making it so only the span-first ones are controlled by the span-first option. (This means that span-first detectors are subject to the legacy detector enablement, but if the legacy detectors are off, the span-first ones have nothing to which to compare their results, so there's no sense in running them.)

- Now that we're planning to run the two sets of detectors for different purposes, it made sense to pull all of the shim/legacy detector/occurrence creation logic together into one spot, and put the span-first logic together in another. This therefore pulls both operations into helper functions.

- Since we're going to have the detector call here take the place of the existing detector call, this removes the code switching the problem type to `PerformanceStreamedSpansGroupTypeExperimental`.