### PR TITLE
fix(issues): Make activity drawer easier to open

### DIFF
--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -100,6 +100,8 @@ describe('BreadcrumbsDataSection', () => {
     expect(screen.getByText('May 21, 2019 6:00:48.760 PM UTC')).toBeInTheDocument();
     expect(screen.queryByText('-1min 2ms')).not.toBeInTheDocument();
 
+    expect(screen.getByRole('button', {name: 'Expand'})).toBeInTheDocument();
+
     const timeControl = screen.getByRole('button', {
       name: 'Change Time Format for Breadcrumbs',
     });

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.tsx
@@ -190,7 +190,7 @@ export function BreadcrumbsDataSection({
               onClick={() => (isDrawerOpen ? closeDrawer() : onViewAllBreadcrumbs())}
               ref={viewAllButtonRef}
             >
-              {numHiddenCrumbs > 0 ? t('View %s more', numHiddenCrumbs) : t('View All')}
+              {numHiddenCrumbs > 0 ? t('View %s more', numHiddenCrumbs) : t('Expand')}
             </ViewAllButton>
           </div>
         </ViewAllContainer>

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -661,6 +661,43 @@ describe('ActivitySection', () => {
     expect(await screen.findByText('View 4 more')).toBeInTheDocument();
   });
 
+  it('shows an expand link when activity does not collapse', async () => {
+    const activities: GroupActivity[] = Array.from({length: 3}, (_, index) => ({
+      type: GroupActivityType.NOTE,
+      id: `note-${index + 1}`,
+      data: {text: `Test Note ${index + 1}`},
+      dateCreated: '2020-01-01T00:00:00',
+      user: UserFixture({id: '2'}),
+      project,
+    }));
+
+    const updatedActivityGroup = GroupFixture({
+      id: '1338',
+      activity: activities,
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider
+        group={updatedActivityGroup}
+        project={updatedActivityGroup.project}
+      >
+        <ActivitySection group={updatedActivityGroup} />
+      </GroupDataContextProvider>
+    );
+
+    for (const activity of activities) {
+      expect(
+        await screen.findByText((activity.data as {text: string}).text)
+      ).toBeInTheDocument();
+    }
+
+    expect(screen.getByRole('button', {name: 'View all activity'})).toHaveTextContent(
+      'Expand'
+    );
+    expect(screen.queryByText(/View \d+ more/)).not.toBeInTheDocument();
+  });
+
   it('does not collapse activity when rendered in the drawer', async () => {
     const activities: GroupActivity[] = Array.from({length: 7}, (_, index) => ({
       type: GroupActivityType.NOTE,

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -323,35 +323,38 @@ export function ActivitySection({
   );
 
   const timeline = renderActivityList(filteredActivities.map(renderActivityItem));
-  const sidebarActivityItems =
-    filteredActivities.length < 5 ? (
-      filteredActivities.map(renderActivityItem)
-    ) : (
-      <Fragment>
-        {filteredActivities.slice(0, 3).map(renderActivityItem)}
-        <MoreActivityRow>
-          <MoreActivityIcon>
-            <RotatedEllipsisIcon direction="up" />
-          </MoreActivityIcon>
-          <Container marginTop="xs">
-            <LinkButton
-              aria-label={t('View all activity')}
-              to={activityLink}
-              size="xs"
-              replace
-              preventScrollReset
-              analyticsEventKey="issue_details.activity_expanded"
-              analyticsEventName="Issue Details: Activity Expanded"
-              analyticsParams={{
-                num_activities_hidden: filteredActivities.length - 3,
-              }}
-            >
-              {t('View %s more', filteredActivities.length - 3)}
-            </LinkButton>
-          </Container>
-        </MoreActivityRow>
-      </Fragment>
-    );
+  const hiddenActivityCount =
+    filteredActivities.length >= 5 ? filteredActivities.length - 3 : 0;
+  const sidebarVisibleActivities =
+    hiddenActivityCount > 0 ? filteredActivities.slice(0, 3) : filteredActivities;
+  const sidebarActivityItems = (
+    <Fragment>
+      {sidebarVisibleActivities.map(renderActivityItem)}
+      <MoreActivityRow>
+        <MoreActivityIcon>
+          <RotatedEllipsisIcon direction="up" />
+        </MoreActivityIcon>
+        <Container marginTop="xs">
+          <LinkButton
+            aria-label={t('View all activity')}
+            to={activityLink}
+            size="xs"
+            replace
+            preventScrollReset
+            analyticsEventKey="issue_details.activity_expanded"
+            analyticsEventName="Issue Details: Activity Expanded"
+            analyticsParams={{
+              num_activities_hidden: hiddenActivityCount,
+            }}
+          >
+            {hiddenActivityCount > 0
+              ? t('View %s more', hiddenActivityCount)
+              : t('Expand')}
+          </LinkButton>
+        </Container>
+      </MoreActivityRow>
+    </Fragment>
+  );
 
   if (variant === 'standalone') {
     return (

--- a/static/app/views/issueDetails/hooks/useIssueActivityDrawer.tsx
+++ b/static/app/views/issueDetails/hooks/useIssueActivityDrawer.tsx
@@ -32,7 +32,6 @@ export function useIssueActivityDrawer({group, project}: UseIssueActivityDrawerP
       {
         ariaLabel: t('Issue Activity'),
         drawerKey: 'issue-activity-drawer',
-        shouldCloseOnInteractOutside: () => false,
         onClose: () => {
           navigate(
             {


### PR DESCRIPTION
Activity now always has a way to open the full drawer from the sidebar. If there are hidden rows it still says `View N more`; otherwise it says `Expand`.

Breadcrumbs uses the same copy, and the activity drawer now closes on outside click instead of opting out entirely.

fixes https://linear.app/getsentry/issue/ID-1671/allow-users-to-open-the-activity-drawer-at-all-times
fixes https://linear.app/getsentry/issue/ID-1673/activity-drawer-should-close-on-click-outside