### PR TITLE
ref(auth): Lower log level of OAuth error response

### DIFF
--- a/src/sentry/web/frontend/oauth_token.py
+++ b/src/sentry/web/frontend/oauth_token.py
@@ -68,7 +68,7 @@ class OAuthTokenView(View):
     def error(self, request: HttpRequest, name, reason=None, status=400):
         client_id = request.POST.get("client_id")
 
-        logger.error(
+        logger.info(
             "oauth.token-error",
             extra={
                 "error_name": name,


### PR DESCRIPTION
This log has been emitted for the past 9 years to Sentry. Its not actionable since OAuth failures are expected. The vast majority of the error volume comes from three IPs so its not a broadly experienced issue among Sentry users.

I'm lowering the log level to remove some noise from Sentry. Though a metric might be better depending on if/how people use this data.