### PR TITLE
fix(issues): Re-parent children when filtering low-value spans

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -189,12 +189,29 @@ export function getPythonSpanFilterSnippet(
 
 
 def before_send_transaction(event, hint):
-    event["spans"] = [
-        span for span in event.get("spans", [])
-        if not (
+    dropped_parents = {}
+    kept_spans = []
+    for span in event.get("spans", []):
+        if (
 ${conditions.join('\n')}
-        )
-    ]
+        ):
+            dropped_parents[span.get("span_id")] = span.get("parent_span_id")
+        else:
+            kept_spans.append(span)
+
+    if not dropped_parents:
+        return event
+
+    # Re-parent children of dropped spans so the trace stays connected.
+    for span in kept_spans:
+        parent = span.get("parent_span_id")
+        if parent not in dropped_parents:
+            continue
+        while parent in dropped_parents:
+            parent = dropped_parents[parent]
+        span["parent_span_id"] = parent
+
+    event["spans"] = kept_spans
     return event
 
 

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -195,7 +195,9 @@ def before_send_transaction(event, hint):
         if (
 ${conditions.join('\n')}
         ):
-            dropped_parents[span.get("span_id")] = span.get("parent_span_id")
+            span_id = span.get("span_id")
+            if span_id is not None:
+                dropped_parents[span_id] = span.get("parent_span_id")
         else:
             kept_spans.append(span)
 


### PR DESCRIPTION
Update the Python snippet in the low-value span troubleshooting section so filtering a span no longer breaks the trace.

The previous snippet dropped matching spans from `event["spans"]`, which orphaned any child span whose `parent_span_id` referenced the dropped span — the trace shows up as disconnected subtrees in the UI. The new snippet records a `dropped_span_id → parent_span_id` map, then walks that chain for each kept span to re-attach it to the nearest surviving ancestor. An early return when nothing matched keeps the common case allocation-free (no `kept_spans` list rebuild, no `event["spans"]` reassignment).

Considered path compression on the dropped-parents dict and doing everything in a single pass; both hurt clarity without a real payoff since chains of dropped spans are almost always length 1 and users copy this snippet verbatim.