### PR TITLE
fix(traces): encode linked logs filter + row state in the URL

### DIFF
--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -15,6 +15,7 @@ export const LOGS_FIELDS_KEY = 'logsFields';
 export const LOGS_AGGREGATE_FN_KEY = 'logsAggregate'; // e.g., p99
 export const LOGS_AGGREGATE_PARAM_KEY = 'logsAggregateParam'; // e.g., message.parameters.0
 export const LOGS_GROUP_BY_KEY = 'logsGroupBy'; // e.g., message.template
+export const LOGS_ROW_ID_KEY = 'logsRowId'; // Deep-links to a log row to highlight + expand it.
 
 export interface PersistedLogsPageParams {
   fields: string[];

--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -1,13 +1,14 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {
   useTraceItemDetails,
   usePrefetchTraceItemDetailsOnHover,
+  usePrefetchTraceItemDetailsOnMount,
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -198,7 +199,7 @@ describe('useTraceItemDetails', () => {
     );
   });
 
-  it('fetches details on mount without hover when prefetchOnMount is set', async () => {
+  it('fetches details when the hover prefetch is invoked', async () => {
     initializePageFilters({
       period: '14d',
       start: null,
@@ -207,7 +208,7 @@ describe('useTraceItemDetails', () => {
     });
     const traceItemDetailsMock = addTraceItemDetailsMock();
 
-    renderHookWithProviders(usePrefetchTraceItemDetailsOnHover, {
+    const {result} = renderHookWithProviders(usePrefetchTraceItemDetailsOnHover, {
       organization,
       initialProps: {
         projectId: project.id,
@@ -218,38 +219,45 @@ describe('useTraceItemDetails', () => {
         timestamp: 123,
         sharedHoverTimeoutRef: {current: null},
         timeout: 0,
-        prefetchOnMount: true,
       },
     });
+
+    await waitFor(() => expect(ProjectsStore.getState().projects).toHaveLength(1));
+    act(() => result.current.prefetch());
 
     await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
   });
 
-  it('does not fetch on mount when prefetchOnMount is not set', async () => {
-    initializePageFilters({
-      period: '14d',
-      start: null,
-      end: null,
-      utc: false,
-    });
-    const traceItemDetailsMock = addTraceItemDetailsMock();
+  it('runs the prefetch on mount when enabled and the project is ready', () => {
+    const prefetch = jest.fn();
 
-    renderHookWithProviders(usePrefetchTraceItemDetailsOnHover, {
+    renderHookWithProviders(usePrefetchTraceItemDetailsOnMount, {
       organization,
-      initialProps: {
-        projectId: project.id,
-        traceItemId: 'item-id',
-        traceId: '1234567890abcdef1234567890abcdef',
-        traceItemType: TraceItemDataset.LOGS,
-        referrer: 'api.explore.log-item-details',
-        timestamp: 123,
-        sharedHoverTimeoutRef: {current: null},
-        timeout: 0,
-      },
+      initialProps: {prefetch, enabled: true, isProjectReady: true},
     });
 
-    // Give any effects a chance to run before asserting the request never fired.
-    await waitFor(() => expect(ProjectsStore.getState().projects).toHaveLength(1));
-    expect(traceItemDetailsMock).not.toHaveBeenCalled();
+    expect(prefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run the prefetch on mount when not enabled', () => {
+    const prefetch = jest.fn();
+
+    renderHookWithProviders(usePrefetchTraceItemDetailsOnMount, {
+      organization,
+      initialProps: {prefetch, enabled: false, isProjectReady: true},
+    });
+
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+
+  it('does not run the prefetch on mount until the project is ready', () => {
+    const prefetch = jest.fn();
+
+    renderHookWithProviders(usePrefetchTraceItemDetailsOnMount, {
+      organization,
+      initialProps: {prefetch, enabled: true, isProjectReady: false},
+    });
+
+    expect(prefetch).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.spec.tsx
@@ -5,7 +5,10 @@ import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary'
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {
+  useTraceItemDetails,
+  usePrefetchTraceItemDetailsOnHover,
+} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 describe('useTraceItemDetails', () => {
@@ -193,5 +196,60 @@ describe('useTraceItemDetails', () => {
     expect(traceItemDetailsMock.mock.calls[0]![1].query).not.toHaveProperty(
       'statsPeriod'
     );
+  });
+
+  it('fetches details on mount without hover when prefetchOnMount is set', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderHookWithProviders(usePrefetchTraceItemDetailsOnHover, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+        timestamp: 123,
+        sharedHoverTimeoutRef: {current: null},
+        timeout: 0,
+        prefetchOnMount: true,
+      },
+    });
+
+    await waitFor(() => expect(traceItemDetailsMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not fetch on mount when prefetchOnMount is not set', async () => {
+    initializePageFilters({
+      period: '14d',
+      start: null,
+      end: null,
+      utc: false,
+    });
+    const traceItemDetailsMock = addTraceItemDetailsMock();
+
+    renderHookWithProviders(usePrefetchTraceItemDetailsOnHover, {
+      organization,
+      initialProps: {
+        projectId: project.id,
+        traceItemId: 'item-id',
+        traceId: '1234567890abcdef1234567890abcdef',
+        traceItemType: TraceItemDataset.LOGS,
+        referrer: 'api.explore.log-item-details',
+        timestamp: 123,
+        sharedHoverTimeoutRef: {current: null},
+        timeout: 0,
+      },
+    });
+
+    // Give any effects a chance to run before asserting the request never fired.
+    await waitFor(() => expect(ProjectsStore.getState().projects).toHaveLength(1));
+    expect(traceItemDetailsMock).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
@@ -204,6 +204,7 @@ export function usePrefetchTraceItemDetailsOnHover({
   referrer,
   timestamp,
   hoverPrefetchDisabled,
+  prefetchOnMount,
   sharedHoverTimeoutRef,
   timeout,
 }: UseTraceItemDetailsProps & {
@@ -220,6 +221,13 @@ export function usePrefetchTraceItemDetailsOnHover({
    * Whether the hover prefetch should be disabled.
    */
   hoverPrefetchDisabled?: boolean;
+  /**
+   * Fetch the details once on mount (e.g. for a deep-linked, auto-expanded row)
+   * without requiring a hover. The reactive `useTraceItemDetails` query in the
+   * expanded details can be torn down by virtualizer re-layout during the
+   * initial load, so this guarantees the request fires and populates the cache.
+   */
+  prefetchOnMount?: boolean;
 }) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
@@ -232,36 +240,55 @@ export function usePrefetchTraceItemDetailsOnHover({
     TraceItemResponseAttribute[] | undefined
   >();
 
+  const prefetch = useCallback(() => {
+    const currentProject = projectRef.current;
+    if (!currentProject?.slug) {
+      return;
+    }
+    const timeQueryParams = defined(timestamp)
+      ? {timestamp: normalizeTimestampToSeconds(timestamp)}
+      : normalizeDateTimeParams(selection.datetime);
+    const options = traceItemDetailsApiOptions({
+      organizationSlug: organization.slug,
+      projectSlug: currentProject.slug,
+      traceItemId,
+      traceItemType,
+      referrer,
+      traceId,
+      ...timeQueryParams,
+    });
+    queryClient.fetchQuery(options).then(
+      response => {
+        setTraceItemMeta(response?.json?.meta);
+        setTraceItemAttributes(response?.json?.attributes);
+      },
+      () => {}
+    );
+  }, [
+    organization.slug,
+    queryClient,
+    referrer,
+    selection.datetime,
+    timestamp,
+    traceId,
+    traceItemId,
+    traceItemType,
+  ]);
+
+  const hasPrefetchedOnMount = useRef(false);
+  useEffect(() => {
+    if (prefetchOnMount && !hasPrefetchedOnMount.current && project?.slug) {
+      hasPrefetchedOnMount.current = true;
+      prefetch();
+    }
+  }, [prefetchOnMount, project?.slug, prefetch]);
+
   const {hoverProps} = useHover({
     onHoverStart: () => {
       if (sharedHoverTimeoutRef.current) {
         clearTimeout(sharedHoverTimeoutRef.current);
       }
-      sharedHoverTimeoutRef.current = setTimeout(() => {
-        const currentProject = projectRef.current;
-        if (!currentProject?.slug) {
-          return;
-        }
-        const timeQueryParams = defined(timestamp)
-          ? {timestamp: normalizeTimestampToSeconds(timestamp)}
-          : normalizeDateTimeParams(selection.datetime);
-        const options = traceItemDetailsApiOptions({
-          organizationSlug: organization.slug,
-          projectSlug: currentProject.slug,
-          traceItemId,
-          traceItemType,
-          referrer,
-          traceId,
-          ...timeQueryParams,
-        });
-        queryClient.fetchQuery(options).then(
-          response => {
-            setTraceItemMeta(response?.json?.meta);
-            setTraceItemAttributes(response?.json?.attributes);
-          },
-          () => {}
-        );
-      }, timeout);
+      sharedHoverTimeoutRef.current = setTimeout(prefetch, timeout);
     },
     onHoverEnd: () => {
       if (sharedHoverTimeoutRef.current) {

--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
@@ -196,39 +196,14 @@ function traceItemDetailsApiOptions({
   );
 }
 
-export function usePrefetchTraceItemDetailsOnHover({
+function useTraceItemDetailsPrefetch({
   traceItemId,
   projectId,
   traceId,
   traceItemType,
   referrer,
   timestamp,
-  hoverPrefetchDisabled,
-  prefetchOnMount,
-  sharedHoverTimeoutRef,
-  timeout,
-}: UseTraceItemDetailsProps & {
-  /**
-   * A ref to a shared timeout so multiple hover events can be handled
-   * without creating multiple timeouts and firing multiple prefetches.
-   */
-  sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
-  /**
-   * Custom timeout for the prefetched item.
-   */
-  timeout: number;
-  /**
-   * Whether the hover prefetch should be disabled.
-   */
-  hoverPrefetchDisabled?: boolean;
-  /**
-   * Fetch the details once on mount (e.g. for a deep-linked, auto-expanded row)
-   * without requiring a hover. The reactive `useTraceItemDetails` query in the
-   * expanded details can be torn down by virtualizer re-layout during the
-   * initial load, so this guarantees the request fires and populates the cache.
-   */
-  prefetchOnMount?: boolean;
-}) {
+}: UseTraceItemDetailsProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const project = useProjectFromId({project_id: projectId});
@@ -275,13 +250,43 @@ export function usePrefetchTraceItemDetailsOnHover({
     traceItemType,
   ]);
 
-  const hasPrefetchedOnMount = useRef(false);
-  useEffect(() => {
-    if (prefetchOnMount && !hasPrefetchedOnMount.current && project?.slug) {
-      hasPrefetchedOnMount.current = true;
-      prefetch();
-    }
-  }, [prefetchOnMount, project?.slug, prefetch]);
+  return {prefetch, project, traceItemMeta, traceItemAttributes};
+}
+
+export function usePrefetchTraceItemDetailsOnHover({
+  traceItemId,
+  projectId,
+  traceId,
+  traceItemType,
+  referrer,
+  timestamp,
+  hoverPrefetchDisabled,
+  sharedHoverTimeoutRef,
+  timeout,
+}: UseTraceItemDetailsProps & {
+  /**
+   * A ref to a shared timeout so multiple hover events can be handled
+   * without creating multiple timeouts and firing multiple prefetches.
+   */
+  sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  /**
+   * Custom timeout for the prefetched item.
+   */
+  timeout: number;
+  /**
+   * Whether the hover prefetch should be disabled.
+   */
+  hoverPrefetchDisabled?: boolean;
+}) {
+  const {prefetch, project, traceItemMeta, traceItemAttributes} =
+    useTraceItemDetailsPrefetch({
+      traceItemId,
+      projectId,
+      traceId,
+      traceItemType,
+      referrer,
+      timestamp,
+    });
 
   const {hoverProps} = useHover({
     onHoverStart: () => {
@@ -298,5 +303,27 @@ export function usePrefetchTraceItemDetailsOnHover({
     isDisabled: hoverPrefetchDisabled,
   });
 
-  return {hoverProps, traceItemMeta, traceItemAttributes};
+  return {
+    hoverProps,
+    prefetch,
+    isProjectReady: Boolean(project?.slug),
+    traceItemMeta,
+    traceItemAttributes,
+  };
+}
+
+export function usePrefetchTraceItemDetailsOnMount({
+  prefetch,
+  enabled,
+  isProjectReady,
+}: {
+  isProjectReady: boolean;
+  prefetch: () => void;
+  enabled?: boolean;
+}) {
+  const hasPrefetched = useRef(false);
+  if (enabled && isProjectReady && !hasPrefetched.current) {
+    hasPrefetched.current = true;
+    prefetch();
+  }
 }

--- a/static/app/views/explore/logs/logsQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsQueryParamsProvider.tsx
@@ -51,7 +51,8 @@ export function LogsQueryParamsProvider({
     throw new Error(`Unknown source for LogsQueryParamsProvider: ${source}`);
   }
 
-  const isTableFrozen = source === 'state';
+  const isTableFrozen =
+    source === 'state' || (!!freeze && Object.keys(freeze).length > 0);
 
   return (
     <LogsAnalyticsPageSourceContext value={analyticsPageSource}>

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -89,7 +89,8 @@ export const LogTableRow = styled(TableRow)<LogTableRowProps>`
       }
     `}
 
-  &[data-row-hover-linked='true']:not(thead > &) {
+  &[data-row-hover-linked='true']:not(thead > &),
+  &[data-row-linked='true']:not(thead > &) {
     background-color: ${p =>
       p.theme.tokens.interactive.transparent.accent.selected.background.active};
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import qs from 'query-string';
 import {LogFixture} from 'sentry-fixture/log';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -592,8 +593,65 @@ describe('LogsInfiniteTable', () => {
 
     expect(linkedRow).toHaveAttribute('data-row-linked', 'true');
     expect(otherRow).not.toHaveAttribute('data-row-linked', 'true');
-    // The linked row is expanded on load, which fetches its full details.
+    // The linked row is expanded on load: its detail actions render and its
+    // full details are fetched.
+    expect(
+      await screen.findByRole('button', {name: 'Copy as JSON'})
+    ).toBeInTheDocument();
     await waitFor(() => expect(traceItemRequest).toHaveBeenCalled());
+  });
+
+  it('expands the linked row when navigation adds logsRowId', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/2/`,
+      method: 'GET',
+      body: {
+        itemId: '2',
+        links: null,
+        meta: {},
+        timestamp: mockLogsData[1]![OurLogKnownFieldKey.TIMESTAMP],
+        attributes: [],
+      },
+    });
+
+    const {router} = renderWithProviders(
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+            },
+          },
+        },
+      }
+    );
+
+    await screen.findAllByTestId('log-table-row');
+    // Nothing is expanded before a logsRowId is present.
+    expect(
+      screen.queryByRole('button', {name: 'Copy as JSON'})
+    ).not.toBeInTheDocument();
+
+    router.navigate(
+      `/organizations/${organization.slug}/explore/logs/?${qs.stringify({
+        [LOGS_FIELDS_KEY]: visibleColumnFields,
+        [LOGS_SORT_BYS_KEY]: '-timestamp',
+        [LOGS_ROW_ID_KEY]: '2',
+      })}`
+    );
+
+    // The newly linked row expands in place: its detail actions now render.
+    expect(
+      await screen.findByRole('button', {name: 'Copy as JSON'})
+    ).toBeInTheDocument();
+    const rows = screen.getAllByTestId('log-table-row');
+    const newlyLinkedRow = rows.find(row =>
+      within(row).queryByText('test log body 2')
+    )!;
+    expect(newlyLinkedRow).toHaveAttribute('data-row-linked', 'true');
   });
 
   it('links the body instance hover state when the pinned instance is hovered', async () => {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -595,9 +595,7 @@ describe('LogsInfiniteTable', () => {
     expect(otherRow).not.toHaveAttribute('data-row-linked', 'true');
     // The linked row is expanded on load: its detail actions render and its
     // full details are fetched.
-    expect(
-      await screen.findByRole('button', {name: 'Copy as JSON'})
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
     await waitFor(() => expect(traceItemRequest).toHaveBeenCalled());
   });
 
@@ -631,9 +629,7 @@ describe('LogsInfiniteTable', () => {
 
     await screen.findAllByTestId('log-table-row');
     // Nothing is expanded before a logsRowId is present.
-    expect(
-      screen.queryByRole('button', {name: 'Copy as JSON'})
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Copy as JSON'})).not.toBeInTheDocument();
 
     router.navigate(
       `/organizations/${organization.slug}/explore/logs/?${qs.stringify({
@@ -644,13 +640,9 @@ describe('LogsInfiniteTable', () => {
     );
 
     // The newly linked row expands in place: its detail actions now render.
-    expect(
-      await screen.findByRole('button', {name: 'Copy as JSON'})
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
     const rows = screen.getAllByTestId('log-table-row');
-    const newlyLinkedRow = rows.find(row =>
-      within(row).queryByText('test log body 2')
-    )!;
+    const newlyLinkedRow = rows.find(row => within(row).queryByText('test log body 2'))!;
     expect(newlyLinkedRow).toHaveAttribute('data-row-linked', 'true');
   });
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -21,6 +21,7 @@ import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageD
 import {
   LOGS_FIELDS_KEY,
   LOGS_QUERY_KEY,
+  LOGS_ROW_ID_KEY,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {DEFAULT_TRACE_ITEM_HOVER_TIMEOUT} from 'sentry/views/explore/logs/constants';
@@ -554,6 +555,45 @@ describe('LogsInfiniteTable', () => {
     expect(screen.getByTestId('pinned-logs-table-body').contains(firstRow ?? null)).toBe(
       true
     );
+  });
+
+  it('highlights and expands the row referenced by the logsRowId param', async () => {
+    const traceItemRequest = MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/1/`,
+      method: 'GET',
+      body: {
+        itemId: '1',
+        links: null,
+        meta: {},
+        timestamp: mockLogsData[0]![OurLogKnownFieldKey.TIMESTAMP],
+        attributes: [],
+      },
+    });
+
+    renderWithProviders(
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/logs/`,
+            query: {
+              [LOGS_FIELDS_KEY]: visibleColumnFields,
+              [LOGS_SORT_BYS_KEY]: '-timestamp',
+              [LOGS_ROW_ID_KEY]: '1',
+            },
+          },
+        },
+      }
+    );
+
+    const rows = await screen.findAllByTestId('log-table-row');
+    const linkedRow = rows.find(row => within(row).queryByText('test log body 1'))!;
+    const otherRow = rows.find(row => within(row).queryByText('test log body 2'))!;
+
+    expect(linkedRow).toHaveAttribute('data-row-linked', 'true');
+    expect(otherRow).not.toHaveAttribute('data-row-linked', 'true');
+    // The linked row is expanded on load, which fetches its full details.
+    await waitFor(() => expect(traceItemRequest).toHaveBeenCalled());
   });
 
   it('links the body instance hover state when the pinned instance is hovered', async () => {

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -42,8 +42,8 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
-import {LOGS_ROW_ID_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
+import {LOGS_ROW_ID_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {logsTimestampDescendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';
 import {
   MINIMUM_INFINITE_SCROLL_FETCH_COOLDOWN_MS,

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -29,8 +29,10 @@ import type {Event} from 'sentry/types/event';
 import type {TagCollection} from 'sentry/types/group';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {defined} from 'sentry/utils/defined';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useElementOffset} from 'sentry/utils/useElementOffset';
+import {useLocation} from 'sentry/utils/useLocation';
 import {
   TableBodyCell,
   TableHead,
@@ -40,6 +42,7 @@ import {
   useTableStyles,
 } from 'sentry/views/explore/components/table';
 import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
+import {LOGS_ROW_ID_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {logsTimestampDescendingSortBy} from 'sentry/views/explore/contexts/logs/sortBys';
 import {
@@ -134,6 +137,8 @@ export function LogsInfiniteTable({
   showCellActions,
   showExploreSimilarSpansLink,
 }: LogsTableProps) {
+  const location = useLocation();
+  const linkedRowId = decodeScalar(location.query[LOGS_ROW_ID_KEY]);
   const fields = useQueryParamsFields();
   const search = useQueryParamsSearch();
   const autoRefresh = useLogsAutoRefreshEnabled();
@@ -235,7 +240,10 @@ export function LogsInfiniteTable({
   const {width: tableWidth} = useDimensions({elementRef: tableRef});
   const {top: backToTopOffset} = useElementOffset(tableBodyRef, tableRef);
   const [expandedLogRows, setExpandedLogRows] = useState(
-    new Set(embeddedOptions?.openWithExpandedIds)
+    new Set([
+      ...(embeddedOptions?.openWithExpandedIds ?? []),
+      ...(linkedRowId ? [linkedRowId] : []),
+    ])
   );
   const [expandedLogRowsHeights, setExpandedLogRowsHeights] = useState<
     Record<string, number>
@@ -625,6 +633,7 @@ export function LogsInfiniteTable({
                   showCellActions={showCellActions}
                   showExploreSimilarSpansLink={showExploreSimilarSpansLink}
                   isPinned={logsPinning?.hasPinnedRow?.(rowId)}
+                  isHighlighted={!!linkedRowId && rowId === linkedRowId}
                   isHoverLinked={hoveredRowId === rowId}
                   setHoveredRowId={setHoveredRowId}
                   togglePinnedRow={logsPinning ? handleTogglePinnedRow : undefined}

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -248,6 +248,24 @@ export function LogsInfiniteTable({
   const [expandedLogRowsHeights, setExpandedLogRowsHeights] = useState<
     Record<string, number>
   >({});
+
+  // Keep the linked row expanded across client-side navigations that change
+  // `logsRowId`. This is additive: we never collapse a previously expanded row
+  // since we can't tell a prior link apart from a user-expanded row.
+  useEffect(() => {
+    if (!linkedRowId) {
+      return;
+    }
+    setExpandedLogRows(prev => {
+      if (prev.has(linkedRowId)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(linkedRowId);
+      return next;
+    });
+  }, [linkedRowId]);
+
   const [isFunctionScrolling, setIsFunctionScrolling] = useState(false);
   const [hoveredRowId, setHoveredRowId] = useState<string | null>(null);
   const autorefreshEnabled = useLogsAutoRefreshEnabled();

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -610,7 +610,59 @@ describe('logsTableRow', () => {
     expect(copiedUrl).toContain('logsQuery=id%3A1');
   });
 
-  it.isKnownFlake('copies a row link with logsRowId in a frozen view', async () => {
+  it('clears a stale logsRowId when copying a non-frozen link', async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+    });
+
+    render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              logsRowId: '999',
+            },
+          },
+        },
+        additionalWrapper: ProviderWrapper,
+      }
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow);
+
+    const actionsButton = screen.getAllByRole('button', {name: 'Actions'})[0]!;
+    await userEvent.click(actionsButton);
+
+    const copyLinkItem = await screen.findByRole('menuitemradio', {name: 'Copy link'});
+    await userEvent.click(copyLinkItem);
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+    });
+
+    const copiedUrl = mockWriteText.mock.calls[0]![0];
+    expect(copiedUrl).toContain('logsQuery=id%3A1');
+    expect(copiedUrl).not.toContain('logsRowId');
+  });
+
+  it('copies a row link with logsRowId in a frozen view', async () => {
     const mockWriteText = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, 'clipboard', {
       value: {

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -610,47 +610,44 @@ describe('logsTableRow', () => {
     expect(copiedUrl).toContain('logsQuery=id%3A1');
   });
 
-  it.isKnownFlake(
-    'copies a row link with logsRowId in a frozen view',
-    async () => {
-      const mockWriteText = jest.fn().mockResolvedValue(undefined);
-      Object.defineProperty(window.navigator, 'clipboard', {
-        value: {
-          writeText: mockWriteText,
-        },
-        writable: true,
-      });
+  it.isKnownFlake('copies a row link with logsRowId in a frozen view', async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+    });
 
-      render(
-        <LogRowContent
-          dataRow={rowData}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowData)}
-          sharedHoverTimeoutRef={{
-            current: null,
-          }}
-        />,
-        {organization, initialRouterConfig, additionalWrapper: FrozenProviderWrapper}
-      );
+    render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: FrozenProviderWrapper}
+    );
 
-      const logTableRow = await screen.findByTestId('log-table-row');
-      await userEvent.hover(logTableRow);
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow);
 
-      const actionsButton = screen.getAllByRole('button', {name: 'Actions'})[0]!;
-      await userEvent.click(actionsButton);
+    const actionsButton = screen.getAllByRole('button', {name: 'Actions'})[0]!;
+    await userEvent.click(actionsButton);
 
-      const copyLinkItem = await screen.findByRole('menuitemradio', {name: 'Copy link'});
-      await userEvent.click(copyLinkItem);
+    const copyLinkItem = await screen.findByRole('menuitemradio', {name: 'Copy link'});
+    await userEvent.click(copyLinkItem);
 
-      await waitFor(() => {
-        expect(mockWriteText).toHaveBeenCalledTimes(1);
-      });
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+    });
 
-      const copiedUrl = mockWriteText.mock.calls[0]![0];
-      expect(copiedUrl).toContain('logsRowId=1');
-      expect(copiedUrl).not.toContain('logsQuery=id');
-    }
-  );
+    const copiedUrl = mockWriteText.mock.calls[0]![0];
+    expect(copiedUrl).toContain('logsRowId=1');
+    expect(copiedUrl).not.toContain('logsQuery=id');
+  });
 
   it('adds a grouping and opens the sidebar when the attributes menu group by is clicked', async () => {
     const setSidebarOpen = jest.fn();

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -42,6 +42,20 @@ function ProviderWrapper({children}: {children?: React.ReactNode}) {
   );
 }
 
+function FrozenProviderWrapper({children}: {children?: React.ReactNode}) {
+  return (
+    <LogsQueryParamsProvider
+      analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
+      source="state"
+      freeze={{traceId: '7b91699f'}}
+    >
+      <table>
+        <tbody>{children}</tbody>
+      </table>
+    </LogsQueryParamsProvider>
+  );
+}
+
 describe('logsTableRow', () => {
   let stacktraceLinkMock: jest.Mock;
   let releaseMock: jest.Mock;
@@ -595,6 +609,48 @@ describe('logsTableRow', () => {
     const copiedUrl = mockWriteText.mock.calls[0]![0];
     expect(copiedUrl).toContain('logsQuery=id%3A1');
   });
+
+  it.isKnownFlake(
+    'copies a row link with logsRowId in a frozen view',
+    async () => {
+      const mockWriteText = jest.fn().mockResolvedValue(undefined);
+      Object.defineProperty(window.navigator, 'clipboard', {
+        value: {
+          writeText: mockWriteText,
+        },
+        writable: true,
+      });
+
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{
+            current: null,
+          }}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: FrozenProviderWrapper}
+      );
+
+      const logTableRow = await screen.findByTestId('log-table-row');
+      await userEvent.hover(logTableRow);
+
+      const actionsButton = screen.getAllByRole('button', {name: 'Actions'})[0]!;
+      await userEvent.click(actionsButton);
+
+      const copyLinkItem = await screen.findByRole('menuitemradio', {name: 'Copy link'});
+      await userEvent.click(copyLinkItem);
+
+      await waitFor(() => {
+        expect(mockWriteText).toHaveBeenCalledTimes(1);
+      });
+
+      const copiedUrl = mockWriteText.mock.calls[0]![0];
+      expect(copiedUrl).toContain('logsRowId=1');
+      expect(copiedUrl).not.toContain('logsQuery=id');
+    }
+  );
 
   it('adds a grouping and opens the sidebar when the attributes menu group by is clicked', async () => {
     const setSidebarOpen = jest.fn();

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -62,7 +62,10 @@ import type {
   TraceItemDetailsResponse,
   TraceItemResponseAttribute,
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
-import {usePrefetchTraceItemDetailsOnHover} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {
+  usePrefetchTraceItemDetailsOnHover,
+  usePrefetchTraceItemDetailsOnMount,
+} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {
   DEFAULT_TRACE_ITEM_HOVER_TIMEOUT,
   DEFAULT_TRACE_ITEM_HOVER_TIMEOUT_WITH_AUTO_REFRESH,
@@ -340,7 +343,7 @@ export const LogRowContent = memo(function LogRowContent({
   const logTimestampSeconds = isRegularLogResponseItem(dataRow)
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
-  const {hoverProps, traceItemMeta, traceItemAttributes} =
+  const {hoverProps, prefetch, isProjectReady, traceItemMeta, traceItemAttributes} =
     usePrefetchTraceItemDetailsOnHover({
       traceItemId: rowId,
       projectId: String(dataRow[OurLogKnownFieldKey.PROJECT_ID]),
@@ -350,8 +353,12 @@ export const LogRowContent = memo(function LogRowContent({
       timestamp: logTimestampSeconds,
       sharedHoverTimeoutRef,
       timeout: prefetchTimeout,
-      prefetchOnMount: isHighlighted,
     });
+  usePrefetchTraceItemDetailsOnMount({
+    prefetch,
+    enabled: isHighlighted,
+    isProjectReady,
+  });
   const [caseInsensitivity] = useCaseInsensitivity();
 
   const observedTimestamp = traceItemAttributes?.find(

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -53,7 +53,10 @@ import {
   useLogsAutoRefreshEnabled,
   useSetLogsAutoRefresh,
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
-import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
+import {
+  LOGS_QUERY_KEY,
+  LOGS_ROW_ID_KEY,
+} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {
   TraceItemDetailsResponse,
@@ -129,6 +132,7 @@ type LogsRowProps = {
   };
   expansionKey?: string;
   isExpanded?: boolean;
+  isHighlighted?: boolean;
   isHoverLinked?: boolean;
   isPinned?: boolean;
   logEnd?: string;
@@ -229,6 +233,7 @@ export const LogRowContent = memo(function LogRowContent({
   logEnd,
   isPinned,
   isHoverLinked,
+  isHighlighted,
   setHoveredRowId,
   togglePinnedRow,
   showCellActions,
@@ -243,6 +248,7 @@ export const LogRowContent = memo(function LogRowContent({
 
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
+  const isFrozen = useLogsFrozenIsFrozen();
   const measureRef = useRef<HTMLTableRowElement>(null);
 
   const rowId = String(dataRow[OurLogKnownFieldKey.ID]);
@@ -423,6 +429,7 @@ export const LogRowContent = memo(function LogRowContent({
       <LogTableRow
         data-test-id="log-table-row"
         data-row-hover-linked={isHoverLinked}
+        data-row-linked={isHighlighted}
         highlighted={isPseudoRow}
         pinned={isPinned}
         {...omit(rowInteractProps, 'className')}
@@ -575,7 +582,15 @@ export const LogRowContent = memo(function LogRowContent({
                         const logId = String(dataRow[OurLogKnownFieldKey.ID]);
                         const url = new URL(window.location.origin + location.pathname);
                         const params = new URLSearchParams(location.search);
-                        params.set(LOGS_QUERY_KEY, `id:${logId}`);
+                        // In frozen/embedded views (e.g. trace details) the row set is
+                        // bounded, so link to the row and let it highlight + expand in
+                        // context. On the standalone logs page the row may not be loaded,
+                        // so filter to it instead.
+                        if (isFrozen) {
+                          params.set(LOGS_ROW_ID_KEY, logId);
+                        } else {
+                          params.set(LOGS_QUERY_KEY, `id:${logId}`);
+                        }
                         url.search = params.toString();
                         copy(url.toString(), {
                           successMessage: t('Copied!'),

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -350,6 +350,7 @@ export const LogRowContent = memo(function LogRowContent({
       timestamp: logTimestampSeconds,
       sharedHoverTimeoutRef,
       timeout: prefetchTimeout,
+      prefetchOnMount: isHighlighted,
     });
   const [caseInsensitivity] = useCaseInsensitivity();
 

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -591,6 +591,7 @@ export const LogRowContent = memo(function LogRowContent({
                           params.set(LOGS_ROW_ID_KEY, logId);
                         } else {
                           params.set(LOGS_QUERY_KEY, `id:${logId}`);
+                          params.delete(LOGS_ROW_ID_KEY);
                         }
                         url.search = params.toString();
                         copy(url.toString(), {

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.spec.tsx
@@ -1,8 +1,15 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import {mockGetBoundingClientRect} from 'sentry/utils/fixtures/virtualization';
+import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {
   TraceViewLogsDataProvider,
@@ -97,6 +104,30 @@ describe('TraceViewLogsSection', () => {
     );
 
     expect(await screen.findByRole('option', {name: 'severity'})).toBeInTheDocument();
+  });
+
+  it('reflects an added filter in the URL', async () => {
+    const organization = OrganizationFixture({features: ['ourlogs-enabled']});
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {
+        data: [],
+        meta: {},
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'POST',
+      body: [],
+    });
+    const {router} = render(<Component traceSlug={TRACE_SLUG} />, {organization});
+
+    const search = await screen.findByRole('combobox', {name: 'Add a search term'});
+    await userEvent.type(search, 'hello{enter}');
+
+    await waitFor(() => {
+      expect(router.location.query[LOGS_QUERY_KEY]).toContain('hello');
+    });
   });
 
   it('shows the similar spans log row action', async () => {

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -32,7 +32,7 @@ export function TraceViewLogsDataProvider({
   return (
     <LogsQueryParamsProvider
       analyticsPageSource={LogsAnalyticsPageSource.TRACE_DETAILS}
-      source="state"
+      source="location"
       freeze={{traceId: traceSlug}}
     >
       <LogsPageDataProvider>{children}</LogsPageDataProvider>


### PR DESCRIPTION
On the trace details logs tab, search/filter state was held in local React state, so it was never reflected in the URL and the row-level "Copy link" action produced a link that restored nothing on reload.

This adds URL (location) reading to the logs infinite table that additionally expands any rows that are specified there. In particular this makes logs fetch on mount if they're linked (initially expanded). So really most of the changes in here are `fix(ourlogs)`, they just happen to all fall under the `state="location"` line in `traceOurLogs.tsx`.

Example visible on: `explore/traces/trace/8fb184b3d3e84d229b9d9267cce1102a/?crossEvents=%5B%7B%22query%22%3A%22message%3A%5C%22Cycle%20detected%20in%20trace%20tree%20structure%5C%22%22%2C%22type%22%3A%22logs%22%7D%5D&end=2026-06-27T06%3A42%3A00&node=span-b8b7070f8e7de5b0&pageEnd=2026-06-27T06%3A42%3A00.000&pageStart=2026-06-27T04%3A14%3A00.000&project=11276&source=traces&start=2026-06-27T04%3A14%3A00&tab=logs&targetId=9576059668ade62c&timestamp=1782542513` -> `/explore/traces/trace/8fb184b3d3e84d229b9d9267cce1102a/?crossEvents=%5B%7B%22query%22%3A%22message%3A%5C%22Cycle+detected+in+trace+tree+structure%5C%22%22%2C%22type%22%3A%22logs%22%7D%5D&end=2026-06-27T06%3A42%3A00&node=span-b8b7070f8e7de5b0&pageEnd=2026-06-27T06%3A42%3A00.000&pageStart=2026-06-27T04%3A14%3A00.000&project=11276&source=traces&start=2026-06-27T04%3A14%3A00&tab=logs&targetId=9576059668ade62c&timestamp=1782542513&logsRowId=019f07d033e87014b035cf50784046fe`.

Closes LOGS-899.
