### PR TITLE
feat(seer): Summarize a run via the agent_question one-shot

### DIFF
--- a/src/sentry/seer/oneshot.py
+++ b/src/sentry/seer/oneshot.py
@@ -105,7 +105,7 @@ def run_oneshot(
         body,
         organization,
         error_metric="seer.oneshot.error",
-        error_metric_tags={"oneshot_id": oneshot_id},
+        error_metric_tags={},
         user_id=user_id,
         timeout=timeout,
     )

--- a/src/sentry/seer/run_questions.py
+++ b/src/sentry/seer/run_questions.py
@@ -1,0 +1,157 @@
+"""Ask a fixed set of questions about a Seer Agent (Explorer) run.
+
+Each question is answered by the ``agent_question`` one-shot on Seer: a single
+structured LLM call over the run's conversation history that returns a markdown
+``answer``. The question *text* lives here in Sentry, not in Seer, so we can
+iterate on the questions without a Seer deploy.
+
+Answers are cached in Redis per (organization, run, question) because narrating
+a run is expensive and the answer is stable for a completed run. Every
+(run, question) pair is answered concurrently since they are all independent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TypedDict
+
+from sentry.cache import default_cache
+from sentry.models.organization import Organization
+from sentry.seer.oneshot import run_oneshot
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+_ONESHOT_ID = "agent_question"
+
+# For now cache the results in Redis. Long term we should persist these
+# (probably to objectstore) but it's very unclear what the eventual
+# structure will be so avoid making a call on model/stoage for now.
+_ANSWER_CACHE_TTL = int(timedelta(hours=24).total_seconds())
+
+_MAX_WORKERS = 10
+
+
+@dataclass(frozen=True)
+class Question:
+    # Stable identifier (does not change when the prompt does).
+    key: str
+    # The prompt sent to the one-shot.
+    question: str
+
+
+class RunQuestion(TypedDict):
+    # Stable identifier (does not change when the prompt does).
+    key: str
+    # The prompt sent to the one-shot.
+    question: str
+    # The one-shot's markdown answer, or "" when unavailable.
+    answer: str
+
+
+# For now define the questions here so they are easy to iterate on.
+# Eventually we can move them to Seer where they will be easier to use
+# in evals.
+QUESTIONS: tuple[Question, ...] = (
+    Question(
+        key="summary",
+        question=(
+            "Summarize this Autofix run the way an engineer would write up an issue: "
+            "what the problem is, how you investigated and debugged it (the key "
+            "evidence and root cause you found), and the fix you're proposing. "
+            "This should be short, 1 paragraph at most."
+        ),
+    ),
+    Question(
+        key="follow_up",
+        question=(
+            "Given this Autofix suggest 5 or less bullet point follow ups for "
+            "those working on the project. If there are no reasonable follow ups "
+            "return the empty string."
+        ),
+    ),
+)
+
+
+def _answer_cache_key(organization: Organization, run_id: int, question: str) -> str:
+    digest = hashlib.sha1(question.encode("utf-8")).hexdigest()[:8]
+    return f"seer-run-question-v1:{organization.id}:{run_id}:{digest}"
+
+
+def _get_answer(
+    organization: Organization,
+    run_id: int,
+    question: str,
+    *,
+    user_id: int | None,
+    timeout: int | float | None,
+) -> str:
+    """Return the cached answer for one question, or ask Seer and cache it.
+
+    Best-effort: returns an empty string when the one-shot fails or produces no
+    answer so the remaining questions (and the enclosing response) still
+    resolve.
+    """
+    cache_key = _answer_cache_key(organization, run_id, question)
+    cached = default_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        result = run_oneshot(
+            _ONESHOT_ID,
+            {"run_id": run_id, "question": question},
+            organization,
+            user_id=user_id,
+            timeout=timeout,
+        )
+    except Exception:
+        logger.exception("seer.run_questions.failed", extra={"run_id": run_id})
+        return ""
+
+    answer = result.get("answer")
+    # A missing answer means the one-shot failed, so retry rather than cache it.
+    # An empty string is a real answer (e.g. no follow-ups) and is cached.
+    if answer is None:
+        return ""
+
+    default_cache.set(cache_key, answer, timeout=_ANSWER_CACHE_TTL)
+    return answer
+
+
+def get_run_questions(
+    run_ids: Sequence[int],
+    organization: Organization,
+    *,
+    user_id: int | None = None,
+    timeout: int | float | None = None,
+) -> dict[int, list[RunQuestion]]:
+    """Answer ``QUESTIONS`` about each run in ``run_ids``.
+
+    Every (run, question) pair is answered concurrently in a single shared pool,
+    so multiple runs parallelize with each other as well as across questions.
+    Returns a mapping from run id to its answers in ``QUESTIONS`` order.
+    """
+    unique_run_ids = list(dict.fromkeys(run_ids))
+    tasks = [(run_id, question) for run_id in unique_run_ids for question in QUESTIONS]
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=_MAX_WORKERS) as executor:
+        answers = list(
+            executor.map(
+                lambda task: _get_answer(
+                    organization, task[0], task[1].question, user_id=user_id, timeout=timeout
+                ),
+                tasks,
+            )
+        )
+
+    result: dict[int, list[RunQuestion]] = {run_id: [] for run_id in unique_run_ids}
+    for (run_id, question), answer in zip(tasks, answers):
+        result[run_id].append(
+            {"key": question.key, "question": question.question, "answer": answer}
+        )
+    return result

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -413,10 +413,9 @@ def make_oneshot_request(
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
-        "/v1/automation/agent/oneshot/run",
+        "/v1/automation/oneshot/run",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
-        metric_tags={"oneshot_id": body["oneshot_id"]},
         viewer_context=viewer_context,
     )
 

--- a/tests/sentry/seer/test_run_questions.py
+++ b/tests/sentry/seer/test_run_questions.py
@@ -1,0 +1,84 @@
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import patch
+
+from sentry.models.organization import Organization
+from sentry.seer.run_questions import QUESTIONS, get_run_questions
+from sentry.testutils.cases import TestCase
+
+
+class GetRunQuestionsTest(TestCase):
+    def _answer_for(self, run_id: int, question: str) -> str:
+        return f"run {run_id} answer to: {question}"
+
+    def _fake_oneshot(
+        self,
+        oneshot_id: str,
+        payload: Mapping[str, Any],
+        organization: Organization,
+        **kwargs: Any,
+    ) -> dict[str, str]:
+        return {"answer": self._answer_for(payload["run_id"], payload["question"])}
+
+    def test_answers_every_question_in_order(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot", side_effect=self._fake_oneshot
+        ) as mock_run:
+            result = get_run_questions([123], self.organization)
+
+        answers = result[123]
+        assert [q["key"] for q in answers] == [q.key for q in QUESTIONS]
+        assert [q["question"] for q in answers] == [q.question for q in QUESTIONS]
+        assert [q["answer"] for q in answers] == [
+            self._answer_for(123, q.question) for q in QUESTIONS
+        ]
+        assert mock_run.call_count == len(QUESTIONS)
+
+    def test_answers_multiple_runs_in_parallel(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot", side_effect=self._fake_oneshot
+        ) as mock_run:
+            result = get_run_questions([1, 2, 3], self.organization)
+
+        assert set(result) == {1, 2, 3}
+        for run_id in (1, 2, 3):
+            assert [q["answer"] for q in result[run_id]] == [
+                self._answer_for(run_id, q.question) for q in QUESTIONS
+            ]
+        # One one-shot per (run, question) pair.
+        assert mock_run.call_count == 3 * len(QUESTIONS)
+
+    def test_duplicate_run_ids_answered_once(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot", side_effect=self._fake_oneshot
+        ) as mock_run:
+            result = get_run_questions([7, 7, 7], self.organization)
+
+        assert set(result) == {7}
+        assert [q["answer"] for q in result[7]] == [
+            self._answer_for(7, q.question) for q in QUESTIONS
+        ]
+        # A repeated run is answered only once, not once per occurrence.
+        assert mock_run.call_count == len(QUESTIONS)
+
+    def test_empty_run_ids_returns_empty(self) -> None:
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            result = get_run_questions([], self.organization)
+
+        assert result == {}
+        assert mock_run.call_count == 0
+
+    def test_best_effort_on_api_error(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot",
+            side_effect=Exception("boom"),
+        ):
+            result = get_run_questions([789], self.organization)
+
+        assert [q["answer"] for q in result[789]] == ["" for _ in QUESTIONS]
+
+    def test_best_effort_on_empty_result(self) -> None:
+        with patch("sentry.seer.run_questions.run_oneshot", return_value={}):
+            result = get_run_questions([1011], self.organization)
+
+        assert [q["answer"] for q in result[1011]] == ["" for _ in QUESTIONS]


### PR DESCRIPTION
Adds a `run_questions` module that asks the `agent_question` one-shot a single, free-form question about a Seer Agent run.

Two thing to fix once we're finished iterating on the prompts:
- Where to store the results. This caches in Redis, we probably want to store in objectstore and have some DB model.
- Move the prompts into Seer where they can be evaled.