### PR TITLE
ref(seer-explorer): Source chat history from the /seer/runs/ endpoint

### DIFF
--- a/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
@@ -53,9 +53,9 @@ describe('SeerExplorerContent', () => {
       .mockReturnValue(defaultHookReturn);
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/explorer-runs/`,
+      url: `/organizations/${organization.slug}/seer/runs/`,
       method: 'GET',
-      body: {data: []},
+      body: [],
     });
   });
 

--- a/static/app/views/seerExplorer/components/seerExplorerHeader.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerHeader.tsx
@@ -94,13 +94,13 @@ export function SeerExplorerHeader({
       return [];
     }
     return (
-      data?.data.map(session => ({
-        value: session.sentry_run_id ?? session.run_id,
-        label: session.title,
+      data?.map(session => ({
+        value: session.id,
+        label: session.title ?? t('Untitled chat'),
         details: (
           <TimeSince
             tooltipPrefix="Last updated"
-            date={moment.utc(session.last_triggered_at).toDate()}
+            date={moment.utc(session.lastTriggeredAt).toDate()}
             suffix="ago"
           />
         ),

--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
@@ -134,9 +134,9 @@ describe('SeerExplorerSidebarLayout', () => {
       .spyOn(useSeerExplorerModule, 'useSeerExplorer')
       .mockReturnValue(defaultHookReturn);
     MockApiClient.addMockResponse({
-      url: `/organizations/${orgWithSidebar.slug}/seer/explorer-runs/`,
+      url: `/organizations/${orgWithSidebar.slug}/seer/runs/`,
       method: 'GET',
-      body: {data: []},
+      body: [],
     });
   });
 

--- a/static/app/views/seerExplorer/seerExplorerSessionContext.spec.tsx
+++ b/static/app/views/seerExplorer/seerExplorerSessionContext.spec.tsx
@@ -1,0 +1,33 @@
+import {buildRunsSearchQuery} from 'sentry/views/seerExplorer/seerExplorerSessionContext';
+
+describe('buildRunsSearchQuery', () => {
+  it('scopes to the current user and Explorer sessions when there is no search', () => {
+    expect(buildRunsSearchQuery()).toBe('is:mine type:explorer');
+    expect(buildRunsSearchQuery('')).toBe('is:mine type:explorer');
+    expect(buildRunsSearchQuery('   ')).toBe('is:mine type:explorer');
+  });
+
+  it('wraps free-text search in quotes so it stays a title filter', () => {
+    expect(buildRunsSearchQuery('database error')).toBe(
+      'is:mine type:explorer "database error"'
+    );
+  });
+
+  it('trims the search before quoting', () => {
+    expect(buildRunsSearchQuery('  padded  ')).toBe('is:mine type:explorer "padded"');
+  });
+
+  it('quotes input that looks like structured search instead of parsing it', () => {
+    // Without quoting these would be parsed by the runs search grammar and 400.
+    expect(buildRunsSearchQuery('unknownkey:value')).toBe(
+      'is:mine type:explorer "unknownkey:value"'
+    );
+    expect(buildRunsSearchQuery('type:not-a-real-type')).toBe(
+      'is:mine type:explorer "type:not-a-real-type"'
+    );
+  });
+
+  it('escapes embedded double quotes', () => {
+    expect(buildRunsSearchQuery('say "hi"')).toBe('is:mine type:explorer "say \\"hi\\""');
+  });
+});

--- a/static/app/views/seerExplorer/seerExplorerSessionContext.tsx
+++ b/static/app/views/seerExplorer/seerExplorerSessionContext.tsx
@@ -19,8 +19,8 @@ export function useSeerExplorerSessionsQuery({
   const isEnabled = enabled && isSeerExplorerEnabled(organization);
 
   return useQuery({
-    ...apiOptions.as<{data: ExplorerSession[]}>()(
-      '/organizations/$organizationIdOrSlug/seer/explorer-runs/',
+    ...apiOptions.as<ExplorerSession[]>()(
+      '/organizations/$organizationIdOrSlug/seer/runs/',
       {
         path:
           isEnabled && organization
@@ -28,7 +28,11 @@ export function useSeerExplorerSessionsQuery({
             : skipToken,
         query: {
           per_page: limit,
-          ...(searchQuery ? {query: searchQuery} : {}),
+          // Scope the shared runs endpoint to the current user's Explorer
+          // sessions; free-text search is appended as a title filter.
+          query: ['is:mine', 'type:explorer', searchQuery?.trim()]
+            .filter(Boolean)
+            .join(' '),
         },
         staleTime: 0,
       }

--- a/static/app/views/seerExplorer/seerExplorerSessionContext.tsx
+++ b/static/app/views/seerExplorer/seerExplorerSessionContext.tsx
@@ -1,10 +1,24 @@
 import {createContext} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
+import {escapeDoubleQuotes} from 'sentry/utils';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {ExplorerSession} from 'sentry/views/seerExplorer/types';
 import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
+
+// Quote free-text search so the runs search grammar treats it as a title
+// filter rather than parsing filter-like input (`foo:bar`) and returning 400.
+export function buildRunsSearchQuery(searchQuery?: string) {
+  const trimmed = searchQuery?.trim();
+  return [
+    'is:mine',
+    'type:explorer',
+    trimmed ? `"${escapeDoubleQuotes(trimmed)}"` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
 
 export function useSeerExplorerSessionsQuery({
   limit = 20,
@@ -28,11 +42,7 @@ export function useSeerExplorerSessionsQuery({
             : skipToken,
         query: {
           per_page: limit,
-          // Scope the shared runs endpoint to the current user's Explorer
-          // sessions; free-text search is appended as a title filter.
-          query: ['is:mine', 'type:explorer', searchQuery?.trim()]
-            .filter(Boolean)
-            .join(' '),
+          query: buildRunsSearchQuery(searchQuery),
         },
         staleTime: 0,
       }

--- a/static/app/views/seerExplorer/types.tsx
+++ b/static/app/views/seerExplorer/types.tsx
@@ -110,11 +110,10 @@ export interface Block {
 }
 
 export interface ExplorerSession {
-  created_at: string;
-  last_triggered_at: string;
-  run_id: number;
-  title: string;
-  sentry_run_id?: string | null;
+  dateCreated: string;
+  id: string;
+  lastTriggeredAt: string;
+  title: string | null;
 }
 
 export interface Artifact<T = Record<string, unknown>> {


### PR DESCRIPTION
Point the Seer Explorer chat-history dropdown at the org-wide `/seer/runs/` endpoint (`OrganizationSeerRunsEndpoint`, served from the `SeerRun`/`SeerAgentRun` mirror tables) instead of the Seer-proxied `/seer/explorer-runs/` endpoint.

Runs are now sourced from the Sentry-side mirror tables, so only mirrored runs appear in history (legacy unmirrored runs are intentionally dropped).

Agent transcript: https://claudescope.sentry.dev/share/OB1j0co3LAzMKbmhh7bT2jB6WIjA337ANhgd_gSw5UM