### PR TITLE
ref(conversations): Reuse shared SaveQueryModal for conversations

### DIFF
--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -26,7 +26,7 @@ export type SaveQueryModalProps = {
   saveQuery: (name: string, starred?: boolean) => Promise<SavedQuery>;
   traceItemDataset: TraceItemDataset;
   name?: string;
-  source?: 'toolbar' | 'table';
+  source?: 'toolbar' | 'table' | 'conversations';
 };
 
 type Props = ModalRenderProps & SaveQueryModalProps;
@@ -59,7 +59,14 @@ function SaveQueryModal({
       }
       addSuccessMessage(t('Query saved successfully'));
       if (defined(source)) {
-        if (traceItemDataset === TraceItemDataset.LOGS) {
+        if (source === 'conversations') {
+          trackAnalytics('conversations.save_query_modal', {
+            action: 'submit',
+            save_type: initialName === undefined ? 'save_new_query' : 'rename_query',
+            ui_source: 'table',
+            organization,
+          });
+        } else if (traceItemDataset === TraceItemDataset.LOGS) {
           trackAnalytics('logs.save_query_modal', {
             action: 'submit',
             save_type: initialName === undefined ? 'save_new_query' : 'rename_query',

--- a/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
@@ -14,6 +14,11 @@ export type ConversationsEventParameters = {
   'conversations.message.click-tool-call': Record<string, unknown>;
   'conversations.onboarding.page-view': Record<string, unknown>;
   'conversations.page-view': Record<string, unknown>;
+  'conversations.save_query_modal': {
+    action: 'open' | 'submit';
+    save_type?: 'save_new_query' | 'rename_query';
+    ui_source?: 'table';
+  };
   'conversations.table.page-view': Record<string, unknown>;
   'conversations.table.paginate': {
     direction: 'next' | 'previous';
@@ -23,6 +28,7 @@ export type ConversationsEventParameters = {
 export const conversationsEventMap: Record<keyof ConversationsEventParameters, string> = {
   'conversations.onboarding.page-view': 'Conversations: Onboarding Page View',
   'conversations.page-view': 'Conversations: Page View',
+  'conversations.save_query_modal': 'Conversations: Save Query Modal',
   'conversations.table.page-view': 'Conversations: Table Page View',
   'conversations.table.paginate': 'Conversations: Table Paginate',
   'conversations.detail.expand-thinking': 'Conversations: Detail Expand Thinking',

--- a/static/app/views/explore/conversations/components/saveConversationQueryButton.tsx
+++ b/static/app/views/explore/conversations/components/saveConversationQueryButton.tsx
@@ -1,94 +1,15 @@
-import {Fragment, useState} from 'react';
-import * as Sentry from '@sentry/react';
-import {parseAsString, useQueryState} from 'nuqs';
+import {parseAsArrayOf, parseAsString, useQueryState, useQueryStates} from 'nuqs';
 
 import {Button} from '@sentry/scraps/button';
-import {Input} from '@sentry/scraps/input';
-import {Container, Flex} from '@sentry/scraps/layout';
-import {Switch} from '@sentry/scraps/switch';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
-import {type ModalRenderProps, openModal} from 'sentry/actionCreators/modal';
+import {openSaveQueryModal} from 'sentry/actionCreators/modal';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
-import {trackAnalytics} from 'sentry/utils/analytics';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useInvalidateSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
-
-type SaveModalProps = ModalRenderProps & {
-  onSave: (name: string, starred: boolean) => Promise<void>;
-};
-
-function SaveConversationQueryModal({
-  Header,
-  Body,
-  Footer,
-  closeModal,
-  onSave,
-}: SaveModalProps) {
-  const [name, setName] = useState('');
-  const [starred, setStarred] = useState(true);
-  const [isSaving, setIsSaving] = useState(false);
-
-  async function handleSave() {
-    try {
-      setIsSaving(true);
-      addLoadingMessage(t('Saving query...'));
-      await onSave(name, starred);
-      addSuccessMessage(t('Query saved successfully'));
-      closeModal();
-    } catch (error) {
-      addErrorMessage(t('Failed to save query'));
-      Sentry.captureException(error);
-    } finally {
-      setIsSaving(false);
-    }
-  }
-
-  return (
-    <Fragment>
-      <Header closeButton>
-        <h4>{t('New Query')}</h4>
-      </Header>
-      <Body>
-        <Container marginBottom="xl">
-          <h6>{t('Name')}</h6>
-          <Input
-            autoFocus
-            placeholder={t('Enter a name for your new query')}
-            onChange={e => setName(e.target.value)}
-            value={name}
-            title={t('Enter a name for your new query')}
-          />
-        </Container>
-        <Flex gap="md" align="center">
-          <Switch
-            checked={starred}
-            onChange={() => setStarred(!starred)}
-            title={t('Starred')}
-          />
-          <h6>{t('Starred')}</h6>
-        </Flex>
-      </Body>
-      <Footer>
-        <Flex gap="lg" align="center" justify="end">
-          <Button onClick={closeModal} disabled={isSaving}>
-            {t('Cancel')}
-          </Button>
-          <Button onClick={handleSave} disabled={!name || isSaving} variant="primary">
-            {t('Create a New Query')}
-          </Button>
-        </Flex>
-      </Footer>
-    </Fragment>
-  );
-}
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export function SaveConversationQueryButton() {
   const api = useApi();
@@ -99,19 +20,21 @@ export function SaveConversationQueryButton() {
     'query',
     parseAsString.withOptions({history: 'replace'})
   );
+  const [{agent}] = useQueryStates(
+    {agent: parseAsArrayOf(parseAsString)},
+    {history: 'replace'}
+  );
 
   function handleClick() {
-    trackAnalytics('conversations.save_query_modal', {
-      action: 'open',
+    openSaveQueryModal({
       organization,
-    });
-
-    openModal(modalProps => (
-      <SaveConversationQueryModal
-        {...modalProps}
-        onSave={async (name, starred) => {
-          const {datetime, projects, environments} = selection;
-          await api.requestPromise(`/organizations/${organization.slug}/explore/saved/`, {
+      source: 'conversations',
+      traceItemDataset: TraceItemDataset.SPANS,
+      saveQuery: async (name, starred) => {
+        const {datetime, projects, environments} = selection;
+        const response = await api.requestPromise(
+          `/organizations/${organization.slug}/explore/saved/`,
+          {
             method: 'POST',
             data: {
               name,
@@ -121,7 +44,8 @@ export function SaveConversationQueryButton() {
               range: datetime.period ?? undefined,
               start: datetime.start ?? undefined,
               end: datetime.end ?? undefined,
-              starred,
+              starred: starred ?? true,
+              agent: agent?.length ? agent : undefined,
               query: [
                 {
                   fields: [],
@@ -130,16 +54,12 @@ export function SaveConversationQueryButton() {
                 },
               ],
             },
-          });
-          invalidateSavedQueries();
-
-          trackAnalytics('conversations.save_query_modal', {
-            action: 'submit',
-            organization,
-          });
-        }}
-      />
-    ));
+          }
+        );
+        invalidateSavedQueries();
+        return response;
+      },
+    });
   }
 
   return (

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -122,6 +122,7 @@ export type ReadableSavedQuery = {
   projects: number[];
   query: [ReadableQuery, ...ReadableQuery[]];
   starred: boolean;
+  agent?: string[];
   caseInsensitive?: CaseInsensitive;
   changedReason?: ExploreQueryChangedReason | null;
   createdBy?: User;
@@ -145,6 +146,7 @@ export class SavedQuery {
   query: [SavedQueryQuery, ...SavedQueryQuery[]];
   dataset: ReadableSavedQuery['dataset'];
   starred: boolean;
+  agent?: string[];
   changedReason?: ExploreQueryChangedReason | null;
   crossEvents?: CrossEvent[];
   createdBy?: User;
@@ -155,6 +157,7 @@ export class SavedQuery {
   start?: string | DateString;
 
   constructor(savedQuery: ReadableSavedQuery) {
+    this.agent = savedQuery.agent;
     this.changedReason = savedQuery.changedReason;
     this.crossEvents = savedQuery.crossEvents;
     this.dateAdded = savedQuery.dateAdded;

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -702,7 +702,10 @@ function getConversationsUrlFromSavedQueryUrl({
     title: savedQuery.name,
   };
 
-  const queryString = qs.stringify(queryParams, {skipNull: true});
+  let queryString = qs.stringify(queryParams, {skipNull: true});
+  if (savedQuery.agent?.length) {
+    queryString += `&agent=${savedQuery.agent.map(encodeURIComponent).join(',')}`;
+  }
   const basePath = normalizeUrl(
     `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
   );


### PR DESCRIPTION
Replace the custom `SaveConversationQueryModal` with the shared `openSaveQueryModal` so the dialog is identical to logs/traces.

Adds `'conversations'` to the modal's `source` type so it fires `conversations.save_query_modal` analytics instead of misattributing to traces.

Persists the agent filter: the save button reads the `agent` URL param and includes it in the POST. The URL builder restores it using comma-separated format for nuqs compatibility.

> **Depends on #118982 being merged and deployed** (backend serializer support for the `agent` field).

Contributes to TET-2552