### PR TITLE
fix(explore): keep timestamp column when opening logs widget

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -80,6 +80,38 @@ describe('getWidgetExploreUrl', () => {
     });
   });
 
+  it('includes the timestamp column when a logs widget has a group-by column', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      widgetType: WidgetType.LOGS,
+      queries: [
+        WidgetQueryFixture({
+          fields: ['message', 'count()'],
+          aggregates: ['count()'],
+          columns: ['message'],
+          conditions: '',
+          orderby: '-count()',
+        }),
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, undefined, selection, organization);
+
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/explore/logs/',
+      params: [
+        ['aggregateField', '{"chartType":1,"yAxes":["count(message)"]}'],
+        ['interval', '3h'],
+        ['logsFields', 'timestamp'],
+        ['logsFields', 'message'],
+        ['logsGroupBy', 'message'],
+        ['mode', 'aggregate'],
+        ['project', ''],
+        ['statsPeriod', '14d'],
+      ],
+    });
+  });
+
   it('returns the correct aggregate mode url for table widgets with equations sort', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.TABLE,

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -353,11 +353,17 @@ function _getWidgetExploreUrl(
       yAxes: v.yAxes.map(transformLogsYAxis),
     }));
 
+    const logsField =
+      queryParams.field.length > 0 &&
+      !queryParams.field.includes(OurLogKnownFieldKey.TIMESTAMP)
+        ? [OurLogKnownFieldKey.TIMESTAMP, ...queryParams.field]
+        : queryParams.field;
+
     return getLogsUrl({
       organization: queryParams.organization,
       selection: queryParams.selection,
       query: queryParams.query,
-      field: queryParams.field,
+      field: logsField,
       groupBy: queryParams.groupBy,
       aggregateFields: logsVisualize,
       interval: queryParams.interval,


### PR DESCRIPTION
When constructing the logs URL (`getLogsUrl`), the presence of `queryParams.field` overrides any default columns. That includes timestamps. So this PR adds that back in if it's not there.

Closes EXP-741.
