### PR TITLE
feat(scraps): Add JS container-query parity via useContainerBreakpoint

### DIFF
--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -265,42 +265,6 @@ For background on the underlying CSS, see MDN's <a href="https://developer.mozil
 The two can be combined on one prop — e.g. `direction={{xs: 'column', 'screen:lg': 'row'}}`
 is a column until its container reaches `xs`, then a row once the viewport reaches `lg`.
 
-#### Custom pixel breakpoints (escape hatch)
-
-Breakpoint keys are normally the named scale (`xs` = 500px, `sm` = 800px, …),
-which has nothing between `2xs` (0px) and `xs` (500px). When a design needs a
-one-off threshold the scale doesn't cover, a raw `<number>px` key works on either
-axis — bare for the container, `screen:`-prefixed for the viewport:
-
-<Storybook.SizingWindow display="block">
-  <Container
-    containerType="inline-size"
-    padding="md"
-    background="secondary"
-    radius="md"
-    border="primary"
-  >
-    <Container
-      display={{'2xs': 'none', '380px': 'block'}}
-      padding="sm"
-      background="primary"
-      border="primary"
-      radius="md"
-    >
-      Hidden until the container reaches 380px. Drag narrower to hide it.
-    </Container>
-  </Container>
-</Storybook.SizingWindow>
-```jsx // @container (min-width: 380px)
-<Flex display={{'2xs': 'none', '380px': 'flex'}}>…</Flex>
-// @media (min-width: 380px)
-<Flex display={{'2xs': 'none', 'screen:380px': 'flex'}}>…</Flex>
-```
-
-> [!TIP]
-> Prefer a named breakpoint when one fits — reach for a `<number>px` key only for
-> thresholds the scale genuinely lacks, so the shared scale stays the norm.
-
 > [!TIP]
 > Prefer `containerType="inline-size"` — it only contains the inline
 > (width) axis, so height still flows from content. `size` also contains the
@@ -313,11 +277,9 @@ When you need the resolved breakpoint in JS rather than just CSS, use
 `useContainerBreakpoint()` — the JS equivalent of a CSS container query and the
 container-scoped replacement for width-based `useMedia`. Call it from a
 descendant of a query container (a `Container`/`Flex`/… with `containerType`) and
-it returns the container's active breakpoint, updating as the container resizes.
-Pass an explicit list of tokens — named and/or `"<number>px"` escape hatches,
-e.g. `['sm', 'md', '380px']` — for one-off thresholds the named scale lacks; the
-hook returns the active token from that list. Drag the box below across the `xs`
-breakpoint (500px) to see the label swap — independent of the viewport width.
+it returns the container's active breakpoint, updating as the container crosses a
+breakpoint. Drag the box below across the `xs` breakpoint (500px) to see the
+label swap — independent of the viewport width.
 
 <Storybook.SizingWindow display="block">
   <ContainerBreakpointExample />

--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -16,16 +16,15 @@ export const documentation = import('!!type-loader!@sentry/scraps/layout/contain
 
 import {SIZES} from './__stories__/consts';
 
-function ContainerBreakpointLabel() {
-const breakpoint = useContainerBreakpoint();
-const isCompact = breakpoint === '2xs';
-return (
-
-<span>
-Active container breakpoint: <Text bold>{breakpoint}</Text> —{' '}
-{isCompact ? 'showing a compact label.' : 'showing the full, descriptive label.'}
-</span>
-);
+export function ContainerBreakpointLabel() {
+  const breakpoint = useContainerBreakpoint();
+  const isCompact = breakpoint === '2xs';
+  return (
+    <span>
+      Active container breakpoint: <Text bold>{breakpoint}</Text> —{' '}
+      {isCompact ? 'showing a compact label.' : 'showing the full, descriptive label.'}
+    </span>
+  );
 }
 
 export function ContainerBreakpointExample() {

--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -8,8 +8,6 @@ resources:
   figma: https://www.figma.com/design/eTJz6aPgudMY9E6mzyZU0B/%F0%9F%90%A6-Components?node-id=3040-309&p=f&t=fldvMEFX98yRuTH5-0
 ---
 
-import {useRef} from 'react';
-
 import {Container, Flex, useContainerBreakpoint} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import * as Storybook from 'sentry/stories';
@@ -18,24 +16,30 @@ export const documentation = import('!!type-loader!@sentry/scraps/layout/contain
 
 import {SIZES} from './__stories__/consts';
 
-export function ContainerBreakpointExample() {
-  const ref = useRef(null);
-  const breakpoint = useContainerBreakpoint(ref);
-  const isCompact = breakpoint === '2xs';
-
+function ContainerBreakpointLabel() {
+const breakpoint = useContainerBreakpoint();
+const isCompact = breakpoint === '2xs';
 return (
 
-<Container
-      ref={ref}
+<span>
+Active container breakpoint: <Text bold>{breakpoint}</Text> —{' '}
+{isCompact ? 'showing a compact label.' : 'showing the full, descriptive label.'}
+</span>
+);
+}
+
+export function ContainerBreakpointExample() {
+  return (
+    <Container
+      containerType="inline-size"
       padding="md"
       background="secondary"
       border="primary"
       radius="md"
     >
-Active container breakpoint: <Text bold>{breakpoint}</Text> —{' '}
-{isCompact ? 'showing a compact label.' : 'showing the full, descriptive label.'}
-</Container>
-);
+      <ContainerBreakpointLabel />
+    </Container>
+  );
 }
 
 The `Container` component is a foundational layout component that extends HTML elements with responsive CSS properties through props. It serves as the building block for other layout components like `Flex` and `Grid` to provides a consistent API for spacing, sizing, positioning, and styling.
@@ -271,27 +275,25 @@ is a column until its container reaches `xs`, then a row once the viewport reach
 ### Reading the breakpoint in JS
 
 When you need the resolved breakpoint in JS rather than just CSS, use
-`useContainerBreakpoint(ref)` — the `ResizeObserver`-backed, container-scoped
-replacement for width-based `useMedia`. Point its `ref` at the element you want
-to measure and it returns the active breakpoint, updating as that element
-resizes. Drag the box below across the `xs` breakpoint (500px) to see the label
-swap — independent of the viewport width.
+`useContainerBreakpoint()` — the JS equivalent of a CSS container query and the
+container-scoped replacement for width-based `useMedia`. Call it from a
+descendant of a query container (a `Container`/`Flex`/… with `containerType`) and
+it returns the container's active breakpoint, updating as the container resizes.
+Pass an explicit list of tokens — named and/or `"<number>px"` escape hatches,
+e.g. `['sm', 'md', '380px']` — for one-off thresholds the named scale lacks; the
+hook returns the active token from that list. Drag the box below across the `xs`
+breakpoint (500px) to see the label swap — independent of the viewport width.
 
 <Storybook.SizingWindow display="block">
   <ContainerBreakpointExample />
 </Storybook.SizingWindow>
 ```jsx
-function MyComponent() {
-  const ref = useRef(null);
-  const breakpoint = useContainerBreakpoint(ref);
+// Rendered inside a query container, e.g.
+// <Container containerType="inline-size">…</Container>
+function PanelLabel() {
+  const breakpoint = useContainerBreakpoint();
   const isCompact = breakpoint === '2xs';
-
-return (
-
-<Container ref={ref} width="100%">
-{isCompact ? 'Compact label' : 'Full, descriptive label'}
-</Container>
-);
+  return isCompact ? 'Compact label' : 'Full, descriptive label';
 }
 ```
 

--- a/static/app/components/core/layout/container.mdx
+++ b/static/app/components/core/layout/container.mdx
@@ -265,6 +265,42 @@ For background on the underlying CSS, see MDN's <a href="https://developer.mozil
 The two can be combined on one prop — e.g. `direction={{xs: 'column', 'screen:lg': 'row'}}`
 is a column until its container reaches `xs`, then a row once the viewport reaches `lg`.
 
+#### Custom pixel breakpoints (escape hatch)
+
+Breakpoint keys are normally the named scale (`xs` = 500px, `sm` = 800px, …),
+which has nothing between `2xs` (0px) and `xs` (500px). When a design needs a
+one-off threshold the scale doesn't cover, a raw `<number>px` key works on either
+axis — bare for the container, `screen:`-prefixed for the viewport:
+
+<Storybook.SizingWindow display="block">
+  <Container
+    containerType="inline-size"
+    padding="md"
+    background="secondary"
+    radius="md"
+    border="primary"
+  >
+    <Container
+      display={{'2xs': 'none', '380px': 'block'}}
+      padding="sm"
+      background="primary"
+      border="primary"
+      radius="md"
+    >
+      Hidden until the container reaches 380px. Drag narrower to hide it.
+    </Container>
+  </Container>
+</Storybook.SizingWindow>
+```jsx // @container (min-width: 380px)
+<Flex display={{'2xs': 'none', '380px': 'flex'}}>…</Flex>
+// @media (min-width: 380px)
+<Flex display={{'2xs': 'none', 'screen:380px': 'flex'}}>…</Flex>
+```
+
+> [!TIP]
+> Prefer a named breakpoint when one fits — reach for a `<number>px` key only for
+> thresholds the scale genuinely lacks, so the shared scale stays the norm.
+
 > [!TIP]
 > Prefer `containerType="inline-size"` — it only contains the inline
 > (width) axis, so height still flows from content. `size` also contains the

--- a/static/app/components/core/layout/index.tsx
+++ b/static/app/components/core/layout/index.tsx
@@ -16,6 +16,5 @@ export {
   rc,
   type Responsive,
   useContainerBreakpoint,
-  useResponsivePropValue,
 } from './styles';
 export {getBorder, getMargin, getRadius, getSpacing} from './styles';

--- a/static/app/components/core/layout/styles.spec.tsx
+++ b/static/app/components/core/layout/styles.spec.tsx
@@ -179,32 +179,6 @@ describe('rc', () => {
     );
     expect(rc('container-type', undefined, theme)).toBeUndefined();
   });
-
-  it('supports raw `<number>px` container breakpoints as an escape hatch', () => {
-    // `380px` has no named equivalent; it should emit a @container min-width rule.
-    const output = rc('display', {'2xs': 'none', '380px': 'flex'}, theme);
-    assert(output);
-    // 2xs (the base) is a plain declaration.
-    expect(output).toContain('display: none;');
-    expect(output).toContain('@container (min-width: 380px)');
-    expect(output).not.toContain('@media');
-  });
-
-  it('supports `screen:<number>px` viewport breakpoints as an escape hatch', () => {
-    const output = rc('display', {'2xs': 'none', 'screen:380px': 'flex'}, theme);
-    assert(output);
-    expect(output).toContain('@media (min-width: 380px)');
-    expect(output).not.toContain('@container');
-  });
-
-  it('interleaves custom px and named breakpoints mobile-first', () => {
-    // Ordering by width: 2xs (0) base, then 380px, then xs (500px).
-    const output = rc('display', {'2xs': 'none', '380px': 'flex', xs: 'grid'}, theme);
-    assert(output);
-    expect(output.indexOf('min-width: 380px')).toBeLessThan(
-      output.indexOf(`min-width: ${theme.breakpoints.xs}`)
-    );
-  });
 });
 
 describe('getBorder', () => {
@@ -588,11 +562,6 @@ describe('useContainerBreakpoint', () => {
     return <div>breakpoint:{breakpoint}</div>;
   }
 
-  function CustomBreakpointProbe() {
-    const breakpoint = useContainerBreakpoint(['0px', '380px']);
-    return <div>breakpoint:{breakpoint}</div>;
-  }
-
   function Container({children}: {children: ReactNode}) {
     const ref = useRef<HTMLDivElement>(null);
     return (
@@ -621,25 +590,5 @@ describe('useContainerBreakpoint', () => {
       </Container>
     );
     expect(screen.getByText('breakpoint:2xs')).toBeInTheDocument();
-  });
-
-  it('resolves against a custom `<number>px` token list', () => {
-    setClientWidth(400);
-    render(
-      <Container>
-        <CustomBreakpointProbe />
-      </Container>
-    );
-    expect(screen.getByText('breakpoint:380px')).toBeInTheDocument();
-  });
-
-  it('returns the smallest token when below every threshold', () => {
-    setClientWidth(300);
-    render(
-      <Container>
-        <CustomBreakpointProbe />
-      </Container>
-    );
-    expect(screen.getByText('breakpoint:0px')).toBeInTheDocument();
   });
 });

--- a/static/app/components/core/layout/styles.spec.tsx
+++ b/static/app/components/core/layout/styles.spec.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {type ReactNode, useRef} from 'react';
 import {css} from '@emotion/react';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
@@ -13,6 +13,7 @@ import {assert} from 'sentry/types/utils';
 import type {BreakpointSize} from 'sentry/utils/theme';
 
 import {
+  ContainerQueryProvider,
   getBorder,
   rc,
   useActiveBreakpoint,
@@ -177,6 +178,32 @@ describe('rc', () => {
       'container-type: inline-size;'
     );
     expect(rc('container-type', undefined, theme)).toBeUndefined();
+  });
+
+  it('supports raw `<number>px` container breakpoints as an escape hatch', () => {
+    // `380px` has no named equivalent; it should emit a @container min-width rule.
+    const output = rc('display', {'2xs': 'none', '380px': 'flex'}, theme);
+    assert(output);
+    // 2xs (the base) is a plain declaration.
+    expect(output).toContain('display: none;');
+    expect(output).toContain('@container (min-width: 380px)');
+    expect(output).not.toContain('@media');
+  });
+
+  it('supports `screen:<number>px` viewport breakpoints as an escape hatch', () => {
+    const output = rc('display', {'2xs': 'none', 'screen:380px': 'flex'}, theme);
+    assert(output);
+    expect(output).toContain('@media (min-width: 380px)');
+    expect(output).not.toContain('@container');
+  });
+
+  it('interleaves custom px and named breakpoints mobile-first', () => {
+    // Ordering by width: 2xs (0) base, then 380px, then xs (500px).
+    const output = rc('display', {'2xs': 'none', '380px': 'flex', xs: 'grid'}, theme);
+    assert(output);
+    expect(output.indexOf('min-width: 380px')).toBeLessThan(
+      output.indexOf(`min-width: ${theme.breakpoints.xs}`)
+    );
   });
 });
 
@@ -553,22 +580,66 @@ describe('useContainerBreakpoint', () => {
     });
   };
 
+  // The hook reads the nearest query container's size from context, so render
+  // the probe inside a ContainerQueryProvider whose measured element reports the
+  // faked width.
   function BreakpointProbe() {
-    const ref = useRef<HTMLDivElement>(null);
-    const breakpoint = useContainerBreakpoint(ref);
-    return <div ref={ref}>breakpoint:{breakpoint}</div>;
+    const breakpoint = useContainerBreakpoint();
+    return <div>breakpoint:{breakpoint}</div>;
   }
 
-  it('resolves the largest breakpoint the element width satisfies', () => {
+  function CustomBreakpointProbe() {
+    const breakpoint = useContainerBreakpoint(['0px', '380px']);
+    return <div>breakpoint:{breakpoint}</div>;
+  }
+
+  function Container({children}: {children: ReactNode}) {
+    const ref = useRef<HTMLDivElement>(null);
+    return (
+      <ContainerQueryProvider elementRef={ref}>
+        <div ref={ref}>{children}</div>
+      </ContainerQueryProvider>
+    );
+  }
+
+  it('resolves the largest breakpoint the container width satisfies', () => {
     // md = 992px, lg = 1200px -> 1000px resolves to md.
     setClientWidth(1000);
-    render(<BreakpointProbe />);
+    render(
+      <Container>
+        <BreakpointProbe />
+      </Container>
+    );
     expect(screen.getByText('breakpoint:md')).toBeInTheDocument();
   });
 
-  it('falls back to 2xs when the element is narrower than the smallest breakpoint', () => {
+  it('falls back to 2xs when the container is narrower than the smallest breakpoint', () => {
     setClientWidth(0);
-    render(<BreakpointProbe />);
+    render(
+      <Container>
+        <BreakpointProbe />
+      </Container>
+    );
     expect(screen.getByText('breakpoint:2xs')).toBeInTheDocument();
+  });
+
+  it('resolves against a custom `<number>px` token list', () => {
+    setClientWidth(400);
+    render(
+      <Container>
+        <CustomBreakpointProbe />
+      </Container>
+    );
+    expect(screen.getByText('breakpoint:380px')).toBeInTheDocument();
+  });
+
+  it('returns the smallest token when below every threshold', () => {
+    setClientWidth(300);
+    render(
+      <Container>
+        <CustomBreakpointProbe />
+      </Container>
+    );
+    expect(screen.getByText('breakpoint:0px')).toBeInTheDocument();
   });
 });

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -423,55 +423,6 @@ export function useContainerBreakpoint(): BreakpointSize {
 }
 
 /**
- * Observes an element's content-box inline size (the box CSS `@container`
- * resolves against), calling `onSize` immediately and on every resize. Returns
- * a disconnect function.
- */
-function observeInlineSize(element: Element, onSize: (size: number) => void): () => void {
-  // Measure synchronously on attach so the first resolved breakpoint is right.
-  onSize(getContentBoxInlineSize(element));
-
-  const observer = new ResizeObserver(entries => {
-    const entry = entries[0];
-    if (!entry) {
-      return;
-    }
-    // `contentBoxSize` is exactly the box CSS `@container` queries against; fall
-    // back to a computed content box for engines without it.
-    onSize(entry.contentBoxSize?.[0]?.inlineSize ?? getContentBoxInlineSize(element));
-  });
-  observer.observe(element);
-  return () => observer.disconnect();
-}
-
-/**
- * The largest breakpoint whose min-width threshold `inlineSize` satisfies,
- * falling back mobile-first to the smallest when it satisfies none.
- */
-function resolveContainerBreakpoint(
-  inlineSize: number,
-  breakpoints: Record<string, string>
-): BreakpointSize {
-  let active: {label: string; px: number} | undefined;
-  let smallest: {label: string; px: number} | undefined;
-
-  for (const [label, value] of Object.entries(breakpoints)) {
-    const px = parseFloat(value);
-    if (Number.isNaN(px)) {
-      continue;
-    }
-    if (smallest === undefined || px < smallest.px) {
-      smallest = {label, px};
-    }
-    if (inlineSize >= px && (active === undefined || px > active.px)) {
-      active = {label, px};
-    }
-  }
-
-  return (active?.label ?? smallest?.label ?? '2xs') as BreakpointSize;
-}
-
-/**
  * The content-box inline size — the box CSS `@container` resolves against. We
  * avoid `clientWidth` (padding-box) so the JS breakpoint can't disagree with the
  * CSS reflow at boundaries on padded containers. `clientWidth` already excludes
@@ -498,20 +449,47 @@ export function ContainerQueryProvider({
   elementRef: RefObject<Element | null>;
 }) {
   const theme = useTheme();
-  const [breakpoint, setBreakpoint] = useState<BreakpointSize>('2xs');
+  const [inlineSize, setInlineSize] = useState(0);
 
-  // The observed element is rendered by the caller and passed in via `elementRef`
-  // (e.g. a Container's own node or a Modal's portal), so it's attached before
-  // this provider's layout effect runs — no callback ref needed here.
   useLayoutEffect(() => {
     const element = elementRef.current;
     if (!element) {
       return;
     }
-    return observeInlineSize(element, size =>
-      setBreakpoint(resolveContainerBreakpoint(size, theme.breakpoints))
-    );
-  }, [elementRef, theme.breakpoints]);
+
+    // Read synchronously before paint so the first resolved breakpoint is right.
+    setInlineSize(getContentBoxInlineSize(element));
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+      // `contentBoxSize` is exactly the box CSS `@container` queries against;
+      // fall back to a computed content box for engines without it.
+      const size =
+        entry.contentBoxSize?.[0]?.inlineSize ?? getContentBoxInlineSize(element);
+      setInlineSize(size);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [elementRef]);
+
+  // Resolve to the active breakpoint here (not the raw size) so the broadcast
+  // context value only changes on a breakpoint boundary — descendants aren't
+  // re-rendered on every pixel of a resize.
+  const breakpoint = useMemo(() => {
+    for (let i = BREAKPOINT_ORDER.length - 1; i >= 0; i--) {
+      const bp = BREAKPOINT_ORDER[i];
+      if (bp === undefined) {
+        continue;
+      }
+      if (inlineSize >= parseInt(theme.breakpoints[bp], 10)) {
+        return bp;
+      }
+    }
+    return '2xs';
+  }, [inlineSize, theme.breakpoints]);
 
   return <ContainerQueryContext value={breakpoint}>{children}</ContainerQueryContext>;
 }

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -48,34 +48,15 @@ export function rc<T>(
   }
 
   // A responsive value is keyed by breakpoint on two independent axes:
-  // - bare keys (`xs`, `380px`, …) resolve against the nearest query container (@container)
+  // - bare keys (`xs`, `md`, …) resolve against the nearest query container (@container)
   // - `screen:`-prefixed keys (`screen:md`, …) resolve against the viewport (@media)
-  // Keys may be a named breakpoint or a raw `<number>px` escape hatch. We resolve
-  // every declared key into a { minWidth, axis } slot, order them mobile-first
-  // (smallest first), emit the smallest as the always-applied base declaration
-  // (so it applies even with no query container present), and emit the rest as
-  // min-width overrides on their respective axis.
-  const slots: Array<{
-    axis: (typeof RESPONSIVE_AXES)[number];
-    declaration: string;
-    minWidth: number;
-    minWidthPx: string;
-  }> = [];
+  // Both can be combined on the same prop. The smallest defined breakpoint
+  // (container first within a breakpoint) is the always-applied base, emitted as
+  // a plain declaration so it applies even with no query container present; the
+  // rest override it via min-width rules of their respective axis, mobile-first.
+  let first = true;
+  const declarations: string[] = [];
 
-  const pushSlot = (
-    axis: (typeof RESPONSIVE_AXES)[number],
-    minWidthPx: string,
-    resolvedValue: string
-  ) => {
-    slots.push({
-      axis,
-      declaration: `${property}: ${resolvedValue};`,
-      minWidth: parseFloat(minWidthPx),
-      minWidthPx,
-    });
-  };
-
-  // Named breakpoints, in scale order, on both axes.
   for (const breakpoint of BREAKPOINT_ORDER) {
     for (const axis of RESPONSIVE_AXES) {
       const key = axis === 'container' ? breakpoint : `screen:${breakpoint}`;
@@ -87,50 +68,22 @@ export function rc<T>(
         continue;
       }
 
-      pushSlot(axis, theme.breakpoints[breakpoint], resolvedValue as string);
+      if (first) {
+        first = false;
+        declarations.push(`${property}: ${resolvedValue as string};`);
+        continue;
+      }
+
+      const atRule = axis === 'container' ? '@container' : '@media';
+      declarations.push(
+        `${atRule} (min-width: ${theme.breakpoints[breakpoint]}) {
+          ${property}: ${resolvedValue as string};
+        }`
+      );
     }
   }
 
-  // `<number>px` escape-hatch keys (e.g. `380px`, `screen:380px`) the named
-  // scale doesn't cover. The resolver receives an undefined breakpoint.
-  for (const key of Object.keys(value)) {
-    const axis = key.startsWith('screen:') ? 'viewport' : 'container';
-    const raw = axis === 'viewport' ? key.slice('screen:'.length) : key;
-    if (!raw.endsWith('px') || Number.isNaN(parseFloat(raw))) {
-      continue;
-    }
-
-    const v = (value as Partial<Record<string, T>>)[key];
-    const resolvedValue = resolver ? resolver(v, undefined, theme) : v;
-    if (resolvedValue === undefined) {
-      continue;
-    }
-
-    pushSlot(axis, raw, resolvedValue as string);
-  }
-
-  return (
-    slots
-      // Mobile-first order: smallest min-width first; container before viewport at an
-      // equal threshold (matching the named-key iteration order). The first slot is
-      // the always-applied base; the rest become min-width overrides.
-      .toSorted(
-        (a, b) =>
-          a.minWidth - b.minWidth ||
-          (a.axis === b.axis ? 0 : a.axis === 'container' ? -1 : 1)
-      )
-      .map((slot, index) => {
-        if (index === 0) {
-          return slot.declaration;
-        }
-
-        const atRule = slot.axis === 'container' ? '@container' : '@media';
-        return `${atRule} (min-width: ${slot.minWidthPx}) {
-          ${slot.declaration}
-        }`;
-      })
-      .join('')
-  );
+  return declarations.join('');
 }
 
 const BREAKPOINT_ORDER: readonly BreakpointSize[] = [
@@ -168,20 +121,7 @@ export type Shorthand<T extends string, N extends 4 | 2> = N extends 4
  * container reaches `xs`, then a row once the viewport reaches `lg`.
  */
 type ScreenBreakpoint = `screen:${BreakpointSize}`;
-/**
- * Escape hatch for a one-off pixel threshold the named scale doesn't cover,
- * e.g. `"380px"`. Like named keys it resolves against the container by default
- * and the viewport with a `screen:` prefix (`"screen:380px"`). Prefer a named
- * breakpoint when one fits — reach for this only when a design genuinely needs a
- * width the scale lacks.
- */
-type CustomBreakpoint = `${number}px`;
-type ScreenCustomBreakpoint = `screen:${CustomBreakpoint}`;
-type ResponsiveBreakpoint =
-  | BreakpointSize
-  | ScreenBreakpoint
-  | CustomBreakpoint
-  | ScreenCustomBreakpoint;
+type ResponsiveBreakpoint = BreakpointSize | ScreenBreakpoint;
 
 export type Responsive<T> = T | Partial<Record<ResponsiveBreakpoint, T>>;
 
@@ -325,15 +265,10 @@ type ResponsiveValue<T> = T extends Responsive<infer U> ? U : never;
 export function useResponsivePropValue<T extends Responsive<any>>(
   prop: T
 ): T | ResponsiveValue<T> {
-  const theme = useTheme();
   const viewportBreakpoint = useActiveBreakpoint();
   // No container ancestor → '2xs', the only value CSS applies in that case (the
   // plain base declaration), so JS and the @container rules stay in agreement.
-  const containerSize = useContext(ContainerQueryContext);
-  const containerBreakpoint =
-    containerSize === null
-      ? '2xs'
-      : (resolveContainerBreakpoint(containerSize, theme.breakpoints) as BreakpointSize);
+  const containerBreakpoint = useContext(ContainerQueryContext) ?? '2xs';
 
   // Only resolve the active breakpoint if the prop is responsive, else ignore it.
   if (!isResponsive(prop)) {
@@ -451,63 +386,40 @@ function findLargestBreakpoint(
 }
 
 /**
- * Holds the content-box inline-size (the box CSS `@container` resolves against)
- * of the nearest ancestor query container, or null when there is no container
- * ancestor. Provided by container elements (those with a `containerType`) so
- * that JS-resolved container queries (`useResponsivePropValue`,
- * `useContainerBreakpoint`) can resolve against the container's width.
+ * Holds the active breakpoint of the nearest ancestor query container, or null
+ * when there is no container ancestor. Provided by container elements (those
+ * with a `containerType`) so JS-resolved container queries
+ * (`useResponsivePropValue`, `useContainerBreakpoint`) can resolve against the
+ * container instead of the viewport.
  *
- * We broadcast the raw size rather than a pre-resolved breakpoint because the
- * container is generic and can't know which thresholds each descendant cares
- * about — each consumer resolves its own breakpoints off this one measurement.
+ * We broadcast the already-resolved breakpoint (not the raw inline-size) so the
+ * context value only changes when a breakpoint boundary is crossed — consumers
+ * aren't re-rendered on every pixel of a resize.
  *
  * CSS-only responsive props don't need this — they resolve natively via
  * `@container` queries. This context exists purely for the JS resolution path.
  */
-const ContainerQueryContext = createContext<number | null>(null);
+const ContainerQueryContext = createContext<BreakpointSize | null>(null);
 
 /**
- * The JS equivalent of a CSS container query: resolves the active breakpoint of
+ * The JS equivalent of a CSS container query: returns the active breakpoint of
  * the nearest ancestor query container (read from `ContainerQueryContext`),
  * mirroring the mobile-first behavior of `rc()`/`@container`. Must be called
  * inside a query container (a `Container`/`Flex`/… with `containerType`); with
- * no container ancestor it resolves as if the container were 0px wide (the base,
- * matching CSS's plain base declaration).
+ * no container ancestor it resolves to `2xs` (the base, matching CSS's plain
+ * base declaration).
  *
  * Prefer CSS responsive props (bare breakpoint keys like `{xs: …}`) when
  * possible; reach for this hook only when you genuinely need the resolved
  * breakpoint in JS (e.g. to branch rendering). It replaces width-based
  * `useMedia` usage.
  *
- * By default it resolves against the theme's named breakpoints. Pass an explicit
- * list of tokens — named and/or `<number>px` escape hatches, e.g.
- * `['sm', 'md', '380px']` — for one-off thresholds the named scale lacks; the
- * hook then returns the active token from that list.
- *
- * This returns the active breakpoint *key* so you can branch on it. To resolve a
+ * Returns the active breakpoint *key* so you can branch on it. To resolve a
  * `Responsive<T>` prop to its current *value* in JS (when building a responsive
  * prop of your own), use {@link useResponsivePropValue} instead.
- * @public
  */
-export function useContainerBreakpoint(): BreakpointSize;
-export function useContainerBreakpoint<
-  const T extends ReadonlyArray<BreakpointSize | `${number}px`>,
->(tokens: T): T[number];
-export function useContainerBreakpoint(tokens?: readonly string[]): string {
-  const theme = useTheme();
-  const inlineSize = useContext(ContainerQueryContext) ?? 0;
-
-  return useMemo(() => {
-    const thresholds: Record<string, string> = {};
-    for (const token of tokens ?? BREAKPOINT_ORDER) {
-      // A `<number>px` token is its own threshold; a named token maps through
-      // the theme scale.
-      thresholds[token] = token.endsWith('px')
-        ? token
-        : theme.breakpoints[token as BreakpointSize];
-    }
-    return resolveContainerBreakpoint(inlineSize, thresholds);
-  }, [inlineSize, tokens, theme.breakpoints]);
+export function useContainerBreakpoint(): BreakpointSize {
+  return useContext(ContainerQueryContext) ?? '2xs';
 }
 
 /**
@@ -539,7 +451,7 @@ function observeInlineSize(element: Element, onSize: (size: number) => void): ()
 function resolveContainerBreakpoint(
   inlineSize: number,
   breakpoints: Record<string, string>
-): string {
+): BreakpointSize {
   let active: {label: string; px: number} | undefined;
   let smallest: {label: string; px: number} | undefined;
 
@@ -556,7 +468,7 @@ function resolveContainerBreakpoint(
     }
   }
 
-  return active?.label ?? smallest?.label ?? '2xs';
+  return (active?.label ?? smallest?.label ?? '2xs') as BreakpointSize;
 }
 
 /**
@@ -574,9 +486,9 @@ function getContentBoxInlineSize(element: Element): number {
 }
 
 /**
- * Measures the given element and broadcasts its content-box inline-size through
- * ContainerQueryContext. Rendered by container elements so descendants can
- * resolve container-mode responsive props in JS. Renders no DOM of its own.
+ * Measures the given element, resolves its active breakpoint, and broadcasts it
+ * through ContainerQueryContext. Rendered by container elements so descendants
+ * can resolve container-mode responsive props in JS.
  */
 export function ContainerQueryProvider({
   elementRef,
@@ -585,7 +497,8 @@ export function ContainerQueryProvider({
   children: ReactNode;
   elementRef: RefObject<Element | null>;
 }) {
-  const [inlineSize, setInlineSize] = useState(0);
+  const theme = useTheme();
+  const [breakpoint, setBreakpoint] = useState<BreakpointSize>('2xs');
 
   // The observed element is rendered by the caller and passed in via `elementRef`
   // (e.g. a Container's own node or a Modal's portal), so it's attached before
@@ -593,10 +506,12 @@ export function ContainerQueryProvider({
   useLayoutEffect(() => {
     const element = elementRef.current;
     if (!element) {
-      return () => {};
+      return;
     }
-    return observeInlineSize(element, setInlineSize);
-  }, [elementRef]);
+    return observeInlineSize(element, size =>
+      setBreakpoint(resolveContainerBreakpoint(size, theme.breakpoints))
+    );
+  }, [elementRef, theme.breakpoints]);
 
-  return <ContainerQueryContext value={inlineSize}>{children}</ContainerQueryContext>;
+  return <ContainerQueryContext value={breakpoint}>{children}</ContainerQueryContext>;
 }

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -417,6 +417,7 @@ const ContainerQueryContext = createContext<BreakpointSize | null>(null);
  * Returns the active breakpoint *key* so you can branch on it. To resolve a
  * `Responsive<T>` prop to its current *value* in JS (when building a responsive
  * prop of your own), use {@link useResponsivePropValue} instead.
+ * @public
  */
 export function useContainerBreakpoint(): BreakpointSize {
   return useContext(ContainerQueryContext) ?? '2xs';

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -487,6 +487,7 @@ const ContainerQueryContext = createContext<number | null>(null);
  * This returns the active breakpoint *key* so you can branch on it. To resolve a
  * `Responsive<T>` prop to its current *value* in JS (when building a responsive
  * prop of your own), use {@link useResponsivePropValue} instead.
+ * @public
  */
 export function useContainerBreakpoint(): BreakpointSize;
 export function useContainerBreakpoint<

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -48,15 +48,34 @@ export function rc<T>(
   }
 
   // A responsive value is keyed by breakpoint on two independent axes:
-  // - bare keys (`xs`, `md`, …) resolve against the nearest query container (@container)
+  // - bare keys (`xs`, `380px`, …) resolve against the nearest query container (@container)
   // - `screen:`-prefixed keys (`screen:md`, …) resolve against the viewport (@media)
-  // Both can be combined on the same prop. The smallest defined breakpoint
-  // (container first within a breakpoint) is the always-applied base, emitted as
-  // a plain declaration so it applies even with no query container present; the
-  // rest override it via min-width rules of their respective axis, mobile-first.
-  let first = true;
-  const declarations: string[] = [];
+  // Keys may be a named breakpoint or a raw `<number>px` escape hatch. We resolve
+  // every declared key into a { minWidth, axis } slot, order them mobile-first
+  // (smallest first), emit the smallest as the always-applied base declaration
+  // (so it applies even with no query container present), and emit the rest as
+  // min-width overrides on their respective axis.
+  const slots: Array<{
+    axis: (typeof RESPONSIVE_AXES)[number];
+    declaration: string;
+    minWidth: number;
+    minWidthPx: string;
+  }> = [];
 
+  const pushSlot = (
+    axis: (typeof RESPONSIVE_AXES)[number],
+    minWidthPx: string,
+    resolvedValue: string
+  ) => {
+    slots.push({
+      axis,
+      declaration: `${property}: ${resolvedValue};`,
+      minWidth: parseFloat(minWidthPx),
+      minWidthPx,
+    });
+  };
+
+  // Named breakpoints, in scale order, on both axes.
   for (const breakpoint of BREAKPOINT_ORDER) {
     for (const axis of RESPONSIVE_AXES) {
       const key = axis === 'container' ? breakpoint : `screen:${breakpoint}`;
@@ -68,22 +87,50 @@ export function rc<T>(
         continue;
       }
 
-      if (first) {
-        first = false;
-        declarations.push(`${property}: ${resolvedValue as string};`);
-        continue;
-      }
-
-      const atRule = axis === 'container' ? '@container' : '@media';
-      declarations.push(
-        `${atRule} (min-width: ${theme.breakpoints[breakpoint]}) {
-          ${property}: ${resolvedValue as string};
-        }`
-      );
+      pushSlot(axis, theme.breakpoints[breakpoint], resolvedValue as string);
     }
   }
 
-  return declarations.join('');
+  // `<number>px` escape-hatch keys (e.g. `380px`, `screen:380px`) the named
+  // scale doesn't cover. The resolver receives an undefined breakpoint.
+  for (const key of Object.keys(value)) {
+    const axis = key.startsWith('screen:') ? 'viewport' : 'container';
+    const raw = axis === 'viewport' ? key.slice('screen:'.length) : key;
+    if (!raw.endsWith('px') || Number.isNaN(parseFloat(raw))) {
+      continue;
+    }
+
+    const v = (value as Partial<Record<string, T>>)[key];
+    const resolvedValue = resolver ? resolver(v, undefined, theme) : v;
+    if (resolvedValue === undefined) {
+      continue;
+    }
+
+    pushSlot(axis, raw, resolvedValue as string);
+  }
+
+  return (
+    slots
+      // Mobile-first order: smallest min-width first; container before viewport at an
+      // equal threshold (matching the named-key iteration order). The first slot is
+      // the always-applied base; the rest become min-width overrides.
+      .toSorted(
+        (a, b) =>
+          a.minWidth - b.minWidth ||
+          (a.axis === b.axis ? 0 : a.axis === 'container' ? -1 : 1)
+      )
+      .map((slot, index) => {
+        if (index === 0) {
+          return slot.declaration;
+        }
+
+        const atRule = slot.axis === 'container' ? '@container' : '@media';
+        return `${atRule} (min-width: ${slot.minWidthPx}) {
+          ${slot.declaration}
+        }`;
+      })
+      .join('')
+  );
 }
 
 const BREAKPOINT_ORDER: readonly BreakpointSize[] = [
@@ -121,7 +168,20 @@ export type Shorthand<T extends string, N extends 4 | 2> = N extends 4
  * container reaches `xs`, then a row once the viewport reaches `lg`.
  */
 type ScreenBreakpoint = `screen:${BreakpointSize}`;
-type ResponsiveBreakpoint = BreakpointSize | ScreenBreakpoint;
+/**
+ * Escape hatch for a one-off pixel threshold the named scale doesn't cover,
+ * e.g. `"380px"`. Like named keys it resolves against the container by default
+ * and the viewport with a `screen:` prefix (`"screen:380px"`). Prefer a named
+ * breakpoint when one fits — reach for this only when a design genuinely needs a
+ * width the scale lacks.
+ */
+type CustomBreakpoint = `${number}px`;
+type ScreenCustomBreakpoint = `screen:${CustomBreakpoint}`;
+type ResponsiveBreakpoint =
+  | BreakpointSize
+  | ScreenBreakpoint
+  | CustomBreakpoint
+  | ScreenCustomBreakpoint;
 
 export type Responsive<T> = T | Partial<Record<ResponsiveBreakpoint, T>>;
 
@@ -250,18 +310,30 @@ export function getMargin(
 }
 
 /**
- * Hook that resolves responsive values to their current breakpoint value.
- * Mirrors the behavior of the rc() function but returns the resolved value
- * instead of generating CSS media queries.
+ * Resolves a `Responsive<T>` prop to its current value in JS, across both the
+ * container and viewport axes — the JS mirror of what `rc()` emits as CSS.
+ *
+ * This is a low-level building block for **component authors** who accept a
+ * `Responsive<T>` prop and must resolve it in JS rather than via CSS (e.g.
+ * `Stack`'s `direction`, `SplitPanel`'s `orientation`). Most code shouldn't need
+ * it: use plain responsive props (resolved in CSS) for styling, or
+ * {@link useContainerBreakpoint} when you need the container's active breakpoint
+ * to branch logic. Prefer those unless you're building a responsive prop of your
+ * own.
  */
 type ResponsiveValue<T> = T extends Responsive<infer U> ? U : never;
 export function useResponsivePropValue<T extends Responsive<any>>(
   prop: T
 ): T | ResponsiveValue<T> {
+  const theme = useTheme();
   const viewportBreakpoint = useActiveBreakpoint();
   // No container ancestor → '2xs', the only value CSS applies in that case (the
   // plain base declaration), so JS and the @container rules stay in agreement.
-  const containerBreakpoint = useContext(ContainerQueryContext) ?? '2xs';
+  const containerSize = useContext(ContainerQueryContext);
+  const containerBreakpoint =
+    containerSize === null
+      ? '2xs'
+      : (resolveContainerBreakpoint(containerSize, theme.breakpoints) as BreakpointSize);
 
   // Only resolve the active breakpoint if the prop is responsive, else ignore it.
   if (!isResponsive(prop)) {
@@ -379,71 +451,111 @@ function findLargestBreakpoint(
 }
 
 /**
- * Holds the active breakpoint of the nearest ancestor query container, or null
- * when there is no container ancestor. Provided by container elements (those
- * with a `containerType`) so that JS-resolved responsive props (e.g. Stack's
- * orientation) can resolve against the container instead of the viewport.
+ * Holds the content-box inline-size (the box CSS `@container` resolves against)
+ * of the nearest ancestor query container, or null when there is no container
+ * ancestor. Provided by container elements (those with a `containerType`) so
+ * that JS-resolved container queries (`useResponsivePropValue`,
+ * `useContainerBreakpoint`) can resolve against the container's width.
+ *
+ * We broadcast the raw size rather than a pre-resolved breakpoint because the
+ * container is generic and can't know which thresholds each descendant cares
+ * about — each consumer resolves its own breakpoints off this one measurement.
  *
  * CSS-only responsive props don't need this — they resolve natively via
  * `@container` queries. This context exists purely for the JS resolution path.
  */
-const ContainerQueryContext = createContext<BreakpointSize | null>(null);
+const ContainerQueryContext = createContext<number | null>(null);
 
 /**
- * ResizeObserver-backed equivalent of useActiveBreakpoint, scoped to a single
- * element rather than the viewport. Returns the largest breakpoint whose
- * min-width threshold is satisfied by the element's inline-size, mirroring the
- * mobile-first behavior of rc()/useActiveBreakpoint.
+ * The JS equivalent of a CSS container query: resolves the active breakpoint of
+ * the nearest ancestor query container (read from `ContainerQueryContext`),
+ * mirroring the mobile-first behavior of `rc()`/`@container`. Must be called
+ * inside a query container (a `Container`/`Flex`/… with `containerType`); with
+ * no container ancestor it resolves as if the container were 0px wide (the base,
+ * matching CSS's plain base declaration).
  *
  * Prefer CSS responsive props (bare breakpoint keys like `{xs: …}`) when
  * possible; reach for this hook only when you genuinely need the resolved
  * breakpoint in JS (e.g. to branch rendering). It replaces width-based
  * `useMedia` usage.
+ *
+ * By default it resolves against the theme's named breakpoints. Pass an explicit
+ * list of tokens — named and/or `<number>px` escape hatches, e.g.
+ * `['sm', 'md', '380px']` — for one-off thresholds the named scale lacks; the
+ * hook then returns the active token from that list.
+ *
+ * This returns the active breakpoint *key* so you can branch on it. To resolve a
+ * `Responsive<T>` prop to its current *value* in JS (when building a responsive
+ * prop of your own), use {@link useResponsivePropValue} instead.
  */
-export function useContainerBreakpoint(ref: RefObject<Element | null>): BreakpointSize {
+export function useContainerBreakpoint(): BreakpointSize;
+export function useContainerBreakpoint<
+  const T extends ReadonlyArray<BreakpointSize | `${number}px`>,
+>(tokens: T): T[number];
+export function useContainerBreakpoint(tokens?: readonly string[]): string {
   const theme = useTheme();
-  const [inlineSize, setInlineSize] = useState(0);
-
-  useLayoutEffect(() => {
-    const element = ref.current;
-    if (!element) {
-      return;
-    }
-
-    // Read synchronously before paint so the first resolved breakpoint is right.
-    setInlineSize(getContentBoxInlineSize(element));
-
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (!entry) {
-        return;
-      }
-      // `contentBoxSize` is exactly the box CSS `@container` queries against;
-      // fall back to a computed content box for engines without it.
-      const size =
-        entry.contentBoxSize?.[0]?.inlineSize ?? getContentBoxInlineSize(element);
-      setInlineSize(size);
-    });
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [ref]);
+  const inlineSize = useContext(ContainerQueryContext) ?? 0;
 
   return useMemo(() => {
-    // Iterate from largest to smallest and return the first breakpoint whose
-    // min-width threshold the element satisfies.
-    for (let i = BREAKPOINT_ORDER.length - 1; i >= 0; i--) {
-      const breakpoint = BREAKPOINT_ORDER[i];
-      if (breakpoint === undefined) {
-        continue;
-      }
-
-      if (inlineSize >= parseInt(theme.breakpoints[breakpoint], 10)) {
-        return breakpoint;
-      }
+    const thresholds: Record<string, string> = {};
+    for (const token of tokens ?? BREAKPOINT_ORDER) {
+      // A `<number>px` token is its own threshold; a named token maps through
+      // the theme scale.
+      thresholds[token] = token.endsWith('px')
+        ? token
+        : theme.breakpoints[token as BreakpointSize];
     }
+    return resolveContainerBreakpoint(inlineSize, thresholds);
+  }, [inlineSize, tokens, theme.breakpoints]);
+}
 
-    return '2xs';
-  }, [inlineSize, theme.breakpoints]);
+/**
+ * Observes an element's content-box inline size (the box CSS `@container`
+ * resolves against), calling `onSize` immediately and on every resize. Returns
+ * a disconnect function.
+ */
+function observeInlineSize(element: Element, onSize: (size: number) => void): () => void {
+  // Measure synchronously on attach so the first resolved breakpoint is right.
+  onSize(getContentBoxInlineSize(element));
+
+  const observer = new ResizeObserver(entries => {
+    const entry = entries[0];
+    if (!entry) {
+      return;
+    }
+    // `contentBoxSize` is exactly the box CSS `@container` queries against; fall
+    // back to a computed content box for engines without it.
+    onSize(entry.contentBoxSize?.[0]?.inlineSize ?? getContentBoxInlineSize(element));
+  });
+  observer.observe(element);
+  return () => observer.disconnect();
+}
+
+/**
+ * The largest breakpoint whose min-width threshold `inlineSize` satisfies,
+ * falling back mobile-first to the smallest when it satisfies none.
+ */
+function resolveContainerBreakpoint(
+  inlineSize: number,
+  breakpoints: Record<string, string>
+): string {
+  let active: {label: string; px: number} | undefined;
+  let smallest: {label: string; px: number} | undefined;
+
+  for (const [label, value] of Object.entries(breakpoints)) {
+    const px = parseFloat(value);
+    if (Number.isNaN(px)) {
+      continue;
+    }
+    if (smallest === undefined || px < smallest.px) {
+      smallest = {label, px};
+    }
+    if (inlineSize >= px && (active === undefined || px > active.px)) {
+      active = {label, px};
+    }
+  }
+
+  return active?.label ?? smallest?.label ?? '2xs';
 }
 
 /**
@@ -461,7 +573,7 @@ function getContentBoxInlineSize(element: Element): number {
 }
 
 /**
- * Measures the given element and broadcasts its active breakpoint through
+ * Measures the given element and broadcasts its content-box inline-size through
  * ContainerQueryContext. Rendered by container elements so descendants can
  * resolve container-mode responsive props in JS. Renders no DOM of its own.
  */
@@ -472,6 +584,18 @@ export function ContainerQueryProvider({
   children: ReactNode;
   elementRef: RefObject<Element | null>;
 }) {
-  const breakpoint = useContainerBreakpoint(elementRef);
-  return <ContainerQueryContext value={breakpoint}>{children}</ContainerQueryContext>;
+  const [inlineSize, setInlineSize] = useState(0);
+
+  // The observed element is rendered by the caller and passed in via `elementRef`
+  // (e.g. a Container's own node or a Modal's portal), so it's attached before
+  // this provider's layout effect runs — no callback ref needed here.
+  useLayoutEffect(() => {
+    const element = elementRef.current;
+    if (!element) {
+      return () => {};
+    }
+    return observeInlineSize(element, setInlineSize);
+  }, [elementRef]);
+
+  return <ContainerQueryContext value={inlineSize}>{children}</ContainerQueryContext>;
 }

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -1,12 +1,10 @@
 import {useCallback, useImperativeHandle, useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {
-  Container,
-  Flex,
-  type Responsive,
-  useResponsivePropValue,
-} from '@sentry/scraps/layout';
+import {Container, Flex, type Responsive} from '@sentry/scraps/layout';
+// `useResponsivePropValue` is intentionally not part of the public scraps
+// surface — it's an internal building block for authoring responsive props.
+import {useResponsivePropValue} from '@sentry/scraps/layout/styles';
 
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -2,8 +2,6 @@ import {useCallback, useImperativeHandle, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex, type Responsive} from '@sentry/scraps/layout';
-// `useResponsivePropValue` is intentionally not part of the public scraps
-// surface — it's an internal building block for authoring responsive props.
 import {useResponsivePropValue} from '@sentry/scraps/layout/styles';
 
 import {useDimensions} from 'sentry/utils/useDimensions';

--- a/static/app/utils/useMedia.tsx
+++ b/static/app/utils/useMedia.tsx
@@ -10,7 +10,7 @@ import {useEffect, useState} from 'react';
  * For width-based checks, prefer scraps responsive props — bare breakpoint
  * keys react to the nearest container (`<Flex direction={{xs: 'column'}} />`),
  * `screen:`-prefixed keys to the viewport — or, when you need the resolved
- * value in JS, `useContainerBreakpoint(ref)` from `@sentry/scraps/layout`.
+ * value in JS, `useContainerBreakpoint()` from `@sentry/scraps/layout`.
  * Those react to an element's available space rather than the raw viewport,
  * which is almost always what width checks actually want.
  */


### PR DESCRIPTION
## Summary

Two changes to the scraps layout responsive system.

### `useContainerBreakpoint` — JS parity with CSS container queries

`useContainerBreakpoint()` now resolves the **nearest query container's** active breakpoint by reading it from `ContainerQueryContext` — no ref, no per-consumer `ResizeObserver`. Call it from inside a `containerType` container:

```tsx
const breakpoint = useContainerBreakpoint(); // → BreakpointSize
```

`ContainerQueryProvider` observes the container once, resolves the size to a breakpoint, and broadcasts the **resolved breakpoint** (not the raw inline-size). So the context value only changes when a breakpoint boundary is crossed — descendants aren't re-rendered on every pixel of a resize. `useResponsivePropValue` reads the same resolved breakpoint from context (behavior unchanged).

### `useResponsivePropValue` is now private to scraps

It's a building block for authoring responsive props (used by `Stack`/`SplitPanel`), not something app code should reach for. Dropped from the public `@sentry/scraps/layout` barrel; `SplitPanel` imports it from `@sentry/scraps/layout/styles` instead.

## Docs

`container.mdx` — the "Reading the breakpoint in JS" section documents the context-based `useContainerBreakpoint`.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run lint:js` ✅
- Layout, splitPanel, and modal specs pass ✅

> [!NOTE]
> JSDOM has no layout engine, so the hook/provider tests drive `clientWidth` + the mocked `ResizeObserver` to control the resolved breakpoint.
