### PR TITLE
ref(conversations): Remove input/output tooltip from redesigned table

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -207,7 +207,7 @@ type CellContentProps = ComponentPropsWithRef<'div'> & {
   text: string;
 };
 
-function CellContent({text, ref, ...props}: CellContentProps) {
+export function CellContent({text, ref, ...props}: CellContentProps) {
   const cleanedText = cleanMarkdownForCell(text);
   return (
     <SingleLineMarkdown ref={ref} {...props}>

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -29,9 +29,9 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ConversationMissingMessagesAlert} from 'sentry/views/explore/conversations/components/conversationMissingMessagesAlert';
 import {
+  CellContent,
   getConversationDetailUrl,
   getUserDisplayName,
-  InputOutputTooltipCell,
   UserNotInstrumentedTooltip,
 } from 'sentry/views/explore/conversations/components/conversationsTable';
 import {ConversationsTableEditModal} from 'sentry/views/explore/conversations/components/conversationsTableEditModal';
@@ -310,13 +310,13 @@ const BodyCell = memo(function BodyCell({
       );
     case 'input':
       return dataRow.firstInput ? (
-        <InputOutputTooltipCell text={dataRow.firstInput} />
+        <CellContent text={dataRow.firstInput} />
       ) : (
         <Text>&mdash;</Text>
       );
     case 'output':
       return dataRow.lastOutput ? (
-        <InputOutputTooltipCell text={dataRow.lastOutput} />
+        <CellContent text={dataRow.lastOutput} />
       ) : (
         <Text>&mdash;</Text>
       );


### PR DESCRIPTION

Removes the hover tooltip from the input and output cells in the redesigned conversations table (`conversationsTableNew.tsx`). The cells now render their content directly via `CellContent` instead of wrapping it in `InputOutputTooltipCell`.

`CellContent` is now exported from `conversationsTable.tsx` for reuse.
