### PR TITLE
fix(ui): Resize autosize textarea on container width changes

### DIFF
--- a/static/app/components/core/textarea/textarea.tsx
+++ b/static/app/components/core/textarea/textarea.tsx
@@ -62,7 +62,7 @@ function AutosizeTextArea({ref, rows, maxRows, ...p}: AutosizeTextAreaProps) {
         ref.current = node;
       }
 
-      if (!node || typeof ResizeObserver === 'undefined') {
+      if (!node) {
         return;
       }
 

--- a/static/app/components/core/textarea/textarea.tsx
+++ b/static/app/components/core/textarea/textarea.tsx
@@ -1,3 +1,4 @@
+import {useCallback, useState} from 'react';
 import TextareaAutosize, {type TextareaAutosizeProps} from 'react-textarea-autosize';
 import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
@@ -34,13 +35,51 @@ function TextAreaControl({
   ...p
 }: TextAreaProps) {
   return autosize ? (
-    <TextareaAutosize {...p} ref={ref} minRows={rows} maxRows={maxRows} />
+    <AutosizeTextArea {...p} ref={ref} rows={rows} maxRows={maxRows} />
   ) : (
     <textarea ref={ref} {...p} rows={rows} />
   );
 }
 
 TextAreaControl.displayName = 'TextAreaControl';
+
+interface AutosizeTextAreaProps extends Omit<TextAreaProps, 'autosize' | 'size'> {
+  rows: number;
+}
+
+// react-textarea-autosize doesn't observe the element's own width, so
+// container-driven resizes leave the height stale. Force a recompute on
+// border-box width changes (border box ignores internal-scrollbar jitter).
+function AutosizeTextArea({ref, rows, maxRows, ...p}: AutosizeTextAreaProps) {
+  // Storing width in state re-renders on change so react-textarea-autosize recomputes
+  const [, setWidth] = useState<number>();
+
+  const observerRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+
+      if (!node || typeof ResizeObserver === 'undefined') {
+        return;
+      }
+
+      const observer = new ResizeObserver(entries => {
+        const entry = entries[0];
+        const width = entry?.borderBoxSize?.[0]?.inlineSize ?? entry?.contentRect.width;
+        setWidth(width);
+      });
+      observer.observe(node, {box: 'border-box'});
+
+      return () => observer.disconnect();
+    },
+    [ref]
+  );
+
+  return <TextareaAutosize {...p} ref={observerRef} minRows={rows} maxRows={maxRows} />;
+}
 
 const StyledTextArea = styled(TextAreaControl, {
   shouldForwardProp: (p: string) => ['autosize', 'maxRows'].includes(p) || isPropValid(p),

--- a/static/app/components/core/textarea/textarea.tsx
+++ b/static/app/components/core/textarea/textarea.tsx
@@ -1,8 +1,9 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import TextareaAutosize, {type TextareaAutosizeProps} from 'react-textarea-autosize';
 import isPropValid from '@emotion/is-prop-valid';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import {mergeRefs} from '@react-aria/utils';
 
 import {inputStyles, type InputStylesProps} from '@sentry/scraps/input/inputStyles';
 
@@ -54,31 +55,24 @@ function AutosizeTextArea({ref, rows, maxRows, ...p}: AutosizeTextAreaProps) {
   // Storing width in state re-renders on change so react-textarea-autosize recomputes
   const [, setWidth] = useState<number>();
 
-  const observerRef = useCallback(
-    (node: HTMLTextAreaElement | null) => {
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
+  const observerRef = useCallback((node: HTMLTextAreaElement | null) => {
+    if (!node) {
+      return;
+    }
 
-      if (!node) {
-        return;
-      }
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      const width = entry?.borderBoxSize?.[0]?.inlineSize ?? entry?.contentRect.width;
+      setWidth(width);
+    });
+    observer.observe(node, {box: 'border-box'});
 
-      const observer = new ResizeObserver(entries => {
-        const entry = entries[0];
-        const width = entry?.borderBoxSize?.[0]?.inlineSize ?? entry?.contentRect.width;
-        setWidth(width);
-      });
-      observer.observe(node, {box: 'border-box'});
+    return () => observer.disconnect();
+  }, []);
 
-      return () => observer.disconnect();
-    },
-    [ref]
-  );
+  const mergedRef = useMemo(() => mergeRefs(ref, observerRef), [ref, observerRef]);
 
-  return <TextareaAutosize {...p} ref={observerRef} minRows={rows} maxRows={maxRows} />;
+  return <TextareaAutosize {...p} ref={mergedRef} minRows={rows} maxRows={maxRows} />;
 }
 
 const StyledTextArea = styled(TextAreaControl, {


### PR DESCRIPTION
refs DE-1343

| before | after |
|--------|--------|
|<img width="390" height="105" alt="Screenshot 2026-07-01 at 19 23 12" src="https://github.com/user-attachments/assets/852067dc-839e-4046-92eb-f53853a890db" />|<img width="379" height="128" alt="Screenshot 2026-07-01 at 19 22 59" src="https://github.com/user-attachments/assets/2057b073-955a-435d-9d85-aee69ba6d2c0" />| 

## Summary

Autosize textareas (`<InputGroup.TextArea autosize />`) did not resize when their **container** changed width — only when the window resized or the component re-rendered. This was most visible in the Seer Explorer input: dragging the Seer panel/sidebar wider or narrower rewrapped the placeholder/text visually (1 ↔ 2 lines) but left the textarea's pinned height stale, so it looked broken until an unrelated window resize snapped it back.

## Root cause

`react-textarea-autosize` only recomputes height on three triggers:

```js
React.useLayoutEffect(resizeTextarea);   // every React re-render
useWindowResizeListener(resizeTextarea); // window 'resize'
useFontsLoadedListener(resizeTextarea);  // font load
```

It has no `ResizeObserver` on the element itself (a deliberate, long-standing limitation of the library). A container-driven width change fires none of those, so the height never updates.

## Fix

In the shared core `textarea.tsx`, the `autosize` branch now attaches a `ResizeObserver` (via a React 19 callback ref that also handles cleanup) and re-renders when the width changes, letting the library recompute height. The observer watches the **border box**, not the content box: when a recompute lands the text right at a row boundary, an internal scrollbar can briefly appear and shrink the *content* width — observing that would oscillate the height (flickering scrollbar, bouncing between one and two rows). The border box is unaffected by an internal scrollbar, so it only reacts to genuine container/window resizes.

Width is stored in state; setting the same value bails out of the re-render, so it only recomputes on real width changes.

Fixes the behavior for the Seer input and every other `autosize` textarea, since the fix lives in the shared core component.

## Test plan

- [ ] Open Seer Explorer, drag the panel/sidebar narrower and wider — the empty input grows/shrinks between one and two lines in real time (no window nudge needed).
- [ ] Resize the browser window across the row boundary — height settles cleanly with no scrollbar flicker or 1↔2 line oscillation.
- [ ] Typing that wraps still grows the textarea up to `maxRows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
