### PR TITLE
perf(sentry-apps): Cache installation org id lookup by token

### DIFF
--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -129,6 +129,10 @@ class RpcSentryAppInstallation(RpcModel):
     api_token: str | None = Field(repr=False, default=None)
 
 
+class RpcOrganizationIdResult(RpcModel):
+    organization_id: int = -1
+
+
 class RpcSentryAppComponent(RpcModel):
     uuid: str = ""
     sentry_app_id: int = -1

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -13,6 +13,7 @@ from sentry.hybridcloud.rpc.filter_query import OpaqueSerializedResponse
 from sentry.hybridcloud.rpc.service import RpcService, rpc_method
 from sentry.sentry_apps.services.app import (
     RpcAlertRuleActionResult,
+    RpcOrganizationIdResult,
     RpcSentryApp,
     RpcSentryAppComponent,
     RpcSentryAppEventData,
@@ -266,6 +267,22 @@ def get_installations_for_organization(organization_id: int) -> list[RpcSentryAp
 @back_with_silo_cache("app_service.get_by_application_id", SiloMode.CELL, RpcSentryApp)
 def get_by_application_id(application_id: int) -> RpcSentryApp | None:
     return app_service.find_service_hook_sentry_app(api_application_id=application_id)
+
+
+@back_with_silo_cache(
+    "app_service.get_installation_org_id_by_token_id",
+    SiloMode.CELL,
+    RpcOrganizationIdResult,
+    # Short TTL: this is only used to pick a rate-limit bucket, not for authentication,
+    # so a stale entry has no security impact -- it just bounds how long a revoked or
+    # reassigned token can be bucketed by its old organization.
+    timeout=60,
+)
+def get_installation_org_id_by_token(token_id: int) -> RpcOrganizationIdResult | None:
+    organization_id = app_service.get_installation_org_id_by_token_id(token_id=token_id)
+    if organization_id is None:
+        return None
+    return RpcOrganizationIdResult(organization_id=organization_id)
 
 
 app_service = AppService.create_delegation()

--- a/tests/sentry/sentry_apps/services/test_app.py
+++ b/tests/sentry/sentry_apps/services/test_app.py
@@ -1,11 +1,15 @@
+from django.core.cache import cache
+
 from sentry.constants import SentryAppInstallationStatus
+from sentry.hybridcloud.rpc.caching import cell_caching_service
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.app import app_service, get_installation_org_id_by_token
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, assume_test_silo_mode_of
+from sentry.types.cell import get_local_cell
 from sentry.users.models.useremail import UserEmail
 
 
@@ -239,6 +243,38 @@ def test_get_installation_org_id_by_token_id() -> None:
     # Installation must be installed
     result = app_service.get_installation_org_id_by_token_id(token_id=token.id)
     assert result is None
+
+
+@django_db_all(transaction=True)
+def test_get_installation_org_id_by_token_cached() -> None:
+    cache.clear()
+
+    user = Factories.create_user()
+    org = Factories.create_organization(owner=user)
+    sentry_app = Factories.create_internal_integration(organization_id=org.id, is_alertable=True)
+    token = Factories.create_internal_integration_token(user=user, internal_integration=sentry_app)
+
+    result = get_installation_org_id_by_token(token.id)
+    assert result is not None
+    assert result.organization_id == org.id
+    assert result == get_installation_org_id_by_token.cb(token.id)
+
+    with assume_test_silo_mode_of(SentryAppInstallation):
+        install = sentry_app.installations.get(organization_id=org.id)
+        install.status = SentryAppInstallationStatus.PENDING
+        install.save()
+
+    # Stale cache still returns the previously resolved organization id.
+    assert get_installation_org_id_by_token(token.id) == result
+
+    # The raw (uncached) lookup reflects the status change immediately.
+    assert get_installation_org_id_by_token.cb(token.id) is None
+
+    cell_caching_service.clear_key(
+        cell_name=get_local_cell().name,
+        key=get_installation_org_id_by_token.key_from(token.id),
+    )
+    assert get_installation_org_id_by_token(token.id) is None
 
 
 @django_db_all(transaction=True)


### PR DESCRIPTION
Adds a `back_with_silo_cache`-wrapped `get_installation_org_id_by_token` alongside the existing RPC, same pattern as `get_installation`/`get_installations_for_organization`.

Not wired into any call site yet. This is prep for CORE-255 (slow RetrieveTeam/ListTeamMembers APIs) — the rate-limit middleware currently calls the raw RPC on every request. Once this has rolled out everywhere, a follow-up PR will switch it over.

Refs CORE-255