### PR TITLE
feat(seer): Expose per-run one-shot outputs on the runs list via ?outputs

### DIFF
--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.seer.models.run import SeerAgentRun, SeerRun
+
+
+class RunQuestionOutput(TypedDict):
+    key: str
+    answer: str
 
 
 class SeerRunResponse(TypedDict):
@@ -18,6 +23,9 @@ class SeerRunResponse(TypedDict):
     source: str | None
     projectId: str | None
     groupId: str | None
+    # One-shot outputs (question answers), injected by the endpoint when
+    # ?outputs is passed; the serializer itself never populates them.
+    outputs: NotRequired[list[RunQuestionOutput]]
 
 
 @register(SeerRun)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -288,6 +288,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-autofix-code-review", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the PR iteration feedback flow in the explorer autofix drawer
     manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Expose one-shot question answers on the Seer runs list (?expand=questions)
+    manager.add("organizations:seer-run-questions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable showing seer in a persistent sidebar
     manager.add("organizations:seer-explorer-persistent-sidebar", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show Seer run ID in Slack notification footers

--- a/src/sentry/seer/endpoints/organization_seer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_runs.py
@@ -1,21 +1,58 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.seer_run import SeerRunSerializer
+from sentry.api.serializers.models.seer_run import (
+    RunQuestionOutput,
+    SeerRunResponse,
+    SeerRunSerializer,
+)
 from sentry.api.utils import get_date_range_from_params
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
+from sentry.seer.models.run import SeerRun, SeerRunType
+from sentry.seer.run_questions import get_run_questions
 from sentry.seer.runs_query import filtered_runs_queryset
+
+
+def _fetch_run_outputs(
+    runs: Sequence[SeerRun],
+    organization: Organization,
+    *,
+    user_id: int | None,
+) -> dict[int, list[RunQuestionOutput]]:
+    qualifying = [
+        run
+        for run in runs
+        if run.type == SeerRunType.EXPLORER and run.seer_run_state_id is not None
+    ]
+    if not qualifying:
+        return {}
+
+    answers_by_state_id = get_run_questions(
+        [run.seer_run_state_id for run in qualifying],
+        organization,
+        user_id=user_id,
+    )
+    return {
+        run.id: [
+            {"key": q["key"], "answer": q["answer"]}
+            for q in answers_by_state_id.get(run.seer_run_state_id, [])
+        ]
+        for run in qualifying
+    }
 
 
 class OrganizationSeerRunsPermission(OrganizationPermission):
@@ -46,10 +83,16 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             query: Optional structured search string. Supports ``source``, ``type``,
                 ``project``, ``is:agent``/``!is:agent``, ``is:mine``/``!is:mine``,
                 and free-text title search.
+            outputs: Optional boolean flag. When present, include one-shot outputs
+                per run (requires the ``seer-run-questions`` feature).
         """
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
         if not has_access:
             raise PermissionDenied(error)
+
+        include_outputs = "outputs" in request.GET and features.has(
+            "organizations:seer-run-questions", organization, actor=request.user
+        )
 
         query = request.GET.get("query", "").strip()
         accessible_project_ids = [
@@ -74,12 +117,22 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             # of InvalidSearchQuery do the same as this.
             return Response({"detail": str(e)}, status=400)
 
+        def on_results(runs: Sequence[SeerRun]) -> list[SeerRunResponse]:
+            serialized: list[SeerRunResponse] = serialize(runs, request.user, SeerRunSerializer())
+            if include_outputs:
+                outputs_by_run_id = _fetch_run_outputs(runs, organization, user_id=request.user.id)
+                for run, data in zip(runs, serialized):
+                    data["outputs"] = outputs_by_run_id.get(run.id, [])
+            return serialized
+
         return self.paginate(
             request=request,
             queryset=queryset,
             order_by="-last_triggered_at",
-            on_results=lambda runs: serialize(runs, request.user, SeerRunSerializer()),
+            on_results=on_results,
             paginator_cls=OffsetPaginator,
-            default_per_page=100,
-            max_per_page=100,
+            # Computing outputs is expensive (one one-shot per question per run),
+            # so use a small default and cap the page size when they're requested.
+            default_per_page=10 if include_outputs else 100,
+            max_per_page=10 if include_outputs else 100,
         )

--- a/src/sentry/seer/oneshot.py
+++ b/src/sentry/seer/oneshot.py
@@ -105,7 +105,7 @@ def run_oneshot(
         body,
         organization,
         error_metric="seer.oneshot.error",
-        error_metric_tags={"oneshot_id": oneshot_id},
+        error_metric_tags={},
         user_id=user_id,
         timeout=timeout,
     )

--- a/src/sentry/seer/run_questions.py
+++ b/src/sentry/seer/run_questions.py
@@ -1,0 +1,157 @@
+"""Ask a fixed set of questions about a Seer Agent (Explorer) run.
+
+Each question is answered by the ``agent_question`` one-shot on Seer: a single
+structured LLM call over the run's conversation history that returns a markdown
+``answer``. The question *text* lives here in Sentry, not in Seer, so we can
+iterate on the questions without a Seer deploy.
+
+Answers are cached in Redis per (organization, run, question) because narrating
+a run is expensive and the answer is stable for a completed run. Every
+(run, question) pair is answered concurrently since they are all independent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TypedDict
+
+from sentry.cache import default_cache
+from sentry.models.organization import Organization
+from sentry.seer.oneshot import run_oneshot
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
+
+logger = logging.getLogger(__name__)
+
+_ONESHOT_ID = "agent_question"
+
+# For now cache the results in Redis. Long term we should persist these
+# (probably to objectstore) but it's very unclear what the eventual
+# structure will be so avoid making a call on model/stoage for now.
+_ANSWER_CACHE_TTL = int(timedelta(hours=24).total_seconds())
+
+_MAX_WORKERS = 10
+
+
+@dataclass(frozen=True)
+class Question:
+    # Stable identifier (does not change when the prompt does).
+    key: str
+    # The prompt sent to the one-shot.
+    question: str
+
+
+class RunQuestion(TypedDict):
+    # Stable identifier (does not change when the prompt does).
+    key: str
+    # The prompt sent to the one-shot.
+    question: str
+    # The one-shot's markdown answer, or "" when unavailable.
+    answer: str
+
+
+# For now define the questions here so they are easy to iterate on.
+# Eventually we can move them to Seer where they will be easier to use
+# in evals.
+QUESTIONS: tuple[Question, ...] = (
+    Question(
+        key="summary",
+        question=(
+            "Summarize this Autofix run the way an engineer would write up an issue: "
+            "what the problem is, how you investigated and debugged it (the key "
+            "evidence and root cause you found), and the fix you're proposing. "
+            "This should be short, 1 paragraph at most."
+        ),
+    ),
+    Question(
+        key="follow_up",
+        question=(
+            "Given this Autofix suggest 5 or less bullet point follow ups for "
+            "those working on the project. If there are no reasonable follow ups "
+            "return the empty string."
+        ),
+    ),
+)
+
+
+def _answer_cache_key(organization: Organization, run_id: int, question: str) -> str:
+    digest = hashlib.sha1(question.encode("utf-8")).hexdigest()[:8]
+    return f"seer-run-question-v1:{organization.id}:{run_id}:{digest}"
+
+
+def _get_answer(
+    organization: Organization,
+    run_id: int,
+    question: str,
+    *,
+    user_id: int | None,
+    timeout: int | float | None,
+) -> str:
+    """Return the cached answer for one question, or ask Seer and cache it.
+
+    Best-effort: returns an empty string when the one-shot fails or produces no
+    answer so the remaining questions (and the enclosing response) still
+    resolve.
+    """
+    cache_key = _answer_cache_key(organization, run_id, question)
+    cached = default_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        result = run_oneshot(
+            _ONESHOT_ID,
+            {"run_id": run_id, "question": question},
+            organization,
+            user_id=user_id,
+            timeout=timeout,
+        )
+    except Exception:
+        logger.exception("seer.run_questions.failed", extra={"run_id": run_id})
+        return ""
+
+    answer = result.get("answer")
+    # A missing answer means the one-shot failed, so retry rather than cache it.
+    # An empty string is a real answer (e.g. no follow-ups) and is cached.
+    if answer is None:
+        return ""
+
+    default_cache.set(cache_key, answer, timeout=_ANSWER_CACHE_TTL)
+    return answer
+
+
+def get_run_questions(
+    run_ids: Sequence[int],
+    organization: Organization,
+    *,
+    user_id: int | None = None,
+    timeout: int | float | None = None,
+) -> dict[int, list[RunQuestion]]:
+    """Answer ``QUESTIONS`` about each run in ``run_ids``.
+
+    Every (run, question) pair is answered concurrently in a single shared pool,
+    so multiple runs parallelize with each other as well as across questions.
+    Returns a mapping from run id to its answers in ``QUESTIONS`` order.
+    """
+    unique_run_ids = list(dict.fromkeys(run_ids))
+    tasks = [(run_id, question) for run_id in unique_run_ids for question in QUESTIONS]
+
+    with ContextPropagatingThreadPoolExecutor(max_workers=_MAX_WORKERS) as executor:
+        answers = list(
+            executor.map(
+                lambda task: _get_answer(
+                    organization, task[0], task[1].question, user_id=user_id, timeout=timeout
+                ),
+                tasks,
+            )
+        )
+
+    result: dict[int, list[RunQuestion]] = {run_id: [] for run_id in unique_run_ids}
+    for (run_id, question), answer in zip(tasks, answers):
+        result[run_id].append(
+            {"key": question.key, "question": question.question, "answer": answer}
+        )
+    return result

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -413,10 +413,9 @@ def make_oneshot_request(
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
-        "/v1/automation/agent/oneshot/run",
+        "/v1/automation/oneshot/run",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
-        metric_tags={"oneshot_id": body["oneshot_id"]},
         viewer_context=viewer_context,
     )
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -1,4 +1,9 @@
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import patch
+
 from sentry.seer.models.run import SeerRunType
+from sentry.seer.run_questions import QUESTIONS
 from sentry.seer.runs_query import filtered_runs_queryset
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -271,6 +276,34 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         assert [r["id"] for r in response.data] == expected
         assert 'rel="next"; results="true"' in response.headers["Link"]
 
+    @with_feature("organizations:seer-run-questions")
+    def test_default_page_size_is_10_with_outputs(self) -> None:
+        for i in range(1, 12):
+            self.create_seer_run(
+                organization=self.organization,
+                user_id=self.user.id,
+                last_triggered_at=before_now(minutes=i),
+            )
+
+        response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+
+        assert len(response.data) == 10
+        assert 'rel="next"; results="true"' in response.headers["Link"]
+
+    def test_default_page_size_without_outputs(self) -> None:
+        for i in range(1, 12):
+            self.create_seer_run(
+                organization=self.organization,
+                user_id=self.user.id,
+                last_triggered_at=before_now(minutes=i),
+            )
+
+        # Without ?outputs the small default doesn't apply, so all runs fit on
+        # the first page.
+        response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 11
+
     def test_ids_serialized_as_strings(self) -> None:
         run = self.create_seer_run(
             organization=self.organization, user_id=self.user.id, seer_run_state_id=42
@@ -280,6 +313,80 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         data = response.data[0]
         assert data["id"] == str(run.uuid)
         assert data["userId"] == str(self.user.id)
+
+    def test_outputs_absent_without_flag(self) -> None:
+        self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=1
+        )
+
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            response = self.get_success_response(self.organization.slug)
+
+        assert "outputs" not in response.data[0]
+        assert mock_run.call_count == 0
+
+    def test_outputs_requires_feature(self) -> None:
+        self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=1
+        )
+
+        # Feature off: the flag is ignored, no one-shot calls, no outputs field.
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+
+        assert "outputs" not in response.data[0]
+        assert mock_run.call_count == 0
+
+    @with_feature("organizations:seer-run-questions")
+    def test_outputs(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+
+        def fake_oneshot(
+            oneshot_id: str, payload: Mapping[str, Any], organization: Any, **kwargs: Any
+        ) -> dict[str, str]:
+            return {"answer": f"answer to: {payload['question']}"}
+
+        with patch("sentry.seer.run_questions.run_oneshot", side_effect=fake_oneshot) as mock_run:
+            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        assert [q["key"] for q in row["outputs"]] == [q.key for q in QUESTIONS]
+        assert [q["answer"] for q in row["outputs"]] == [
+            f"answer to: {q.question}" for q in QUESTIONS
+        ]
+        assert mock_run.call_count == len(QUESTIONS)
+
+    @with_feature("organizations:seer-run-questions")
+    def test_outputs_skips_non_explorer_runs(self) -> None:
+        pr_review = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            seer_run_state_id=7,
+            type=SeerRunType.PR_REVIEW,
+        )
+
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+
+        row = next(r for r in response.data if r["id"] == str(pr_review.uuid))
+        # Non-explorer runs carry an empty list and trigger no one-shot calls.
+        assert row["outputs"] == []
+        assert mock_run.call_count == 0
+
+    @with_feature("organizations:seer-run-questions")
+    def test_outputs_skips_runs_without_state_id(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=None
+        )
+
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        assert row["outputs"] == []
+        assert mock_run.call_count == 0
 
 
 class OrganizationSeerRunsEndpointAccessTest(APITestCase):

--- a/tests/sentry/seer/test_run_questions.py
+++ b/tests/sentry/seer/test_run_questions.py
@@ -1,0 +1,84 @@
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import patch
+
+from sentry.models.organization import Organization
+from sentry.seer.run_questions import QUESTIONS, get_run_questions
+from sentry.testutils.cases import TestCase
+
+
+class GetRunQuestionsTest(TestCase):
+    def _answer_for(self, run_id: int, question: str) -> str:
+        return f"run {run_id} answer to: {question}"
+
+    def _fake_oneshot(
+        self,
+        oneshot_id: str,
+        payload: Mapping[str, Any],
+        organization: Organization,
+        **kwargs: Any,
+    ) -> dict[str, str]:
+        return {"answer": self._answer_for(payload["run_id"], payload["question"])}
+
+    def test_answers_every_question_in_order(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot", side_effect=self._fake_oneshot
+        ) as mock_run:
+            result = get_run_questions([123], self.organization)
+
+        answers = result[123]
+        assert [q["key"] for q in answers] == [q.key for q in QUESTIONS]
+        assert [q["question"] for q in answers] == [q.question for q in QUESTIONS]
+        assert [q["answer"] for q in answers] == [
+            self._answer_for(123, q.question) for q in QUESTIONS
+        ]
+        assert mock_run.call_count == len(QUESTIONS)
+
+    def test_answers_multiple_runs_in_parallel(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot", side_effect=self._fake_oneshot
+        ) as mock_run:
+            result = get_run_questions([1, 2, 3], self.organization)
+
+        assert set(result) == {1, 2, 3}
+        for run_id in (1, 2, 3):
+            assert [q["answer"] for q in result[run_id]] == [
+                self._answer_for(run_id, q.question) for q in QUESTIONS
+            ]
+        # One one-shot per (run, question) pair.
+        assert mock_run.call_count == 3 * len(QUESTIONS)
+
+    def test_duplicate_run_ids_answered_once(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot", side_effect=self._fake_oneshot
+        ) as mock_run:
+            result = get_run_questions([7, 7, 7], self.organization)
+
+        assert set(result) == {7}
+        assert [q["answer"] for q in result[7]] == [
+            self._answer_for(7, q.question) for q in QUESTIONS
+        ]
+        # A repeated run is answered only once, not once per occurrence.
+        assert mock_run.call_count == len(QUESTIONS)
+
+    def test_empty_run_ids_returns_empty(self) -> None:
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            result = get_run_questions([], self.organization)
+
+        assert result == {}
+        assert mock_run.call_count == 0
+
+    def test_best_effort_on_api_error(self) -> None:
+        with patch(
+            "sentry.seer.run_questions.run_oneshot",
+            side_effect=Exception("boom"),
+        ):
+            result = get_run_questions([789], self.organization)
+
+        assert [q["answer"] for q in result[789]] == ["" for _ in QUESTIONS]
+
+    def test_best_effort_on_empty_result(self) -> None:
+        with patch("sentry.seer.run_questions.run_oneshot", return_value={}):
+            result = get_run_questions([1011], self.organization)
+
+        assert [q["answer"] for q in result[1011]] == ["" for _ in QUESTIONS]


### PR DESCRIPTION
Exposes the per-run one-shot outputs (see the base PR) on the organization Seer runs list endpoint.

- New feature flag `organizations:seer-run-questions`.
- A boolean `?outputs` flag (present/absent) opts a request into per-run outputs. When set (and the feature is on), each `explorer` run with a mirrored `seer_run_state_id` gets an `outputs` array of `{key, question, answer}`; other runs get `[]` and trigger no one-shot calls.