### PR TITLE
ref(seer): remove two options which now live in Seer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -282,10 +282,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-seer-agent-debug", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable autofix introspection for early stopping of autofix runs
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Run new autofix sessions with high intelligence and reasoning levels
-    manager.add("organizations:seer-autofix-high-intelligence-high-reasoning", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Expose the code review tool to autofix coding runs
-    manager.add("organizations:seer-autofix-code-review", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the PR iteration feedback flow in the explorer autofix drawer
     manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable showing seer in a persistent sidebar

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -63,7 +63,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_UNSET: Any = object()
 UNKNOWN_RUN_ID_FOR_GROUP = "Unknown run id for group"
 
 
@@ -343,27 +342,6 @@ def _get_group_run_state(client: SeerAgentClient, group: Group, run_id: int) -> 
     return state
 
 
-def _default_intelligence_level(organization: Organization) -> Literal["low", "medium", "high"]:
-    if features.has("organizations:seer-autofix-high-intelligence-high-reasoning", organization):
-        return "high"
-    return "medium"
-
-
-def _default_reasoning_effort(
-    organization: Organization,
-    step_default: Literal["low", "medium", "high"] | None,
-) -> Literal["low", "medium", "high"] | None:
-    if features.has("organizations:seer-autofix-high-intelligence-high-reasoning", organization):
-        return "high"
-    return step_default
-
-
-def _code_review_enabled(organization: Organization) -> bool:
-    # Gated purely on the option: Seer decides where the review_code_changes tool
-    # is actually useful (e.g. only once code edits have accumulated).
-    return features.has("organizations:seer-autofix-code-review", organization)
-
-
 def _build_base_shas_metadata(group: Group, referrer: AutofixReferrer) -> str | None:
     preference = read_preference_from_sentry_db(group.project)
     # Imported lazily to avoid a circular import: sentry.scm pulls in the
@@ -411,8 +389,6 @@ def trigger_autofix_agent(
     referrer: AutofixReferrer,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = _UNSET,
-    reasoning_effort: Literal["low", "medium", "high"] | None = _UNSET,
     user_context: str | None = None,
     insert_index: int | None = None,
     feedback: Sequence[Feedback] | None = None,
@@ -440,26 +416,12 @@ def trigger_autofix_agent(
 
     config = STEP_CONFIGS[step]
 
-    resolved_intelligence_level = (
-        _default_intelligence_level(group.organization)
-        if intelligence_level is _UNSET
-        else intelligence_level
-    )
-    resolved_reasoning_effort = (
-        _default_reasoning_effort(group.organization, config.reasoning_effort)
-        if reasoning_effort is _UNSET
-        else reasoning_effort
-    )
-
     pr_iteration_enabled = features.has("organizations:autofix-pr-iteration", group.organization)
     is_iteration_step = step == AutofixStep.PR_ITERATION
 
     client = get_autofix_agent_client(
         group,
-        intelligence_level=resolved_intelligence_level,
-        reasoning_effort=resolved_reasoning_effort,
         enable_coding=config.enable_coding,
-        code_review_enabled=_code_review_enabled(group.organization),
         enable_pr_context_tools=is_iteration_step,
     )
 

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -613,55 +613,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_reasoning_effort_falls_back_to_step_config_default(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
-    ):
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
-
-        trigger_autofix_agent(
-            group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
-            referrer=AutofixReferrer.UNKNOWN,
-            run_id=None,
-        )
-
-        assert (
-            mock_client_class.call_args.kwargs["reasoning_effort"]
-            == STEP_CONFIGS[AutofixStep.ROOT_CAUSE].reasoning_effort
-        )
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_explicit_none_reasoning_effort_bypasses_step_default(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
-    ):
-        # Guard against the step default drifting to None and making this test
-        # pass coincidentally.
-        assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].reasoning_effort is not None
-
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
-
-        trigger_autofix_agent(
-            group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
-            referrer=AutofixReferrer.UNKNOWN,
-            run_id=None,
-            reasoning_effort=None,
-        )
-
-        assert mock_client_class.call_args.kwargs["reasoning_effort"] is None
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_code_review_disabled_without_flag(
+    def test_code_review_always_disabled(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
         mock_client = MagicMock()
@@ -676,54 +628,6 @@ class TestTriggerAutofixAgent(TestCase):
         )
 
         assert mock_client_class.call_args.kwargs["code_review_enabled"] is False
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_code_review_enabled_on_coding_step_with_flag(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
-    ):
-        assert STEP_CONFIGS[AutofixStep.CODE_CHANGES].enable_coding is True
-
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
-
-        with self.feature("organizations:seer-autofix-code-review"):
-            trigger_autofix_agent(
-                group=self.group,
-                step=AutofixStep.CODE_CHANGES,
-                referrer=AutofixReferrer.UNKNOWN,
-                run_id=None,
-            )
-
-        assert mock_client_class.call_args.kwargs["code_review_enabled"] is True
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_code_review_enabled_on_non_coding_step_with_flag(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
-    ):
-        # code_review_enabled is gated purely on the option, so it is set even on
-        # steps that don't enable coding. Seer decides where the tool is useful.
-        assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].enable_coding is False
-
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = MagicMock(seer_run_state_id=123)
-
-        with self.feature("organizations:seer-autofix-code-review"):
-            trigger_autofix_agent(
-                group=self.group,
-                step=AutofixStep.ROOT_CAUSE,
-                referrer=AutofixReferrer.UNKNOWN,
-                run_id=None,
-            )
-
-        assert mock_client_class.call_args.kwargs["code_review_enabled"] is True
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)


### PR DESCRIPTION
These experiments got moved into `getsentry/seer`:

- `organizations:seer-autofix-high-intelligence-high-reasoning`
- `organizations:seer-autofix-code-review`

So we can remove them from `getsentry/sentry`

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC0BB3MPP7PE%3A1782909772.939609/?project=4510944073809921)

<!-- junior-session-footer:end -->