### PR TITLE
feat(preprod): Add adjustable opacity to the snapshot diff overlay

### DIFF
--- a/static/app/views/preprod/snapshots/main/diffOverlay.tsx
+++ b/static/app/views/preprod/snapshots/main/diffOverlay.tsx
@@ -4,6 +4,7 @@ export const DiffOverlay = styled('span')<{
   $maskSize: string;
   $maskUrl: string;
   $overlayColor: string;
+  $opacity?: number | null;
 }>`
   position: absolute;
   top: 0;
@@ -12,6 +13,7 @@ export const DiffOverlay = styled('span')<{
   height: 100%;
   pointer-events: none;
   background-color: ${p => p.$overlayColor};
+  opacity: ${p => (p.$opacity ?? 100) / 100};
   mask-image: url('${p => p.$maskUrl}');
   mask-size: ${p => p.$maskSize};
   mask-position: top left;

--- a/static/app/views/preprod/snapshots/main/diffOverlay.tsx
+++ b/static/app/views/preprod/snapshots/main/diffOverlay.tsx
@@ -4,7 +4,7 @@ export const DiffOverlay = styled('span')<{
   $maskSize: string;
   $maskUrl: string;
   $overlayColor: string;
-  $opacity?: number | null;
+  $opacity?: number;
 }>`
   position: absolute;
   top: 0;
@@ -13,7 +13,7 @@ export const DiffOverlay = styled('span')<{
   height: 100%;
   pointer-events: none;
   background-color: ${p => p.$overlayColor};
-  opacity: ${p => (p.$opacity ?? 100) / 100};
+  opacity: ${p => (p.$opacity ?? 50) / 100};
   mask-image: url('${p => p.$maskUrl}');
   mask-size: ${p => p.$maskSize};
   mask-position: top left;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -34,6 +34,7 @@ interface DiffImageDisplayProps {
   overlayColor: string;
   pair: SnapshotDiffPair;
   headLabel?: string;
+  overlayOpacity?: number | null;
 }
 
 export function DiffImageDisplay({
@@ -41,6 +42,7 @@ export function DiffImageDisplay({
   imageBaseUrl,
   diffImageBaseUrl,
   overlayColor,
+  overlayOpacity,
   diffMode,
   headLabel = t('Head'),
 }: DiffImageDisplayProps) {
@@ -61,6 +63,7 @@ export function DiffImageDisplay({
           baseImageUrl={baseImageUrl}
           headImageUrl={headImageUrl}
           overlayColor={overlayColor}
+          overlayOpacity={overlayOpacity}
           diffMaskUrl={diffMaskUrl}
           maskSize={maskSize}
           headLabel={headLabel}
@@ -95,6 +98,7 @@ interface SplitViewProps {
   headLabel: string;
   maskSize: string;
   overlayColor: string;
+  overlayOpacity?: number | null;
 }
 
 function SplitView({
@@ -102,6 +106,7 @@ function SplitView({
   headImageUrl,
   headLabel,
   overlayColor,
+  overlayOpacity,
   diffMaskUrl,
   maskSize,
 }: SplitViewProps) {
@@ -166,6 +171,7 @@ function SplitView({
                   {showOverlay && (
                     <DiffOverlay
                       $overlayColor={overlayColor}
+                      $opacity={overlayOpacity}
                       $maskUrl={displayMaskUrl}
                       $maskSize={maskSize}
                     />

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -34,7 +34,7 @@ interface DiffImageDisplayProps {
   overlayColor: string;
   pair: SnapshotDiffPair;
   headLabel?: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
 }
 
 export function DiffImageDisplay({
@@ -98,7 +98,7 @@ interface SplitViewProps {
   headLabel: string;
   maskSize: string;
   overlayColor: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
 }
 
 function SplitView({

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -81,6 +81,7 @@ export const PairCard = memo(function PairCard({
   copyUrl,
   diffMode,
   overlayColor,
+  overlayOpacity,
   diffImageBaseUrl,
   snapshotKey,
   status = DiffStatus.CHANGED,
@@ -102,6 +103,7 @@ export const PairCard = memo(function PairCard({
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
+  overlayOpacity?: number | null;
   status?: DiffStatus;
 }) {
   const [isDark, setIsDark] = useState(false);
@@ -131,6 +133,7 @@ export const PairCard = memo(function PairCard({
           headLabel={headBranch ?? t('Head')}
           altPrefix={getImageName(image)}
           overlayColor={overlayColor}
+          overlayOpacity={overlayOpacity}
           diffImageKey={pair.diff_image_key}
           diffImageBaseUrl={diffImageBaseUrl}
         />

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -103,7 +103,7 @@ export const PairCard = memo(function PairCard({
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
   status?: DiffStatus;
 }) {
   const [isDark, setIsDark] = useState(false);

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -54,7 +54,7 @@ export const SplitPairBody = memo(function SplitPairBody({
   diffImageBaseUrl?: string;
   diffImageKey?: string | null;
   overlayColor?: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
 }) {
   const [zoom1, zoom2] = useSyncedD3Zoom({wheelRequiresModifier: true});
   const hasVisibleOverlay = !!overlayColor && overlayColor !== 'transparent';
@@ -137,7 +137,7 @@ export const ImageColumn = memo(function ImageColumn({
   diffImageBaseUrl?: string;
   diffImageKey?: string | null;
   overlayColor?: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
 }) {
   const hasVisibleOverlay = !!overlayColor && overlayColor !== 'transparent';
   const diffMaskUrl =

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -41,6 +41,7 @@ export const SplitPairBody = memo(function SplitPairBody({
   headLabel,
   altPrefix,
   overlayColor,
+  overlayOpacity,
   diffImageKey,
   diffImageBaseUrl,
 }: {
@@ -53,6 +54,7 @@ export const SplitPairBody = memo(function SplitPairBody({
   diffImageBaseUrl?: string;
   diffImageKey?: string | null;
   overlayColor?: string;
+  overlayOpacity?: number | null;
 }) {
   const [zoom1, zoom2] = useSyncedD3Zoom({wheelRequiresModifier: true});
   const hasVisibleOverlay = !!overlayColor && overlayColor !== 'transparent';
@@ -100,6 +102,7 @@ export const SplitPairBody = memo(function SplitPairBody({
                   {diffMaskUrl && (
                     <DiffOverlay
                       $overlayColor={overlayColor!}
+                      $opacity={overlayOpacity}
                       $maskUrl={diffMaskUrl}
                       $maskSize={computeMaskSize(baseImage, headImage)}
                     />
@@ -124,6 +127,7 @@ export const ImageColumn = memo(function ImageColumn({
   alt,
   image,
   overlayColor,
+  overlayOpacity,
   diffImageKey,
   diffImageBaseUrl,
 }: {
@@ -133,6 +137,7 @@ export const ImageColumn = memo(function ImageColumn({
   diffImageBaseUrl?: string;
   diffImageKey?: string | null;
   overlayColor?: string;
+  overlayOpacity?: number | null;
 }) {
   const hasVisibleOverlay = !!overlayColor && overlayColor !== 'transparent';
   const diffMaskUrl =
@@ -151,6 +156,7 @@ export const ImageColumn = memo(function ImageColumn({
           {diffMaskUrl && (
             <DiffOverlay
               $overlayColor={overlayColor!}
+              $opacity={overlayOpacity}
               $maskUrl={diffMaskUrl}
               $maskSize="100% 100%"
             />

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -41,6 +41,7 @@ interface SnapshotListViewProps {
   onSelectSnapshot?: (key: string | null) => void;
   onVisibleGroupChange?: (name: string | null) => void;
   overlayColor?: string;
+  overlayOpacity?: number | null;
   ref?: React.Ref<SnapshotListViewHandle>;
   selectedSnapshotKey?: string | null;
 }
@@ -194,6 +195,7 @@ export const SnapshotListView = memo(function SnapshotListView({
   onScrollProgress,
   diffMode = 'split',
   overlayColor,
+  overlayOpacity,
   diffImageBaseUrl,
   ref,
   onVisibleGroupChange,
@@ -603,6 +605,7 @@ export const SnapshotListView = memo(function SnapshotListView({
                 onOpenSnapshot={onOpenSnapshot}
                 diffMode={diffMode}
                 overlayColor={overlayColor}
+                overlayOpacity={overlayOpacity}
                 diffImageBaseUrl={diffImageBaseUrl}
               />
             </RowPositioner>
@@ -622,6 +625,7 @@ const GroupContainer = memo(function GroupContainer({
   onOpenSnapshot,
   diffMode,
   overlayColor,
+  overlayOpacity,
   diffImageBaseUrl,
 }: {
   diffMode: DiffMode;
@@ -633,6 +637,7 @@ const GroupContainer = memo(function GroupContainer({
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
+  overlayOpacity?: number | null;
 }) {
   const organization = useOrganization();
   const cards = group.cards.map(card => {
@@ -661,6 +666,7 @@ const GroupContainer = memo(function GroupContainer({
         copyUrl={copyUrl}
         diffMode={diffMode}
         overlayColor={overlayColor}
+        overlayOpacity={overlayOpacity}
         diffImageBaseUrl={diffImageBaseUrl}
         snapshotKey={snapshotKey}
         onSelectSnapshot={onSelectSnapshot}

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -41,7 +41,7 @@ interface SnapshotListViewProps {
   onSelectSnapshot?: (key: string | null) => void;
   onVisibleGroupChange?: (name: string | null) => void;
   overlayColor?: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
   ref?: React.Ref<SnapshotListViewHandle>;
   selectedSnapshotKey?: string | null;
 }
@@ -637,7 +637,7 @@ const GroupContainer = memo(function GroupContainer({
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
   overlayColor?: string;
-  overlayOpacity?: number | null;
+  overlayOpacity?: number;
 }) {
   const organization = useOrganization();
   const cards = group.cards.map(card => {

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -227,7 +227,7 @@ describe('SnapshotMainContent', () => {
     expect(onOverlayOpacityChange).toHaveBeenCalledWith(50);
   });
 
-  it('leaves every opacity preset unselected until one is chosen', async () => {
+  it('marks only the active opacity preset as pressed', async () => {
     const changedItem = {
       key: 'changed-buttons',
       name: 'Buttons',
@@ -242,18 +242,17 @@ describe('SnapshotMainContent', () => {
       isSoloView: false,
       listItems: [changedItem],
       selectedItem: changedItem,
-      overlayOpacity: null,
+      overlayOpacity: 50,
       viewMode: 'single',
     });
 
     await userEvent.click(screen.getByRole('button', {name: 'Pick overlay color'}));
 
-    // Untouched state: overlay renders at full opacity and no preset is pressed.
-    for (const label of [
-      'Overlay opacity 0%',
-      'Overlay opacity 50%',
-      'Overlay opacity 100%',
-    ]) {
+    expect(screen.getByRole('button', {name: 'Overlay opacity 50%'})).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    for (const label of ['Overlay opacity 0%', 'Overlay opacity 100%']) {
       expect(screen.getByRole('button', {name: label})).toHaveAttribute(
         'aria-pressed',
         'false'

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -48,9 +48,11 @@ function renderSnapshotMainContent(
     onDiffModeChange: jest.fn(),
     onNavigateSingleView: jest.fn(),
     onOverlayColorChange: jest.fn(),
+    onOverlayOpacityChange: jest.fn(),
     onToggleSoloView: jest.fn(),
     onViewModeChange: jest.fn(),
     overlayColor: 'transparent',
+    overlayOpacity: 100,
     selectedItem: null,
     variantIndex: 0,
     viewMode: 'list',
@@ -184,6 +186,103 @@ describe('SnapshotMainContent', () => {
     await userEvent.click(nextButton);
 
     expect(onNavigateSingleView).toHaveBeenCalledWith('next');
+  });
+
+  it('exposes overlay opacity presets inside the color picker in split mode', async () => {
+    const onOverlayOpacityChange = jest.fn();
+    const changedItem = {
+      key: 'changed-buttons',
+      name: 'Buttons',
+      displayName: 'Buttons',
+      pairs: [changedPair],
+      type: 'changed' as const,
+    };
+
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      diffMode: 'split',
+      isSoloView: false,
+      listItems: [changedItem],
+      selectedItem: changedItem,
+      onOverlayOpacityChange,
+      overlayOpacity: 100,
+      viewMode: 'single',
+    });
+
+    // Presets live inside the color picker popover, not the toolbar itself.
+    expect(
+      screen.queryByRole('button', {name: 'Overlay opacity 50%'})
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Pick overlay color'}));
+
+    expect(screen.getByRole('button', {name: 'Overlay opacity 0%'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Overlay opacity 50%'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Overlay opacity 100%'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Overlay opacity 50%'}));
+
+    expect(onOverlayOpacityChange).toHaveBeenCalledWith(50);
+  });
+
+  it('leaves every opacity preset unselected until one is chosen', async () => {
+    const changedItem = {
+      key: 'changed-buttons',
+      name: 'Buttons',
+      displayName: 'Buttons',
+      pairs: [changedPair],
+      type: 'changed' as const,
+    };
+
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      diffMode: 'split',
+      isSoloView: false,
+      listItems: [changedItem],
+      selectedItem: changedItem,
+      overlayOpacity: null,
+      viewMode: 'single',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Pick overlay color'}));
+
+    // Untouched state: overlay renders at full opacity and no preset is pressed.
+    for (const label of [
+      'Overlay opacity 0%',
+      'Overlay opacity 50%',
+      'Overlay opacity 100%',
+    ]) {
+      expect(screen.getByRole('button', {name: label})).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    }
+  });
+
+  it('hides the color picker and opacity presets outside of split mode', () => {
+    const changedItem = {
+      key: 'changed-buttons',
+      name: 'Buttons',
+      displayName: 'Buttons',
+      pairs: [changedPair],
+      type: 'changed' as const,
+    };
+
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      diffMode: 'wipe',
+      isSoloView: false,
+      listItems: [changedItem],
+      selectedItem: changedItem,
+      viewMode: 'single',
+    });
+
+    expect(
+      screen.queryByRole('button', {name: 'Pick overlay color'})
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Wipe'})).toBeChecked();
   });
 
   it('renders focused errored snapshots side-by-side with a failed badge', () => {

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -63,9 +63,11 @@ interface SnapshotMainContentProps {
   onDiffModeChange: (mode: DiffMode) => void;
   onNavigateSingleView: (direction: 'prev' | 'next') => void;
   onOverlayColorChange: (color: string) => void;
+  onOverlayOpacityChange: (opacity: number) => void;
   onToggleSoloView: () => void;
   onViewModeChange: (mode: ViewMode) => void;
   overlayColor: string;
+  overlayOpacity: number | null;
   selectedItem: SidebarItem | null;
   variantIndex: number;
   viewMode: ViewMode;
@@ -85,6 +87,8 @@ export function SnapshotMainContent({
   diffImageBaseUrl,
   overlayColor,
   onOverlayColorChange,
+  overlayOpacity,
+  onOverlayOpacityChange,
   diffMode,
   onDiffModeChange,
   viewMode,
@@ -198,7 +202,12 @@ export function SnapshotMainContent({
   const diffControls = hasChangedInList ? (
     <Fragment>
       {diffMode === 'split' && (
-        <ColorPickerButton color={overlayColor} onChange={onOverlayColorChange} />
+        <ColorPickerButton
+          color={overlayColor}
+          onChange={onOverlayColorChange}
+          opacity={overlayOpacity}
+          onOpacityChange={onOverlayOpacityChange}
+        />
       )}
       <DiffModeToggle
         diffMode={diffMode}
@@ -239,6 +248,7 @@ export function SnapshotMainContent({
           onScrollProgress={handleListScrollProgress}
           diffMode={diffMode}
           overlayColor={overlayColor}
+          overlayOpacity={overlayOpacity}
           diffImageBaseUrl={diffImageBaseUrl}
           onVisibleGroupChange={onVisibleGroupChange}
         />
@@ -312,6 +322,7 @@ export function SnapshotMainContent({
             imageBaseUrl={imageBaseUrl}
             diffImageBaseUrl={diffImageBaseUrl}
             overlayColor={overlayColor}
+            overlayOpacity={overlayOpacity}
             diffMode={isChanged ? diffMode : 'split'}
             headLabel={headBranch ?? t('Head')}
           />

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -67,7 +67,7 @@ interface SnapshotMainContentProps {
   onToggleSoloView: () => void;
   onViewModeChange: (mode: ViewMode) => void;
   overlayColor: string;
-  overlayOpacity: number | null;
+  overlayOpacity: number;
   selectedItem: SidebarItem | null;
   variantIndex: number;
   viewMode: ViewMode;

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -44,7 +44,9 @@ function SnapshotsToolbarWithControls({
     mode: DiffMode;
     onModeChange: (mode: DiffMode) => void;
     onOverlayColorChange: (color: string) => void;
+    onOverlayOpacityChange: (opacity: number) => void;
     overlayColor: string;
+    overlayOpacity: number | null;
     showSplit?: boolean;
   };
   progress?: {
@@ -95,6 +97,8 @@ function SnapshotsToolbarWithControls({
               <ColorPickerButton
                 color={diff.overlayColor}
                 onChange={diff.onOverlayColorChange}
+                opacity={diff.overlayOpacity}
+                onOpacityChange={diff.onOverlayOpacityChange}
               />
             )}
             <DiffModeToggle
@@ -134,6 +138,8 @@ describe('SnapshotsToolbar', () => {
                   onModeChange: noop,
                   overlayColor: '#f55459',
                   onOverlayColorChange: noop,
+                  overlayOpacity: 50,
+                  onOverlayOpacityChange: noop,
                   showSplit: isSm,
                 }}
                 solo={{isActive: false, onToggle: noop}}
@@ -206,6 +212,8 @@ describe('SnapshotsToolbar', () => {
                 onModeChange: noop,
                 overlayColor: '#f55459',
                 onOverlayColorChange: noop,
+                overlayOpacity: 50,
+                onOverlayOpacityChange: noop,
               }}
             />
           </div>

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -46,7 +46,7 @@ function SnapshotsToolbarWithControls({
     onOverlayColorChange: (color: string) => void;
     onOverlayOpacityChange: (opacity: number) => void;
     overlayColor: string;
-    overlayOpacity: number | null;
+    overlayOpacity: number;
     showSplit?: boolean;
   };
   progress?: {

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import {Fragment, useEffect, useRef, useState} from 'react';
+import type {Theme} from '@emotion/react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -17,6 +18,19 @@ import {t} from 'sentry/locale';
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 
 const TRANSPARENT_COLOR = 'transparent';
+
+// Diagonal slash drawn across an empty/transparent swatch. `halfWidth` is the
+// half-thickness of the line in px, so larger swatches can use a bolder slash.
+const slashGradient = (theme: Theme, halfWidth: number) => css`
+  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+  background-image: linear-gradient(
+    to top right,
+    transparent calc(50% - ${halfWidth + 1}px),
+    ${theme.tokens.content.danger} calc(50% - ${halfWidth}px),
+    ${theme.tokens.content.danger} calc(50% + ${halfWidth}px),
+    transparent calc(50% + ${halfWidth + 1}px)
+  );
+`;
 
 export type ViewMode = 'single' | 'list';
 export type SortBy = 'diff' | 'alpha';
@@ -299,18 +313,7 @@ const ColorTrigger = styled('button')<{$color: string; $slash: boolean}>`
   border: 1px solid
     ${p => p.theme.tokens.border.onVibrant[p.theme.type === 'dark' ? 'light' : 'dark']};
   background-color: ${p => (p.$slash ? 'transparent' : p.$color)};
-  ${p =>
-    p.$slash &&
-    css`
-      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-      background-image: linear-gradient(
-        to top right,
-        transparent calc(50% - 2px),
-        ${p.theme.tokens.content.danger} calc(50% - 1px),
-        ${p.theme.tokens.content.danger} calc(50% + 1px),
-        transparent calc(50% + 2px)
-      );
-    `}
+  ${p => p.$slash && slashGradient(p.theme, 1)}
 
   &:hover {
     border-color: ${p => p.theme.tokens.border.accent};
@@ -365,14 +368,7 @@ const OpacitySwatchFill = styled('div')<{$color: string; $opacity: number}>`
     css`
       opacity: 1;
       background-color: transparent;
-      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-      background-image: linear-gradient(
-        to top right,
-        transparent calc(50% - 1.5px),
-        ${p.theme.tokens.content.danger} calc(50% - 0.5px),
-        ${p.theme.tokens.content.danger} calc(50% + 0.5px),
-        transparent calc(50% + 1.5px)
-      );
+      ${slashGradient(p.theme, 0.5)}
     `}
 `;
 
@@ -390,20 +386,8 @@ const ColorSwatch = styled('button')<{$color: string; $selected: boolean}>`
   cursor: pointer;
   border: 2px solid
     ${p => (p.$selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
-  background-color: ${p => (p.$color === TRANSPARENT_COLOR ? 'transparent' : p.$color)};
+  background-color: ${p => p.$color};
   padding: 0;
   outline: ${p => (p.$selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
   outline-offset: 1px;
-  ${p =>
-    p.$color === TRANSPARENT_COLOR &&
-    css`
-      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-      background-image: linear-gradient(
-        to top right,
-        transparent calc(50% - 1.5px),
-        ${p.theme.tokens.content.danger} calc(50% - 0.5px),
-        ${p.theme.tokens.content.danger} calc(50% + 0.5px),
-        transparent calc(50% + 1.5px)
-      );
-    `}
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -197,7 +197,8 @@ export function ColorPickerButton({
       <Tooltip title={t('Overlay color')} skipWrapper>
         <ColorTrigger
           $color={color}
-          $slash={opacity === 0}
+          // `transparent` supports legacy localStorage color values.
+          $slash={opacity === 0 || color === TRANSPARENT_COLOR}
           aria-label={t('Pick overlay color')}
           onClick={() => setIsOpen(v => !v)}
         />
@@ -361,13 +362,14 @@ const OpacitySwatch = styled('button')<{$selected: boolean}>`
 const OpacitySwatchFill = styled('div')<{$color: string; $opacity: number}>`
   position: absolute;
   inset: 0;
-  background-color: ${p => (p.$color === TRANSPARENT_COLOR ? 'transparent' : p.$color)};
-  opacity: ${p => p.$opacity / 100};
+  /* Fill the circle left-to-right by the opacity amount, so 50% reads as ◐. */
+  background: ${p =>
+    p.$color === TRANSPARENT_COLOR
+      ? 'transparent'
+      : `linear-gradient(to right, ${p.$color} ${p.$opacity}%, transparent ${p.$opacity}%)`};
   ${p =>
     p.$opacity === 0 &&
     css`
-      opacity: 1;
-      background-color: transparent;
       ${slashGradient(p.theme, 0.5)}
     `}
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -147,17 +147,23 @@ export function SortDropdown({
   );
 }
 
+const OPACITY_PRESETS = [0, 50, 100];
+
 export function ColorPickerButton({
   color,
   onChange,
+  opacity,
+  onOpacityChange,
 }: {
   color: string;
   onChange: (color: string) => void;
+  onOpacityChange: (opacity: number) => void;
+  opacity: number | null;
 }) {
   const theme = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
-  const overlayColors = [TRANSPARENT_COLOR, ...theme.chart.getColorPalette(10)];
+  const palette = theme.chart.getColorPalette(10);
 
   useEffect(() => {
     if (!isOpen) {
@@ -176,23 +182,40 @@ export function ColorPickerButton({
     <ColorPickerWrapper ref={pickerRef}>
       <Tooltip title={t('Overlay color')} skipWrapper>
         <ColorTrigger
-          color={color}
+          $color={color}
+          $slash={opacity === 0}
           aria-label={t('Pick overlay color')}
           onClick={() => setIsOpen(v => !v)}
         />
       </Tooltip>
       {isOpen && (
         <ColorPickerDropdown>
-          <Flex gap="xs">
-            {overlayColors.map(c => (
+          <Flex gap="xs" align="center">
+            <Text size="xs" variant="muted">
+              {t('Opacity')}
+            </Text>
+            {OPACITY_PRESETS.map(preset => (
+              <Tooltip key={preset} title={t('%s opacity', `${preset}%`)} skipWrapper>
+                <OpacitySwatch
+                  $selected={opacity === preset}
+                  aria-pressed={opacity === preset}
+                  onClick={() => onOpacityChange(preset)}
+                  aria-label={t('Overlay opacity %s', `${preset}%`)}
+                >
+                  <OpacitySwatchFill $color={color} $opacity={preset} />
+                </OpacitySwatch>
+              </Tooltip>
+            ))}
+            <PickerDivider />
+            <Text size="xs" variant="muted">
+              {t('Color')}
+            </Text>
+            {palette.map(c => (
               <ColorSwatch
                 key={c}
-                color={c}
-                selected={color === c}
-                onClick={() => {
-                  onChange(c);
-                  setIsOpen(false);
-                }}
+                $color={c}
+                $selected={color === c}
+                onClick={() => onChange(c)}
                 aria-label={t('Overlay color %s', c)}
               />
             ))}
@@ -267,17 +290,17 @@ const ColorPickerDropdown = styled('div')`
   z-index: ${p => p.theme.zIndex.dropdown};
 `;
 
-const ColorTrigger = styled('button')<{color: string}>`
+const ColorTrigger = styled('button')<{$color: string; $slash: boolean}>`
   width: 24px;
   height: 24px;
   border-radius: 50%;
   cursor: pointer;
+  padding: 0;
   border: 1px solid
     ${p => p.theme.tokens.border.onVibrant[p.theme.type === 'dark' ? 'light' : 'dark']};
-  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
-  padding: 0;
+  background-color: ${p => (p.$slash ? 'transparent' : p.$color)};
   ${p =>
-    p.color === TRANSPARENT_COLOR &&
+    p.$slash &&
     css`
       /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
       background-image: linear-gradient(
@@ -313,19 +336,66 @@ export const ToolbarProgressBar = styled(ProgressBar)`
   }
 `;
 
-const ColorSwatch = styled('button')<{color: string; selected: boolean}>`
+const OpacitySwatch = styled('button')<{$selected: boolean}>`
+  position: relative;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  padding: 0;
+  overflow: hidden;
+  background: none;
+  border: 2px solid
+    ${p => (p.$selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
+  outline: ${p => (p.$selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
+  outline-offset: 1px;
+
+  &:hover {
+    border-color: ${p => p.theme.tokens.border.accent};
+  }
+`;
+
+const OpacitySwatchFill = styled('div')<{$color: string; $opacity: number}>`
+  position: absolute;
+  inset: 0;
+  background-color: ${p => (p.$color === TRANSPARENT_COLOR ? 'transparent' : p.$color)};
+  opacity: ${p => p.$opacity / 100};
+  ${p =>
+    p.$opacity === 0 &&
+    css`
+      opacity: 1;
+      background-color: transparent;
+      /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+      background-image: linear-gradient(
+        to top right,
+        transparent calc(50% - 1.5px),
+        ${p.theme.tokens.content.danger} calc(50% - 0.5px),
+        ${p.theme.tokens.content.danger} calc(50% + 0.5px),
+        transparent calc(50% + 1.5px)
+      );
+    `}
+`;
+
+const PickerDivider = styled('div')`
+  align-self: stretch;
+  min-height: 20px;
+  margin: 0 ${p => p.theme.space.xs};
+  border-left: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const ColorSwatch = styled('button')<{$color: string; $selected: boolean}>`
   width: 20px;
   height: 20px;
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid
-    ${p => (p.selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
-  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
+    ${p => (p.$selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
+  background-color: ${p => (p.$color === TRANSPARENT_COLOR ? 'transparent' : p.$color)};
   padding: 0;
-  outline: ${p => (p.selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
+  outline: ${p => (p.$selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
   outline-offset: 1px;
   ${p =>
-    p.color === TRANSPARENT_COLOR &&
+    p.$color === TRANSPARENT_COLOR &&
     css`
       /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
       background-image: linear-gradient(

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -172,7 +172,7 @@ export function ColorPickerButton({
   color: string;
   onChange: (color: string) => void;
   onOpacityChange: (opacity: number) => void;
-  opacity: number | null;
+  opacity: number;
 }) {
   const theme = useTheme();
   const [isOpen, setIsOpen] = useState(false);

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -362,7 +362,6 @@ const OpacitySwatch = styled('button')<{$selected: boolean}>`
 const OpacitySwatchFill = styled('div')<{$color: string; $opacity: number}>`
   position: absolute;
   inset: 0;
-  /* Fill the circle left-to-right by the opacity amount, so 50% reads as ◐. */
   background: ${p =>
     p.$color === TRANSPARENT_COLOR
       ? 'transparent'

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -178,7 +178,7 @@ export default function SnapshotsPage() {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
   const [overlayColor, setOverlayColor] = useLocalStorageState<string>(
     'snapshot-overlay-color',
-    palette.at(-5) ?? palette[0]
+    palette.at(-3) ?? palette[0]
   );
   const [diffMode, setDiffMode] = useLocalStorageState<DiffMode>(
     'snapshot-diff-mode',

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -184,6 +184,10 @@ export default function SnapshotsPage() {
     'snapshot-diff-mode',
     'split'
   );
+  const [overlayOpacity, setOverlayOpacity] = useLocalStorageState<number | null>(
+    'snapshot-overlay-opacity',
+    null
+  );
   const breakpoints = useBreakpoints();
   const effectiveDiffMode = !breakpoints.sm && diffMode === 'split' ? 'wipe' : diffMode;
   const [viewMode, setViewMode] = useQueryState(
@@ -814,6 +818,8 @@ export default function SnapshotsPage() {
             diffImageBaseUrl={diffImageBaseUrl}
             overlayColor={overlayColor}
             onOverlayColorChange={setOverlayColor}
+            overlayOpacity={overlayOpacity}
+            onOverlayOpacityChange={setOverlayOpacity}
             diffMode={effectiveDiffMode}
             onDiffModeChange={setDiffMode}
             viewMode={viewMode}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -184,9 +184,9 @@ export default function SnapshotsPage() {
     'snapshot-diff-mode',
     'split'
   );
-  const [overlayOpacity, setOverlayOpacity] = useLocalStorageState<number | null>(
+  const [overlayOpacity, setOverlayOpacity] = useLocalStorageState(
     'snapshot-overlay-opacity',
-    null
+    50
   );
   const breakpoints = useBreakpoints();
   const effectiveDiffMode = !breakpoints.sm && diffMode === 'split' ? 'wipe' : diffMode;


### PR DESCRIPTION
In split diff mode, the colored change highlight on the head image was always fully opaque. This adds an opacity control so reviewers can fade the highlight and see the underlying head pixels through it. Color and opacity are independent axes — you pick a color *and* an opacity.

The overlay color picker popover has two labeled groups separated by a divider: **Opacity** (`0%` / `50%` / `100%` circles, each previewing the current color at that level — `0%` shown as a slash, intermediate levels as a left-to-right gradient fill so `50%` reads as a partially filled circle) and **Color** (the swatches). The collapsed toolbar trigger reflects the current selection: the slash circle when the overlay is off, otherwise the solid color.

Preferences persist in `localStorage`: opacity under `snapshot-overlay-opacity` and color under `snapshot-overlay-color`, alongside the existing diff-mode preference. Opacity defaults to `50%` and the default color is `palette.at(-3)`. The chosen values apply consistently across the detail split view and the list/card split view.

Two reviewer-facing notes:
- The picker's swatch styled-components were switched to transient (`$`-prefixed) props. They previously leaked non-DOM attributes (`selected`, `color`) onto the button element, which threw React warnings the moment the popover was opened (no prior test exercised that path).
- `transparent` is no longer offered as a color swatch — opacity `0%` is the way to hide the overlay now. For legacy sessions that still have `transparent` saved under `snapshot-overlay-color`, the collapsed trigger shows the slash so the "overlay off" state still reads correctly.

<img width="1432" height="296" alt="CleanShot 2026-07-02 at 11 31 39@2x" src="https://github.com/user-attachments/assets/71d46324-065e-48c2-89b8-d09421d6f759" />
