### PR TITLE
feat(conversations): Move project and copy ID into detail breadcrumbs

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -8,9 +8,7 @@ import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {Count} from 'sentry/components/count';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconOpen, IconUser} from 'sentry/icons';
@@ -19,7 +17,6 @@ import {escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 import {
   getUserDisplayName,
   UserNotInstrumentedTooltip,
@@ -55,15 +52,6 @@ export function ConversationSummaryNew({
   const aggregates = useMemo(() => calculateAggregates(nodes), [nodes]);
   const user = useMemo(() => getConversationUser(nodes), [nodes]);
   const userDisplayName = user ? getUserDisplayName(user) : null;
-
-  const projectSlug = useMemo(
-    () => nodes.find(node => node.projectSlug)?.projectSlug,
-    [nodes]
-  );
-  const {projects} = useProjects({slugs: projectSlug ? [projectSlug] : []});
-  const project = projectSlug
-    ? (projects.find(p => p.slug === projectSlug) ?? {slug: projectSlug})
-    : undefined;
 
   const displayId = isUUID(conversationId) ? conversationId.slice(0, 8) : conversationId;
 
@@ -110,36 +98,20 @@ export function ConversationSummaryNew({
       minWidth={0}
     >
       <Stack gap="md" minWidth={0} flex={1}>
-        <Flex align="center" gap="md" minWidth={0}>
-          <Container minWidth={0}>
-            <Tooltip
-              title={conversationId}
-              showOnlyOnOverflow={!isUUID(conversationId)}
-              skipWrapper
-            >
-              <Heading as="h2" ellipsis>
-                {displayId}
-              </Heading>
-            </Tooltip>
-          </Container>
-          <CopyToClipboardButton
-            size="zero"
-            variant="transparent"
-            aria-label={t('Copy conversation ID')}
-            tooltipProps={{title: t('Copy conversation ID')}}
-            text={conversationId}
-            onCopy={() =>
-              trackAnalytics('conversations.detail.copy-conversation-id', {organization})
-            }
-          />
-        </Flex>
+        <Container minWidth={0}>
+          <Tooltip
+            title={conversationId}
+            showOnlyOnOverflow={!isUUID(conversationId)}
+            skipWrapper
+          >
+            <Heading as="h2" ellipsis>
+              {displayId}
+            </Heading>
+          </Tooltip>
+        </Container>
         <Flex align="center" gap="xl" minWidth={0} wrap="wrap">
           {isLoading ? (
             <Fragment>
-              <Flex align="center" gap="sm">
-                <Placeholder width="16px" height="16px" />
-                <Placeholder width="64px" height="14px" />
-              </Flex>
               <Flex align="center" gap="xs">
                 <Placeholder width="16px" height="16px" />
                 <Placeholder width="120px" height="14px" />
@@ -151,14 +123,6 @@ export function ConversationSummaryNew({
             </Fragment>
           ) : (
             <Fragment>
-              {project && (
-                <ProjectBadge
-                  project={project}
-                  avatarSize={16}
-                  disableLink
-                  hideOverflow
-                />
-              )}
               <Flex align="center" gap="xs" minWidth={0}>
                 <IconUser size="md" />
                 {userDisplayName ? (

--- a/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
+++ b/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
@@ -1,4 +1,5 @@
 import {RevealOnHover} from '@sentry/scraps/revealOnHover';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -69,14 +70,20 @@ function ConversationCrumb({
   return (
     <RevealOnHover minWidth={0}>
       {project && (
-        <ProjectBadge project={project} avatarSize={16} disableLink hideOverflow />
+        <ProjectBadge
+          project={project}
+          avatarSize={16}
+          disableLink
+          hideName
+          avatarProps={{hasTooltip: true, tooltip: project.slug}}
+        />
       )}
       <Tooltip
         title={conversationId}
         showOnlyOnOverflow={!isUUID(conversationId)}
         skipWrapper
       >
-        <span>{displayId}</span>
+        <Text>{displayId}</Text>
       </Tooltip>
       <RevealOnHover.Action>
         <CopyToClipboardButton

--- a/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
+++ b/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
@@ -1,0 +1,116 @@
+import styled from '@emotion/styled';
+
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {AvatarProject} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {isUUID} from 'sentry/utils/string/isUUID';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  CONVERSATIONS_LANDING_SUB_PATH,
+  CONVERSATIONS_SIDEBAR_LABEL,
+} from 'sentry/views/explore/conversations/settings';
+
+interface ConversationsBreadcrumbsProps {
+  conversationId: string;
+  project?: AvatarProject;
+}
+
+/**
+ * Breadcrumbs for a single conversation. The leaf crumb carries the project
+ * badge and a copy-to-clipboard affordance revealed on hover, keeping the
+ * conversation detail header aligned with the trace view.
+ */
+export function ConversationsBreadcrumbs({
+  conversationId,
+  project,
+}: ConversationsBreadcrumbsProps) {
+  const organization = useOrganization();
+  const conversationsBaseUrl = normalizeUrl(
+    `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
+  );
+
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: CONVERSATIONS_SIDEBAR_LABEL,
+          to: {
+            pathname: conversationsBaseUrl,
+            query: {statsPeriod: '24h', start: undefined, end: undefined},
+          },
+          preservePageFilters: true,
+        },
+        {
+          label: (
+            <ConversationCrumb
+              conversationId={conversationId}
+              project={project}
+              organization={organization}
+            />
+          ),
+        },
+      ]}
+    />
+  );
+}
+
+function ConversationCrumb({
+  conversationId,
+  project,
+  organization,
+}: {
+  conversationId: string;
+  organization: Organization;
+  project?: AvatarProject;
+}) {
+  const displayId = isUUID(conversationId) ? conversationId.slice(0, 8) : conversationId;
+
+  return (
+    <CrumbWrapper>
+      {project && (
+        <ProjectBadge project={project} avatarSize={16} disableLink hideOverflow />
+      )}
+      <Tooltip
+        title={conversationId}
+        showOnlyOnOverflow={!isUUID(conversationId)}
+        skipWrapper
+      >
+        <span>{displayId}</span>
+      </Tooltip>
+      <CopyToClipboardButton
+        className="copy-conversation-id"
+        size="zero"
+        variant="transparent"
+        aria-label={t('Copy conversation ID')}
+        tooltipProps={{title: t('Copy conversation ID')}}
+        text={conversationId}
+        onCopy={() =>
+          trackAnalytics('conversations.detail.copy-conversation-id', {organization})
+        }
+      />
+    </CrumbWrapper>
+  );
+}
+
+const CrumbWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  min-width: 0;
+
+  .copy-conversation-id {
+    visibility: hidden;
+  }
+
+  &:hover .copy-conversation-id,
+  &:focus-within .copy-conversation-id {
+    visibility: visible;
+  }
+`;

--- a/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
+++ b/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
@@ -21,11 +21,6 @@ interface ConversationsBreadcrumbsProps {
   project?: AvatarProject;
 }
 
-/**
- * Breadcrumbs for a single conversation. The leaf crumb carries the project
- * badge and a copy-to-clipboard affordance revealed on hover, keeping the
- * conversation detail header aligned with the trace view.
- */
 export function ConversationsBreadcrumbs({
   conversationId,
   project,

--- a/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
+++ b/static/app/views/explore/conversations/components/conversationsBreadcrumbs.tsx
@@ -1,5 +1,4 @@
-import styled from '@emotion/styled';
-
+import {RevealOnHover} from '@sentry/scraps/revealOnHover';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -73,7 +72,7 @@ function ConversationCrumb({
   const displayId = isUUID(conversationId) ? conversationId.slice(0, 8) : conversationId;
 
   return (
-    <CrumbWrapper>
+    <RevealOnHover minWidth={0}>
       {project && (
         <ProjectBadge project={project} avatarSize={16} disableLink hideOverflow />
       )}
@@ -84,33 +83,18 @@ function ConversationCrumb({
       >
         <span>{displayId}</span>
       </Tooltip>
-      <CopyToClipboardButton
-        className="copy-conversation-id"
-        size="zero"
-        variant="transparent"
-        aria-label={t('Copy conversation ID')}
-        tooltipProps={{title: t('Copy conversation ID')}}
-        text={conversationId}
-        onCopy={() =>
-          trackAnalytics('conversations.detail.copy-conversation-id', {organization})
-        }
-      />
-    </CrumbWrapper>
+      <RevealOnHover.Action>
+        <CopyToClipboardButton
+          size="zero"
+          variant="transparent"
+          aria-label={t('Copy conversation ID')}
+          tooltipProps={{title: t('Copy conversation ID')}}
+          text={conversationId}
+          onCopy={() =>
+            trackAnalytics('conversations.detail.copy-conversation-id', {organization})
+          }
+        />
+      </RevealOnHover.Action>
+    </RevealOnHover>
   );
 }
-
-const CrumbWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  min-width: 0;
-
-  .copy-conversation-id {
-    visibility: hidden;
-  }
-
-  &:hover .copy-conversation-id,
-  &:focus-within .copy-conversation-id {
-    visibility: visible;
-  }
-`;

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -8,7 +8,9 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {useProjects} from 'sentry/utils/useProjects';
 import {ViewportConstrainedPage} from 'sentry/views/explore/components/viewportConstrainedPage';
+import {ConversationsBreadcrumbs} from 'sentry/views/explore/conversations/components/conversationsBreadcrumbs';
 import {ConversationSummaryNew} from 'sentry/views/explore/conversations/components/conversationSummaryNew';
 import {
   CONVERSATION_VIEW_TABS,
@@ -16,6 +18,7 @@ import {
 } from 'sentry/views/explore/conversations/components/conversationViewNew';
 import {ConversationViewContainer} from 'sentry/views/explore/conversations/conversationDetail';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
+import {TopBar} from 'sentry/views/navigation/topBar';
 
 function useConversationDetailQueryState() {
   return useQueryStates(
@@ -37,6 +40,15 @@ export function ConversationDetailPageNew() {
 
   const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
 
+  const projectSlug = useMemo(
+    () => nodes.find(node => node.projectSlug)?.projectSlug,
+    [nodes]
+  );
+  const {projects} = useProjects({slugs: projectSlug ? [projectSlug] : []});
+  const project = projectSlug
+    ? (projects.find(p => p.slug === projectSlug) ?? {slug: projectSlug})
+    : undefined;
+
   useEffect(() => {
     trackAnalytics('conversations.detail.page-view', {
       organization,
@@ -52,6 +64,9 @@ export function ConversationDetailPageNew() {
 
   return (
     <ViewportConstrainedPage background="secondary">
+      <TopBar.Slot name="title">
+        <ConversationsBreadcrumbs conversationId={conversationId} project={project} />
+      </TopBar.Slot>
       <Container flexShrink={0} background="primary" borderBottom="primary" padding="xl">
         <ConversationSummaryNew
           nodes={nodes}

--- a/static/app/views/explore/conversations/layout.tsx
+++ b/static/app/views/explore/conversations/layout.tsx
@@ -23,6 +23,7 @@ import {
   CONVERSATIONS_SIDEBAR_LABEL,
   MAX_PICKABLE_DAYS,
 } from 'sentry/views/explore/conversations/settings';
+import {hasGenAiConversationsRedesignFeature} from 'sentry/views/explore/conversations/utils/features';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
 function ConversationsLayout() {
@@ -75,6 +76,10 @@ function ConversationsHeader() {
   const {conversationId} = useParams<{conversationId?: string}>();
 
   const isDetailPage = !!conversationId;
+  // The redesigned detail page renders its own breadcrumbs (with the project
+  // badge and copy affordance) into the title slot, so the layout only owns
+  // the breadcrumbs for the landing and legacy detail pages.
+  const isRedesign = hasGenAiConversationsRedesignFeature(organization);
   const conversationsBaseUrl = normalizeUrl(
     `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
   );
@@ -82,7 +87,7 @@ function ConversationsHeader() {
   return (
     <Fragment>
       <TopBar.Slot name="title">
-        {isDetailPage ? (
+        {isDetailPage && isRedesign ? null : isDetailPage ? (
           <Breadcrumbs
             crumbs={[
               {


### PR DESCRIPTION
Aligns the redesigned conversation detail header with the trace view by moving the project badge and the copy-ID button (revealed on hover) into the breadcrumbs. The redesigned detail page now owns its title-slot breadcrumbs, while the layout keeps them for the landing and legacy pages.


**Preview**


https://github.com/user-attachments/assets/e1d94e86-25dd-4214-81fa-a151bf8874a8

