### PR TITLE
feat(sdk): double-write explore spans tag to attribute

### DIFF
--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -62,6 +62,7 @@ function useHasCrossEvents() {
 
 export function ExploreContent() {
   Sentry.setTag('explore.visited', 'yes');
+  Sentry.setAttribute('explore.visited', 'yes');
 
   return (
     <SpansQueryParamsProvider>


### PR DESCRIPTION
Double writes tags written onto errors and formerly transactions to scope attributes so that they apply to streamed spans, logs and metrics. 

This PR is part of a setTag -> setAttribute migration initiative 
PR-specific area: Explore 