### PR TITLE
fix(project): Skip optimistic update on project slug change

### DIFF
--- a/static/app/utils/project/useUpdateProject.spec.tsx
+++ b/static/app/utils/project/useUpdateProject.spec.tsx
@@ -115,4 +115,99 @@ describe('useUpdateProject', () => {
       })
     );
   });
+
+  it('optimistically updates the cache when the slug is unchanged', async () => {
+    const queryClient = makeTestQueryClient();
+    const project = DetailedProjectFixture({
+      id: '2',
+      slug: 'project-slug',
+      name: 'Original Project',
+    });
+    const queryKey = makeDetailedProjectQueryKey({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+
+    queryClient.setQueryData(queryKey, {headers: {}, json: project});
+
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {...project, name: 'Updated Project'},
+      // Delay so we can observe the optimistic state while the request is in flight
+      asyncDelay: 100,
+    });
+
+    const {result} = renderHookWithProviders(() => useUpdateProject(project), {
+      organization,
+      additionalWrapper: ({children}: {children?: ReactNode}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    let promise: Promise<unknown>;
+    act(() => {
+      promise = result.current.mutateAsync({name: 'Updated Project'});
+    });
+
+    // onMutate ran synchronously: the cache reflects the new name before the
+    // request resolves.
+    expect(queryClient.getQueryData(queryKey)?.json.name).toBe('Updated Project');
+
+    await act(async () => {
+      await promise;
+    });
+  });
+
+  it('does not optimistically update when the slug changes', async () => {
+    const queryClient = makeTestQueryClient();
+    const project = DetailedProjectFixture({id: '2', slug: 'project-slug'});
+    ProjectsStore.loadInitialData([project]);
+    const queryKey = makeDetailedProjectQueryKey({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+
+    queryClient.setQueryData(queryKey, {headers: {}, json: project});
+
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {...project, slug: 'new-slug'},
+      asyncDelay: 100,
+    });
+    // Invalidation after settle refetches the (old) key
+    MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'GET',
+      body: {...project, slug: 'new-slug'},
+    });
+
+    const {result} = renderHookWithProviders(() => useUpdateProject(project), {
+      organization,
+      additionalWrapper: ({children}: {children?: ReactNode}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    let promise: Promise<unknown>;
+    act(() => {
+      promise = result.current.mutateAsync({slug: 'new-slug'});
+    });
+
+    // No optimistic write while the request is in flight: the cache and store
+    // still hold the original slug, so the URL-canonicalization redirect is not
+    // triggered and backend errors are not masked.
+    expect(queryClient.getQueryData(queryKey)?.json.slug).toBe('project-slug');
+    expect(ProjectsStore.getById('2')?.slug).toBe('project-slug');
+
+    await act(async () => {
+      await promise;
+    });
+
+    // The confirmed server response is still applied on success.
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)?.json.slug).toBe('new-slug')
+    );
+  });
 });

--- a/static/app/utils/project/useUpdateProject.tsx
+++ b/static/app/utils/project/useUpdateProject.tsx
@@ -50,6 +50,16 @@ export function useUpdateProjectMutationOptions(project: Project) {
       });
     },
     onMutate: data => {
+      // A slug change re-keys the detailed-project query and triggers URL
+      // canonicalization (see projectRouteContext's redirect effect). An
+      // optimistic write would flip the cached slug before the server confirms
+      // it — popping the "project moved" redirect and masking backend errors
+      // (e.g. a duplicate slug). Only update optimistically when the slug is
+      // unchanged; for slug changes we wait for the server response.
+      if (data.slug !== undefined && data.slug !== project.slug) {
+        return;
+      }
+
       const previousCachedDetailedProject = queryClient.getQueryData(queryKey)?.json;
       const storeProject = ProjectsStore.getById(project.id);
 


### PR DESCRIPTION
## Summary

`useUpdateProject` optimistically writes the mutated project into the detailed-project query cache (keyed by the current slug) and into `ProjectsStore` via `onMutate`. For a **slug change** this flips the cached slug *before the server confirms it*, which has two bad side effects:

1. It trips `projectRouteContext`'s URL-canonicalization effect (`detailedProject.slug !== projectSlug`), popping the "project moved / redirecting…" modal mid-flight — even when the save ultimately fails.
2. It masks backend validation errors (e.g. *"Another project is already using that slug"*), because the UI looks like it succeeded.

This changes `onMutate` to only apply the optimistic update when the slug is **unchanged**. For slug changes we skip the optimistic write and wait for the server response (`onSuccess` still applies the confirmed result). All other fields keep their optimistic behavior.

## Test plan

Added two isolation tests in `useUpdateProject.spec.tsx`:

- **optimistically updates the cache when the slug is unchanged** — asserts the cache reflects the new value while the request is in flight (via `asyncDelay`).
- **does not optimistically update when the slug changes** — asserts the query cache and `ProjectsStore` still hold the original slug during the in-flight window, then that the confirmed response is applied on success.

Verified the second test fails without the guard (cache flips to the new slug optimistically) and passes with it.

- [x] `pnpm lint:js`
- [x] `pnpm typecheck`
- [x] Hook + consuming view specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)