### PR TITLE
fix(aci): Update the resolution API to use `create_group_activity`

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -643,39 +643,43 @@ def process_group_resolution(
     if assigned_to is not None:
         result["assignedTo"] = assigned_to
 
-    activity = Activity.objects.create_group_activity(
-        group,
-        ActivityType(activity_type),
-        user_id=acting_user.id if acting_user else None,
-        data=dict(activity_data),
-        ident=resolution.id if resolution else None,
-        send_notification=False,  # deferred via on_commit below
-    )
-    record_group_history_from_activity_type(group, activity_type, actor=acting_user)
-    publish_action_from_context(
-        ResolveAction(),
-        group_id=group.id,
-        project=group.project,
-    )
-
-    # TODO(dcramer): we need a solution for activity rollups
-    # before sending notifications on bulk changes
-    if not len(group_list) > 1:
-        # TODO - This will trigger it every time a user clicks resolved
-        # should this only trigger through workflow engine or the activity handler?
-        transaction.on_commit(
-            lambda: activity.send_notification(),
-            router.db_for_write(Group),
+    if bool(affected):
+        # If the group is resolved, then create an activities, actions, etc.
+        activity = Activity.objects.create_group_activity(
+            group,
+            ActivityType(activity_type),
+            user_id=acting_user.id if acting_user else None,
+            data=dict(activity_data),
+            ident=resolution.id if resolution else None,
+            send_notification=False,  # deferred via on_commit below, will also trigger the handlers
         )
 
-    update_group_open_period(
-        group=group,
-        new_status=GroupStatus.RESOLVED,
-        resolution_time=now,
-        resolution_activity=activity,
-    )
-    if group.issue_type == MetricIssue:
-        update_incident_based_on_open_period_status_change(group, GroupStatus.RESOLVED)
+        record_group_history_from_activity_type(group, activity_type, actor=acting_user)
+
+        publish_action_from_context(
+            ResolveAction(),
+            group_id=group.id,
+            project=group.project,
+        )
+
+        # TODO(dcramer): we need a solution for activity rollups
+        # before sending notifications on bulk changes
+        if not len(group_list) > 1:
+            # TODO - This will trigger it every time a user clicks resolved
+            # should this only trigger through workflow engine or the activity handler?
+            transaction.on_commit(
+                lambda: activity.send_notification(),
+                router.db_for_write(Group),
+            )
+
+        update_group_open_period(
+            group=group,
+            new_status=GroupStatus.RESOLVED,
+            resolution_time=now,
+            resolution_activity=activity,
+        )
+        if group.issue_type == MetricIssue:
+            update_incident_based_on_open_period_status_change(group, GroupStatus.RESOLVED)
 
 
 def merge_groups(

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -509,7 +509,6 @@ def process_group_resolution(
 
     now = django_timezone.now()
     resolution = None
-    created = None
     if release:
         # These are the parameters that are set for creating a GroupResolution
         resolution_params: ResolutionParams = {
@@ -606,10 +605,10 @@ def process_group_resolution(
                         # fall back to our current model
                         ...
 
-        resolution, created = GroupResolution.objects.get_or_create(
+        resolution, resolution_created = GroupResolution.objects.get_or_create(
             group=group, defaults=resolution_params
         )
-        if not created:
+        if not resolution_created:
             resolution.update(datetime=django_timezone.now(), **resolution_params)
 
     if commit:
@@ -626,8 +625,6 @@ def process_group_resolution(
     affected = Group.objects.filter(id=group.id).update(
         status=GroupStatus.RESOLVED, resolved_at=now, substatus=None
     )
-    if not resolution:
-        created = bool(affected)
 
     group.status = GroupStatus.RESOLVED
     group.substatus = None
@@ -646,35 +643,39 @@ def process_group_resolution(
     if assigned_to is not None:
         result["assignedTo"] = assigned_to
 
-    if created:
-        activity = Activity.objects.create(
-            project=group.project,
-            group=group,
-            type=activity_type,
-            user_id=acting_user.id if acting_user else None,
-            ident=resolution.id if resolution else None,
-            data=dict(activity_data),
-        )
-        record_group_history_from_activity_type(group, activity_type, actor=acting_user)
-        publish_action_from_context(
-            ResolveAction(),
-            group_id=group.id,
-            project=group.project,
+    activity = Activity.objects.create_group_activity(
+        group,
+        ActivityType(activity_type),
+        user_id=acting_user.id if acting_user else None,
+        data=dict(activity_data),
+        ident=resolution.id if resolution else None,
+        send_notification=False,  # deferred via on_commit below
+    )
+    record_group_history_from_activity_type(group, activity_type, actor=acting_user)
+    publish_action_from_context(
+        ResolveAction(),
+        group_id=group.id,
+        project=group.project,
+    )
+
+    # TODO(dcramer): we need a solution for activity rollups
+    # before sending notifications on bulk changes
+    if not len(group_list) > 1:
+        # TODO - This will trigger it every time a user clicks resolved
+        # should this only trigger through workflow engine or the activity handler?
+        transaction.on_commit(
+            lambda: activity.send_notification(),
+            router.db_for_write(Group),
         )
 
-        # TODO(dcramer): we need a solution for activity rollups
-        # before sending notifications on bulk changes
-        if not len(group_list) > 1:
-            transaction.on_commit(lambda: activity.send_notification(), router.db_for_write(Group))
-
-        update_group_open_period(
-            group=group,
-            new_status=GroupStatus.RESOLVED,
-            resolution_time=now,
-            resolution_activity=activity,
-        )
-        if group.issue_type == MetricIssue:
-            update_incident_based_on_open_period_status_change(group, GroupStatus.RESOLVED)
+    update_group_open_period(
+        group=group,
+        new_status=GroupStatus.RESOLVED,
+        resolution_time=now,
+        resolution_activity=activity,
+    )
+    if group.issue_type == MetricIssue:
+        update_incident_based_on_open_period_status_change(group, GroupStatus.RESOLVED)
 
 
 def merge_groups(

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -88,6 +88,7 @@ class ActivityManager(BaseManager["Activity"]):
         send_notification: bool = True,
         datetime: datetime | None = None,
         detector_id: DetectorId | None = None,
+        ident: str | int | None = None,
     ) -> Activity:
         if user:
             user_id = user.id
@@ -101,6 +102,8 @@ class ActivityManager(BaseManager["Activity"]):
             activity_args["user_id"] = user_id
         if datetime is not None:
             activity_args["datetime"] = datetime
+        if ident is not None:
+            activity_args["ident"] = ident
         activity = self.create(**activity_args)
 
         if send_notification:

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -28,6 +28,10 @@ SEER_WORKFLOW_ACTIVITIES = [
 # Activity types handled by the generic activity_handler.
 SUPPORTED_ACTIVITIES = [
     ActivityType.SET_RESOLVED,
+    ActivityType.SET_RESOLVED_IN_RELEASE,
+    ActivityType.SET_RESOLVED_BY_AGE,
+    ActivityType.SET_RESOLVED_IN_COMMIT,
+    ActivityType.SET_RESOLVED_IN_PULL_REQUEST,
 ]
 
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -28,6 +28,7 @@ from sentry.api.helpers.group_index.update import (
 from sentry.api.helpers.group_index.validators import ValidationError
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer
+from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.action_log import ActionSource, GroupActionActor, action_context_scope
 from sentry.issues.issue_search import parse_search_query
 from sentry.models.activity import Activity
@@ -49,6 +50,7 @@ from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 from sentry.types.actor import Actor
 from sentry.types.group import GroupSubStatus
+from sentry.workflow_engine.models import Detector
 
 pytestmark = [requires_snuba]
 
@@ -317,6 +319,96 @@ class UpdateGroupsTest(TestCase):
         assert send_robust.called
         assert send_robust.call_args.kwargs["resolution_type"] == "in_commit"
         assert send_robust.call_args.kwargs["commit_id"] == commit.id
+
+    @patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_resolving_dispatches_workflow_activity(
+        self, mock_process_workflow_activity: Mock
+    ) -> None:
+        # Resolving now routes through create_group_activity, which invokes the workflow
+        # engine's generic activity handler and dispatches process_workflow_activity.
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        detector = Detector.objects.get(project=self.project, type=ErrorGroupType.slug)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={group.id}")
+        request = _wrap_request(http_request, data={"status": "resolved", "substatus": None})
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        update_groups(request, group_list)
+
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED.value)
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=activity.id,
+            group_id=group.id,
+            detector_id=detector.id,
+        )
+        # A plain resolve has no GroupResolution, so no ident is stamped.
+        assert activity.ident is None
+
+    @patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_resolving_in_release_dispatches_workflow_activity(
+        self, mock_process_workflow_activity: Mock
+    ) -> None:
+        release = self.create_release(project=self.project, version="test@1.0.0")
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        detector = Detector.objects.get(project=self.project, type=ErrorGroupType.slug)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={group.id}")
+        request = _wrap_request(
+            http_request,
+            data={"status": "resolved", "statusDetails": {"inRelease": release.version}},
+        )
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        update_groups(request, group_list)
+
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
+        )
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=activity.id,
+            group_id=group.id,
+            detector_id=detector.id,
+        )
+        # The release resolution stamps the GroupResolution id onto the activity's ident.
+        resolution = group.groupresolution_set.get()
+        assert activity.ident == str(resolution.id)
+
+    @patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_resolving_in_commit_dispatches_workflow_activity(
+        self, mock_process_workflow_activity: Mock
+    ) -> None:
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(project=group.project)
+        commit = self.create_commit(project=group.project, repo=repo)
+        detector = Detector.objects.get(project=self.project, type=ErrorGroupType.slug)
+
+        http_request = self.make_request(user=self.user, method="GET")
+        http_request.GET = QueryDict(query_string=f"id={group.id}")
+        request = _wrap_request(
+            http_request,
+            data={
+                "status": "resolved",
+                "statusDetails": {"inCommit": {"commit": commit.key, "repository": repo.name}},
+            },
+        )
+
+        group_list = get_group_list(self.organization.id, [self.project], request.GET.getlist("id"))
+        update_groups(request, group_list)
+
+        activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
+        mock_process_workflow_activity.delay.assert_called_once_with(
+            activity_id=activity.id,
+            group_id=group.id,
+            detector_id=detector.id,
+        )
 
     @patch("sentry.signals.issue_ignored.send_robust")
     @patch("sentry.issues.status_change.post_save")

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -418,3 +418,33 @@ class ActivityTest(TestCase):
         after = datetime.now(timezone.utc)
 
         assert before <= activity.datetime <= after
+
+    def test_create_group_activity_with_ident(self) -> None:
+        project = self.create_project(name="test_with_ident")
+        group = self.create_group(project)
+
+        # `ident` is typically a related row's id (e.g. a GroupResolution id) passed as an int.
+        activity = Activity.objects.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE,
+            data={"version": ""},
+            send_notification=False,
+            ident=12345,
+        )
+
+        # Activity.ident is a CharField, so the value is persisted as a string.
+        activity.refresh_from_db()
+        assert activity.ident == "12345"
+
+    def test_create_group_activity_without_ident(self) -> None:
+        project = self.create_project(name="test_without_ident")
+        group = self.create_group(project)
+
+        activity = Activity.objects.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED,
+            send_notification=False,
+        )
+
+        activity.refresh_from_db()
+        assert activity.ident is None

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -8,6 +8,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
     SEER_WORKFLOW_ACTIVITIES,
+    SUPPORTED_ACTIVITIES,
     activity_handler,
     seer_activity_handler,
 )
@@ -162,6 +163,37 @@ class GenericActivityHandlerTest(TestCase):
             group_id=self.group.id,
             detector_id=self.detector.id,
         )
+
+    @mock.patch(
+        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
+    )
+    def test_resolution_activity_types_dispatch(
+        self, mock_process_workflow_activity: MagicMock
+    ) -> None:
+        # Enumerate the resolution types explicitly (rather than looping over
+        # SUPPORTED_ACTIVITIES) so that removing any of these from the source list makes
+        # this test fail rather than silently test fewer types.
+        resolution_activity_types = [
+            ActivityType.SET_RESOLVED,
+            ActivityType.SET_RESOLVED_IN_RELEASE,
+            ActivityType.SET_RESOLVED_BY_AGE,
+            ActivityType.SET_RESOLVED_IN_COMMIT,
+            ActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+        ]
+        assert set(resolution_activity_types) <= set(SUPPORTED_ACTIVITIES)
+
+        for activity_type in resolution_activity_types:
+            mock_process_workflow_activity.reset_mock()
+            activity = self.create_group_activity(group=self.group, type=activity_type.value)
+            activity_handler(self.group, activity, self.detector.id)
+            assert mock_process_workflow_activity.delay.called, (
+                f"Task not dispatched for {activity_type.value}"
+            )
+            mock_process_workflow_activity.delay.assert_called_once_with(
+                activity_id=activity.id,
+                group_id=self.group.id,
+                detector_id=self.detector.id,
+            )
 
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"


### PR DESCRIPTION
# Description
Currently, when a user clicks `Resolve` on an issue, it uses this API. The issue is resolved, but we never trigger the registry of handlers to know when we create a new Activity.

This PR changes the `Activity.objects.create` to use `Activity.objects.create_group_activity` which wraps all the calls we care about when creating an activity for a group.