### PR TITLE
fix(aci): Add more debug information to the metric, so we can filter by detector type

### DIFF
--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -43,7 +43,11 @@ def invoke_workflow_activity_handlers(
         try:
             with metrics.timer(
                 DURATION_METRIC,
-                tags={"handler": handler_key, "activity_type": activity_type},
+                tags={
+                    "handler": handler_key,
+                    "activity_type": activity_type,
+                    "detector_type": group.type,
+                },
             ):
                 handler(group, activity, detector_id)
 

--- a/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
+++ b/src/sentry/workflow_engine/handlers/registry/invoke_activities.py
@@ -46,7 +46,7 @@ def invoke_workflow_activity_handlers(
                 tags={
                     "handler": handler_key,
                     "activity_type": activity_type,
-                    "detector_type": group.type,
+                    "detector_type": group.issue_type.slug,
                 },
             ):
                 handler(group, activity, detector_id)

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -148,7 +148,10 @@ def activity_handler(
 
     metrics.incr(
         "workflow_engine.activity_handler.complete",
-        tags={"activity_name": activity_type.name},
+        tags={
+            "activity_name": activity_type.name,
+            "detector_type": detector.type,
+        },
     )
     logger.info(
         "workflow_engine.activity_handler.complete",

--- a/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
+++ b/tests/sentry/workflow_engine/handlers/registry/test_invoke_activities.py
@@ -12,7 +12,8 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
     def setUp(self) -> None:
         self.group = self.create_group()
         self.activity = self.create_group_activity(
-            group=self.group, type=ActivityType.SEER_PR_CREATED.value
+            group=self.group,
+            type=ActivityType.SEER_PR_CREATED.value,
         )
 
     def test_invoke_handlers_safely(self) -> None:
@@ -66,6 +67,7 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
                     "handler": "handler_a",
                     "result": "success",
                     "activity_type": "SEER_PR_CREATED",
+                    "detector_type": "error",
                 },
             ),
             (
@@ -74,6 +76,7 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
                     "handler": "handler_b",
                     "result": "success",
                     "activity_type": "SEER_PR_CREATED",
+                    "detector_type": "error",
                 },
             ),
         ]
@@ -99,6 +102,7 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
                     "handler": "handler_a",
                     "result": "failure",
                     "activity_type": "SEER_PR_CREATED",
+                    "detector_type": "error",
                 },
             ),
             (
@@ -107,6 +111,7 @@ class InvokeWorkflowActivityHandlersTest(TestCase):
                     "handler": "handler_b",
                     "result": "success",
                     "activity_type": "SEER_PR_CREATED",
+                    "detector_type": "error",
                 },
             ),
         ]


### PR DESCRIPTION
# Description
Add the detector type to the metric so we can understand if there's a problem with activity types on a given issue type.

The change to invoke_activities is the generic metric for "did we see this?" and the `workflow_activity_handler` change is the "we completed this handler and made a change".