### PR TITLE
fix(issues): Polish new issue activity feed rows

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -767,28 +767,28 @@ interface GroupActivitySetByResolvedInRelease extends GroupActivityBase {
 
 interface GroupActivitySetByResolvedInCommit extends GroupActivityBase {
   data: {
-    commit?: Commit;
+    commit?: Commit | null;
   };
   type: GroupActivityType.SET_RESOLVED_IN_COMMIT;
 }
 
 interface GroupActivityReferencedInCommit extends GroupActivityBase {
   data: {
-    commit?: Commit;
+    commit?: Commit | null;
   };
   type: GroupActivityType.REFERENCED_IN_COMMIT;
 }
 
 export interface GroupActivitySetByResolvedInPullRequest extends GroupActivityBase {
   data: {
-    pullRequest?: PullRequest;
+    pullRequest?: PullRequest | null;
   };
   type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST;
 }
 
 export interface GroupActivityPullRequestClosed extends GroupActivityBase {
   data: {
-    pullRequest?: PullRequest;
+    pullRequest?: PullRequest | null;
   };
   type: GroupActivityType.PULL_REQUEST_CLOSED;
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/commitChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/commitChip.tsx
@@ -49,17 +49,23 @@ function formatCommitId(id: string) {
 }
 
 export function CommitChip({commit}: {commit: Commit}) {
-  const content = (
-    <InlineChip>
-      <IconCommit size="xs" />
-      {formatCommitId(commit.id)}
-    </InlineChip>
-  );
   const commitUrl = getCommitUrl(commit);
 
   if (!commitUrl) {
-    return content;
+    return (
+      <InlineChip>
+        <IconCommit size="xs" />
+        {formatCommitId(commit.id)}
+      </InlineChip>
+    );
   }
 
-  return <ExternalLink href={commitUrl}>{content}</ExternalLink>;
+  return (
+    <ExternalLink href={commitUrl}>
+      <InlineChip interactive>
+        <IconCommit size="xs" />
+        {formatCommitId(commit.id)}
+      </InlineChip>
+    </ExternalLink>
+  );
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/commitChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/commitChip.tsx
@@ -4,6 +4,7 @@ import {IconCommit} from 'sentry/icons';
 import type {Commit} from 'sentry/types/integrations';
 import {getShortCommitHash} from 'sentry/utils/git/getShortCommitHash';
 
+import {getCommitRepository} from './commitRepository';
 import {InlineChip} from './inlineChip';
 
 const COMMIT_URL_PATH_BY_PROVIDER = [
@@ -24,7 +25,7 @@ const COMMIT_URL_PATH_BY_PROVIDER = [
 ];
 
 function getCommitUrl(commit: Commit) {
-  const repository = commit.repository;
+  const repository = getCommitRepository(commit);
   const provider = repository?.provider;
 
   if (!repository?.url || !provider) {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/commitRepository.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/commitRepository.ts
@@ -1,0 +1,9 @@
+import type {Commit, Repository} from 'sentry/types/integrations';
+
+export function getCommitRepository(commit: Commit): Repository | undefined {
+  if (commit.repository?.url && commit.repository.provider?.id !== 'unknown') {
+    return commit.repository;
+  }
+
+  return commit.pullRequest?.repository ?? commit.repository;
+}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/externalIssueChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/externalIssueChip.tsx
@@ -43,7 +43,7 @@ export function ExternalIssueChip({label, location, provider}: ExternalIssueChip
 
   return (
     <ExternalLink href={location}>
-      <InlineChip tone="accent">
+      <InlineChip interactive tone="accent">
         <Icon size="xs" />
         {getExternalIssueLabel({label, provider})}
       </InlineChip>

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/inlineChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/inlineChip.tsx
@@ -3,6 +3,11 @@ import styled from '@emotion/styled';
 
 interface InlineChipProps {
   children: React.ReactNode;
+  /**
+   * Applies a hover affordance (pointer cursor and background step) for chips
+   * that are wrapped in a link or are otherwise clickable.
+   */
+  interactive?: boolean;
   tone?: 'accent' | 'default';
   variant?: 'compactLeading' | 'constrained' | 'constrainedCompactLeading' | 'default';
 }
@@ -10,6 +15,7 @@ interface InlineChipProps {
 interface ChipFrameProps {
   children: React.ReactNode;
   constrained?: boolean;
+  interactive?: boolean;
   maxWidth?: React.CSSProperties['maxWidth'];
   minWidth?: React.CSSProperties['minWidth'];
   paddingLeft?: React.CSSProperties['paddingLeft'];
@@ -18,6 +24,7 @@ interface ChipFrameProps {
 
 export function InlineChip({
   children,
+  interactive = false,
   tone = 'default',
   variant = 'default',
 }: InlineChipProps) {
@@ -30,6 +37,7 @@ export function InlineChip({
   return (
     <ChipFrame
       constrained={constrained}
+      interactive={interactive}
       maxWidth={constrained ? '100%' : undefined}
       minWidth={constrained ? 0 : undefined}
       paddingLeft={compactLeading ? theme.space.xs : undefined}
@@ -43,6 +51,7 @@ export function InlineChip({
 function ChipFrame({
   children,
   constrained,
+  interactive,
   maxWidth,
   minWidth,
   paddingLeft,
@@ -51,6 +60,7 @@ function ChipFrame({
   return (
     <ChipFrameElement
       data-constrained={constrained ? true : undefined}
+      data-interactive={interactive ? true : undefined}
       data-tone={tone}
       style={{maxWidth, minWidth, paddingLeft}}
     >
@@ -77,6 +87,15 @@ const chipFrameStyles = (p: {theme: Theme}) => css`
     text-overflow: ellipsis;
   }
 
+  &[data-interactive='true'] {
+    cursor: pointer;
+    transition: background 80ms ease-out;
+  }
+
+  &[data-interactive='true']:hover {
+    background: ${p.theme.colors.gray200};
+  }
+
   svg {
     flex-shrink: 0;
   }
@@ -94,6 +113,10 @@ const chipFrameStyles = (p: {theme: Theme}) => css`
   &[data-tone='accent'] {
     background: ${p.theme.tokens.background.transparent.accent.muted};
     color: ${p.theme.tokens.content.accent};
+  }
+
+  &[data-interactive='true'][data-tone='accent']:hover {
+    background: ${p.theme.colors.blue200};
   }
 `;
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/inlineChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/inlineChip.tsx
@@ -68,6 +68,7 @@ const chipFrameStyles = (p: {theme: Theme}) => css`
   border-radius: ${p.theme.radius.xs};
   background: ${p.theme.colors.gray100};
   color: ${p.theme.tokens.content.secondary};
+  font-weight: ${p.theme.font.weight.sans.regular};
   vertical-align: middle;
   white-space: nowrap;
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/pullRequestChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/pullRequestChip.tsx
@@ -25,7 +25,7 @@ export function PullRequestChip({pullRequest}: {pullRequest: PullRequest}) {
 
   return (
     <ExternalLink href={pullRequest.externalUrl}>
-      <InlineChip>
+      <InlineChip interactive>
         <IconPullRequest size="xs" />
         {displayId}
       </InlineChip>
@@ -45,7 +45,7 @@ export function SeerPullRequestChip({
 }) {
   return (
     <ExternalLink href={pullRequest.pull_request.pr_url}>
-      <InlineChip>
+      <InlineChip interactive>
         <IconPullRequest size="xs" />
         {formatPullRequestId(pullRequest.pull_request.pr_number)}
       </InlineChip>

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -320,7 +320,7 @@ export function getCompactGroupActivityItem({
       };
     case GroupActivityType.REFERENCED_IN_COMMIT:
       return {
-        title: t('Commit created'),
+        title: t('Referenced in commit'),
         details: activity.data.commit
           ? tct('on [provider] [commit]', {
               commit: <CommitChip commit={activity.data.commit} />,
@@ -329,7 +329,7 @@ export function getCompactGroupActivityItem({
                   activity.data.commit.repository?.provider?.id
               ),
             })
-          : t('in a commit'),
+          : undefined,
       };
     case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST: {
       const pullRequest = activity.data.pullRequest;
@@ -385,11 +385,11 @@ export function getCompactGroupActivityItem({
       };
     case GroupActivityType.SET_PUBLIC:
       return {
-        title: t('Made public'),
+        title: t('Issue made public'),
       };
     case GroupActivityType.SET_PRIVATE:
       return {
-        title: t('Made private'),
+        title: t('Issue made private'),
       };
     case GroupActivityType.SET_REGRESSION: {
       const {data} = activity;
@@ -432,7 +432,10 @@ export function getCompactGroupActivityItem({
     }
     case GroupActivityType.CREATE_ISSUE:
       return {
-        title: activity.data.new === false ? t('Linked issue') : t('Created issue'),
+        title:
+          activity.data.new === false
+            ? t('External issue linked')
+            : t('External issue created'),
         details: tct('on [provider] [title]', {
           provider: activity.data.provider,
           title: (
@@ -502,11 +505,11 @@ export function getCompactGroupActivityItem({
       return getAssignedActivityItem({activity, author});
     case GroupActivityType.UNASSIGNED:
       return {
-        title: t('Unassigned'),
+        title: t('Issue unassigned'),
       };
     case GroupActivityType.REPROCESS:
       return {
-        title: t('Reprocessed events'),
+        title: t('Events reprocessed'),
         details: (
           <Link
             to={`/organizations/${organization.slug}/issues/?query=reprocessing.original_issue_id:${activity.data.oldGroupId}&referrer=group-activity-reprocesses`}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -237,11 +237,8 @@ export function getCompactGroupActivityItem({
       return {
         title: t('Issue resolved'),
         details: integrationLink
-          ? tct('by [author] via [integration]', {
-              author,
-              integration: integrationLink,
-            })
-          : tct('by [author]', {author}),
+          ? tct('via [integration]', {integration: integrationLink})
+          : undefined,
       };
     }
     case GroupActivityType.SET_RESOLVED_BY_AGE: {
@@ -377,10 +374,7 @@ export function getCompactGroupActivityItem({
       return {
         title: t('Unresolved'),
         details: integrationLink
-          ? tct('by [author] via [integration]', {
-              author,
-              integration: integrationLink,
-            })
+          ? tct('via [integration]', {integration: integrationLink})
           : null,
       };
     }
@@ -395,12 +389,10 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.SET_PUBLIC:
       return {
         title: t('Made public'),
-        details: tct('by [author]', {author}),
       };
     case GroupActivityType.SET_PRIVATE:
       return {
         title: t('Made private'),
-        details: tct('by [author]', {author}),
       };
     case GroupActivityType.SET_REGRESSION: {
       const {data} = activity;
@@ -437,7 +429,7 @@ export function getCompactGroupActivityItem({
                 />
               ),
             })
-          : tct('by [author]', {author}),
+          : undefined,
         subtext: comparison,
       };
     }
@@ -459,20 +451,18 @@ export function getCompactGroupActivityItem({
       return {
         title: t('Merged'),
         details: tn(
-          '%1$s issue into this issue by %2$s',
-          '%1$s issues into this issue by %2$s',
-          activity.data.issues.length,
-          author
+          '%s issue into this issue',
+          '%s issues into this issue',
+          activity.data.issues.length
         ),
       };
     case GroupActivityType.UNMERGE_SOURCE:
       return {
         title: t('Unmerged'),
         details: tn(
-          '%1$s fingerprint to %3$s by %2$s',
-          '%1$s fingerprints to %3$s by %2$s',
+          '%1$s fingerprint to %2$s',
+          '%1$s fingerprints to %2$s',
           activity.data.fingerprints.length,
-          author,
           activity.data.destination ? (
             <Link
               to={`${issuesLink}${activity.data.destination.id}?referrer=group-activity-unmerged-source`}
@@ -488,10 +478,9 @@ export function getCompactGroupActivityItem({
       return {
         title: t('Unmerged'),
         details: tn(
-          '%1$s fingerprint from %3$s by %2$s',
-          '%1$s fingerprints from %3$s by %2$s',
+          '%1$s fingerprint from %2$s',
+          '%1$s fingerprints from %2$s',
           activity.data.fingerprints.length,
-          author,
           activity.data.source ? (
             <Link
               to={`${issuesLink}${activity.data.source.id}?referrer=group-activity-unmerged-destination`}
@@ -517,26 +506,21 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.UNASSIGNED:
       return {
         title: t('Unassigned'),
-        details: tct('by [author]', {author}),
       };
     case GroupActivityType.REPROCESS:
       return {
         title: t('Reprocessed events'),
-        details: tct('by [author]. [newEvents]', {
-          author,
-          newEvents: (
-            <Link
-              to={`/organizations/${organization.slug}/issues/?query=reprocessing.original_issue_id:${activity.data.oldGroupId}&referrer=group-activity-reprocesses`}
-            >
-              {tn('See %s new event', 'See %s new events', activity.data.eventCount)}
-            </Link>
-          ),
-        }),
+        details: (
+          <Link
+            to={`/organizations/${organization.slug}/issues/?query=reprocessing.original_issue_id:${activity.data.oldGroupId}&referrer=group-activity-reprocesses`}
+          >
+            {tn('See %s new event', 'See %s new events', activity.data.eventCount)}
+          </Link>
+        ),
       };
     case GroupActivityType.MARK_REVIEWED:
       return {
         title: t('Issue reviewed'),
-        details: tct('by [author]', {author}),
       };
     case GroupActivityType.AUTO_SET_ONGOING:
       return {
@@ -558,7 +542,6 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.DELETED_ATTACHMENT:
       return {
         title: t('Attachment deleted'),
-        details: tct('by [author]', {author}),
       };
     case GroupActivityType.SEER_RCA_STARTED:
       return {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -25,6 +25,7 @@ import {PullRequestChip, SeerPullRequestChip} from './chips/pullRequestChip';
 import {ActivityRelease} from './chips/releaseChip';
 import {getAssignedActivityItem} from './compactActivityItem/assignment';
 import {getResolvedInCommitDetails} from './compactActivityItem/commitDetails';
+import {getProviderName} from './compactActivityItem/provider';
 import type {CompactGroupActivityItem} from './compactActivityItem/types';
 
 export type {CompactGroupActivityItem} from './compactActivityItem/types';
@@ -45,24 +46,6 @@ function getAuthorName(item: GroupActivity) {
     return item.data.pullRequest.author.name;
   }
   return 'Sentry';
-}
-
-function getProviderName(provider: null | string | undefined) {
-  const normalized = provider?.toLowerCase();
-
-  if (!normalized) {
-    return t('Git provider');
-  }
-  if (normalized.includes('github')) {
-    return t('GitHub');
-  }
-  if (normalized.includes('gitlab')) {
-    return t('GitLab');
-  }
-  if (normalized.includes('bitbucket')) {
-    return t('Bitbucket');
-  }
-  return provider;
 }
 
 function getPullRequestProvider(pullRequest: PullRequest) {
@@ -360,7 +343,7 @@ export function getCompactGroupActivityItem({
               provider: getPullRequestProvider(pullRequest),
               pullRequest: <PullRequestChip pullRequest={pullRequest} />,
             })
-          : t('in a pull request'),
+          : null,
       };
     }
     case GroupActivityType.PULL_REQUEST_CLOSED: {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -346,17 +346,14 @@ export function getCompactGroupActivityItem({
     case GroupActivityType.PULL_REQUEST_CLOSED: {
       const pullRequest = activity.data.pullRequest;
       return {
-        title: t('Pull Request closed'),
+        title: t('Pull request closed'),
         details: pullRequest
           ? tct('by [author] on [provider] [pullRequest]', {
               author,
               provider: getPullRequestProvider(pullRequest),
               pullRequest: <PullRequestChip pullRequest={pullRequest} />,
             })
-          : tct('by [author]. [pullRequest]', {
-              author,
-              pullRequest: t('PR not available'),
-            }),
+          : tct('by [author]', {author}),
       };
     }
     case GroupActivityType.SET_UNRESOLVED: {
@@ -372,7 +369,7 @@ export function getCompactGroupActivityItem({
 
       const integrationLink = getIntegrationLink({data: activity.data, organization});
       return {
-        title: t('Unresolved'),
+        title: t('Issue unresolved'),
         details: integrationLink
           ? tct('via [integration]', {integration: integrationLink})
           : null,
@@ -435,7 +432,7 @@ export function getCompactGroupActivityItem({
     }
     case GroupActivityType.CREATE_ISSUE:
       return {
-        title: activity.data.new === false ? t('Linked Issue') : t('Created Issue'),
+        title: activity.data.new === false ? t('Linked issue') : t('Created issue'),
         details: tct('on [provider] [title]', {
           provider: activity.data.provider,
           title: (
@@ -581,12 +578,12 @@ export function getCompactGroupActivityItem({
     }
     case GroupActivityType.SEER_ITERATION_STARTED:
       return {
-        title: t('PR iteration started'),
+        title: t('Pull request iteration started'),
       };
     case GroupActivityType.SEER_ITERATION_COMPLETED: {
       const pullRequest = activity.data.pull_requests?.[0];
       return {
-        title: t('Pull Request updated'),
+        title: t('Pull request updated'),
         details: pullRequest
           ? tct('on [provider] [pullRequest]', {
               provider: getProviderName(pullRequest.provider),

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -135,7 +135,7 @@ export function getAssignedActivityItem({
   const integrationName = getAssignmentIntegrationName(activity.data.integration);
 
   return {
-    title: t('Assigned'),
+    title: t('Issue assigned'),
     details: <AssignedActivityDetails activity={activity} />,
     subtext:
       integrationName && activity.data.rule ? (

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -1,4 +1,5 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Fragment} from 'react';
+
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -70,30 +71,6 @@ function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
   return t('an unknown user');
 }
 
-function AssignmentLead({children}: {children: React.ReactNode}) {
-  return (
-    <Flex
-      as="span"
-      display="inline-flex"
-      align="center"
-      wrap="wrap"
-      gap="xs"
-      maxWidth="100%"
-      minWidth={0}
-    >
-      {children}
-    </Flex>
-  );
-}
-
-function AssignmentTitleText({children}: {children: React.ReactNode}) {
-  return (
-    <Text as="span" bold density="comfortable">
-      {children}
-    </Text>
-  );
-}
-
 function AssignmentDetailText({children}: {children: React.ReactNode}) {
   return (
     <Text as="span" variant="muted" bold={false} density="comfortable">
@@ -126,7 +103,7 @@ function RuleText({children}: {children: React.ReactNode}) {
   );
 }
 
-function AssignedActivityTitle({activity, author}: GetAssignedActivityItemParams) {
+function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) {
   const {teams} = useTeamsById();
   const {data} = activity;
   const assignedToSelf =
@@ -138,37 +115,28 @@ function AssignedActivityTitle({activity, author}: GetAssignedActivityItemParams
   );
   const integrationName = getAssignmentIntegrationName(data.integration);
 
-  if (integrationName) {
-    return (
-      <AssignmentLead>
-        <AssignmentTitleText>{t('Assigned')}</AssignmentTitleText>
-        <AssignmentDetailText>{t('to')}</AssignmentDetailText>
-        {assignee}
-        <AssignmentDetailText>{t('due to')}</AssignmentDetailText>
-        <RuleSource>{integrationName}</RuleSource>
-      </AssignmentLead>
-    );
-  }
-
   return (
-    <AssignmentLead>
-      <AssignmentTitleText>{t('Assigned')}</AssignmentTitleText>
+    <Fragment>
       <AssignmentDetailText>{t('to')}</AssignmentDetailText>
       {assignee}
-      {assignedToSelf ? null : <AssignmentDetailText>{t('by')}</AssignmentDetailText>}
-      {assignedToSelf ? null : <AssignmentDetailText>{author}</AssignmentDetailText>}
-    </AssignmentLead>
+      {integrationName ? (
+        <Fragment>
+          <AssignmentDetailText>{t('due to')}</AssignmentDetailText>
+          <RuleSource>{integrationName}</RuleSource>
+        </Fragment>
+      ) : null}
+    </Fragment>
   );
 }
 
 export function getAssignedActivityItem({
   activity,
-  author,
 }: GetAssignedActivityItemParams): CompactGroupActivityItem {
   const integrationName = getAssignmentIntegrationName(activity.data.integration);
 
   return {
-    title: <AssignedActivityTitle activity={activity} author={author} />,
+    title: t('Assigned'),
+    details: <AssignedActivityDetails activity={activity} />,
     subtext:
       integrationName && activity.data.rule ? (
         <RuleText>{activity.data.rule}</RuleText>

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/commitDetails.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/commitDetails.tsx
@@ -1,16 +1,51 @@
 import moment from 'moment-timezone';
 
-import {CommitLink} from 'sentry/components/commitLink';
-import {t, tct} from 'sentry/locale';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {t, tct, tn} from 'sentry/locale';
 import type {GroupActivity} from 'sentry/types/group';
 import {GroupActivityType} from 'sentry/types/group';
-import type {Commit} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import type {BaseRelease} from 'sentry/types/release';
+import {CommitChip} from 'sentry/views/issueDetails/activitySection/activityLineItem/chips/commitChip';
+import {getCommitRepository} from 'sentry/views/issueDetails/activitySection/activityLineItem/chips/commitRepository';
 import {ActivityRelease} from 'sentry/views/issueDetails/activitySection/activityLineItem/chips/releaseChip';
+import {getProviderName} from 'sentry/views/issueDetails/activitySection/activityLineItem/compactActivityItem/provider';
 
-function CommitActivityLink({commit}: {commit: Commit}) {
-  return <CommitLink inline commitId={commit.id} repository={commit.repository} />;
+const MAX_OTHER_RELEASES_IN_TOOLTIP = 5;
+
+function ReleaseOverflow({releases}: {releases: BaseRelease[]}) {
+  const count = releases.length;
+  const visibleReleases = releases.slice(0, MAX_OTHER_RELEASES_IN_TOOLTIP);
+  const hiddenCount = count - visibleReleases.length;
+
+  return (
+    <Tooltip
+      skipWrapper
+      maxWidth={320}
+      title={
+        <Stack gap="xs">
+          {visibleReleases.map(release => (
+            <Text key={release.version} as="span" size="sm" ellipsis>
+              {release.version}
+            </Text>
+          ))}
+          {hiddenCount > 0 ? (
+            <Text as="span" size="sm" variant="muted">
+              {tn('+%s more release', '+%s more releases', hiddenCount)}
+            </Text>
+          ) : null}
+        </Stack>
+      }
+    >
+      <Text as="span" size="sm" variant="muted">
+        {tn('%s other', '%s others', count)}
+      </Text>
+    </Tooltip>
+  );
 }
 
 export function getResolvedInCommitDetails(
@@ -27,35 +62,43 @@ export function getResolvedInCommitDetails(
     .filter(release => release.dateReleased !== null)
     .sort((a, b) => moment(a.dateReleased).valueOf() - moment(b.dateReleased).valueOf());
   const firstRelease = deployedReleases[0];
+  const repository = getCommitRepository(commit);
+  const provider = getProviderName(
+    repository?.provider?.name ?? repository?.provider?.id
+  );
+  const commitChip = <CommitChip commit={commit} />;
 
-  if (deployedReleases.length === 1 && firstRelease) {
-    return tct('in [commit], released in [release]', {
-      commit: <CommitActivityLink commit={commit} />,
-      release: (
-        <ActivityRelease
-          organization={organization}
-          project={project}
-          version={firstRelease.version}
-        />
-      ),
+  if (!firstRelease) {
+    return tct('by commit [commit] on [provider]', {
+      commit: commitChip,
+      provider,
     });
   }
 
-  if (deployedReleases.length > 1 && firstRelease) {
-    return tct('in [commit], released in [release] and [otherCount] others', {
-      commit: <CommitActivityLink commit={commit} />,
-      otherCount: deployedReleases.length - 1,
-      release: (
-        <ActivityRelease
-          organization={organization}
-          project={project}
-          version={firstRelease.version}
-        />
-      ),
+  const releaseChip = (
+    <ActivityRelease
+      organization={organization}
+      project={project}
+      version={firstRelease.version}
+    />
+  );
+  const otherReleases = deployedReleases.slice(1);
+
+  if (otherReleases.length === 0) {
+    return tct('by commit [commit] on [provider], released in [release]', {
+      commit: commitChip,
+      provider,
+      release: releaseChip,
     });
   }
 
-  return tct('in [commit]', {
-    commit: <CommitActivityLink commit={commit} />,
-  });
+  return tct(
+    'by commit [commit] on [provider], released in [release] and [otherReleases]',
+    {
+      commit: commitChip,
+      otherReleases: <ReleaseOverflow releases={otherReleases} />,
+      provider,
+      release: releaseChip,
+    }
+  );
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/provider.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/provider.ts
@@ -1,0 +1,19 @@
+import {t} from 'sentry/locale';
+
+export function getProviderName(provider: null | string | undefined) {
+  const normalized = provider?.toLowerCase();
+
+  if (!normalized || normalized === 'unknown' || normalized === 'unknown provider') {
+    return t('Git provider');
+  }
+  if (normalized.includes('github')) {
+    return t('GitHub');
+  }
+  if (normalized.includes('gitlab')) {
+    return t('GitLab');
+  }
+  if (normalized.includes('bitbucket')) {
+    return t('Bitbucket');
+  }
+  return provider;
+}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
@@ -37,7 +37,7 @@ export function ActivityLineHeadline({
       column={3}
       row={1}
       minWidth={0}
-      minHeight={22}
+      minHeight="22px"
       align="center"
       wrap="wrap"
       gap="xs"

--- a/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
@@ -2,6 +2,7 @@ import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 export type ActivityLineVariant = 'compact' | 'full';
 
@@ -41,11 +42,17 @@ export function ActivityLineHeadline({
       wrap="wrap"
       gap="xs"
     >
-      <ActivityLineTitle>{title}</ActivityLineTitle>
+      <Text as="span" bold density="comfortable" wordBreak="break-word">
+        {title}
+      </Text>
       {details && <ActivityLineDetails>{details}</ActivityLineDetails>}
       <ActivityLineMeta>
-        <ActivityLineMutedText>&bull;</ActivityLineMutedText>
-        <ActivityLineTimestamp>{timestamp}</ActivityLineTimestamp>
+        <Text as="span" variant="muted" density="comfortable">
+          &bull;
+        </Text>
+        <Text as="span" variant="muted" density="comfortable" wrap="nowrap">
+          {timestamp}
+        </Text>
         {actions}
       </ActivityLineMeta>
     </Flex>
@@ -94,28 +101,6 @@ const ActivityLineDetails = styled('span')`
   line-height: 1.4;
   overflow-wrap: anywhere;
   word-break: break-word;
-`;
-
-const ActivityLineTitle = styled('span')`
-  color: ${p => p.theme.tokens.content.primary};
-  font-size: ${p => p.theme.font.size.md};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  line-height: 1.6;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-`;
-
-const ActivityLineMutedText = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.md};
-  line-height: 1.4;
-`;
-
-const ActivityLineTimestamp = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.sm};
-  line-height: 1.4;
-  white-space: nowrap;
 `;
 
 const ActivityLineMeta = styled('span')`

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -450,7 +450,6 @@ describe('ActivitySection', () => {
     const timeline = await screen.findByTestId('activity-timeline');
     expect(timeline).toHaveTextContent('Assigned');
     expect(timeline).toHaveTextContent('#frontend');
-    expect(timeline).toHaveTextContent('Taylor');
     expect(timeline).not.toHaveTextContent('themselves');
   });
 

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -3,6 +3,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {PullRequestFixture} from 'sentry-fixture/pullRequest';
+import {RepositoryFixture} from 'sentry-fixture/repository';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
@@ -22,6 +23,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {GroupActivity} from 'sentry/types/group';
 import {GroupActivityType} from 'sentry/types/group';
+import {RepositoryStatus} from 'sentry/types/integrations';
 import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
 import {GroupDataContextProvider} from 'sentry/views/issueDetails/groupDataContext';
 
@@ -895,6 +897,144 @@ describe('ActivitySection', () => {
     expect(screen.getByText('f7f395d')).toBeInTheDocument();
   });
 
+  it('prefers commit repository details for resolved commit activity line items', async () => {
+    const commitRepository = RepositoryFixture({
+      name: 'getsentry/sentry',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+      url: 'https://github.com/getsentry/sentry',
+    });
+    const pullRequestRepository = RepositoryFixture({
+      name: 'getsentry/seer',
+      provider: {id: 'integrations:gitlab', name: 'GitLab'},
+      url: 'https://gitlab.com/getsentry/seer',
+    });
+    const resolvedCommitGroup = GroupFixture({
+      id: '1352',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_COMMIT,
+          id: 'resolved-commit-prefers-commit-repository',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            commit: CommitFixture({
+              id: '90857de21d98deda68d51a17e1411048fd74fbc4',
+              pullRequest: PullRequestFixture({repository: pullRequestRepository}),
+              repository: commitRepository,
+            }),
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider
+        group={resolvedCommitGroup}
+        project={resolvedCommitGroup.project}
+      >
+        <ActivitySection group={resolvedCommitGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(await screen.findByText('Issue resolved')).toBeInTheDocument();
+    expect(screen.getByText(/on GitHub/)).toBeInTheDocument();
+    expect(screen.queryByText(/GitLab/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: /90857de/})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/commit/90857de21d98deda68d51a17e1411048fd74fbc4'
+    );
+  });
+
+  it('uses pull request repository details for resolved commit activity line items when commit repository is unknown', async () => {
+    const activeRepository = RepositoryFixture({
+      name: 'getsentry/seer',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+      url: 'https://github.com/getsentry/seer',
+    });
+    const resolvedCommitGroup = GroupFixture({
+      id: '1351',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_COMMIT,
+          id: 'resolved-commit-with-pr-repository',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            commit: CommitFixture({
+              id: '42485aa330b1719b43faede3436717ee2ce8a1ed',
+              pullRequest: PullRequestFixture({repository: activeRepository}),
+              repository: RepositoryFixture({
+                name: 'getsentry/seer',
+                provider: {id: 'unknown', name: 'Unknown Provider'},
+                status: RepositoryStatus.DISABLED,
+                url: '',
+              }),
+            }),
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider
+        group={resolvedCommitGroup}
+        project={resolvedCommitGroup.project}
+      >
+        <ActivitySection group={resolvedCommitGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(await screen.findByText('Issue resolved')).toBeInTheDocument();
+    expect(screen.getByText(/by commit/)).toBeInTheDocument();
+    expect(screen.getByText(/on GitHub/)).toBeInTheDocument();
+    expect(screen.queryByText(/Unknown Provider/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: /42485aa/})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/seer/commit/42485aa330b1719b43faede3436717ee2ce8a1ed'
+    );
+  });
+
+  it('renders fallback details for missing resolved commit activity line item data', async () => {
+    const resolvedCommitGroup = GroupFixture({
+      id: '1353',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_COMMIT,
+          id: 'resolved-commit-missing-commit',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            commit: null,
+          },
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider
+        group={resolvedCommitGroup}
+        project={resolvedCommitGroup.project}
+      >
+        <ActivitySection group={resolvedCommitGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(await screen.findByText('Issue resolved')).toBeInTheDocument();
+    expect(screen.getByText('in a commit')).toBeInTheDocument();
+  });
+
   it('renders Seer activity when feature flag is enabled', async () => {
     const seerGroup = GroupFixture({
       id: '1342',
@@ -1127,6 +1267,43 @@ describe('ActivitySection', () => {
     );
     expect(await screen.findByText('Pull Request Created')).toBeInTheDocument();
     expect(screen.getByText('Sentry')).toBeInTheDocument();
+  });
+
+  it('does not render missing pull request details in activity line items', async () => {
+    const prGroup = GroupFixture({
+      id: '1350',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'pr-missing-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            pullRequest: null,
+          },
+          user: null,
+        },
+        {
+          type: GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+          id: 'pr-missing-2',
+          dateCreated: '2020-01-01T00:01:00',
+          data: {},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={prGroup} project={prGroup.project}>
+        <ActivitySection group={prGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(await screen.findAllByText('Pull request created')).toHaveLength(2);
+    expect(screen.queryByText('in a pull request')).not.toBeInTheDocument();
   });
 
   it('falls back to Sentry for bot authors with @localhost email', async () => {

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1362,7 +1362,7 @@ describe('ActivitySection', () => {
       }
     );
 
-    expect(await screen.findByText('Pull Request closed')).toBeInTheDocument();
+    expect(await screen.findByText('Pull request closed')).toBeInTheDocument();
     expect(screen.getByText(/by Shashank N Jarmale on GitHub/)).toBeInTheDocument();
     expect(screen.queryByText('Sentry')).not.toBeInTheDocument();
   });
@@ -1395,7 +1395,7 @@ describe('ActivitySection', () => {
       }
     );
 
-    expect(await screen.findByText('Pull Request closed')).toBeInTheDocument();
+    expect(await screen.findByText('Pull request closed')).toBeInTheDocument();
     expect(screen.getByText(/by Sentry on GitHub/)).toBeInTheDocument();
     expect(screen.queryByText('sentry[bot]')).not.toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -448,7 +448,7 @@ describe('ActivitySection', () => {
     );
 
     const timeline = await screen.findByTestId('activity-timeline');
-    expect(timeline).toHaveTextContent('Assigned');
+    expect(timeline).toHaveTextContent('Issue assigned');
     expect(timeline).toHaveTextContent('#frontend');
     expect(timeline).not.toHaveTextContent('themselves');
   });


### PR DESCRIPTION
Polish for the new issue activity feed (behind `issue-activity-feed-v2`):

- Use the commit chip for resolved-in-commit rows, preferring commit repo over PR repo metadata.
- Keep the bullet and timestamp inline with the text instead of wrapping below, and fix title/details/timestamp alignment and sizing.
- Render chip text (team names, commits, PRs) at a regular weight instead of bold.
- Drop the redundant "by <author>" where the actor avatar already shows who acted. Kept on pull request closed, which names the git author.

before

<img width="411" height="46" alt="image" src="https://github.com/user-attachments/assets/80a39718-712a-4fa3-af5e-9b29a753e73a" />

after

<img width="562" height="57" alt="image" src="https://github.com/user-attachments/assets/b418d197-7f5c-49e8-8d44-0d6a4d383470" />
