### PR TITLE
feat(conversations): Source summary header from meta endpoint

### DIFF
--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -70,6 +70,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/access-requests/$requestId/'
   | '/organizations/$organizationIdOrSlug/ai-conversations/'
   | '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/'
+  | '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/meta/'
   | '/organizations/$organizationIdOrSlug/alert-rule-detector/'
   | '/organizations/$organizationIdOrSlug/alert-rule-workflow/'
   | '/organizations/$organizationIdOrSlug/alert-rules/'

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -23,8 +23,6 @@ import {isUUID} from 'sentry/utils/string/isUUID';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {normalizeUserField} from 'sentry/views/explore/conversations/components/conversationsTable';
-import type {ConversationUser} from 'sentry/views/explore/conversations/hooks/useConversations';
 import {getTimeBoundsFromNodes} from 'sentry/views/explore/conversations/utils/timeBounds';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
@@ -71,7 +69,7 @@ function getGenAiOpType(node: AITraceSpanNode): string | undefined {
   return getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
 }
 
-export function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
+function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
   let llmCalls = 0;
   let toolCalls = 0;
   let errorCount = 0;
@@ -113,28 +111,6 @@ export function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggre
     totalCost,
     toolNames: Array.from(toolNameSet).sort(),
   };
-}
-
-/**
- * Derives the conversation's user from the first span node that carries any
- * user identity attribute. Returns null when the spans aren't user-instrumented.
- */
-export function getConversationUser(nodes: AITraceSpanNode[]): ConversationUser | null {
-  for (const node of nodes) {
-    const email = normalizeUserField(getStringAttr(node, SpanFields.USER_EMAIL));
-    const username = normalizeUserField(getStringAttr(node, SpanFields.USER_USERNAME));
-    const ipAddress = normalizeUserField(getStringAttr(node, SpanFields.USER_IP));
-    const id = normalizeUserField(getStringAttr(node, SpanFields.USER_ID));
-    if (email || username || ipAddress || id) {
-      return {
-        email,
-        username,
-        ip_address: ipAddress,
-        id,
-      };
-    }
-  }
-  return null;
 }
 
 /**

--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -1,8 +1,9 @@
 import type React from 'react';
 import {Fragment, useMemo} from 'react';
 
+import {Tag} from '@sentry/scraps/badge';
 import {InfoText} from '@sentry/scraps/info';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -14,43 +15,38 @@ import {IconOpen, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getDuration} from 'sentry/utils/duration/getDuration';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   getUserDisplayName,
   UserNotInstrumentedTooltip,
 } from 'sentry/views/explore/conversations/components/conversationsTable';
-import {
-  calculateAggregates,
-  getConversationUser,
-  getTraceUrl,
-} from 'sentry/views/explore/conversations/components/conversationSummary';
+import {getTraceUrl} from 'sentry/views/explore/conversations/components/conversationSummary';
 import {ToolTag} from 'sentry/views/explore/conversations/components/toolTag';
+import type {ConversationToolSummary} from 'sentry/views/explore/conversations/hooks/useConversationMeta';
+import {useConversationMeta} from 'sentry/views/explore/conversations/hooks/useConversationMeta';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
-import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 
 interface ConversationSummaryNewProps {
   conversationId: string;
-  nodes: AITraceSpanNode[];
-  isLoading?: boolean;
   nodeTraceMap?: Map<string, string>;
 }
 
 const VISIBLE_TOOL_COUNT = 6;
 
 export function ConversationSummaryNew({
-  nodes,
   conversationId,
-  isLoading,
   nodeTraceMap,
 }: ConversationSummaryNewProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
-  const aggregates = useMemo(() => calculateAggregates(nodes), [nodes]);
-  const user = useMemo(() => getConversationUser(nodes), [nodes]);
+  const {data: meta, isLoading} = useConversationMeta({conversationId});
+  const tools = meta?.tools ?? [];
+  const user = meta?.user ?? null;
   const userDisplayName = user ? getUserDisplayName(user) : null;
 
   const displayId = isUUID(conversationId) ? conversationId.slice(0, 8) : conversationId;
@@ -87,6 +83,11 @@ export function ConversationSummaryNew({
         query: `gen_ai.conversation.id:"${escapeDoubleQuotes(conversationId)}"`,
         table: 'trace',
       });
+
+  const errorCount = meta?.errors ?? 0;
+  const totalTokens = meta?.totalTokens ?? 0;
+  const toolCalls = meta?.toolCalls ?? 0;
+  const totalCost = meta?.totalCost ?? 0;
 
   return (
     <Flex
@@ -127,13 +128,13 @@ export function ConversationSummaryNew({
                 <IconUser size="md" />
                 {userDisplayName ? (
                   <Tooltip title={userDisplayName} showOnlyOnOverflow skipWrapper>
-                    <Text size="xs" variant="muted" ellipsis>
+                    <Text size="sm" variant="muted" ellipsis>
                       {userDisplayName}
                     </Text>
                   </Tooltip>
                 ) : (
                   <InfoText
-                    size="xs"
+                    size="sm"
                     variant="muted"
                     title={<UserNotInstrumentedTooltip />}
                   >
@@ -152,39 +153,35 @@ export function ConversationSummaryNew({
                 >
                   <Flex align="center" gap="xs">
                     <IconOpen size="xs" />
-                    <Text size="xs" variant="inherit" wrap="nowrap">
+                    <Text size="sm" variant="inherit" wrap="nowrap">
                       {tn('Trace', 'Traces', traces.length)}
                     </Text>
                   </Flex>
                 </Link>
               )}
-              {aggregates.toolNames.length > 0 && (
+              {tools.length > 0 && (
                 <Flex align="center" gap="sm" minWidth={0} wrap="wrap">
-                  {aggregates.toolNames.slice(0, VISIBLE_TOOL_COUNT).map(name => (
-                    <ToolTag
-                      key={name}
-                      name={name}
-                      hasError={aggregates.erroredToolNames.has(name)}
-                    />
+                  {tools.slice(0, VISIBLE_TOOL_COUNT).map(tool => (
+                    <ToolTag key={tool.name} name={tool.name} hasError={tool.hasError} />
                   ))}
-                  {aggregates.toolNames.length > VISIBLE_TOOL_COUNT && (
+                  {tools.length > VISIBLE_TOOL_COUNT && (
                     <InfoText
                       size="sm"
                       variant="muted"
                       wrap="nowrap"
                       title={
                         <Flex wrap="wrap" gap="sm" paddingTop="xs" paddingBottom="xs">
-                          {aggregates.toolNames.slice(VISIBLE_TOOL_COUNT).map(name => (
+                          {tools.slice(VISIBLE_TOOL_COUNT).map(tool => (
                             <ToolTag
-                              key={name}
-                              name={name}
-                              hasError={aggregates.erroredToolNames.has(name)}
+                              key={tool.name}
+                              name={tool.name}
+                              hasError={tool.hasError}
                             />
                           ))}
                         </Flex>
                       }
                     >
-                      {t('+%s more', aggregates.toolNames.length - VISIBLE_TOOL_COUNT)}
+                      {t('+%s more', tools.length - VISIBLE_TOOL_COUNT)}
                     </InfoText>
                   )}
                 </Flex>
@@ -196,15 +193,21 @@ export function ConversationSummaryNew({
       <Flex align="start" gap="xl" wrap="wrap" flexShrink={0}>
         <Stat
           label={t('LLM Calls')}
-          value={<Count value={aggregates.llmCalls} />}
+          value={<Count value={meta?.llmCalls ?? 0} />}
+          isLoading={isLoading}
+        />
+        <Stat
+          label={t('Tool Calls')}
+          value={<Count value={toolCalls} />}
+          tooltip={toolCalls > 0 ? <ToolCallsBreakdown tools={tools} /> : undefined}
           isLoading={isLoading}
         />
         <Stat
           label={t('Errors')}
-          value={<Count value={aggregates.errorCount} />}
-          to={aggregates.errorCount > 0 ? errorsUrl : undefined}
+          value={<Count value={errorCount} />}
+          to={errorCount > 0 ? errorsUrl : undefined}
           onClick={
-            aggregates.errorCount > 0
+            errorCount > 0
               ? () =>
                   trackAnalytics('conversations.detail.click-errors-link', {organization})
               : undefined
@@ -213,16 +216,25 @@ export function ConversationSummaryNew({
         />
         <Stat
           label={t('Tokens')}
-          value={<Count value={aggregates.totalTokens} />}
+          value={<Count value={totalTokens} />}
+          tooltip={
+            totalTokens > 0 ? (
+              <TokensBreakdown
+                inputTokens={meta?.inputTokens ?? 0}
+                outputTokens={meta?.outputTokens ?? 0}
+                totalTokens={totalTokens}
+              />
+            ) : undefined
+          }
           isLoading={isLoading}
         />
         <Stat
           label={t('Cost')}
           value={
-            aggregates.totalCost < 0 ? (
-              <NegativeCostInfo cost={aggregates.totalCost} />
+            totalCost < 0 ? (
+              <NegativeCostInfo cost={totalCost} />
             ) : (
-              formatLLMCosts(aggregates.totalCost)
+              formatLLMCosts(totalCost)
             )
           }
           isLoading={isLoading}
@@ -238,12 +250,14 @@ function Stat({
   isLoading,
   to,
   onClick,
+  tooltip,
 }: {
   label: string;
   value: React.ReactNode;
   isLoading?: boolean;
   onClick?: () => void;
   to?: string;
+  tooltip?: React.ReactNode;
 }) {
   const isInteractive = !!to && !isLoading;
 
@@ -261,10 +275,70 @@ function Stat({
           </Text>
         </Link>
       ) : (
-        <Text size="xl" tabular wrap="nowrap">
+        <InfoText size="xl" tabular wrap="nowrap" maxWidth={400} title={tooltip}>
           {value}
-        </Text>
+        </InfoText>
       )}
     </Stack>
+  );
+}
+
+function ToolCallsBreakdown({tools}: {tools: ConversationToolSummary[]}) {
+  return (
+    <Grid columns="1fr max-content max-content" gap="md xl" align="center">
+      {tools.map(tool => (
+        <Fragment key={tool.name}>
+          <Tag
+            variant={tool.hasError ? 'danger' : 'muted'}
+            title={tool.name}
+            // Cap long tool names; the inner Text truncates with an ellipsis.
+            style={{justifySelf: 'start', maxWidth: 200, minWidth: 0}}
+          >
+            <Text ellipsis variant="inherit">
+              {tool.name}
+            </Text>
+          </Tag>
+          <Text size="sm" tabular>
+            <Count value={tool.calls} /> {tn('call', 'calls', tool.calls)}
+          </Text>
+          <Text size="sm" align="right" tabular>
+            {getDuration(tool.duration / 1000, 1, true)}
+          </Text>
+        </Fragment>
+      ))}
+    </Grid>
+  );
+}
+
+function TokensBreakdown({
+  inputTokens,
+  outputTokens,
+  totalTokens,
+}: {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}) {
+  return (
+    <Grid columns="1fr max-content" gap="md xl" align="center">
+      <Text size="sm" align="left">
+        {t('Input')}
+      </Text>
+      <Text size="sm" align="right" tabular>
+        <Count value={inputTokens} />
+      </Text>
+      <Text size="sm" align="left">
+        {t('Output')}
+      </Text>
+      <Text size="sm" align="right" tabular>
+        <Count value={outputTokens} />
+      </Text>
+      <Text size="sm" align="left">
+        {t('Total')}
+      </Text>
+      <Text size="sm" align="right" tabular>
+        <Count value={totalTokens} />
+      </Text>
+    </Grid>
   );
 }

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -170,7 +170,7 @@ function ConversationsTableInner() {
   );
 }
 
-export function normalizeUserField(value: string | null | undefined): string | null {
+function normalizeUserField(value: string | null | undefined): string | null {
   if (!value || value.toLowerCase() === 'none') {
     return null;
   }

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -38,7 +38,7 @@ export function ConversationDetailPageNew() {
 
   const conversation = useMemo(() => ({conversationId}), [conversationId]);
 
-  const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
+  const {nodes, nodeTraceMap} = useConversation(conversation);
 
   const projectSlug = useMemo(
     () => nodes.find(node => node.projectSlug)?.projectSlug,
@@ -69,10 +69,8 @@ export function ConversationDetailPageNew() {
       </TopBar.Slot>
       <Container flexShrink={0} background="primary" borderBottom="primary" padding="xl">
         <ConversationSummaryNew
-          nodes={nodes}
           nodeTraceMap={nodeTraceMap}
           conversationId={conversationId}
-          isLoading={isLoading}
         />
       </Container>
       <Stack flex={1} minHeight="0" overflow="hidden" padding="xl" gap="xl">

--- a/static/app/views/explore/conversations/hooks/useConversationMeta.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationMeta.tsx
@@ -1,0 +1,57 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {ConversationUser} from 'sentry/views/explore/conversations/hooks/useConversations';
+
+export interface ConversationToolSummary {
+  calls: number;
+  duration: number;
+  hasError: boolean;
+  name: string;
+}
+
+/**
+ * Server-computed summary for a single conversation. Mirrors the numbers the
+ * conversations list and details endpoints derive, so the header and the table
+ * never disagree.
+ */
+export interface ConversationMeta {
+  errors: number;
+  inputTokens: number;
+  llmCalls: number;
+  outputTokens: number;
+  toolCalls: number;
+  tools: ConversationToolSummary[];
+  totalCost: number;
+  totalTokens: number;
+  traceIds: string[];
+  user: ConversationUser | null;
+}
+
+/**
+ * Fetches the server-computed summary for a conversation. The endpoint probes
+ * progressively wider time windows to locate the conversation, so no explicit
+ * range is passed here.
+ */
+export function useConversationMeta({conversationId}: {conversationId: string}) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+  const project =
+    selection.projects.length > 0 ? selection.projects : [ALL_ACCESS_PROJECTS];
+
+  return useQuery(
+    apiOptions.as<ConversationMeta>()(
+      '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/meta/',
+      {
+        path: conversationId
+          ? {organizationIdOrSlug: organization.slug, conversationId}
+          : skipToken,
+        query: {project},
+        staleTime: 0,
+      }
+    )
+  );
+}


### PR DESCRIPTION
Sources the conversation detail header from the new server-side meta endpoint (#118820) instead of computing it client-side, so the header, list, and details views report the same numbers. Also adds a **Tool Calls** stat with a per-tool hover card and an **Input / Output / Total** breakdown on the Tokens tooltip.

Depends on #118820 deploying first (frontend and backend aren't atomically deployed).