### PR TITLE
fix(tracemetrics): Allow clearing equation to trigger update

### DIFF
--- a/static/app/views/explore/metrics/equationBuilder/index.spec.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.spec.tsx
@@ -81,4 +81,29 @@ describe('EquationBuilder', () => {
       ''
     );
   });
+
+  it('submits an empty expression when the user types a bunch of spaces', async () => {
+    const handleExpressionChange = jest.fn();
+
+    render(
+      <EquationBuilder
+        expression=""
+        referenceMap={{A: 'count(value,metricA,distribution,none)'}}
+        handleExpressionChange={handleExpressionChange}
+      />
+    );
+
+    // Type a bunch of spaces and then enter to submit the expression
+    await userEvent.type(
+      screen.getByRole('combobox', {name: 'Add a term'}),
+      '    {enter}'
+    );
+
+    expect(handleExpressionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: '',
+      }),
+      ''
+    );
+  });
 });

--- a/static/app/views/explore/metrics/equationBuilder/index.spec.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.spec.tsx
@@ -59,4 +59,26 @@ describe('EquationBuilder', () => {
       'A * 2'
     );
   });
+
+  it('allows the expression to be cleared', async () => {
+    const expression = 'count(value,metricA,distribution,none)';
+    const handleExpressionChange = jest.fn();
+
+    render(
+      <EquationBuilder
+        expression={expression}
+        referenceMap={{A: 'count(value,metricA,distribution,none)'}}
+        handleExpressionChange={handleExpressionChange}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Remove reference A'}));
+
+    expect(handleExpressionChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: '',
+      }),
+      ''
+    );
+  });
 });

--- a/static/app/views/explore/metrics/equationBuilder/index.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.tsx
@@ -50,7 +50,7 @@ export function EquationBuilder({
   const handleInternalExpressionChange = useCallback(
     (newExpression: Expression) => {
       startTransition(() => {
-        if (newExpression.isValid) {
+        if (newExpression.isValid || newExpression.text.trim() === '') {
           handleExpressionChange(
             resolveExpression(newExpression, referenceMap),
             newExpression.text


### PR DESCRIPTION
Prior, an empty string isn't considered "valid" because there is nothing in the equation. Since we do want to update the state (i.e. return to an empty state) we need to specifically account for the empty string when checking validity.
