### PR TITLE
ref(sentry-apps): add types to webhook event types

### DIFF
--- a/src/sentry/sentry_apps/logic.py
+++ b/src/sentry/sentry_apps/logic.py
@@ -80,7 +80,7 @@ def expand_events(rolled_up_events: list[str]) -> list[str]:
     Can also be given a list of event types (e.g. ['issue.created', 'issue.resolved'])
     """
 
-    expanded_events = []
+    expanded_events: list[str] = []
     for event in rolled_up_events:
         if event in EVENT_EXPANSION:
             expanded_events.extend(EVENT_EXPANSION.get(SentryAppResourceType(event), [event]))

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final
 
+from sentry.sentry_apps.event_types import SentryAppEventType
+
 if TYPE_CHECKING:
     from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 
@@ -67,16 +69,6 @@ class PreprodArtifactActionType(SentryAppActionType):
 
 
 class SentryAppResourceType(StrEnum):
-    @staticmethod
-    def map_sentry_app_webhook_events(
-        resource: str, action_type: type[SentryAppActionType]
-    ) -> list[str]:
-        # Turn resource + action into webhook event e.g issue.created, issue.resolved, etc.
-        webhook_events = [
-            f"{resource}.{action.value}" for action in action_type._member_map_.values()
-        ]
-        return webhook_events
-
     ISSUE = "issue"
     ERROR = "error"
     COMMENT = "comment"
@@ -91,24 +83,37 @@ class SentryAppResourceType(StrEnum):
 
 
 # When a developer selects to receive "<Resource> Webhooks" it really means
-# listening to a list of specific events. This is a mapping of what those
-# specific events are for each resource.
-EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[str]]] = {
-    SentryAppResourceType.ISSUE: SentryAppResourceType.map_sentry_app_webhook_events(
-        SentryAppResourceType.ISSUE.value, IssueActionType
-    ),
-    SentryAppResourceType.ERROR: SentryAppResourceType.map_sentry_app_webhook_events(
-        SentryAppResourceType.ERROR.value, ErrorActionType
-    ),
-    SentryAppResourceType.COMMENT: SentryAppResourceType.map_sentry_app_webhook_events(
-        SentryAppResourceType.COMMENT.value, CommentActionType
-    ),
-    SentryAppResourceType.SEER: SentryAppResourceType.map_sentry_app_webhook_events(
-        SentryAppResourceType.SEER.value, SeerActionType
-    ),
-    SentryAppResourceType.PREPROD_ARTIFACT: SentryAppResourceType.map_sentry_app_webhook_events(
-        SentryAppResourceType.PREPROD_ARTIFACT.value, PreprodArtifactActionType
-    ),
+# listening to a list of specific events. This maps each resource to those
+# events, referencing SentryAppEventType as the single source of event tokens.
+EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[SentryAppEventType]]] = {
+    SentryAppResourceType.ISSUE: [
+        SentryAppEventType.ISSUE_ASSIGNED,
+        SentryAppEventType.ISSUE_CREATED,
+        SentryAppEventType.ISSUE_IGNORED,
+        SentryAppEventType.ISSUE_RESOLVED,
+        SentryAppEventType.ISSUE_UNRESOLVED,
+    ],
+    SentryAppResourceType.ERROR: [SentryAppEventType.ERROR_CREATED],
+    SentryAppResourceType.COMMENT: [
+        SentryAppEventType.COMMENT_CREATED,
+        SentryAppEventType.COMMENT_DELETED,
+        SentryAppEventType.COMMENT_UPDATED,
+    ],
+    SentryAppResourceType.SEER: [
+        SentryAppEventType.SEER_ROOT_CAUSE_STARTED,
+        SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED,
+        SentryAppEventType.SEER_SOLUTION_STARTED,
+        SentryAppEventType.SEER_SOLUTION_COMPLETED,
+        SentryAppEventType.SEER_CODING_STARTED,
+        SentryAppEventType.SEER_CODING_COMPLETED,
+        SentryAppEventType.SEER_PR_CREATED,
+        SentryAppEventType.SEER_ITERATION_STARTED,
+        SentryAppEventType.SEER_ITERATION_COMPLETED,
+    ],
+    SentryAppResourceType.PREPROD_ARTIFACT: [
+        SentryAppEventType.PREPROD_ARTIFACT_SIZE_ANALYSIS_COMPLETED,
+        SentryAppEventType.PREPROD_ARTIFACT_BUILD_DISTRIBUTION_COMPLETED,
+    ],
 }
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not
 # per-event-type (issue.created, project.deleted, etc.). These are valid


### PR DESCRIPTION
Explicitly construct the mapping of resource -> event webhooks. This helps set up https://github.com/getsentry/sentry/pull/118923.

Refs https://linear.app/getsentry/issue/ISWF-2965/more-granular-controls-for-internal-integration-webhook-events