### PR TITLE
ref(code-mappings): Fix n+1 integration lookup in RepositoryProjectPathConfigSerializer

### DIFF
--- a/src/sentry/integrations/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/integrations/api/serializers/models/repository_project_path_config.py
@@ -4,6 +4,7 @@ from sentry.api.serializers import Serializer, register
 from sentry.integrations.api.serializers.models.integration import serialize_provider
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration.model import RpcIntegration
 
 
 @register(RepositoryProjectPathConfig)
@@ -16,14 +17,42 @@ class RepositoryProjectPathConfigSerializer(Serializer):
             item_list, "project_repository__project", "project_repository__repository"
         )
 
-        return {item: {} for item in item_list}
+        integration_by_oi_id: dict[int, RpcIntegration] = {}
+
+        org_integration_ids = set(
+            item.organization_integration_id
+            for item in item_list
+            if item.organization_integration_id
+        )
+        if org_integration_ids:
+            # We bulk look-up organization-integrations and integrations. We need to map them to
+            # one another so there are two intermediate maps before the final item->integration
+            # map can be returned.
+            org_integrations = integration_service.get_organization_integrations(
+                org_integration_ids=list(org_integration_ids)
+            )
+
+            integration_ids = set(oi.integration_id for oi in org_integrations)
+            integrations = (
+                integration_service.get_integrations(integration_ids=list(integration_ids))
+                if integration_ids
+                else []
+            )
+
+            integration_by_id = {integration.id: integration for integration in integrations}
+            integration_by_oi_id = {
+                oi.id: integration_by_id[oi.integration_id]
+                for oi in org_integrations
+                if oi.integration_id in integration_by_id
+            }
+
+        return {
+            item: {"integration": integration_by_oi_id.get(item.organization_integration_id)}
+            for item in item_list
+        }
 
     def serialize(self, obj, attrs, user, **kwargs):
-        integration = None
-        if obj.organization_integration_id:
-            integration = integration_service.get_integration(
-                organization_integration_id=obj.organization_integration_id
-            )
+        integration = attrs.get("integration")
 
         provider = integration.get_provider() if integration else None
         serialized_provider = serialize_provider(provider) if provider else None


### PR DESCRIPTION
Removes an N+1 look-up for integrations and replaces it with two bulk queries to the integration services.

Fixes this waterfall: https://sentry.sentry.io/insights/summary/trace/ce01d2fff56349a0ad9a03bbe77fefe6/?fov=1%2C7671.20703125&node=span-8c413c5a241fe766&project=1&source=performance_transaction_summary&statsPeriod=7d&timestamp=1782820575&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fcode-mappings%2F

More info on customer impact here: https://sentry.slack.com/archives/CQDHVRS2W/p1782463777634469