### PR TITLE
feat(dynamic-sampling): Replace MOD-based org bucketing with CursoredScheduler

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1146,7 +1146,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "dynamic-sampling-schedule-per-org-calculations": {
         "task": "telemetry-experience:sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
-        "schedule": crontab("*", "*", "*", "*", "*"),
+        "schedule": timedelta(minutes=1),
     },
     "weekly-escalating-forecast": {
         "task": "issues:sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -49,12 +49,12 @@ CYCLE_DURATION = timedelta(minutes=10)
     processing_deadline_duration=2 * 60,  # 2 minute timeout per org
     silo_mode=SiloMode.CELL,
 )
-def run_calculations_per_org_task(org_id: OrganizationId) -> None:
-    _run_calculations_per_org(org_id)
+def run_calculations_per_org_task_entry(org_id: OrganizationId) -> None:
+    run_calculations_per_org_task(org_id)
 
 
 @track_dynamic_sampling
-def _run_calculations_per_org(org_id: OrganizationId) -> DynamicSamplingStatus | None:
+def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStatus | None:
     config = get_configuration(org_id)
     if not config.is_enabled:
         return DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
@@ -118,7 +118,7 @@ def schedule_per_org_calculations() -> None:
         name="ds_per_org",
         schedule_key="dynamic-sampling-schedule-per-org-calculations",
         queryset=Organization.objects.filter(status=OrganizationStatus.ACTIVE),
-        task=run_calculations_per_org_task,
+        task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=is_org_in_rollout,
     )

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -134,6 +134,7 @@ def schedule_per_org_calculations() -> None:
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
+        jitter=True,
     )
     scheduler.tick()
 

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -113,7 +113,7 @@ def _run_calculations_per_org(org_id: OrganizationId) -> DynamicSamplingStatus |
     silo_mode=SiloMode.CELL,
 )
 @track_dynamic_sampling
-def schedule_per_org_calculations():
+def schedule_per_org_calculations() -> None:
     scheduler = CursoredScheduler(
         name="ds_per_org",
         schedule_key="dynamic-sampling-schedule-per-org-calculations",

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import random
-from datetime import datetime, timezone
+from datetime import timedelta
 
 import sentry_sdk
-from django.db.models import F
-from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
 from sentry.dynamic_sampling.per_org.calculations import (
@@ -32,81 +29,18 @@ from sentry.dynamic_sampling.per_org.queries import (
     get_eap_transaction_volumes,
 )
 from sentry.dynamic_sampling.per_org.telemetry import (
-    SCHEDULER_BUCKET_ORG_STATUS_METRIC,
     DynamicSamplingStatus,
-    emit_status,
     track_dynamic_sampling,
 )
-from sentry.dynamic_sampling.rules.utils import OrganizationId, get_redis_client_for_ds
+from sentry.dynamic_sampling.rules.utils import OrganizationId
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import telemetry_experience_tasks
-from sentry.utils.query import RangeQuerySetWrapper
+from sentry.utils.cursored_scheduler import CursoredScheduler
 
-BUCKET_COUNT = 10
-JITTER_WINDOW_SECONDS = 60
-BUCKET_CURSOR_KEY = "ds::per_org:bucket_cursor"
-
-
-def _next_bucket_index() -> int:
-    try:
-        redis_client = get_redis_client_for_ds()
-        bucket_index = (redis_client.incr(BUCKET_CURSOR_KEY) - 1) % BUCKET_COUNT
-    except Exception as exc:
-        sentry_sdk.capture_exception(exc)
-        return datetime.now(tz=timezone.utc).minute % BUCKET_COUNT
-    return bucket_index
-
-
-@instrumented_task(
-    name="sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
-    namespace=telemetry_experience_tasks,
-    processing_deadline_duration=1 * 60,
-    retry=Retry(times=0),
-    silo_mode=SiloMode.CELL,
-)
-@track_dynamic_sampling
-def schedule_per_org_calculations() -> None:
-    bucket_index = _next_bucket_index()
-    bucket_tag = {"bucket_index": str(bucket_index)}
-    dispatched = 0
-    skipped = 0
-    queryset = (
-        Organization.objects.filter(status=OrganizationStatus.ACTIVE)
-        .annotate(_bucket=Mod(F("id"), BUCKET_COUNT))
-        .filter(_bucket=bucket_index)
-        .values_list("id", flat=True)
-    )
-    org_ids = RangeQuerySetWrapper[int](
-        queryset,
-        step=1000,
-        result_value_getter=lambda org_id: org_id,
-    )
-
-    for org_id in org_ids:
-        if not is_org_in_rollout(org_id):
-            skipped += 1
-            continue
-        run_calculations_per_org_task.apply_async(
-            args=(org_id,),
-            countdown=random.randint(0, JITTER_WINDOW_SECONDS),
-        )
-        dispatched += 1
-
-    emit_status(
-        SCHEDULER_BUCKET_ORG_STATUS_METRIC,
-        DynamicSamplingStatus.DISPATCHED,
-        amount=dispatched,
-        extra_tags=bucket_tag,
-    )
-    emit_status(
-        SCHEDULER_BUCKET_ORG_STATUS_METRIC,
-        DynamicSamplingStatus.ROLLOUT_EXCLUDED,
-        amount=skipped,
-        extra_tags=bucket_tag,
-    )
-    return None
+# How long a full pass through all organizations should take.
+CYCLE_DURATION = timedelta(minutes=10)
 
 
 @instrumented_task(
@@ -115,8 +49,12 @@ def schedule_per_org_calculations() -> None:
     processing_deadline_duration=2 * 60,  # 2 minute timeout per org
     silo_mode=SiloMode.CELL,
 )
+def run_calculations_per_org_task(org_id: OrganizationId) -> None:
+    _run_calculations_per_org(org_id)
+
+
 @track_dynamic_sampling
-def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStatus | None:
+def _run_calculations_per_org(org_id: OrganizationId) -> DynamicSamplingStatus | None:
     config = get_configuration(org_id)
     if not config.is_enabled:
         return DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
@@ -165,3 +103,23 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
     )
 
     return None
+
+
+@instrumented_task(
+    name="sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
+    namespace=telemetry_experience_tasks,
+    processing_deadline_duration=1 * 60,
+    retry=Retry(times=0),
+    silo_mode=SiloMode.CELL,
+)
+@track_dynamic_sampling
+def schedule_per_org_calculations():
+    scheduler = CursoredScheduler(
+        name="ds_per_org",
+        schedule_key="dynamic-sampling-schedule-per-org-calculations",
+        queryset=Organization.objects.filter(status=OrganizationStatus.ACTIVE),
+        task=run_calculations_per_org_task,
+        cycle_duration=CYCLE_DURATION,
+        validate_item=is_org_in_rollout,
+    )
+    scheduler.tick()

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -38,7 +38,7 @@ from sentry.dynamic_sampling.rules.utils import OrganizationId
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import dynamic_sampling_tasks, telemetry_experience_tasks
+from sentry.taskworker.namespaces import telemetry_experience_tasks
 from sentry.utils.cursored_scheduler import CursoredScheduler
 
 # How long a full pass through all organizations should take.
@@ -47,9 +47,8 @@ CYCLE_DURATION = timedelta(minutes=10)
 
 @instrumented_task(
     name="sentry.dynamic_sampling.per_org.run_calculations_per_org",
-    namespace=dynamic_sampling_tasks,
+    namespace=telemetry_experience_tasks,
     processing_deadline_duration=2 * 60,  # 2 minute timeout per org
-    expires=10 * 60,  # discard if not picked up within one cycle
     silo_mode=SiloMode.CELL,
 )
 def run_calculations_per_org_task_entry(org_id: OrganizationId) -> None:

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from datetime import timedelta
 
 import sentry_sdk
@@ -43,8 +42,6 @@ from sentry.utils.cursored_scheduler import CursoredScheduler
 
 # How long a full pass through all organizations should take.
 CYCLE_DURATION = timedelta(minutes=10)
-JITTER_WINDOW_SECONDS = 60
-
 SCHEDULER_METRIC = "dynamic_sampling.schedule_per_org_calculations.org_status"
 
 
@@ -122,18 +119,13 @@ def schedule_per_org_calculations() -> None:
     dispatched = 0
     skipped = 0
 
-    def validate_and_dispatch(org_id: int) -> bool:
+    def validate_and_track(org_id: int) -> bool:
         nonlocal dispatched, skipped
         if not is_org_in_rollout(org_id):
             skipped += 1
             return False
-        run_calculations_per_org_task_entry.apply_async(
-            args=(org_id,),
-            countdown=random.randint(0, JITTER_WINDOW_SECONDS),
-        )
         dispatched += 1
-        # Return False so CursoredScheduler does not call task.delay() again.
-        return False
+        return True
 
     scheduler = CursoredScheduler(
         name="ds_per_org",
@@ -141,7 +133,7 @@ def schedule_per_org_calculations() -> None:
         queryset=Organization.objects.filter(status=OrganizationStatus.ACTIVE),
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
-        validate_item=validate_and_dispatch,
+        validate_item=validate_and_track,
     )
     scheduler.tick()
 

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from datetime import timedelta
 
 import sentry_sdk
@@ -30,6 +31,7 @@ from sentry.dynamic_sampling.per_org.queries import (
 )
 from sentry.dynamic_sampling.per_org.telemetry import (
     DynamicSamplingStatus,
+    emit_status,
     track_dynamic_sampling,
 )
 from sentry.dynamic_sampling.rules.utils import OrganizationId
@@ -41,6 +43,9 @@ from sentry.utils.cursored_scheduler import CursoredScheduler
 
 # How long a full pass through all organizations should take.
 CYCLE_DURATION = timedelta(minutes=10)
+JITTER_WINDOW_SECONDS = 60
+
+SCHEDULER_METRIC = "dynamic_sampling.schedule_per_org_calculations.org_status"
 
 
 @instrumented_task(
@@ -114,12 +119,31 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
 )
 @track_dynamic_sampling
 def schedule_per_org_calculations() -> None:
+    dispatched = 0
+    skipped = 0
+
+    def validate_and_dispatch(org_id: int) -> bool:
+        nonlocal dispatched, skipped
+        if not is_org_in_rollout(org_id):
+            skipped += 1
+            return False
+        run_calculations_per_org_task_entry.apply_async(
+            args=(org_id,),
+            countdown=random.randint(0, JITTER_WINDOW_SECONDS),
+        )
+        dispatched += 1
+        # Return False so CursoredScheduler does not call task.delay() again.
+        return False
+
     scheduler = CursoredScheduler(
         name="ds_per_org",
         schedule_key="dynamic-sampling-schedule-per-org-calculations",
         queryset=Organization.objects.filter(status=OrganizationStatus.ACTIVE),
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
-        validate_item=is_org_in_rollout,
+        validate_item=validate_and_dispatch,
     )
     scheduler.tick()
+
+    emit_status(SCHEDULER_METRIC, DynamicSamplingStatus.DISPATCHED, amount=dispatched)
+    emit_status(SCHEDULER_METRIC, DynamicSamplingStatus.ROLLOUT_EXCLUDED, amount=skipped)

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -29,6 +29,7 @@ from sentry.dynamic_sampling.per_org.queries import (
     get_eap_transaction_volumes,
 )
 from sentry.dynamic_sampling.per_org.telemetry import (
+    SCHEDULER_BUCKET_ORG_STATUS_METRIC,
     DynamicSamplingStatus,
     emit_status,
     track_dynamic_sampling,
@@ -37,18 +38,18 @@ from sentry.dynamic_sampling.rules.utils import OrganizationId
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import telemetry_experience_tasks
+from sentry.taskworker.namespaces import dynamic_sampling_tasks, telemetry_experience_tasks
 from sentry.utils.cursored_scheduler import CursoredScheduler
 
 # How long a full pass through all organizations should take.
 CYCLE_DURATION = timedelta(minutes=10)
-SCHEDULER_METRIC = "dynamic_sampling.schedule_per_org_calculations.org_status"
 
 
 @instrumented_task(
     name="sentry.dynamic_sampling.per_org.run_calculations_per_org",
-    namespace=telemetry_experience_tasks,
+    namespace=dynamic_sampling_tasks,
     processing_deadline_duration=2 * 60,  # 2 minute timeout per org
+    expires=10 * 60,  # discard if not picked up within one cycle
     silo_mode=SiloMode.CELL,
 )
 def run_calculations_per_org_task_entry(org_id: OrganizationId) -> None:
@@ -134,9 +135,16 @@ def schedule_per_org_calculations() -> None:
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
-        jitter=True,
     )
     scheduler.tick()
 
-    emit_status(SCHEDULER_METRIC, DynamicSamplingStatus.DISPATCHED, amount=dispatched)
-    emit_status(SCHEDULER_METRIC, DynamicSamplingStatus.ROLLOUT_EXCLUDED, amount=skipped)
+    emit_status(
+        SCHEDULER_BUCKET_ORG_STATUS_METRIC,
+        DynamicSamplingStatus.DISPATCHED,
+        amount=dispatched,
+    )
+    emit_status(
+        SCHEDULER_BUCKET_ORG_STATUS_METRIC,
+        DynamicSamplingStatus.ROLLOUT_EXCLUDED,
+        amount=skipped,
+    )

--- a/src/sentry/dynamic_sampling/per_org/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/telemetry.py
@@ -20,6 +20,10 @@ F = TypeVar("F", bound=Callable[..., object])
 
 METRIC_PREFIX = "dynamic_sampling"
 
+SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
+    "dynamic_sampling.schedule_per_org_calculations_bucket.org_status"
+)
+
 
 class DynamicSamplingStatus(StrEnum):
     COMPLETED = "completed"

--- a/src/sentry/dynamic_sampling/per_org/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/telemetry.py
@@ -20,12 +20,6 @@ F = TypeVar("F", bound=Callable[..., object])
 
 METRIC_PREFIX = "dynamic_sampling"
 
-SCHEDULER_BEAT_STATUS_METRIC = "dynamic_sampling.schedule_per_org_calculations.status"
-SCHEDULER_BUCKET_STATUS_METRIC = "dynamic_sampling.schedule_per_org_calculations_bucket.status"
-SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
-    "dynamic_sampling.schedule_per_org_calculations_bucket.org_status"
-)
-
 
 class DynamicSamplingStatus(StrEnum):
     COMPLETED = "completed"

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -284,6 +284,11 @@ telemetry_experience_tasks = app.taskregistry.create_namespace(
     app_feature="transactions",
 )
 
+dynamic_sampling_tasks = app.taskregistry.create_namespace(
+    "dynamic-sampling",
+    app_feature="transactions",
+)
+
 tempest_tasks = app.taskregistry.create_namespace(
     "tempest",
     app_feature="errors",

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -284,10 +284,6 @@ telemetry_experience_tasks = app.taskregistry.create_namespace(
     app_feature="transactions",
 )
 
-dynamic_sampling_tasks = app.taskregistry.create_namespace(
-    "dynamic-sampling",
-    app_feature="transactions",
-)
 
 tempest_tasks = app.taskregistry.create_namespace(
     "tempest",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -83,7 +83,6 @@ SAMPLED_TASKS = {
     "sentry.dynamic_sampling.tasks.recalibrate_orgs": 0.2 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.dynamic_sampling.per_org.run_calculations_per_org": 1.0,
     "sentry.dynamic_sampling.per_org.schedule_per_org_calculations": 1.0,
-    "sentry.dynamic_sampling.per_org.schedule_per_org_calculations_bucket": 1.0,
     "sentry.dynamic_sampling.tasks.sliding_window_org": 0.2 * settings.SENTRY_BACKEND_APM_SAMPLING,
     "sentry.tasks.autofix.configure_seer_for_existing_org": 1.0,
     "sentry.tasks.seer.context_engine_index.schedule_context_engine_indexing_tasks": 1.0,

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -1,27 +1,43 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest.mock import Mock, patch
 
+from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
+from django.test import override_settings
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
 from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.per_org.scheduler import (
-    BUCKET_COUNT,
-    BUCKET_CURSOR_KEY,
-    _next_bucket_index,
-    run_calculations_per_org_task,
+    _run_calculations_per_org,
     schedule_per_org_calculations,
 )
 from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
-from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.dynamic_sampling.types import DynamicSamplingMode
 from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
+from sentry.utils.cursored_scheduler import (
+    BATCH_SIZE_CACHE_KEY_PREFIX,
+    CURSOR_CACHE_KEY_PREFIX,
+    CYCLE_START_CACHE_KEY_PREFIX,
+    PK_LIST_CACHE_KEY_PREFIX,
+    TICK_INTERVAL_CACHE_KEY_PREFIX,
+)
+from sentry.utils.redis import redis_clusters
+
+SCHEDULER_NAME = "ds_per_org"
+
+DS_SCHEDULES = {
+    "dynamic-sampling-schedule-per-org-calculations": {
+        "task": "telemetry-experience:sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
+        "schedule": timedelta(minutes=1),
+    },
+}
 
 
 def _assert_called_once_with_config(
@@ -45,22 +61,17 @@ def _drain_dispatched_org_ids(burst) -> list[int]:
     return ids
 
 
+@override_settings(TASKWORKER_SCHEDULES=DS_SCHEDULES)
 class SchedulePerOrgCalculationsTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.redis = get_redis_client_for_ds()
-        self.redis.delete(BUCKET_CURSOR_KEY)
-        self.addCleanup(self.redis.delete, BUCKET_CURSOR_KEY)
-
-    def create_orgs_across_buckets(self, per_bucket: int = 2) -> dict[int, list[int]]:
-        by_bucket: dict[int, list[int]] = {bucket: [] for bucket in range(BUCKET_COUNT)}
-        for _ in range(BUCKET_COUNT * per_bucket * 20):
-            if all(len(ids) >= per_bucket for ids in by_bucket.values()):
-                break
-            org = self.create_organization()
-            by_bucket[org.id % BUCKET_COUNT].append(org.id)
-        assert all(len(ids) >= per_bucket for ids in by_bucket.values())
-        return by_bucket
+        self.redis = redis_clusters.get("default")
+        # Reset scheduler state between tests
+        cache.delete(f"{CURSOR_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
+        cache.delete(f"{BATCH_SIZE_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
+        cache.delete(f"{CYCLE_START_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
+        cache.delete(f"{TICK_INTERVAL_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
+        self.redis.delete(f"{PK_LIST_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
 
     @override_options(
         {
@@ -69,12 +80,13 @@ class SchedulePerOrgCalculationsTest(TestCase):
         }
     )
     def test_is_noop_when_killswitch_engaged(self) -> None:
+        self.create_organization()
+
         with BurstTaskRunner() as burst:
             schedule_per_org_calculations()
             dispatched = _drain_dispatched_org_ids(burst)
 
         assert dispatched == []
-        assert self.redis.get(BUCKET_CURSOR_KEY) is None
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 0.0})
     def test_does_not_scan_when_rollout_zero(self) -> None:
@@ -85,55 +97,36 @@ class SchedulePerOrgCalculationsTest(TestCase):
             dispatched = _drain_dispatched_org_ids(burst)
 
         assert dispatched == []
-        assert self.redis.get(BUCKET_CURSOR_KEY) is None
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_advances_bucket_cursor(self) -> None:
-        with BurstTaskRunner() as burst:
-            schedule_per_org_calculations()
-
-        assert burst.queue == []
-        cursor = self.redis.get(BUCKET_CURSOR_KEY)
-        assert cursor is not None
-        assert int(cursor) == 1
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_dispatches_only_orgs_in_target_bucket(self) -> None:
-        by_bucket = self.create_orgs_across_buckets(per_bucket=2)
-        target = 3
-        self.redis.set(BUCKET_CURSOR_KEY, target)
+    def test_dispatches_active_orgs(self) -> None:
+        org = self.create_organization()
 
         with BurstTaskRunner() as burst:
-            schedule_per_org_calculations()
+            # Tick enough times to complete a full cycle
+            for _ in range(20):
+                schedule_per_org_calculations()
             dispatched = _drain_dispatched_org_ids(burst)
 
-        for org_id in dispatched:
-            assert org_id % BUCKET_COUNT == target
-        for org_id in by_bucket[target]:
-            assert org_id in dispatched
-        for bucket, org_ids in by_bucket.items():
-            if bucket == target:
-                continue
-            for org_id in org_ids:
-                assert org_id not in dispatched
-        assert len(dispatched) >= len(by_bucket[target])
+        assert org.id in dispatched
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_bucket_skips_inactive_orgs(self) -> None:
+    def test_skips_inactive_orgs(self) -> None:
         active = self.create_organization()
         pending_deletion = self.create_organization()
         pending_deletion.status = OrganizationStatus.PENDING_DELETION
         pending_deletion.save()
 
         with BurstTaskRunner() as burst:
-            for bucket in range(BUCKET_COUNT):
-                self.redis.set(BUCKET_CURSOR_KEY, bucket)
+            for _ in range(20):
                 schedule_per_org_calculations()
             dispatched = _drain_dispatched_org_ids(burst)
 
         assert active.id in dispatched
         assert pending_deletion.id not in dispatched
 
+
+class RunCalculationsPerOrgTest(TestCase):
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_returns_no_volume_without_traffic(self) -> None:
         org = self.create_organization()
@@ -152,7 +145,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
             ) as get_project_volumes,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.NO_ORG_VOLUME
         _assert_called_once_with_config(get_volume, org.id)
@@ -207,7 +200,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result is None
         _assert_called_once_with_config(get_volume, org.id)
@@ -250,7 +243,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 return_value=None,
             ) as project_balancing,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.NO_PROJECT_VOLUMES
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -297,7 +290,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 return_value=[],
             ) as get_transaction_volumes,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -350,13 +343,11 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result is None
         get_blended_sample_rate.assert_not_called()
         _assert_called_once_with_config(get_volume, org.id)
-        # Project volumes are fetched even in project mode (transaction balancing
-        # needs full per-project totals) but project balancing itself is skipped.
         _assert_called_once_with_config(get_project_volumes, org.id)
         project_balancing.assert_not_called()
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
@@ -413,7 +404,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result is None
         get_blended_sample_rate.assert_not_called()
@@ -447,7 +438,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
             ) as get_project_volumes,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_blended_sample_rate.assert_not_called()
@@ -502,7 +493,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result is None
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -531,7 +522,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
             ) as get_volume,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -550,7 +541,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
             ) as get_volume,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
         get_volume.assert_not_called()
@@ -568,7 +559,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
             ) as get_volume,
         ):
-            result = run_calculations_per_org_task(org.id)
+            result = _run_calculations_per_org(org.id)
 
         assert result == DynamicSamplingStatus.NO_SUBSCRIPTION
         get_volume.assert_not_called()
@@ -578,26 +569,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         with patch(
             "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
         ) as get_volume:
-            result = run_calculations_per_org_task(99999999)
+            result = _run_calculations_per_org(99999999)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_volume.assert_not_called()
-
-
-class NextBucketIndexTest(TestCase):
-    def test_uses_redis_cursor(self) -> None:
-        redis = get_redis_client_for_ds()
-        redis.delete(BUCKET_CURSOR_KEY)
-        self.addCleanup(redis.delete, BUCKET_CURSOR_KEY)
-
-        first_cycle = [_next_bucket_index() for _ in range(BUCKET_COUNT)]
-        cursor_after_cycle = redis.get(BUCKET_CURSOR_KEY)
-        next_cycle = [_next_bucket_index() for _ in range(2)]
-        cursor_after_next_cycle = redis.get(BUCKET_CURSOR_KEY)
-
-        assert first_cycle == list(range(BUCKET_COUNT))
-        assert cursor_after_cycle is not None
-        assert int(cursor_after_cycle) == BUCKET_COUNT
-        assert next_cycle == [0, 1]
-        assert cursor_after_next_cycle is not None
-        assert int(cursor_after_next_cycle) == BUCKET_COUNT + 2

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -6,9 +6,11 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
+from sentry.dynamic_sampling.per_org.gate import is_org_in_rollout
 from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.per_org.scheduler import (
     run_calculations_per_org_task,
+    schedule_per_org_calculations,
 )
 from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
@@ -30,6 +32,38 @@ def _assert_called_once_with_config(
 
 def _project_volume(project_id: int, total: int = 100, keep: int = 25) -> ProjectVolume:
     return ProjectVolume(project_id=project_id, total=total, keep=keep, drop=max(total - keep, 0))
+
+
+class SchedulePerOrgCalculationsTest(TestCase):
+    """Tests for the scheduling wrapper: rollout gating and active-org filtering."""
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_dispatches_only_active_orgs(self) -> None:
+        active = self.create_organization()
+        pending_deletion = self.create_organization()
+        pending_deletion.status = 1  # PENDING_DELETION
+        pending_deletion.save()
+
+        with patch("sentry.dynamic_sampling.per_org.scheduler.CursoredScheduler") as MockScheduler:
+            mock_instance = MockScheduler.return_value
+            mock_instance.tick.return_value = False
+            schedule_per_org_calculations()
+
+            queryset = MockScheduler.call_args.kwargs["queryset"]
+            org_ids = set(queryset.values_list("id", flat=True))
+
+        assert active.id in org_ids
+        assert pending_deletion.id not in org_ids
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_org_in_rollout_is_dispatched(self) -> None:
+        org = self.create_organization()
+        assert is_org_in_rollout(org.id) is True
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 0.0})
+    def test_org_not_in_rollout_is_skipped(self) -> None:
+        org = self.create_organization()
+        assert is_org_in_rollout(org.id) is False
 
 
 class RunCalculationsPerOrgTest(TestCase):

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -1,43 +1,20 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from unittest.mock import Mock, patch
 
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
-from django.test import override_settings
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
 from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.per_org.scheduler import (
-    _run_calculations_per_org,
-    schedule_per_org_calculations,
+    run_calculations_per_org_task,
 )
 from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.dynamic_sampling.types import DynamicSamplingMode
-from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.testutils.helpers.task_runner import BurstTaskRunner
-from sentry.utils.cursored_scheduler import (
-    BATCH_SIZE_CACHE_KEY_PREFIX,
-    CURSOR_CACHE_KEY_PREFIX,
-    CYCLE_START_CACHE_KEY_PREFIX,
-    PK_LIST_CACHE_KEY_PREFIX,
-    TICK_INTERVAL_CACHE_KEY_PREFIX,
-)
-from sentry.utils.redis import redis_clusters
-
-SCHEDULER_NAME = "ds_per_org"
-
-DS_SCHEDULES = {
-    "dynamic-sampling-schedule-per-org-calculations": {
-        "task": "telemetry-experience:sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
-        "schedule": timedelta(minutes=1),
-    },
-}
 
 
 def _assert_called_once_with_config(
@@ -53,77 +30,6 @@ def _assert_called_once_with_config(
 
 def _project_volume(project_id: int, total: int = 100, keep: int = 25) -> ProjectVolume:
     return ProjectVolume(project_id=project_id, total=total, keep=keep, drop=max(total - keep, 0))
-
-
-def _drain_dispatched_org_ids(burst) -> list[int]:
-    ids = [args[0] for _task, args, _kwargs in burst.queue]
-    burst.queue.clear()
-    return ids
-
-
-@override_settings(TASKWORKER_SCHEDULES=DS_SCHEDULES)
-class SchedulePerOrgCalculationsTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.redis = redis_clusters.get("default")
-        # Reset scheduler state between tests
-        cache.delete(f"{CURSOR_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
-        cache.delete(f"{BATCH_SIZE_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
-        cache.delete(f"{CYCLE_START_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
-        cache.delete(f"{TICK_INTERVAL_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
-        self.redis.delete(f"{PK_LIST_CACHE_KEY_PREFIX}:{SCHEDULER_NAME}")
-
-    @override_options(
-        {
-            "dynamic-sampling.per_org.killswitch": True,
-            "dynamic-sampling.per_org.rollout-rate": 1.0,
-        }
-    )
-    def test_is_noop_when_killswitch_engaged(self) -> None:
-        self.create_organization()
-
-        with BurstTaskRunner() as burst:
-            schedule_per_org_calculations()
-            dispatched = _drain_dispatched_org_ids(burst)
-
-        assert dispatched == []
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 0.0})
-    def test_does_not_scan_when_rollout_zero(self) -> None:
-        self.create_organization()
-
-        with BurstTaskRunner() as burst:
-            schedule_per_org_calculations()
-            dispatched = _drain_dispatched_org_ids(burst)
-
-        assert dispatched == []
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_dispatches_active_orgs(self) -> None:
-        org = self.create_organization()
-
-        with BurstTaskRunner() as burst:
-            # Tick enough times to complete a full cycle
-            for _ in range(20):
-                schedule_per_org_calculations()
-            dispatched = _drain_dispatched_org_ids(burst)
-
-        assert org.id in dispatched
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_skips_inactive_orgs(self) -> None:
-        active = self.create_organization()
-        pending_deletion = self.create_organization()
-        pending_deletion.status = OrganizationStatus.PENDING_DELETION
-        pending_deletion.save()
-
-        with BurstTaskRunner() as burst:
-            for _ in range(20):
-                schedule_per_org_calculations()
-            dispatched = _drain_dispatched_org_ids(burst)
-
-        assert active.id in dispatched
-        assert pending_deletion.id not in dispatched
 
 
 class RunCalculationsPerOrgTest(TestCase):
@@ -145,7 +51,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
             ) as get_project_volumes,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_ORG_VOLUME
         _assert_called_once_with_config(get_volume, org.id)
@@ -200,7 +106,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result is None
         _assert_called_once_with_config(get_volume, org.id)
@@ -243,7 +149,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 return_value=None,
             ) as project_balancing,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_PROJECT_VOLUMES
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -290,7 +196,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 return_value=[],
             ) as get_transaction_volumes,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -343,7 +249,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result is None
         get_blended_sample_rate.assert_not_called()
@@ -404,7 +310,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result is None
         get_blended_sample_rate.assert_not_called()
@@ -438,7 +344,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
             ) as get_project_volumes,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_blended_sample_rate.assert_not_called()
@@ -493,7 +399,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 return_value={},
             ) as transaction_balancing,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result is None
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -522,7 +428,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
             ) as get_volume,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -541,7 +447,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
             ) as get_volume,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
         get_volume.assert_not_called()
@@ -559,7 +465,7 @@ class RunCalculationsPerOrgTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
             ) as get_volume,
         ):
-            result = _run_calculations_per_org(org.id)
+            result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_SUBSCRIPTION
         get_volume.assert_not_called()
@@ -569,7 +475,7 @@ class RunCalculationsPerOrgTest(TestCase):
         with patch(
             "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
         ) as get_volume:
-            result = _run_calculations_per_org(99999999)
+            result = run_calculations_per_org_task(99999999)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
         get_volume.assert_not_called()


### PR DESCRIPTION
The per-org scheduler runs `MOD(id, 10)` against all active orgs every minute. Postgres can't index a modulo expression, so it walks the full PK index evaluating MOD on every row.

Replaces the bucket logic with `CursoredScheduler`: snapshots org PKs into Redis once per cycle, reads batches via LRANGE on subsequent ticks. Zero DB queries after init.

Closes TET-2274