### PR TITLE
feat(text): Allow responsive display prop, exclusive with ellipsis

### DIFF
--- a/static/app/components/core/text/heading.spec.tsx
+++ b/static/app/components/core/text/heading.spec.tsx
@@ -89,6 +89,16 @@ describe('Heading', () => {
     );
   });
 
+  it('does not accept a display prop', () => {
+    render(
+      // @ts-expect-error: Heading does not support the display prop
+      <Heading as="h1" display="none">
+        Title
+      </Heading>
+    );
+    expect(screen.getByText('Title').tagName).toBe('H1');
+  });
+
   describe('types', () => {
     it('default signature requires as and limits children to React.ReactNode', () => {
       const props: HeadingProps = {as: 'h1', children: 'Title'};

--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -6,9 +6,13 @@ import {rc, type Responsive} from '@sentry/scraps/layout';
 import type {HeadingSize} from 'sentry/utils/theme';
 
 import {getFontSize, getLineHeight, getTextDecoration} from './styles';
-import {type BaseTextProps, type ExclusiveTextEllipsisProps} from './text';
+import {type BaseTextProps} from './text';
 
 type BaseHeadingProps = Omit<BaseTextProps, 'bold' | 'uppercase'>;
+
+type ExclusiveHeadingEllipsisProps =
+  | {ellipsis?: true; wrap?: never}
+  | {ellipsis?: never; wrap?: BaseTextProps['wrap']};
 
 export type HeadingProps = BaseHeadingProps & {
   /**
@@ -32,10 +36,10 @@ export type HeadingProps = BaseHeadingProps & {
     React.DetailedHTMLProps<React.HTMLAttributes<HTMLHeadingElement>, HTMLHeadingElement>,
     'style'
   > &
-  ExclusiveTextEllipsisProps;
+  ExclusiveHeadingEllipsisProps;
 
 export type HeadingPropsWithRenderFunction = BaseHeadingProps &
-  ExclusiveTextEllipsisProps & {
+  ExclusiveHeadingEllipsisProps & {
     children: (props: {className: string}) => React.ReactNode | undefined;
     as?: never;
     ref?: never;

--- a/static/app/components/core/text/text.spec.tsx
+++ b/static/app/components/core/text/text.spec.tsx
@@ -1,5 +1,6 @@
 import {createRef, Fragment} from 'react';
 import {expectTypeOf} from 'expect-type';
+import {ThemeFixture} from 'sentry-fixture/theme';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -8,6 +9,38 @@ import {
   type TextProps,
   type TextPropsWithRenderFunction,
 } from '@sentry/scraps/text';
+
+const theme = ThemeFixture();
+
+/**
+ * Emotion injects its styles through the CSSOM (`insertRule`), so they are not
+ * reflected in `getComputedStyle` under jsdom. Read the generated rules for an
+ * element directly off `document.styleSheets` instead.
+ */
+function getEmotionRules(element: HTMLElement): string[] {
+  const classes = element.className.split(' ').filter(c => c.startsWith('css-'));
+  const rules: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    let sheetRules: CSSRuleList;
+    try {
+      sheetRules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+    for (const rule of Array.from(sheetRules)) {
+      if (classes.some(cls => rule.cssText.includes(cls))) {
+        rules.push(rule.cssText);
+      }
+    }
+  }
+  return rules;
+}
+
+/** The `display` value of the always-applied base declaration (no at-rule). */
+function getBaseDisplay(element: HTMLElement): string | undefined {
+  const base = getEmotionRules(element).find(rule => rule.trimStart().startsWith('.'));
+  return base?.match(/display:\s*([\w-]+)/)?.[1];
+}
 
 describe('Text', () => {
   it('Defaults to span', () => {
@@ -105,6 +138,116 @@ describe('Text', () => {
         {props => <Child {...props} />}
       </Text>
     );
+  });
+
+  describe('display', () => {
+    it('emits no display for a plain span', () => {
+      render(<Text>Hello World</Text>);
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBeUndefined();
+    });
+
+    it('defaults to block when as="div"', () => {
+      render(<Text as="div">Hello World</Text>);
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('block');
+    });
+
+    it('forces block for ellipsis', () => {
+      render(<Text ellipsis>Hello World</Text>);
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('block');
+    });
+
+    it('forces inline-block for an explicit span with ellipsis', () => {
+      render(
+        <Text as="span" ellipsis>
+          Hello World
+        </Text>
+      );
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('inline-block');
+    });
+
+    it('applies a scalar display prop', () => {
+      render(<Text display="none">Hello World</Text>);
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('none');
+    });
+
+    it('lets an explicit display prop override the as-derived default', () => {
+      render(
+        <Text as="div" display="inline">
+          Hello World
+        </Text>
+      );
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('inline');
+    });
+
+    it('seeds the base breakpoint with the derived default for a responsive prop', () => {
+      render(
+        <Text as="div" display={{md: 'none'}}>
+          Hello World
+        </Text>
+      );
+      const element = screen.getByText('Hello World');
+      // The default (block) fills the base so the div is not hidden below md...
+      expect(getBaseDisplay(element)).toBe('block');
+      // ...and the explicit value overrides it from md up.
+      expect(getEmotionRules(element)).toContainEqual(
+        expect.stringMatching(
+          new RegExp(`@container \\(min-width: ${theme.breakpoints.md}\\).*display: none`)
+        )
+      );
+    });
+
+    it('seeds the base with the native block display for a responsive prop', () => {
+      render(
+        <Text as="p" display={{md: 'none'}}>
+          Hello World
+        </Text>
+      );
+      const element = screen.getByText('Hello World');
+      // Without a derived default, the element's native display (block for <p>)
+      // seeds the base so the paragraph is not hidden below md...
+      expect(getBaseDisplay(element)).toBe('block');
+      // ...and the explicit value overrides it from md up.
+      expect(getEmotionRules(element)).toContainEqual(
+        expect.stringMatching(
+          new RegExp(`@container \\(min-width: ${theme.breakpoints.md}\\).*display: none`)
+        )
+      );
+    });
+
+    it('seeds the base with the native inline display for a responsive span', () => {
+      render(<Text display={{md: 'none'}}>Hello World</Text>);
+      // A span is inline by default, so it stays visible below md instead of
+      // inheriting the `none` from the smallest specified breakpoint.
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('inline');
+    });
+
+    it('does not seed when the base breakpoint is explicitly set', () => {
+      render(
+        <Text as="div" display={{'2xs': 'none', md: 'block'}}>
+          Hello World
+        </Text>
+      );
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('none');
+    });
+
+    it('preserves the align-required display below the smallest breakpoint', () => {
+      render(
+        <Text align="center" display={{md: 'inline'}}>
+          Hello World
+        </Text>
+      );
+      // align needs a block-level box; the derived block seeds the base.
+      expect(getBaseDisplay(screen.getByText('Hello World'))).toBe('block');
+    });
+
+    it('is mutually exclusive with ellipsis', () => {
+      render(
+        // @ts-expect-error: display cannot be combined with ellipsis
+        <Text ellipsis display="none">
+          Hello World
+        </Text>
+      );
+    });
   });
 
   describe('types', () => {

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {rc, type Responsive} from '@sentry/scraps/layout';
 
-import type {ContentVariant, TextSize} from 'sentry/utils/theme';
+import type {ContentVariant, TextSize, Theme} from 'sentry/utils/theme';
 
 import {getFontSize, getLineHeight, getTextDecoration} from './styles';
 
@@ -100,8 +100,17 @@ export interface BaseTextProps {
 }
 
 export type ExclusiveTextEllipsisProps =
-  | {ellipsis?: true; wrap?: never}
-  | {ellipsis?: never; wrap?: BaseTextProps['wrap']};
+  | {
+      // ellipsis always needs a block-level box to truncate
+      display?: never;
+      ellipsis?: true;
+      wrap?: never;
+    }
+  | {
+      display?: Responsive<DisplayValue>;
+      ellipsis?: never;
+      wrap?: BaseTextProps['wrap'];
+    };
 
 interface TextAttributes<T extends TextPrimitive = 'span'>
   extends
@@ -154,6 +163,60 @@ interface TextAttributes<T extends TextPrimitive = 'span'>
 
 type TextPrimitive = 'span' | 'p' | 'label' | 'div' | 'time' | 'legend';
 
+type DisplayValue = 'inline' | 'block' | 'inline-block' | 'none';
+
+function getDefaultDisplay(p: {
+  align?: BaseTextProps['align'];
+  as?: TextPrimitive;
+  ellipsis?: boolean;
+}): DisplayValue | undefined {
+  if (p.as === 'div') {
+    return 'block';
+  }
+  if (p.ellipsis || p.align) {
+    return p.as === 'span' ? 'inline-block' : 'block';
+  }
+  return undefined;
+}
+
+/** The browser's default display for the rendered element. */
+function getNativeDisplay(as: TextPrimitive | undefined): DisplayValue {
+  return as === 'p' || as === 'div' || as === 'legend' ? 'block' : 'inline';
+}
+
+/**
+ * Resolves the `display` CSS. When no explicit `display` prop is set, the derived
+ * default is applied. An explicit prop takes precedence; for a responsive prop we
+ * seed the base (`2xs`) slot when the consumer left it unset — with the derived
+ * default, or the element's native display when there is none — so unspecified
+ * small breakpoints keep the sensible default instead of inheriting the value of
+ * the smallest specified breakpoint (which `rc` would otherwise make the base).
+ */
+function resolveDisplay(p: {
+  theme: Theme;
+  align?: BaseTextProps['align'];
+  as?: TextPrimitive;
+  display?: Responsive<DisplayValue>;
+  ellipsis?: boolean;
+}): string | undefined {
+  const fallback = getDefaultDisplay(p);
+
+  if (p.display === undefined) {
+    return fallback ? `display: ${fallback};` : undefined;
+  }
+
+  if (typeof p.display === 'string') {
+    return `display: ${p.display};`;
+  }
+
+  const value =
+    p.display['2xs'] === undefined
+      ? {'2xs': fallback ?? getNativeDisplay(p.as), ...p.display}
+      : p.display;
+
+  return rc('display', value, p.theme);
+}
+
 export type TextProps<T extends TextPrimitive> = TextAttributes<T> &
   ExclusiveTextEllipsisProps;
 
@@ -200,6 +263,7 @@ export const Text = styled(
 )`
   ${p => rc('font-size', p.size, p.theme, v => getFontSize(v, p.theme))};
   ${p => rc('line-height', p.density, p.theme, v => getLineHeight(v, p.theme))};
+  ${p => resolveDisplay(p)};
   ${p => rc('text-align', p.align, p.theme)};
 
   font-style: ${p => (p.italic ? 'italic' : undefined)};
@@ -219,14 +283,6 @@ export const Text = styled(
   text-wrap: ${p => p.textWrap ?? undefined};
   word-break: ${p => p.wordBreak ?? undefined};
   width: ${p => (p.ellipsis ? '100%' : undefined)};
-  display: ${p =>
-    p.as === 'div'
-      ? 'block'
-      : p.ellipsis || p.align
-        ? p.as === 'span'
-          ? 'inline-block'
-          : 'block'
-        : undefined};
 
   font-family: ${p => p.theme.font.family[p.monospace ? 'mono' : 'sans']};
   font-weight: ${p =>

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -99,7 +99,7 @@ export interface BaseTextProps {
   wrap?: 'nowrap' | 'normal' | 'pre' | 'pre-line' | 'pre-wrap';
 }
 
-export type ExclusiveTextEllipsisProps =
+type ExclusiveTextEllipsisProps =
   | {
       // ellipsis always needs a block-level box to truncate
       display?: never;

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -179,17 +179,15 @@ function getDefaultDisplay(p: {
   return undefined;
 }
 
-/** The browser's default display for the rendered element. */
 function getNativeDisplay(as: TextPrimitive | undefined): DisplayValue {
   return as === 'p' || as === 'div' || as === 'legend' ? 'block' : 'inline';
 }
 
 /**
- * Resolves the `display` CSS. When no explicit `display` prop is set, the derived
- * default is applied. An explicit prop takes precedence; for a responsive prop we
- * seed the base (`2xs`) slot when the consumer left it unset — with the derived
- * default, or the element's native display when there is none — so unspecified
- * small breakpoints keep the sensible default instead of inheriting the value of
+ * When no explicit `display` prop is set, the derived default is applied.
+ * For a responsive prop we seed the base (`2xs`) slot when the consumer left it unset
+ * (with the derived default, or the element's native display when there is none)
+ * so unspecified small breakpoints keep the sensible default instead of inheriting the value of
  * the smallest specified breakpoint (which `rc` would otherwise make the base).
  */
 function resolveDisplay(p: {


### PR DESCRIPTION
Make `Text`'s `display` prop responsive and the source of truth. Previously `display` was derived from `as`/`ellipsis`/`align` in a second CSS declaration that came *after* the explicit `display` prop, so the derived value silently clobbered it — e.g. `<Text as="div" display="inline">` was ignored.

**Explicit prop now wins, with a sensible responsive default**

Both declarations are collapsed into a single `resolveDisplay`. For a responsive prop, the derived default seeds the base (`2xs`) slot when you don't specify it, so unspecified small breakpoints keep the right default instead of falling back to the browser default.

Before, `as="div"` + `display={{md: 'none'}}` would drop the block default below `md` (div hidden):

```css
display: none;                          /* md became the unconditional base */
@container (min-width: 992px) { display: none; }
```

After, the derived default fills the base and the prop overrides upward:

```css
display: block;
@container (min-width: 992px) { display: none; }
```

**`display` and `ellipsis` are now mutually exclusive**

`ellipsis` needs a block-level box to truncate, and a responsive `display` can't be statically vetted for that. Rather than resolve the conflict at runtime, they're mutually exclusive at the type level (via the existing `ExclusiveTextEllipsisProps` union), so `<Text ellipsis display={...}>` is a compile error.