### PR TITLE
ref(discover): Refactor render* functions into their own components inside views/discover/results.tsx

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -760,7 +760,6 @@ export class Results extends Component<Props, State> {
                   dataset={hasDatasetSelectorFeature ? eventView.dataset : undefined}
                 />
               </Layout.Main>
-              {/* {showTags ? this.renderTagsTable() : null} */}\
               {showTags ? (
                 <TagsTable
                   confirmedQuery={confirmedQuery}

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -2,7 +2,7 @@ import {Component, Fragment, useCallback, useEffect, useMemo, useState} from 're
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {useQueryClient} from '@tanstack/react-query';
-import type {Location} from 'history';
+import type {Location, LocationDescriptor} from 'history';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
@@ -140,7 +140,6 @@ type State = {
   savedQueryDataset?: SavedQueryDatasets;
   showForcedDatasetAlert?: boolean;
   showQueryIncompatibleWithDataset?: boolean;
-  showTransactionsDeprecationAlert?: boolean;
   showUnparameterizedBanner?: boolean;
   splitDecision?: SavedQueryDatasets;
 };
@@ -206,7 +205,6 @@ export class Results extends Component<Props, State> {
     tips: [],
     showForcedDatasetAlert: true,
     showQueryIncompatibleWithDataset: false,
-    showTransactionsDeprecationAlert: true,
   };
 
   componentDidMount() {
@@ -605,196 +603,9 @@ export class Results extends Component<Props, State> {
     return generateTitle({eventView, isHomepage});
   }
 
-  renderTagsTable() {
-    const {organization, location} = this.props;
-    const {eventView, totalValues, confirmedQuery} = this.state;
-
-    return (
-      <Layout.Side>
-        <Tags
-          generateUrl={this.generateTagUrl}
-          totalValues={totalValues}
-          eventView={eventView}
-          organization={organization}
-          location={location}
-          confirmedQuery={confirmedQuery}
-        />
-      </Layout.Side>
-    );
-  }
-
-  generateTagUrl = (key: string, value: string) => {
-    const {organization, isHomepage} = this.props;
-    const {eventView, savedQueryDataset} = this.state;
-
-    const url = eventView.getResultsViewUrlTarget(
-      organization,
-      isHomepage,
-      hasDatasetSelector(organization) ? savedQueryDataset : undefined
-    );
-    url.query = generateQueryWithTag(url.query, {
-      key: formatTagKey(key),
-      value,
-    });
-    return url;
-  };
-
-  renderError(error: string) {
-    if (!error) {
-      return null;
-    }
-    return (
-      <Alert.Container>
-        <Alert variant="danger">{error}</Alert>
-      </Alert.Container>
-    );
-  }
-
   setError = (error: string, errorCode: number) => {
     this.setState({error, errorCode});
   };
-
-  renderMetricsFallbackBanner() {
-    if (this.state.showUnparameterizedBanner) {
-      return (
-        <Alert.Container>
-          <Alert variant="info">
-            {tct(
-              'These are unparameterized transactions. To better organize your transactions, [link:set transaction names manually].',
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/automatic-instrumentation/#beforenavigate" />
-                ),
-              }
-            )}
-          </Alert>
-        </Alert.Container>
-      );
-    }
-    return null;
-  }
-
-  renderQueryIncompatibleWithDatasetBanner() {
-    const {organization} = this.props;
-    if (hasDatasetSelector(organization) && this.state.showQueryIncompatibleWithDataset) {
-      return (
-        <Alert.Container>
-          <Alert
-            variant="warning"
-            trailingItems={
-              <StyledCloseButton
-                icon={<IconClose size="sm" />}
-                aria-label={t('Close')}
-                onClick={() => {
-                  this.setState({showQueryIncompatibleWithDataset: false});
-                }}
-                size="zero"
-                variant="transparent"
-              />
-            }
-          >
-            {t('Your query was updated to make it compatible with this dataset.')}
-          </Alert>
-        </Alert.Container>
-      );
-    }
-    return null;
-  }
-
-  renderTransactionsDatasetDeprecationBanner() {
-    const {savedQueryDataset, savedQuery} = this.state;
-    const {location, organization, selection} = this.props;
-    const dataset = getDatasetFromLocationOrSavedQueryDataset(
-      location,
-      savedQueryDataset
-    );
-
-    if (dataset === DiscoverDatasets.TRANSACTIONS && savedQuery?.exploreQuery) {
-      const exploreUrl = getExploreUrl({
-        organization,
-        ...savedQuery.exploreQuery?.query?.[0],
-        field: savedQuery.exploreQuery?.query?.[0].fields,
-        sort: savedQuery.exploreQuery?.query?.[0].orderby,
-        groupBy: savedQuery.exploreQuery?.query?.[0].groupby,
-        id: savedQuery.exploreQuery.id,
-        title: savedQuery.exploreQuery.name,
-        selection: {
-          projects: savedQuery.exploreQuery.projects ?? selection.projects,
-          environments: savedQuery.exploreQuery.environment ?? selection.environments,
-          datetime: {
-            start: savedQuery.exploreQuery.start ?? null,
-            end: savedQuery.exploreQuery.end ?? null,
-            period: savedQuery.exploreQuery.range ?? null,
-            utc: selection.datetime.utc ?? null,
-          },
-        },
-        interval: savedQuery.exploreQuery?.interval,
-        referrer: 'discover_v2.transactions_query_migration_banner',
-      });
-      return (
-        <Alert.Container>
-          <Alert variant="warning">
-            {tct(
-              'This query has been migrated to Explore, the fancy new UI that will soon replace Discover. Try it out in [explore:Explore] instead.',
-              {
-                explore: <Link to={exploreUrl} />,
-              }
-            )}
-          </Alert>
-        </Alert.Container>
-      );
-    }
-
-    if (
-      this.state.showTransactionsDeprecationAlert &&
-      organization.features.includes('performance-transaction-deprecation-banner') &&
-      dataset === DiscoverDatasets.TRANSACTIONS
-    ) {
-      return (
-        <Alert.Container>
-          <Alert
-            variant="warning"
-            trailingItems={
-              <StyledCloseButton
-                icon={<IconClose size="sm" />}
-                aria-label={t('Close')}
-                onClick={() => {
-                  this.setState({showTransactionsDeprecationAlert: false});
-                }}
-                size="zero"
-                variant="transparent"
-              />
-            }
-          >
-            {tctCode(
-              'The transactions dataset is being deprecated. Please use [traceLink:Explore / Traces] with the [code:is_transaction:true] filter instead. Please read these [FAQLink:FAQs] for more information.',
-              {
-                traceLink: <Link to="/explore/traces/?query=is_transaction:true" />,
-                FAQLink: (
-                  <ExternalLink href="https://www.sentry.help/en/articles/13964151-faq-transactions-spans-migration" />
-                ),
-              }
-            )}
-          </Alert>
-        </Alert.Container>
-      );
-    }
-    return null;
-  }
-
-  renderTips() {
-    const {tips} = this.state;
-    if (tips) {
-      return tips.map((tip, index) => (
-        <Alert.Container key={`tip-${index}`}>
-          <Alert variant="info" key={`tip-${index}`}>
-            <TipContainer as="span" text={tip} />
-          </Alert>
-        </Alert.Container>
-      ));
-    }
-    return null;
-  }
 
   setTips = (tips: string[]) => {
     // If there are currently no tips set and the new tips are empty, do nothing
@@ -817,38 +628,6 @@ export class Results extends Component<Props, State> {
     });
   };
 
-  renderSearchBar(customMeasurements: CustomMeasurementCollection | undefined) {
-    const {organization} = this.props;
-    const {eventView} = this.state;
-    const fields = eventView.hasAggregateField()
-      ? generateAggregateFields(organization, eventView.fields)
-      : eventView.fields;
-
-    let savedSearchType: SavedSearchType | undefined = SavedSearchType.EVENT;
-    if (hasDatasetSelector(organization)) {
-      savedSearchType =
-        eventView.dataset === DiscoverDatasets.TRANSACTIONS
-          ? SavedSearchType.TRANSACTION
-          : SavedSearchType.ERROR;
-    }
-
-    return (
-      <Wrapper>
-        <ResultsSearchQueryBuilder
-          projectIds={eventView.project}
-          query={eventView.query}
-          fields={fields}
-          onSearch={this.handleSearch}
-          customMeasurements={customMeasurements}
-          dataset={eventView.dataset}
-          enableAISearch
-          includeTransactions
-          recentSearches={savedSearchType}
-        />
-      </Wrapper>
-    );
-  }
-
   render() {
     const {organization, location, selection, api, setSavedQuery, isHomepage} =
       this.props;
@@ -860,8 +639,11 @@ export class Results extends Component<Props, State> {
       showTags,
       confirmedQuery,
       savedQuery,
-      splitDecision,
       savedQueryDataset,
+      showQueryIncompatibleWithDataset,
+      showUnparameterizedBanner,
+      splitDecision,
+      tips,
     } = this.state;
     const hasDatasetSelectorFeature = hasDatasetSelector(organization);
 
@@ -889,11 +671,28 @@ export class Results extends Component<Props, State> {
           <Layout.Body>
             <CustomMeasurementsProvider organization={organization} selection={selection}>
               <Top width="full">
-                {this.renderMetricsFallbackBanner()}
-                {this.renderError(error)}
-                {this.renderTips()}
-                {this.renderQueryIncompatibleWithDatasetBanner()}
-                {this.renderTransactionsDatasetDeprecationBanner()}
+                {showUnparameterizedBanner ? <MetricsFallbackBanner /> : null}
+                {error ? (
+                  <Alert.Container>
+                    <Alert variant="danger">{error}</Alert>
+                  </Alert.Container>
+                ) : null}
+                <Tips tips={tips} />
+                {hasDatasetSelectorFeature && showQueryIncompatibleWithDataset ? (
+                  <QueryIncompatibleWithDatasetBanner
+                    onClick={() =>
+                      this.setState({showQueryIncompatibleWithDataset: false})
+                    }
+                  />
+                ) : null}
+                <TransactionsDatasetDeprecationBanner
+                  location={location}
+                  organization={organization}
+                  savedQuery={savedQuery}
+                  savedQueryDataset={savedQueryDataset}
+                  selection={selection}
+                />
+
                 {!hasDatasetSelectorFeature && <SampleDataAlert query={query} />}
 
                 <DiscoverPageFilters
@@ -907,9 +706,14 @@ export class Results extends Component<Props, State> {
                   errorCode={errorCode}
                 />
                 <CustomMeasurementsContext.Consumer>
-                  {contextValue =>
-                    this.renderSearchBar(contextValue?.customMeasurements ?? undefined)
-                  }
+                  {contextValue => (
+                    <SearchBar
+                      organization={organization}
+                      eventView={eventView}
+                      handleSearch={this.handleSearch}
+                      customMeasurements={contextValue?.customMeasurements ?? undefined}
+                    />
+                  )}
                 </CustomMeasurementsContext.Consumer>
                 <MetricsCardinalityProvider
                   organization={organization}
@@ -956,7 +760,18 @@ export class Results extends Component<Props, State> {
                   dataset={hasDatasetSelectorFeature ? eventView.dataset : undefined}
                 />
               </Layout.Main>
-              {showTags ? this.renderTagsTable() : null}
+              {/* {showTags ? this.renderTagsTable() : null} */}\
+              {showTags ? (
+                <TagsTable
+                  confirmedQuery={confirmedQuery}
+                  eventView={eventView}
+                  isHomepage={isHomepage}
+                  location={location}
+                  organization={organization}
+                  savedQueryDataset={savedQueryDataset}
+                  totalValues={totalValues}
+                />
+              ) : null}
               <Confirm
                 priority="primary"
                 header={<strong>{t('May lead to thumb twiddling')}</strong>}
@@ -987,6 +802,229 @@ export class Results extends Component<Props, State> {
       </SentryDocumentTitle>
     );
   }
+}
+
+function MetricsFallbackBanner() {
+  return (
+    <Alert.Container>
+      <Alert variant="info">
+        {tct(
+          'These are unparameterized transactions. To better organize your transactions, [link:set transaction names manually].',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/tracing/instrumentation/automatic-instrumentation/#beforenavigate" />
+            ),
+          }
+        )}
+      </Alert>
+    </Alert.Container>
+  );
+}
+
+function Tips({tips}: {tips: string[]}) {
+  return tips.map((tip, index) => (
+    <Alert.Container key={`tip-${index}`}>
+      <Alert variant="info" key={`tip-${index}`}>
+        <TipContainer as="span" text={tip} />
+      </Alert>
+    </Alert.Container>
+  ));
+}
+
+function QueryIncompatibleWithDatasetBanner({onClick}: {onClick: () => void}) {
+  return (
+    <Alert.Container>
+      <Alert
+        variant="warning"
+        trailingItems={
+          <StyledCloseButton
+            icon={<IconClose size="sm" />}
+            aria-label={t('Close')}
+            onClick={onClick}
+            size="zero"
+            variant="transparent"
+          />
+        }
+      >
+        {t('Your query was updated to make it compatible with this dataset.')}
+      </Alert>
+    </Alert.Container>
+  );
+}
+
+function TransactionsDatasetDeprecationBanner({
+  location,
+  organization,
+  savedQuery,
+  savedQueryDataset,
+  selection,
+}: {
+  location: Location;
+  organization: Organization;
+  savedQuery: SavedQuery | undefined;
+  savedQueryDataset: SavedQueryDatasets | undefined;
+  selection: PageFilters;
+}) {
+  const [showAlert, setShowAlert] = useState(true);
+
+  const dataset = getDatasetFromLocationOrSavedQueryDataset(location, savedQueryDataset);
+
+  if (dataset === DiscoverDatasets.TRANSACTIONS && savedQuery?.exploreQuery) {
+    const exploreUrl = getExploreUrl({
+      organization,
+      ...savedQuery.exploreQuery?.query?.[0],
+      field: savedQuery.exploreQuery?.query?.[0].fields,
+      sort: savedQuery.exploreQuery?.query?.[0].orderby,
+      groupBy: savedQuery.exploreQuery?.query?.[0].groupby,
+      id: savedQuery.exploreQuery.id,
+      title: savedQuery.exploreQuery.name,
+      selection: {
+        projects: savedQuery.exploreQuery.projects ?? selection.projects,
+        environments: savedQuery.exploreQuery.environment ?? selection.environments,
+        datetime: {
+          start: savedQuery.exploreQuery.start ?? null,
+          end: savedQuery.exploreQuery.end ?? null,
+          period: savedQuery.exploreQuery.range ?? null,
+          utc: selection.datetime.utc ?? null,
+        },
+      },
+      interval: savedQuery.exploreQuery?.interval,
+      referrer: 'discover_v2.transactions_query_migration_banner',
+    });
+    return (
+      <Alert.Container>
+        <Alert variant="warning">
+          {tct(
+            'This query has been migrated to Explore, the fancy new UI that will soon replace Discover. Try it out in [explore:Explore] instead.',
+            {
+              explore: <Link to={exploreUrl} />,
+            }
+          )}
+        </Alert>
+      </Alert.Container>
+    );
+  }
+
+  if (
+    showAlert &&
+    organization.features.includes('performance-transaction-deprecation-banner') &&
+    dataset === DiscoverDatasets.TRANSACTIONS
+  ) {
+    return (
+      <Alert.Container>
+        <Alert
+          variant="warning"
+          trailingItems={
+            <StyledCloseButton
+              icon={<IconClose size="sm" />}
+              aria-label={t('Close')}
+              onClick={() => setShowAlert(false)}
+              size="zero"
+              variant="transparent"
+            />
+          }
+        >
+          {tctCode(
+            'The transactions dataset is being deprecated. Please use [traceLink:Explore / Traces] with the [code:is_transaction:true] filter instead. Please read these [FAQLink:FAQs] for more information.',
+            {
+              traceLink: <Link to="/explore/traces/?query=is_transaction:true" />,
+              FAQLink: (
+                <ExternalLink href="https://www.sentry.help/en/articles/13964151-faq-transactions-spans-migration" />
+              ),
+            }
+          )}
+        </Alert>
+      </Alert.Container>
+    );
+  }
+  return null;
+}
+
+function SearchBar({
+  customMeasurements,
+  eventView,
+  handleSearch,
+  organization,
+}: {
+  customMeasurements: CustomMeasurementCollection | undefined;
+  eventView: EventView;
+  handleSearch: (query: string) => void;
+  organization: Organization;
+}) {
+  const fields = eventView.hasAggregateField()
+    ? generateAggregateFields(organization, eventView.fields)
+    : eventView.fields;
+
+  let savedSearchType: SavedSearchType | undefined = SavedSearchType.EVENT;
+  if (hasDatasetSelector(organization)) {
+    savedSearchType =
+      eventView.dataset === DiscoverDatasets.TRANSACTIONS
+        ? SavedSearchType.TRANSACTION
+        : SavedSearchType.ERROR;
+  }
+
+  return (
+    <Wrapper>
+      <ResultsSearchQueryBuilder
+        projectIds={eventView.project}
+        query={eventView.query}
+        fields={fields}
+        onSearch={handleSearch}
+        customMeasurements={customMeasurements}
+        dataset={eventView.dataset}
+        enableAISearch
+        includeTransactions
+        recentSearches={savedSearchType}
+      />
+    </Wrapper>
+  );
+}
+
+function TagsTable({
+  confirmedQuery,
+  eventView,
+  isHomepage,
+  location,
+  organization,
+  savedQueryDataset,
+  totalValues,
+}: {
+  confirmedQuery: boolean;
+  eventView: EventView;
+  isHomepage: boolean | undefined;
+  location: Location;
+  organization: Organization;
+  savedQueryDataset: SavedQueryDatasets | undefined;
+  totalValues: number | null;
+}) {
+  const generateTagUrl = useCallback(
+    (key: string, value: string): LocationDescriptor => {
+      const url = eventView.getResultsViewUrlTarget(
+        organization,
+        isHomepage,
+        hasDatasetSelector(organization) ? savedQueryDataset : undefined
+      );
+      url.query = generateQueryWithTag(url.query, {
+        key: formatTagKey(key),
+        value,
+      });
+      return url;
+    },
+    [eventView, organization, isHomepage, savedQueryDataset]
+  );
+
+  return (
+    <Layout.Side>
+      <Tags
+        generateUrl={generateTagUrl}
+        totalValues={totalValues}
+        eventView={eventView}
+        organization={organization}
+        location={location}
+        confirmedQuery={confirmedQuery}
+      />
+    </Layout.Side>
+  );
 }
 
 function DiscoverContextMenu({


### PR DESCRIPTION
By pulling out the render functions i hope to slim down the actual class component and make the next move easier. 
