### PR TITLE
ci(file-filters): exclude .generated files from frontend_all label filter

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -43,7 +43,7 @@ mdx_typecheckable: &mdx_typecheckable
 frontend_all: &frontend_all
   - *sentry_frontend_workflow_file
   - *sentry_frontend_snapshots_workflow_file
-  - added|modified: '**/*.{ts,tsx,js,jsx,mjs}'
+  - added|modified: '**/!(*.generated).{ts,tsx,js,jsx,mjs}'
   - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
   - added|modified: '{vercel,tsconfig,biome,package}.json'
 


### PR DESCRIPTION
## Problem

When a backend-only PR adds a new API endpoint, `getsentry[bot]` automatically commits `static/app/utils/api/knownSentryApiUrls.generated.ts` to sync the URL types. This auto-commit triggers the `frontend_all` path filter, which then:
1. Labels the PR `Scope: Frontend`
2. Posts the 🚨 "Warning: This pull request contains Frontend and Backend changes!" comment

The PR author only touched backend code — the frontend file was machine-generated, not a human frontend change.

## Fix

Exclude `*.generated.*` files from the `frontend_all` filter by using the same negation pattern that `testable_modified` already uses:

```diff
- added|modified: '**/*.{ts,tsx,js,jsx,mjs}'
+ added|modified: '**/!(*.generated).{ts,tsx,js,jsx,mjs}'
```

This is a one-char-class addition; no other logic changes.

Refs #118782

<!-- junior-session-footer:start -->

[View Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC8V02RHC7%3A1782853648.047889/?project=4510944073809921)

<!-- junior-session-footer:end -->