### PR TITLE
feat(conversations): Add input as a default table column

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -129,11 +129,11 @@ export function ConversationsTableNew() {
           justify={RIGHT_ALIGNED_CONVERSATION_COLUMNS.has(column.key) ? 'end' : 'start'}
         >
           {column.name}
-          {/* Raise the user column's growth-limit so it absorbs the leftover
+          {/* Raise the input column's growth-limit so it absorbs the leftover
               width instead of the last column stretching. The panel's
               horizontal scroll (and the `minWidth: 0` wrapper) keeps this from
               overflowing when there are too many columns to fit. */}
-          {column.key === 'user' && <Container width="100vw" />}
+          {column.key === 'input' && <Container width="100vw" />}
         </Flex>
       );
     },

--- a/static/app/views/explore/conversations/utils/tableColumns.tsx
+++ b/static/app/views/explore/conversations/utils/tableColumns.tsx
@@ -22,14 +22,14 @@ interface ColumnDefinition {
 }
 
 export const CONVERSATION_COLUMNS: Record<ConversationColumnKey, ColumnDefinition> = {
-  conversationId: {name: t('Conv. ID'), width: 150, type: FieldValueType.STRING},
+  conversationId: {name: t('Conv. ID'), width: 100, type: FieldValueType.STRING},
   llmCalls: {name: t('LLM Calls'), width: 100, type: FieldValueType.INTEGER},
-  user: {name: t('User'), width: COL_WIDTH_UNDEFINED, type: FieldValueType.STRING},
+  user: {name: t('User'), width: 139, type: FieldValueType.STRING},
   toolCalls: {name: t('Tool Calls'), width: 120, type: FieldValueType.INTEGER},
   errors: {name: t('Errors'), width: 100, type: FieldValueType.INTEGER},
   cost: {name: t('Cost'), width: 110, type: FieldValueType.CURRENCY},
   timestamp: {name: t('Last Message'), width: 140, type: FieldValueType.DATE},
-  input: {name: t('Input'), width: 250, type: FieldValueType.STRING},
+  input: {name: t('Input'), width: COL_WIDTH_UNDEFINED, type: FieldValueType.STRING},
   output: {name: t('Output'), width: 250, type: FieldValueType.STRING},
   inputTokens: {name: t('Input Tokens'), width: 120, type: FieldValueType.INTEGER},
   outputTokens: {name: t('Output Tokens'), width: 130, type: FieldValueType.INTEGER},
@@ -52,6 +52,7 @@ export const ALL_CONVERSATION_COLUMNS: ConversationColumnKey[] = [
 export const DEFAULT_CONVERSATION_COLUMNS: ConversationColumnKey[] = [
   'conversationId',
   'user',
+  'input',
   'llmCalls',
   'toolCalls',
   'errors',

--- a/static/app/views/explore/conversations/utils/tableColumns.tsx
+++ b/static/app/views/explore/conversations/utils/tableColumns.tsx
@@ -24,7 +24,7 @@ interface ColumnDefinition {
 export const CONVERSATION_COLUMNS: Record<ConversationColumnKey, ColumnDefinition> = {
   conversationId: {name: t('Conv. ID'), width: 100, type: FieldValueType.STRING},
   llmCalls: {name: t('LLM Calls'), width: 100, type: FieldValueType.INTEGER},
-  user: {name: t('User'), width: 139, type: FieldValueType.STRING},
+  user: {name: t('User'), width: 200, type: FieldValueType.STRING},
   toolCalls: {name: t('Tool Calls'), width: 120, type: FieldValueType.INTEGER},
   errors: {name: t('Errors'), width: 100, type: FieldValueType.INTEGER},
   cost: {name: t('Cost'), width: 110, type: FieldValueType.CURRENCY},


### PR DESCRIPTION
Adds the Input column to the conversations table by default (right after User) and makes it the flexible column that absorbs leftover table width. Also tunes the Conv. ID and User column widths.

**Preview**
<img width="2285" height="753" alt="image" src="https://github.com/user-attachments/assets/aef4cf6b-ab72-4566-8188-8539cdf47c20" />
