### PR TITLE
fix(eap): Resolve unprefixed new attributes to their public alias

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -741,6 +741,32 @@ def is_starred_segment_context_constructor(
     )
 
 
+def _unprefixed_convention_overrides(
+    search_type: Literal["string", "number", "boolean"],
+) -> dict[str, str]:
+    """`simple_sentry_field` assumes an attribute's internal storage key is
+    `sentry.<public_alias>`, but span-v2/streaming SDKs write some of these
+    attributes (e.g. `os.name`, `user.email`) unprefixed, matching the current
+    canonical name in `sentry_conventions`. An unprefixed key doesn't match any
+    entry in the reverse map above, so it falls through to the ambiguous
+    `tags[name,type]` representation instead of resolving to the public alias.
+    Add the unprefixed name as an extra reverse-map entry wherever it is the
+    package's current (non-deprecated) canonical form, so both old prefixed and
+    new unprefixed data resolve to the same public alias.
+    """
+    return {
+        definition.public_alias: definition.public_alias
+        for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
+        if (
+            not definition.secondary_alias
+            and definition.search_type == search_type
+            and definition.internal_name == f"sentry.{definition.public_alias}"
+            and (meta := ATTRIBUTE_METADATA.get(definition.public_alias)) is not None
+            and meta.deprecation is None
+        )
+    }
+
+
 SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     Literal["string", "number", "boolean"], dict[str, str]
 ] = {
@@ -758,12 +784,14 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
         "sentry.description": "sentry.normalized_description",
         "sentry.span_id": "id",
         "sentry.segment_name": "transaction",
-    },
+    }
+    | _unprefixed_convention_overrides("string"),
     "boolean": {
         definition.internal_name: definition.public_alias
         for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
         if not definition.secondary_alias and definition.search_type == "boolean"
-    },
+    }
+    | _unprefixed_convention_overrides("boolean"),
     "number": {
         definition.internal_name: definition.public_alias
         for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
@@ -773,7 +801,9 @@ SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS: dict[
     | {
         "sentry.start_timestamp": PRECISE_START_TS,
         "sentry.end_timestamp": PRECISE_FINISH_TS,
-    },
+    }
+    | _unprefixed_convention_overrides("boolean")
+    | _unprefixed_convention_overrides("number"),
 }
 
 SPANS_PRIVATE_ATTRIBUTES: set[str] = {


### PR DESCRIPTION
Some span attributes (`os.name`, `os.rooted`, `browser.name`, `user.email`, `user.id`, and several `device.*`/`user.geo.*` fields) come back from the trace-items API wrapped as `tags[name,type]` instead of their clean public alias when the underlying span data uses the unprefixed attribute name.

The registry's `simple_sentry_field` helper assumes an attribute's internal storage key is `sentry.<public_alias>`. Span-v2/streaming SDKs write several of these attributes unprefixed instead, matching the current canonical name in `sentry_conventions` (e.g. `os.name` rather than `sentry.os.name`). The reverse map used to resolve an internal key back to its public alias only had an entry for the prefixed form, so the unprefixed key fell through to a defensive "ambiguous name" branch and got wrapped in `tags[name,type]` rather than resolving cleanly.

`_unprefixed_convention_overrides` adds a reverse-map entry for the unprefixed form wherever it is the package's current (non-deprecated) canonical name, so both the legacy prefixed and the newer unprefixed data resolve to the same public alias. Fields where the unprefixed name is itself deprecated in `sentry_conventions` (`environment`, `release`, `runtime.name`, `app_start_type`) are correctly excluded, since a compliant SDK wouldn't emit those unprefixed.

This also affects filtering/autocomplete in Explore, not just the trace-items details response, since both consume the same reverse map.

---

Before: 

<img width="1183" height="370" alt="Screenshot 2026-07-06 at 14 26 37" src="https://github.com/user-attachments/assets/7a7aaf98-bada-48d5-9bb7-c798afb0abb9" />


---

After (only together with the frontend fix as well):

<img width="953" height="463" alt="Screenshot 2026-07-06 at 14 26 51" src="https://github.com/user-attachments/assets/671a9262-dc37-4af8-8fd0-1fca1aeddd6d" />
