### PR TITLE
ref(sentry-apps): unify webhook dispatch to a single helper

### DIFF
--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -9,9 +9,9 @@ from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
-from sentry.sentry_apps.logic import consolidate_events
 from sentry.sentry_apps.services.app import RpcSentryAppInstallation, app_service
 from sentry.sentry_apps.tasks.sentry_apps import build_comment_webhook, workflow_notification
+from sentry.sentry_apps.utils.webhooks import is_subscribed
 from sentry.signals import (
     comment_created,
     comment_deleted,
@@ -118,7 +118,7 @@ def send_comment_webhooks(organization, issue, user, event, data=None):
     if "timestamp" in data:
         data["timestamp"] = data["timestamp"].isoformat()
 
-    for install in installations_to_notify(organization, "comment"):
+    for install in installations_to_notify(organization, event):
         build_comment_webhook.delay(
             installation_id=install.id,
             issue_id=issue.id,
@@ -136,9 +136,7 @@ def send_workflow_webhooks(
     data: Mapping[str, Any] | None = None,
 ) -> None:
     data = data or {}
-    for install in installations_to_notify(
-        organization=organization, resource_type=event.split(".")[0]
-    ):
+    for install in installations_to_notify(organization, event):
         event_type = backwards_compatible_event_name(install=install, event=event).split(".")[-1]
         workflow_notification.delay(
             installation_id=install.id,
@@ -150,13 +148,10 @@ def send_workflow_webhooks(
 
 
 def installations_to_notify(
-    organization: Organization, resource_type: str
+    organization: Organization, event: str
 ) -> list[RpcSentryAppInstallation]:
     installations = app_service.installations_for_organization(organization_id=organization.id)
-    # All issue webhooks are under one subscription, so if an intallation is subscribed to any issue
-    # events it should get notified for all the issue events
-    # TODO: Refactor sentry_app model so it doesn't store event, instead it stores subscription
-    return [i for i in installations if resource_type in consolidate_events(i.sentry_app.events)]
+    return [i for i in installations if is_subscribed(i.sentry_app.events, event)]
 
 
 def backwards_compatible_event_name(install: RpcSentryAppInstallation, event: str) -> str:

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -71,6 +71,7 @@ from sentry.sentry_apps.utils.webhooks import (
     MetricAlertActionType,
     SentryAppResourceType,
     find_alert_rule_action_ui_component,
+    is_subscribed,
 )
 from sentry.services.eventstore.models import BaseEvent, Event, GroupEvent
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
@@ -351,7 +352,7 @@ def _process_resource_change(
                 for installation in app_service.installations_for_organization(
                     organization_id=org.id
                 )
-                if event in installation.sentry_app.events
+                if is_subscribed(installation.sentry_app.events, event)
             ]
             data: dict[str, Any] = {}
             if isinstance(instance, (Event, GroupEvent)):
@@ -1150,13 +1151,10 @@ def broadcast_webhooks_for_organization(
         # Get installations for this organization
         installations = app_service.installations_for_organization(organization_id=organization_id)
 
-        # Filter for installations that subscribe to the event category
-        from sentry.sentry_apps.logic import consolidate_events
-
         relevant_installations = [
             installation
             for installation in installations
-            if resource_name in consolidate_events(installation.sentry_app.events)
+            if is_subscribed(installation.sentry_app.events, event_type)
         ]
 
         if not relevant_installations:

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Collection
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Final
 
@@ -119,6 +120,27 @@ EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[SentryAppEventType]]] = 
 # per-event-type (issue.created, project.deleted, etc.). These are valid
 # resources a Sentry App may subscribe to.
 VALID_EVENT_RESOURCES = EVENT_EXPANSION.keys()
+EVENT_TO_RESOURCE: Final[dict[str, SentryAppResourceType]] = {
+    event: resource for resource, events in EVENT_EXPANSION.items() for event in events
+}
+
+
+def resource_of(event: str) -> SentryAppResourceType | None:
+    """The resource a subscribable event belongs to ("issue.resolved" -> ISSUE), else None."""
+    return EVENT_TO_RESOURCE.get(event)
+
+
+def is_subscribed(stored_events: Collection[str], event: str) -> bool:
+    """
+    Whether a stored subscription covers a fired event.
+
+    Matched at the resource level: subscribing to any event of a resource
+    subscribes to all of that resource's events.
+    """
+    resource = resource_of(event)
+    if resource is None:
+        return False
+    return any(e in stored_events for e in EVENT_EXPANSION[resource])
 
 
 def find_alert_rule_action_ui_component(

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -1,12 +1,32 @@
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
+from sentry.sentry_apps.utils.webhooks import SentryAppResourceType, is_subscribed, resource_of
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
+
+
+def test_resource_of() -> None:
+    assert resource_of("issue.resolved") is SentryAppResourceType.ISSUE
+    assert resource_of("comment.deleted") is SentryAppResourceType.COMMENT
+    assert resource_of("seer.root_cause_started") is SentryAppResourceType.SEER
+    # Events outside the subscribable taxonomy (e.g. alerts) resolve to None.
+    assert resource_of("metric_alert.critical") is None
+    assert resource_of("bogus.thing") is None
+
+
+def test_is_subscribed_matches_at_resource_level() -> None:
+    # Subscribing to one issue event subscribes the install to every issue event.
+    assert is_subscribed(["issue.ignored"], "issue.resolved")
+    # A different resource, or nothing, does not match.
+    assert not is_subscribed(["error.created"], "issue.resolved")
+    assert not is_subscribed([], "issue.resolved")
+    # Events whose resource has no subscribable events never match.
+    assert not is_subscribed(["metric_alert.open"], "metric_alert.critical")
 
 
 @cell_silo_test
@@ -141,8 +161,8 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
 
     @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
     @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
-    def test_broadcast_filters_by_consolidated_events(self, mock_installations, mock_send_webhook):
-        """Test that installations are filtered based on consolidated events."""
+    def test_broadcast_filters_by_subscription(self, mock_installations, mock_send_webhook):
+        """Only installations subscribed to the event's resource are notified."""
         # Create an app that doesn't subscribe to the event resource
         sentry_app_5 = self.create_sentry_app(
             name="App5",
@@ -227,36 +247,6 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
 
         # No webhook tasks should be queued
         mock_send_webhook.delay.assert_not_called()
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
-    def test_broadcast_consolidate_events_integration(self, mock_installations, mock_send_webhook):
-        """Test that consolidate_events function is used correctly for filtering."""
-        # Mock installation with specific events
-        mock_installation = Mock()
-        mock_installation.sentry_app.events = ["issue.created", "issue.assigned"]
-        mock_installations.return_value = [mock_installation]
-
-        payload = {"event": "data"}
-
-        # Mock consolidate_events to return the expected resource categories
-        with patch("sentry.sentry_apps.logic.consolidate_events") as mock_consolidate:
-            mock_consolidate.return_value = ["issue"]
-
-            broadcast_webhooks_for_organization(
-                resource_name="issue",
-                event_name="created",
-                organization_id=self.organization.id,
-                payload=payload,
-            )
-
-            # Verify consolidate_events was called with the installation's events
-            mock_consolidate.assert_called_once_with(mock_installation.sentry_app.events)
-
-            # Webhook task should be queued since "issue" is in consolidated events
-            mock_send_webhook.delay.assert_called_once_with(
-                mock_installation.id, "issue.created", payload
-            )
 
     @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
     @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
@@ -460,26 +450,6 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
         payload = {"event": "data"}
 
         with pytest.raises(Exception, match="App service unavailable"):
-            broadcast_webhooks_for_organization(
-                resource_name="issue",
-                event_name="created",
-                organization_id=self.organization.id,
-                payload=payload,
-            )
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
-    @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
-    @patch("sentry.sentry_apps.logic.consolidate_events")
-    def test_broadcast_consolidate_events_exception(
-        self, mock_consolidate, mock_installations, mock_send_webhook
-    ):
-        """Test handling of exceptions from consolidate_events."""
-        mock_installations.return_value = [self.installation_1]
-        mock_consolidate.side_effect = Exception("Consolidation failed")
-
-        payload = {"event": "data"}
-
-        with pytest.raises(Exception, match="Consolidation failed"):
             broadcast_webhooks_for_organization(
                 resource_name="issue",
                 event_name="created",


### PR DESCRIPTION
Introduce `is_subscribed` helper to determine whether a particular sentry app install is subscribed to a webhook. No functional changes — this mostly removes semantics around doing `event.split('.')[0]` that we were using to determine the resource type (issue from `issue.created`). This prepares the way for us to allow more granular subscriptions.

We do change the `_process_resource_change` slightly to match on the resource level rather than on the exact event (e.g. match on issues vs issue.created, etc.), but since the API doesn't allow any subscriptions to individual events yet, this doesn't introduce any behavior changes for that path.

Refs https://linear.app/getsentry/issue/ISWF-2965/more-granular-controls-for-internal-integration-webhook-events