### PR TITLE
ci: Exclude API URL codegen from frontend/backend warning

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -38,6 +38,9 @@ frontend_all: &frontend_all
   - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
   - added|modified: '{vercel,tsconfig,biome,package}.json'
 
+api_url_codegen:
+  - added|modified: 'static/app/utils/api/knownSentryApiUrls.generated.ts'
+
 # Also used in `getsentry-dispatch.yml` to dispatch backend tests on getsentry
 backend_dependencies: &backend_dependencies
   - 'requirements-*.txt'

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Add frontend/backend warning comment
         uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
         if: >
-          steps.changes.outputs.frontend_all == 'true' &&
+          fromJSON(steps.changes.outputs.frontend_all_count) >
+          fromJSON(steps.changes.outputs.api_url_codegen_count) &&
           steps.changes.outputs.backend_src == 'true' &&
           steps.fc.outputs.comment-id == 0
         with:


### PR DESCRIPTION
Backend-only PRs no longer receive the frontend/backend deployment warning when `knownSentryApiUrls.generated.ts` is their only frontend change. The generated file still counts toward existing frontend labels and checks.

The warning compares the total frontend file count with the API URL codegen file count, so it still appears when a PR changes any other frontend file.

Refs #118782