### PR TITLE
feat(sdk): double-write performanceForSentry tag to attribute

### DIFF
--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -274,6 +274,7 @@ export const setGroupedEntityTag = (
   }
   groups = [...groups, +Infinity];
   Sentry.setTag(`${tagName}.grouped`, `<=${groups.find(g => n <= g)}`);
+  Sentry.setAttribute(`${tagName}.grouped`, `<=${groups.find(g => n <= g)}`);
 };
 
 /**


### PR DESCRIPTION
Double writes tags written onto errors and formerly transactions to scope attributes so that they apply to streamed spans, logs and metrics. 

This PR is part of a setTag -> setAttribute migration initiative.
PR-specific area:`performanceForSentry`  