### PR TITLE
fix(ourlogs): fall back to message value when a log has no template

### DIFF
--- a/static/app/views/explore/logs/tables/getMessageFilter.spec.tsx
+++ b/static/app/views/explore/logs/tables/getMessageFilter.spec.tsx
@@ -47,6 +47,25 @@ describe('getMessageFilter', () => {
     });
   });
 
+  it('uses the message value when the template is null', () => {
+    const row = {
+      ...baseRow,
+      [OurLogKnownFieldKey.MESSAGE]: 'User 123 logged in',
+      [OurLogKnownFieldKey.TEMPLATE]: null,
+    };
+
+    const filter = getMessageFilter(
+      OurLogKnownFieldKey.MESSAGE,
+      row,
+      'User 123 logged in'
+    );
+
+    expect(filter).toEqual({
+      key: OurLogKnownFieldKey.MESSAGE,
+      value: 'User 123 logged in',
+    });
+  });
+
   it('uses the field and cell value when filtering on a non-message field', () => {
     const row = {
       ...baseRow,

--- a/static/app/views/explore/logs/tables/getMessageFilter.tsx
+++ b/static/app/views/explore/logs/tables/getMessageFilter.tsx
@@ -1,7 +1,5 @@
-import {
-  OurLogKnownFieldKey,
-  type OurLogsResponseItem,
-} from 'sentry/views/explore/logs/types';
+import {defined} from 'sentry/utils/defined';
+import {OurLogKnownFieldKey, type OurLogFieldKey} from 'sentry/views/explore/logs/types';
 
 export interface MessageFilter {
   key: string;
@@ -10,12 +8,16 @@ export interface MessageFilter {
 
 export function getMessageFilter(
   field: string,
-  dataRow: OurLogsResponseItem,
+  // A selected-but-absent attribute (e.g. a template-less log's message.template)
+  // comes back as null from the EAP response.
+  dataRow: Record<OurLogFieldKey, string | number | null>,
   cellValue: string | number | boolean
 ): MessageFilter {
   if (field === OurLogKnownFieldKey.MESSAGE) {
     const template = dataRow[OurLogKnownFieldKey.TEMPLATE];
-    if (template !== undefined) {
+    // A template-less log returns `message.template` as null; filtering on it would
+    // produce a nonsensical `message.template:null`, so fall back to the message value.
+    if (defined(template)) {
       return {key: OurLogKnownFieldKey.TEMPLATE, value: template};
     }
   }

--- a/static/app/views/explore/logs/tables/getMessageFilter.tsx
+++ b/static/app/views/explore/logs/tables/getMessageFilter.tsx
@@ -8,15 +8,11 @@ export interface MessageFilter {
 
 export function getMessageFilter(
   field: string,
-  // A selected-but-absent attribute (e.g. a template-less log's message.template)
-  // comes back as null from the EAP response.
   dataRow: Record<OurLogFieldKey, string | number | null>,
   cellValue: string | number | boolean
 ): MessageFilter {
   if (field === OurLogKnownFieldKey.MESSAGE) {
     const template = dataRow[OurLogKnownFieldKey.TEMPLATE];
-    // A template-less log returns `message.template` as null; filtering on it would
-    // produce a nonsensical `message.template:null`, so fall back to the message value.
     if (defined(template)) {
       return {key: OurLogKnownFieldKey.TEMPLATE, value: template};
     }


### PR DESCRIPTION
In Explore > Logs, message cells' **Add to filter** (`…` menu) buids a nonsensical `message.template:null` filter for logs with no message template, which matches nothing. I'd messed up `null` vs. `undefined` and didn't catch it in QA or tests. Which I did/added here.

Closes LOGS-908.