### PR TITLE
fix(notifications): Record halt on subscription miss rather than erring

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -75,6 +75,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     CIRCUIT_BROKEN = "circuit_broken"
     EMAIL_FAILED = "email_failed"
     APP_DISABLED = "app_disabled"
+    EVENT_NOT_IN_SERVICEHOOK = "event_not_in_servicehook"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -805,18 +805,21 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
             )
             raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_SERVICEHOOK)
         if event not in servicehook.events:
-            lifecycle.add_extras(
-                {
+            # This is an expected condition, not a failure: the app simply did not
+            # subscribe to this event type. Record a halt (metric + log, no Sentry
+            # issue) instead of raising, otherwise every mismatched fan-out creates
+            # a captured exception and floods Sentry with noise.
+            lifecycle.record_halt(
+                halt_reason=SentryAppWebhookHaltReason.EVENT_NOT_IN_SERVICEHOOK,
+                extra={
                     "events": servicehook.events,
                     "event": event,
                     "installation_id": installation.id,
                     "sentry_app_id": installation.sentry_app.id,
                     "sentry_app_events": installation.sentry_app.events,
-                }
+                },
             )
-            raise SentryAppSentryError(
-                message=SentryAppWebhookFailureReason.EVENT_NOT_IN_SERVCEHOOK
-            )
+            return
 
         # TODO(nola): This is disabled for now, because it could potentially affect internal integrations w/ error.created
         # # If the event is error.created & the request is going out to the Org that owns the Sentry App,

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -805,10 +805,8 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
             )
             raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_SERVICEHOOK)
         if event not in servicehook.events:
-            # This is an expected condition, not a failure: the app simply did not
-            # subscribe to this event type. Record a halt (metric + log, no Sentry
-            # issue) instead of raising, otherwise every mismatched fan-out creates
-            # a captured exception and floods Sentry with noise.
+            # `sentry_app.events` can diverge from `servicehook.events`. Its a non-critical failure.
+            # The service-hook register-er chose not to listen for this particular event.
             lifecycle.record_halt(
                 halt_reason=SentryAppWebhookHaltReason.EVENT_NOT_IN_SERVICEHOOK,
                 extra={

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -562,7 +562,9 @@ def workflow_notification(
         data = kwargs.get("data", {})
         data.update({"issue": serialize(issue)})
 
-    send_webhooks(installation=install, event=event, data=data, actor=user)
+    sent = send_webhooks(installation=install, event=event, data=data, actor=user)
+    if not sent:
+        return
 
     analytics_event: analytics.Event | None = None
     if event == SentryAppEventType.ISSUE_ASSIGNED:
@@ -638,7 +640,10 @@ def build_comment_webhook(
             "comment": data.get("comment"),
         }
 
-    send_webhooks(installation=install, event=event, data=payload, actor=user)
+    sent = send_webhooks(installation=install, event=event, data=payload, actor=user)
+    if not sent:
+        return
+
     # `event` is comment.created, comment.updated, or comment.deleted
     analytics_event: CommentEvent | None = None
     if event == SentryAppEventType.COMMENT_CREATED:
@@ -779,14 +784,17 @@ def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
     return sentry_app.is_disabled
 
 
-def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:
+def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> bool:
+    """Dispatch a webhook for the given event. Returns True if a webhook was
+    actually sent, False if delivery was halted (e.g. the app is disabled or the
+    servicehook is not subscribed to the event)."""
     with SentryAppInteractionEvent(
         operation_type=SentryAppInteractionType.SEND_WEBHOOK,
         event_type=SentryAppEventType(event),
     ).capture() as lifecycle:
         if _is_sentry_app_disabled_for_webhooks(installation.sentry_app):
             lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
-            return
+            return False
 
         servicehook: ServiceHook | None = _load_service_hook(
             installation.organization_id, installation.id
@@ -817,7 +825,7 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
                     "sentry_app_events": installation.sentry_app.events,
                 },
             )
-            return
+            return False
 
         # TODO(nola): This is disabled for now, because it could potentially affect internal integrations w/ error.created
         # # If the event is error.created & the request is going out to the Org that owns the Sentry App,
@@ -847,6 +855,7 @@ def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: 
         request_data,
         installation.sentry_app.webhook_url,
     )
+    return True
 
 
 @instrumented_task(

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1676,15 +1676,17 @@ class TestWorkflowNotification(TestCase):
         install = self.create_sentry_app_installation(
             organization=self.project.organization, slug=sentry_app.slug
         )
-        with pytest.raises(SentryAppSentryError):
-            workflow_notification(install.id, self.issue.id, "assigned", self.user.id)
+        # The event not being in the servicehook is an expected condition, so the
+        # task returns cleanly and records a halt (no exception raised).
+        workflow_notification(install.id, self.issue.id, "assigned", self.user.id)
         assert not safe_urlopen.called
 
         # SLO assertions
-        assert_failure_metric(
-            mock_record, SentryAppSentryError(SentryAppWebhookFailureReason.EVENT_NOT_IN_SERVCEHOOK)
+        assert_halt_metric(
+            mock_record=mock_record,
+            error_msg=SentryAppWebhookHaltReason.EVENT_NOT_IN_SERVICEHOOK,
         )
-        # APP_CREATE (success) -> UPDATE_WEBHOOK (success) -> GRANT_EXCHANGER (success) -> PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (failure)
+        # APP_CREATE (success) -> UPDATE_WEBHOOK (success) -> GRANT_EXCHANGER (success) -> PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (halt)
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=5
         )
@@ -1692,7 +1694,7 @@ class TestWorkflowNotification(TestCase):
             mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=4
         )
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=1
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=1
         )
 
 

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1676,8 +1676,6 @@ class TestWorkflowNotification(TestCase):
         install = self.create_sentry_app_installation(
             organization=self.project.organization, slug=sentry_app.slug
         )
-        # The event not being in the servicehook is an expected condition, so the
-        # task returns cleanly and records a halt (no exception raised).
         workflow_notification(install.id, self.issue.id, "assigned", self.user.id)
         assert not safe_urlopen.called
 

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1371,18 +1371,22 @@ class TestSendResourceChangeWebhook(TestCase):
                 eventstream_type=EventStreamEventType.Error.value,
             )
 
-        assert_success_metric(mock_record)
+        # The servicehook is not subscribed to the event, so SEND_WEBHOOK halts
+        # (no exception), and the enclosing PREPARE_WEBHOOK completes successfully.
+        assert_halt_metric(
+            mock_record=mock_record,
+            error_msg=SentryAppWebhookHaltReason.EVENT_NOT_IN_SERVICEHOOK,
+        )
         # APP_CREATE (success) -> UPDATE_WEBHOOK (success) -> GRANT_EXCHANGER (success) ->
-        # PREPARE_WEBHOOK (failure, exception propagates from send_resource_change_webhook) ->
-        # SEND_WEBHOOK (success) x 1 -> SEND_WEBHOOK (failure)
+        # PREPARE_WEBHOOK (success) -> SEND_WEBHOOK (success) -> SEND_WEBHOOK (halt)
         assert_count_of_metric(
             mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=6
         )
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=4
+            mock_record=mock_record, outcome=EventLifecycleOutcome.SUCCESS, outcome_count=5
         )
         assert_count_of_metric(
-            mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=2
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=1
         )
 
 
@@ -1645,6 +1649,12 @@ class TestWorkflowNotification(TestCase):
         install = self.create_sentry_app_installation(
             organization=self.project.organization, slug=sentry_app.slug
         )
+        # Installation creates a servicehook; delete it so we exercise the
+        # genuinely-missing-servicehook path (which raises), not the
+        # event-not-subscribed halt path.
+        with assume_test_silo_mode_of(ServiceHookProject):
+            ServiceHookProject.objects.all().delete()
+            ServiceHook.objects.all().delete()
         with pytest.raises(SentryAppSentryError):
             workflow_notification(install.id, self.issue.id, "assigned", self.user.id)
         assert not safe_urlopen.called
@@ -1664,9 +1674,10 @@ class TestWorkflowNotification(TestCase):
             mock_record=mock_record, outcome=EventLifecycleOutcome.FAILURE, outcome_count=1
         )
 
+    @patch("sentry.sentry_apps.tasks.sentry_apps.analytics.record")
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_does_not_send_if_event_not_in_app_events(
-        self, mock_record: MagicMock, safe_urlopen: MagicMock
+        self, mock_record: MagicMock, mock_analytics_record: MagicMock, safe_urlopen: MagicMock
     ) -> None:
         sentry_app = self.create_sentry_app(
             name="Another App",
@@ -1676,8 +1687,13 @@ class TestWorkflowNotification(TestCase):
         install = self.create_sentry_app_installation(
             organization=self.project.organization, slug=sentry_app.slug
         )
+        # Ignore analytics events recorded during factory setup above.
+        mock_analytics_record.reset_mock()
         workflow_notification(install.id, self.issue.id, "assigned", self.user.id)
         assert not safe_urlopen.called
+
+        # No webhook was delivered, so no analytics event should be recorded.
+        assert not mock_analytics_record.called
 
         # SLO assertions
         assert_halt_metric(


### PR DESCRIPTION
The Sentry issue shows a significant amount of volume over a period greater than 90 days. Its clearly not actionable in an "errors" sense. It seems to be a todo item judging from the comment [here](https://github.com/getsentry/sentry/blob/3d48962b141fa169193d47da6b38950f0fc8342b/src/sentry/receivers/sentry_apps.py#L152-L159). Let's record a halt and exit gracefully.

We should prevent this task from being scheduled in the first place. Can we do the [`servicehook.events`](https://github.com/getsentry/sentry/blob/3d48962b141fa169193d47da6b38950f0fc8342b/src/sentry/sentry_apps/tasks/sentry_apps.py#L807) comparison in the scheduler?

I decided to signal sent state since this is likely what the analytics intend to record (success). I can revert if this isn't wanted.

Fixes SENTRY-5H9Z