### PR TITLE
fix(search): Support multi-value release.package filters

### DIFF
--- a/src/sentry/search/eap/spans/filter_aliases.py
+++ b/src/sentry/search/eap/spans/filter_aliases.py
@@ -151,11 +151,11 @@ def semver_package_filter_converter(
     if organization_id is None:
         raise ValueError("organization is a required param")
 
-    if not isinstance(search_filter.value.raw_value, str):
+    if not isinstance(search_filter.value.raw_value, (str, list)):
         raise InvalidSearchQuery(
             f"{search_filter.key.name}: Invalid value: {search_filter.value.raw_value}. Expected a semver package."
         )
-    package: str = search_filter.value.raw_value
+    package: str | list[str] = search_filter.value.raw_value
 
     versions = list(
         Release.objects.filter_by_semver(

--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -275,9 +275,9 @@ def semver_package_filter_converter(
     if builder.params.organization is None:
         raise ValueError("organization is a required param")
     raw_value = search_filter.value.raw_value
-    if not isinstance(raw_value, str):
+    if not isinstance(raw_value, (str, list)):
         raise InvalidSearchQuery("Invalid value for semver package filter")
-    package: str = raw_value
+    package: str | list[str] = raw_value
 
     versions = list(
         Release.objects.filter_by_semver(

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1417,6 +1417,32 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
             release_2_e_1,
         }
 
+    def test_semver_package_multiple_values(self) -> None:
+        release_1 = self.create_release(version="test@1.2.3")
+        release_2 = self.create_release(version="test2@1.2.4")
+        release_3 = self.create_release(version="test3@1.2.5")
+
+        release_1_e_1 = self.store_event(
+            data={"release": release_1.version, "timestamp": self.ten_mins_ago_iso},
+            project_id=self.project.id,
+        ).event_id
+        release_2_e_1 = self.store_event(
+            data={"release": release_2.version, "timestamp": self.ten_mins_ago_iso},
+            project_id=self.project.id,
+        ).event_id
+        self.store_event(
+            data={"release": release_3.version, "timestamp": self.ten_mins_ago_iso},
+            project_id=self.project.id,
+        )
+
+        query = {"field": ["id"], "query": f"{constants.SEMVER_PACKAGE_ALIAS}:[test, test2]"}
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert {r["id"] for r in response.data["data"]} == {
+            release_1_e_1,
+            release_2_e_1,
+        }
+
     def test_semver_build(self) -> None:
         release_1 = self.create_release(version="test@1.2.3+123")
         release_2 = self.create_release(version="test2@1.2.4+124")

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -5873,6 +5873,44 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
             },
         ]
 
+    def test_semver_package_multiple_values(self) -> None:
+        release_1 = self.create_release(version="test1@1.2.1")
+        release_2 = self.create_release(version="test2@1.2.1")
+        release_3 = self.create_release(version="test3@1.2.1")
+
+        span1 = self.create_span(
+            {"sentry_tags": {"release": release_1.version}}, start_ts=self.ten_mins_ago
+        )
+        span2 = self.create_span(
+            {"sentry_tags": {"release": release_2.version}}, start_ts=self.ten_mins_ago
+        )
+        span3 = self.create_span(
+            {"sentry_tags": {"release": release_3.version}}, start_ts=self.ten_mins_ago
+        )
+        self.store_spans([span1, span2, span3])
+
+        request = {
+            "field": ["release"],
+            "project": self.project.id,
+            "dataset": "spans",
+            "orderby": "release",
+        }
+
+        response = self.do_request({**request, "query": "release.package:[test1, test2]"})
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "id": span1["span_id"],
+                "project.name": self.project.slug,
+                "release": "test1@1.2.1",
+            },
+            {
+                "id": span2["span_id"],
+                "project.name": self.project.slug,
+                "release": "test2@1.2.1",
+            },
+        ]
+
     def test_semver_build(self) -> None:
         release_1 = self.create_release(version="test@1.2.3+121")
         release_2 = self.create_release(version="test@1.2.3+122")


### PR DESCRIPTION
Selecting more than one release package on the Project Details page (`release.package:[foo,bar]`) blew up with an InvalidSearchQuery, while a single package worked fine. Regressed when SearchQueryBuilder went GA in Oct 2024 and started sending multi-select values as a list.

The semver package converters only accepted a single string, so let them take a list too. This matches the issues search path, which has handled it since Sep 2024.

fixes #118568
