### PR TITLE
fix(slack): Ensure Slack user is member of org for Seer actions

### DIFF
--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -58,6 +58,7 @@ from sentry.notifications.services import notifications_service
 from sentry.notifications.utils.actions import BlockKitMessageAction, MessageAction
 from sentry.seer.entrypoints.operator import SeerAutofixOperator
 from sentry.seer.entrypoints.slack.entrypoint import SlackAutofixEntrypoint
+from sentry.seer.entrypoints.slack.messaging import send_not_org_member_message
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models import User
 from sentry.users.services.user import RpcUser
@@ -497,6 +498,7 @@ class SlackActionEndpoint(Endpoint):
                             slack_request=slack_request,
                             action=action,
                             group=group,
+                            user=identity_user,
                         )
                     defer_attachment_update = True
             except client.ApiError as error:
@@ -570,6 +572,38 @@ class SlackActionEndpoint(Endpoint):
 
         return self.respond()
 
+    def _has_seer_org_access(
+        self,
+        *,
+        slack_request: SlackActionRequest,
+        entrypoint: SlackAutofixEntrypoint,
+        group: Group,
+        user: RpcUser,
+    ) -> bool:
+        """
+        Ensure the acting Slack user is a member of the group's organization before triggering Seer
+        """
+        if group.organization.has_access(user):
+            return True
+
+        _logger.info(
+            "seer.slack.autofix.user_not_org_member",
+            extra={
+                "group_id": group.id,
+                "organization_id": group.project.organization_id,
+                "user_id": user.id,
+            },
+        )
+        if entrypoint.slack_user_id:
+            send_not_org_member_message(
+                integration_id=slack_request.integration.id,
+                slack_user_id=entrypoint.slack_user_id,
+                channel_id=entrypoint.channel_id,
+                thread_ts=entrypoint.thread_ts,
+                org_name=group.organization.name,
+            )
+        return False
+
     def handle_seer_autofix_start(
         self,
         *,
@@ -584,6 +618,11 @@ class SlackActionEndpoint(Endpoint):
             group=group,
             organization_id=group.project.organization_id,
         )
+        if not self._has_seer_org_access(
+            slack_request=slack_request, entrypoint=entrypoint, group=group, user=user
+        ):
+            return
+
         stopping_point = entrypoint.autofix_stopping_point
         is_continuation = entrypoint.autofix_run_id is not None
         logging_ctx = {
@@ -625,6 +664,7 @@ class SlackActionEndpoint(Endpoint):
         slack_request: SlackActionRequest,
         action: BlockKitMessageAction,
         group: Group,
+        user: RpcUser,
     ) -> None:
         entrypoint = SlackAutofixEntrypoint(
             slack_request=slack_request,
@@ -632,6 +672,11 @@ class SlackActionEndpoint(Endpoint):
             group=group,
             organization_id=group.project.organization_id,
         )
+        if not self._has_seer_org_access(
+            slack_request=slack_request, entrypoint=entrypoint, group=group, user=user
+        ):
+            return
+
         run_id = entrypoint.autofix_run_id
         if run_id is None:
             _logger.info(

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -572,20 +572,17 @@ class SlackActionEndpoint(Endpoint):
 
         return self.respond()
 
-    def _has_seer_org_access(
+    def _notify_not_org_member(
         self,
         *,
         slack_request: SlackActionRequest,
         entrypoint: SlackAutofixEntrypoint,
         group: Group,
         user: RpcUser,
-    ) -> bool:
+    ) -> None:
         """
-        Ensure the acting Slack user is a member of the group's organization before triggering Seer
+        Let the acting Slack user know they must be a member of the group's organization to use Seer
         """
-        if group.organization.has_access(user):
-            return True
-
         _logger.info(
             "seer.slack.autofix.user_not_org_member",
             extra={
@@ -602,7 +599,6 @@ class SlackActionEndpoint(Endpoint):
                 thread_ts=entrypoint.thread_ts,
                 org_name=group.organization.name,
             )
-        return False
 
     def handle_seer_autofix_start(
         self,
@@ -618,9 +614,10 @@ class SlackActionEndpoint(Endpoint):
             group=group,
             organization_id=group.project.organization_id,
         )
-        if not self._has_seer_org_access(
-            slack_request=slack_request, entrypoint=entrypoint, group=group, user=user
-        ):
+        if not group.organization.has_access(user):
+            self._notify_not_org_member(
+                slack_request=slack_request, entrypoint=entrypoint, group=group, user=user
+            )
             return
 
         stopping_point = entrypoint.autofix_stopping_point
@@ -672,9 +669,10 @@ class SlackActionEndpoint(Endpoint):
             group=group,
             organization_id=group.project.organization_id,
         )
-        if not self._has_seer_org_access(
-            slack_request=slack_request, entrypoint=entrypoint, group=group, user=user
-        ):
+        if not group.organization.has_access(user):
+            self._notify_not_org_member(
+                slack_request=slack_request, entrypoint=entrypoint, group=group, user=user
+            )
             return
 
         run_id = entrypoint.autofix_run_id

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -376,3 +376,34 @@ def send_halt_message(
         logger.exception("send_halt_message.error", extra=logging_ctx)
     else:
         logger.info("send_halt_message.success", extra=logging_ctx)
+
+
+@all_silo_function
+def send_not_org_member_message(
+    *,
+    integration_id: int,
+    slack_user_id: str,
+    channel_id: str,
+    thread_ts: str | None,
+    org_name: str,
+) -> None:
+    """Send an ephemeral message informing the user they are not a member of the organization."""
+    from sentry.integrations.slack.workspace import send_threaded_ephemeral_message
+
+    message = (
+        f"You must be a member of the *{org_name}* Sentry organization to use Seer Agent in Slack."
+    )
+    renderable = SlackRenderable(
+        blocks=[MarkdownBlock(text=message)],
+        text=message,
+    )
+    try:
+        send_threaded_ephemeral_message(
+            integration_id=integration_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            renderable=renderable,
+            slack_user_id=slack_user_id,
+        )
+    except Exception as e:
+        logger.warning("seer.slack.send_not_org_member_message_failed", exc_info=e)

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -33,7 +33,10 @@ from sentry.seer.entrypoints.slack.mention import (
     extract_slack_message_links,
     find_message_in_attachments,
 )
-from sentry.seer.entrypoints.slack.messaging import send_halt_message
+from sentry.seer.entrypoints.slack.messaging import (
+    send_halt_message,
+    send_not_org_member_message,
+)
 from sentry.seer.entrypoints.slack.metrics import (
     ProcessMentionFailureReason,
     ProcessMentionHaltReason,
@@ -143,8 +146,10 @@ def process_mention_for_slack(
 
         if not organization.has_access(user):
             lifecycle.record_halt(ProcessMentionHaltReason.USER_NOT_ORG_MEMBER)
-            _send_not_org_member_message(
-                entrypoint=entrypoint,
+            send_not_org_member_message(
+                integration_id=entrypoint.integration.id,
+                slack_user_id=entrypoint.slack_user_id,
+                channel_id=entrypoint.channel_id,
                 thread_ts=thread_ts if thread_ts else "",
                 org_name=organization.name,
             )
@@ -296,31 +301,6 @@ def _count_linked_users(
         }
     )
     return len(identities)
-
-
-def _send_not_org_member_message(
-    *,
-    entrypoint: SlackAgentEntrypoint,
-    thread_ts: str,
-    org_name: str,
-) -> None:
-    """Send an ephemeral message informing the user they are not a member of the organization."""
-    message = (
-        f"You must be a member of the *{org_name}* Sentry organization to use Seer Agent in Slack."
-    )
-    renderable = SlackRenderable(
-        blocks=[MarkdownBlock(text=message)],
-        text=message,
-    )
-    try:
-        entrypoint.install.send_threaded_ephemeral_message(
-            slack_user_id=entrypoint.slack_user_id,
-            channel_id=entrypoint.channel_id,
-            renderable=renderable,
-            thread_ts=thread_ts,
-        )
-    except Exception as e:
-        _logger.warning("seer.slack.process_mention.send_not_org_member_message_failed", exc_info=e)
 
 
 class _LinkedMessagesResult(NamedTuple):

--- a/tests/sentry/integrations/slack/webhooks/actions/test_seer_autofix.py
+++ b/tests/sentry/integrations/slack/webhooks/actions/test_seer_autofix.py
@@ -1,0 +1,122 @@
+from unittest.mock import patch
+
+import orjson
+
+from sentry.integrations.slack.message_builder.routing import encode_action_id
+from sentry.integrations.slack.message_builder.types import SlackAction
+from sentry.seer.autofix.utils import AutofixStoppingPoint
+
+from . import BaseEventTest
+
+
+class SeerAutofixActionTest(BaseEventTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+
+    def get_original_message(self):
+        return {
+            "ts": "1458170866.000004",
+            "blocks": [
+                {
+                    "type": "section",
+                    "block_id": orjson.dumps({"issue": self.group.id}).decode(),
+                    "text": {"type": "mrkdwn", "text": "boop", "verbatim": False},
+                }
+            ],
+        }
+
+    def get_autofix_start_action(self):
+        return {
+            "action_id": encode_action_id(
+                action=SlackAction.SEER_AUTOFIX_START,
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+            ),
+            "block_id": "autofix",
+            "text": {"type": "plain_text", "text": "Find Root Cause", "emoji": True},
+            "value": AutofixStoppingPoint.ROOT_CAUSE.value,
+            "type": "button",
+            "action_ts": "1458170917.164398",
+        }
+
+    def get_autofix_handoff_action(self):
+        return {
+            "action_id": encode_action_id(
+                action=SlackAction.SEER_AUTOFIX_HANDOFF,
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+            ),
+            "block_id": "autofix",
+            "text": {"type": "plain_text", "text": "Hand off to Cursor", "emoji": True},
+            "value": "",
+            "type": "button",
+            "action_ts": "1458170917.164398",
+        }
+
+    def non_member_slack_user(self):
+        """A Slack user with a linked Sentry identity but no membership in the org"""
+        non_member = self.create_user()
+        external_id = "slack:2"
+        self.create_identity(non_member, self.idp, external_id)
+        return {
+            "id": external_id,
+            "name": "outsider",
+            "username": "outsider",
+            "team_id": "TXXXXXXX1",
+        }
+
+    @patch("sentry.integrations.slack.webhooks.action.send_not_org_member_message")
+    @patch("sentry.integrations.slack.webhooks.action.SeerAutofixOperator.trigger_autofix")
+    def test_autofix_start_non_member_is_blocked(self, mock_trigger, mock_not_member_message):
+        response = self.post_webhook_block_kit(
+            action_data=[self.get_autofix_start_action()],
+            original_message=self.get_original_message(),
+            slack_user=self.non_member_slack_user(),
+        )
+
+        assert response.status_code == 200
+        assert not mock_trigger.called
+        assert mock_not_member_message.called
+        assert mock_not_member_message.call_args.kwargs["org_name"] == self.organization.name
+
+    @patch("sentry.integrations.slack.webhooks.action.send_not_org_member_message")
+    @patch("sentry.integrations.slack.webhooks.action.SeerAutofixOperator.trigger_autofix")
+    def test_autofix_start_member_is_allowed(self, mock_trigger, mock_not_member_message):
+        # The default Slack user is linked to the org owner
+        response = self.post_webhook_block_kit(
+            action_data=[self.get_autofix_start_action()],
+            original_message=self.get_original_message(),
+        )
+
+        assert response.status_code == 200
+        assert mock_trigger.called
+        assert not mock_not_member_message.called
+
+    @patch("sentry.integrations.slack.webhooks.action.send_not_org_member_message")
+    @patch("sentry.integrations.slack.webhooks.action.SeerAutofixOperator.trigger_handoff")
+    def test_autofix_handoff_non_member_is_blocked(self, mock_trigger, mock_not_member_message):
+        response = self.post_webhook_block_kit(
+            action_data=[self.get_autofix_handoff_action()],
+            original_message=self.get_original_message(),
+            slack_user=self.non_member_slack_user(),
+            callback_id=orjson.dumps({"issue": self.group.id, "run_id": 123}).decode(),
+        )
+
+        assert response.status_code == 200
+        assert not mock_trigger.called
+        assert mock_not_member_message.called
+        assert mock_not_member_message.call_args.kwargs["org_name"] == self.organization.name
+
+    @patch("sentry.integrations.slack.webhooks.action.send_not_org_member_message")
+    @patch("sentry.integrations.slack.webhooks.action.SeerAutofixOperator.trigger_handoff")
+    def test_autofix_handoff_member_is_allowed(self, mock_trigger, mock_not_member_message):
+        response = self.post_webhook_block_kit(
+            action_data=[self.get_autofix_handoff_action()],
+            original_message=self.get_original_message(),
+            callback_id=orjson.dumps({"issue": self.group.id, "run_id": 123}).decode(),
+        )
+
+        assert response.status_code == 200
+        assert mock_trigger.called
+        assert not mock_not_member_message.called

--- a/tests/sentry/seer/entrypoints/slack/test_tasks.py
+++ b/tests/sentry/seer/entrypoints/slack/test_tasks.py
@@ -179,7 +179,7 @@ class ProcessMentionForSlackTest(TestCase):
         assert_halt_metric(mock_record, ProcessMentionHaltReason.IDENTITY_NOT_LINKED)
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    @patch("sentry.seer.entrypoints.slack.tasks._send_not_org_member_message")
+    @patch("sentry.seer.entrypoints.slack.tasks.send_not_org_member_message")
     @patch("sentry.seer.entrypoints.slack.tasks.SeerAgentOperator")
     @patch("sentry.seer.entrypoints.slack.tasks.SlackAgentEntrypoint")
     @patch("sentry.seer.entrypoints.slack.tasks._resolve_user")
@@ -203,7 +203,9 @@ class ProcessMentionForSlackTest(TestCase):
 
         mock_operator_cls.assert_not_called()
         mock_send_not_member.assert_called_once_with(
-            entrypoint=mock_entrypoint,
+            integration_id=mock_entrypoint.integration.id,
+            slack_user_id=mock_entrypoint.slack_user_id,
+            channel_id=mock_entrypoint.channel_id,
             thread_ts="1234567890.123456",
             org_name="Other Org",
         )


### PR DESCRIPTION
Add a check to make sure the acting Slack user is a member of the group's organization before performing Slack Seer autofix actions