### PR TITLE
ref(issues): Share progress marker icons

### DIFF
--- a/static/app/components/progressMarker.stories.tsx
+++ b/static/app/components/progressMarker.stories.tsx
@@ -1,0 +1,39 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {ProgressMarker, type ProgressMarkerStep} from 'sentry/components/progressMarker';
+import * as Storybook from 'sentry/stories';
+
+const PROGRESS_MARKER_STEPS = [
+  'empty',
+  'quarter',
+  'half',
+  'three-quarters',
+  'complete',
+] satisfies ProgressMarkerStep[];
+
+const STEP_LABELS: Record<ProgressMarkerStep, string> = {
+  complete: 'Complete',
+  empty: 'Start',
+  half: 'Half',
+  quarter: 'Quarter',
+  'three-quarters': 'Three quarters',
+};
+
+export default Storybook.story('ProgressMarker', story => {
+  story('Steps', () => (
+    <Stack gap="lg">
+      {PROGRESS_MARKER_STEPS.map(step => (
+        <Flex key={step} align="center" gap="sm">
+          <ProgressMarker step={step} aria-label={STEP_LABELS[step]} />
+          <Stack gap="xs">
+            <Text>{STEP_LABELS[step]}</Text>
+            <Text size="sm" variant="muted">
+              {step}
+            </Text>
+          </Stack>
+        </Flex>
+      ))}
+    </Stack>
+  ));
+});

--- a/static/app/components/progressMarker.tsx
+++ b/static/app/components/progressMarker.tsx
@@ -1,0 +1,64 @@
+import type {HTMLAttributes} from 'react';
+import styled from '@emotion/styled';
+
+import {IconCircle} from 'sentry/icons/iconCircle';
+import {IconCircleCheckmark} from 'sentry/icons/iconCircleCheckmark';
+import {IconPieHalf} from 'sentry/icons/iconPieHalf';
+import {IconPieQuarter} from 'sentry/icons/iconPieQuarter';
+import {IconPieThreeQuarters} from 'sentry/icons/iconPieThreeQuarters';
+
+export type ProgressMarkerStep =
+  | 'complete'
+  | 'empty'
+  | 'half'
+  | 'quarter'
+  | 'three-quarters';
+
+interface ProgressMarkerProps extends HTMLAttributes<HTMLSpanElement> {
+  step: ProgressMarkerStep;
+}
+
+export function ProgressMarker({
+  step,
+  'aria-label': ariaLabel,
+  ...props
+}: ProgressMarkerProps) {
+  return (
+    <ProgressIconFrame
+      aria-hidden={ariaLabel ? undefined : true}
+      aria-label={ariaLabel}
+      role={ariaLabel ? 'img' : undefined}
+      {...props}
+    >
+      {getProgressMarkerIcon(step)}
+    </ProgressIconFrame>
+  );
+}
+
+function getProgressMarkerIcon(step: ProgressMarkerStep) {
+  switch (step) {
+    case 'quarter':
+      return <IconPieQuarter size="md" variant="muted" />;
+    case 'half':
+      return <IconPieHalf size="md" variant="warning" />;
+    case 'three-quarters':
+      return <IconPieThreeQuarters size="md" variant="success" />;
+    case 'complete':
+      return <IconCircleCheckmark size="md" variant="success" />;
+    case 'empty':
+      return <IconCircle size="md" variant="muted" />;
+    default:
+      return null;
+  }
+}
+
+const ProgressIconFrame = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+
+  svg {
+    display: block;
+  }
+`;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -66,7 +66,7 @@ import {
 import {
   formatProgressState,
   getProgressIcon,
-  ProgressState,
+  type ProgressState,
 } from 'sentry/views/issueList/utils/progress';
 
 export const DEFAULT_STREAM_GROUP_STATS_PERIOD = '24h';
@@ -753,7 +753,7 @@ export function StreamGroup({
               {progressState ? (
                 <Container position="relative">
                   <ProgressActivityTooltip group={group}>
-                    <Stack direction="row" align="center" gap="sm">
+                    <Stack direction="row" align="center" gap="sm" wrap="nowrap">
                       {getProgressIcon(progressState)}
                       {formatProgressState(progressState)}
                     </Stack>

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/index.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 
 import type {GroupActivity} from 'sentry/types/group';
 
-import {ProgressMarker} from './progressMarker';
-import {getProgressMarkerVariant} from './variant';
+import {ActivityProgressMarker} from './progressMarker';
+import {getActivityMarkerState} from './variant';
 
 export function ActivityLineMarker({item}: {item: GroupActivity}) {
   return (
     <MarkerCell>
-      <ProgressMarker variant={getProgressMarkerVariant(item)} />
+      <ActivityProgressMarker state={getActivityMarkerState(item)} />
     </MarkerCell>
   );
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/progressMarker.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/progressMarker.tsx
@@ -1,40 +1,34 @@
 import styled from '@emotion/styled';
 
-import {IconCircle} from 'sentry/icons/iconCircle';
-import {IconCircleCheckmark} from 'sentry/icons/iconCircleCheckmark';
-import {IconPieHalf} from 'sentry/icons/iconPieHalf';
-import {IconPieQuarter} from 'sentry/icons/iconPieQuarter';
-import {IconPieThreeQuarters} from 'sentry/icons/iconPieThreeQuarters';
+import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip';
 
-import type {ProgressMarkerVariant} from './variant';
+import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
-export function ProgressMarker({variant}: {variant: ProgressMarkerVariant}) {
-  if (variant === 'dot') {
-    return (
-      <ProgressDotFrame>
-        <ProgressDot />
-      </ProgressDotFrame>
-    );
-  }
+import {formatActivityMarkerState, type ActivityMarkerState} from './variant';
 
-  return <ProgressIconFrame>{getProgressMarkerIcon(variant)}</ProgressIconFrame>;
+interface ProgressMarkerProps {
+  state: ActivityMarkerState;
+  tooltipProps?: Omit<TooltipProps, 'children' | 'skipWrapper' | 'title'>;
 }
 
-function getProgressMarkerIcon(variant: ProgressMarkerVariant) {
-  switch (variant) {
-    case 'routed':
-      return <IconPieQuarter size="md" variant="muted" />;
-    case 'diagnosed':
-      return <IconPieHalf size="md" variant="warning" />;
-    case 'fix-applied':
-      return <IconCircleCheckmark size="md" variant="success" />;
-    case 'fix-proposed':
-      return <IconPieThreeQuarters size="md" variant="success" />;
-    case 'identified':
-      return <IconCircle size="md" variant="muted" />;
-    default:
-      return null;
-  }
+export function ActivityProgressMarker({state, tooltipProps}: ProgressMarkerProps) {
+  const label = formatActivityMarkerState(state);
+  const marker =
+    state === 'activity' ? (
+      <ProgressDotFrame aria-label={label} role="img">
+        <ProgressDot />
+      </ProgressDotFrame>
+    ) : (
+      <ProgressIconFrame aria-label={label} role="img">
+        {getProgressIcon(state)}
+      </ProgressIconFrame>
+    );
+
+  return (
+    <Tooltip title={label} {...tooltipProps} skipWrapper>
+      {marker}
+    </Tooltip>
+  );
 }
 
 const ProgressIconFrame = styled('span')`
@@ -47,10 +41,6 @@ const ProgressIconFrame = styled('span')`
   border: 1px solid ${p => p.theme.tokens.border.transparent.neutral.muted};
   border-radius: 100%;
   background: ${p => p.theme.tokens.background.primary};
-
-  svg {
-    display: block;
-  }
 `;
 
 const ProgressDotFrame = styled('span')`

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/variant.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/variant.ts
@@ -1,29 +1,25 @@
+import {t} from 'sentry/locale';
 import type {GroupActivity} from 'sentry/types/group';
 import {GroupActivityType} from 'sentry/types/group';
+import {formatProgressState, ProgressState} from 'sentry/views/issueList/utils/progress';
 
-export type ProgressMarkerVariant =
-  | 'diagnosed'
-  | 'dot'
-  | 'fix-applied'
-  | 'fix-proposed'
-  | 'identified'
-  | 'routed';
+export type ActivityMarkerState = ProgressState | 'activity';
 
-export function getProgressMarkerVariant(item: GroupActivity): ProgressMarkerVariant {
+export function getActivityMarkerState(item: GroupActivity): ActivityMarkerState {
   switch (item.type) {
     case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST:
     case GroupActivityType.REFERENCED_IN_COMMIT:
     case GroupActivityType.SEER_PR_CREATED:
-      return 'fix-proposed';
+      return ProgressState.FIX_PROPOSED;
     case GroupActivityType.SET_RESOLVED:
     case GroupActivityType.SET_RESOLVED_BY_AGE:
     case GroupActivityType.SET_RESOLVED_IN_RELEASE:
     case GroupActivityType.SET_RESOLVED_IN_COMMIT:
     case GroupActivityType.MARK_REVIEWED:
-      return 'fix-applied';
+      return ProgressState.FIX_APPLIED;
     case GroupActivityType.SET_ESCALATING:
     case GroupActivityType.SEER_RCA_COMPLETED:
-      return 'diagnosed';
+      return ProgressState.DIAGNOSED;
     case GroupActivityType.SEER_RCA_STARTED:
     case GroupActivityType.SEER_SOLUTION_STARTED:
     case GroupActivityType.SEER_SOLUTION_COMPLETED:
@@ -35,19 +31,29 @@ export function getProgressMarkerVariant(item: GroupActivity): ProgressMarkerVar
     case GroupActivityType.SET_PUBLIC:
     case GroupActivityType.SET_PRIVATE:
     case GroupActivityType.SET_PRIORITY:
-      return 'dot';
+      return 'activity';
     case GroupActivityType.SET_REGRESSION:
-      return 'identified';
+      return ProgressState.IDENTIFIED;
     case GroupActivityType.SET_IGNORED:
-      return 'routed';
+      return ProgressState.ASSIGNED;
     case GroupActivityType.SET_UNRESOLVED:
-      return 'forecast' in item.data && item.data.forecast ? 'diagnosed' : 'identified';
+      return 'forecast' in item.data && item.data.forecast
+        ? ProgressState.DIAGNOSED
+        : ProgressState.IDENTIFIED;
     case GroupActivityType.NOTE:
-      return 'dot';
+      return 'activity';
     case GroupActivityType.ASSIGNED:
     case GroupActivityType.UNASSIGNED:
-      return 'routed';
+      return ProgressState.ASSIGNED;
     default:
-      return 'identified';
+      return ProgressState.IDENTIFIED;
   }
+}
+
+export function formatActivityMarkerState(state: ActivityMarkerState) {
+  if (state === 'activity') {
+    return t('Activity update');
+  }
+
+  return formatProgressState(state);
 }

--- a/static/app/views/issueList/utils/progress.tsx
+++ b/static/app/views/issueList/utils/progress.tsx
@@ -1,10 +1,6 @@
 import type {ReactNode} from 'react';
 
-import {IconCircle} from 'sentry/icons/iconCircle';
-import {IconCircleCheckmark} from 'sentry/icons/iconCircleCheckmark';
-import {IconPieHalf} from 'sentry/icons/iconPieHalf';
-import {IconPieQuarter} from 'sentry/icons/iconPieQuarter';
-import {IconPieThreeQuarters} from 'sentry/icons/iconPieThreeQuarters';
+import {ProgressMarker, type ProgressMarkerStep} from 'sentry/components/progressMarker';
 import {t} from 'sentry/locale';
 
 export enum ProgressState {
@@ -30,17 +26,18 @@ export function formatProgressState(state: ProgressState | null): string {
   return PROGRESS_STATE_LABELS[state] ?? state;
 }
 
-const PROGRESS_STATE_ICONS: Record<ProgressState, ReactNode> = {
-  [ProgressState.IDENTIFIED]: <IconCircle size="md" variant="muted" />,
-  [ProgressState.ASSIGNED]: <IconPieQuarter size="md" variant="muted" />,
-  [ProgressState.DIAGNOSED]: <IconPieHalf size="md" variant="warning" />,
-  [ProgressState.FIX_PROPOSED]: <IconPieThreeQuarters size="md" variant="success" />,
-  [ProgressState.FIX_APPLIED]: <IconCircleCheckmark size="md" variant="success" />,
+const PROGRESS_STATE_STEPS: Record<ProgressState, ProgressMarkerStep> = {
+  [ProgressState.IDENTIFIED]: 'empty',
+  [ProgressState.ASSIGNED]: 'quarter',
+  [ProgressState.DIAGNOSED]: 'half',
+  [ProgressState.FIX_PROPOSED]: 'three-quarters',
+  [ProgressState.FIX_APPLIED]: 'complete',
 };
 
 export function getProgressIcon(state: ProgressState | null): ReactNode {
   if (!state) {
     return null;
   }
-  return PROGRESS_STATE_ICONS[state] ?? null;
+  const step = PROGRESS_STATE_STEPS[state];
+  return step ? <ProgressMarker step={step} /> : null;
 }


### PR DESCRIPTION
pulls the progress icon rendering into a tiny shared component so the issue stream and activity timeline use the same glyphs without sharing status-specific logic.

activity timeline keeps the framed marker, generic dot, and tooltips. issue stream keeps the compact icon and label row.

<img width="407" height="415" alt="image" src="https://github.com/user-attachments/assets/7265be85-5e7c-4865-9bc0-2f15cdef91f7" />

fixes https://linear.app/getsentry/issue/ID-1675/progress-tooltips-and-stories