### PR TITLE
ref(devenv): Remove dedicated eval taskworkers

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -117,14 +117,6 @@ x-sentry-service-config:
     # Taskworker services
     taskworker:
       description: Workers that process tasks from the taskbroker
-    taskworker-evals-ingest-errors:
-      description: Dedicated taskworker for eval error ingest tasks
-    taskworker-evals-ingest-errors-postprocess:
-      description: Dedicated taskworker for eval error post-processing tasks
-    taskworker-evals-issues:
-      description: Dedicated taskworker for eval issue-side tasks
-    taskworker-evals-relay:
-      description: Dedicated taskworker for eval Relay project config tasks
     taskworker-scheduler:
       description: Task scheduler that can spawn tasks based on their schedules
     # Kafka consumer services for event ingestion
@@ -269,10 +261,7 @@ x-sentry-service-config:
         spotlight,
         objectstore,
         taskbroker,
-        taskworker-evals-relay,
-        taskworker-evals-ingest-errors,
-        taskworker-evals-ingest-errors-postprocess,
-        taskworker-evals-issues,
+        taskworker,
         ingest-events,
         post-process-forwarder-errors,
       ]
@@ -377,14 +366,6 @@ x-programs:
     command: sentry devserver
   taskworker:
     command: sentry run taskworker
-  taskworker-evals-ingest-errors:
-    command: sentry run taskworker --namespace ingest.errors --concurrency 2 --processing-pool-name eval-ingest-errors
-  taskworker-evals-ingest-errors-postprocess:
-    command: sentry run taskworker --namespace ingest.errors.postprocess --concurrency 1 --processing-pool-name eval-ingest-errors-postprocess
-  taskworker-evals-issues:
-    command: sentry run taskworker --namespace issues --concurrency 1 --processing-pool-name eval-issues
-  taskworker-evals-relay:
-    command: sentry run taskworker --namespace relay --concurrency 1 --processing-pool-name eval-relay
   taskworker-scheduler:
     command: sentry run taskworker-scheduler
   ingest-events:


### PR DESCRIPTION
## What

The `evals` devenv mode ran four dedicated taskworkers — `taskworker-evals-relay`, `taskworker-evals-ingest-errors`, `taskworker-evals-ingest-errors-postprocess`, and `taskworker-evals-issues` — each pinned to a single namespace with its own processing pool.

With a single shared taskbroker pool, one general `taskworker` (no namespace filter) already processes every namespace from the broker, so the dedicated workers add no coverage. Replace all four with the general `taskworker`.

## How

- Removed the four `taskworker-evals-*` dependency entries and their `x-programs` commands.
- In the `evals` mode, swapped the four eval taskworkers for a single `taskworker`.

## Testing

Boot the `evals` mode and confirm eval tasks (ingest errors, postprocess, issues, relay) still process through the single taskworker.