### PR TITLE
ref(performance issues): Remove unused `EventPerformanceProblem` class

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -411,15 +411,11 @@ class MNPlusOneDBSpanDetector(PerformanceDetector):
         self.state, performance_problem = self.state.next(span)
         if performance_problem:
             if self.detector_id is not None:
-                if performance_problem.evidence_data is None:
-                    performance_problem.evidence_data = {}
                 performance_problem.evidence_data["detector_id"] = self.detector_id
             self.stored_problems[performance_problem.fingerprint] = performance_problem
 
     def on_complete(self) -> None:
         if performance_problem := self.state.finish():
             if self.detector_id is not None:
-                if performance_problem.evidence_data is None:
-                    performance_problem.evidence_data = {}
                 performance_problem.evidence_data["detector_id"] = self.detector_id
             self.stored_problems[performance_problem.fingerprint] = performance_problem

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import logging
 import random
 from collections.abc import Sequence
@@ -13,16 +12,14 @@ from django.db import router, transaction
 from sentry_sdk.traces import StreamedSpan
 from sentry_sdk.tracing import Span
 
-from sentry import features, nodestore, options, projectoptions
+from sentry import features, options, projectoptions
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.projectoptions.defaults import DEFAULT_PROJECT_PERFORMANCE_DETECTION_SETTINGS
-from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
 from sentry.utils.event import is_event_from_browser_javascript_sdk
 from sentry.utils.event_frames import get_sdk_name
-from sentry.utils.safe import get_path
 from sentry.utils.tracing import set_span_tag, start_span
 from sentry.workflow_engine.models import Detector
 
@@ -125,67 +122,6 @@ WFE_DETECTOR_TYPE_TO_CONFIG_MAPPING: dict[str, DetectorType] = {
 PERFORMANCE_WFE_DETECTOR_TYPES: frozenset[str] = frozenset(
     mapping.wfe_detector_type for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()
 )
-
-
-class EventPerformanceProblem:
-    """
-    Wrapper that binds an Event and PerformanceProblem together and allow the problem to be saved
-    to and fetch from Nodestore
-    """
-
-    def __init__(self, event: Event | GroupEvent, problem: PerformanceProblem):
-        self.event = event
-        self.problem = problem
-
-    @property
-    def identifier(self) -> str:
-        return self.build_identifier(self.event.event_id, self.problem.fingerprint)
-
-    @classmethod
-    def build_identifier(cls, event_id: str, problem_hash: str) -> str:
-        identifier = hashlib.md5(f"{problem_hash}:{event_id}".encode()).hexdigest()
-        return f"p-i-e:{identifier}"
-
-    @property
-    def evidence_hashes(self) -> dict[str, list[str]]:
-        evidence_ids = self.problem.to_dict()
-        evidence_hashes = {}
-
-        spans_by_id = {span["span_id"]: span for span in self.event.data.get("spans", [])}
-
-        trace = get_path(self.event.data, "contexts", "trace")
-        if trace:
-            spans_by_id[trace["span_id"]] = trace
-
-        for key in ["parent", "cause", "offender"]:
-            span_ids = evidence_ids.get(key + "_span_ids", []) or []
-            spans = [spans_by_id.get(id) for id in span_ids]
-            hashes = [span.get("hash") for span in spans if span]
-            evidence_hashes[key + "_span_hashes"] = hashes
-
-        return evidence_hashes
-
-    def save(self) -> None:
-        nodestore.backend.set(self.identifier, self.problem.to_dict())
-
-    @classmethod
-    def fetch(cls, event: Event, problem_hash: str) -> EventPerformanceProblem | None:
-        return cls.fetch_multi([(event, problem_hash)])[0]
-
-    @classmethod
-    def fetch_multi(
-        cls, items: Sequence[tuple[Event | GroupEvent, str]]
-    ) -> list[EventPerformanceProblem | None]:
-        ids = [cls.build_identifier(event.event_id, problem_hash) for event, problem_hash in items]
-        results = nodestore.backend.get_multi(ids)
-        ret: list[EventPerformanceProblem | None] = []
-        for _id, (event, _) in zip(ids, items):
-            result = results.get(_id)
-            if result:
-                ret.append(cls(event, PerformanceProblem.from_dict(result)))
-            else:
-                ret.append(None)
-        return ret
 
 
 # Facade in front of performance detection to limit impact of detection on our events ingestion

--- a/src/sentry/issue_detection/performance_problem.py
+++ b/src/sentry/issue_detection/performance_problem.py
@@ -18,11 +18,7 @@ class PerformanceProblem:
     # The actual bad spans
     offender_span_ids: Sequence[str]
     # Evidence to be used for the group
-    # TODO: make evidence_data and evidence_display required once all detectors have been migrated to platform
-    # We can't make it required until we stop loading these from nodestore via EventPerformanceProblem,
-    # since there's legacy data in there that won't have these fields.
-    # So until we disable transaction based perf issues we'll need to keep this optional.
-    evidence_data: dict[str, Any] | None
+    evidence_data: dict[str, Any]
     # User-friendly evidence to be displayed directly
     evidence_display: Sequence[IssueEvidence]
 
@@ -55,10 +51,10 @@ class PerformanceProblem:
             data["parent_span_ids"],
             data["cause_span_ids"],
             data["offender_span_ids"],
-            data.get("evidence_data", {}),
+            data["evidence_data"],
             [
                 IssueEvidence(evidence["name"], evidence["value"], evidence["important"])
-                for evidence in data.get("evidence_display", [])
+                for evidence in data["evidence_display"]
             ],
         )
 

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -11,7 +11,6 @@ from sentry.issue_detection.detectors.utils import total_span_time
 from sentry.issue_detection.performance_detection import (
     PERFORMANCE_DETECTOR_CONFIG_MAPPINGS,
     SETTINGS_PROJECT_OPTION_KEY,
-    EventPerformanceProblem,
     SettingsMode,
     _detect_performance_problems,
     detect_performance_problems,
@@ -29,7 +28,6 @@ from sentry.issues.grouptype import (
     PerformanceSlowDBQueryGroupType,
     registry,
 )
-from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.issue_detection.event_generators import get_event
@@ -476,107 +474,6 @@ class PerformanceDetectionTest(TestCase):
         # Ensure all other detections are set to false in tags
         pre_checked_keys = ["sdk_name", "is_early_adopter", "browser_name", "uncompressed_assets"]
         assert not any([v for k, v in tags.items() if k not in pre_checked_keys])
-
-
-class EventPerformanceProblemTest(TestCase):
-    def test_save_and_fetch(self) -> None:
-        event = Event(self.project.id, "something")
-        problem = PerformanceProblem(
-            "test",
-            "db",
-            "something bad happened",
-            PerformanceNPlusOneGroupType,
-            ["1"],
-            ["2", "3", "4"],
-            ["4", "5", "6"],
-            {},
-            [],
-        )
-
-        EventPerformanceProblem(event, problem).save()
-        found = EventPerformanceProblem.fetch(event, problem.fingerprint)
-        assert found is not None
-        assert found.problem == problem
-
-    def test_fetch_multi(self) -> None:
-        event_1 = Event(self.project.id, "something")
-        event_1_problems = [
-            PerformanceProblem(
-                "test",
-                "db",
-                "something bad happened",
-                PerformanceNPlusOneGroupType,
-                ["1"],
-                ["2", "3", "4"],
-                ["4", "5", "6"],
-                {},
-                [],
-            ),
-            PerformanceProblem(
-                "test_2",
-                "db",
-                "something horrible happened",
-                PerformanceSlowDBQueryGroupType,
-                ["234"],
-                ["67", "87686", "786"],
-                ["4", "5", "6"],
-                {},
-                [],
-            ),
-        ]
-        event_2 = Event(self.project.id, "something else")
-        event_2_problems = [
-            PerformanceProblem(
-                "event_2_test",
-                "db",
-                "something happened",
-                PerformanceNPlusOneGroupType,
-                ["1"],
-                ["a", "b", "c"],
-                ["d", "e", "f"],
-                {},
-                [],
-            ),
-            PerformanceProblem(
-                "event_2_test_2",
-                "db",
-                "hello",
-                PerformanceSlowDBQueryGroupType,
-                ["234"],
-                ["fdgh", "gdhgf", "gdgh"],
-                ["gdf", "yu", "kjl"],
-                {},
-                [],
-            ),
-        ]
-        all_event_problems = [
-            (event, problem)
-            for event, problems in ((event_1, event_1_problems), (event_2, event_2_problems))
-            for problem in problems
-        ]
-        for event, problem in all_event_problems:
-            EventPerformanceProblem(event, problem).save()
-
-        unsaved_problem = PerformanceProblem(
-            "fake_fingerprint",
-            "db",
-            "hello",
-            PerformanceSlowDBQueryGroupType,
-            ["234"],
-            ["fdgh", "gdhgf", "gdgh"],
-            ["gdf", "yu", "kjl"],
-            {},
-            [],
-        )
-        result = EventPerformanceProblem.fetch_multi(
-            [
-                (event, problem.fingerprint)
-                for event, problem in all_event_problems + [(event, unsaved_problem)]
-            ]
-        )
-        assert [r.problem if r else None for r in result] == [
-            problem for _, problem in all_event_problems
-        ] + [None]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Back when we were storing performance issue data attached to events in nodestore, we used an `EventPerformanceProblem` class to associate performance problems to their corresponding events. However, once we moved performance issues over to issue platform, we were able to [stop using that class](https://github.com/getsentry/sentry/pull/49732). One place we missed in that cleanup, however, was the class's use in the grouping info endpoint, and because the endpoint was still using it, the class itself couldn't be removed. That final use was cleaned up [last summer](https://github.com/getsentry/sentry/pull/97016), so now nothing is using the class.

This PR therefore removes it and its associated tests. It also handles a related TODO (about making certain attributes of the `PerformanceProblem` class required), which noted that it could be done once `EventPerformanceProblem` was no longer being used.