### PR TITLE
fix(deps): Bump idna to 3.18 for GHSA-65pc-fj4g-8rjx

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1048,10 +1048,10 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.18"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `idna` from 3.7 to 3.18 to resolve Dependabot alert #573 (GHSA-65pc-fj4g-8rjx / CVE-2026-45409, medium).

`idna.encode()` on specially crafted inputs (e.g. long runs of certain codepoints) can consume significant resources before length rejection, causing a denial of service. This is an incomplete-fix follow-up to CVE-2024-3651; the mitigation lands fully in idna 3.15.

`idna` is a transitive dependency (via `requests`, `httpx`, the `google-cloud-*` stack, and ~30 others) and the lockfile had pinned 3.7 by inertia — nothing constrained it below the fix. Re-pinning to the already-published 3.18 wheel is a lockfile-only change; no `pyproject.toml` constraint or dependent bump is needed, and idna is API-stable across the 3.x line so consumers are unaffected.

Dependabot's own auto-fix failed here because it cannot bump a transitive dependency directly.

Refs GHSA-65pc-fj4g-8rjx