### PR TITLE
chore(seer-billing): Remove contributor action rollout feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -350,8 +350,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Organizations on the new seat-based Seer plan
     manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Kill switch for recording contributor actions and assigning Seer seats
-    manager.add("organizations:seat-based-seer-skip-record-action", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Render Sentry App schema-backed forms using the backend JSON form adapter.
     manager.add("organizations:sentry-app-schema-form-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enable new SentryApp webhook request endpoint

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -151,7 +151,6 @@ def record_contributor_action(
 
     if (
         not is_opened
-        or features.has("organizations:seat-based-seer-skip-record-action", organization)
         or not should_increment_contributor_seat(organization, repo, contributor)
     ):
         return

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -149,10 +149,7 @@ def record_contributor_action(
         defaults={"alias": user_username},
     )
 
-    if (
-        not is_opened
-        or not should_increment_contributor_seat(organization, repo, contributor)
-    ):
+    if not is_opened or not should_increment_contributor_seat(organization, repo, contributor):
         return
 
     with transaction.atomic(router.db_for_write(OrganizationContributors)):


### PR DESCRIPTION
Relates to CW-1572

Removes the `organizations:seat-based-seer-skip-record-action` kill switch flag--no longer needed as the cutover to the new billing system is done, and the flag is at 0% rollout.