### PR TITLE
feat(action-log): Add reconciliation action to support overwriting features from external source of truth

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -86,7 +86,7 @@ class GroupActionType(IntEnum):
     AUTOFIX_CODING_COMPLETE = 27
     SET_REGRESSED = 28
     PULL_REQUEST_CLOSED = 29
-    RECONCILE_FEATURE = 30
+    RECONCILE_FEATURES = 30
 
 
 class GroupAction(BaseModel, abc.ABC):
@@ -329,18 +329,18 @@ class PullRequestClosedAction(GroupAction):
         return GroupActionType.PULL_REQUEST_CLOSED
 
 
-class FeatureChange(BaseModel):
+class _FeatureChange(BaseModel):
     feature_name: str
     new_value: object
 
 
-class ReconcileFeatureAction(GroupAction):
+class _ReconcileFeaturesAction(GroupAction):
     """
     Action to reset a feature to a known-correct value based on out-of-log information.
     """
 
-    changes: list[FeatureChange]
+    changes: list[_FeatureChange]
 
     @classmethod
     def get_type(cls) -> GroupActionType:
-        return GroupActionType.RECONCILE_FEATURE
+        return GroupActionType.RECONCILE_FEATURES

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -329,17 +329,14 @@ class PullRequestClosedAction(GroupAction):
         return GroupActionType.PULL_REQUEST_CLOSED
 
 
-class _FeatureChange(BaseModel):
+class _ReconcileFeatureAction(GroupAction):
+    """
+    Action to reset a single derived feature to a known-correct value
+    based on out-of-log information.
+    """
+
     feature_name: str
     new_value: object
-
-
-class _ReconcileFeaturesAction(GroupAction):
-    """
-    Action to reset a feature to a known-correct value based on out-of-log information.
-    """
-
-    changes: list[_FeatureChange]
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -86,6 +86,7 @@ class GroupActionType(IntEnum):
     AUTOFIX_CODING_COMPLETE = 27
     SET_REGRESSED = 28
     PULL_REQUEST_CLOSED = 29
+    RECONCILE_FEATURE = 30
 
 
 class GroupAction(BaseModel, abc.ABC):
@@ -326,3 +327,20 @@ class PullRequestClosedAction(GroupAction):
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.PULL_REQUEST_CLOSED
+
+
+class FeatureChange(BaseModel):
+    feature_name: str
+    new_value: object
+
+
+class ReconcileFeatureAction(GroupAction):
+    """
+    Action to reset a feature to a known-correct value based on out-of-log information.
+    """
+
+    changes: list[FeatureChange]
+
+    @classmethod
+    def get_type(cls) -> GroupActionType:
+        return GroupActionType.RECONCILE_FEATURE

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -109,7 +109,11 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
 )
 def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     if entry.type == GroupActionType.RECONCILE_FEATURES:
-        return reconcile_features(state, entry, PROGRESS, LAST_PROGRESSED_AT)
+        result = reconcile_features(state, entry, PROGRESS, LAST_PROGRESSED_AT)
+        if result is not None:
+            return result
+        # Fall through: a reconciliation of another feature (e.g. STATUS)
+        # may still require progress to react.
     current = state[PROGRESS]
     ts = entry.date_added
 

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -1,4 +1,6 @@
-from sentry.issues.action_log.types import GroupActionType
+from typing import Any, Sequence
+
+from sentry.issues.action_log.types import FeatureChange, GroupActionType, ReconcileFeatureAction
 from sentry.issues.derived.features import (
     LAST_PROGRESSED_AT,
     PROGRESS,
@@ -9,12 +11,45 @@ from sentry.issues.derived.features import (
 from sentry.issues.derived.framework import (
     Aggregator,
     AggregatorResult,
+    Feature,
+    FeatureEntry,
     StateView,
     aggregator,
     emit,
 )
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.progress_state import IssueProgressState
+
+
+def reconcile_features(
+    state: StateView, entry: GroupActionLogEntry, *features: Feature[Any]
+) -> AggregatorResult:
+    assert entry.type == GroupActionType.RECONCILE_FEATURE
+    for f in features:
+        if f not in state:
+            raise ValueError(f"Attempted to reconcile feature not found in state: {f.name}")
+    rec_action = ReconcileFeatureAction(**entry.data)
+    features_by_name = {f.name: f for f in features}
+    updates_by_name = {ch.feature_name: ch.new_value for ch in rec_action.changes}
+    hits = updates_by_name.keys() & features_by_name.keys()
+    if not hits:
+        return None
+    changes: list[FeatureEntry] = []
+    for name in hits:
+        f = features_by_name[name]
+        val = f.load(updates_by_name[name])
+        changes.append((f, val))
+    return emit(*changes)
+
+
+def create_reconciliation_action(updates: Sequence[FeatureEntry]) -> ReconcileFeatureAction:
+    if len(updates) == 0:
+        raise ValueError("Reconciliation Actions can't be created with no updates")
+    return ReconcileFeatureAction(
+        changes=[
+            FeatureChange(feature_name=feat.name, new_value=feat.dump(val)) for feat, val in updates
+        ]
+    )
 
 
 @aggregator((VIEW_COUNT,), scope=(GroupActionType.VIEW,))
@@ -30,9 +65,12 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
         GroupActionType.RESOLVED_IN_PULL_REQUEST,
         GroupActionType.ARCHIVE,
         GroupActionType.SET_REGRESSED,
+        GroupActionType.RECONCILE_FEATURE,
     ),
 )
 def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    if entry.type == GroupActionType.RECONCILE_FEATURE:
+        return reconcile_features(state, entry, STATUS)
     current = state[STATUS]
     resolves = (
         GroupActionType.RESOLVE.value,
@@ -104,6 +142,8 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
     deps=(STATUS,),
 )
 def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    if entry.type == GroupActionType.RECONCILE_FEATURE:
+        return reconcile_features(state, entry, PROGRESS, LAST_PROGRESSED_AT)
     current = state[PROGRESS]
     ts = entry.date_added
 

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -109,7 +109,10 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
 )
 def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     if entry.type == GroupActionType.RECONCILE_FEATURES:
-        result = reconcile_features(state, entry, PROGRESS, LAST_PROGRESSED_AT)
+        # Reconciliation corrects a value, it doesn't represent a real
+        # progression event — so we intentionally don't auto-update
+        # LAST_PROGRESSED_AT when PROGRESS is reconciled.
+        result = reconcile_features(state, entry, PROGRESS)
         if result is not None:
             return result
         # Fall through: a reconciliation of another feature (e.g. STATUS)

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -1,6 +1,4 @@
-from typing import Any, Sequence
-
-from sentry.issues.action_log.types import FeatureChange, GroupActionType, ReconcileFeatureAction
+from sentry.issues.action_log.types import GroupActionType
 from sentry.issues.derived.features import (
     LAST_PROGRESSED_AT,
     PROGRESS,
@@ -11,45 +9,13 @@ from sentry.issues.derived.features import (
 from sentry.issues.derived.framework import (
     Aggregator,
     AggregatorResult,
-    Feature,
-    FeatureEntry,
     StateView,
     aggregator,
     emit,
 )
+from sentry.issues.derived.reconciliation import reconcile_features
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.progress_state import IssueProgressState
-
-
-def reconcile_features(
-    state: StateView, entry: GroupActionLogEntry, *features: Feature[Any]
-) -> AggregatorResult:
-    assert entry.type == GroupActionType.RECONCILE_FEATURE
-    for f in features:
-        if f not in state:
-            raise ValueError(f"Attempted to reconcile feature not found in state: {f.name}")
-    rec_action = ReconcileFeatureAction(**entry.data)
-    features_by_name = {f.name: f for f in features}
-    updates_by_name = {ch.feature_name: ch.new_value for ch in rec_action.changes}
-    hits = updates_by_name.keys() & features_by_name.keys()
-    if not hits:
-        return None
-    changes: list[FeatureEntry] = []
-    for name in hits:
-        f = features_by_name[name]
-        val = f.load(updates_by_name[name])
-        changes.append((f, val))
-    return emit(*changes)
-
-
-def create_reconciliation_action(updates: Sequence[FeatureEntry]) -> ReconcileFeatureAction:
-    if len(updates) == 0:
-        raise ValueError("Reconciliation Actions can't be created with no updates")
-    return ReconcileFeatureAction(
-        changes=[
-            FeatureChange(feature_name=feat.name, new_value=feat.dump(val)) for feat, val in updates
-        ]
-    )
 
 
 @aggregator((VIEW_COUNT,), scope=(GroupActionType.VIEW,))
@@ -65,11 +31,11 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
         GroupActionType.RESOLVED_IN_PULL_REQUEST,
         GroupActionType.ARCHIVE,
         GroupActionType.SET_REGRESSED,
-        GroupActionType.RECONCILE_FEATURE,
+        GroupActionType.RECONCILE_FEATURES,
     ),
 )
 def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
-    if entry.type == GroupActionType.RECONCILE_FEATURE:
+    if entry.type == GroupActionType.RECONCILE_FEATURES:
         return reconcile_features(state, entry, STATUS)
     current = state[STATUS]
     resolves = (
@@ -142,7 +108,7 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
     deps=(STATUS,),
 )
 def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
-    if entry.type == GroupActionType.RECONCILE_FEATURE:
+    if entry.type == GroupActionType.RECONCILE_FEATURES:
         return reconcile_features(state, entry, PROGRESS, LAST_PROGRESSED_AT)
     current = state[PROGRESS]
     ts = entry.date_added

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -109,14 +109,17 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
 )
 def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     if entry.type == GroupActionType.RECONCILE_FEATURES:
-        # Reconciliation corrects a value, it doesn't represent a real
-        # progression event — so we intentionally don't auto-update
-        # LAST_PROGRESSED_AT when PROGRESS is reconciled.
+        # Direct PROGRESS reconciliation sets only that feature — the
+        # caller is correcting a value, not recording a progression event,
+        # so LAST_PROGRESSED_AT is intentionally left unchanged.
+        #
+        # If the reconciliation targets a different feature (e.g. STATUS),
+        # we fall through to normal logic so progress reacts to the state
+        # change. In that case LAST_PROGRESSED_AT *is* updated, since the
+        # progress transition is a real downstream consequence.
         result = reconcile_features(state, entry, PROGRESS)
         if result is not None:
             return result
-        # Fall through: a reconciliation of another feature (e.g. STATUS)
-        # may still require progress to react.
     current = state[PROGRESS]
     ts = entry.date_added
 

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -108,18 +108,9 @@ _ACTION_TO_MIN_PROGRESS: dict[int, IssueProgressState] = {
     deps=(STATUS,),
 )
 def track_progress(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
-    if entry.type == GroupActionType.RECONCILE_FEATURES:
-        # Direct PROGRESS reconciliation sets only that feature — the
-        # caller is correcting a value, not recording a progression event,
-        # so LAST_PROGRESSED_AT is intentionally left unchanged.
-        #
-        # If the reconciliation targets a different feature (e.g. STATUS),
-        # we fall through to normal logic so progress reacts to the state
-        # change. In that case LAST_PROGRESSED_AT *is* updated, since the
-        # progress transition is a real downstream consequence.
-        result = reconcile_features(state, entry, PROGRESS)
-        if result is not None:
-            return result
+    # RECONCILE_FEATURES entries may change STATUS, which requires progress
+    # to react (e.g. closing nulls progress). No fall-through guard needed
+    # since PROGRESS is not currently reconcilable.
     current = state[PROGRESS]
     ts = entry.date_added
 

--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -178,6 +178,7 @@ class StateView:
     def __init__(self, data: dict[Feature[Any], Any], allowed: frozenset[Feature[Any]]) -> None:
         self._data = data
         self._allowed = allowed
+        # TODO: Track valid scope?
 
     def __getitem__[T](self, key: Feature[T]) -> T:
         if key not in self._allowed:
@@ -218,6 +219,8 @@ def emit(*entries: FeatureEntry) -> AggregatorResult:
 
     >>> return emit(VIEW_COUNT.value(5), STATUS.value(IssueStatus.CLOSED))
     """
+    if not entries:
+        return None
     return StateUpdate(dict(entries))
 
 

--- a/src/sentry/issues/derived/reconciliation.py
+++ b/src/sentry/issues/derived/reconciliation.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry.issues.action_log.types import GroupActionType, _ReconcileFeatureAction
-from sentry.issues.derived.features import LAST_PROGRESSED_AT, PROGRESS, STATUS
+from sentry.issues.derived.features import PROGRESS, STATUS
 from sentry.issues.derived.framework import (
     AggregatorResult,
     Feature,
@@ -14,7 +14,7 @@ from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 # Features that have been validated for reconciliation. Each must be handled by
 # an aggregator that includes RECONCILE_FEATURES in its scope and has tests
 # covering the reconciliation path.
-RECONCILABLE_FEATURES: frozenset[Feature[Any]] = frozenset({STATUS, PROGRESS, LAST_PROGRESSED_AT})
+RECONCILABLE_FEATURES: frozenset[Feature[Any]] = frozenset({STATUS, PROGRESS})
 
 
 def reconcile_features(

--- a/src/sentry/issues/derived/reconciliation.py
+++ b/src/sentry/issues/derived/reconciliation.py
@@ -1,0 +1,59 @@
+from collections.abc import Sequence
+from typing import Any
+
+from sentry.issues.action_log.types import (
+    GroupActionType,
+    _FeatureChange,
+    _ReconcileFeaturesAction,
+)
+from sentry.issues.derived.features import LAST_PROGRESSED_AT, PROGRESS, STATUS
+from sentry.issues.derived.framework import (
+    AggregatorResult,
+    Feature,
+    FeatureEntry,
+    StateView,
+    emit,
+)
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+
+# Features that have been validated for reconciliation. Each must be handled by
+# an aggregator that includes RECONCILE_FEATURES in its scope and has tests
+# covering the reconciliation path.
+RECONCILABLE_FEATURES: frozenset[Feature[Any]] = frozenset({STATUS, PROGRESS, LAST_PROGRESSED_AT})
+
+
+def reconcile_features(
+    state: StateView, entry: GroupActionLogEntry, *features: Feature[Any]
+) -> AggregatorResult:
+    if entry.type != GroupActionType.RECONCILE_FEATURES:
+        raise ValueError(f"Expected RECONCILE_FEATURES, got {entry.type}")
+    for f in features:
+        if f not in state:
+            raise ValueError(f"Attempted to reconcile feature not found in state: {f.name}")
+    # Trying to be efficient in no-op cases: check the raw dict before
+    # constructing the Pydantic model.
+    features_by_name = {f.name: f for f in features}
+    raw_changes = entry.data.get("changes", ())
+    if not any(ch["feature_name"] in features_by_name for ch in raw_changes):
+        return None
+    rec_action = _ReconcileFeaturesAction(**entry.data)
+    changes: list[FeatureEntry] = []
+    for ch in rec_action.changes:
+        f = features_by_name.get(ch.feature_name)
+        if f is not None:
+            changes.append((f, f.load(ch.new_value)))
+    return emit(*changes)
+
+
+def create_reconciliation_action(updates: Sequence[FeatureEntry]) -> _ReconcileFeaturesAction:
+    if len(updates) == 0:
+        raise ValueError("Reconciliation actions can't be created with no updates")
+    unsupported = {feat.name for feat, _ in updates if feat not in RECONCILABLE_FEATURES}
+    if unsupported:
+        raise ValueError(f"Features not supported for reconciliation: {unsupported}")
+    return _ReconcileFeaturesAction(
+        changes=[
+            _FeatureChange(feature_name=feat.name, new_value=feat.dump(val))
+            for feat, val in updates
+        ]
+    )

--- a/src/sentry/issues/derived/reconciliation.py
+++ b/src/sentry/issues/derived/reconciliation.py
@@ -1,11 +1,6 @@
-from collections.abc import Sequence
 from typing import Any
 
-from sentry.issues.action_log.types import (
-    GroupActionType,
-    _FeatureChange,
-    _ReconcileFeaturesAction,
-)
+from sentry.issues.action_log.types import GroupActionType, _ReconcileFeatureAction
 from sentry.issues.derived.features import LAST_PROGRESSED_AT, PROGRESS, STATUS
 from sentry.issues.derived.framework import (
     AggregatorResult,
@@ -32,28 +27,19 @@ def reconcile_features(
             raise ValueError(f"Attempted to reconcile feature not found in state: {f.name}")
     # Trying to be efficient in no-op cases: check the raw dict before
     # constructing the Pydantic model.
-    features_by_name = {f.name: f for f in features}
-    raw_changes = entry.data.get("changes", ())
-    if not any(ch["feature_name"] in features_by_name for ch in raw_changes):
+    target_name = entry.data.get("feature_name")
+    match = next((f for f in features if f.name == target_name), None)
+    if match is None:
         return None
-    rec_action = _ReconcileFeaturesAction(**entry.data)
-    changes: list[FeatureEntry] = []
-    for ch in rec_action.changes:
-        f = features_by_name.get(ch.feature_name)
-        if f is not None:
-            changes.append((f, f.load(ch.new_value)))
-    return emit(*changes)
+    action = _ReconcileFeatureAction(**entry.data)
+    return emit((match, match.load(action.new_value)))
 
 
-def create_reconciliation_action(updates: Sequence[FeatureEntry]) -> _ReconcileFeaturesAction:
-    if len(updates) == 0:
-        raise ValueError("Reconciliation actions can't be created with no updates")
-    unsupported = {feat.name for feat, _ in updates if feat not in RECONCILABLE_FEATURES}
-    if unsupported:
-        raise ValueError(f"Features not supported for reconciliation: {unsupported}")
-    return _ReconcileFeaturesAction(
-        changes=[
-            _FeatureChange(feature_name=feat.name, new_value=feat.dump(val))
-            for feat, val in updates
-        ]
+def create_reconciliation_action(update: FeatureEntry) -> _ReconcileFeatureAction:
+    feat, val = update
+    if feat not in RECONCILABLE_FEATURES:
+        raise ValueError(f"Feature not supported for reconciliation: {feat.name}")
+    return _ReconcileFeatureAction(
+        feature_name=feat.name,
+        new_value=feat.dump(val),
     )

--- a/src/sentry/issues/derived/reconciliation.py
+++ b/src/sentry/issues/derived/reconciliation.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry.issues.action_log.types import GroupActionType, _ReconcileFeatureAction
-from sentry.issues.derived.features import PROGRESS, STATUS
+from sentry.issues.derived.features import STATUS
 from sentry.issues.derived.framework import (
     AggregatorResult,
     Feature,
@@ -14,7 +14,7 @@ from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 # Features that have been validated for reconciliation. Each must be handled by
 # an aggregator that includes RECONCILE_FEATURES in its scope and has tests
 # covering the reconciliation path.
-RECONCILABLE_FEATURES: frozenset[Feature[Any]] = frozenset({STATUS, PROGRESS})
+RECONCILABLE_FEATURES: frozenset[Feature[Any]] = frozenset({STATUS})
 
 
 def reconcile_features(

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -36,6 +36,7 @@ from sentry.issues.derived.processing import (
     invalidate_group_derived_data,
     process_group_log,
 )
+from sentry.issues.derived.reconciliation import create_reconciliation_action
 from sentry.issues.derived.store import GroupDerivedDataStore
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import GroupDerivedData
@@ -255,6 +256,19 @@ class ProcessGroupLogTest(TestCase):
         invalidate_group_derived_data(group.id)
         derived = process_group_log(group.id)
         assert derived.view_count == 2  # rebuilt from scratch
+
+    def test_reconcile_overrides_status(self) -> None:
+        group = self.create_group()
+        actor = GroupActionActor.user(self.user.id)
+
+        _publish(group=group, action=ResolveAction(), actor=actor)
+        derived = process_group_log(group.id)
+        assert derived.data["status"] == "closed"
+
+        action = create_reconciliation_action([STATUS.value(IssueStatus.OPEN)])
+        _publish(group=group, action=action, actor=actor)
+        derived = process_group_log(group.id)
+        assert derived.data["status"] == "open"
 
     def test_resolved_in_pull_request_closes(self) -> None:
         group = self.create_group()

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -265,7 +265,7 @@ class ProcessGroupLogTest(TestCase):
         derived = process_group_log(group.id)
         assert derived.data["status"] == "closed"
 
-        action = create_reconciliation_action([STATUS.value(IssueStatus.OPEN)])
+        action = create_reconciliation_action(STATUS.value(IssueStatus.OPEN))
         _publish(group=group, action=action, actor=actor)
         derived = process_group_log(group.id)
         assert derived.data["status"] == "open"

--- a/tests/sentry/issues/derived/test_reconciliation.py
+++ b/tests/sentry/issues/derived/test_reconciliation.py
@@ -1,5 +1,5 @@
 """
-Tests for reconciliation: creating ReconcileFeatureActions and applying them
+Tests for reconciliation: creating reconciliation actions and applying them
 through the pipeline to override derived feature values.
 """
 
@@ -25,9 +25,7 @@ from sentry.issues.derived.framework import (
     Pipeline,
     resolve,
 )
-from sentry.issues.derived.reconciliation import (
-    create_reconciliation_action,
-)
+from sentry.issues.derived.reconciliation import create_reconciliation_action
 from sentry.issues.progress_state import IssueProgressState
 
 
@@ -54,8 +52,8 @@ def _run_for_feature[T](feature: Feature[T], entries: list[FakeEntry]) -> T:
     return p.run(entries)[feature]
 
 
-def _reconcile_entry(*updates: FeatureEntry) -> FakeEntry:
-    action = create_reconciliation_action(updates)
+def _reconcile_entry(update: FeatureEntry) -> FakeEntry:
+    action = create_reconciliation_action(update)
     return FakeEntry(
         type=GroupActionType.RECONCILE_FEATURES,
         data=action.dict(),
@@ -68,57 +66,28 @@ def _reconcile_entry(*updates: FeatureEntry) -> FakeEntry:
 
 
 def test_create_reconciliation_action_roundtrips_enum() -> None:
-    action = create_reconciliation_action(
-        [STATUS.value(IssueStatus.CLOSED)],
-    )
-    assert len(action.changes) == 1
-    ch = action.changes[0]
-    assert ch.feature_name == "status"
-    # Value should be the codec-dumped form (string, not the enum)
-    assert ch.new_value == "closed"
-    # Round-trip back through load
-    assert STATUS.load(ch.new_value) == IssueStatus.CLOSED
+    action = create_reconciliation_action(STATUS.value(IssueStatus.CLOSED))
+    assert action.feature_name == "status"
+    assert action.new_value == "closed"
+    assert STATUS.load(action.new_value) == IssueStatus.CLOSED
 
 
 def test_create_reconciliation_action_roundtrips_optional_enum() -> None:
-    action = create_reconciliation_action(
-        [PROGRESS.value(IssueProgressState.DIAGNOSED)],
-    )
-    ch = action.changes[0]
-    assert ch.new_value == "diagnosed"
-    assert PROGRESS.load(ch.new_value) == IssueProgressState.DIAGNOSED
+    action = create_reconciliation_action(PROGRESS.value(IssueProgressState.DIAGNOSED))
+    assert action.new_value == "diagnosed"
+    assert PROGRESS.load(action.new_value) == IssueProgressState.DIAGNOSED
 
 
 def test_create_reconciliation_action_roundtrips_none() -> None:
-    action = create_reconciliation_action(
-        [PROGRESS.value(None)],
-    )
-    ch = action.changes[0]
-    assert ch.new_value is None
-    assert PROGRESS.load(ch.new_value) is None
-
-
-def test_create_reconciliation_action_multiple_features() -> None:
-    action = create_reconciliation_action(
-        [
-            STATUS.value(IssueStatus.CLOSED),
-            PROGRESS.value(None),
-        ],
-    )
-    assert len(action.changes) == 2
-    names = {ch.feature_name for ch in action.changes}
-    assert names == {"status", "progress"}
-
-
-def test_create_reconciliation_action_rejects_empty() -> None:
-    with pytest.raises(ValueError, match="no updates"):
-        create_reconciliation_action([])
+    action = create_reconciliation_action(PROGRESS.value(None))
+    assert action.new_value is None
+    assert PROGRESS.load(action.new_value) is None
 
 
 def test_create_reconciliation_action_rejects_unsupported_feature() -> None:
     unsupported = Feature[int]("not_reconcilable", default=0)
     with pytest.raises(ValueError, match="not supported for reconciliation"):
-        create_reconciliation_action([unsupported.value(42)])
+        create_reconciliation_action(unsupported.value(42))
 
 
 # ---------------------------------------------------------------------------
@@ -251,18 +220,16 @@ def test_reconcile_unrelated_feature_is_noop() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Multi-feature reconciliation
+# Multi-feature reconciliation (separate actions)
 # ---------------------------------------------------------------------------
 
 
-def test_reconcile_status_and_progress_together() -> None:
+def test_reconcile_status_and_progress_separately() -> None:
     p = _pipeline()
     state = p.run(
         [
-            _reconcile_entry(
-                STATUS.value(IssueStatus.CLOSED),
-                PROGRESS.value(None),
-            ),
+            _reconcile_entry(STATUS.value(IssueStatus.CLOSED)),
+            _reconcile_entry(PROGRESS.value(None)),
         ]
     )
     assert state[STATUS] == IssueStatus.CLOSED

--- a/tests/sentry/issues/derived/test_reconciliation.py
+++ b/tests/sentry/issues/derived/test_reconciliation.py
@@ -72,18 +72,6 @@ def test_create_reconciliation_action_roundtrips_enum() -> None:
     assert STATUS.load(action.new_value) == IssueStatus.CLOSED
 
 
-def test_create_reconciliation_action_roundtrips_optional_enum() -> None:
-    action = create_reconciliation_action(PROGRESS.value(IssueProgressState.DIAGNOSED))
-    assert action.new_value == "diagnosed"
-    assert PROGRESS.load(action.new_value) == IssueProgressState.DIAGNOSED
-
-
-def test_create_reconciliation_action_roundtrips_none() -> None:
-    action = create_reconciliation_action(PROGRESS.value(None))
-    assert action.new_value is None
-    assert PROGRESS.load(action.new_value) is None
-
-
 def test_create_reconciliation_action_rejects_unsupported_feature() -> None:
     unsupported = Feature[int]("not_reconcilable", default=0)
     with pytest.raises(ValueError, match="not supported for reconciliation"):
@@ -156,60 +144,7 @@ def test_normal_actions_continue_after_reconcile() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Reconciliation through the pipeline: progress
-# ---------------------------------------------------------------------------
-
-
-def test_reconcile_progress_forward() -> None:
-    assert (
-        _run_for_feature(
-            PROGRESS,
-            [_reconcile_entry(PROGRESS.value(IssueProgressState.DIAGNOSED))],
-        )
-        == IssueProgressState.DIAGNOSED
-    )
-
-
-def test_reconcile_progress_to_none() -> None:
-    assert (
-        _run_for_feature(
-            PROGRESS,
-            [_reconcile_entry(PROGRESS.value(None))],
-        )
-        is None
-    )
-
-
-def test_reconcile_progress_backward() -> None:
-    assert (
-        _run_for_feature(
-            PROGRESS,
-            [
-                FakeEntry(type=GroupActionType.ROOT_CAUSE_IDENTIFIED),
-                _reconcile_entry(PROGRESS.value(IssueProgressState.IDENTIFIED)),
-            ],
-        )
-        == IssueProgressState.IDENTIFIED
-    )
-
-
-# ---------------------------------------------------------------------------
-# Reconciliation with unrelated features (ignored by aggregator)
-# ---------------------------------------------------------------------------
-
-
-def test_reconcile_unrelated_feature_is_noop() -> None:
-    assert (
-        _run_for_feature(
-            STATUS,
-            [_reconcile_entry(PROGRESS.value(IssueProgressState.FIX_APPLIED))],
-        )
-        == IssueStatus.OPEN
-    )
-
-
-# ---------------------------------------------------------------------------
-# Cross-feature coupling
+# Cross-feature coupling: status reconciliation affects progress
 # ---------------------------------------------------------------------------
 
 
@@ -248,37 +183,3 @@ def test_reconcile_status_to_open_resets_progress() -> None:
     )
     assert state[STATUS] == IssueStatus.OPEN
     assert state[PROGRESS] == IssueProgressState.IDENTIFIED
-
-
-# ---------------------------------------------------------------------------
-# Multi-feature reconciliation (separate actions)
-# ---------------------------------------------------------------------------
-
-
-def test_reconcile_status_and_progress_separately() -> None:
-    p = _pipeline()
-    state = p.run(
-        [
-            _reconcile_entry(STATUS.value(IssueStatus.CLOSED)),
-            _reconcile_entry(PROGRESS.value(None)),
-        ]
-    )
-    assert state[STATUS] == IssueStatus.CLOSED
-    assert state[PROGRESS] is None
-
-
-def test_reconcile_mid_sequence_with_continuation() -> None:
-    assert (
-        _run_for_feature(
-            PROGRESS,
-            [
-                FakeEntry(type=GroupActionType.ASSIGN),
-                FakeEntry(type=GroupActionType.ROOT_CAUSE_IDENTIFIED),
-                # Reconcile backward to IDENTIFIED
-                _reconcile_entry(PROGRESS.value(IssueProgressState.IDENTIFIED)),
-                # Then advance again normally
-                FakeEntry(type=GroupActionType.ASSIGN),
-            ],
-        )
-        == IssueProgressState.ASSIGNED
-    )

--- a/tests/sentry/issues/derived/test_reconciliation.py
+++ b/tests/sentry/issues/derived/test_reconciliation.py
@@ -14,7 +14,6 @@ import pytest
 from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.features import (
-    LAST_PROGRESSED_AT,
     PROGRESS,
     STATUS,
     IssueStatus,
@@ -193,17 +192,6 @@ def test_reconcile_progress_backward() -> None:
     )
 
 
-def test_reconcile_last_progressed_at() -> None:
-    t = datetime(2025, 6, 15, 12, 0, tzinfo=UTC)
-    assert (
-        _run_for_feature(
-            LAST_PROGRESSED_AT,
-            [_reconcile_entry(LAST_PROGRESSED_AT.value(t))],
-        )
-        == t
-    )
-
-
 # ---------------------------------------------------------------------------
 # Reconciliation with unrelated features (ignored by aggregator)
 # ---------------------------------------------------------------------------
@@ -217,6 +205,35 @@ def test_reconcile_unrelated_feature_is_noop() -> None:
         )
         == IssueStatus.OPEN
     )
+
+
+# ---------------------------------------------------------------------------
+# Cross-feature coupling
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_status_to_closed_nulls_progress() -> None:
+    p = _pipeline()
+    state = p.run(
+        [
+            FakeEntry(type=GroupActionType.ASSIGN),
+            _reconcile_entry(STATUS.value(IssueStatus.CLOSED)),
+        ]
+    )
+    assert state[STATUS] == IssueStatus.CLOSED
+    assert state[PROGRESS] is None
+
+
+def test_reconcile_status_to_open_resets_progress() -> None:
+    p = _pipeline()
+    state = p.run(
+        [
+            FakeEntry(type=GroupActionType.RESOLVE),
+            _reconcile_entry(STATUS.value(IssueStatus.OPEN)),
+        ]
+    )
+    assert state[STATUS] == IssueStatus.OPEN
+    assert state[PROGRESS] == IssueProgressState.IDENTIFIED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sentry/issues/derived/test_reconciliation.py
+++ b/tests/sentry/issues/derived/test_reconciliation.py
@@ -1,0 +1,286 @@
+"""
+Tests for reconciliation: creating ReconcileFeatureActions and applying them
+through the pipeline to override derived feature values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.issues.derived.aggregators import AGGREGATORS
+from sentry.issues.derived.features import (
+    LAST_PROGRESSED_AT,
+    PROGRESS,
+    STATUS,
+    IssueStatus,
+)
+from sentry.issues.derived.framework import (
+    Feature,
+    FeatureEntry,
+    Pipeline,
+    resolve,
+)
+from sentry.issues.derived.reconciliation import (
+    create_reconciliation_action,
+)
+from sentry.issues.progress_state import IssueProgressState
+
+
+@dataclass(frozen=True)
+class FakeEntry:
+    type: int
+    date_added: datetime = datetime(2025, 1, 1, tzinfo=UTC)
+    actor_type: int = GroupActorType.SYSTEM
+    actor_id: int = 0
+    data: dict[str, object] = field(default_factory=dict)
+
+
+def _pipeline(
+    targets: tuple[Feature[Any], ...] | None = None,
+) -> Pipeline[Any]:
+    aggs = AGGREGATORS
+    if targets is not None:
+        aggs = resolve(targets, aggs)
+    return Pipeline(aggs, version=1, check_mutations=True)
+
+
+def _run_for_feature[T](feature: Feature[T], entries: list[FakeEntry]) -> T:
+    p = _pipeline(targets=(feature,))
+    return p.run(entries)[feature]
+
+
+def _reconcile_entry(*updates: FeatureEntry) -> FakeEntry:
+    action = create_reconciliation_action(updates)
+    return FakeEntry(
+        type=GroupActionType.RECONCILE_FEATURES,
+        data=action.dict(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_reconciliation_action
+# ---------------------------------------------------------------------------
+
+
+def test_create_reconciliation_action_roundtrips_enum() -> None:
+    action = create_reconciliation_action(
+        [STATUS.value(IssueStatus.CLOSED)],
+    )
+    assert len(action.changes) == 1
+    ch = action.changes[0]
+    assert ch.feature_name == "status"
+    # Value should be the codec-dumped form (string, not the enum)
+    assert ch.new_value == "closed"
+    # Round-trip back through load
+    assert STATUS.load(ch.new_value) == IssueStatus.CLOSED
+
+
+def test_create_reconciliation_action_roundtrips_optional_enum() -> None:
+    action = create_reconciliation_action(
+        [PROGRESS.value(IssueProgressState.DIAGNOSED)],
+    )
+    ch = action.changes[0]
+    assert ch.new_value == "diagnosed"
+    assert PROGRESS.load(ch.new_value) == IssueProgressState.DIAGNOSED
+
+
+def test_create_reconciliation_action_roundtrips_none() -> None:
+    action = create_reconciliation_action(
+        [PROGRESS.value(None)],
+    )
+    ch = action.changes[0]
+    assert ch.new_value is None
+    assert PROGRESS.load(ch.new_value) is None
+
+
+def test_create_reconciliation_action_multiple_features() -> None:
+    action = create_reconciliation_action(
+        [
+            STATUS.value(IssueStatus.CLOSED),
+            PROGRESS.value(None),
+        ],
+    )
+    assert len(action.changes) == 2
+    names = {ch.feature_name for ch in action.changes}
+    assert names == {"status", "progress"}
+
+
+def test_create_reconciliation_action_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="no updates"):
+        create_reconciliation_action([])
+
+
+def test_create_reconciliation_action_rejects_unsupported_feature() -> None:
+    unsupported = Feature[int]("not_reconcilable", default=0)
+    with pytest.raises(ValueError, match="not supported for reconciliation"):
+        create_reconciliation_action([unsupported.value(42)])
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation through the pipeline: status
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_overrides_status() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                FakeEntry(type=GroupActionType.RESOLVE),
+                FakeEntry(type=GroupActionType.UNRESOLVE),
+                _reconcile_entry(STATUS.value(IssueStatus.CLOSED)),
+            ],
+        )
+        == IssueStatus.CLOSED
+    )
+
+
+def test_reconcile_status_from_initial() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [_reconcile_entry(STATUS.value(IssueStatus.CLOSED))],
+        )
+        == IssueStatus.CLOSED
+    )
+
+
+def test_reconcile_status_reopens_closed() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                FakeEntry(type=GroupActionType.RESOLVE),
+                _reconcile_entry(STATUS.value(IssueStatus.OPEN)),
+            ],
+        )
+        == IssueStatus.OPEN
+    )
+
+
+def test_reconcile_status_same_value_is_noop() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [_reconcile_entry(STATUS.value(IssueStatus.OPEN))],
+        )
+        == IssueStatus.OPEN
+    )
+
+
+def test_normal_actions_continue_after_reconcile() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                _reconcile_entry(STATUS.value(IssueStatus.CLOSED)),
+                FakeEntry(type=GroupActionType.UNRESOLVE),
+            ],
+        )
+        == IssueStatus.OPEN
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation through the pipeline: progress
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_progress_forward() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [_reconcile_entry(PROGRESS.value(IssueProgressState.DIAGNOSED))],
+        )
+        == IssueProgressState.DIAGNOSED
+    )
+
+
+def test_reconcile_progress_to_none() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [_reconcile_entry(PROGRESS.value(None))],
+        )
+        is None
+    )
+
+
+def test_reconcile_progress_backward() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(type=GroupActionType.ROOT_CAUSE_IDENTIFIED),
+                _reconcile_entry(PROGRESS.value(IssueProgressState.IDENTIFIED)),
+            ],
+        )
+        == IssueProgressState.IDENTIFIED
+    )
+
+
+def test_reconcile_last_progressed_at() -> None:
+    t = datetime(2025, 6, 15, 12, 0, tzinfo=UTC)
+    assert (
+        _run_for_feature(
+            LAST_PROGRESSED_AT,
+            [_reconcile_entry(LAST_PROGRESSED_AT.value(t))],
+        )
+        == t
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation with unrelated features (ignored by aggregator)
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_unrelated_feature_is_noop() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [_reconcile_entry(PROGRESS.value(IssueProgressState.FIX_APPLIED))],
+        )
+        == IssueStatus.OPEN
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-feature reconciliation
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_status_and_progress_together() -> None:
+    p = _pipeline()
+    state = p.run(
+        [
+            _reconcile_entry(
+                STATUS.value(IssueStatus.CLOSED),
+                PROGRESS.value(None),
+            ),
+        ]
+    )
+    assert state[STATUS] == IssueStatus.CLOSED
+    assert state[PROGRESS] is None
+
+
+def test_reconcile_mid_sequence_with_continuation() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(type=GroupActionType.ASSIGN),
+                FakeEntry(type=GroupActionType.ROOT_CAUSE_IDENTIFIED),
+                # Reconcile backward to IDENTIFIED
+                _reconcile_entry(PROGRESS.value(IssueProgressState.IDENTIFIED)),
+                # Then advance again normally
+                FakeEntry(type=GroupActionType.ASSIGN),
+            ],
+        )
+        == IssueProgressState.ASSIGNED
+    )

--- a/tests/sentry/issues/derived/test_reconciliation.py
+++ b/tests/sentry/issues/derived/test_reconciliation.py
@@ -14,6 +14,7 @@ import pytest
 from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.features import (
+    LAST_PROGRESSED_AT,
     PROGRESS,
     STATUS,
     IssueStatus,
@@ -222,6 +223,19 @@ def test_reconcile_status_to_closed_nulls_progress() -> None:
     )
     assert state[STATUS] == IssueStatus.CLOSED
     assert state[PROGRESS] is None
+
+
+def test_reconcile_status_updates_last_progressed_at() -> None:
+    p = _pipeline()
+    state = p.run(
+        [
+            FakeEntry(type=GroupActionType.ASSIGN),
+            # Status reconciliation triggers a real progress transition
+            # (closed → progress=None), so LAST_PROGRESSED_AT is updated.
+            _reconcile_entry(STATUS.value(IssueStatus.CLOSED)),
+        ]
+    )
+    assert state[LAST_PROGRESSED_AT] is not None
 
 
 def test_reconcile_status_to_open_resets_progress() -> None:


### PR DESCRIPTION
This is likely to end up as a decorator on the aggregator, but I think manual is ok for now.
The aim is for this to be fairly safe assuming a stable set of features and correctly functioning codec stuff; we'll need to follow up on that to be more realistic. This should allow backfill operations to end with a check and a correction as needed.

The new feature is private to discourage direct use, as it should be created.
Originally I had this as a "set many" event, but there are some awkward implications for dependent values that we can avoid by just setting one at a time, which is likely to be the common case anyway.

Fixes ISWF-2960.
