### PR TITLE
feat(pr-metrics): Add stale PR detection and abandoned verdict

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -30,9 +30,7 @@ class PrCloseMetricsEvent(analytics.Event):
     # Group (issue) IDs this PR resolves, from the resolving GroupLink rows
     # (parsed from the PR title/message). Empty when the PR resolves nothing.
     group_ids: list[int]
-    close_action: Literal["closed", "merged"]
-    # Always present on a close/merge webhook — read fail-fast so a malformed
-    # payload errors loudly instead of emitting a silent null.
+    close_action: Literal["closed", "merged", "abandoned"]
     head_commit_sha: str
     closed_at: str
     # Null when Sentry never saw the PR open (late-installed integration, missed

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1212,6 +1212,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "demomode:sentry.demo_mode.tasks.sync_debug_artifacts",
         "schedule": crontab("0", "*/1", "*", "*", "*"),
     },
+    "pr-metrics-detect-stale": {
+        "task": "seer.code_review:sentry.pr_metrics.tasks.detect_stale_pull_requests",
+        "schedule": crontab("0", "2", "*", "*", "*"),
+    },
     "relocation-find-transfer-region": {
         "task": "relocation:sentry.relocation.transfer.find_relocation_transfer_region",
         "schedule": crontab("*/5", "*", "*", "*", "*"),

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -59,9 +59,8 @@ class PullRequestVerdict(models.TextChoices):
     MERGED_UNCHANGED = "merged_unchanged"
     MERGED_WITH_ITERATION = "merged_with_iteration"
     CLOSED_UNMERGED = "closed_unmerged"
-    # PR was still open but had no qualifying engagement (review, new commit,
-    # ready-for-review, or review request) for 4 weeks. Emitted by the stale-detection
-    # cron task, not the webhook.
+    # Open PR with no engagement for 4 weeks; emitted by the stale-detection
+    # cron, not the webhook.
     ABANDONED = "abandoned"
     # Transient, internal: a terminal event whose outcome a judge must decide has
     # been claimed and forwarded to Seer, but the judged verdict hasn't returned.

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -59,6 +59,10 @@ class PullRequestVerdict(models.TextChoices):
     MERGED_UNCHANGED = "merged_unchanged"
     MERGED_WITH_ITERATION = "merged_with_iteration"
     CLOSED_UNMERGED = "closed_unmerged"
+    # PR was still open but had no qualifying engagement (review, new commit,
+    # ready-for-review, or review request) for 4 weeks. Emitted by the stale-detection
+    # cron task, not the webhook.
+    ABANDONED = "abandoned"
     # Transient, internal: a terminal event whose outcome a judge must decide has
     # been claimed and forwarded to Seer, but the judged verdict hasn't returned.
     # Reuses the verdict column as the redelivery guard so a redelivered terminal

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -715,15 +715,17 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
     return events
 
 
-# Mirrors tasks.STALENESS_WINDOW's engagement vocabulary: the same event types
-# that reset the stale clock for legacy PullRequestActivity rows, read here off
-# the document instead. Chosen for low bot-risk: all four require deliberate
-# human action on the PR.
-ENGAGING_ACTIVITY_TYPES = frozenset(
+# Event types that count as reviewer engagement for the NO_REVIEWER_ENGAGEMENT
+# diagnosis label — a review submission or a review request, both requiring a
+# human reviewer to act. Narrower than tasks.ENGAGING_ACTIVITY_TYPES (which
+# also resets the staleness clock on SYNCHRONIZED/READY_FOR_REVIEW, PR-author
+# actions with no reviewer involved). Shared by has_reviewer_engagement (reads
+# the document) and detect_stale_pull_requests_task's legacy-track check
+# (reads PullRequestActivity rows directly), so both tracks apply the label
+# under the same definition of "reviewer engagement".
+REVIEWER_ENGAGEMENT_ACTIVITY_TYPES = frozenset(
     {
-        PullRequestActivityType.SYNCHRONIZED,
         PullRequestActivityType.REVIEW_SUBMITTED,
-        PullRequestActivityType.READY_FOR_REVIEW,
         PullRequestActivityType.REVIEW_REQUESTED,
     }
 )
@@ -732,8 +734,9 @@ ENGAGING_ACTIVITY_TYPES = frozenset(
 def has_reviewer_engagement(doc: Mapping[str, Any]) -> bool:
     """Whether ``doc`` records any reviewer engagement throughout the PR's lifetime.
 
-    Reviewer engagement includes review submissions and review requests.
-    Used to determine if NO_REVIEWER_ENGAGEMENT label should be applied.
+    Reviewer engagement includes review submissions and review requests (see
+    ``REVIEWER_ENGAGEMENT_ACTIVITY_TYPES``). Used to determine if
+    NO_REVIEWER_ENGAGEMENT label should be applied.
 
     Conservative on the events cap: once ``events_dropped`` is nonzero, the
     ``events`` list is no longer a complete lifecycle record, so we assume
@@ -743,12 +746,7 @@ def has_reviewer_engagement(doc: Mapping[str, Any]) -> bool:
         # If events were dropped, we can't be sure there was no engagement
         return True
 
-    reviewer_activity_types = {
-        PullRequestActivityType.REVIEW_SUBMITTED,
-        PullRequestActivityType.REVIEW_REQUESTED,
-    }
-
     for entry in doc.get("events") or ():
-        if entry.get("event_type") in reviewer_activity_types:
+        if entry.get("event_type") in REVIEWER_ENGAGEMENT_ACTIVITY_TYPES:
             return True
     return False

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any, TypedDict
+
+from django.utils.dateparse import parse_datetime
 
 from sentry.models.pullrequest import PullRequestActivityType
 from sentry.utils import metrics
@@ -713,3 +716,45 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
 
     events.sort(key=lambda event: event["timestamp"] or "")
     return events
+
+
+# Mirrors tasks.STALENESS_WINDOW's engagement vocabulary: the same event types
+# that reset the stale clock for legacy PullRequestActivity rows, read here off
+# the document instead. Chosen for low bot-risk: all four require deliberate
+# human action on the PR.
+ENGAGING_ACTIVITY_TYPES = frozenset(
+    {
+        PullRequestActivityType.SYNCHRONIZED,
+        PullRequestActivityType.REVIEW_SUBMITTED,
+        PullRequestActivityType.READY_FOR_REVIEW,
+        PullRequestActivityType.REVIEW_REQUESTED,
+    }
+)
+
+
+def has_engaging_activity_since(doc: Mapping[str, Any], cutoff: datetime) -> bool:
+    """Whether ``doc`` records engaging activity (see ``ENGAGING_ACTIVITY_TYPES``)
+    at or after ``cutoff``.
+
+    The document-store counterpart to the ``~Exists`` check
+    ``find_stale_pull_requests`` runs against legacy ``PullRequestActivity``
+    rows: a PR routed onto this document (see ``_use_activity_document``) never
+    writes those rows, so that SQL-only check can't see its engagement and
+    always reads it as stale. Callers use this to cross-check document-backed
+    candidates before settling them as abandoned.
+
+    Conservative on the events cap: once ``events_dropped`` is nonzero, the
+    ``events`` list is no longer a complete lifecycle record (see
+    ``MAX_EVENTS``) and a dropped entry carries no timestamp to rule out here —
+    so a capped document reads as engaged rather than risking a false abandoned
+    verdict on a PR pathological enough to hit the cap.
+    """
+    if doc.get("events_dropped"):
+        return True
+    for entry in doc.get("events") or ():
+        if entry.get("event_type") not in ENGAGING_ACTIVITY_TYPES:
+            continue
+        ts = parse_datetime(entry.get("ts") or "")
+        if ts is not None and ts >= cutoff:
+            return True
+    return False

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -15,10 +15,7 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Any, TypedDict
-
-from django.utils.dateparse import parse_datetime
 
 from sentry.models.pullrequest import PullRequestActivityType
 from sentry.utils import metrics
@@ -730,34 +727,6 @@ ENGAGING_ACTIVITY_TYPES = frozenset(
         PullRequestActivityType.REVIEW_REQUESTED,
     }
 )
-
-
-def has_engaging_activity_since(doc: Mapping[str, Any], cutoff: datetime) -> bool:
-    """Whether ``doc`` records engaging activity (see ``ENGAGING_ACTIVITY_TYPES``)
-    at or after ``cutoff``.
-
-    The document-store counterpart to the ``~Exists`` check
-    ``find_stale_pull_requests`` runs against legacy ``PullRequestActivity``
-    rows: a PR routed onto this document (see ``_use_activity_document``) never
-    writes those rows, so that SQL-only check can't see its engagement and
-    always reads it as stale. Callers use this to cross-check document-backed
-    candidates before settling them as abandoned.
-
-    Conservative on the events cap: once ``events_dropped`` is nonzero, the
-    ``events`` list is no longer a complete lifecycle record (see
-    ``MAX_EVENTS``) and a dropped entry carries no timestamp to rule out here —
-    so a capped document reads as engaged rather than risking a false abandoned
-    verdict on a PR pathological enough to hit the cap.
-    """
-    if doc.get("events_dropped"):
-        return True
-    for entry in doc.get("events") or ():
-        if entry.get("event_type") not in ENGAGING_ACTIVITY_TYPES:
-            continue
-        ts = parse_datetime(entry.get("ts") or "")
-        if ts is not None and ts >= cutoff:
-            return True
-    return False
 
 
 def has_reviewer_engagement(doc: Mapping[str, Any]) -> bool:

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -758,3 +758,28 @@ def has_engaging_activity_since(doc: Mapping[str, Any], cutoff: datetime) -> boo
         if ts is not None and ts >= cutoff:
             return True
     return False
+
+
+def has_reviewer_engagement(doc: Mapping[str, Any]) -> bool:
+    """Whether ``doc`` records any reviewer engagement throughout the PR's lifetime.
+
+    Reviewer engagement includes review submissions and review requests.
+    Used to determine if NO_REVIEWER_ENGAGEMENT label should be applied.
+
+    Conservative on the events cap: once ``events_dropped`` is nonzero, the
+    ``events`` list is no longer a complete lifecycle record, so we assume
+    there was engagement rather than risk incorrectly labeling a PR.
+    """
+    if doc.get("events_dropped"):
+        # If events were dropped, we can't be sure there was no engagement
+        return True
+
+    reviewer_activity_types = {
+        PullRequestActivityType.REVIEW_SUBMITTED,
+        PullRequestActivityType.REVIEW_REQUESTED,
+    }
+
+    for entry in doc.get("events") or ():
+        if entry.get("event_type") in reviewer_activity_types:
+            return True
+    return False

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -715,14 +715,11 @@ def timeline_events_from_doc(doc: ActivityDoc) -> list[dict[str, Any]]:
     return events
 
 
-# Event types that count as reviewer engagement for the NO_REVIEWER_ENGAGEMENT
-# diagnosis label — a review submission or a review request, both requiring a
-# human reviewer to act. Narrower than tasks.ENGAGING_ACTIVITY_TYPES (which
-# also resets the staleness clock on SYNCHRONIZED/READY_FOR_REVIEW, PR-author
-# actions with no reviewer involved). Shared by has_reviewer_engagement (reads
-# the document) and detect_stale_pull_requests_task's legacy-track check
-# (reads PullRequestActivity rows directly), so both tracks apply the label
-# under the same definition of "reviewer engagement".
+# Reviewer engagement for the NO_REVIEWER_ENGAGEMENT diagnosis label. Narrower
+# than tasks.ENGAGING_ACTIVITY_TYPES, which also counts PR-author actions with
+# no reviewer involved. Shared by has_reviewer_engagement (document) and
+# detect_stale_pull_requests_task's legacy-track check (PullRequestActivity
+# rows), so both tracks use the same definition.
 REVIEWER_ENGAGEMENT_ACTIVITY_TYPES = frozenset(
     {
         PullRequestActivityType.REVIEW_SUBMITTED,
@@ -734,16 +731,10 @@ REVIEWER_ENGAGEMENT_ACTIVITY_TYPES = frozenset(
 def has_reviewer_engagement(doc: Mapping[str, Any]) -> bool:
     """Whether ``doc`` records any reviewer engagement throughout the PR's lifetime.
 
-    Reviewer engagement includes review submissions and review requests (see
-    ``REVIEWER_ENGAGEMENT_ACTIVITY_TYPES``). Used to determine if
-    NO_REVIEWER_ENGAGEMENT label should be applied.
-
-    Conservative on the events cap: once ``events_dropped`` is nonzero, the
-    ``events`` list is no longer a complete lifecycle record, so we assume
-    there was engagement rather than risk incorrectly labeling a PR.
+    A capped ``events_dropped`` doc reads as engaged rather than risk a false
+    NO_REVIEWER_ENGAGEMENT label off an incomplete record.
     """
     if doc.get("events_dropped"):
-        # If events were dropped, we can't be sure there was no engagement
         return True
 
     for entry in doc.get("events") or ():

--- a/src/sentry/pr_metrics/contracts.py
+++ b/src/sentry/pr_metrics/contracts.py
@@ -25,8 +25,9 @@ from sentry.seer.code_review.models import SeerCodeReviewRepoDefinition
 # on the PR row disambiguates a merge from a plain close.
 CLOSE_ACTION_CLOSED: Final = "closed"
 CLOSE_ACTION_MERGED: Final = "merged"
+CLOSE_ACTION_ABANDONED: Final = "abandoned"
 
-CloseAction = Literal["closed", "merged"]
+CloseAction = Literal["closed", "merged", "abandoned"]
 
 
 class PrConversationAnalysis(BaseModel):

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -13,7 +13,6 @@ from enum import Enum
 from typing import Any, NamedTuple, cast
 
 from django.db.models import Count, Q
-
 from django.utils import timezone as dj_timezone
 
 from sentry import analytics
@@ -216,11 +215,12 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
 # the PR's own check-suite activity rather than a judge's opinion.
 CI_FAILING_AT_CLOSE = "ci_failing_at_close"
 
-# Diagnosis label for the stale-detection path: unconditional, not read off any
-# activity row. find_stale_pull_requests already filters to PRs with zero
-# engaging activity (no commits, reviews, review requests) in the detection
-# window, so every PR the cron settles as ABANDONED satisfies this by
-# construction — there's nothing left to check at emit time.
+# Diagnosis label for the stale-detection path, applied when a PR shows no
+# reviewer engagement across its whole lifetime, not just the detection
+# window. A document-track PR is checked via has_reviewer_engagement(doc); a
+# legacy-track PR (no PullRequestActivityLog document) is checked directly
+# against its full PullRequestActivity history for
+# REVIEWER_ENGAGEMENT_ACTIVITY_TYPES. See detect_stale_pull_requests_task.
 NO_REVIEWER_ENGAGEMENT = "no_reviewer_engagement"
 
 # Conclusions that unambiguously mean the check errored out, as opposed to
@@ -501,11 +501,6 @@ def build_pr_metrics_row(
     ``CLOSED_UNMERGED`` path can also populate it (see ``ci_failing_at_close``),
     so its presence doesn't by itself mean the row was judged.
     """
-    # Validate that non-abandoned PRs have the required lifecycle data. The
-    # webhook always persists both on a close/merge; a null here means emit ran
-    # on a PR that never reached a terminal state. Fail loud. Abandoned PRs are
-    # the one exception: the PR is still open, so both fields are legitimately
-    # unset on the model.
     if close_action != CLOSE_ACTION_ABANDONED:
         if pull_request.head_commit_sha is None or pull_request.closed_at is None:
             raise ValueError(

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -501,12 +501,18 @@ def build_pr_metrics_row(
     ``CLOSED_UNMERGED`` path can also populate it (see ``ci_failing_at_close``),
     so its presence doesn't by itself mean the row was judged.
     """
-    # Validate that non-abandoned PRs have the required lifecycle data
-    if close_action != CLOSE_ACTION_ABANDONED and pull_request.closed_at is None:
-        raise ValueError(
-            f"PR {pull_request.id} has close_action='{close_action}' but closed_at is None. "
-            "Only abandoned PRs are allowed to have null closed_at."
-        )
+    # Validate that non-abandoned PRs have the required lifecycle data. The
+    # webhook always persists both on a close/merge; a null here means emit ran
+    # on a PR that never reached a terminal state. Fail loud. Abandoned PRs are
+    # the one exception: the PR is still open, so both fields are legitimately
+    # unset on the model.
+    if close_action != CLOSE_ACTION_ABANDONED:
+        if pull_request.head_commit_sha is None or pull_request.closed_at is None:
+            raise ValueError(
+                f"PR {pull_request.id} has close_action='{close_action}' but is missing "
+                "head_commit_sha and/or closed_at. Only abandoned PRs are allowed to have "
+                "null lifecycle fields."
+            )
 
     head_commit_sha = pull_request.head_commit_sha or "unknown"
     # For abandoned PRs there's no `closed_at` value populated; fall back to now().

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -501,6 +501,13 @@ def build_pr_metrics_row(
     ``CLOSED_UNMERGED`` path can also populate it (see ``ci_failing_at_close``),
     so its presence doesn't by itself mean the row was judged.
     """
+    # Validate that non-abandoned PRs have the required lifecycle data
+    if close_action != CLOSE_ACTION_ABANDONED and pull_request.closed_at is None:
+        raise ValueError(
+            f"PR {pull_request.id} has close_action='{close_action}' but closed_at is None. "
+            "Only abandoned PRs are allowed to have null closed_at."
+        )
+
     head_commit_sha = pull_request.head_commit_sha or "unknown"
     # For abandoned PRs there's no `closed_at` value populated; fall back to now().
     effective_closed_at = pull_request.closed_at or dj_timezone.now()

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -216,6 +216,13 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
 # the PR's own check-suite activity rather than a judge's opinion.
 CI_FAILING_AT_CLOSE = "ci_failing_at_close"
 
+# Diagnosis label for the stale-detection path: unconditional, not read off any
+# activity row. find_stale_pull_requests already filters to PRs with zero
+# engaging activity (no commits, reviews, review requests) in the detection
+# window, so every PR the cron settles as ABANDONED satisfies this by
+# construction — there's nothing left to check at emit time.
+NO_REVIEWER_ENGAGEMENT = "no_reviewer_engagement"
+
 # Conclusions that unambiguously mean the check errored out, as opposed to
 # cancelled/skipped/stale (never ran to completion, not a failure verdict),
 # neutral (a soft pass), or action_required (blocked on approval, not broken).

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -14,6 +14,8 @@ from typing import Any, NamedTuple, cast
 
 from django.db.models import Count, Q
 
+from django.utils import timezone as dj_timezone
+
 from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
@@ -31,6 +33,7 @@ from sentry.models.repository import Repository
 from sentry.pr_metrics import activity_doc
 from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
 from sentry.pr_metrics.contracts import (
+    CLOSE_ACTION_ABANDONED,
     CLOSE_ACTION_CLOSED,
     CLOSE_ACTION_MERGED,
     CloseAction,
@@ -472,13 +475,17 @@ def build_pr_metrics_row(
     conversation_analysis: PrConversationAnalysis | None = None,
     diagnosis_labels: Sequence[str] | None = None,
 ) -> PrCloseMetricsEvent:
-    """Assemble the close/merge analytics row.
+    """Assemble the close/merge/abandoned analytics row.
 
     Every fact is read from the stored ``PullRequest`` / ``PullRequestMetrics``
     rows, so the judge path (Seer RPC callback, which has no webhook payload) can
     reuse this. ``attributions`` is passed in so the tracking gate and the
     emitted row read the same query. A missing metrics row (a PR Sentry never saw
     active) coalesces every counter to its default.
+
+    For ``abandoned``, ``closed_at`` is set to the current UTC time (the
+    detection timestamp), since the PR is still open and the field is null on
+    the model. For close/merge, ``pull_request.closed_at`` is used.
 
     ``conversation_analysis`` is set on the judge path only: the conversation
     judge's result (semantic outputs become columns, its ``metadata`` is
@@ -487,12 +494,9 @@ def build_pr_metrics_row(
     ``CLOSED_UNMERGED`` path can also populate it (see ``ci_failing_at_close``),
     so its presence doesn't by itself mean the row was judged.
     """
-    head_commit_sha = pull_request.head_commit_sha
-    closed_at = pull_request.closed_at
-    if head_commit_sha is None or closed_at is None:
-        # The webhook always persists both on a close/merge; a null here means
-        # emit ran on a PR that never reached a terminal state. Fail loud.
-        raise ValueError("PR metrics row requires a persisted head_commit_sha and closed_at")
+    head_commit_sha = pull_request.head_commit_sha or "unknown"
+    # For abandoned PRs there's no `closed_at` value populated; fall back to now().
+    effective_closed_at = pull_request.closed_at or dj_timezone.now()
 
     # A bare instance carries the model's zero/false field defaults, so a PR with
     # no stored metrics row emits zeroed counters rather than erroring.
@@ -513,7 +517,7 @@ def build_pr_metrics_row(
         group_ids=group_ids,
         close_action=close_action,
         head_commit_sha=head_commit_sha,
-        closed_at=closed_at.isoformat(),
+        closed_at=effective_closed_at.isoformat(),
         merge_commit_sha=pull_request.merge_commit_sha,
         merge_commit_id=_merge_commit_id(pull_request),
         merged_at=iso_or_none(pull_request.merged_at),
@@ -722,6 +726,11 @@ def emit_pr_metrics_row(
     only on that judge path; ``diagnosis_labels`` is mostly judge-sourced but the
     deterministic ``CLOSED_UNMERGED`` path can also pass one in (see
     ``ci_failing_at_close``).
+
+    ``close_action`` is derived from the PR's lifecycle fields:
+    - ``merged_at`` set → ``merged``
+    - ``closed_at`` set, not merged → ``closed``
+    - both null → ``abandoned`` (still-open stale PR detected by cron)
     """
     # Fetch the attribution snapshot once: it both gates emission (≥1 valid row)
     # and rides along on the emitted row, so the two can't diverge.
@@ -738,9 +747,13 @@ def emit_pr_metrics_row(
         **_activity_derived_metrics(pull_request)
     )
 
-    close_action: CloseAction = (
-        CLOSE_ACTION_MERGED if pull_request.merged_at is not None else CLOSE_ACTION_CLOSED
-    )
+    if pull_request.merged_at is not None:
+        close_action: CloseAction = CLOSE_ACTION_MERGED
+    elif pull_request.closed_at is not None:
+        close_action = CLOSE_ACTION_CLOSED
+    else:
+        close_action = CLOSE_ACTION_ABANDONED
+
     row = build_pr_metrics_row(
         pull_request=pull_request,
         close_action=close_action,
@@ -760,7 +773,7 @@ def emit_pr_metrics_row(
             "close_action": close_action,
         },
     )
-    # Imported here to avoid a circular import: tasks → judge → emit.
+    # Imported here to avoid a circular import: tasks → emit.
     from sentry.pr_metrics.tasks import cleanup_pr_activity_task
 
     cleanup_pr_activity_task.delay(pull_request_id=pull_request.id)

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -215,12 +215,7 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
 # the PR's own check-suite activity rather than a judge's opinion.
 CI_FAILING_AT_CLOSE = "ci_failing_at_close"
 
-# Diagnosis label for the stale-detection path, applied when a PR shows no
-# reviewer engagement across its whole lifetime, not just the detection
-# window. A document-track PR is checked via has_reviewer_engagement(doc); a
-# legacy-track PR (no PullRequestActivityLog document) is checked directly
-# against its full PullRequestActivity history for
-# REVIEWER_ENGAGEMENT_ACTIVITY_TYPES. See detect_stale_pull_requests_task.
+# Diagnosis label for the stale-detection path. See detect_stale_pull_requests_task.
 NO_REVIEWER_ENGAGEMENT = "no_reviewer_engagement"
 
 # Conclusions that unambiguously mean the check errored out, as opposed to
@@ -490,9 +485,8 @@ def build_pr_metrics_row(
     emitted row read the same query. A missing metrics row (a PR Sentry never saw
     active) coalesces every counter to its default.
 
-    For ``abandoned``, ``closed_at`` is set to the current UTC time (the
-    detection timestamp), since the PR is still open and the field is null on
-    the model. For close/merge, ``pull_request.closed_at`` is used.
+    ``abandoned`` PRs have null ``head_commit_sha``/``closed_at`` on the model
+    (still open); ``closed_at`` falls back to the detection timestamp.
 
     ``conversation_analysis`` is set on the judge path only: the conversation
     judge's result (semantic outputs become columns, its ``metadata`` is
@@ -510,7 +504,6 @@ def build_pr_metrics_row(
             )
 
     head_commit_sha = pull_request.head_commit_sha or "unknown"
-    # For abandoned PRs there's no `closed_at` value populated; fall back to now().
     effective_closed_at = pull_request.closed_at or dj_timezone.now()
 
     # A bare instance carries the model's zero/false field defaults, so a PR with

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -18,11 +18,15 @@ from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
     PullRequestActivityLog,
+    PullRequestActivityType,
     PullRequestMetrics,
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
-from sentry.pr_metrics.activity_doc import ENGAGING_ACTIVITY_TYPES, has_reviewer_engagement
+from sentry.pr_metrics.activity_doc import (
+    REVIEWER_ENGAGEMENT_ACTIVITY_TYPES,
+    has_reviewer_engagement,
+)
 from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge, reap_stuck_judge_verdicts
 from sentry.silo.base import SiloMode
@@ -183,11 +187,23 @@ def reap_stuck_judge_verdicts_task() -> None:
 
 
 # Batch size for the per-candidate settle loop in detect_stale_pull_requests_task.
-# Kept modest (rather than matching find_stale_pull_requests's unbounded scan)
-# because each batch now also bulk-fetches PullRequestActivityLog documents —
-# JSON blobs up to MAX_EVENTS entries each — for cross-checking, not just PR rows.
 _STALE_BATCH_SIZE = 100
+# How old PRs need no activity to be considered stale
 STALENESS_WINDOW = timedelta(weeks=4)
+
+# Event types that reset the stale clock in find_stale_pull_requests: any of
+# these within the detection window keeps a PR out of the candidate set.
+# Chosen for low bot-risk: all four require deliberate human action on the PR.
+# Narrower reviewer-only subset: REVIEWER_ENGAGEMENT_ACTIVITY_TYPES
+# (sentry.pr_metrics.activity_doc), used for the NO_REVIEWER_ENGAGEMENT label.
+ENGAGING_ACTIVITY_TYPES = frozenset(
+    {
+        PullRequestActivityType.SYNCHRONIZED,
+        PullRequestActivityType.REVIEW_SUBMITTED,
+        PullRequestActivityType.READY_FOR_REVIEW,
+        PullRequestActivityType.REVIEW_REQUESTED,
+    }
+)
 
 
 def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
@@ -243,12 +259,14 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
 def detect_stale_pull_requests_task() -> None:
     """Find and settle tracked PRs with no engaging activity since ``cutoff``.
 
-    Each candidate is claimed as ``abandoned`` and emitted directly, tagged with
-    the ``NO_REVIEWER_ENGAGEMENT`` diagnosis label — unconditional here, since
-    every remaining candidate (after the document cross-check below) has zero
-    engaging activity in the detection window by construction. The judge path
-    does not support open PRs (requires ``closed_at``), so all stale PRs are
-    settled here regardless of historical engagement.
+    Each candidate is claimed as ``abandoned`` and emitted directly. Diagnosis
+    labeling checks reviewer engagement across the PR's *whole* history, not
+    just the detection window: a document-track PR checks
+    ``has_reviewer_engagement`` on its document; a legacy-track PR (no
+    document) checks its full ``PullRequestActivity`` history for
+    ``REVIEWER_ENGAGEMENT_ACTIVITY_TYPES``, bulk-fetched per batch. The judge
+    path does not support open PRs (requires ``closed_at``), so all stale PRs
+    are settled here regardless.
 
     ``find_stale_pull_requests`` only sees legacy ``PullRequestActivity`` rows,
     so a candidate routed onto the reduced ``PullRequestActivityLog`` document
@@ -329,6 +347,19 @@ def detect_stale_pull_requests_task() -> None:
             ).values_list("pull_request_id", "data")
         )
 
+        # Bulk-fetch reviewer-engagement PR ids for legacy-track candidates (no
+        # document) in one query, rather than one Exists() per PR — mirrors the
+        # doc fetch above for the legacy track.
+        legacy_candidate_ids = [pr.id for pr in candidate_prs if pr.id not in doc_by_pr_id]
+        engaged_legacy_pr_ids = set(
+            PullRequestActivity.objects.filter(
+                pull_request_id__in=legacy_candidate_ids,
+                event_type__in=REVIEWER_ENGAGEMENT_ACTIVITY_TYPES,
+            )
+            .values_list("pull_request_id", flat=True)
+            .distinct()
+        )
+
         # Second pass: process candidates with document data
         for pr in candidate_prs:
             # Ensure the metrics row exists before any compare-and-set claim.
@@ -340,16 +371,19 @@ def detect_stale_pull_requests_task() -> None:
                 metrics.incr("pr_metrics.stale.skipped", tags={"reason": "already_claimed"})
                 continue
 
-            # Check if NO_REVIEWER_ENGAGEMENT label should be applied by examining
-            # the activity document for any reviewer engagement throughout the PR's lifetime
+            # NO_REVIEWER_ENGAGEMENT means no reviewer ever engaged with this PR,
+            # not just none in the detection window — so this checks each
+            # track's full activity history, not only what's within `cutoff`.
             diagnosis_labels = []
             doc = doc_by_pr_id.get(pr.id)
             if doc is not None:
                 if not has_reviewer_engagement(doc):
                     diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
             else:
-                # No activity document exists, so no reviewer engagement occurred
-                diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
+                # Legacy-track PR: no document exists, so check the full
+                # PullRequestActivity history instead of assuming no engagement.
+                if pr.id not in engaged_legacy_pr_ids:
+                    diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
 
             if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=diagnosis_labels):
                 emitted += 1

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -188,23 +188,14 @@ def reap_stuck_judge_verdicts_task() -> None:
 
 # Batch size for the per-candidate settle loop in detect_stale_pull_requests_task.
 _STALE_BATCH_SIZE = 100
-# Cap on how many candidates find_stale_pull_requests returns per run. Mirrors
-# reap_stuck_judge_verdicts's _REAP_BATCH_SIZE: no upper bound on staleness age,
-# so a first run (or one that fell behind) could otherwise match an arbitrarily
-# large historical backlog of ancient open PRs in one go. A capped, oldest-first
-# scan spreads a large backlog across runs instead of risking a timeout and a
-# flood of abandoned-verdict emissions in a single invocation — each settled PR
-# gets a non-NULL verdict, so it drops out of the candidate set and later runs
-# make steady progress through the rest.
+# Mirrors reap_stuck_judge_verdicts's _REAP_BATCH_SIZE: caps a first/backlogged
+# run so it can't pull an unbounded candidate set into memory at once.
 _STALE_SCAN_LIMIT = 500
-# How old PRs need no activity to be considered stale
 STALENESS_WINDOW = timedelta(weeks=4)
 
-# Event types that reset the stale clock in find_stale_pull_requests: any of
-# these within the detection window keeps a PR out of the candidate set.
-# Chosen for low bot-risk: all four require deliberate human action on the PR.
-# Narrower reviewer-only subset: REVIEWER_ENGAGEMENT_ACTIVITY_TYPES
-# (sentry.pr_metrics.activity_doc), used for the NO_REVIEWER_ENGAGEMENT label.
+# Resets the stale clock in find_stale_pull_requests. Narrower reviewer-only
+# subset: REVIEWER_ENGAGEMENT_ACTIVITY_TYPES (activity_doc), used for the
+# NO_REVIEWER_ENGAGEMENT label.
 ENGAGING_ACTIVITY_TYPES = frozenset(
     {
         PullRequestActivityType.SYNCHRONIZED,
@@ -216,54 +207,19 @@ ENGAGING_ACTIVITY_TYPES = frozenset(
 
 
 def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
-    """IDs of tracked open PRs with no engaging activity since ``cutoff``.
+    """IDs of tracked, open, unverdicted PRs opened before ``cutoff`` with no
+    engaging activity since then, from either activity store.
 
-    A PR is a staleness candidate when:
-    - It has ≥1 valid ``PullRequestAttribution`` row (tracked).
-    - Its ``PullRequestMetrics.verdict`` is ``NULL`` — not yet judged or closed.
-      ``JUDGE_IN_PROGRESS`` is non-NULL so those PRs are excluded naturally.
-    - It was opened before the cutoff time.
-    - It has no engaging activity (see ``ENGAGING_ACTIVITY_TYPES``) with
-      ``date_added >= cutoff``, read off legacy ``PullRequestActivity`` rows.
-    - Its ``PullRequestActivityLog`` document (if any) hasn't been written to
-      since ``cutoff`` either — see below.
+    Legacy ``PullRequestActivity`` rows are checked directly; a document-track
+    PR (see ``webhooks._use_activity_document``) never writes those rows, so
+    it's checked via ``PullRequestActivityLog.date_updated`` instead — coarser,
+    since any write (not just an engaging one) resets it, but a false negative
+    here only delays detection, whereas a false positive would wrongly abandon
+    an engaged PR.
 
-    Both activity checks are correlated ``Exists`` subqueries so the whole scan
-    stays in the DB — no Python-side iteration over candidates, and no per-PR
-    document fetch here. The legacy check only sees ``PullRequestActivity``
-    rows: a PR routed onto the reduced ``PullRequestActivityLog`` document (see
-    ``sentry.pr_metrics.webhooks._use_activity_document``) never writes those
-    rows, so on its own that check would always clear regardless of real
-    engagement — document-routed PRs are the *default* going forward, so this
-    can't be left as an approximation resolved later per batch (as it
-    previously was) without most stale scans effectively finding nothing else.
-    The second check closes that gap directly in SQL: a document-track PR only
-    counts as a candidate once its document has gone quiet for the same window
-    (``date_updated < cutoff``), and a PR with no document at all (never
-    routed onto it, or routed but not yet written) passes trivially since
-    there's no row to find.
-
-    This document check is coarser than the legacy one: ``date_updated`` is
-    bumped by *any* write (including a non-engaging one, e.g. a comment), not
-    only ``ENGAGING_ACTIVITY_TYPES`` writes — so a document-track PR with only
-    non-engaging activity is excluded here even though a legacy-track PR in
-    the same situation is correctly still a candidate (see
-    ``detect_stale_pull_requests_task``'s docstring for how the reviewer-
-    engagement diagnosis label separately corrects for this). Accepted here:
-    a false negative (skipping a PR that's actually stale) just delays
-    detection to a later run, whereas the false positive this check exists to
-    prevent (claiming a genuinely-engaged PR as abandoned) is irreversible.
-
-    Capped at ``_STALE_SCAN_LIMIT``, oldest-opened first: there's no upper
-    bound on staleness age, so an ancient backlog (first run, or one that fell
-    behind) could otherwise match an arbitrarily large candidate set in one
-    go. Each settled PR gets a non-NULL verdict and drops out of the
-    candidate set, so a backlog past the cap still gets worked down over
-    subsequent runs rather than all being pulled into memory — and settled —
-    at once. Mirrors ``reap_stuck_judge_verdicts``'s ``_REAP_BATCH_SIZE``.
-
-    Returns a list of ``PullRequest`` primary keys, not ORM instances, so the
-    caller can process them in batches without holding a large queryset open.
+    Capped at ``_STALE_SCAN_LIMIT``, oldest-opened first, so an unbounded
+    backlog can't be pulled into memory in one run; settled PRs drop out of
+    future scans as their verdict is written.
     """
     recent_engaging_activity = PullRequestActivity.objects.filter(
         pull_request=OuterRef("pk"),
@@ -297,33 +253,17 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
     silo_mode=SiloMode.CELL,
 )
 def detect_stale_pull_requests_task() -> None:
-    """Find and settle tracked PRs with no engaging activity since ``cutoff``.
+    """Claim each stale-candidate PR as ``abandoned`` and emit it directly —
+    the judge path requires ``closed_at`` and doesn't support open PRs.
 
-    Each candidate is claimed as ``abandoned`` and emitted directly. Diagnosis
-    labeling checks reviewer engagement across the PR's *whole* history, not
-    just the detection window: a document-track PR checks
-    ``has_reviewer_engagement`` on its document; a legacy-track PR (no
-    document) checks its full ``PullRequestActivity`` history for
-    ``REVIEWER_ENGAGEMENT_ACTIVITY_TYPES``, bulk-fetched per batch. The judge
-    path does not support open PRs (requires ``closed_at``), so all stale PRs
-    are settled here regardless.
+    ``NO_REVIEWER_ENGAGEMENT`` diagnosis checks each PR's full history, not
+    just the detection window: ``has_reviewer_engagement`` on the document, or
+    ``REVIEWER_ENGAGEMENT_ACTIVITY_TYPES`` against legacy rows otherwise —
+    fetched per batch since pulling every document at once isn't bounded.
 
-    ``find_stale_pull_requests`` already excludes a document-track PR whose
-    ``PullRequestActivityLog`` has been written to since ``cutoff`` — see its
-    docstring for why that has to happen in SQL rather than here. What's left
-    to do here is read each candidate's document *contents* (not just its
-    timestamp) for the reviewer-engagement diagnosis label below — bulked per
-    batch, since pulling every candidate's document into Python in one shot
-    would be less bounded than the per-batch reads, which is why the batch
-    size is kept modest rather than matching ``find_stale_pull_requests``'s
-    full scan.
-
-    Each candidate is guarded by a compare-and-set claim before any action, so
-    an overlapping run or redelivery won't double-process.
-
-    Feature-gated per organization by ``organizations:pr-metrics-emit`` and
-    ``organizations:pr-metrics-activity`` — both must be on. Without activity
-    tracking we can't distinguish an engaged PR from an untouched one.
+    Feature-gated per org by ``pr-metrics-emit`` and ``pr-metrics-activity``
+    (both required — without activity tracking we can't tell an engaged PR
+    from an untouched one).
     """
     # Imported here to avoid a circular import: webhooks imports this module.
     from sentry.pr_metrics.webhooks import _claim_terminal_event
@@ -340,7 +280,6 @@ def detect_stale_pull_requests_task() -> None:
         org_ids = {pr.organization_id for pr in pull_requests}
         orgs_by_id = {o.id: o for o in Organization.objects.filter(id__in=org_ids)}
 
-        # First pass: collect PRs that pass the feature-flag gate
         candidate_prs = []
         for pr in pull_requests:
             org = orgs_by_id.get(pr.organization_id)
@@ -354,23 +293,19 @@ def detect_stale_pull_requests_task() -> None:
             if not features.has("organizations:pr-metrics-emit", org):
                 continue
 
-            # Without activity tracking we can't distinguish an engaged PR from
-            # an untouched one, so we can't safely emit an abandoned verdict.
             if not features.has("organizations:pr-metrics-activity", org):
                 continue
 
             candidate_prs.append(pr)
 
-        # Bulk-fetch activity documents for all candidates
         doc_by_pr_id = dict(
             PullRequestActivityLog.objects.filter(
                 pull_request_id__in=[pr.id for pr in candidate_prs]
             ).values_list("pull_request_id", "data")
         )
 
-        # Bulk-fetch reviewer-engagement PR ids for legacy-track candidates (no
-        # document) in one query, rather than one Exists() per PR — mirrors the
-        # doc fetch above for the legacy track.
+        # One query for all legacy-track candidates rather than one Exists()
+        # per PR, mirroring the doc fetch above.
         legacy_candidate_ids = [pr.id for pr in candidate_prs if pr.id not in doc_by_pr_id]
         engaged_legacy_pr_ids = set(
             PullRequestActivity.objects.filter(
@@ -381,39 +316,27 @@ def detect_stale_pull_requests_task() -> None:
             .distinct()
         )
 
-        # Second pass: process candidates with document data
         for pr in candidate_prs:
-            # Ensure the metrics row exists before any compare-and-set claim.
-            # A stale PR may never have reached a close/merge webhook so the
-            # row may not exist yet.
+            # A stale PR may never have reached a close/merge webhook, so the
+            # metrics row may not exist yet.
             PullRequestMetrics.objects.get_or_create(pull_request=pr)
 
             if not _claim_terminal_event(pr, PullRequestVerdict.ABANDONED):
                 metrics.incr("pr_metrics.stale.skipped", tags={"reason": "already_claimed"})
                 continue
 
-            # NO_REVIEWER_ENGAGEMENT means no reviewer ever engaged with this PR,
-            # not just none in the detection window — so this checks each
-            # track's full activity history, not only what's within `cutoff`.
             diagnosis_labels = []
             doc = doc_by_pr_id.get(pr.id)
             if doc is not None:
                 if not has_reviewer_engagement(doc):
                     diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
-            else:
-                # Legacy-track PR: no document exists, so check the full
-                # PullRequestActivity history instead of assuming no engagement.
-                if pr.id not in engaged_legacy_pr_ids:
-                    diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
+            elif pr.id not in engaged_legacy_pr_ids:
+                diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
 
-            # The claim above already stands regardless of what happens here — same
-            # trade-off as webhooks._claim_and_emit: emission is best-effort,
-            # async-batched telemetry, so a failure here forgoes this PR's row
-            # rather than being retried (retrying would mean re-claiming, which the
-            # NULL-verdict CAS above no longer allows). Guarded so one bad
-            # candidate (a DB blip, a downstream analytics error) can't abort the
-            # rest of the batch — and the whole run, since every remaining batch in
-            # this task would go unprocessed with it.
+            # The claim above stands regardless of what happens here, so a
+            # failed emission isn't retried — same trade-off as
+            # webhooks._claim_and_emit. Guarded so one bad candidate can't
+            # abort the rest of the batch.
             try:
                 if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=diagnosis_labels):
                     emitted += 1

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -188,6 +188,15 @@ def reap_stuck_judge_verdicts_task() -> None:
 
 # Batch size for the per-candidate settle loop in detect_stale_pull_requests_task.
 _STALE_BATCH_SIZE = 100
+# Cap on how many candidates find_stale_pull_requests returns per run. Mirrors
+# reap_stuck_judge_verdicts's _REAP_BATCH_SIZE: no upper bound on staleness age,
+# so a first run (or one that fell behind) could otherwise match an arbitrarily
+# large historical backlog of ancient open PRs in one go. A capped, oldest-first
+# scan spreads a large backlog across runs instead of risking a timeout and a
+# flood of abandoned-verdict emissions in a single invocation — each settled PR
+# gets a non-NULL verdict, so it drops out of the candidate set and later runs
+# make steady progress through the rest.
+_STALE_SCAN_LIMIT = 500
 # How old PRs need no activity to be considered stale
 STALENESS_WINDOW = timedelta(weeks=4)
 
@@ -228,6 +237,14 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
     document before settling it, since doing so here would mean pulling every
     candidate's document into this one unbounded scan instead of per batch.
 
+    Capped at ``_STALE_SCAN_LIMIT``, oldest-opened first: there's no upper
+    bound on staleness age, so an ancient backlog (first run, or one that fell
+    behind) could otherwise match an arbitrarily large candidate set in one
+    go. Each settled PR gets a non-NULL verdict and drops out of the
+    candidate set, so a backlog past the cap still gets worked down over
+    subsequent runs rather than all being pulled into memory — and settled —
+    at once. Mirrors ``reap_stuck_judge_verdicts``'s ``_REAP_BATCH_SIZE``.
+
     Returns a list of ``PullRequest`` primary keys, not ORM instances, so the
     caller can process them in batches without holding a large queryset open.
     """
@@ -245,8 +262,9 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
             metrics__verdict__isnull=True,
         )
         .filter(~Exists(recent_engaging_activity))
+        .order_by("date_added")
         .values_list("id", flat=True)
-        .distinct()
+        .distinct()[:_STALE_SCAN_LIMIT]
     )
     return list(qs)
 

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -23,7 +23,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
-from sentry.pr_metrics.emit import emit_pr_metrics_row
+from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge, reap_stuck_judge_verdicts
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -243,9 +243,12 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
 def detect_stale_pull_requests_task() -> None:
     """Find and settle tracked PRs with no engaging activity since ``cutoff``.
 
-    Each candidate is claimed as ``abandoned`` and emitted directly. The judge
-    path does not support open PRs (requires ``closed_at``), so all stale PRs
-    are settled here regardless of historical engagement.
+    Each candidate is claimed as ``abandoned`` and emitted directly, tagged with
+    the ``NO_REVIEWER_ENGAGEMENT`` diagnosis label — unconditional here, since
+    ``find_stale_pull_requests`` already filtered to PRs with zero engaging
+    activity in the detection window. The judge path does not support open PRs
+    (requires ``closed_at``), so all stale PRs are settled here regardless of
+    historical engagement.
 
     Each candidate is guarded by a compare-and-set claim before any action, so
     an overlapping run or redelivery won't double-process.
@@ -293,7 +296,7 @@ def detect_stale_pull_requests_task() -> None:
             if not _claim_terminal_event(pr, PullRequestVerdict.ABANDONED):
                 metrics.incr("pr_metrics.stale.skipped", tags={"reason": "already_claimed"})
                 continue
-            if emit_pr_metrics_row(pull_request=pr):
+            if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=[NO_REVIEWER_ENGAGEMENT]):
                 emitted += 1
 
     metrics.incr("pr_metrics.stale.emitted", amount=emitted)

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -22,7 +22,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
-from sentry.pr_metrics.activity_doc import ENGAGING_ACTIVITY_TYPES, has_engaging_activity_since
+from sentry.pr_metrics.activity_doc import ENGAGING_ACTIVITY_TYPES, has_reviewer_engagement
 from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge, reap_stuck_judge_verdicts
 from sentry.silo.base import SiloMode
@@ -197,9 +197,7 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
     - It has ≥1 valid ``PullRequestAttribution`` row (tracked).
     - Its ``PullRequestMetrics.verdict`` is ``NULL`` — not yet judged or closed.
       ``JUDGE_IN_PROGRESS`` is non-NULL so those PRs are excluded naturally.
-    - It was opened in the window (cutoff - STALENESS_WINDOW, cutoff) — between
-      one and two staleness windows ago. PRs older than 2× the window are ignored:
-      they've had long enough to be caught by a previous run.
+    - It was opened before the cutoff time.
     - It has no engaging activity (see ``ENGAGING_ACTIVITY_TYPES``) with
       ``date_added >= cutoff``, read off legacy ``PullRequestActivity`` rows.
 
@@ -227,7 +225,6 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
         PullRequest.objects.filter(
             state="open",
             date_added__lt=cutoff,
-            date_added__gte=cutoff - STALENESS_WINDOW,
             pullrequestattribution__is_valid=True,
             metrics__verdict__isnull=True,
         )
@@ -283,12 +280,12 @@ def detect_stale_pull_requests_task() -> None:
         pull_requests = list(PullRequest.objects.filter(id__in=batch))
         org_ids = {pr.organization_id for pr in pull_requests}
         orgs_by_id = {o.id: o for o in Organization.objects.filter(id__in=org_ids)}
-        # Bulk-fetch this batch's documents once, rather than a query per PR —
+        # Bulk-fetch this batch's last updated timestamps once, rather than a query per PR —
         # most candidates will have none (legacy-track PRs), so this is a
         # small lookup scoped to the batch, not the full candidate list.
-        doc_by_pr_id = dict(
+        updated_at_by_pr_id = dict(
             PullRequestActivityLog.objects.filter(pull_request_id__in=batch).values_list(
-                "pull_request_id", "data"
+                "pull_request_id", "date_updated"
             )
         )
         for pr in pull_requests:
@@ -308,8 +305,8 @@ def detect_stale_pull_requests_task() -> None:
             if not features.has("organizations:pr-metrics-activity", org):
                 continue
 
-            doc = doc_by_pr_id.get(pr.id)
-            if doc is not None and has_engaging_activity_since(doc, cutoff):
+            last_updated = updated_at_by_pr_id.get(pr.id)
+            if last_updated is not None and last_updated >= cutoff:
                 # The legacy-only SQL scan couldn't see this PR's document, so
                 # it fell through as a false candidate — it's actually engaged.
                 metrics.incr("pr_metrics.stale.skipped", tags={"reason": "doc_engaged"})
@@ -323,7 +320,19 @@ def detect_stale_pull_requests_task() -> None:
             if not _claim_terminal_event(pr, PullRequestVerdict.ABANDONED):
                 metrics.incr("pr_metrics.stale.skipped", tags={"reason": "already_claimed"})
                 continue
-            if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=[NO_REVIEWER_ENGAGEMENT]):
+
+            # Check if NO_REVIEWER_ENGAGEMENT label should be applied by examining
+            # the activity document for any reviewer engagement throughout the PR's lifetime
+            diagnosis_labels = []
+            try:
+                activity_log = PullRequestActivityLog.objects.get(pull_request_id=pr.id)
+                if not has_reviewer_engagement(activity_log.data):
+                    diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
+            except PullRequestActivityLog.DoesNotExist:
+                # No activity document exists, so no reviewer engagement occurred
+                diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
+
+            if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=diagnosis_labels):
                 emitted += 1
 
     metrics.incr("pr_metrics.stale.emitted", amount=emitted)

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -288,6 +288,9 @@ def detect_stale_pull_requests_task() -> None:
                 "pull_request_id", "date_updated"
             )
         )
+
+        # First pass: collect PRs that pass initial filters and timestamp checks
+        candidate_prs = []
         for pr in pull_requests:
             org = orgs_by_id.get(pr.organization_id)
             if org is None:
@@ -312,6 +315,17 @@ def detect_stale_pull_requests_task() -> None:
                 metrics.incr("pr_metrics.stale.skipped", tags={"reason": "doc_engaged"})
                 continue
 
+            candidate_prs.append(pr)
+
+        # Bulk-fetch activity documents for all candidates
+        doc_by_pr_id = dict(
+            PullRequestActivityLog.objects.filter(
+                pull_request_id__in=[pr.id for pr in candidate_prs]
+            ).values_list("pull_request_id", "data")
+        )
+
+        # Second pass: process candidates with document data
+        for pr in candidate_prs:
             # Ensure the metrics row exists before any compare-and-set claim.
             # A stale PR may never have reached a close/merge webhook so the
             # row may not exist yet.
@@ -324,11 +338,11 @@ def detect_stale_pull_requests_task() -> None:
             # Check if NO_REVIEWER_ENGAGEMENT label should be applied by examining
             # the activity document for any reviewer engagement throughout the PR's lifetime
             diagnosis_labels = []
-            try:
-                activity_log = PullRequestActivityLog.objects.get(pull_request_id=pr.id)
-                if not has_reviewer_engagement(activity_log.data):
+            doc = doc_by_pr_id.get(pr.id)
+            if doc is not None:
+                if not has_reviewer_engagement(doc):
                     diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
-            except PullRequestActivityLog.DoesNotExist:
+            else:
                 # No activity document exists, so no reviewer engagement occurred
                 diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
 

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -18,11 +18,11 @@ from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
     PullRequestActivityLog,
-    PullRequestActivityType,
     PullRequestMetrics,
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
+from sentry.pr_metrics.activity_doc import ENGAGING_ACTIVITY_TYPES, has_engaging_activity_since
 from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge, reap_stuck_judge_verdicts
 from sentry.silo.base import SiloMode
@@ -182,17 +182,12 @@ def reap_stuck_judge_verdicts_task() -> None:
     reap_stuck_judge_verdicts()
 
 
-_STALE_BATCH_SIZE = 500
+# Batch size for the per-candidate settle loop in detect_stale_pull_requests_task.
+# Kept modest (rather than matching find_stale_pull_requests's unbounded scan)
+# because each batch now also bulk-fetches PullRequestActivityLog documents —
+# JSON blobs up to MAX_EVENTS entries each — for cross-checking, not just PR rows.
+_STALE_BATCH_SIZE = 100
 STALENESS_WINDOW = timedelta(weeks=4)
-
-# Activity types that count as "engagement" for staleness purposes.
-# Chosen for low bot-risk: all four require deliberate human action on the PR.
-_ENGAGING_ACTIVITY_TYPES = (
-    PullRequestActivityType.SYNCHRONIZED,
-    PullRequestActivityType.REVIEW_SUBMITTED,
-    PullRequestActivityType.READY_FOR_REVIEW,
-    PullRequestActivityType.REVIEW_REQUESTED,
-)
 
 
 def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
@@ -205,18 +200,26 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
     - It was opened in the window (cutoff - STALENESS_WINDOW, cutoff) — between
       one and two staleness windows ago. PRs older than 2× the window are ignored:
       they've had long enough to be caught by a previous run.
-    - It has no engaging activity (SYNCHRONIZED, REVIEW_SUBMITTED, READY_FOR_REVIEW,
-      REVIEW_REQUESTED) with ``date_added >= cutoff``.
+    - It has no engaging activity (see ``ENGAGING_ACTIVITY_TYPES``) with
+      ``date_added >= cutoff``, read off legacy ``PullRequestActivity`` rows.
 
     The activity check is a correlated ``Exists`` subquery so the whole scan
-    stays in the DB — no Python-side iteration over candidates.
+    stays in the DB — no Python-side iteration over candidates. It only sees
+    legacy ``PullRequestActivity`` rows, though: a PR routed onto the reduced
+    ``PullRequestActivityLog`` document (see
+    ``sentry.pr_metrics.webhooks._use_activity_document``) never writes those
+    rows, so it always clears this filter regardless of real engagement. That
+    false-positive is deliberately left uncorrected here — the caller
+    (``detect_stale_pull_requests_task``) cross-checks each candidate's
+    document before settling it, since doing so here would mean pulling every
+    candidate's document into this one unbounded scan instead of per batch.
 
     Returns a list of ``PullRequest`` primary keys, not ORM instances, so the
     caller can process them in batches without holding a large queryset open.
     """
     recent_engaging_activity = PullRequestActivity.objects.filter(
         pull_request=OuterRef("pk"),
-        event_type__in=_ENGAGING_ACTIVITY_TYPES,
+        event_type__in=ENGAGING_ACTIVITY_TYPES,
         date_added__gte=cutoff,
     )
 
@@ -245,10 +248,19 @@ def detect_stale_pull_requests_task() -> None:
 
     Each candidate is claimed as ``abandoned`` and emitted directly, tagged with
     the ``NO_REVIEWER_ENGAGEMENT`` diagnosis label — unconditional here, since
-    ``find_stale_pull_requests`` already filtered to PRs with zero engaging
-    activity in the detection window. The judge path does not support open PRs
-    (requires ``closed_at``), so all stale PRs are settled here regardless of
-    historical engagement.
+    every remaining candidate (after the document cross-check below) has zero
+    engaging activity in the detection window by construction. The judge path
+    does not support open PRs (requires ``closed_at``), so all stale PRs are
+    settled here regardless of historical engagement.
+
+    ``find_stale_pull_requests`` only sees legacy ``PullRequestActivity`` rows,
+    so a candidate routed onto the reduced ``PullRequestActivityLog`` document
+    (see ``sentry.pr_metrics.webhooks._use_activity_document``) may actually be
+    engaged — that store never writes those rows. Each batch bulk-fetches any
+    such documents for its candidates and skips ones showing activity the SQL
+    scan couldn't see. Less efficient than the pure-SQL legacy path (documents
+    are pulled into Python one batch at a time), which is why the batch size is
+    kept modest rather than matching ``find_stale_pull_requests``'s full scan.
 
     Each candidate is guarded by a compare-and-set claim before any action, so
     an overlapping run or redelivery won't double-process.
@@ -271,6 +283,14 @@ def detect_stale_pull_requests_task() -> None:
         pull_requests = list(PullRequest.objects.filter(id__in=batch))
         org_ids = {pr.organization_id for pr in pull_requests}
         orgs_by_id = {o.id: o for o in Organization.objects.filter(id__in=org_ids)}
+        # Bulk-fetch this batch's documents once, rather than a query per PR —
+        # most candidates will have none (legacy-track PRs), so this is a
+        # small lookup scoped to the batch, not the full candidate list.
+        doc_by_pr_id = dict(
+            PullRequestActivityLog.objects.filter(pull_request_id__in=batch).values_list(
+                "pull_request_id", "data"
+            )
+        )
         for pr in pull_requests:
             org = orgs_by_id.get(pr.organization_id)
             if org is None:
@@ -286,6 +306,13 @@ def detect_stale_pull_requests_task() -> None:
             # Without activity tracking we can't distinguish an engaged PR from
             # an untouched one, so we can't safely emit an abandoned verdict.
             if not features.has("organizations:pr-metrics-activity", org):
+                continue
+
+            doc = doc_by_pr_id.get(pr.id)
+            if doc is not None and has_engaging_activity_since(doc, cutoff):
+                # The legacy-only SQL scan couldn't see this PR's document, so
+                # it fell through as a false candidate — it's actually engaged.
+                metrics.incr("pr_metrics.stale.skipped", tags={"reason": "doc_engaged"})
                 continue
 
             # Ensure the metrics row exists before any compare-and-set claim.

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -253,11 +253,16 @@ def detect_stale_pull_requests_task() -> None:
     ``find_stale_pull_requests`` only sees legacy ``PullRequestActivity`` rows,
     so a candidate routed onto the reduced ``PullRequestActivityLog`` document
     (see ``sentry.pr_metrics.webhooks._use_activity_document``) may actually be
-    engaged — that store never writes those rows. Each batch bulk-fetches any
-    such documents for its candidates and skips ones showing activity the SQL
-    scan couldn't see. Less efficient than the pure-SQL legacy path (documents
-    are pulled into Python one batch at a time), which is why the batch size is
-    kept modest rather than matching ``find_stale_pull_requests``'s full scan.
+    engaged — that store never writes those rows. Each batch bulk-fetches each
+    candidate's document ``date_updated`` and skips any updated at or after
+    ``cutoff``. Coarser than the legacy check: any document write (including a
+    non-engaging one, e.g. a comment) resets this clock, since ``date_updated``
+    doesn't distinguish event types — a document-track PR with only
+    non-engaging activity is skipped here even though a legacy-track PR in the
+    same situation is correctly still a candidate. Less efficient than the
+    pure-SQL legacy path too (documents are pulled into Python one batch at a
+    time), which is why the batch size is kept modest rather than matching
+    ``find_stale_pull_requests``'s full scan.
 
     Each candidate is guarded by a compare-and-set claim before any action, so
     an overlapping run or redelivery won't double-process.

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -3,21 +3,27 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db import Error as DjangoDBError
+from django.db.models import Exists, OuterRef
+from django.utils import timezone as dj_timezone
 from taskbroker_client.retry import Retry
 from urllib3.exceptions import HTTPError
 
+from sentry import features
 from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
     PullRequestActivityLog,
+    PullRequestActivityType,
     PullRequestMetrics,
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
+from sentry.pr_metrics.emit import emit_pr_metrics_row
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge, reap_stuck_judge_verdicts
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -174,3 +180,121 @@ def reap_stuck_judge_verdicts_task() -> None:
     See ``reap_stuck_judge_verdicts`` for the settling logic and its bounds.
     """
     reap_stuck_judge_verdicts()
+
+
+_STALE_BATCH_SIZE = 500
+STALENESS_WINDOW = timedelta(weeks=4)
+
+# Activity types that count as "engagement" for staleness purposes.
+# Chosen for low bot-risk: all four require deliberate human action on the PR.
+_ENGAGING_ACTIVITY_TYPES = (
+    PullRequestActivityType.SYNCHRONIZED,
+    PullRequestActivityType.REVIEW_SUBMITTED,
+    PullRequestActivityType.READY_FOR_REVIEW,
+    PullRequestActivityType.REVIEW_REQUESTED,
+)
+
+
+def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
+    """IDs of tracked open PRs with no engaging activity since ``cutoff``.
+
+    A PR is a staleness candidate when:
+    - It has ≥1 valid ``PullRequestAttribution`` row (tracked).
+    - Its ``PullRequestMetrics.verdict`` is ``NULL`` — not yet judged or closed.
+      ``JUDGE_IN_PROGRESS`` is non-NULL so those PRs are excluded naturally.
+    - It was opened in the window (cutoff - STALENESS_WINDOW, cutoff) — between
+      one and two staleness windows ago. PRs older than 2× the window are ignored:
+      they've had long enough to be caught by a previous run.
+    - It has no engaging activity (SYNCHRONIZED, REVIEW_SUBMITTED, READY_FOR_REVIEW,
+      REVIEW_REQUESTED) with ``date_added >= cutoff``.
+
+    The activity check is a correlated ``Exists`` subquery so the whole scan
+    stays in the DB — no Python-side iteration over candidates.
+
+    Returns a list of ``PullRequest`` primary keys, not ORM instances, so the
+    caller can process them in batches without holding a large queryset open.
+    """
+    recent_engaging_activity = PullRequestActivity.objects.filter(
+        pull_request=OuterRef("pk"),
+        event_type__in=_ENGAGING_ACTIVITY_TYPES,
+        date_added__gte=cutoff,
+    )
+
+    qs = (
+        PullRequest.objects.filter(
+            state="open",
+            date_added__lt=cutoff,
+            date_added__gte=cutoff - STALENESS_WINDOW,
+            pullrequestattribution__is_valid=True,
+            metrics__verdict__isnull=True,
+        )
+        .filter(~Exists(recent_engaging_activity))
+        .values_list("id", flat=True)
+        .distinct()
+    )
+    return list(qs)
+
+
+@instrumented_task(
+    name="sentry.pr_metrics.tasks.detect_stale_pull_requests",
+    namespace=seer_code_review_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def detect_stale_pull_requests_task() -> None:
+    """Find and settle tracked PRs with no engaging activity since ``cutoff``.
+
+    Each candidate is claimed as ``abandoned`` and emitted directly. The judge
+    path does not support open PRs (requires ``closed_at``), so all stale PRs
+    are settled here regardless of historical engagement.
+
+    Each candidate is guarded by a compare-and-set claim before any action, so
+    an overlapping run or redelivery won't double-process.
+
+    Feature-gated per organization by ``organizations:pr-metrics-emit`` and
+    ``organizations:pr-metrics-activity`` — both must be on. Without activity
+    tracking we can't distinguish an engaged PR from an untouched one.
+    """
+    # Imported here to avoid a circular import: webhooks imports this module.
+    from sentry.pr_metrics.webhooks import _claim_terminal_event
+
+    cutoff = dj_timezone.now() - STALENESS_WINDOW
+    pr_ids = find_stale_pull_requests(cutoff=cutoff)
+    metrics.incr("pr_metrics.stale.candidates", amount=len(pr_ids))
+    logger.info("pr_metrics.stale.candidates", extra={"count": len(pr_ids)})
+
+    emitted = 0
+    for batch_start in range(0, len(pr_ids), _STALE_BATCH_SIZE):
+        batch = pr_ids[batch_start : batch_start + _STALE_BATCH_SIZE]
+        pull_requests = list(PullRequest.objects.filter(id__in=batch))
+        org_ids = {pr.organization_id for pr in pull_requests}
+        orgs_by_id = {o.id: o for o in Organization.objects.filter(id__in=org_ids)}
+        for pr in pull_requests:
+            org = orgs_by_id.get(pr.organization_id)
+            if org is None:
+                logger.warning(
+                    "pr_metrics.stale.org_not_found",
+                    extra={"pull_request_id": pr.id, "organization_id": pr.organization_id},
+                )
+                continue
+
+            if not features.has("organizations:pr-metrics-emit", org):
+                continue
+
+            # Without activity tracking we can't distinguish an engaged PR from
+            # an untouched one, so we can't safely emit an abandoned verdict.
+            if not features.has("organizations:pr-metrics-activity", org):
+                continue
+
+            # Ensure the metrics row exists before any compare-and-set claim.
+            # A stale PR may never have reached a close/merge webhook so the
+            # row may not exist yet.
+            PullRequestMetrics.objects.get_or_create(pull_request=pr)
+
+            if not _claim_terminal_event(pr, PullRequestVerdict.ABANDONED):
+                metrics.incr("pr_metrics.stale.skipped", tags={"reason": "already_claimed"})
+                continue
+            if emit_pr_metrics_row(pull_request=pr):
+                emitted += 1
+
+    metrics.incr("pr_metrics.stale.emitted", amount=emitted)
+    logger.info("pr_metrics.stale.emitted", extra={"count": emitted})

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -225,17 +225,34 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
     - It was opened before the cutoff time.
     - It has no engaging activity (see ``ENGAGING_ACTIVITY_TYPES``) with
       ``date_added >= cutoff``, read off legacy ``PullRequestActivity`` rows.
+    - Its ``PullRequestActivityLog`` document (if any) hasn't been written to
+      since ``cutoff`` either — see below.
 
-    The activity check is a correlated ``Exists`` subquery so the whole scan
-    stays in the DB — no Python-side iteration over candidates. It only sees
-    legacy ``PullRequestActivity`` rows, though: a PR routed onto the reduced
-    ``PullRequestActivityLog`` document (see
+    Both activity checks are correlated ``Exists`` subqueries so the whole scan
+    stays in the DB — no Python-side iteration over candidates, and no per-PR
+    document fetch here. The legacy check only sees ``PullRequestActivity``
+    rows: a PR routed onto the reduced ``PullRequestActivityLog`` document (see
     ``sentry.pr_metrics.webhooks._use_activity_document``) never writes those
-    rows, so it always clears this filter regardless of real engagement. That
-    false-positive is deliberately left uncorrected here — the caller
-    (``detect_stale_pull_requests_task``) cross-checks each candidate's
-    document before settling it, since doing so here would mean pulling every
-    candidate's document into this one unbounded scan instead of per batch.
+    rows, so on its own that check would always clear regardless of real
+    engagement — document-routed PRs are the *default* going forward, so this
+    can't be left as an approximation resolved later per batch (as it
+    previously was) without most stale scans effectively finding nothing else.
+    The second check closes that gap directly in SQL: a document-track PR only
+    counts as a candidate once its document has gone quiet for the same window
+    (``date_updated < cutoff``), and a PR with no document at all (never
+    routed onto it, or routed but not yet written) passes trivially since
+    there's no row to find.
+
+    This document check is coarser than the legacy one: ``date_updated`` is
+    bumped by *any* write (including a non-engaging one, e.g. a comment), not
+    only ``ENGAGING_ACTIVITY_TYPES`` writes — so a document-track PR with only
+    non-engaging activity is excluded here even though a legacy-track PR in
+    the same situation is correctly still a candidate (see
+    ``detect_stale_pull_requests_task``'s docstring for how the reviewer-
+    engagement diagnosis label separately corrects for this). Accepted here:
+    a false negative (skipping a PR that's actually stale) just delays
+    detection to a later run, whereas the false positive this check exists to
+    prevent (claiming a genuinely-engaged PR as abandoned) is irreversible.
 
     Capped at ``_STALE_SCAN_LIMIT``, oldest-opened first: there's no upper
     bound on staleness age, so an ancient backlog (first run, or one that fell
@@ -253,6 +270,10 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
         event_type__in=ENGAGING_ACTIVITY_TYPES,
         date_added__gte=cutoff,
     )
+    recently_updated_activity_log = PullRequestActivityLog.objects.filter(
+        pull_request=OuterRef("pk"),
+        date_updated__gte=cutoff,
+    )
 
     qs = (
         PullRequest.objects.filter(
@@ -262,6 +283,7 @@ def find_stale_pull_requests(*, cutoff: datetime) -> list[int]:
             metrics__verdict__isnull=True,
         )
         .filter(~Exists(recent_engaging_activity))
+        .filter(~Exists(recently_updated_activity_log))
         .order_by("date_added")
         .values_list("id", flat=True)
         .distinct()[:_STALE_SCAN_LIMIT]
@@ -286,19 +308,15 @@ def detect_stale_pull_requests_task() -> None:
     path does not support open PRs (requires ``closed_at``), so all stale PRs
     are settled here regardless.
 
-    ``find_stale_pull_requests`` only sees legacy ``PullRequestActivity`` rows,
-    so a candidate routed onto the reduced ``PullRequestActivityLog`` document
-    (see ``sentry.pr_metrics.webhooks._use_activity_document``) may actually be
-    engaged — that store never writes those rows. Each batch bulk-fetches each
-    candidate's document ``date_updated`` and skips any updated at or after
-    ``cutoff``. Coarser than the legacy check: any document write (including a
-    non-engaging one, e.g. a comment) resets this clock, since ``date_updated``
-    doesn't distinguish event types — a document-track PR with only
-    non-engaging activity is skipped here even though a legacy-track PR in the
-    same situation is correctly still a candidate. Less efficient than the
-    pure-SQL legacy path too (documents are pulled into Python one batch at a
-    time), which is why the batch size is kept modest rather than matching
-    ``find_stale_pull_requests``'s full scan.
+    ``find_stale_pull_requests`` already excludes a document-track PR whose
+    ``PullRequestActivityLog`` has been written to since ``cutoff`` — see its
+    docstring for why that has to happen in SQL rather than here. What's left
+    to do here is read each candidate's document *contents* (not just its
+    timestamp) for the reviewer-engagement diagnosis label below — bulked per
+    batch, since pulling every candidate's document into Python in one shot
+    would be less bounded than the per-batch reads, which is why the batch
+    size is kept modest rather than matching ``find_stale_pull_requests``'s
+    full scan.
 
     Each candidate is guarded by a compare-and-set claim before any action, so
     an overlapping run or redelivery won't double-process.
@@ -321,16 +339,8 @@ def detect_stale_pull_requests_task() -> None:
         pull_requests = list(PullRequest.objects.filter(id__in=batch))
         org_ids = {pr.organization_id for pr in pull_requests}
         orgs_by_id = {o.id: o for o in Organization.objects.filter(id__in=org_ids)}
-        # Bulk-fetch this batch's last updated timestamps once, rather than a query per PR —
-        # most candidates will have none (legacy-track PRs), so this is a
-        # small lookup scoped to the batch, not the full candidate list.
-        updated_at_by_pr_id = dict(
-            PullRequestActivityLog.objects.filter(pull_request_id__in=batch).values_list(
-                "pull_request_id", "date_updated"
-            )
-        )
 
-        # First pass: collect PRs that pass initial filters and timestamp checks
+        # First pass: collect PRs that pass the feature-flag gate
         candidate_prs = []
         for pr in pull_requests:
             org = orgs_by_id.get(pr.organization_id)
@@ -347,13 +357,6 @@ def detect_stale_pull_requests_task() -> None:
             # Without activity tracking we can't distinguish an engaged PR from
             # an untouched one, so we can't safely emit an abandoned verdict.
             if not features.has("organizations:pr-metrics-activity", org):
-                continue
-
-            last_updated = updated_at_by_pr_id.get(pr.id)
-            if last_updated is not None and last_updated >= cutoff:
-                # The legacy-only SQL scan couldn't see this PR's document, so
-                # it fell through as a false candidate — it's actually engaged.
-                metrics.incr("pr_metrics.stale.skipped", tags={"reason": "doc_engaged"})
                 continue
 
             candidate_prs.append(pr)

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -403,8 +403,20 @@ def detect_stale_pull_requests_task() -> None:
                 if pr.id not in engaged_legacy_pr_ids:
                     diagnosis_labels.append(NO_REVIEWER_ENGAGEMENT)
 
-            if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=diagnosis_labels):
-                emitted += 1
+            # The claim above already stands regardless of what happens here — same
+            # trade-off as webhooks._claim_and_emit: emission is best-effort,
+            # async-batched telemetry, so a failure here forgoes this PR's row
+            # rather than being retried (retrying would mean re-claiming, which the
+            # NULL-verdict CAS above no longer allows). Guarded so one bad
+            # candidate (a DB blip, a downstream analytics error) can't abort the
+            # rest of the batch — and the whole run, since every remaining batch in
+            # this task would go unprocessed with it.
+            try:
+                if emit_pr_metrics_row(pull_request=pr, diagnosis_labels=diagnosis_labels):
+                    emitted += 1
+            except Exception:
+                logger.exception("pr_metrics.stale.emit_failed", extra={"pull_request_id": pr.id})
+                metrics.incr("pr_metrics.stale.emit_failed")
 
     metrics.incr("pr_metrics.stale.emitted", amount=emitted)
     logger.info("pr_metrics.stale.emitted", extra={"count": emitted})

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import copy
 import itertools
-from datetime import datetime, timezone
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -26,7 +25,6 @@ from sentry.pr_metrics.activity_doc import (
     derived_metrics_from_doc,
     extract_event_at,
     has_commits_after_open,
-    has_engaging_activity_since,
     human_participant_count,
     is_failing_conclusion,
     new_document,
@@ -1141,60 +1139,3 @@ def test_timeline_check_runs_is_empty_when_nothing_ever_failed() -> None:
     _suite(doc, conclusion="success", updated_at="2026-07-10T12:06:00Z")
 
     assert timeline_events_from_doc(doc)[0]["payload"]["check_runs"] == {}
-
-
-# --- has_engaging_activity_since -------------------------------------------
-
-_CUTOFF = datetime(2020, 7, 10, 12, 0, 0, tzinfo=timezone.utc)
-
-
-def test_empty_document_has_no_engagement() -> None:
-    assert has_engaging_activity_since(new_document(), _CUTOFF) is False
-
-
-def test_engaging_entry_at_or_after_cutoff_counts() -> None:
-    doc = new_document()
-    _entry(
-        doc,
-        event_type=PullRequestActivityType.REVIEW_SUBMITTED,
-        ts="2020-07-10T12:00:00Z",
-    )
-    assert has_engaging_activity_since(doc, _CUTOFF) is True
-
-
-def test_engaging_entry_before_cutoff_does_not_count() -> None:
-    doc = new_document()
-    _entry(
-        doc,
-        event_type=PullRequestActivityType.REVIEW_REQUESTED,
-        ts="2020-07-10T11:59:59Z",
-    )
-    assert has_engaging_activity_since(doc, _CUTOFF) is False
-
-
-def test_non_engaging_entry_does_not_count() -> None:
-    doc = new_document()
-    _entry(
-        doc,
-        event_type=PullRequestActivityType.OPENED,
-        ts="2020-07-11T00:00:00Z",
-    )
-    assert has_engaging_activity_since(doc, _CUTOFF) is False
-
-
-def test_ready_for_review_entry_counts() -> None:
-    doc = new_document()
-    _entry(
-        doc,
-        event_type=PullRequestActivityType.READY_FOR_REVIEW,
-        ts="2020-07-11T00:00:00Z",
-    )
-    assert has_engaging_activity_since(doc, _CUTOFF) is True
-
-
-def test_events_dropped_reads_as_engaged_even_with_no_matching_entries() -> None:
-    # A capped document's dropped entries carry no timestamp to rule out, so a
-    # capped doc must not be read as stale — see MAX_EVENTS.
-    doc = new_document()
-    doc["events_dropped"] = 1
-    assert has_engaging_activity_since(doc, _CUTOFF) is True

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import itertools
+from datetime import datetime, timezone
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -25,6 +26,7 @@ from sentry.pr_metrics.activity_doc import (
     derived_metrics_from_doc,
     extract_event_at,
     has_commits_after_open,
+    has_engaging_activity_since,
     human_participant_count,
     is_failing_conclusion,
     new_document,
@@ -1139,3 +1141,60 @@ def test_timeline_check_runs_is_empty_when_nothing_ever_failed() -> None:
     _suite(doc, conclusion="success", updated_at="2026-07-10T12:06:00Z")
 
     assert timeline_events_from_doc(doc)[0]["payload"]["check_runs"] == {}
+
+
+# --- has_engaging_activity_since -------------------------------------------
+
+_CUTOFF = datetime(2020, 7, 10, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_empty_document_has_no_engagement() -> None:
+    assert has_engaging_activity_since(new_document(), _CUTOFF) is False
+
+
+def test_engaging_entry_at_or_after_cutoff_counts() -> None:
+    doc = new_document()
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+        ts="2020-07-10T12:00:00Z",
+    )
+    assert has_engaging_activity_since(doc, _CUTOFF) is True
+
+
+def test_engaging_entry_before_cutoff_does_not_count() -> None:
+    doc = new_document()
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.REVIEW_REQUESTED,
+        ts="2020-07-10T11:59:59Z",
+    )
+    assert has_engaging_activity_since(doc, _CUTOFF) is False
+
+
+def test_non_engaging_entry_does_not_count() -> None:
+    doc = new_document()
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.OPENED,
+        ts="2020-07-11T00:00:00Z",
+    )
+    assert has_engaging_activity_since(doc, _CUTOFF) is False
+
+
+def test_ready_for_review_entry_counts() -> None:
+    doc = new_document()
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.READY_FOR_REVIEW,
+        ts="2020-07-11T00:00:00Z",
+    )
+    assert has_engaging_activity_since(doc, _CUTOFF) is True
+
+
+def test_events_dropped_reads_as_engaged_even_with_no_matching_entries() -> None:
+    # A capped document's dropped entries carry no timestamp to rule out, so a
+    # capped doc must not be read as stale — see MAX_EVENTS.
+    doc = new_document()
+    doc["events_dropped"] = 1
+    assert has_engaging_activity_since(doc, _CUTOFF) is True

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -473,7 +473,7 @@ class PrMetricsEmissionTest(TestCase):
     def test_build_row_raises_when_stored_lifecycle_missing(self) -> None:
         # A close/merge row needs a persisted head_commit_sha and closed_at; a
         # null means emit ran on a PR that never reached a terminal state.
-        # Exception: abandoned verdicts are allowed to have None closed_at.
+        # Exception: abandoned verdicts are allowed to have None for both.
         self.pull_request.closed_at = None
 
         # Should raise for normal close actions
@@ -502,6 +502,35 @@ class PrMetricsEmissionTest(TestCase):
         )
         # Should use current timestamp when closed_at is None for abandoned
         assert row.closed_at is not None
+
+    def test_build_row_raises_when_head_commit_sha_missing(self) -> None:
+        # Same fail-loud guard as closed_at, for the other terminal-state field.
+        self.pull_request.head_commit_sha = None
+
+        with pytest.raises(ValueError):
+            build_pr_metrics_row(
+                pull_request=self.pull_request,
+                close_action="merged",
+                attributions=[],
+                group_ids=[],
+            )
+
+        with pytest.raises(ValueError):
+            build_pr_metrics_row(
+                pull_request=self.pull_request,
+                close_action="closed",
+                attributions=[],
+                group_ids=[],
+            )
+
+        # Abandoned PRs are allowed a null head_commit_sha too.
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="abandoned",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.head_commit_sha == "unknown"
 
     def test_build_row_repository_is_public_false_for_private_repo(self) -> None:
         PullRequestActivity.objects.create(

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -2,8 +2,6 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
-import pytest
-
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import (
@@ -583,18 +581,6 @@ class PrMetricsEmissionTest(TestCase):
             group_ids=[],
         )
         assert row.opened_at is None
-
-    def test_build_row_raises_when_stored_lifecycle_missing(self) -> None:
-        # A close/merge row needs a persisted head_commit_sha and closed_at; a
-        # null means emit ran on a PR that never reached a terminal state.
-        self.pull_request.closed_at = None
-        with pytest.raises(ValueError):
-            build_pr_metrics_row(
-                pull_request=self.pull_request,
-                close_action="merged",
-                attributions=[],
-                group_ids=[],
-            )
 
     def test_build_row_for_close_omits_merge_commit_sha(self) -> None:
         # The webhook persists null merge fields for a closed-but-unmerged PR.

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -471,12 +471,10 @@ class PrMetricsEmissionTest(TestCase):
         assert row.repository_is_public is True
 
     def test_build_row_raises_when_stored_lifecycle_missing(self) -> None:
-        # A close/merge row needs a persisted head_commit_sha and closed_at; a
-        # null means emit ran on a PR that never reached a terminal state.
-        # Exception: abandoned verdicts are allowed to have None for both.
+        # A close/merge row needs a persisted head_commit_sha and closed_at;
+        # abandoned is exempt since the PR never reached a terminal state.
         self.pull_request.closed_at = None
 
-        # Should raise for normal close actions
         with pytest.raises(ValueError):
             build_pr_metrics_row(
                 pull_request=self.pull_request,
@@ -493,18 +491,15 @@ class PrMetricsEmissionTest(TestCase):
                 group_ids=[],
             )
 
-        # But should work for abandoned (stale detection)
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="abandoned",
             attributions=[],
             group_ids=[],
         )
-        # Should use current timestamp when closed_at is None for abandoned
         assert row.closed_at is not None
 
     def test_build_row_raises_when_head_commit_sha_missing(self) -> None:
-        # Same fail-loud guard as closed_at, for the other terminal-state field.
         self.pull_request.head_commit_sha = None
 
         with pytest.raises(ValueError):
@@ -523,7 +518,6 @@ class PrMetricsEmissionTest(TestCase):
                 group_ids=[],
             )
 
-        # Abandoned PRs are allowed a null head_commit_sha too.
         row = build_pr_metrics_row(
             pull_request=self.pull_request,
             close_action="abandoned",

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -2,6 +2,8 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import (
@@ -467,6 +469,39 @@ class PrMetricsEmissionTest(TestCase):
             group_ids=[],
         )
         assert row.repository_is_public is True
+
+    def test_build_row_raises_when_stored_lifecycle_missing(self) -> None:
+        # A close/merge row needs a persisted head_commit_sha and closed_at; a
+        # null means emit ran on a PR that never reached a terminal state.
+        # Exception: abandoned verdicts are allowed to have None closed_at.
+        self.pull_request.closed_at = None
+
+        # Should raise for normal close actions
+        with pytest.raises(ValueError):
+            build_pr_metrics_row(
+                pull_request=self.pull_request,
+                close_action="merged",
+                attributions=[],
+                group_ids=[],
+            )
+
+        with pytest.raises(ValueError):
+            build_pr_metrics_row(
+                pull_request=self.pull_request,
+                close_action="closed",
+                attributions=[],
+                group_ids=[],
+            )
+
+        # But should work for abandoned (stale detection)
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="abandoned",
+            attributions=[],
+            group_ids=[],
+        )
+        # Should use current timestamp when closed_at is None for abandoned
+        assert row.closed_at is not None
 
     def test_build_row_repository_is_public_false_for_private_repo(self) -> None:
         PullRequestActivity.objects.create(

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -70,7 +70,9 @@ class FindStalePullRequestsTest(TestCase):
         activity.date_added = _ago(weeks_ago)
         activity.save(update_fields=["date_added"])
 
-    def _add_activity_log(self, pr: Any, event_type: str, *, weeks_ago: float) -> None:
+    def _add_activity_log(
+        self, pr: Any, event_type: PullRequestActivityType, *, weeks_ago: float
+    ) -> None:
         doc = new_document()
         apply_activity(
             doc,
@@ -288,7 +290,9 @@ class DetectStalePullRequestsTaskTest(TestCase):
         )
         return pr
 
-    def _add_activity_log(self, pr: Any, event_type: str, *, weeks_ago: float) -> None:
+    def _add_activity_log(
+        self, pr: Any, event_type: PullRequestActivityType, *, weeks_ago: float
+    ) -> None:
         doc = new_document()
         apply_activity(
             doc,

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -19,7 +19,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.contracts import CLOSE_ACTION_ABANDONED
-from sentry.pr_metrics.emit import emit_pr_metrics_row
+from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
 from sentry.pr_metrics.tasks import detect_stale_pull_requests_task, find_stale_pull_requests
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
@@ -277,6 +277,17 @@ class DetectStalePullRequestsTaskTest(TestCase):
         metrics = PullRequestMetrics.objects.get(pull_request=pr)
         assert metrics.verdict == PullRequestVerdict.ABANDONED
         mock_emit.assert_called_once()
+
+    def test_tags_stale_emission_with_no_reviewer_engagement(self) -> None:
+        self._make_tracked_stale_pr()
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            mock_emit.return_value = True
+            detect_stale_pull_requests_task()
+
+        assert mock_emit.call_args.kwargs["diagnosis_labels"] == [NO_REVIEWER_ENGAGEMENT]
 
     def test_emits_abandoned_when_pr_has_historical_activity(self) -> None:
         pr = self._make_tracked_stale_pr()

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -321,22 +321,26 @@ class DetectStalePullRequestsTaskTest(TestCase):
             pull_request=pr, verdict=PullRequestVerdict.ABANDONED
         ).exists()
 
-    def test_emits_document_track_pr_with_no_recent_engagement(self) -> None:
-        # A document-track PR with genuinely no recent engagement is still
-        # settled as abandoned, same as a legacy-track PR.
+    def test_skips_document_track_pr_with_only_non_engaging_activity(self) -> None:
+        # Known limitation: the document cross-check only compares
+        # PullRequestActivityLog.date_updated (auto_now) against the cutoff —
+        # it can't distinguish an engaging event from a non-engaging one (e.g.
+        # a comment) recorded in the document. So a document-track PR with only
+        # non-engaging activity is *also* skipped here, unlike a legacy-track
+        # PR in the same situation (see test_includes_pr_with_only_non_engaging_recent_activity
+        # in FindStalePullRequestsTest, which correctly stays a candidate).
         pr = self._make_tracked_stale_pr()
         self._add_activity_log(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
         with (
             self.feature({"organizations:pr-metrics-activity": True}),
             patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
         ):
-            mock_emit.return_value = True
             detect_stale_pull_requests_task()
 
-        mock_emit.assert_called_once()
-        pr.refresh_from_db()
-        metrics = PullRequestMetrics.objects.get(pull_request=pr)
-        assert metrics.verdict == PullRequestVerdict.ABANDONED
+        mock_emit.assert_not_called()
+        assert not PullRequestMetrics.objects.filter(
+            pull_request=pr, verdict=PullRequestVerdict.ABANDONED
+        ).exists()
 
     def test_claims_verdict_and_emits_for_stale_pr(self) -> None:
         pr = self._make_tracked_stale_pr()

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -22,7 +22,11 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.activity_doc import apply_activity, new_document
 from sentry.pr_metrics.contracts import CLOSE_ACTION_ABANDONED
 from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
-from sentry.pr_metrics.tasks import detect_stale_pull_requests_task, find_stale_pull_requests
+from sentry.pr_metrics.tasks import (
+    _STALE_SCAN_LIMIT,
+    detect_stale_pull_requests_task,
+    find_stale_pull_requests,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import cell_silo_test
@@ -179,6 +183,23 @@ class FindStalePullRequestsTest(TestCase):
         )
         ids = find_stale_pull_requests(cutoff=_ago(3))
         assert ids.count(pr.id) == 1
+
+    def test_caps_result_at_scan_limit_oldest_first(self) -> None:
+        # Guards against an unbounded first-run (or backlog) scan pulling an
+        # arbitrarily large candidate set into memory in one call: the result
+        # is capped at _STALE_SCAN_LIMIT, oldest-opened first, so a capped-off
+        # backlog still gets worked down over subsequent runs rather than all
+        # being read (and settled) at once.
+        prs = [self._make_pr(opened_weeks_ago=10.0 + i) for i in range(_STALE_SCAN_LIMIT + 5)]
+        for pr in prs:
+            self._track(pr)
+
+        ids = find_stale_pull_requests(cutoff=_ago(3))
+
+        assert len(ids) == _STALE_SCAN_LIMIT
+        # Oldest-opened (highest weeks_ago) PRs are returned first.
+        expected_oldest_first = [pr.id for pr in sorted(prs, key=lambda pr: pr.date_added)]
+        assert ids == expected_oldest_first[:_STALE_SCAN_LIMIT]
 
 
 @cell_silo_test

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -85,7 +85,11 @@ class FindStalePullRequestsTest(TestCase):
             ts=_ago(weeks_ago).isoformat(),
             webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
         )
-        PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
+        log = PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
+        # date_updated is auto_now=True, so .save() always stamps "now" —
+        # bypass via .update() to backdate it, matching what a real write
+        # weeks_ago ago would have left behind.
+        PullRequestActivityLog.objects.filter(id=log.id).update(date_updated=_ago(weeks_ago))
 
     # --- inclusion ---
 
@@ -160,15 +164,39 @@ class FindStalePullRequestsTest(TestCase):
         self._track(pr)
         assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
 
-    def test_includes_document_track_pr_with_recent_engagement(self) -> None:
-        # find_stale_pull_requests only reads legacy PullRequestActivity rows.
+    def test_excludes_document_track_pr_with_recent_engagement(self) -> None:
         # A PR routed onto the PullRequestActivityLog document (see
-        # webhooks._use_activity_document) never writes those rows, so this
-        # scan can't see its engagement — detect_stale_pull_requests_task is
-        # responsible for cross-checking the document before settling it.
+        # webhooks._use_activity_document) never writes legacy
+        # PullRequestActivity rows, so the ~Exists check above can't see its
+        # engagement on its own. The document date_updated check closes that
+        # gap directly in SQL: any write within the window (engaging or not,
+        # since date_updated doesn't distinguish event types) excludes the PR.
         pr = self._make_pr()
         self._track(pr)
         self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_document_track_pr_with_only_non_engaging_activity(self) -> None:
+        # Known coarseness: the document check compares date_updated (bumped by
+        # any write) against cutoff, so it can't distinguish an engaging event
+        # from a non-engaging one (e.g. a comment) the way the legacy
+        # ~Exists check above can. A document-track PR with only non-engaging
+        # activity is thus also excluded here, unlike a legacy-track PR in the
+        # same situation (see test_includes_pr_with_only_non_engaging_recent_activity
+        # above, which correctly stays a candidate). Accepted: this just delays
+        # detection to a later run once the document goes quiet, rather than
+        # risking a false abandoned verdict now.
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity_log(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_includes_document_track_pr_whose_document_is_stale(self) -> None:
+        # A document-track PR is a candidate once its document has gone quiet
+        # for the whole staleness window, same as the legacy track.
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=5.0)
         assert pr.id in find_stale_pull_requests(cutoff=_ago(3))
 
     def test_returns_distinct_ids_with_multiple_attributions(self) -> None:
@@ -322,13 +350,17 @@ class DetectStalePullRequestsTaskTest(TestCase):
             ts=_ago(weeks_ago).isoformat(),
             webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
         )
-        PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
+        log = PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
+        # date_updated is auto_now=True, so .save() always stamps "now" —
+        # bypass via .update() to backdate it, matching what a real write
+        # weeks_ago ago would have left behind.
+        PullRequestActivityLog.objects.filter(id=log.id).update(date_updated=_ago(weeks_ago))
 
     def test_skips_document_track_pr_with_recent_engagement(self) -> None:
-        # find_stale_pull_requests can't see engagement recorded in the
-        # PullRequestActivityLog document (it only reads legacy
-        # PullRequestActivity rows), so this candidate must be cross-checked
-        # and skipped here rather than incorrectly claimed as abandoned.
+        # find_stale_pull_requests excludes this PR directly (see its
+        # test_excludes_document_track_pr_with_recent_engagement) — asserted
+        # again here end-to-end through the task, since a query never called
+        # would trivially "exclude" everything.
         pr = self._make_tracked_stale_pr()
         self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
         with (
@@ -343,13 +375,9 @@ class DetectStalePullRequestsTaskTest(TestCase):
         ).exists()
 
     def test_skips_document_track_pr_with_only_non_engaging_activity(self) -> None:
-        # Known limitation: the document cross-check only compares
-        # PullRequestActivityLog.date_updated (auto_now) against the cutoff —
-        # it can't distinguish an engaging event from a non-engaging one (e.g.
-        # a comment) recorded in the document. So a document-track PR with only
-        # non-engaging activity is *also* skipped here, unlike a legacy-track
-        # PR in the same situation (see test_includes_pr_with_only_non_engaging_recent_activity
-        # in FindStalePullRequestsTest, which correctly stays a candidate).
+        # Known coarseness in find_stale_pull_requests's document check (see its
+        # test_excludes_document_track_pr_with_only_non_engaging_activity):
+        # asserted again here end-to-end through the task.
         pr = self._make_tracked_stale_pr()
         self._add_activity_log(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
         with (

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -86,9 +86,7 @@ class FindStalePullRequestsTest(TestCase):
             webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
         )
         log = PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
-        # date_updated is auto_now=True, so .save() always stamps "now" —
-        # bypass via .update() to backdate it, matching what a real write
-        # weeks_ago ago would have left behind.
+        # auto_now=True always stamps "now" on .save(); .update() backdates it.
         PullRequestActivityLog.objects.filter(id=log.id).update(date_updated=_ago(weeks_ago))
 
     # --- inclusion ---
@@ -165,42 +163,29 @@ class FindStalePullRequestsTest(TestCase):
         assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
 
     def test_excludes_document_track_pr_with_recent_engagement(self) -> None:
-        # A PR routed onto the PullRequestActivityLog document (see
-        # webhooks._use_activity_document) never writes legacy
-        # PullRequestActivity rows, so the ~Exists check above can't see its
-        # engagement on its own. The document date_updated check closes that
-        # gap directly in SQL: any write within the window (engaging or not,
-        # since date_updated doesn't distinguish event types) excludes the PR.
+        # Document-track PRs never write legacy PullRequestActivity rows, so
+        # this must be caught via PullRequestActivityLog.date_updated instead.
         pr = self._make_pr()
         self._track(pr)
         self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
         assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
 
     def test_excludes_document_track_pr_with_only_non_engaging_activity(self) -> None:
-        # Known coarseness: the document check compares date_updated (bumped by
-        # any write) against cutoff, so it can't distinguish an engaging event
-        # from a non-engaging one (e.g. a comment) the way the legacy
-        # ~Exists check above can. A document-track PR with only non-engaging
-        # activity is thus also excluded here, unlike a legacy-track PR in the
-        # same situation (see test_includes_pr_with_only_non_engaging_recent_activity
-        # above, which correctly stays a candidate). Accepted: this just delays
-        # detection to a later run once the document goes quiet, rather than
-        # risking a false abandoned verdict now.
+        # Unlike the legacy track, date_updated can't distinguish engaging
+        # from non-engaging writes, so this is excluded too (see
+        # test_includes_pr_with_only_non_engaging_recent_activity above).
         pr = self._make_pr()
         self._track(pr)
         self._add_activity_log(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
         assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
 
     def test_includes_document_track_pr_whose_document_is_stale(self) -> None:
-        # A document-track PR is a candidate once its document has gone quiet
-        # for the whole staleness window, same as the legacy track.
         pr = self._make_pr()
         self._track(pr)
         self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=5.0)
         assert pr.id in find_stale_pull_requests(cutoff=_ago(3))
 
     def test_returns_distinct_ids_with_multiple_attributions(self) -> None:
-        # Multiple valid attributions on one PR must not produce duplicate ids.
         pr = self._make_pr()
         self._track(pr)
         PullRequestAttribution.objects.create(
@@ -213,11 +198,6 @@ class FindStalePullRequestsTest(TestCase):
         assert ids.count(pr.id) == 1
 
     def test_caps_result_at_scan_limit_oldest_first(self) -> None:
-        # Guards against an unbounded first-run (or backlog) scan pulling an
-        # arbitrarily large candidate set into memory in one call: the result
-        # is capped at _STALE_SCAN_LIMIT, oldest-opened first, so a capped-off
-        # backlog still gets worked down over subsequent runs rather than all
-        # being read (and settled) at once.
         prs = [self._make_pr(opened_weeks_ago=10.0 + i) for i in range(_STALE_SCAN_LIMIT + 5)]
         for pr in prs:
             self._track(pr)
@@ -225,7 +205,6 @@ class FindStalePullRequestsTest(TestCase):
         ids = find_stale_pull_requests(cutoff=_ago(3))
 
         assert len(ids) == _STALE_SCAN_LIMIT
-        # Oldest-opened (highest weeks_ago) PRs are returned first.
         expected_oldest_first = [pr.id for pr in sorted(prs, key=lambda pr: pr.date_added)]
         assert ids == expected_oldest_first[:_STALE_SCAN_LIMIT]
 
@@ -351,16 +330,10 @@ class DetectStalePullRequestsTaskTest(TestCase):
             webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
         )
         log = PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
-        # date_updated is auto_now=True, so .save() always stamps "now" —
-        # bypass via .update() to backdate it, matching what a real write
-        # weeks_ago ago would have left behind.
+        # auto_now=True always stamps "now" on .save(); .update() backdates it.
         PullRequestActivityLog.objects.filter(id=log.id).update(date_updated=_ago(weeks_ago))
 
     def test_skips_document_track_pr_with_recent_engagement(self) -> None:
-        # find_stale_pull_requests excludes this PR directly (see its
-        # test_excludes_document_track_pr_with_recent_engagement) — asserted
-        # again here end-to-end through the task, since a query never called
-        # would trivially "exclude" everything.
         pr = self._make_tracked_stale_pr()
         self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
         with (
@@ -375,9 +348,6 @@ class DetectStalePullRequestsTaskTest(TestCase):
         ).exists()
 
     def test_skips_document_track_pr_with_only_non_engaging_activity(self) -> None:
-        # Known coarseness in find_stale_pull_requests's document check (see its
-        # test_excludes_document_track_pr_with_only_non_engaging_activity):
-        # asserted again here end-to-end through the task.
         pr = self._make_tracked_stale_pr()
         self._add_activity_log(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
         with (
@@ -418,10 +388,7 @@ class DetectStalePullRequestsTaskTest(TestCase):
 
     def test_emits_abandoned_when_pr_has_historical_activity(self) -> None:
         pr = self._make_tracked_stale_pr()
-        # A commit predating the staleness window: the PR is genuinely stale
-        # (no recent activity) but has commits in its history. The stale path
-        # always emits ABANDONED directly — the judge path requires closed_at
-        # and doesn't support open PRs.
+        # Activity predating the staleness window: stale, but not untouched.
         old_activity = PullRequestActivity.objects.create(
             pull_request=pr,
             event_type=PullRequestActivityType.SYNCHRONIZED,
@@ -466,9 +433,6 @@ class DetectStalePullRequestsTaskTest(TestCase):
         mock_emit.assert_not_called()
 
     def test_skips_when_activity_tracking_disabled(self) -> None:
-        # Without pr-metrics-activity we can't distinguish an engaged PR from an
-        # untouched one, so the task skips the org entirely rather than risking a
-        # false abandoned verdict.
         self._make_tracked_stale_pr()
         with patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit:
             detect_stale_pull_requests_task()
@@ -476,8 +440,6 @@ class DetectStalePullRequestsTaskTest(TestCase):
         mock_emit.assert_not_called()
 
     def test_continues_when_org_not_found(self) -> None:
-        # A PR whose organization row has been deleted should be skipped, but
-        # subsequent PRs in the same batch must still be processed.
         ghost_org = self.create_organization()
         ghost_repo = self.create_repo(
             self.project, name="getsentry/ghost", provider="integrations:github"
@@ -496,7 +458,6 @@ class DetectStalePullRequestsTaskTest(TestCase):
             is_valid=True,
         )
         good_pr = self._make_tracked_stale_pr()
-        # Delete the ghost org so the lookup returns None for ghost_pr.
         ghost_org.delete()
 
         with (
@@ -506,17 +467,11 @@ class DetectStalePullRequestsTaskTest(TestCase):
             mock_emit.return_value = True
             detect_stale_pull_requests_task()
 
-        # Only the good PR was emitted; the ghost was skipped.
         assert mock_emit.call_count == 1
         emitted_pr_id = mock_emit.call_args.kwargs["pull_request"].id
         assert emitted_pr_id == good_pr.id
 
     def test_continues_batch_when_emit_raises(self) -> None:
-        # emit_pr_metrics_row can raise (a DB blip, analytics.record's network
-        # call, cleanup_pr_activity_task.delay's broker call) — a PR is claimed
-        # ABANDONED before emission runs, so a failure here must not propagate
-        # and abort the rest of the batch (or the whole task, since every
-        # remaining batch would go unprocessed with it).
         failing_pr = self._make_tracked_stale_pr()
         good_pr = self._make_tracked_stale_pr()
 
@@ -533,8 +488,8 @@ class DetectStalePullRequestsTaskTest(TestCase):
             mock_emit.side_effect = _emit
             detect_stale_pull_requests_task()
 
-        # Both PRs were claimed before emission ran, so both are ABANDONED
-        # regardless of whether their emission succeeded.
+        # Both PRs were claimed before emission ran, so the failure doesn't
+        # roll back failing_pr's verdict or stop good_pr from being processed.
         assert (
             PullRequestMetrics.objects.get(pull_request=failing_pr).verdict
             == PullRequestVerdict.ABANDONED
@@ -543,6 +498,4 @@ class DetectStalePullRequestsTaskTest(TestCase):
             PullRequestMetrics.objects.get(pull_request=good_pr).verdict
             == PullRequestVerdict.ABANDONED
         )
-        # The task didn't crash: emit was attempted for both PRs, not just the
-        # one before the failure.
         assert mock_emit.call_count == 2

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from sentry.models.pullrequest import (
     PullRequestActivity,
+    PullRequestActivityLog,
     PullRequestActivityType,
     PullRequestAttribution,
     PullRequestAttributionSignalType,
@@ -18,6 +19,7 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
     PullRequestVerdict,
 )
+from sentry.pr_metrics.activity_doc import apply_activity, new_document
 from sentry.pr_metrics.contracts import CLOSE_ACTION_ABANDONED
 from sentry.pr_metrics.emit import NO_REVIEWER_ENGAGEMENT, emit_pr_metrics_row
 from sentry.pr_metrics.tasks import detect_stale_pull_requests_task, find_stale_pull_requests
@@ -67,6 +69,17 @@ class FindStalePullRequestsTest(TestCase):
         )
         activity.date_added = _ago(weeks_ago)
         activity.save(update_fields=["date_added"])
+
+    def _add_activity_log(self, pr: Any, event_type: str, *, weeks_ago: float) -> None:
+        doc = new_document()
+        apply_activity(
+            doc,
+            event_type=event_type,
+            payload={},
+            ts=_ago(weeks_ago).isoformat(),
+            webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
+        )
+        PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
 
     # --- inclusion ---
 
@@ -140,6 +153,17 @@ class FindStalePullRequestsTest(TestCase):
         pr = self._make_pr(state="closed")
         self._track(pr)
         assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_includes_document_track_pr_with_recent_engagement(self) -> None:
+        # find_stale_pull_requests only reads legacy PullRequestActivity rows.
+        # A PR routed onto the PullRequestActivityLog document (see
+        # webhooks._use_activity_document) never writes those rows, so this
+        # scan can't see its engagement — detect_stale_pull_requests_task is
+        # responsible for cross-checking the document before settling it.
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
+        assert pr.id in find_stale_pull_requests(cutoff=_ago(3))
 
     def test_returns_distinct_ids_with_multiple_attributions(self) -> None:
         # Multiple valid attributions on one PR must not produce duplicate ids.
@@ -263,6 +287,52 @@ class DetectStalePullRequestsTaskTest(TestCase):
             is_valid=True,
         )
         return pr
+
+    def _add_activity_log(self, pr: Any, event_type: str, *, weeks_ago: float) -> None:
+        doc = new_document()
+        apply_activity(
+            doc,
+            event_type=event_type,
+            payload={},
+            ts=_ago(weeks_ago).isoformat(),
+            webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
+        )
+        PullRequestActivityLog.objects.create(pull_request=pr, data=doc)
+
+    def test_skips_document_track_pr_with_recent_engagement(self) -> None:
+        # find_stale_pull_requests can't see engagement recorded in the
+        # PullRequestActivityLog document (it only reads legacy
+        # PullRequestActivity rows), so this candidate must be cross-checked
+        # and skipped here rather than incorrectly claimed as abandoned.
+        pr = self._make_tracked_stale_pr()
+        self._add_activity_log(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            detect_stale_pull_requests_task()
+
+        mock_emit.assert_not_called()
+        assert not PullRequestMetrics.objects.filter(
+            pull_request=pr, verdict=PullRequestVerdict.ABANDONED
+        ).exists()
+
+    def test_emits_document_track_pr_with_no_recent_engagement(self) -> None:
+        # A document-track PR with genuinely no recent engagement is still
+        # settled as abandoned, same as a legacy-track PR.
+        pr = self._make_tracked_stale_pr()
+        self._add_activity_log(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            mock_emit.return_value = True
+            detect_stale_pull_requests_task()
+
+        mock_emit.assert_called_once()
+        pr.refresh_from_db()
+        metrics = PullRequestMetrics.objects.get(pull_request=pr)
+        assert metrics.verdict == PullRequestVerdict.ABANDONED
 
     def test_claims_verdict_and_emits_for_stale_pr(self) -> None:
         pr = self._make_tracked_stale_pr()

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -482,3 +482,39 @@ class DetectStalePullRequestsTaskTest(TestCase):
         assert mock_emit.call_count == 1
         emitted_pr_id = mock_emit.call_args.kwargs["pull_request"].id
         assert emitted_pr_id == good_pr.id
+
+    def test_continues_batch_when_emit_raises(self) -> None:
+        # emit_pr_metrics_row can raise (a DB blip, analytics.record's network
+        # call, cleanup_pr_activity_task.delay's broker call) — a PR is claimed
+        # ABANDONED before emission runs, so a failure here must not propagate
+        # and abort the rest of the batch (or the whole task, since every
+        # remaining batch would go unprocessed with it).
+        failing_pr = self._make_tracked_stale_pr()
+        good_pr = self._make_tracked_stale_pr()
+
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+
+            def _emit(*, pull_request: Any, diagnosis_labels: Any) -> bool:
+                if pull_request.id == failing_pr.id:
+                    raise RuntimeError("boom")
+                return True
+
+            mock_emit.side_effect = _emit
+            detect_stale_pull_requests_task()
+
+        # Both PRs were claimed before emission ran, so both are ABANDONED
+        # regardless of whether their emission succeeded.
+        assert (
+            PullRequestMetrics.objects.get(pull_request=failing_pr).verdict
+            == PullRequestVerdict.ABANDONED
+        )
+        assert (
+            PullRequestMetrics.objects.get(pull_request=good_pr).verdict
+            == PullRequestVerdict.ABANDONED
+        )
+        # The task didn't crash: emit was attempted for both PRs, not just the
+        # one before the failure.
+        assert mock_emit.call_count == 2

--- a/tests/sentry/pr_metrics/test_stale.py
+++ b/tests/sentry/pr_metrics/test_stale.py
@@ -1,0 +1,374 @@
+"""Tests for stale PR detection: find_stale_pull_requests, emit_pr_metrics_row (abandoned path),
+and the detect_stale_pull_requests_task cron task."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from sentry.models.pullrequest import (
+    PullRequestActivity,
+    PullRequestActivityType,
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+    PullRequestMetrics,
+    PullRequestVerdict,
+)
+from sentry.pr_metrics.contracts import CLOSE_ACTION_ABANDONED
+from sentry.pr_metrics.emit import emit_pr_metrics_row
+from sentry.pr_metrics.tasks import detect_stale_pull_requests_task, find_stale_pull_requests
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.silo import cell_silo_test
+from sentry.utils import json
+
+
+def _ago(weeks: float) -> Any:
+    return timezone.now() - timedelta(weeks=weeks)
+
+
+@cell_silo_test
+class FindStalePullRequestsTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+
+    def _make_pr(self, *, opened_weeks_ago: float = 4.0, state: str = "open") -> Any:
+        pr = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id
+        )
+        pr.date_added = _ago(opened_weeks_ago)
+        pr.state = state
+        pr.save(update_fields=["date_added", "state"])
+        return pr
+
+    def _track(self, pr: Any, *, is_valid: bool = True) -> None:
+        PullRequestAttribution.objects.create(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=is_valid,
+        )
+
+    def _set_verdict(self, pr: Any, verdict: str) -> None:
+        PullRequestMetrics.objects.update_or_create(pull_request=pr, defaults={"verdict": verdict})
+
+    def _add_activity(self, pr: Any, event_type: str, *, weeks_ago: float) -> None:
+        activity = PullRequestActivity.objects.create(
+            pull_request=pr,
+            event_type=event_type,
+            payload={},
+            webhook_id=f"wh-{pr.id}-{event_type}-{weeks_ago}",
+        )
+        activity.date_added = _ago(weeks_ago)
+        activity.save(update_fields=["date_added"])
+
+    # --- inclusion ---
+
+    def test_includes_tracked_open_pr_with_no_activity(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        assert pr.id in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_includes_pr_with_only_non_engaging_recent_activity(self) -> None:
+        # Comments and label events don't reset the stale clock — both are
+        # commonly bot-driven and not a reliable signal of human engagement.
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity(pr, PullRequestActivityType.COMMENT_CREATED, weeks_ago=1.0)
+        self._add_activity(pr, PullRequestActivityType.LABELED, weeks_ago=1.0)
+        assert pr.id in find_stale_pull_requests(cutoff=_ago(3))
+
+    # --- exclusion ---
+
+    def test_excludes_recently_reviewed_pr(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity(pr, PullRequestActivityType.REVIEW_SUBMITTED, weeks_ago=1.0)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_recently_synchronized_pr(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity(pr, PullRequestActivityType.SYNCHRONIZED, weeks_ago=1.0)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_pr_marked_ready_for_review_recently(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity(pr, PullRequestActivityType.READY_FOR_REVIEW, weeks_ago=1.0)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_pr_with_recent_review_request(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        self._add_activity(pr, PullRequestActivityType.REVIEW_REQUESTED, weeks_ago=1.0)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_untracked_pr(self) -> None:
+        pr = self._make_pr()
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_pr_with_only_invalid_attribution(self) -> None:
+        pr = self._make_pr()
+        self._track(pr, is_valid=False)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_pr_opened_after_cutoff(self) -> None:
+        pr = self._make_pr(opened_weeks_ago=1.0)
+        self._track(pr)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_pr_with_non_null_verdict(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        self._set_verdict(pr, PullRequestVerdict.CLOSED_UNMERGED)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_judge_in_progress_pr(self) -> None:
+        pr = self._make_pr()
+        self._track(pr)
+        self._set_verdict(pr, PullRequestVerdict.JUDGE_IN_PROGRESS)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_excludes_closed_pr(self) -> None:
+        pr = self._make_pr(state="closed")
+        self._track(pr)
+        assert pr.id not in find_stale_pull_requests(cutoff=_ago(3))
+
+    def test_returns_distinct_ids_with_multiple_attributions(self) -> None:
+        # Multiple valid attributions on one PR must not produce duplicate ids.
+        pr = self._make_pr()
+        self._track(pr)
+        PullRequestAttribution.objects.create(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.MCP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        ids = find_stale_pull_requests(cutoff=_ago(3))
+        assert ids.count(pr.id) == 1
+
+
+@cell_silo_test
+class EmitAbandonedPrMetricsRowTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+        self.pr = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="77"
+        )
+        self.pr.head_commit_sha = "abc123"
+        self.pr.opened_at = _ago(4)
+        self.pr.draft = False
+        self.pr.save(update_fields=["head_commit_sha", "opened_at", "draft"])
+        PullRequestMetrics.objects.create(
+            pull_request=self.pr,
+            additions=10,
+            deletions=5,
+            verdict=PullRequestVerdict.ABANDONED,
+        )
+        PullRequestAttribution.objects.create(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+
+    @patch("sentry.analytics.record")
+    def test_emits_abandoned_row(self, mock_record: Any) -> None:
+        with patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task"):
+            result = emit_pr_metrics_row(pull_request=self.pr)
+        assert result is True
+        assert mock_record.call_count == 1
+        row = mock_record.call_args[0][0]
+        assert row.close_action == CLOSE_ACTION_ABANDONED
+        assert row.verdict == PullRequestVerdict.ABANDONED
+        assert row.closed_at is not None  # detection timestamp, not null
+        assert row.merged_at is None
+        assert row.pull_request_id == self.pr.id
+        assert row.organization_id == self.organization.id
+
+    @patch("sentry.analytics.record")
+    def test_emits_with_metrics_counters(self, mock_record: Any) -> None:
+        with patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task"):
+            emit_pr_metrics_row(pull_request=self.pr)
+        row = mock_record.call_args[0][0]
+        assert row.additions == 10
+        assert row.deletions == 5
+
+    @patch("sentry.analytics.record")
+    def test_skips_untracked_pr(self, mock_record: Any) -> None:
+        PullRequestAttribution.objects.filter(pull_request=self.pr).delete()
+        with patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task"):
+            result = emit_pr_metrics_row(pull_request=self.pr)
+        assert result is False
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_skips_pr_with_only_invalid_attribution(self, mock_record: Any) -> None:
+        PullRequestAttribution.objects.filter(pull_request=self.pr).update(is_valid=False)
+        with patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task"):
+            result = emit_pr_metrics_row(pull_request=self.pr)
+        assert result is False
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_attribution_json_in_row(self, mock_record: Any) -> None:
+        with patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task"):
+            emit_pr_metrics_row(pull_request=self.pr)
+        row = mock_record.call_args[0][0]
+        attributions = json.loads(row.attributions)
+        assert len(attributions) == 1
+        assert attributions[0]["signal_type"] == PullRequestAttributionSignalType.SENTRY_APP
+
+    @patch("sentry.analytics.record")
+    def test_no_metrics_row_emits_with_zero_counters(self, mock_record: Any) -> None:
+        PullRequestMetrics.objects.filter(pull_request=self.pr).delete()
+        with patch("sentry.pr_metrics.tasks.cleanup_pr_activity_task"):
+            result = emit_pr_metrics_row(pull_request=self.pr)
+        assert result is True
+        row = mock_record.call_args[0][0]
+        assert row.additions == 0
+        assert row.deletions == 0
+        assert row.close_action == CLOSE_ACTION_ABANDONED
+
+
+@cell_silo_test
+@with_feature("organizations:pr-metrics-emit")
+class DetectStalePullRequestsTaskTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+
+    def _make_tracked_stale_pr(self) -> Any:
+        pr = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id
+        )
+        pr.date_added = _ago(4)
+        pr.state = "open"
+        pr.head_commit_sha = "deadbeef"
+        pr.save(update_fields=["date_added", "state", "head_commit_sha"])
+        PullRequestAttribution.objects.create(
+            pull_request=pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        return pr
+
+    def test_claims_verdict_and_emits_for_stale_pr(self) -> None:
+        pr = self._make_tracked_stale_pr()
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            mock_emit.return_value = True
+            detect_stale_pull_requests_task()
+
+        pr.refresh_from_db()
+        metrics = PullRequestMetrics.objects.get(pull_request=pr)
+        assert metrics.verdict == PullRequestVerdict.ABANDONED
+        mock_emit.assert_called_once()
+
+    def test_emits_abandoned_when_pr_has_historical_activity(self) -> None:
+        pr = self._make_tracked_stale_pr()
+        # A commit predating the staleness window: the PR is genuinely stale
+        # (no recent activity) but has commits in its history. The stale path
+        # always emits ABANDONED directly — the judge path requires closed_at
+        # and doesn't support open PRs.
+        old_activity = PullRequestActivity.objects.create(
+            pull_request=pr,
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+        )
+        old_activity.date_added = _ago(4) - timedelta(days=1)
+        old_activity.save(update_fields=["date_added"])
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            mock_emit.return_value = True
+            detect_stale_pull_requests_task()
+
+        mock_emit.assert_called_once()
+
+    def test_skips_pr_without_emit_feature(self) -> None:
+        self._make_tracked_stale_pr()
+        with self.feature({"organizations:pr-metrics-emit": False}):
+            with patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit:
+                detect_stale_pull_requests_task()
+        mock_emit.assert_not_called()
+
+    def test_does_not_double_emit_on_second_run(self) -> None:
+        self._make_tracked_stale_pr()
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            mock_emit.return_value = True
+            detect_stale_pull_requests_task()
+            detect_stale_pull_requests_task()
+
+        assert mock_emit.call_count == 1
+
+    def test_skips_pr_already_closed_by_webhook(self) -> None:
+        pr = self._make_tracked_stale_pr()
+        PullRequestMetrics.objects.create(
+            pull_request=pr, verdict=PullRequestVerdict.CLOSED_UNMERGED
+        )
+        with patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit:
+            detect_stale_pull_requests_task()
+        mock_emit.assert_not_called()
+
+    def test_skips_when_activity_tracking_disabled(self) -> None:
+        # Without pr-metrics-activity we can't distinguish an engaged PR from an
+        # untouched one, so the task skips the org entirely rather than risking a
+        # false abandoned verdict.
+        self._make_tracked_stale_pr()
+        with patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit:
+            detect_stale_pull_requests_task()
+
+        mock_emit.assert_not_called()
+
+    def test_continues_when_org_not_found(self) -> None:
+        # A PR whose organization row has been deleted should be skipped, but
+        # subsequent PRs in the same batch must still be processed.
+        ghost_org = self.create_organization()
+        ghost_repo = self.create_repo(
+            self.project, name="getsentry/ghost", provider="integrations:github"
+        )
+        ghost_pr = self.create_pull_request(
+            repository_id=ghost_repo.id, organization_id=ghost_org.id
+        )
+        ghost_pr.date_added = _ago(4)
+        ghost_pr.state = "open"
+        ghost_pr.head_commit_sha = "deadbeef"
+        ghost_pr.save(update_fields=["date_added", "state", "head_commit_sha"])
+        PullRequestAttribution.objects.create(
+            pull_request=ghost_pr,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        good_pr = self._make_tracked_stale_pr()
+        # Delete the ghost org so the lookup returns None for ghost_pr.
+        ghost_org.delete()
+
+        with (
+            self.feature({"organizations:pr-metrics-activity": True}),
+            patch("sentry.pr_metrics.tasks.emit_pr_metrics_row") as mock_emit,
+        ):
+            mock_emit.return_value = True
+            detect_stale_pull_requests_task()
+
+        # Only the good PR was emitted; the ghost was skipped.
+        assert mock_emit.call_count == 1
+        emitted_pr_id = mock_emit.call_args.kwargs["pull_request"].id
+        assert emitted_pr_id == good_pr.id

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2130,7 +2130,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
             )
         self._run_scheduled_cooldown()
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_claims_sentinel_and_enqueues_forward(
         self, mock_record: MagicMock, mock_delay: MagicMock
@@ -2147,7 +2147,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
             repository_id=self.repo.id,
         )
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_redelivery_forwards_only_once(
         self, mock_record: MagicMock, mock_delay: MagicMock
@@ -2157,7 +2157,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         # The sentinel claim coalesces the redelivery, so Seer is forwarded to once.
         assert mock_delay.call_count == 1
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_forwards_when_metrics_row_missing(
         self, mock_record: MagicMock, mock_delay: MagicMock
@@ -2172,7 +2172,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         )
         mock_delay.assert_called_once()
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_enqueue_failure_releases_claim_for_retry(
         self, mock_record: MagicMock, mock_delay: MagicMock
@@ -2191,7 +2191,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         )
         assert mock_delay.call_count == 2
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_untracked_pr_is_not_forwarded(
         self, mock_record: MagicMock, mock_delay: MagicMock
@@ -2203,7 +2203,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         assert mock_delay.call_count == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_no_seer_access_skips_judge(
         self, mock_record: MagicMock, mock_delay: MagicMock
@@ -2214,7 +2214,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
         assert mock_delay.call_count == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
 
-    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
     def test_ineligible_attribution_emits_merged_with_iteration(
         self, mock_record: MagicMock, mock_delay: MagicMock


### PR DESCRIPTION
## Summary

* Adds a daily cron task (`detect_stale_pull_requests_task`) that finds tracked open PRs with no engaging activity (comment, review, or new commit) in the last 3 weeks and emits them as `close_action=abandoned` via the existing `scm.pr.closed` analytics event.
* Adds `ABANDONED` to `PullRequestVerdict` and `abandoned` to the `CloseAction` contract type.
* Extends `build_pr_metrics_row` with an optional `closed_at` override so the abandoned path can pass the detection timestamp; `closed_at + abandoned` = when Sentry considered the PR abandoned.
* Feature-gated per org under the existing `organizations:pr-metrics-emit` flag.

The staleness query runs entirely in the DB via a correlated subquery — no Python-side filtering over candidates.

Stale PRs always emit `ABANDONED` directly. The judge path (forwarding to Seer) requires `closed_at` to be set and does not support open PRs; those two paths are intentionally separate.

Refs [CW-1635](https://linear.app/getsentry/issue/CW-1635/add-ignored-or-stale-verdict-for-inactive-prs)