### PR TITLE
feat(seer): Add group filter to the org Seer runs search

### DIFF
--- a/src/sentry/seer/runs_search.py
+++ b/src/sentry/seer/runs_search.py
@@ -30,6 +30,7 @@ search_config = SearchConfig.create_from(
     },
     allowed_keys={
         "agent",
+        "group",
         "has",
         "is",
         "mine",
@@ -57,13 +58,20 @@ def _validate_type(value: object) -> str:
     return raw
 
 
-def _validate_project_id(value: object) -> int:
-    # ``project`` maps to the integer ``agent__project_id`` column. Validate up
-    # front so a non-numeric value raises InvalidSearchQuery (a 400) rather than
-    # a ValueError during lazy SQL compilation (a 500).
+# ``project``/``group`` map to the integer ``agent__project_id`` /
+# ``agent__group_id`` columns.
+_ID_FIELDS: dict[str, str] = {
+    "project": "agent__project_id",
+    "group": "agent__group_id",
+}
+
+
+def _validate_numeric_id(value: object, *, field: str) -> int:
+    # Validate up front so a non-numeric value raises InvalidSearchQuery (a 400)
+    # rather than a ValueError during lazy SQL compilation (a 500).
     raw = str(value)
     if not raw.isdigit():
-        raise InvalidSearchQuery(f"Invalid project value: {value}. Expected a numeric project ID.")
+        raise InvalidSearchQuery(f"Invalid {field} value: {value}. Expected a numeric {field} ID.")
     return int(raw)
 
 
@@ -136,14 +144,18 @@ def apply_filters(
             queryset = queryset.exclude(q) if token.is_negation else queryset.filter(q)
             continue
 
-        if name == "project":
+        if name in _ID_FIELDS:
+            # ``project``/``group`` accept a single id or an ``[a, b, c]`` IN
+            # list. ``group:[...]`` lets a caller scope runs to a known set of
+            # groups (e.g. the issues on a page) in one query.
+            db_field = _ID_FIELDS[name]
             if token.is_in_filter or token.value.value != "":
                 values = token.value.value if token.is_in_filter else [token.value.value]
-                q = Q(agent__project_id__in=[_validate_project_id(v) for v in values])
+                q = Q(**{f"{db_field}__in": [_validate_numeric_id(v, field=name) for v in values]})
             else:
-                # ``has:project`` / ``!has:project`` — filter on whether a
-                # project is set rather than parsing the (empty) value as an ID.
-                q = Q(agent__project_id__isnull=False)
+                # ``has:project`` / ``!has:project`` — filter on whether the id
+                # is set rather than parsing the (empty) value as an id.
+                q = Q(**{f"{db_field}__isnull": False})
             queryset = queryset.exclude(q) if token.is_negation else queryset.filter(q)
             continue
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -235,6 +235,56 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         )
         assert [r["id"] for r in response.data] == [str(without_project.uuid)]
 
+    def test_group_filter(self) -> None:
+        project = self.create_project(organization=self.organization)
+        group = self.create_group(project=project)
+        run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=run, project=project, group=group)
+        other = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=other, project=project)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"group:{group.id}"}
+        )
+        assert [r["id"] for r in response.data] == [str(run.uuid)]
+
+    def test_group_in_filter(self) -> None:
+        project = self.create_project(organization=self.organization)
+        group_a = self.create_group(project=project)
+        group_b = self.create_group(project=project)
+        run_a = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=run_a, project=project, group=group_a)
+        run_b = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=run_b, project=project, group=group_b)
+        other = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=other, project=project)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"query": f"group:[{group_a.id}, {group_b.id}]"},
+        )
+        assert {r["id"] for r in response.data} == {str(run_a.uuid), str(run_b.uuid)}
+
+    def test_has_group_filter(self) -> None:
+        # has:group / !has:group filter on whether a group is set rather than
+        # 400ing on the empty (non-numeric) value.
+        project = self.create_project(organization=self.organization)
+        group = self.create_group(project=project)
+        with_group = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=with_group, project=project, group=group)
+        without_group = self.create_seer_run(organization=self.organization, user_id=self.user.id)
+        self.create_seer_agent_run(run=without_group, project=project, group=None)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "has:group"}
+        )
+        assert [r["id"] for r in response.data] == [str(with_group.uuid)]
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "!has:group"}
+        )
+        assert [r["id"] for r in response.data] == [str(without_group.uuid)]
+
     def test_free_text_query_matches_title(self) -> None:
         run = self.create_seer_run(organization=self.organization, user_id=self.user.id)
         self.create_seer_agent_run(run=run, title="Fix login bug")
@@ -258,6 +308,12 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         # A non-integer project value must 400, not 500 during SQL compilation.
         self.get_error_response(
             self.organization.slug, qs_params={"query": "project:abc"}, status_code=400
+        )
+
+    def test_non_numeric_group_returns_400(self) -> None:
+        # A non-integer group value must 400, not 500 during SQL compilation.
+        self.get_error_response(
+            self.organization.slug, qs_params={"query": "group:abc"}, status_code=400
         )
 
     def test_pagination(self) -> None:


### PR DESCRIPTION
Adds a `group` filter to the organization Seer runs list search (`GET /api/0/organizations/{org}/seer/runs/`).

The runs search now accepts:
- `group:<id>` — runs for a single group
- `group:[a, b, c]` — runs for a set of groups (IN list)
- `has:group` / `!has:group` — runs that do (not) have a group set

These map to `agent__group_id` and mirror the existing `project` filter exactly. 

Agent transcript: https://claudescope.sentry.dev/share/-3CC99kGOozSbjOrgJsBvbmQiTyLFZJrwlmLi2WYVkQ