### PR TITLE
ref(devenv): Merge all taskbroker pools into one

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -84,20 +84,8 @@ x-sentry-service-config:
         repo_name: chartcuterie
         branch: master
         repo_link: https://github.com/getsentry/chartcuterie.git
-    taskbroker: &taskbroker
+    taskbroker:
       description: Service used to process asynchronous tasks
-      remote:
-        repo_name: taskbroker
-        branch: main
-        repo_link: https://github.com/getsentry/taskbroker.git
-        mode: containerized
-    # ingest-profiles runs taskbroker in passthrough mode (STREAM-1041). Ideally
-    # this would be a remote dependency like taskbroker, but devservices doesn't
-    # support passing custom environment variables to remote services (DI-1956).
-    ingest-profiles:
-      description: Kafka consumer for processing profiling data via taskbroker passthrough mode
-    subscriptions:
-      description: Kafka consumer for processing subscription results via taskbroker passthrough mode
     memcached:
       description: Memcached used for caching
     spotlight:
@@ -137,12 +125,8 @@ x-sentry-service-config:
       description: Dedicated taskworker for eval issue-side tasks
     taskworker-evals-relay:
       description: Dedicated taskworker for eval Relay project config tasks
-    taskworker-ingest-profiles:
-      description: Taskworker for ingest-profiles passthrough broker
     taskworker-scheduler:
       description: Task scheduler that can spawn tasks based on their schedules
-    taskworker-subscriptions:
-      description: Taskworker for subscriptions passthrough broker
     # Kafka consumer services for event ingestion
     ingest-events:
       description: Kafka consumer for processing ingested events
@@ -215,8 +199,6 @@ x-sentry-service-config:
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
         post-process-forwarder-issue-platform,
-        subscriptions,
-        taskworker-subscriptions,
         process-spans,
         ingest-occurrences,
         process-segments,
@@ -245,11 +227,9 @@ x-sentry-service-config:
         spotlight,
         ingest-events,
         ingest-transactions,
-        ingest-profiles,
         ingest-occurrences,
         taskbroker,
         taskworker,
-        taskworker-ingest-profiles,
         post-process-forwarder-errors,
         post-process-forwarder-transactions,
       ]
@@ -338,7 +318,6 @@ x-sentry-service-config:
         ingest-metrics,
         ingest-monitors,
         ingest-occurrences,
-        ingest-profiles,
         ingest-transactions,
         ingest-replay-recordings,
         monitors-clock-tasks,
@@ -357,7 +336,6 @@ x-sentry-service-config:
         spotlight,
         taskbroker,
         taskworker,
-        taskworker-ingest-profiles,
         vroom,
       ]
     full:
@@ -377,7 +355,6 @@ x-sentry-service-config:
         monitors-clock-tick,
         monitors-clock-tasks,
         monitors-incident-occurrences,
-        ingest-profiles,
         ingest-occurrences,
         objectstore,
         process-spans,
@@ -392,7 +369,6 @@ x-sentry-service-config:
         post-process-forwarder-issue-platform,
         taskbroker,
         taskworker,
-        taskworker-ingest-profiles,
         taskworker-scheduler,
       ]
 
@@ -411,10 +387,6 @@ x-programs:
     command: sentry run taskworker --namespace relay --concurrency 1 --processing-pool-name eval-relay
   taskworker-scheduler:
     command: sentry run taskworker-scheduler
-  taskworker-ingest-profiles:
-    command: sentry run taskworker --rpc-host localhost:50052 --namespace ingest.profiling.passthrough
-  taskworker-subscriptions:
-    command: sentry run taskworker --rpc-host localhost:50053 --processing-pool-name subscriptions
   ingest-events:
     command: sentry run consumer ingest-events --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   ingest-attachments:
@@ -551,57 +523,13 @@ services:
     labels:
       - orchestrator=devservices
     restart: unless-stopped
-  # Taskbroker in passthrough mode for ingest-profiles topic (STREAM-1041).
-  # This is a local service rather than a remote dependency because devservices
-  # doesn't support passing custom environment variables to remote services (DI-1956).
-  ingest-profiles:
-    image: ghcr.io/getsentry/taskbroker:nightly
-    environment:
-      # Multi-topic/cluster config via env vars: nested keys use "__", and
-      # figment lowercases each segment, so topic/cluster names can only use
-      # underscores (not hyphens) when set this way.
-      TASKBROKER_KAFKA_CLUSTERS__DEFAULT__ADDRESS: 'kafka-kafka-1:9093'
-      # Consumed topic, in raw (passthrough) mode. Raw mode is configured per
-      # topic via the topic's `raw` block.
-      TASKBROKER_KAFKA_TOPICS__PROFILES__CLUSTER: 'default'
-      TASKBROKER_KAFKA_TOPICS__PROFILES__CONSUMER_GROUP: 'ingest-profiles'
-      TASKBROKER_KAFKA_TOPICS__PROFILES__RAW__NAMESPACE: 'ingest.profiling.passthrough'
-      TASKBROKER_KAFKA_TOPICS__PROFILES__RAW__APPLICATION: 'sentry'
-      TASKBROKER_KAFKA_TOPICS__PROFILES__RAW__TASKNAME: 'sentry.profiles.task.process_profile_from_kafka'
-      TASKBROKER_KAFKA_TOPICS__PROFILES__RAW__PROCESSING_DEADLINE_DURATION: '30'
-      # A raw topic's messages aren't activations, so retries (which are
-      # activation-encoded) cannot loop back into `profiles`; a separate retry
-      # topic is mandatory. Send them to the main `taskworker` topic so the
-      # default taskbroker picks them up instead of standing up another broker.
-      TASKBROKER_KAFKA_RETRY_TOPIC: 'taskworker'
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER__CLUSTER: 'default'
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER__CONSUMER_GROUP: 'ingest-profiles'
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER__PRODUCE_ONLY: 'true'
-      TASKBROKER_KAFKA_DEADLETTER_TOPIC: 'taskworker_dlq'
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__CLUSTER: 'default'
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__CONSUMER_GROUP: 'ingest-profiles'
-      TASKBROKER_KAFKA_TOPICS__TASKWORKER_DLQ__PRODUCE_ONLY: 'true'
-      TASKBROKER_CREATE_MISSING_TOPICS: 'true'
-      # TODO(STREAM-1041): Remove debug logging once passthrough mode is stable
-      TASKBROKER_LOG_FILTER: 'debug'
-    ports:
-      - '127.0.0.1:50052:50051'
-    networks:
-      - devservices
-    extra_hosts:
-      - host.docker.internal:host-gateway
-    labels:
-      - orchestrator=devservices
-    restart: unless-stopped
-    platform: linux/amd64
-  # Taskbroker in passthrough mode for subscription result topics.
-  subscriptions:
+  taskbroker:
     image: ghcr.io/getsentry/taskbroker:nightly
     command: ['/opt/taskbroker', '--config', '/etc/taskbroker/config.yml']
     ports:
-      - '127.0.0.1:50053:50051'
+      - '127.0.0.1:50051:50051'
     volumes:
-      - ./config/taskbroker-subscriptions.yml:/etc/taskbroker/config.yml
+      - ./config/taskbroker.yml:/etc/taskbroker/config.yml
     networks:
       - devservices
     extra_hosts:

--- a/devservices/config/taskbroker.yml
+++ b/devservices/config/taskbroker.yml
@@ -1,13 +1,39 @@
+# Single taskbroker pool for devenv. All topics — the regular taskworker
+# topics, the ingest-profiles passthrough topic, and the subscription-result
+# passthrough topics — are consumed by this one broker so that a single
+# taskworker pool processes everything (mirrors self-hosted).
+#
+# Topics live in this config file (rather than env vars on the service) because
+# env-var config keys can't contain hyphens, and several topic names do.
 kafka_deadletter_topic: taskworker_dlq
 kafka_retry_topic: taskworker
 create_missing_topics: true
-log_filter: debug
 
 kafka_clusters:
   default:
     address: kafka-kafka-1:9093
 
 kafka_topics:
+  taskworker:
+    cluster: default
+    consumer_group: taskworker
+  taskworker_dlq:
+    cluster: default
+    consumer_group: taskworker
+    produce_only: true
+
+  # ingest-profiles passthrough (STREAM-1041). Raw Kafka messages on the
+  # profiles topic are turned into activations for the profile-processing task.
+  profiles:
+    cluster: default
+    consumer_group: ingest-profiles
+    raw:
+      namespace: ingest.profiling.passthrough
+      application: sentry
+      taskname: sentry.profiles.task.process_profile_from_kafka
+      processing_deadline_duration: 30
+
+  # Subscription-result passthrough (STREAM-1207).
   events-subscription-results:
     cluster: default
     consumer_group: sentry-consumer
@@ -48,11 +74,3 @@ kafka_topics:
       application: sentry
       taskname: sentry.snuba.query_subscriptions.run.process_eap_subscription_from_kafka
       processing_deadline_duration: 60
-  taskworker:
-    cluster: default
-    consumer_group: sentry-consumer
-    produce_only: true
-  taskworker_dlq:
-    cluster: default
-    consumer_group: sentry-consumer
-    produce_only: true


### PR DESCRIPTION
ref STREAM-1241

## What

Devenv ran three separate taskbroker pools — the main `taskbroker` plus dedicated passthrough brokers for `ingest-profiles` and `subscriptions` (subscription results) — each on its own port with its own dedicated taskworker.

This consolidates them into a **single taskbroker** consuming every topic, served by the single `taskworker` pool (mirrors self-hosted).

## How

- `taskbroker` becomes a local devservices service (was a remote containerized dependency) mounting a config file that lists all topics. It uses the same `ghcr.io/getsentry/taskbroker:nightly` image the remote dependency was pinned to, so nothing built from source changes. Listing topics in a file (rather than env vars) lets hyphenated topic names work — env-var config keys can't express them, which is why the passthrough brokers were split out originally.
- New `devservices/config/taskbroker.yml` is the union of the old profiles env-var config and `taskbroker-subscriptions.yml`: `taskworker`, `taskworker_dlq`, `profiles`, and the five `*-subscription-results` topics.
- Removed the `ingest-profiles` / `subscriptions` broker services, the `taskworker-ingest-profiles` / `taskworker-subscriptions` programs, and all their references in the modes.
- Deleted `devservices/config/taskbroker-subscriptions.yml` (folded into the combined config).

## Notes

- No `devserver.py` change needed — the honcho path only starts `taskworker`/`taskworker-scheduler` (port 50051), and `SENTRY_EXTRA_WORKERS` is empty by default.
- The remote `taskbroker` dependency used to pull in Kafka transitively; a local service doesn't. Verified every mode listing `taskbroker` also lists `snuba`, which brings up Kafka.

## Testing

Boot a mode that exercises both passthrough paths (e.g. `tracing` or `full`) and confirm profiles and subscription results still process through the single broker.