### PR TITLE
ref(pr-metrics): Gate delegated-agent detection on installed integration

### DIFF
--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -8,6 +8,8 @@ from django.db.models import Q
 from django.utils import timezone
 
 from sentry import features
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
 from sentry.models.commit import Commit
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
@@ -92,6 +94,16 @@ DELEGATED_AGENT_BRANCH_PREFIXES: dict[str, str] = {
 DELEGATED_AGENT_AUTHOR_LOGINS: dict[str, str] = {
     "copilot-swe-agent[bot]": "github_copilot",
 }
+
+
+def org_has_coding_agent_for_provider(organization: Organization, provider_hint: str) -> bool:
+    """Return True if the org has at least one active integration for the given provider."""
+    integrations = integration_service.get_integrations(
+        organization_id=organization.id,
+        providers=[provider_hint],
+        org_integration_status=ObjectStatus.ACTIVE,
+    )
+    return len(integrations) > 0
 
 
 def _commit_shas_from_activity(pull_request: PullRequest) -> set[str]:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -84,6 +84,7 @@ from sentry.pr_metrics.utils import (
     DELEGATED_AGENT_AUTHOR_LOGINS,
     DELEGATED_AGENT_BRANCH_PREFIXES,
     is_activity_tracking_enabled,
+    org_has_coding_agent_for_provider,
     resolved_group_ids,
 )
 from sentry.seer.autofix.utils import (
@@ -174,8 +175,10 @@ def handle_attribution(
         _write_author_attribution(pr, github_user, pr_url=pr_url, group_ids=resolved_group_ids(pr))
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
-    if action == "opened" and pull_request is not None and has_seer_access(organization):
-        _detect_delegated_agent(pr, pull_request, repo)
+    if action == "opened" and pull_request is not None:
+        provider_hint = _is_delegated_agent_candidate(pull_request)
+        if provider_hint and org_has_coding_agent_for_provider(organization, provider_hint):
+            _detect_delegated_agent(pr, pull_request, repo, provider_hint=provider_hint)
 
 
 def _claim_terminal_event(pr: PullRequest, verdict: PullRequestVerdict) -> bool:
@@ -996,7 +999,10 @@ def _write_author_attribution(
 
 
 def _detect_delegated_agent(
-    pr: PullRequest, webhook_pull_request: Mapping[str, Any], repository: Repository
+    pr: PullRequest,
+    webhook_pull_request: Mapping[str, Any],
+    repository: Repository,
+    provider_hint: str,
 ) -> None:
     """
     Filter PRs that could have been delegated by Autofix to external coding agents,
@@ -1004,9 +1010,8 @@ def _detect_delegated_agent(
 
     Then Seer calls the RPC "record_pr_attribution" to write the attribution row async.
     """
-    provider_hint = _is_delegated_agent_candidate(webhook_pull_request)
     group_ids = resolved_group_ids(pr)
-    if provider_hint is None or not group_ids:
+    if not group_ids:
         return
 
     repo_name_sections = repository.name.split("/")

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -1,7 +1,10 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+from unittest.mock import Mock, patch
 
 from django.utils import timezone
 
+from sentry.constants import ObjectStatus
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestAttribution,
@@ -11,7 +14,11 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
     PullRequestVerdict,
 )
-from sentry.pr_metrics.utils import is_activity_tracking_enabled
+from sentry.pr_metrics.utils import (
+    is_activity_tracking_enabled,
+    iso_or_none,
+    org_has_coding_agent_for_provider,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -132,3 +139,34 @@ class IsActivityTrackingEnabledTest(TestCase):
             pr.save()
             with self.feature("organizations:pr-metrics-activity"):
                 assert is_activity_tracking_enabled(self.organization, pr=pr)
+
+
+class IsoOrNoneTest(TestCase):
+    def test_returns_iso_string_for_datetime(self) -> None:
+        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=dt_timezone.utc)
+        assert iso_or_none(dt) == "2024-01-15T12:30:45+00:00"
+
+    def test_returns_none_for_none(self) -> None:
+        assert iso_or_none(None) is None
+
+
+class OrgHasCodingAgentForProviderTest(TestCase):
+    _mock_path = "sentry.pr_metrics.utils.integration_service.get_integrations"
+
+    def test_returns_true_when_active_integration_exists(self) -> None:
+        mock_integration = Mock()
+        with patch(self._mock_path, return_value=[mock_integration]):
+            assert org_has_coding_agent_for_provider(self.organization, "claude_code") is True
+
+    def test_returns_false_when_no_integration_exists(self) -> None:
+        with patch(self._mock_path, return_value=[]):
+            assert org_has_coding_agent_for_provider(self.organization, "claude_code") is False
+
+    def test_passes_provider_and_active_org_status_to_service(self) -> None:
+        with patch(self._mock_path, return_value=[]) as mock_get:
+            org_has_coding_agent_for_provider(self.organization, "github_copilot")
+            mock_get.assert_called_once_with(
+                organization_id=self.organization.id,
+                providers=["github_copilot"],
+                org_integration_status=ObjectStatus.ACTIVE,
+            )

--- a/tests/sentry/pr_metrics/test_utils.py
+++ b/tests/sentry/pr_metrics/test_utils.py
@@ -1,10 +1,12 @@
-from datetime import datetime, timedelta
-from datetime import timezone as dt_timezone
-from unittest.mock import Mock, patch
+from datetime import timedelta
 
 from django.utils import timezone
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.claude_code.integration import PROVIDER_KEY as claude_provider_key
+from sentry.integrations.github_copilot.integration import GithubCopilotIntegrationProvider
+
+copilot_provider_key = GithubCopilotIntegrationProvider.key
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestAttribution,
@@ -14,11 +16,7 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
     PullRequestVerdict,
 )
-from sentry.pr_metrics.utils import (
-    is_activity_tracking_enabled,
-    iso_or_none,
-    org_has_coding_agent_for_provider,
-)
+from sentry.pr_metrics.utils import is_activity_tracking_enabled, org_has_coding_agent_for_provider
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
@@ -141,32 +139,34 @@ class IsActivityTrackingEnabledTest(TestCase):
                 assert is_activity_tracking_enabled(self.organization, pr=pr)
 
 
-class IsoOrNoneTest(TestCase):
-    def test_returns_iso_string_for_datetime(self) -> None:
-        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=dt_timezone.utc)
-        assert iso_or_none(dt) == "2024-01-15T12:30:45+00:00"
-
-    def test_returns_none_for_none(self) -> None:
-        assert iso_or_none(None) is None
-
-
 class OrgHasCodingAgentForProviderTest(TestCase):
-    _mock_path = "sentry.pr_metrics.utils.integration_service.get_integrations"
-
     def test_returns_true_when_active_integration_exists(self) -> None:
-        mock_integration = Mock()
-        with patch(self._mock_path, return_value=[mock_integration]):
-            assert org_has_coding_agent_for_provider(self.organization, "claude_code") is True
+        self.create_integration(
+            organization=self.organization,
+            provider=claude_provider_key,
+            name="Claude Code",
+            external_id="claude_code:1",
+        )
+        assert org_has_coding_agent_for_provider(self.organization, claude_provider_key) is True
 
     def test_returns_false_when_no_integration_exists(self) -> None:
-        with patch(self._mock_path, return_value=[]):
-            assert org_has_coding_agent_for_provider(self.organization, "claude_code") is False
+        assert org_has_coding_agent_for_provider(self.organization, claude_provider_key) is False
 
-    def test_passes_provider_and_active_org_status_to_service(self) -> None:
-        with patch(self._mock_path, return_value=[]) as mock_get:
-            org_has_coding_agent_for_provider(self.organization, "github_copilot")
-            mock_get.assert_called_once_with(
-                organization_id=self.organization.id,
-                providers=["github_copilot"],
-                org_integration_status=ObjectStatus.ACTIVE,
-            )
+    def test_returns_false_for_different_provider(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider=claude_provider_key,
+            name="Claude Code",
+            external_id="claude_code:1",
+        )
+        assert org_has_coding_agent_for_provider(self.organization, copilot_provider_key) is False
+
+    def test_returns_false_when_org_integration_is_disabled(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider=claude_provider_key,
+            name="Claude Code",
+            external_id="claude_code:1",
+            oi_params={"status": ObjectStatus.DISABLED},
+        )
+        assert org_has_coding_agent_for_provider(self.organization, claude_provider_key) is False

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1934,10 +1934,13 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         mock_response.status = status
         return patch(MATCH_RPC, return_value=mock_response)
 
+    def _mock_org_check(self) -> Any:
+        return patch(f"{MODULE}.org_has_coding_agent_for_provider", return_value=True)
+
     # --- Candidate detection calls Seer ---
 
     def test_claude_branch_prefix_sends_to_seer(self) -> None:
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix-the-bug")
 
         mock_rpc.assert_called_once()
@@ -1951,28 +1954,32 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         assert body.repo.external_id == "99"
 
     def test_copilot_branch_prefix_sends_to_seer(self) -> None:
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(head_ref="copilot/fix-the-bug")
 
         mock_rpc.assert_called_once()
         assert mock_rpc.call_args.args[0].provider == "github_copilot"
 
     def test_copilot_author_login_sends_to_seer(self) -> None:
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(login="copilot-swe-agent[bot]", head_ref="some-branch")
 
         mock_rpc.assert_called_once()
         assert mock_rpc.call_args.args[0].provider == "github_copilot"
 
     def test_branch_prefix_takes_precedence_over_author(self) -> None:
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(login="copilot-swe-agent[bot]", head_ref="claude/fix")
 
         mock_rpc.assert_called_once()
         assert mock_rpc.call_args.args[0].provider == "claude_code"
 
     def test_sent_metric_incremented_on_success(self) -> None:
-        with self._mock_seer(status=202), patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr:
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=202),
+            patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr,
+        ):
             self._call(head_ref="claude/fix")
 
         assert any(
@@ -1984,7 +1991,11 @@ class HandleDelegatedAgentDetectionTest(TestCase):
     # --- Error handling ---
 
     def test_seer_non_2xx_logs_warning_and_error_metric(self) -> None:
-        with self._mock_seer(status=500), patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr:
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=500),
+            patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr,
+        ):
             self._call(head_ref="claude/fix")
 
         assert any(
@@ -1994,6 +2005,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
 
     def test_seer_exception_logs_warning_and_error_metric(self) -> None:
         with (
+            self._mock_org_check(),
             patch(MATCH_RPC, side_effect=Exception("network error")),
             patch(f"{MODULE}.sentry_sdk.metrics.count") as mock_incr,
         ):
@@ -2005,7 +2017,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         )
 
     def test_seer_exception_does_not_propagate(self) -> None:
-        with patch(MATCH_RPC, side_effect=Exception("network error")):
+        with self._mock_org_check(), patch(MATCH_RPC, side_effect=Exception("network error")):
             self._call(head_ref="claude/fix")  # must not raise
 
     # --- Non-candidates do not call Seer ---
@@ -2031,23 +2043,15 @@ class HandleDelegatedAgentDetectionTest(TestCase):
 
         mock_rpc.assert_not_called()
 
-    def test_no_seer_access_via_flag_does_not_call_seer(self) -> None:
-        with self._mock_seer() as mock_rpc:
-            with self.feature({"organizations:gen-ai-features": False}):
+    def test_no_matching_integration_does_not_call_seer(self) -> None:
+        with patch(f"{MODULE}.org_has_coding_agent_for_provider", return_value=False):
+            with self._mock_seer() as mock_rpc:
                 self._call(head_ref="claude/fix")
 
         mock_rpc.assert_not_called()
 
-    def test_no_seer_access_via_hidden_ai_features_does_not_call_seer(self) -> None:
-        self.organization.update_option("sentry:hide_ai_features", True)
-
-        with self._mock_seer() as mock_rpc:
-            self._call(head_ref="claude/fix")
-
-        mock_rpc.assert_not_called()
-
     def test_missing_pr_does_not_call_seer(self) -> None:
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix", number=9999)
 
         mock_rpc.assert_not_called()
@@ -2058,7 +2062,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             linked_id=self.pr.id,
         ).delete()
 
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix")
 
         mock_rpc.assert_not_called()
@@ -2067,7 +2071,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         self.repo.provider = None
         self.repo.save()
 
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix")
 
         mock_rpc.assert_not_called()
@@ -2076,7 +2080,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
         self.repo.external_id = None
         self.repo.save()
 
-        with self._mock_seer() as mock_rpc:
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
             self._call(head_ref="claude/fix")
 
         mock_rpc.assert_not_called()


### PR DESCRIPTION
Previously the delegated-agent detection path in `handle_attribution` was gated on `has_seer_access(organization)` — the gen-ai feature flag. This meant Seer would be contacted whenever a PR with a `claude/` or `copilot/` branch prefix was opened, regardless of whether the org had actually installed and configured the corresponding coding-agent integration.

This changes the gate to verify that the org has an active `OrganizationIntegration` for the detected provider (Claude Code or GitHub Copilot). No integration installed → no Seer request.

The check uses `org_integration_status=ObjectStatus.ACTIVE` (the per-org link status) rather than `status=ObjectStatus.ACTIVE` (the global integration status), which matches how `validate_and_get_integration` gates actual agent launches.

As a small cleanup, `_is_delegated_agent_candidate` is now called at the gate site and the resolved `provider_hint` is passed into `_detect_delegated_agent` directly, avoiding a redundant second call inside the function.