### PR TITLE
ref(dropdownMenu): Unify submenu props and allow positioning

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -161,7 +161,7 @@ function getArchiveActions({
     {
       key: 'for',
       label: t('For\u2026'),
-      isSubmenu: true,
+      submenu: true,
       children: [
         ...IGNORE_DURATIONS.map(duration => ({
           key: `for-${duration}`,
@@ -178,7 +178,7 @@ function getArchiveActions({
     {
       key: 'until-reoccur',
       label: t('Until this occurs again\u2026'),
-      isSubmenu: true,
+      submenu: true,
       children: [
         ...IGNORE_COUNTS.map(count => ({
           key: `until-reoccur-${count}-times`,
@@ -186,7 +186,7 @@ function getArchiveActions({
             count === 1
               ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
               : tn('%s time\u2026', '%s times\u2026', count),
-          isSubmenu: true,
+          submenu: true,
           children: [
             {
               key: `until-reoccur-${count}-times-from-now`,
@@ -214,7 +214,7 @@ function getArchiveActions({
     {
       key: 'until-affect',
       label: t('Until this affects an additional\u2026'),
-      isSubmenu: true,
+      submenu: true,
       children: [
         ...IGNORE_COUNTS.map(count => ({
           key: `until-affect-${count}-users`,
@@ -222,7 +222,7 @@ function getArchiveActions({
             count === 1
               ? t('one user\u2026') // This is intentional as unbalanced string formatters are problematic
               : tn('%s user\u2026', '%s users\u2026', count),
-          isSubmenu: true,
+          submenu: true,
           children: [
             {
               key: `until-affect-${count}-users-from-now`,

--- a/static/app/components/dropdownMenu/index.spec.tsx
+++ b/static/app/components/dropdownMenu/index.spec.tsx
@@ -140,7 +140,7 @@ describe('DropdownMenu', () => {
           {
             key: 'item1',
             label: 'Item',
-            isSubmenu: true,
+            submenu: true,
             children: [
               {
                 key: 'subitem',
@@ -234,7 +234,7 @@ describe('DropdownMenu', () => {
           {
             key: 'item1',
             label: 'Item',
-            isSubmenu: true,
+            submenu: true,
             children: [
               {
                 key: 'subitem',

--- a/static/app/components/dropdownMenu/index.stories.tsx
+++ b/static/app/components/dropdownMenu/index.stories.tsx
@@ -162,8 +162,7 @@ export default Storybook.story('DropdownMenu', story => {
         key: 'export',
         label: 'Export',
         leadingItems: <IconDownload size="sm" />,
-        isSubmenu: true,
-        submenuTitle: 'Export Options',
+        submenu: {title: 'Export Options'},
         children: [
           {
             key: 'export-json',
@@ -194,9 +193,14 @@ export default Storybook.story('DropdownMenu', story => {
       <Fragment>
         <p>
           Menu items can trigger submenus by setting{' '}
-          <Storybook.JSXProperty name="isSubmenu" value="true" /> and providing{' '}
+          <Storybook.JSXProperty name="submenu" value="true" /> and providing{' '}
           <Storybook.JSXProperty name="children" value={[]} />. Submenus are opened on
-          hover or arrow key navigation.
+          hover or arrow key navigation. Pass an object like{' '}
+          <Storybook.JSXProperty
+            name="submenu"
+            value={{title: 'Title', position: 'left-start'}}
+          />{' '}
+          to set the submenu header or override where it opens.
         </p>
         <Storybook.SideBySide>
           <DropdownMenu triggerLabel="With Submenu" items={items} />

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -87,7 +87,7 @@ export interface DropdownMenuProps
   /**
    * Items to display inside the dropdown menu. If the item has a `children`
    * prop, it will be rendered as a menu section. If it has a `children` prop
-   * and its `isSubmenu` prop is true, it will be rendered as a submenu.
+   * and its `submenu` prop is set, it will be rendered as a submenu.
    */
   items: MenuItemProps[];
   /**
@@ -277,7 +277,7 @@ function DropdownMenu({
         {(item: MenuItemProps) => {
           const {onAction: _onAction, ...itemProps} = item;
 
-          if (item.children && item.children.length > 0 && !item.isSubmenu) {
+          if (item.children && item.children.length > 0 && !item.submenu) {
             return (
               <Section key={item.key} title={item.label} items={item.children}>
                 {sectionItem => {

--- a/static/app/components/dropdownMenu/item.tsx
+++ b/static/app/components/dropdownMenu/item.tsx
@@ -11,6 +11,7 @@ import type {MenuListItemProps} from '@sentry/scraps/menuListItem';
 import {MenuListItem} from '@sentry/scraps/menuListItem';
 
 import {IconChevron} from 'sentry/icons';
+import type {UseOverlayProps} from 'sentry/utils/useOverlay';
 import {usePrevious} from 'sentry/utils/usePrevious';
 
 import {DropdownMenuContext} from './list';
@@ -23,7 +24,7 @@ export interface MenuItemProps extends MenuListItemProps {
   /**
    * Sub-items that are nested inside this item. By default, sub-items are
    * rendered collectively as menu sections inside the current menu. If
-   * `isSubmenu` is true, then they will be rendered together in a sub-menu.
+   * `submenu` is set, then they will be rendered together in a sub-menu.
    */
   children?: MenuItemProps[];
   /**
@@ -45,11 +46,6 @@ export interface MenuItemProps extends MenuListItemProps {
    */
   hidden?: boolean;
   /**
-   * Whether this menu item is a trigger for a nested sub-menu. Only works
-   * when `children` is also defined.
-   */
-  isSubmenu?: boolean;
-  /**
    * Menu item label. Should preferably be a string. If not, provide a `textValue` prop
    * to enable search & keyboard select.
    */
@@ -60,10 +56,12 @@ export interface MenuItemProps extends MenuListItemProps {
    */
   onAction?: () => void;
   /**
-   * Passed as the `menuTitle` prop onto the associated sub-menu (applicable
-   * if `children` is defined and `isSubmenu` is true)
+   * Renders this item as a trigger for a nested sub-menu (only works when
+   * `children` is also defined). Pass `true` for the defaults, or an object to
+   * customize the sub-menu: `title` is shown as its header, and `position`
+   * overrides where it opens relative to this item (defaults to `right-start`).
    */
-  submenuTitle?: string;
+  submenu?: boolean | {position?: UseOverlayProps['position']; title?: string};
   /**
    * A plain text version of the `label` prop if the label is not a string. Used for
    * filtering and keyboard select (quick-focusing on options by typing the first letter).
@@ -121,12 +119,13 @@ export function DropdownMenuItem({
     onAction,
     to,
     label,
-    isSubmenu,
+    submenu,
     trailingItems,
     externalHref,
     closeOnSelect: itemCloseOnSelect,
     ...itemProps
   } = node.value ?? {};
+  const isSubmenu = !!submenu;
   const {size} = node.props;
   const {rootOverlayState} = useContext(DropdownMenuContext);
   const isLink = to || externalHref;

--- a/static/app/components/dropdownMenu/list.tsx
+++ b/static/app/components/dropdownMenu/list.tsx
@@ -122,7 +122,7 @@ export function DropdownMenuList({
     // logically follows from the tree-like structure and single-selection
     // nature of menus.
     const isLeafSubmenu = !stateCollection.some(node => {
-      const isSection = node.hasChildNodes && !node.value?.isSubmenu;
+      const isSection = node.hasChildNodes && !node.value?.submenu;
       // A submenu with key [key] is expanded if
       // state.selectionManager.isSelected([key]) = true
       return isSection
@@ -166,6 +166,9 @@ export function DropdownMenuList({
       return null;
     }
 
+    const submenuConfig = node.value.submenu;
+    const submenuOptions = typeof submenuConfig === 'object' ? submenuConfig : {};
+
     const trigger = (triggerProps: any) => (
       <DropdownMenuItem
         renderAs="div"
@@ -192,11 +195,11 @@ export function DropdownMenuList({
         onClose={onClose}
         closeOnSelect={closeOnSelect}
         disableTextSelection={disableTextSelection}
-        menuTitle={node.value.submenuTitle}
+        menuTitle={submenuOptions.title}
         shouldCloseOnBlur={false}
         preventOverflowOptions={{boundary: document.body, altAxis: true}}
         renderWrapAs="li"
-        position="right-start"
+        position={submenuOptions.position ?? 'right-start'}
         offset={-4}
         size={size}
       />
@@ -219,7 +222,7 @@ export function DropdownMenuList({
           </DropdownMenuSection>
         );
       } else {
-        itemToRender = node.value?.isSubmenu
+        itemToRender = node.value?.submenu
           ? renderItemWithSubmenu(node)
           : renderItem(node);
       }

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -323,7 +323,7 @@ export function getMenuOptions(
       menuOptions.push({
         key: 'create-alert',
         label: newAlertLabel,
-        isSubmenu: true,
+        submenu: true,
         children: alertMenuOptions,
       });
     }

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
@@ -116,7 +116,7 @@ export function InstrumentationGuide() {
       onAction: () => setPlatformGuide(c.platform, g.key),
     }));
 
-    return {...item, children, isSubmenu: true};
+    return {...item, children, submenu: true};
   });
 
   const genericItems: MenuItemProps = {

--- a/static/app/views/explore/components/chartContextMenu.tsx
+++ b/static/app/views/explore/components/chartContextMenu.tsx
@@ -104,7 +104,7 @@ export function ChartContextMenu({
         label: newAlertLabel,
         children: alertsUrls ?? [],
         disabled: !alertsUrls || alertsUrls.length === 0,
-        isSubmenu: true,
+        submenu: true,
       });
     }
 

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -162,7 +162,7 @@ export function useSaveAsItems({
       textValue: newAlertLabel,
       children: alertsUrls ?? [],
       disabled: !alertsUrls || alertsUrls.length === 0,
-      isSubmenu: true,
+      submenu: true,
     };
   }, [aggregates, interval, organization, pageFilters, project, search]);
 
@@ -237,7 +237,7 @@ export function useSaveAsItems({
       textValue: t('Dashboard widget'),
       children: dashboardsUrls,
       disabled: !dashboardsUrls || dashboardsUrls.length === 0,
-      isSubmenu: true,
+      submenu: true,
     };
   }, [
     aggregates,

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -173,7 +173,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
         textValue: newAlertLabel,
         children: alertsUrls,
         disabled: alertsUrls.length === 0,
-        isSubmenu: true,
+        submenu: true,
       },
     ];
   }, [metricQueries, organization, project, pageFilters, options.interval]);
@@ -184,7 +184,7 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
         key: 'add-to-dashboard',
         label: t('Dashboard widget'),
         textValue: t('Dashboard widget'),
-        isSubmenu: true,
+        submenu: true,
         children: [
           ...(metricQueries.length > 1
             ? [

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -169,7 +169,7 @@ export function ToolbarSaveAs() {
     textValue: newAlertLabel,
     children: alertsUrls ?? [],
     disabled: !alertsUrls || alertsUrls.length === 0,
-    isSubmenu: true,
+    submenu: true,
   });
 
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
@@ -204,7 +204,7 @@ export function ToolbarSaveAs() {
   items.push({
     key: 'add-to-dashboard',
     textValue: t('Dashboard widget'),
-    isSubmenu: chartOptions.length > 1 ? true : false,
+    submenu: chartOptions.length > 1 ? true : false,
     label: (
       <Feature
         overrideName="feature-disabled:dashboards-edit"

--- a/static/app/views/insights/common/components/chartActionDropdown.tsx
+++ b/static/app/views/insights/common/components/chartActionDropdown.tsx
@@ -155,7 +155,7 @@ export function BaseChartActionDropdown({
       disabled: !hasDashboardEdit,
     };
     if (Array.isArray(addToDashboardOptions)) {
-      menuOption.isSubmenu = true;
+      menuOption.submenu = true;
       menuOption.children = addToDashboardOptions.map((option, idx) => ({
         key: `${option.chartType}-${idx}-${option.yAxes}`,
         label: option.widgetName,
@@ -164,7 +164,7 @@ export function BaseChartActionDropdown({
         },
       }));
     } else {
-      menuOption.isSubmenu = false;
+      menuOption.submenu = false;
       menuOption.onAction = () => {
         addToSpanDashboard(addToDashboardOptions);
       };
@@ -180,7 +180,7 @@ export function BaseChartActionDropdown({
     menuOptions.push({
       key: 'create-alert',
       label: newAlertLabel,
-      isSubmenu: true,
+      submenu: true,
       children: alertMenuOptions.map(option => ({
         ...option,
         onAction: () => {

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -47,7 +47,7 @@ export function PrimaryNavigationHelpMenu() {
     {
       key: 'resources',
       label: t('Resources'),
-      isSubmenu: true,
+      submenu: true,
       leadingItems: (
         <MenuIcon>
           <IconQuestion />
@@ -110,7 +110,7 @@ export function PrimaryNavigationHelpMenu() {
     {
       key: 'community',
       label: t('Community'),
-      isSubmenu: true,
+      submenu: true,
       leadingItems: (
         <MenuIcon>
           <IconGroup />
@@ -142,7 +142,7 @@ export function PrimaryNavigationHelpMenu() {
     {
       key: 'legal',
       label: t('Legal'),
-      isSubmenu: true,
+      submenu: true,
       hidden: !privacyUrl && !termsUrl,
       leadingItems: (
         <MenuIcon>

--- a/static/app/views/navigation/primary/organizationDropdown.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.tsx
@@ -157,7 +157,7 @@ export function OrganizationDropdown(props: OrganizationDropdownProps) {
             {
               key: 'switch-organization',
               label: t('Switch Organization'),
-              isSubmenu: true,
+              submenu: true,
               hidden: config.singleOrganization || isDemoModeActive(),
               children: [
                 {


### PR DESCRIPTION
## Summary

Unifies the `DropdownMenu` submenu item props into a single `submenu` prop and adds
control over where a submenu opens.

Previously a submenu was configured with two separate props (`isSubmenu: boolean` +
`submenuTitle: string`), and its placement was **hardcoded** to `right-start` deep inside
`dropdownMenu/list.tsx`. In tight, edge-anchored menus (e.g. a right-aligned overflow menu in
a narrow panel) that fixed side has nowhere to open, so Popper flips/shifts it into awkward
positions with no way for callers to influence it.

The new API:

```ts
submenu?: boolean | {position?: UseOverlayProps['position']; title?: string};
```

- `submenu: true` — submenu with defaults (opens `right-start`, as before)
- `submenu: {title: 'Export Options'}` — sets the submenu header (replaces `submenuTitle`)
- `submenu: {position: 'left-start'}` — **overrides where the submenu opens**

## Changes

- `dropdownMenu/item.tsx`, `index.tsx`, `list.tsx`: replace `isSubmenu`/`submenuTitle` with the
  unified `submenu` prop; thread the optional `position` through to the submenu overlay
  (defaulting to `right-start`).
- Migrate all call sites (`archive`, chart/log/metric "Save as", nav dropdowns, dashboards
  widget menu, cron instrumentation guide) to the new prop.
- Update the story and the DropdownMenu spec.

No behavior change for existing menus — positioning is opt-in.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint:js` ✅
- DropdownMenu spec + affected call-site specs pass ✅

> [!NOTE]
> jsdom has no layout engine, so actual submenu placement isn't asserted by tests — worth a
> quick visual check that `position` overrides land where expected.
