### PR TITLE
fix(ecosystem): Add select_related to slack activity notification task

### DIFF
--- a/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
+++ b/src/sentry/integrations/slack/tasks/send_notifications_on_activity.py
@@ -28,7 +28,7 @@ def send_activity_notifications_to_slack_threads(activity_id) -> None:
     log_params = {"activity_id": activity_id}
 
     try:
-        activity = Activity.objects.get(pk=activity_id)
+        activity = Activity.objects.select_related("project", "group").get(pk=activity_id)
     except Activity.DoesNotExist:
         _default_logger.info("activity does not exist", extra=log_params)
         return


### PR DESCRIPTION
The activity fetch in `send_activity_notifications_to_slack_threads` was doing a bare `.get()`, so every FK access downstream (project, group, group.organization) triggered a separate query. Adding `select_related("project", "group")` joins them upfront in a single query.

Refs SENTRY-54WV