### PR TITLE
feat(quotas): Add value-based equality and ordering to QuotaConfig

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import IntEnum, unique
+from functools import total_ordering
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from django.core.cache import cache
@@ -120,6 +121,7 @@ def build_metric_abuse_quotas() -> list[AbuseQuota]:
     return quotas
 
 
+@total_ordering
 class QuotaConfig:
     """
     Abstract configuration for a quota.
@@ -237,6 +239,46 @@ class QuotaConfig:
 
     def __repr__(self) -> str:
         return str(self.to_json())
+
+    def _comparison_key(self) -> tuple[object, ...]:
+        """A total, deterministic key describing this quota by value.
+
+        ``QuotaConfig`` instances are not persisted and are rebuilt independently on
+        each call, so equality and ordering must be value-based rather than
+        identity-based. ``categories`` is a ``set``, so its members are sorted here to
+        keep the key stable. Optional fields are encoded as ``(present, value)`` pairs
+        so ``None`` never has to be compared against a concrete value.
+        """
+        categories = tuple(sorted(str(category) for category in self.categories))
+        return (
+            self.id is not None,
+            "" if self.id is None else str(self.id),
+            int(self.scope) if self.scope is not None else -1,
+            self.scope_id is not None,
+            self.scope_id or "",
+            categories,
+            self.limit is not None,
+            self.limit if self.limit is not None else 0,
+            self.window is not None,
+            self.window if self.window is not None else 0,
+            self.reason_code is not None,
+            self.reason_code or "",
+            self.namespace is not None,
+            self.namespace or "",
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, QuotaConfig):
+            return NotImplemented
+        return self._comparison_key() == other._comparison_key()
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, QuotaConfig):
+            return NotImplemented
+        return self._comparison_key() < other._comparison_key()
+
+    def __hash__(self) -> int:
+        return hash(self._comparison_key())
 
 
 class RateLimit:

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -116,6 +116,66 @@ def test_quota_config_repr() -> None:
     assert repr(quota) == str(quota.to_json())
 
 
+def test_quota_config_equality_is_value_based() -> None:
+    a = QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast")
+    b = QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast")
+    c = QuotaConfig(id="o", limit=4712, window=42, reason_code="not_so_fast")
+
+    assert a is not b
+    assert a == b
+    assert a != c
+
+
+def test_quota_config_equality_ignores_category_order() -> None:
+    a = QuotaConfig(
+        limit=0,
+        categories=[DataCategory.ERROR, DataCategory.TRANSACTION],
+        reason_code="go_away",
+    )
+    b = QuotaConfig(
+        limit=0,
+        categories=[DataCategory.TRANSACTION, DataCategory.ERROR],
+        reason_code="go_away",
+    )
+
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_quota_config_is_hashable_by_value() -> None:
+    a = QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast")
+    b = QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast")
+
+    assert len({a, b}) == 1
+
+
+def test_quota_config_not_equal_to_other_types() -> None:
+    quota = QuotaConfig(limit=0, reason_code="go_away")
+
+    assert quota != object()
+    assert (quota == "not a quota") is False
+
+
+def test_quota_config_total_ordering() -> None:
+    a = QuotaConfig(id="a", limit=1, window=60, reason_code="go_away")
+    b = QuotaConfig(id="b", limit=1, window=60, reason_code="go_away")
+
+    assert a < b
+    assert b > a
+    assert a <= b
+    assert sorted([b, a]) == [a, b]
+
+
+def test_quota_config_sort_is_deterministic_regardless_of_input_order() -> None:
+    forward = [QuotaConfig(id=i, limit=1, window=60, reason_code="go_away") for i in "abc"]
+    backward = [QuotaConfig(id=i, limit=1, window=60, reason_code="go_away") for i in "cba"]
+
+    # Same quotas assembled in different orders sort to the same canonical list,
+    # so callers can compare quota lists with ``sorted(a) == sorted(b)``.
+    assert sorted(forward) == sorted(backward)
+    assert forward != backward
+
+
 def test_seat_assignable_must_have_reason() -> None:
     with pytest.raises(ValueError):
         SeatAssignmentResult(assignable=False)


### PR DESCRIPTION
`QuotaConfig` now compares and hashes by value and defines a total ordering.

`QuotaConfig` instances are not persisted; they are rebuilt independently on each call. With only identity equality, two lists holding the same quotas never compared equal, and with no ordering, callers could not reduce a quota list to a canonical form. A single `_comparison_key` (with `categories` sorted, since it is a set) now backs `__eq__`, `__lt__`, and `__hash__` via `@total_ordering`.

This is the Sentry half of a two-part change and is purely additive — no existing caller's behavior changes. It lets callers that compare quota lists — notably the getsentry billing-platform shadow comparison — use `sorted(a) == sorted(b)` without being tripped up by the order in which quotas happen to be assembled. The follow-up getsentry PR depends on this.