### PR TITLE
fix(flags): Loosen statsig webhook deserialization

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -386,15 +386,6 @@ class StatsigEventSerializer(serializers.Serializer):
     eventName = serializers.CharField(required=True)
     timestamp = serializers.CharField(required=True)
     metadata = serializers.DictField(required=True)
-
-    # Statsig sends every event type to the webhook (exposures, config changes,
-    # custom events, etc.) but ``handle`` only keeps ``statsig::config_change``
-    # events. Validation runs over the whole batch before that filter, so this
-    # serializer must tolerate the shapes of the events we discard -- otherwise
-    # a single high-volume exposure event fails the entire batch. Only the
-    # fields ``handle`` actually reads are declared here (undeclared keys are
-    # ignored by DRF), and ``user`` is left unconstrained because exposure
-    # events nest non-string objects under it (customIDs, custom, etc.).
     user = serializers.DictField(required=False, allow_null=True)
     userID = serializers.CharField(required=False, allow_blank=True)
 

--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -387,12 +387,16 @@ class StatsigEventSerializer(serializers.Serializer):
     timestamp = serializers.CharField(required=True)
     metadata = serializers.DictField(required=True)
 
-    user = serializers.DictField(required=False, child=serializers.CharField())
-    userID = serializers.CharField(required=False)
-    value = serializers.CharField(required=False)
-    statsigMetadata = serializers.DictField(required=False)
-    timeUUID = serializers.UUIDField(required=False)
-    unitID = serializers.CharField(required=False)
+    # Statsig sends every event type to the webhook (exposures, config changes,
+    # custom events, etc.) but ``handle`` only keeps ``statsig::config_change``
+    # events. Validation runs over the whole batch before that filter, so this
+    # serializer must tolerate the shapes of the events we discard -- otherwise
+    # a single high-volume exposure event fails the entire batch. Only the
+    # fields ``handle`` actually reads are declared here (undeclared keys are
+    # ignored by DRF), and ``user`` is left unconstrained because exposure
+    # events nest non-string objects under it (customIDs, custom, etc.).
+    user = serializers.DictField(required=False, allow_null=True)
+    userID = serializers.CharField(required=False, allow_blank=True)
 
 
 class StatsigItemSerializer(serializers.Serializer):

--- a/tests/sentry/flags/providers/test_statsig.py
+++ b/tests/sentry/flags/providers/test_statsig.py
@@ -296,15 +296,6 @@ def test_handle_unsupported_events() -> None:
 
 
 def test_handle_exposure_event_with_nested_user() -> None:
-    """Regression test for SENTRY-5J6Z.
-
-    Statsig sends every event type to the webhook, including high-volume
-    exposure events whose ``user`` object nests non-string values and whose
-    ``value``/``timeUUID`` fields don't match the shapes we used to require.
-    These events are discarded by ``handle``, so they must not fail validation
-    for the whole batch. A real ``config_change`` event sent alongside them must
-    still be recorded.
-    """
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {
             "data": [

--- a/tests/sentry/flags/providers/test_statsig.py
+++ b/tests/sentry/flags/providers/test_statsig.py
@@ -295,6 +295,52 @@ def test_handle_unsupported_events() -> None:
     assert len(logs) == 0
 
 
+def test_handle_exposure_event_with_nested_user() -> None:
+    """Regression test for SENTRY-5J6Z.
+
+    Statsig sends every event type to the webhook, including high-volume
+    exposure events whose ``user`` object nests non-string values and whose
+    ``value``/``timeUUID`` fields don't match the shapes we used to require.
+    These events are discarded by ``handle``, so they must not fail validation
+    for the whole batch. A real ``config_change`` event sent alongside them must
+    still be recorded.
+    """
+    logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
+        {
+            "data": [
+                {
+                    "eventName": "statsig::gate_exposure",
+                    "timestamp": 1739400185198,
+                    "metadata": {"gate": "my_gate", "gateValue": "true"},
+                    "user": {
+                        "userID": "user-1",
+                        "customIDs": {"stableID": "abc"},
+                        "custom": {"tier": "gold"},
+                        "statsigEnvironment": {"tier": "production"},
+                    },
+                    "value": "",
+                    "timeUUID": "not-a-valid-uuid",
+                },
+                {
+                    "user": {"name": "johndoe", "email": "john@sentry.io"},
+                    "timestamp": 1739400185233,
+                    "eventName": "statsig::config_change",
+                    "metadata": {
+                        "type": "Gate",
+                        "name": "gate1",
+                        "action": "updated",
+                    },
+                },
+            ]
+        }
+    )
+
+    # The exposure event is discarded; the config_change is still recorded.
+    assert len(logs) == 1
+    assert logs[0]["flag"] == "gate1"
+    assert logs[0]["created_by"] == "john@sentry.io"
+
+
 def test_handle_unsupported_config_changes() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {


### PR DESCRIPTION
Webhook deserialization was too strict and was targeting unnecessary fields.

Fixes SENTRY-5J6Z