### PR TITLE
chore(weekly-report): Add transaction to prepare_organization_report

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -185,7 +185,7 @@ def prepare_organization_report(
         name="weekly_reports.prepare_organization_report",
         op="weekly_reports.prepare_organization_report",
         transaction=True,
-        custom_sampling_context={"sample_rate": 0.1},
+        custom_sampling_context={"sample_rate": 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING},
     ) as span:
         batch_id = str(batch_id)
         if email_override and not isinstance(target_user, int):

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -15,7 +15,6 @@ from django.conf import settings
 from django.db.models import F
 from django.utils import dateformat, timezone
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
-from sentry_sdk import set_tag
 from taskbroker_client.retry import Retry
 from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
@@ -47,7 +46,7 @@ from sentry.utils.dates import floor_to_utc_day, to_datetime
 from sentry.utils.email import MessageBuilder
 from sentry.utils.email.sanitize import sanitize_outbound_name
 from sentry.utils.query import RangeQuerySetWrapper
-from sentry.utils.tracing import start_span
+from sentry.utils.tracing import set_span_tag, start_span
 
 date_format = partial(dateformat.format, format_string="F jS, Y")
 
@@ -182,73 +181,80 @@ def prepare_organization_report(
     target_user: int | None = None,
     email_override: str | None = None,
 ):
-    batch_id = str(batch_id)
-    if email_override and not isinstance(target_user, int):
-        logger.error(
-            "Target user must have an ID",
-            extra={
-                "batch_id": str(batch_id),
-                "organization": organization_id,
-                "target_user": target_user,
-                "email_override": email_override,
-            },
-        )
-        return
-    organization = Organization.objects.get(id=organization_id)
-    set_tag("org.slug", organization.slug)
-    sentry_sdk.set_attribute("org.slug", organization.slug)
-    set_tag("org.id", organization_id)
-    sentry_sdk.set_attribute("org.id", organization_id)
-    with WeeklyReportSLO(
-        operation_type=WeeklyReportOperationType.PREPARE_ORGANIZATION_REPORT, dry_run=dry_run
-    ).capture() as lifecycle:
-        lifecycle.add_extras(
-            {
-                "batch_id": batch_id,
-                "organization_id": organization_id,
-                "timestamp": timestamp,
-                "duration": duration,
-            }
-        )
-        ctx = OrganizationReportContextFactory(
-            timestamp=timestamp, duration=duration, organization=organization
-        ).create_context()
-
-        with start_span(
-            op="weekly_reports.check_if_ctx_is_empty", name="weekly_reports.check_if_ctx_is_empty"
-        ):
-            report_is_available = not ctx.is_empty()
-        set_tag("report.available", report_is_available)
-        sentry_sdk.set_attribute("report.available", report_is_available)
-
-        if not report_is_available:
-            lifecycle.record_halt(WeeklyReportHaltReason.EMPTY_REPORT)
+    with start_span(
+        name="weekly_reports.prepare_organization_report",
+        op="weekly_reports.prepare_organization_report",
+        transaction=True,
+        custom_sampling_context={"sample_rate": 0.1},
+    ) as span:
+        batch_id = str(batch_id)
+        if email_override and not isinstance(target_user, int):
+            logger.error(
+                "Target user must have an ID",
+                extra={
+                    "batch_id": str(batch_id),
+                    "organization": organization_id,
+                    "target_user": target_user,
+                    "email_override": email_override,
+                },
+            )
             return
-
-    # Deliver the reports
-    batch = OrganizationReportBatch(ctx, batch_id, dry_run, target_user, email_override)
-    with start_span(op="weekly_reports.deliver_reports", name="weekly_reports.deliver_reports"):
-        logger.info(
-            "weekly_reports.deliver_reports",
-            extra={"batch_id": str(batch_id), "organization": organization_id},
-        )
-        with metrics.timer("weekly_report.deliver_reports.duration"):
-            batch.deliver_reports()
-
-    # Cache after delivery so a failed attempt doesn't poison the
-    # previous-week lookup on retry.
-    if not dry_run:
-        try:
-            project_metrics: dict[int, dict[str, int]] = {}
-            for project_id, project_ctx in ctx.projects_context_map.items():
-                project_metrics[project_id] = {
-                    "e": project_ctx.accepted_error_count,
-                    "t": project_ctx.accepted_transaction_count,
+        organization = Organization.objects.get(id=organization_id)
+        set_span_tag(span, "org.slug", organization.slug)
+        sentry_sdk.set_attribute("org.slug", organization.slug)
+        set_span_tag(span, "org.id", organization_id)
+        sentry_sdk.set_attribute("org.id", organization_id)
+        with WeeklyReportSLO(
+            operation_type=WeeklyReportOperationType.PREPARE_ORGANIZATION_REPORT, dry_run=dry_run
+        ).capture() as lifecycle:
+            lifecycle.add_extras(
+                {
+                    "batch_id": batch_id,
+                    "organization_id": organization_id,
+                    "timestamp": timestamp,
+                    "duration": duration,
                 }
-            if project_metrics:
-                cache_project_metrics(organization_id, project_metrics)
-        except Exception:
-            sentry_sdk.capture_exception()
+            )
+            ctx = OrganizationReportContextFactory(
+                timestamp=timestamp, duration=duration, organization=organization
+            ).create_context()
+
+            with start_span(
+                op="weekly_reports.check_if_ctx_is_empty",
+                name="weekly_reports.check_if_ctx_is_empty",
+            ):
+                report_is_available = not ctx.is_empty()
+            set_span_tag(span, "report.available", report_is_available)
+            sentry_sdk.set_attribute("report.available", report_is_available)
+
+            if not report_is_available:
+                lifecycle.record_halt(WeeklyReportHaltReason.EMPTY_REPORT)
+                return
+
+        # Deliver the reports
+        batch = OrganizationReportBatch(ctx, batch_id, dry_run, target_user, email_override)
+        with start_span(op="weekly_reports.deliver_reports", name="weekly_reports.deliver_reports"):
+            logger.info(
+                "weekly_reports.deliver_reports",
+                extra={"batch_id": str(batch_id), "organization": organization_id},
+            )
+            with metrics.timer("weekly_report.deliver_reports.duration"):
+                batch.deliver_reports()
+
+        # Cache after delivery so a failed attempt doesn't poison the
+        # previous-week lookup on retry.
+        if not dry_run:
+            try:
+                project_metrics: dict[int, dict[str, int]] = {}
+                for project_id, project_ctx in ctx.projects_context_map.items():
+                    project_metrics[project_id] = {
+                        "e": project_ctx.accepted_error_count,
+                        "t": project_ctx.accepted_transaction_count,
+                    }
+                if project_metrics:
+                    cache_project_metrics(organization_id, project_metrics)
+            except Exception:
+                sentry_sdk.capture_exception()
 
 
 @dataclass(frozen=True)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -196,15 +196,18 @@ def traces_sampler(sampling_context):
     if custom_sample_rate is not None:
         return float(custom_sample_rate)
 
-    # If there's already a sampling decision, just use that
-    if sampling_context["parent_sampled"] is not None:
-        return sampling_context["parent_sampled"]
-
+    # Taskworker tasks with explicit sample rates should always use their
+    # configured rate, regardless of parent sampling decisions. This prevents
+    # a negatively-sampled parent trace from suppressing all child task spans.
     if "taskworker" in sampling_context:
         task_name = sampling_context["taskworker"].get("task")
 
         if task_name in SAMPLED_TASKS:
             return SAMPLED_TASKS[task_name]
+
+    # If there's already a sampling decision, just use that
+    if sampling_context.get("parent_sampled") is not None:
+        return sampling_context["parent_sampled"]
 
     # Default to the sampling rate in settings
     return float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -76,8 +76,6 @@ SAMPLED_TASKS = {
     # per-message transaction, now that the work runs as a task.
     "sentry.replays.tasks.process_replay_recording": settings.SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING,
     "sentry.tasks.summaries.weekly_reports.schedule_organizations": 1.0,
-    "sentry.tasks.summaries.weekly_reports.prepare_organization_report": 0.1
-    * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.profiles.task.process_profile": 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.monitors.tasks.clock_pulse": 1.0,
     "sentry.dynamic_sampling.tasks.boost_low_volume_projects": 1.0,
@@ -196,18 +194,15 @@ def traces_sampler(sampling_context):
     if custom_sample_rate is not None:
         return float(custom_sample_rate)
 
-    # Taskworker tasks with explicit sample rates should always use their
-    # configured rate, regardless of parent sampling decisions. This prevents
-    # a negatively-sampled parent trace from suppressing all child task spans.
+    # If there's already a sampling decision, just use that
+    if sampling_context["parent_sampled"] is not None:
+        return sampling_context["parent_sampled"]
+
     if "taskworker" in sampling_context:
         task_name = sampling_context["taskworker"].get("task")
 
         if task_name in SAMPLED_TASKS:
             return SAMPLED_TASKS[task_name]
-
-    # If there's already a sampling decision, just use that
-    if sampling_context.get("parent_sampled") is not None:
-        return sampling_context["parent_sampled"]
 
     # Default to the sampling rate in settings
     return float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)


### PR DESCRIPTION
Goal: add root transaction to `prepare_organization_report`, so its spans are sampled at `0.1 * settings.SENTRY_BACKEND_APM_SAMPLING` independently of the parent `schedule_organization` trace. 

File diff looks large, but all we did was wrap `prepare_organization_report` with `with start_span(...) as span:`