### PR TITLE
ref(devenv): Run ingest-replay-recordings via taskbroker raw mode

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,6 +121,7 @@
 ## Dev
 /devenv/                                                 @getsentry/owners-sentry-dev @getsentry/dev-infra
 /devservices/                                            @getsentry/owners-sentry-dev @getsentry/dev-infra
+/devservices/config/taskbroker.yml                       @getsentry/streaming-platform
 /.github/                                                @getsentry/owners-sentry-dev
 /config/hooks/                                           @getsentry/owners-sentry-dev
 /scripts/                                                @getsentry/owners-sentry-dev

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -140,8 +140,6 @@ x-sentry-service-config:
       description: Kafka consumer for processing issue occurrences
     ingest-feedback-events:
       description: Kafka consumer for processing user feedback events
-    ingest-replay-recordings:
-      description: Kafka consumer for processing ingested replay recordings
     # Monitor-related services
     monitors-clock-tick:
       description: Kafka consumer for monitor clock ticks
@@ -239,7 +237,6 @@ x-sentry-service-config:
         snuba,
         relay,
         spotlight,
-        ingest-replay-recordings,
         ingest-events,
         ingest-transactions,
         taskbroker,
@@ -319,7 +316,6 @@ x-sentry-service-config:
         ingest-monitors,
         ingest-occurrences,
         ingest-transactions,
-        ingest-replay-recordings,
         monitors-clock-tasks,
         monitors-clock-tick,
         monitors-incident-occurrences,
@@ -351,7 +347,6 @@ x-sentry-service-config:
         ingest-transactions,
         ingest-monitors,
         ingest-feedback-events,
-        ingest-replay-recordings,
         monitors-clock-tick,
         monitors-clock-tasks,
         monitors-incident-occurrences,
@@ -423,8 +418,6 @@ x-programs:
     command: sentry run consumer post-process-forwarder-issue-platform --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
   ingest-feedback-events:
     command: sentry run consumer ingest-feedback-events --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
-  ingest-replay-recordings:
-    command: sentry run consumer ingest-replay-recordings --consumer-group=sentry-consumer --auto-offset-reset=latest --no-strict-offset-reset
 services:
   bigtable:
     image: 'ghcr.io/getsentry/cbtemulator:d28ad6b63e461e8c05084b8c83f1c06627068c04'

--- a/devservices/config/taskbroker.yml
+++ b/devservices/config/taskbroker.yml
@@ -74,3 +74,15 @@ kafka_topics:
       application: sentry
       taskname: sentry.snuba.query_subscriptions.run.process_eap_subscription_from_kafka
       processing_deadline_duration: 60
+
+  # ingest-replay-recordings raw mode (STREAM-1287). Raw Kafka messages on the
+  # recordings topic are turned into activations for the recording task, so no
+  # dedicated Kafka consumer is needed.
+  ingest-replay-recordings:
+    cluster: default
+    consumer_group: sentry-consumer
+    raw:
+      namespace: replays.raw
+      application: sentry
+      taskname: sentry.replays.tasks.process_replay_recording
+      processing_deadline_duration: 90


### PR DESCRIPTION
ref STREAM-1287

## What

Move `ingest-replay-recordings` in devenv from a dedicated Kafka consumer to the single taskbroker in raw mode, following the same pattern as ingest-profiles and the subscription-result topics.

## How

- Add the `ingest-replay-recordings` topic to `devservices/config/taskbroker.yml` in raw mode. Raw Kafka messages are turned into activations for `sentry.replays.tasks.process_replay_recording` (namespace `replays.raw`, `processing_deadline_duration: 90` — matching the task's `@instrumented_task` definition) and handled by the existing taskworker pool.
- Remove the `ingest-replay-recordings` Kafka consumer: its dependency entry, its `x-programs` command, and its references in the `replay`, `ingest-all`, and `full` modes. The `taskbroker` + `taskworker` already present in each of those modes now cover it.

## Notes

- No `devserver.py` change needed — the replay consumer was never in the honcho consumer list, and `DEVSERVER_START_KAFKA_CONSUMERS` is empty by default.
- All three modes that referenced the consumer already include `taskbroker` and `taskworker` (verified).

## Testing

Boot the `replay` (or `full`) mode and confirm replay recordings still process through the taskbroker.