### PR TITLE
feat(sdk): double-write bootstrap request tags to attributes

### DIFF
--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -114,10 +114,8 @@ describe('useBootstrapOrganizationQuery', () => {
     expect(mockScope.setTag).toHaveBeenCalledWith('organization', org.id);
     expect(mockScope.setTag).toHaveBeenCalledWith('organization.slug', org.slug);
     expect(mockScope.setAttributes).toHaveBeenCalledWith({
-      organization: {
-        id: org.id,
-        slug: org.slug,
-      },
+      organization: org.id,
+      'organization.slug': org.slug,
     });
     expect(mockScope.setContext).toHaveBeenCalledWith('organization', {
       id: org.id,

--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -113,6 +113,12 @@ describe('useBootstrapOrganizationQuery', () => {
     ]);
     expect(mockScope.setTag).toHaveBeenCalledWith('organization', org.id);
     expect(mockScope.setTag).toHaveBeenCalledWith('organization.slug', org.slug);
+    expect(mockScope.setAttributes).toHaveBeenCalledWith({
+      organization: {
+        id: org.id,
+        slug: org.slug,
+      },
+    });
     expect(mockScope.setContext).toHaveBeenCalledWith('organization', {
       id: org.id,
       slug: org.slug,

--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -90,6 +90,7 @@ describe('useBootstrapOrganizationQuery', () => {
 
     const mockScope = {
       setTag: jest.fn(),
+      setAttributes: jest.fn(),
       setContext: jest.fn(),
     } as unknown as Scope;
     jest.spyOn(Sentry, 'getCurrentScope').mockReturnValue(mockScope);

--- a/static/app/bootstrap/bootstrapRequests.tsx
+++ b/static/app/bootstrap/bootstrapRequests.tsx
@@ -47,6 +47,10 @@ export function useBootstrapOrganizationQuery(orgSlug: string | null) {
       const scope = Sentry.getCurrentScope();
       scope.setTag('organization', organization.id);
       scope.setTag('organization.slug', organization.slug);
+      scope.setAttributes({
+        organization: organization.id,
+        'organization.slug': organization.slug,
+      });
       scope.setContext('organization', {
         id: organization.id,
         slug: organization.slug,


### PR DESCRIPTION
Double writes tags written onto errors and formerly transactions to scope attributes so that they apply to streamed spans, logs and metrics. 

This PR is part of a setTag -> setAttribute PR stack.
PR-specific area: App bootstrap. Also adjusts an SDK mock to expose the setAttribute API.