### PR TITLE
fix(sdk-crash-detection): Allow ART memory/GC context through event stripper

### DIFF
--- a/src/sentry/utils/sdk_crashes/event_stripper.py
+++ b/src/sentry/utils/sdk_crashes/event_stripper.py
@@ -102,6 +102,19 @@ EVENT_DATA_ALLOWLIST = {
             "version": Allow.SIMPLE_TYPE,
             "build": Allow.SIMPLE_TYPE,
         },
+        "art": {
+            "gc.total_count": Allow.SIMPLE_TYPE,
+            "gc.total_time": Allow.SIMPLE_TYPE,
+            "gc.blocking_count": Allow.SIMPLE_TYPE,
+            "gc.blocking_time": Allow.SIMPLE_TYPE,
+            "gc.pre_oome_count": Allow.SIMPLE_TYPE,
+            "gc.waiting_time": Allow.SIMPLE_TYPE,
+            "memory.free": Allow.SIMPLE_TYPE,
+            "memory.free_until_gc": Allow.SIMPLE_TYPE,
+            "memory.free_until_oome": Allow.SIMPLE_TYPE,
+            "memory.total": Allow.SIMPLE_TYPE,
+            "memory.max": Allow.SIMPLE_TYPE,
+        },
     },
 }
 

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -99,20 +99,25 @@ def test_strip_event_data_strips_context(store_and_strip_event) -> None:
 def test_strip_event_data_keeps_art_context(store_and_strip_event) -> None:
     """ART (Android Runtime) memory and GC context from ANR thread dumps must survive stripping."""
     event_data = get_crash_event()
-    event_data["contexts"]["art"] = {
-        "gc.total_count": 42,
-        "gc.total_time": 123.4,
-        "gc.blocking_count": 5,
-        "gc.blocking_time": 50.1,
-        "gc.pre_oome_count": 1,
-        "gc.waiting_time": 10.0,
-        "memory.free": 1024,
-        "memory.free_until_gc": 2048,
-        "memory.free_until_oome": 512,
-        "memory.total": 4096,
-        "memory.max": 8192,
-        "some_private_field": "should_be_stripped",
-    }
+    set_path(
+        event_data,
+        "contexts",
+        "art",
+        value={
+            "gc.total_count": 42,
+            "gc.total_time": 123.4,
+            "gc.blocking_count": 5,
+            "gc.blocking_time": 50.1,
+            "gc.pre_oome_count": 1,
+            "gc.waiting_time": 10.0,
+            "memory.free": 1024,
+            "memory.free_until_gc": 2048,
+            "memory.free_until_oome": 512,
+            "memory.total": 4096,
+            "memory.max": 8192,
+            "some_private_field": "should_be_stripped",
+        },
+    )
 
     stripped_event_data = store_and_strip_event(data=event_data)
 

--- a/tests/sentry/utils/sdk_crashes/test_event_stripper.py
+++ b/tests/sentry/utils/sdk_crashes/test_event_stripper.py
@@ -96,6 +96,43 @@ def test_strip_event_data_strips_context(store_and_strip_event) -> None:
 
 @django_db_all
 @pytest.mark.snuba
+def test_strip_event_data_keeps_art_context(store_and_strip_event) -> None:
+    """ART (Android Runtime) memory and GC context from ANR thread dumps must survive stripping."""
+    event_data = get_crash_event()
+    event_data["contexts"]["art"] = {
+        "gc.total_count": 42,
+        "gc.total_time": 123.4,
+        "gc.blocking_count": 5,
+        "gc.blocking_time": 50.1,
+        "gc.pre_oome_count": 1,
+        "gc.waiting_time": 10.0,
+        "memory.free": 1024,
+        "memory.free_until_gc": 2048,
+        "memory.free_until_oome": 512,
+        "memory.total": 4096,
+        "memory.max": 8192,
+        "some_private_field": "should_be_stripped",
+    }
+
+    stripped_event_data = store_and_strip_event(data=event_data)
+
+    assert stripped_event_data["contexts"]["art"] == {
+        "gc.total_count": 42,
+        "gc.total_time": 123.4,
+        "gc.blocking_count": 5,
+        "gc.blocking_time": 50.1,
+        "gc.pre_oome_count": 1,
+        "gc.waiting_time": 10.0,
+        "memory.free": 1024,
+        "memory.free_until_gc": 2048,
+        "memory.free_until_oome": 512,
+        "memory.total": 4096,
+        "memory.max": 8192,
+    }
+
+
+@django_db_all
+@pytest.mark.snuba
 def test_strip_event_data_strips_sdk(store_and_strip_event) -> None:
     stripped_event_data = store_and_strip_event(data=get_crash_event())
 


### PR DESCRIPTION
## Problem

The Android SDK ([getsentry/sentry-java#5428](https://github.com/getsentry/sentry-java/pull/5428)) added `ArtContext` (serialized under the `"art"` context key) to ANR events. It contains GC stats and heap memory info parsed from ANR thread dumps — exactly the data needed to understand whether OOM pressure contributed to an ANR.

The `sdk_crashes` event stripper was silently dropping the entire `art` context because only `device` and `os` were in `EVENT_DATA_ALLOWLIST["contexts"]`.

## Fix

Add all 11 `ArtContext` fields under `contexts.art` in the allowlist:

- GC counters/timings: `gc.total_count`, `gc.total_time`, `gc.blocking_count`, `gc.blocking_time`, `gc.pre_oome_count`, `gc.waiting_time`
- Heap memory snapshots: `memory.free`, `memory.free_until_gc`, `memory.free_until_oome`, `memory.total`, `memory.max`

All values are numeric (`Long`/`Double` → `int`/`float`), no PII risk.

## Test

Added `test_strip_event_data_keeps_art_context` which injects a full `art` context (including a `some_private_field` that should be stripped) and asserts only the allowlisted fields survive.

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC089VFRB8N9%3A1782999439.636989/?project=4510944073809921)

<!-- junior-session-footer:end -->