### PR TITLE
docs(explore): Add replays and ai_conversations to dataset help text

### DIFF
--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -186,7 +186,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
     dataset = serializers.ChoiceField(
         choices=ExploreSavedQueryDataset.as_text_choices(),
         default=ExploreSavedQueryDataset.get_type_name(ExploreSavedQueryDataset.SPANS),
-        help_text="The dataset you would like to query. Supported values: `spans`, `logs`, `metrics`.",
+        help_text="The dataset you would like to query. Supported values: `spans`, `logs`, `metrics`, `replays`, `ai_conversations`.",
     )
     start = serializers.DateTimeField(
         required=False,


### PR DESCRIPTION
## Summary
- `ExploreSavedQuerySerializer.dataset`'s `help_text` only listed `spans`, `logs`, and `metrics`, even though `replays` and `ai_conversations` are also supported dataset values.
- This text is surfaced in our public API docs, so it should list all supported values.

Addresses review feedback from #118725: https://github.com/getsentry/sentry/pull/118725#pullrequestreview-4606683803