### PR TITLE
DO NOT MERGE — test(ci): dummy endpoint to validate FE+BE warning filter fix

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -47,6 +47,16 @@ frontend_all: &frontend_all
   - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
   - added|modified: '{vercel,tsconfig,biome,package}.json'
 
+# Like frontend_all but excludes auto-generated files (e.g. knownSentryApiUrls.generated.ts)
+# so that bot-committed codegen on backend-only PRs does not trigger the FE+BE warning.
+# frontend_all is still used for labeling and typechecking triggers.
+frontend_non_generated: &frontend_non_generated
+  - *sentry_frontend_workflow_file
+  - *sentry_frontend_snapshots_workflow_file
+  - added|modified: '**/!(*.generated).{ts,tsx,js,jsx,mjs}'
+  - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
+  - added|modified: '{vercel,tsconfig,biome,package}.json'
+
 # Also used in `getsentry-dispatch.yml` to dispatch backend tests on getsentry
 backend_dependencies: &backend_dependencies
   - 'requirements-*.txt'

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Add frontend/backend warning comment
         uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
         if: >
-          steps.changes.outputs.frontend_all == 'true' &&
+          steps.changes.outputs.frontend_non_generated == 'true' &&
           steps.changes.outputs.backend_src == 'true' &&
           steps.fc.outputs.comment-id == 0
         with:

--- a/src/sentry/workflow_engine/endpoints/organization_dummy_junior_test_endpoint.py
+++ b/src/sentry/workflow_engine/endpoints/organization_dummy_junior_test_endpoint.py
@@ -15,14 +15,21 @@ See: https://github.com/getsentry/sentry/pull/118795
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.models.organization import Organization
 
 
-@region_silo_endpoint
-class OrganizationDummyJuniorTestEndpoint(Endpoint):
+@cell_silo_endpoint
+class OrganizationDummyJuniorTestEndpoint(OrganizationEndpoint):
     """Dummy endpoint — DO NOT MERGE."""
 
-    private = True
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ISSUES
 
-    def get(self, request: Request, organization_id_or_slug: str) -> Response:
+    def get(self, request: Request, organization: Organization) -> Response:
         return Response({"ok": True})

--- a/src/sentry/workflow_engine/endpoints/organization_dummy_junior_test_endpoint.py
+++ b/src/sentry/workflow_engine/endpoints/organization_dummy_junior_test_endpoint.py
@@ -1,0 +1,28 @@
+"""
+DO NOT MERGE — dummy endpoint added by Junior to test CI behavior.
+
+This endpoint exists solely to trigger the `api-url-typescript` job in
+backend.yml (which fires whenever a urls.py changes). That job runs
+`python3 -m tools.api_urls_to_typescript` and commits the updated
+`knownSentryApiUrls.generated.ts` back to the PR branch. The test PR
+targeting `fix/fe-be-warning-exclude-generated-files` validates that
+the new `frontend_non_generated` filter prevents that bot commit from
+triggering the spurious "FE+BE changes" warning.
+
+See: https://github.com/getsentry/sentry/pull/118795
+"""
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint, region_silo_endpoint
+
+
+@region_silo_endpoint
+class OrganizationDummyJuniorTestEndpoint(Endpoint):
+    """Dummy endpoint — DO NOT MERGE."""
+
+    private = True
+
+    def get(self, request: Request, organization_id_or_slug: str) -> Response:
+        return Response({"ok": True})

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -9,6 +9,7 @@ from .organization_detector_count import OrganizationDetectorCountEndpoint
 from .organization_detector_details import OrganizationDetectorDetailsEndpoint
 from .organization_detector_index import OrganizationDetectorIndexEndpoint
 from .organization_detector_types import OrganizationDetectorTypeIndexEndpoint
+from .organization_dummy_junior_test_endpoint import OrganizationDummyJuniorTestEndpoint
 from .organization_incident_groupopenperiod_index import (
     OrganizationIncidentGroupOpenPeriodIndexEndpoint,
 )
@@ -18,7 +19,6 @@ from .organization_test_fire_action import OrganizationTestFireActionsEndpoint
 from .organization_workflow_details import OrganizationWorkflowDetailsEndpoint
 from .organization_workflow_group_history import OrganizationWorkflowGroupHistoryEndpoint
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
-from .organization_dummy_junior_test_endpoint import OrganizationDummyJuniorTestEndpoint
 from .organization_workflow_stats import OrganizationWorkflowStatsEndpoint
 
 organization_urlpatterns = [

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -18,6 +18,7 @@ from .organization_test_fire_action import OrganizationTestFireActionsEndpoint
 from .organization_workflow_details import OrganizationWorkflowDetailsEndpoint
 from .organization_workflow_group_history import OrganizationWorkflowGroupHistoryEndpoint
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
+from .organization_dummy_junior_test_endpoint import OrganizationDummyJuniorTestEndpoint
 from .organization_workflow_stats import OrganizationWorkflowStatsEndpoint
 
 organization_urlpatterns = [
@@ -105,5 +106,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/incident-groupopenperiod/$",
         OrganizationIncidentGroupOpenPeriodIndexEndpoint.as_view(),
         name="sentry-api-0-organization-incident-groupopenperiod-index",
+    ),
+    # DO NOT MERGE — dummy endpoint to test CI filter behavior (see PR #118795)
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/junior-test-dummy/$",
+        OrganizationDummyJuniorTestEndpoint.as_view(),
+        name="sentry-api-0-organization-junior-test-dummy",
     ),
 ]

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -233,6 +233,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/issues/$issueId/user-feedback/'
   | '/organizations/$organizationIdOrSlug/issues/$issueId/user-reports/'
   | '/organizations/$organizationIdOrSlug/join-request/'
+  | '/organizations/$organizationIdOrSlug/junior-test-dummy/'
   | '/organizations/$organizationIdOrSlug/key-transactions-list/'
   | '/organizations/$organizationIdOrSlug/key-transactions/'
   | '/organizations/$organizationIdOrSlug/legacy-webhooks/'


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — CI test fixture only

This PR exists solely to validate the fix in #118795. It is safe to close once the behavior is confirmed.

## What

Adds a dummy endpoint (`OrganizationDummyJuniorTestEndpoint`) and registers it in `src/sentry/workflow_engine/endpoints/urls.py`. The URL registration is what matters: changing a `urls.py` triggers the `backend_api_urls` paths-filter, which fires the `api-url-typescript` job in `backend.yml`.

## How this exercises the fix

1. The `urls.py` change triggers `backend_api_urls` → `api-url-typescript` job runs
2. Job executes `python3 -m tools.api_urls_to_typescript` and commits the updated `static/app/utils/api/knownSentryApiUrls.generated.ts` back to this branch
3. That bot commit triggers `label-pullrequest.yml` (via `pull_request_target` synchronize event)
4. Because this PR targets `fix/fe-be-warning-exclude-generated-files`, the **base branch's** `label-pullrequest.yml` runs — the one with `frontend_non_generated` instead of `frontend_all` for the warning condition
5. `frontend_non_generated` excludes `!(*.generated).{ts,tsx,...}` → the bot-committed `.generated.ts` file does **not** trigger the "🚨 FE+BE changes" warning

**Expected outcome:** no spurious FE+BE warning comment, even though the bot committed a `.ts` file.

Refs #118795

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AD0B8FCDQDCZ%3A1782915952.584719/?project=4510944073809921)

<!-- junior-session-footer:end -->