### PR TITLE
feat(sdk): double-write initializeSdk tags to attributes

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -137,9 +137,9 @@ export function initializeSdk(config: Config) {
     tracesSampler: context => {
       const op = context.attributes?.[Sentry.SEMANTIC_ATTRIBUTE_SENTRY_OP] || '';
       if (op.startsWith('ui.action')) {
-        return tracesSampleRate / 100;
+        return context.inheritOrSampleWith(tracesSampleRate / 100);
       }
-      return tracesSampleRate;
+      return context.inheritOrSampleWith(tracesSampleRate);
     },
     ignoreSpans: IGNORED_SPAN_NAMES,
 

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -137,9 +137,9 @@ export function initializeSdk(config: Config) {
     tracesSampler: context => {
       const op = context.attributes?.[Sentry.SEMANTIC_ATTRIBUTE_SENTRY_OP] || '';
       if (op.startsWith('ui.action')) {
-        return context.inheritOrSampleWith(tracesSampleRate / 100);
+        return tracesSampleRate / 100;
       }
-      return context.inheritOrSampleWith(tracesSampleRate);
+      return tracesSampleRate;
     },
     ignoreSpans: IGNORED_SPAN_NAMES,
 
@@ -236,6 +236,7 @@ export function initializeSdk(config: Config) {
   }
   if (window.__SENTRY__VERSION) {
     Sentry.setTag('sentry_version', window.__SENTRY__VERSION);
+    Sentry.setAttribute('sentry_version', window.__SENTRY__VERSION);
   }
 
   const {customerDomain} = window.__initialData;
@@ -245,6 +246,12 @@ export function initializeSdk(config: Config) {
     Sentry.setTag('customerDomain.organizationUrl', customerDomain.organizationUrl);
     Sentry.setTag('customerDomain.sentryUrl', customerDomain.sentryUrl);
     Sentry.setTag('customerDomain.subdomain', customerDomain.subdomain);
+    Sentry.setAttributes({
+      isCustomerDomain: 'yes',
+      'customerDomain.organizationUrl': customerDomain.organizationUrl,
+      'customerDomain.sentryUrl': customerDomain.sentryUrl,
+      'customerDomain.subdomain': customerDomain.subdomain,
+    });
   }
 
   if (sentryClient) {


### PR DESCRIPTION
Double writes tags written onto errors and formerly transactions to scope attributes so that they apply to streamed spans, logs and metrics. 

This PR is part of a setTag -> setAttribute migration initiative.
PR-specific area: SDK intialization. 