### PR TITLE
feat(seer): Add a demo runs list UI with search, pagination, and outputs

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2502,6 +2502,14 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/issueList/pages/autofix/recentlyRun')),
     },
     {
+      path: 'autofix/runs/',
+      component: make(() => import('sentry/views/seerRunsDemo')),
+    },
+    {
+      path: 'autofix/issues/',
+      component: make(() => import('sentry/views/autofixIssuesDemo')),
+    },
+    {
       path: 'views/:viewId/',
       component: errorHandler(OverviewWrapper),
     },

--- a/static/app/views/autofixIssuesDemo/index.tsx
+++ b/static/app/views/autofixIssuesDemo/index.tsx
@@ -1,0 +1,189 @@
+import {useCallback, useMemo} from 'react';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Pagination} from '@sentry/scraps/pagination';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {LoadingError} from 'sentry/components/loadingError';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {
+  COL_WIDTH_UNDEFINED,
+  GridEditable,
+  type GridColumnOrder,
+} from 'sentry/components/tables/gridEditable';
+import {TimeSince} from 'sentry/components/timeSince';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import type {TagVariant} from 'sentry/utils/theme/types';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  AUTOFIX_PHASE_LABELS,
+  type AutofixIssue,
+  type AutofixPhase,
+  DEFAULT_ISSUE_QUERY,
+  REQUIRED_ISSUE_FILTER,
+  useAutofixIssues,
+} from 'sentry/views/autofixIssuesDemo/useAutofixIssues';
+import {IssueListSearchBar} from 'sentry/views/issueList/searchBar';
+
+// Tag color per phase: neutral early, warning mid, promotion/success at PR.
+const AUTOFIX_PHASE_VARIANTS: Record<AutofixPhase, TagVariant> = {
+  rca: 'muted',
+  planning: 'info',
+  coding: 'warning',
+  pr_open: 'promotion',
+  pr_merged: 'success',
+};
+
+export default function AutofixIssuesDemo() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const query = decodeScalar(location.query.query, DEFAULT_ISSUE_QUERY);
+  const cursor = decodeScalar(location.query.cursor);
+
+  const {issues, isPending, isError, refetch, pageLinks} = useAutofixIssues({
+    query,
+    cursor,
+  });
+
+  const handleSearch = useCallback(
+    (newQuery: string) => {
+      navigate({
+        pathname: location.pathname,
+        query: {...location.query, query: newQuery, cursor: undefined},
+      });
+    },
+    [navigate, location.pathname, location.query]
+  );
+
+  const columnOrder = useMemo<Array<GridColumnOrder<string>>>(
+    () => [
+      {key: 'issue', name: t('Issue'), width: 320},
+      {key: 'status', name: t('Status'), width: 120},
+      {key: 'fixability', name: t('Fixability'), width: 110},
+      {key: 'lastRun', name: t('Last run'), width: 150},
+      {key: 'outputs', name: t('Seer answers'), width: COL_WIDTH_UNDEFINED},
+    ],
+    []
+  );
+
+  const renderBodyCell = useCallback(
+    (column: GridColumnOrder<string>, issue: AutofixIssue): React.ReactNode => {
+      switch (column.key) {
+        case 'issue':
+          return (
+            <Stack gap="2xs">
+              <Link to={`/organizations/${organization.slug}/issues/${issue.id}/`}>
+                {issue.shortId || issue.title}
+              </Link>
+              <Text variant="muted" size="sm" wordBreak="break-word">
+                {issue.title}
+              </Text>
+            </Stack>
+          );
+        case 'status': {
+          if (issue.autofixPhase) {
+            return (
+              <Tag variant={AUTOFIX_PHASE_VARIANTS[issue.autofixPhase]}>
+                {AUTOFIX_PHASE_LABELS[issue.autofixPhase]}
+              </Tag>
+            );
+          }
+          return <Text variant="muted">{issue.autofixPhasePending ? '…' : '—'}</Text>;
+        }
+        case 'fixability':
+          return (
+            <Text>
+              {typeof issue.seerFixabilityScore === 'number'
+                ? issue.seerFixabilityScore.toFixed(2)
+                : '—'}
+            </Text>
+          );
+        case 'lastRun': {
+          const lastRun = issue.run?.lastTriggeredAt ?? issue.seerAutofixLastTriggered;
+          return lastRun ? (
+            <TimeSince date={lastRun} />
+          ) : (
+            <Text variant="muted">{'—'}</Text>
+          );
+        }
+        case 'outputs': {
+          const answered = (issue.run?.outputs ?? []).filter(q => q.answer);
+          if (answered.length === 0) {
+            return <Text variant="muted">{'—'}</Text>;
+          }
+          return (
+            <Stack gap="md">
+              {answered.map(q => (
+                <Stack key={q.key} gap="xs">
+                  <Heading as="h4">{q.question ?? q.key}</Heading>
+                  <SeerMarkdown raw={q.answer} />
+                </Stack>
+              ))}
+            </Stack>
+          );
+        }
+        default:
+          return null;
+      }
+    },
+    [organization.slug]
+  );
+
+  return (
+    <SentryDocumentTitle title={t('Autofix Issues')} orgSlug={organization.slug}>
+      <Stack gap="lg" padding="xl" paddingBottom="3xl">
+        <Stack gap="2xs">
+          <Heading as="h1">{t('Autofix Issues')}</Heading>
+          <Text as="p" variant="muted">
+            {t(
+              'Issues Seer has run autofix on, enriched with each run and its one-shot answers.'
+            )}
+          </Text>
+        </Stack>
+
+        {/*
+          Reuse the standard issue search bar. The required
+          `has:issue.seer_last_run` filter is always applied on top by
+          useAutofixIssues, so it isn't part of the editable query.
+        */}
+        <IssueListSearchBar
+          organization={organization}
+          searchSource="autofix_issues_demo"
+          initialQuery={query}
+          placeholder={t('Search %s issues', REQUIRED_ISSUE_FILTER)}
+          onSearch={handleSearch}
+        />
+
+        {isError ? (
+          <LoadingError onRetry={refetch} />
+        ) : (
+          <Container>
+            <GridEditable
+              isLoading={isPending}
+              data={issues}
+              columnOrder={columnOrder}
+              columnSortBy={[]}
+              grid={{
+                renderHeadCell: column => column.name,
+                renderBodyCell,
+              }}
+              emptyMessage={t('No autofix issues found for this organization.')}
+            />
+            <Pagination pageLinks={pageLinks} />
+          </Container>
+        )}
+
+        {/* Clear the floating Seer button so it doesn't overlap the content. */}
+        <Container height="80px" aria-hidden />
+      </Stack>
+    </SentryDocumentTitle>
+  );
+}

--- a/static/app/views/autofixIssuesDemo/useAutofixIssues.tsx
+++ b/static/app/views/autofixIssuesDemo/useAutofixIssues.tsx
@@ -1,0 +1,244 @@
+import {useMemo} from 'react';
+import {skipToken, useQueries, useQuery} from '@tanstack/react-query';
+
+import {
+  type ExplorerAutofixState,
+  getOrderedAutofixSections,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+// Visible default query for the search bar. The required autofix filter below
+// is always applied on top, so it isn't part of the editable query.
+export const DEFAULT_ISSUE_QUERY = 'is:unresolved';
+
+// Always applied to the issue query: only issues Seer has run autofix on.
+export const REQUIRED_ISSUE_FILTER = 'has:issue.seer_last_run';
+
+function withRequiredFilter(query: string): string {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return REQUIRED_ISSUE_FILTER;
+  }
+  return trimmed.includes(REQUIRED_ISSUE_FILTER)
+    ? trimmed
+    : `${trimmed} ${REQUIRED_ISSUE_FILTER}`;
+}
+
+// Runs filter: the explorer runs autofix creates. Combined with a
+// ``group:[...]`` filter so we only fetch runs for the issues on the page.
+const RUNS_QUERY = 'type:explorer source:autofix';
+
+// Custom one-shot question asked about each run, sent to the endpoint as a
+// repeatable `question` param (see organization_seer_runs.py). Edit this list
+// to iterate on prompts without a backend change. Capped at 5 by the endpoint.
+const DEMO_QUESTIONS = [
+  'What was the most important bit of evidence while investigating this issue?',
+  'What is the complexity of the fix? Count or estimate number of lines and files touched.',
+];
+
+// Keep the issue page size at/under the runs endpoint's outputs page cap (10)
+// so a single runs request covers every group on the page.
+const PER_PAGE = 10;
+
+// The furthest phase an autofix run has reached, derived from its state.
+// NOTE: 'pr_merged' is intentionally never produced here — the autofix state
+// endpoint only reports up to "PR opened" (repo_pr_states.pr_creation_status
+// tops out at 'completed'). GitHub merge status lives on sentry.PullRequest and
+// would need a separate backend join to surface. Kept in the union so the UI
+// can label it once that data is available.
+export type AutofixPhase = 'rca' | 'planning' | 'coding' | 'pr_open' | 'pr_merged';
+
+// Human labels for each phase.
+export const AUTOFIX_PHASE_LABELS: Record<AutofixPhase, string> = {
+  rca: 'Root cause',
+  planning: 'Planning',
+  coding: 'Coding',
+  pr_open: 'PR open',
+  pr_merged: 'PR merged',
+};
+
+/**
+ * Derive the furthest phase a run has reached from its full autofix state.
+ *
+ * Reuses getOrderedAutofixSections (the same bucketing the Seer explorer UI
+ * uses): sections are ordered by first-seen step, with synthetic
+ * 'pull_request'/'coding_agents' sections appended last, so the final section
+ * is the furthest-progressed phase. Returns null when there is no run.
+ */
+function deriveAutofixPhase(runState: ExplorerAutofixState | null): AutofixPhase | null {
+  if (!runState) {
+    return null;
+  }
+  const sections = getOrderedAutofixSections(runState);
+  const lastStep = sections[sections.length - 1]?.step;
+  switch (lastStep) {
+    case 'pull_request':
+      return 'pr_open';
+    case 'coding_agents':
+    case 'code_changes':
+      return 'coding';
+    case 'solution':
+      return 'planning';
+    case 'root_cause':
+      return 'rca';
+    default:
+      return null;
+  }
+}
+
+// One answered question, mirrors the run output in
+// src/sentry/api/serializers/models/seer_run.py.
+interface RunQuestion {
+  answer: string;
+  key: string;
+  // The question text, echoed back only for user-supplied questions.
+  question?: string;
+}
+
+// Subset of the runs list response we consume
+// (src/sentry/api/serializers/models/seer_run.py).
+interface SeerRun {
+  groupId: string | null;
+  id: string;
+  lastTriggeredAt: string;
+  // Present only when ?outputs is requested (and the feature is on).
+  outputs?: RunQuestion[];
+}
+
+// Subset of the issue-stream group we render.
+interface Issue {
+  culprit: string;
+  id: string;
+  seerAutofixLastTriggered: string | null;
+  seerFixabilityScore: number | null;
+  shortId: string;
+  title: string;
+}
+
+export interface AutofixIssue extends Issue {
+  // The furthest autofix phase this issue's run has reached, or null when the
+  // per-group autofix state hasn't loaded yet / has no run.
+  autofixPhase: AutofixPhase | null;
+  // Whether the per-group autofix state is still loading.
+  autofixPhasePending: boolean;
+  // The most recent explorer/autofix run for this issue's group, if any.
+  run: SeerRun | null;
+}
+
+interface UseAutofixIssuesParams {
+  cursor?: string;
+  query?: string;
+}
+
+interface UseAutofixIssuesResult {
+  isError: boolean;
+  isPending: boolean;
+  issues: AutofixIssue[];
+  refetch: () => void;
+  pageLinks?: string;
+}
+
+/**
+ * Fetches a page of autofix issues from the issue stream and enriches each one
+ * with its most recent Seer run (including one-shot outputs). The runs request
+ * is scoped to exactly the groups on the page via ``group:[...]``, so we make
+ * one extra request per page rather than fetching every run in the org.
+ */
+export function useAutofixIssues({
+  query,
+  cursor,
+}: UseAutofixIssuesParams): UseAutofixIssuesResult {
+  const organization = useOrganization();
+
+  // 1. Page of autofix issues from the issue stream.
+  const issuesQuery = useQuery({
+    ...apiOptions.as<Issue[]>()('/organizations/$organizationIdOrSlug/issues/', {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {
+        query: withRequiredFilter(query ?? ''),
+        cursor,
+        project: -1,
+        statsPeriod: '90d',
+        limit: PER_PAGE,
+      },
+      staleTime: 30_000,
+    }),
+    select: selectJsonWithHeaders,
+  });
+
+  const issues = useMemo(() => issuesQuery.data?.json ?? [], [issuesQuery.data]);
+  const groupIds = useMemo(() => issues.map(issue => issue.id), [issues]);
+  const runsEnabled = groupIds.length > 0;
+
+  // 2. Enrich with the runs for exactly those groups (one group-scoped request).
+  const runsQuery = useQuery(
+    apiOptions.as<SeerRun[]>()('/organizations/$organizationIdOrSlug/seer/runs/', {
+      path: runsEnabled ? {organizationIdOrSlug: organization.slug} : skipToken,
+      query: {
+        query: `${RUNS_QUERY} group:[${groupIds.join(',')}]`,
+        question: DEMO_QUESTIONS,
+      },
+      staleTime: 30_000,
+    })
+  );
+
+  // 3. Fetch the full autofix state per group to derive its phase. This is one
+  // request per issue on the page (bounded by PER_PAGE) -- the runs list
+  // endpoint doesn't expose fine-grained phase, so we read each run's state
+  // ("the whole history") directly. useQueries preserves groupIds order.
+  const autofixResults = useQueries({
+    queries: groupIds.map(groupId =>
+      apiOptions.as<{autofix: ExplorerAutofixState | null}>()(
+        '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/',
+        {
+          path: {organizationIdOrSlug: organization.slug, issueId: groupId},
+          query: {mode: 'explorer'},
+          staleTime: 30_000,
+        }
+      )
+    ),
+  });
+
+  // 4. Join runs (outputs) and autofix phase onto each issue by group id. Runs
+  // come back ordered by last_triggered_at desc, so the first run seen for a
+  // group is the latest.
+  const runByGroupId = useMemo(() => {
+    const map = new Map<string, SeerRun>();
+    for (const run of runsQuery.data ?? []) {
+      if (run.groupId && !map.has(run.groupId)) {
+        map.set(run.groupId, run);
+      }
+    }
+    return map;
+  }, [runsQuery.data]);
+
+  // Computed each render (not memoized): useQueries returns a new array every
+  // render, so it can't go in a useMemo dep array (@tanstack/query/no-unstable-
+  // deps). The map is cheap -- at most PER_PAGE rows.
+  const enriched: AutofixIssue[] = issues.map((issue, i) => {
+    const autofixResult = autofixResults[i];
+    return {
+      ...issue,
+      run: runByGroupId.get(issue.id) ?? null,
+      autofixPhase: deriveAutofixPhase(autofixResult?.data?.autofix ?? null),
+      autofixPhasePending: autofixResult?.isPending ?? false,
+    };
+  });
+
+  return {
+    issues: enriched,
+    isPending: issuesQuery.isPending || (runsEnabled && runsQuery.isPending),
+    isError: issuesQuery.isError || runsQuery.isError,
+    refetch: () => {
+      issuesQuery.refetch();
+      // Only refetch the runs query when it's enabled; refetching a disabled
+      // (skipToken) query logs a React Query error.
+      if (runsEnabled) {
+        runsQuery.refetch();
+      }
+      autofixResults.forEach(result => result.refetch());
+    },
+    pageLinks: issuesQuery.data?.headers.Link,
+  };
+}

--- a/static/app/views/seerRunsDemo/index.spec.tsx
+++ b/static/app/views/seerRunsDemo/index.spec.tsx
@@ -1,0 +1,146 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import SeerRunsDemo from 'sentry/views/seerRunsDemo';
+
+describe('SeerRunsDemo', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  function mockRuns(body: any[], headers?: Record<string, string>) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body,
+      headers,
+    });
+  }
+
+  it('renders one grid row per run with answers stacked in one column', async () => {
+    mockRuns([
+      {
+        id: 'run-1',
+        type: 'explorer',
+        userId: null,
+        lastTriggeredAt: '2026-06-25T10:00:00Z',
+        dateCreated: '2026-06-25T09:00:00Z',
+        title: 'Fix login bug',
+        source: 'autofix',
+        projectId: '1',
+        groupId: '2',
+        outputs: [
+          {
+            key: 'user_0',
+            question: 'What is the root cause?',
+            answer: 'A null was dereferenced.',
+          },
+          {key: 'user_1', question: 'What is the fix?', answer: ''},
+        ],
+      },
+    ]);
+
+    // Render with a non-default query so the default search doesn't put matching
+    // tokens (explorer/autofix) in the search bar as well as the grid.
+    render(<SeerRunsDemo />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/autofix/runs/`,
+          query: {query: 'is:mine'},
+        },
+      },
+    });
+
+    // Run fields.
+    expect(await screen.findByText('Fix login bug')).toBeInTheDocument();
+    expect(screen.getByText('explorer')).toBeInTheDocument();
+    expect(screen.getByText('autofix')).toBeInTheDocument();
+
+    // A single "Outputs" column holds the answers, stacked one after another.
+    expect(screen.getByRole('columnheader', {name: 'Outputs'})).toBeInTheDocument();
+
+    // Answered questions render the question text as the heading, with the
+    // markdown answer beneath it.
+    expect(screen.getByText('What is the root cause?')).toBeInTheDocument();
+    expect(screen.getByText('A null was dereferenced.')).toBeInTheDocument();
+    // A question with an empty answer is skipped.
+    expect(screen.queryByText('What is the fix?')).not.toBeInTheDocument();
+  });
+
+  it('sends the demo questions to the runs endpoint', async () => {
+    const request = mockRuns([]);
+
+    render(<SeerRunsDemo />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/autofix/runs/`,
+          query: {query: 'is:mine'},
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({question: expect.arrayContaining([])}),
+        })
+      )
+    );
+    const {question} = request.mock.calls[0][1].query;
+    expect(question.length).toBeGreaterThan(0);
+  });
+
+  it('reflects the query from the URL in the search bar', async () => {
+    mockRuns([]);
+
+    render(<SeerRunsDemo />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/issues/autofix/runs/`,
+          query: {query: 'is:mine'},
+        },
+      },
+    });
+
+    expect(await screen.findByText('is')).toBeInTheDocument();
+    expect(screen.getByText('mine')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no runs', async () => {
+    mockRuns([]);
+
+    render(<SeerRunsDemo />, {organization});
+
+    expect(
+      await screen.findByText('No Seer runs found for this organization.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders an error state and can retry', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      statusCode: 500,
+      body: {detail: 'boom'},
+    });
+
+    render(<SeerRunsDemo />, {organization});
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
+
+    mockRuns([]);
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    expect(
+      await screen.findByText('No Seer runs found for this organization.')
+    ).toBeInTheDocument();
+    expect(request).toHaveBeenCalled();
+  });
+});

--- a/static/app/views/seerRunsDemo/index.tsx
+++ b/static/app/views/seerRunsDemo/index.tsx
@@ -1,0 +1,199 @@
+import {useCallback, useMemo} from 'react';
+import {useQuery} from '@tanstack/react-query';
+
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Pagination} from '@sentry/scraps/pagination';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {LoadingError} from 'sentry/components/loadingError';
+import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
+import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {
+  COL_WIDTH_UNDEFINED,
+  GridEditable,
+  type GridColumnOrder,
+} from 'sentry/components/tables/gridEditable';
+import {TimeSince} from 'sentry/components/timeSince';
+import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
+import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+// Default search applied when the URL has no ?query, scoping the demo to
+// explorer runs from autofix.
+const DEFAULT_QUERY = 'type:explorer source:autofix';
+
+// Questions asked about each run, sent to the endpoint as repeatable `question`
+// params (see organization_seer_runs.py). Edit this list to iterate on prompts
+// without touching the built-in server-side set. Capped at 5 by the endpoint.
+const DEMO_QUESTIONS = [
+  'What is the root cause of this issue, in one sentence?',
+  'What is the suggested fix?',
+  'How confident are you in the diagnosis, and why?',
+];
+
+// Filter keys the runs endpoint understands. `is` and `type` have predefined
+// values; `source`/`project` accept free text. Must be a stable reference.
+const FILTER_KEYS: TagCollection = {
+  is: {key: 'is', name: 'is', predefined: true, values: ['agent', 'mine']},
+  type: {
+    key: 'type',
+    name: 'type',
+    predefined: true,
+    values: ['explorer', 'pr_review', 'assisted_query', 'feature_run'],
+  },
+  source: {key: 'source', name: 'source'},
+  project: {key: 'project', name: 'project'},
+};
+
+// One answered question, mirrors the run output in
+// src/sentry/api/serializers/models/seer_run.py.
+interface RunQuestion {
+  answer: string;
+  key: string;
+  // Digest of the question text; always present.
+  hash?: string;
+  // The question text, echoed back only for user questions.
+  question?: string;
+}
+
+// Mirrors SeerRunResponse in src/sentry/api/serializers/models/seer_run.py.
+interface SeerRun {
+  dateCreated: string;
+  groupId: string | null;
+  id: string;
+  lastTriggeredAt: string;
+  projectId: string | null;
+  source: string | null;
+  title: string | null;
+  type: string;
+  userId: string | null;
+  // Present only when ?expand=questions and/or ?question= is requested (feature on).
+  outputs?: RunQuestion[];
+}
+
+export default function SeerRunsDemo() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const query = decodeScalar(location.query.query, DEFAULT_QUERY);
+  const cursor = decodeScalar(location.query.cursor);
+
+  const {data, isPending, isError, refetch} = useQuery({
+    ...apiOptions.as<SeerRun[]>()('/organizations/$organizationIdOrSlug/seer/runs/', {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {query, cursor, question: DEMO_QUESTIONS},
+      staleTime: 30_000,
+    }),
+    select: selectJsonWithHeaders,
+  });
+
+  const runs = useMemo(() => data?.json ?? [], [data]);
+  const pageLinks = data?.headers.Link;
+
+  const handleSearch = useCallback(
+    (newQuery: string) => {
+      navigate({
+        pathname: location.pathname,
+        query: {...location.query, query: newQuery, cursor: undefined},
+      });
+    },
+    [navigate, location.pathname, location.query]
+  );
+
+  // Predefined values (is:, type:) are supplied by the FILTER_KEYS definitions;
+  // source/project are free text, so there are no async values to fetch.
+  const getTagValues = useCallback<GetTagValues>(() => Promise.resolve([]), []);
+
+  const columnOrder = useMemo<Array<GridColumnOrder<string>>>(
+    () => [
+      {key: 'title', name: t('Title'), width: 240},
+      {key: 'type', name: t('Type'), width: 120},
+      {key: 'source', name: t('Source'), width: 120},
+      {key: 'lastTriggered', name: t('Last triggered'), width: 160},
+      {key: 'outputs', name: t('Outputs'), width: COL_WIDTH_UNDEFINED},
+    ],
+    []
+  );
+
+  const renderBodyCell = useCallback(
+    (column: GridColumnOrder<string>, run: SeerRun): React.ReactNode => {
+      switch (column.key) {
+        case 'title':
+          return <Text>{run.title || t('Untitled %s run', run.type)}</Text>;
+        case 'type':
+          return <Text>{run.type}</Text>;
+        case 'source':
+          return <Text>{run.source ?? '—'}</Text>;
+        case 'lastTriggered':
+          return <TimeSince date={run.lastTriggeredAt} />;
+        case 'outputs': {
+          const answered = (run.outputs ?? []).filter(q => q.answer);
+          if (answered.length === 0) {
+            return <Text variant="muted">{'—'}</Text>;
+          }
+          return (
+            <Stack gap="md">
+              {answered.map(q => (
+                <Stack key={q.key} gap="xs">
+                  <Heading as="h4">{q.question ?? q.key}</Heading>
+                  <SeerMarkdown raw={q.answer} />
+                </Stack>
+              ))}
+            </Stack>
+          );
+        }
+        default:
+          return null;
+      }
+    },
+    []
+  );
+
+  return (
+    <SentryDocumentTitle title={t('Seer Runs')} orgSlug={organization.slug}>
+      <Stack gap="lg" padding="xl" paddingBottom="3xl">
+        <Stack gap="2xs">
+          <Heading as="h1">{t('Seer Runs')}</Heading>
+          <Text as="p" variant="muted">
+            {t('Recent Seer runs and one-shot answers to questions about each run.')}
+          </Text>
+        </Stack>
+
+        <SearchQueryBuilder
+          searchSource="seer_runs_demo"
+          initialQuery={query}
+          placeholder={t('Search by source, type, project, is:agent, is:mine, or title')}
+          filterKeys={FILTER_KEYS}
+          getTagValues={getTagValues}
+          onSearch={handleSearch}
+        />
+
+        {isError ? (
+          <LoadingError onRetry={refetch} />
+        ) : (
+          <Container>
+            <GridEditable
+              isLoading={isPending}
+              data={runs}
+              columnOrder={columnOrder}
+              columnSortBy={[]}
+              grid={{
+                renderHeadCell: column => column.name,
+                renderBodyCell,
+              }}
+              emptyMessage={t('No Seer runs found for this organization.')}
+            />
+            <Pagination pageLinks={pageLinks} />
+          </Container>
+        )}
+      </Stack>
+    </SentryDocumentTitle>
+  );
+}


### PR DESCRIPTION
Adds a demo view at `/issues/autofix/runs/` listing an organization's Seer runs with their one-shot outputs.
