### PR TITLE
fix(preprod): Keep metadata popup double-click from opening focus view

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -347,12 +347,7 @@ export const CardHeader = memo(function CardHeader({
 
 function MetadataTooltip({json}: {json: string}) {
   return (
-    <Stack
-      gap="xs"
-      minWidth="260px"
-      onDoubleClick={e => e.stopPropagation()}
-      onClick={e => e.stopPropagation()}
-    >
+    <Stack gap="xs" minWidth="260px">
       <MetadataHint>{t('Click info icon to copy metadata')}</MetadataHint>
       <CodeBlock language="json" hideCopyButton isRounded={false}>
         {json}
@@ -378,18 +373,24 @@ function MetadataInfoButton({
   );
 
   return (
-    <Tooltip title={<MetadataTooltip json={json} />} maxWidth={480} isHoverable>
-      <InfoIconButton
-        type="button"
-        aria-label={t('Copy metadata as JSON')}
-        onClick={() => {
-          copy(json, {successMessage: t('Copied metadata as JSON')});
-          onCopy?.();
-        }}
-      >
-        <IconInfo size="sm" />
-      </InfoIconButton>
-    </Tooltip>
+    <Flex
+      align="center"
+      onDoubleClick={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
+    >
+      <Tooltip title={<MetadataTooltip json={json} />} maxWidth={480} isHoverable>
+        <InfoIconButton
+          type="button"
+          aria-label={t('Copy metadata as JSON')}
+          onClick={() => {
+            copy(json, {successMessage: t('Copied metadata as JSON')});
+            onCopy?.();
+          }}
+        >
+          <IconInfo size="sm" />
+        </InfoIconButton>
+      </Tooltip>
+    </Flex>
   );
 }
 

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -347,7 +347,12 @@ export const CardHeader = memo(function CardHeader({
 
 function MetadataTooltip({json}: {json: string}) {
   return (
-    <Stack gap="xs" minWidth="260px">
+    <Stack
+      gap="xs"
+      minWidth="260px"
+      onDoubleClick={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
+    >
       <MetadataHint>{t('Click info icon to copy metadata')}</MetadataHint>
       <CodeBlock language="json" hideCopyButton isRounded={false}>
         {json}


### PR DESCRIPTION
Double-clicking inside a snapshot card's metadata info (ⓘ) popup now selects text within the popup instead of switching the card to focus view, so users can double-click to select and copy the JSON.

The popup's tooltip content is rendered through a portal, but React synthetic events bubble through the component tree rather than the DOM tree. The double-click therefore reached the card header's `onDoubleClick` handler (which opens focus view). This stops click and double-click propagation at the popup root, keeping those interactions inside the popup. Double-clicking the card header elsewhere still opens focus view.