### PR TITLE
ref(span-buffer): Sample metrics collection

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -32,17 +32,24 @@ ARGS:
                  is detached into its own segment keyed by salt.
 - check_flush_lock -- "true" or "false" -- When true, this script checks for the per-segment flush lock and detaches
                                            the subsegment if the target segment is currently being flushed.
+- metrics_sample_rate -- int -- Collect metrics for 1 in N calls. 1 samples every call; 100 samples ~1%.
 - *span_id -- str[] -- The span ids in the subsegment.
 
 RETURNS:
 - set_key -- str -- The key of the segment, used to look up member-keys index and identify the segment in the queue.
 - has_root_span -- bool -- Whether this segment contains a root span.
 - latency_ms -- number -- Milliseconds elapsed during script execution.
-- latency_table -- table -- Per-step latency measurements, flattened as [key1, value1, key2, value2, ...].
-- metrics_table -- table -- Per-step gauge metrics, flattened as [key1, value1, key2, value2, ...].
+- latency_table -- table -- Per-step latency measurements, flattened as [key1, value1, key2, value2, ...]. Empty
+when this call is not sampled.
+- metrics_table -- table -- Per-step gauge metrics, flattened as [key1, value1, key2, value2, ...]. Empty when
+this call is not sampled.
 - merged_segment_span_ids -- str[] -- Span ids of child segments merged into this segment. These were previously
-                                      queued as their own segments, so they are the only stale queue entries the
-                                      caller needs to remove.
+queued as their own segments, so they are the only stale queue entries the
+caller needs to remove.
+
+NOTE: The latency_table, metrics_table and latency_ms are only populated for a sampled subset of
+calls (1 in metrics_sample_rate, see ARGS above). These are distribution/gauge metrics, so the
+sampled subset is statistically representative.
 
 ]] --
 
@@ -78,15 +85,24 @@ local byte_count = tonumber(ARGV[5])
 local max_segment_bytes = tonumber(ARGV[6])
 local salt = ARGV[7] or ""
 local check_flush_lock = ARGV[8] == "true"
-local NUM_ARGS = 8
+local metrics_sample_rate = tonumber(ARGV[9])
+local NUM_ARGS = 9
 
 local function get_time_ms()
     local time = redis.call("TIME")
     return tonumber(time[1]) * 1000 + tonumber(time[2]) / 1000
 end
 
--- Capture start time for latency measurement
-local start_time_ms = get_time_ms()
+local now = redis.call("TIME")
+
+-- Reuse the time microseconds to make a sampling decision. A rate of 1 samples
+-- every call; a rate of 100 samples ~1% of calls.
+local sample_metrics = (tonumber(now[2]) % metrics_sample_rate) == 0
+
+local start_time_ms = 0
+if sample_metrics then
+    start_time_ms = tonumber(now[1]) * 1000 + tonumber(now[2]) / 1000
+end
 
 local set_span_id = parent_span_id
 local redirect_depth = 0
@@ -105,19 +121,22 @@ for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
     set_span_id = new_set_span
 end
 
+local function insert_metric(t, key, value)
+    table.insert(t, key)
+    table.insert(t, value)
+end
+
 -- latency_table and metrics_table are flattened lists of [key1, value1, key2, value2, ...]
 -- so that the result is a flat array that is trivial to parse in Python, rather than a list
 -- of nested {key, value} pair tables.
 local latency_table = {}
 local metrics_table = {}
 
-local function insert_metric(t, key, value)
-    table.insert(t, key)
-    table.insert(t, value)
+if sample_metrics then
+    insert_metric(metrics_table, "redirect_table_size", redis.call("hlen", main_redirect_key))
+    insert_metric(metrics_table, "redirect_depth", redirect_depth)
 end
 
-insert_metric(metrics_table, "redirect_table_size", redis.call("hlen", main_redirect_key))
-insert_metric(metrics_table, "redirect_depth", redirect_depth)
 local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
 
 -- Reset the set expiry as we saw a new subsegment for this set
@@ -139,8 +158,11 @@ end
 redis.call("hset", main_redirect_key, unpack(hset_args))
 redis.call("expire", main_redirect_key, set_timeout)
 
-local redirect_end_time_ms = get_time_ms()
-insert_metric(latency_table, "redirect_step_latency_ms", redirect_end_time_ms - start_time_ms)
+local redirect_end_time_ms = 0
+if sample_metrics then
+    redirect_end_time_ms = get_time_ms()
+    insert_metric(latency_table, "redirect_step_latency_ms", redirect_end_time_ms - start_time_ms)
+end
 
 local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
 local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
@@ -189,8 +211,10 @@ if segment_too_large or segment_locked then
     set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, salt)
     ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
 end
-insert_metric(metrics_table, "detached_segment_too_large", segment_too_large and 1 or 0)
-insert_metric(metrics_table, "detached_segment_locked", segment_locked and 1 or 0)
+if sample_metrics then
+    insert_metric(metrics_table, "detached_segment_too_large", segment_too_large and 1 or 0)
+    insert_metric(metrics_table, "detached_segment_locked", segment_locked and 1 or 0)
+end
 
 local ingested_count_key = string.format("span-buf:ic:%s", set_key)
 local members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, set_span_id)
@@ -231,8 +255,12 @@ for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     end
 end
 
-local merge_payload_keys_end_time_ms = get_time_ms()
-insert_metric(latency_table, "merge_payload_keys_step_latency_ms", merge_payload_keys_end_time_ms - redirect_end_time_ms)
+local merge_payload_keys_end_time_ms = 0
+if sample_metrics then
+    merge_payload_keys_end_time_ms = get_time_ms()
+    insert_metric(latency_table, "merge_payload_keys_step_latency_ms",
+        merge_payload_keys_end_time_ms - redirect_end_time_ms)
+end
 
 redis.call("sadd", members_key, salt)
 redis.call("expire", members_key, set_timeout)
@@ -243,12 +271,15 @@ redis.call("incrby", ingested_byte_count_key, byte_count)
 redis.call("expire", ingested_count_key, set_timeout)
 redis.call("expire", ingested_byte_count_key, set_timeout)
 
-local counter_merge_end_time_ms = get_time_ms()
-insert_metric(latency_table, "counter_merge_step_latency_ms", counter_merge_end_time_ms - merge_payload_keys_end_time_ms)
+-- -1 is a sentinel meaning "not sampled"; the consumer ignores these so they
+-- don't pollute metrics. A real measurement is always >= 0.
+local latency_ms = -1
+if sample_metrics then
+    local counter_merge_end_time_ms = get_time_ms()
+    insert_metric(latency_table, "counter_merge_step_latency_ms",
+        counter_merge_end_time_ms - merge_payload_keys_end_time_ms)
+    latency_ms = counter_merge_end_time_ms - start_time_ms
+    insert_metric(latency_table, "total_step_latency_ms", latency_ms)
+end
 
--- Capture end time and calculate latency in milliseconds
-local end_time_ms = get_time_ms()
-local latency_ms = end_time_ms - start_time_ms
-insert_metric(latency_table, "total_step_latency_ms", latency_ms)
-
-return {set_key, has_root_span, latency_ms, latency_table, metrics_table, merged_segment_span_ids}
+return { set_key, has_root_span, latency_ms, latency_table, metrics_table, merged_segment_span_ids }

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -37,8 +37,11 @@ ARGS:
 RETURNS:
 - set_key -- str -- The key of the segment, used to look up member-keys index and identify the segment in the queue.
 - has_root_span -- bool -- Whether this segment contains a root span.
-- latency_ms -- number -- Milliseconds elapsed during script execution.
-- latency_table -- table -- Per-step latency measurements, flattened as [key1, value1, key2, value2, ...].
+- latency_us -- int -- Microseconds elapsed during script execution.
+- latency_table -- table -- Per-step latency measurements in integer microseconds, flattened as
+                            [key1, value1, key2, value2, ...]. Latencies are integer microseconds because Redis
+                            truncates Lua numbers to integers in replies; fractional milliseconds would come back
+                            as 0 for virtually every call, degrading these values into 0/1 flags.
 - metrics_table -- table -- Per-step gauge metrics, flattened as [key1, value1, key2, value2, ...].
 - merged_segment_span_ids -- str[] -- Span ids of child segments merged into this segment. These were previously
                                       queued as their own segments, so they are the only stale queue entries the
@@ -80,13 +83,13 @@ local salt = ARGV[7] or ""
 local check_flush_lock = ARGV[8] == "true"
 local NUM_ARGS = 8
 
-local function get_time_ms()
+local function get_time_us()
     local time = redis.call("TIME")
-    return tonumber(time[1]) * 1000 + tonumber(time[2]) / 1000
+    return tonumber(time[1]) * 1000000 + tonumber(time[2])
 end
 
 -- Capture start time for latency measurement
-local start_time_ms = get_time_ms()
+local start_time_us = get_time_us()
 
 local set_span_id = parent_span_id
 local redirect_depth = 0
@@ -139,8 +142,8 @@ end
 redis.call("hset", main_redirect_key, unpack(hset_args))
 redis.call("expire", main_redirect_key, set_timeout)
 
-local redirect_end_time_ms = get_time_ms()
-insert_metric(latency_table, "redirect_step_latency_ms", redirect_end_time_ms - start_time_ms)
+local redirect_end_time_us = get_time_us()
+insert_metric(latency_table, "redirect_step_latency_us", redirect_end_time_us - start_time_us)
 
 local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
 local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
@@ -231,8 +234,8 @@ for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     end
 end
 
-local merge_payload_keys_end_time_ms = get_time_ms()
-insert_metric(latency_table, "merge_payload_keys_step_latency_ms", merge_payload_keys_end_time_ms - redirect_end_time_ms)
+local merge_payload_keys_end_time_us = get_time_us()
+insert_metric(latency_table, "merge_payload_keys_step_latency_us", merge_payload_keys_end_time_us - redirect_end_time_us)
 
 redis.call("sadd", members_key, salt)
 redis.call("expire", members_key, set_timeout)
@@ -243,12 +246,12 @@ redis.call("incrby", ingested_byte_count_key, byte_count)
 redis.call("expire", ingested_count_key, set_timeout)
 redis.call("expire", ingested_byte_count_key, set_timeout)
 
-local counter_merge_end_time_ms = get_time_ms()
-insert_metric(latency_table, "counter_merge_step_latency_ms", counter_merge_end_time_ms - merge_payload_keys_end_time_ms)
+local counter_merge_end_time_us = get_time_us()
+insert_metric(latency_table, "counter_merge_step_latency_us", counter_merge_end_time_us - merge_payload_keys_end_time_us)
 
--- Capture end time and calculate latency in milliseconds
-local end_time_ms = get_time_ms()
-local latency_ms = end_time_ms - start_time_ms
-insert_metric(latency_table, "total_step_latency_ms", latency_ms)
+-- Capture end time and calculate latency in microseconds
+local end_time_us = get_time_us()
+local latency_us = end_time_us - start_time_us
+insert_metric(latency_table, "total_step_latency_us", latency_us)
 
-return {set_key, has_root_span, latency_ms, latency_table, metrics_table, merged_segment_span_ids}
+return {set_key, has_root_span, latency_us, latency_table, metrics_table, merged_segment_span_ids}

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -31,7 +31,7 @@ class BufferAggregate(NamedTuple):
     """
 
     operation_count: int
-    cumulative_latency_ms: int
+    cumulative_latency_ms: float
 
 
 class FlusherLogEntry(NamedTuple):
@@ -123,7 +123,7 @@ class BufferLogger:
         self._metrics_per_trace: dict[str, BufferAggregate] = {}
         self._last_log_time: float | None = None
 
-    def log(self, entries: list[tuple[str, int]]) -> None:
+    def log(self, entries: list[tuple[str, float]]) -> None:
         """
         Record a batch of EVALSHA operations and periodically log the top offenders.
 
@@ -150,7 +150,7 @@ class BufferLogger:
             log_message="spans.buffer.slow_evalsha_operations",
             entries_key="top_slow_operations",
             format_entry=lambda key,
-            val: f"{key}:{val.operation_count}:{val.cumulative_latency_ms}",
+            val: f"{key}:{val.operation_count}:{val.cumulative_latency_ms:.3f}",
         )
 
 
@@ -278,7 +278,7 @@ class SubsegmentDebugLog(NamedTuple):
 
 class InsertSpansMetrics:
     def __init__(self) -> None:
-        self._latency_entries: list[tuple[str, int]] = []
+        self._latency_entries: list[tuple[str, float]] = []
         self._latency_metrics: list[EvalshaData] = []
         self._gauge_metrics: list[EvalshaData] = []
         self._longest_evalsha_data: tuple[float, EvalshaData, EvalshaData] = (
@@ -312,7 +312,7 @@ class InsertSpansMetrics:
             )
 
     @property
-    def evalsha_latency_entries(self) -> list[tuple[str, int]]:
+    def evalsha_latency_entries(self) -> list[tuple[str, float]]:
         return self._latency_entries
 
     def emit_metrics(self) -> None:

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -300,6 +300,13 @@ class InsertSpansMetrics:
         return insert_spans_metrics
 
     def record_evalsha_result(self, project_and_trace: str, result: EvalshaResult) -> None:
+        # add-buffer.lua only populates latency/metrics for a ~1% sample of calls.
+        # Unsampled calls return latency_ms == -1 (sentinel) and empty metric
+        # tables; including those would skew averages and the slow-operation
+        # logger, so we skip them.
+        if result.latency_ms < 0:
+            return
+
         self._latency_entries.append((project_and_trace, result.latency_ms))
         self._latency_metrics.append(result.latency_metrics)
         self._gauge_metrics.append(result.gauge_metrics)

--- a/src/sentry/spans/buffer_store.py
+++ b/src/sentry/spans/buffer_store.py
@@ -25,6 +25,11 @@ from sentry.utils import metrics, redis
 
 add_buffer_script = redis.load_redis_script("spans/add-buffer.lua")
 
+# add-buffer.lua collects observability metrics for only 1 in N calls to keep
+# the hot path cheap. The sampled metrics are distributions/gauges, so the
+# subset stays statistically representative.
+METRICS_SAMPLE_RATE = 100
+
 type RedisClient = RedisCluster[bytes] | StrictRedis[bytes]
 type DecompressPayload = Callable[[bytes], list[bytes]]
 type GetDebugTraceLogger = Callable[[], Any]
@@ -178,6 +183,7 @@ class SpansBufferStore:
                         max_segment_bytes,
                         subsegment.salt,
                         check_flush_lock,
+                        METRICS_SAMPLE_RATE,
                         *subsegment.span_ids,
                     )
 

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -35,11 +35,9 @@ def _unflatten_data(flat: Sequence[Any]) -> EvalshaData:
 
 def _unflatten_latency_data(flat: Sequence[Any]) -> EvalshaData:
     """
-    Latency tables arrive as integer microseconds (Redis truncates Lua numbers
-    to integers in replies, so millisecond floats would collapse to 0 for
-    virtually every call). Convert to fractional milliseconds and rename the
-    `_us` step keys back to `_ms` so metric names and stage tags keep their
-    historical millisecond-based names.
+    Latency tables arrive as integer microseconds. Convert to fractional milliseconds and rename the
+    `_us` step keys back to `_ms` so metric names and stage tags keep their historical millisecond-based
+    names.
     """
     return [(flat[i].replace(b"_us", b"_ms"), flat[i + 1] / 1000.0) for i in range(0, len(flat), 2)]
 

--- a/src/sentry/spans/buffer_types.py
+++ b/src/sentry/spans/buffer_types.py
@@ -33,6 +33,17 @@ def _unflatten_data(flat: Sequence[Any]) -> EvalshaData:
     return [(flat[i], flat[i + 1]) for i in range(0, len(flat), 2)]
 
 
+def _unflatten_latency_data(flat: Sequence[Any]) -> EvalshaData:
+    """
+    Latency tables arrive as integer microseconds (Redis truncates Lua numbers
+    to integers in replies, so millisecond floats would collapse to 0 for
+    virtually every call). Convert to fractional milliseconds and rename the
+    `_us` step keys back to `_ms` so metric names and stage tags keep their
+    historical millisecond-based names.
+    """
+    return [(flat[i].replace(b"_us", b"_ms"), flat[i + 1] / 1000.0) for i in range(0, len(flat), 2)]
+
+
 # NamedTuples are faster to construct than dataclasses
 class Span(NamedTuple):
     trace_id: str
@@ -86,7 +97,7 @@ class Subsegment(NamedTuple):
 class EvalshaResult(NamedTuple):
     segment_key: SegmentKey
     has_root_span: bool
-    latency_ms: int
+    latency_ms: float
     latency_metrics: EvalshaData
     gauge_metrics: EvalshaData
     merged_segment_span_ids: list[bytes]
@@ -96,7 +107,7 @@ class EvalshaResult(NamedTuple):
         (
             segment_key,
             has_root_span,
-            latency_ms,
+            latency_us,
             latency_metrics,
             gauge_metrics,
             merged_segment_span_ids,
@@ -104,8 +115,8 @@ class EvalshaResult(NamedTuple):
         return cls(
             segment_key,
             has_root_span,
-            latency_ms,
-            _unflatten_data(latency_metrics),
+            latency_us / 1000.0,
+            _unflatten_latency_data(latency_metrics),
             _unflatten_data(gauge_metrics),
             merged_segment_span_ids,
         )

--- a/src/sentry/spans/log_analyzer/fetchers.py
+++ b/src/sentry/spans/log_analyzer/fetchers.py
@@ -24,13 +24,13 @@ class TraceSpans:
     """Parsed operation from top_slow_operations field.
 
     Format: {project_id}:{trace_id}:{count}:{cumulative_latency_ms}
-    Example: "123123123:6a499a5de1f6e3b412adb0ef12345678:2303:26557"
+    Example: "123123123:6a499a5de1f6e3b412adb0ef12345678:2303:26557.000"
     """
 
     project_id: str
     trace_id: str
     count: int
-    cumulative_latency_ms: int
+    cumulative_latency_ms: float
 
 
 @dataclass
@@ -97,7 +97,7 @@ def parse_top_traces(operations_list: list[str]) -> list[TraceSpans]:
                         project_id=parts[0],
                         trace_id=parts[1],
                         count=int(parts[2]),
-                        cumulative_latency_ms=int(parts[3]),
+                        cumulative_latency_ms=float(parts[3]),
                     )
                 )
             else:

--- a/tests/sentry/spans/test_add_buffer_lua.py
+++ b/tests/sentry/spans/test_add_buffer_lua.py
@@ -54,6 +54,7 @@ def eval_add_buffer_script(
     byte_count: int = 0,
     max_segment_bytes: int = 0,
     check_flush_lock: bool = False,
+    metrics_sample_rate: int = 1,
 ) -> list[Any]:
     sha = client.script_load(add_buffer_script.script)
     return client.execute_command(
@@ -69,6 +70,7 @@ def eval_add_buffer_script(
         max_segment_bytes,
         salt,
         "true" if check_flush_lock else "false",
+        metrics_sample_rate,
         *span_ids,
     )
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -14,6 +14,7 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.constants import DataCategory
 from sentry.spans.buffer import SpansBuffer
+from sentry.spans.buffer_store import METRICS_SAMPLE_RATE
 from sentry.spans.buffer_types import (
     EvalshaResult,
     FlushCandidate,
@@ -368,6 +369,7 @@ def test_insert_spans_builds_evalsha_commands_and_results() -> None:
                 1024,
                 "root-salt",
                 "true",
+                METRICS_SAMPLE_RATE,
                 root_span.span_id,
             ),
             mock.call(
@@ -383,6 +385,7 @@ def test_insert_spans_builds_evalsha_commands_and_results() -> None:
                 1024,
                 "child-salt",
                 "true",
+                METRICS_SAMPLE_RATE,
                 child_span.span_id,
             ),
         ]

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -322,16 +322,17 @@ def test_insert_spans_builds_evalsha_commands_and_results() -> None:
     root_result = [
         _segment_id(1, trace_id, parent_span_id),
         True,
-        15,
-        # The Lua script returns flattened [key1, value1, key2, value2, ...] lists.
-        [b"latency", 1.0],
+        15000,
+        # The Lua script returns flattened [key1, value1, key2, value2, ...]
+        # lists, with latencies as integer microseconds.
+        [b"latency_us", 1000],
         [b"gauge", 2.0],
         [],
     ]
     child_result = [
         _segment_id(1, trace_id, "b" * 16),
         False,
-        5,
+        5000,
         [],
         [],
         [],
@@ -389,12 +390,12 @@ def test_insert_spans_builds_evalsha_commands_and_results() -> None:
     )
     pipeline.execute.assert_called_once_with()
     buffer._buffer_logger.log.assert_called_once_with(
-        [(project_and_trace, 15), (project_and_trace, 5)]
+        [(project_and_trace, 15.0), (project_and_trace, 5.0)]
     )
     emit_metrics.assert_called_once_with(
-        [[(b"latency", 1.0)], []],
+        [[(b"latency_ms", 1.0)], []],
         [[(b"gauge", 2.0)], []],
-        (15, [(b"latency", 1.0)], [(b"gauge", 2.0)]),
+        (15.0, [(b"latency_ms", 1.0)], [(b"gauge", 2.0)]),
     )
 
 

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -93,6 +93,47 @@ def test_insert_spans_metrics_emits_evalsha_data() -> None:
     )
 
 
+def test_insert_spans_metrics_ignores_unsampled_results() -> None:
+    insert_spans_metrics = InsertSpansMetrics()
+    buffer_logger = mock.Mock()
+
+    # Unsampled call: latency_ms == -1 sentinel with empty metric tables. Should be ignored.
+    insert_spans_metrics.record_evalsha_result(
+        "1:" + "a" * 32,
+        EvalshaResult(
+            segment_key=_segment_id(1, "a" * 32, "a" * 16),
+            has_root_span=False,
+            latency_ms=-1,
+            latency_metrics=[],
+            gauge_metrics=[],
+            merged_segment_span_ids=[],
+        ),
+    )
+    # Sampled call.
+    insert_spans_metrics.record_evalsha_result(
+        "1:" + "b" * 32,
+        EvalshaResult(
+            segment_key=_segment_id(1, "b" * 32, "b" * 16),
+            has_root_span=True,
+            latency_ms=20,
+            latency_metrics=[(b"step", 20.0)],
+            gauge_metrics=[(b"gauge", 2.0)],
+            merged_segment_span_ids=[],
+        ),
+    )
+
+    with mock.patch("sentry.spans.buffer_logger.emit_observability_metrics") as emit_metrics:
+        buffer_logger.log(insert_spans_metrics.evalsha_latency_entries)
+        insert_spans_metrics.emit_metrics()
+
+    buffer_logger.log.assert_called_once_with([("1:" + "b" * 32, 20)])
+    emit_metrics.assert_called_once_with(
+        [[(b"step", 20.0)]],
+        [[(b"gauge", 2.0)]],
+        (20, [(b"step", 20.0)], [(b"gauge", 2.0)]),
+    )
+
+
 def test_insert_spans_metrics_from_inserted_subsegments() -> None:
     trace_id = "a" * 32
     parent_span_id = "b" * 16

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -278,7 +278,7 @@ def test_logs_only_top_50_when_more_than_1000_traces(mock_time, mock_logger):
         entries_list = extra["top_slow_operations"]
         assert len(entries_list) == 50
 
-        assert entries_list[0] == "high_project:trace:10:1500"
+        assert entries_list[0] == "high_project:trace:10:1500.000"
 
         assert extra["num_tracked_keys"] == 50
 

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -228,7 +228,7 @@ def test_accumulates_batches_and_tracks_cumulative_latency(mock_time):
         for i in range(1100):
             # Create entries with different latencies
             # Lower i values get higher latencies to test trimming
-            latency = 1000 - i if i < 500 else 100
+            latency = 1000.0 - i if i < 500 else 100.0
             entries_to_add.append((f"project{i}:trace{i}", latency))
 
         buffer_logger.log(entries_to_add)
@@ -260,9 +260,9 @@ def test_logs_only_top_50_when_more_than_1000_traces(mock_time, mock_logger):
 
         buffer_logger = BufferLogger()
 
-        buffer_logger.log([("high_project:trace", 150)] * 10)
+        buffer_logger.log([("high_project:trace", 150.0)] * 10)
 
-        entries = [(f"project{i}:trace{i}", 100) for i in range(1000)]
+        entries = [(f"project{i}:trace{i}", 100.0) for i in range(1000)]
         buffer_logger.log(entries)
 
         assert len(buffer_logger._metrics_per_trace) == 50

--- a/tests/sentry/spans/test_buffer_types.py
+++ b/tests/sentry/spans/test_buffer_types.py
@@ -84,19 +84,22 @@ def test_subsegment_exposes_span_metadata() -> None:
 def test_evalsha_result_from_redis_result() -> None:
     segment_key = _segment_id(1, "a" * 32, "b" * 16)
     # The Lua script returns flattened [key1, value1, key2, value2, ...] lists.
-    latency_metrics = [b"operation", 12.0, b"another", 5.0]
+    # Latencies arrive as integer microseconds (RESP truncates Lua numbers to
+    # integers) and are converted to millisecond floats, with the `_us` step
+    # keys renamed to their historical `_ms` names.
+    latency_metrics = [b"operation_latency_us", 12500, b"another_latency_us", 500]
     gauge_metrics = [b"gauge", 3.0]
     merged_segment_span_ids = [b"c" * 16]
 
     result = EvalshaResult.from_redis_result(
-        [segment_key, True, 15, latency_metrics, gauge_metrics, merged_segment_span_ids]
+        [segment_key, True, 15000, latency_metrics, gauge_metrics, merged_segment_span_ids]
     )
 
     assert result == EvalshaResult(
         segment_key=segment_key,
         has_root_span=True,
-        latency_ms=15,
-        latency_metrics=[(b"operation", 12.0), (b"another", 5.0)],
+        latency_ms=15.0,
+        latency_metrics=[(b"operation_latency_ms", 12.5), (b"another_latency_ms", 0.5)],
         gauge_metrics=[(b"gauge", 3.0)],
         merged_segment_span_ids=merged_segment_span_ids,
     )
@@ -155,12 +158,12 @@ def test_inserted_subsegment_from_redis_result() -> None:
 
     inserted = InsertedSubsegment.from_redis_result(
         subsegment,
-        [segment_key, False, 12, [], [], []],
+        [segment_key, False, 12000, [], [], []],
     )
 
     assert inserted == InsertedSubsegment(
         subsegment,
-        EvalshaResult(segment_key, False, 12, [], [], []),
+        EvalshaResult(segment_key, False, 12.0, [], [], []),
     )
 
 

--- a/tests/sentry/spans/test_buffer_types.py
+++ b/tests/sentry/spans/test_buffer_types.py
@@ -84,9 +84,6 @@ def test_subsegment_exposes_span_metadata() -> None:
 def test_evalsha_result_from_redis_result() -> None:
     segment_key = _segment_id(1, "a" * 32, "b" * 16)
     # The Lua script returns flattened [key1, value1, key2, value2, ...] lists.
-    # Latencies arrive as integer microseconds (RESP truncates Lua numbers to
-    # integers) and are converted to millisecond floats, with the `_us` step
-    # keys renamed to their historical `_ms` names.
     latency_metrics = [b"operation_latency_us", 12500, b"another_latency_us", 500]
     gauge_metrics = [b"gauge", 3.0]
     merged_segment_span_ids = [b"c" * 16]


### PR DESCRIPTION
Edit: to all those pinged please disregard.

This is an un-revert of https://github.com/getsentry/sentry/pull/118139. Specifically, it was reverted because of a DataDog graph behaving strangely after merge. This was later identified by [#118879](https://github.com/getsentry/sentry/pull/118879) as a measurement error where float latencies were being truncated to integers.