### PR TITLE
feat(preprod): Sync snapshot sidebar search to URL

### DIFF
--- a/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.tsx
+++ b/static/app/views/preprod/snapshots/latestBaseSnapshotResolver.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {RequestError} from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -21,6 +22,7 @@ type LatestBaseSnapshotResponse = {
 export default function LatestBaseSnapshotResolver() {
   const organization = useOrganization();
   const navigate = useNavigate();
+  const location = useLocation();
   const {projectId, appId} = useParams<{appId: string; projectId: string}>();
 
   const {data, isError} = useQuery({
@@ -42,8 +44,11 @@ export default function LatestBaseSnapshotResolver() {
     }
     const {customerDomain} = ConfigStore.getState();
     const orgPrefix = customerDomain ? '' : `/organizations/${organization.slug}`;
-    navigate(`${orgPrefix}/preprod/snapshots/${data.head_artifact_id}/`, {replace: true});
-  }, [data, navigate, organization.slug]);
+    navigate(
+      `${orgPrefix}/preprod/snapshots/${data.head_artifact_id}/${location.search}`,
+      {replace: true}
+    );
+  }, [data, location.search, navigate, organization.slug]);
 
   if (isError) {
     return (

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -172,7 +172,6 @@ export default function SnapshotsPage() {
     });
   }, [isPending, data, organization]);
 
-  const [searchQuery, setSearchQuery] = useState('');
   const pushHistory = {history: 'push' as const};
   const palette = theme.chart.getColorPalette(10);
   // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
@@ -194,6 +193,10 @@ export default function SnapshotsPage() {
       .withOptions(pushHistory)
   );
   const replaceHistory = {history: 'replace' as const};
+  const [searchQuery, setSearchQuery] = useQueryState(
+    'search',
+    parseAsString.withDefault('').withOptions(replaceHistory)
+  );
   const [activeStatusList, setActiveStatusList] = useQueryState(
     'selectedTypes',
     parseAsArrayOf(parseAsStringLiteral(Object.values(DiffStatus)))


### PR DESCRIPTION
The "Search components…" box in the snapshot diff sidebar now persists to the URL as `?search=<term>`, so a filtered view survives reload and can be shared via link. Previously the term lived in local component state and was lost on refresh.

This moves `searchQuery` onto the same `nuqs` `useQueryState` pattern already used by the sidebar's other controls (`selectedTypes`, `view`, `sortBy`, `selectedSnapshot`) in `snapshots.tsx`, using replace-history so typing doesn't stack browser history entries. An empty search drops the param. The sidebar component stays purely prop-driven and is unchanged.