### PR TITLE
feat(sentry-apps): match webhook subscriptions per-event

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -297,6 +297,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-use-agent-sandbox", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable delivery of custom webhook headers configured on a SentryApp
     manager.add("organizations:sentry-apps-custom-webhook-headers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Allow SentryApps to subscribe to individual webhook events instead of whole resources
+    manager.add("organizations:sentry-apps-granular-events", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable select orgs from ingesting mobile replay events.
     # Enable double-read from EAP for session health data validation
     manager.add("organizations:session-health-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -124,6 +124,12 @@ EVENT_TO_RESOURCE: Final[dict[str, SentryAppResourceType]] = {
     event: resource for resource, events in EVENT_EXPANSION.items() for event in events
 }
 
+# Renamed events were never migrated in stored subscriptions, so old and new
+# names are equivalent when matching an exact subscription.
+_LEGACY_EVENT_ALIASES: Final[dict[str, str]] = {
+    SentryAppEventType.ISSUE_IGNORED: SentryAppEventType.ISSUE_ARCHIVED,
+}
+
 
 def resource_of(event: str) -> SentryAppResourceType | None:
     """The resource a subscribable event belongs to ("issue.resolved" -> ISSUE), else None."""
@@ -134,13 +140,15 @@ def is_subscribed(stored_events: Collection[str], event: str) -> bool:
     """
     Whether a stored subscription covers a fired event.
 
-    Matched at the resource level: subscribing to any event of a resource
-    subscribes to all of that resource's events.
+    Only the exact event matches (plus its legacy alias, for installs that
+    stored the pre-rename name). Subscribing to a whole resource stores every
+    event it expands to, so resource-level subscriptions match all of that
+    resource's events by construction.
     """
-    resource = resource_of(event)
-    if resource is None:
+    if resource_of(event) is None:
         return False
-    return any(e in stored_events for e in EVENT_EXPANSION[resource])
+    alias = _LEGACY_EVENT_ALIASES.get(event)
+    return event in stored_events or (alias is not None and alias in stored_events)
 
 
 def find_alert_rule_action_ui_component(

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -370,12 +370,11 @@ class TestComments(APITestCase):
 
 
 @patch("sentry.sentry_apps.tasks.sentry_apps.workflow_notification.delay")
-class TestIssueWorkflowNotificationsForSubscriptionFamily(APITestCase):
+class TestIssueWorkflowNotificationsForExactSubscription(APITestCase):
     def setUp(self) -> None:
         self.issue = self.create_group(project=self.project)
 
-        # Creating an app that is not subscribed to issue.resolved, but subscription is by resource
-        # so if an app is subscribed to issue.anything it should receive webhooks for issue.*
+        # App subscribed only to issue.ignored; only that exact event notifies.
         self.sentry_app = self.create_sentry_app(events=["issue.ignored"])
         self.install = self.create_sentry_app_installation(
             organization=self.organization, slug=self.sentry_app.slug
@@ -383,15 +382,18 @@ class TestIssueWorkflowNotificationsForSubscriptionFamily(APITestCase):
         self.url = f"/api/0/projects/{self.organization.slug}/{self.issue.project.slug}/issues/?id={self.issue.id}"
         self.login_as(self.user)
 
-    def test_notify_for_issue_event_if_subscribed_to_all_issue_events(
-        self, delay: MagicMock
-    ) -> None:
+    def test_skips_unsubscribed_issue_event(self, delay: MagicMock) -> None:
         self.client.put(self.url, data={"status": "resolved"}, format="json")
+
+        assert not delay.called
+
+    def test_notifies_subscribed_issue_event(self, delay: MagicMock) -> None:
+        self.client.put(self.url, data={"status": "ignored"}, format="json")
 
         delay.assert_called_once_with(
             installation_id=self.install.id,
             issue_id=self.issue.id,
-            type="resolved",
+            type="ignored",
             user_id=self.user.id,
-            data={"resolution_type": "now"},
+            data={},
         )

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -19,12 +19,15 @@ def test_resource_of() -> None:
     assert resource_of("bogus.thing") is None
 
 
-def test_is_subscribed_matches_at_resource_level() -> None:
-    # Subscribing to one issue event subscribes the install to every issue event.
-    assert is_subscribed(["issue.ignored"], "issue.resolved")
-    # A different resource, or nothing, does not match.
+def test_is_subscribed_matches_exact_event() -> None:
+    assert is_subscribed(["issue.resolved"], "issue.resolved")
+    # Only the exact stored event matches, not siblings from the same resource.
+    assert not is_subscribed(["issue.ignored"], "issue.resolved")
     assert not is_subscribed(["error.created"], "issue.resolved")
     assert not is_subscribed([], "issue.resolved")
+    # Legacy installs that stored the pre-rename name still match issue.ignored.
+    assert is_subscribed(["issue.archived"], "issue.ignored")
+    assert not is_subscribed(["issue.archived"], "issue.resolved")
     # Events whose resource has no subscribable events never match.
     assert not is_subscribed(["metric_alert.open"], "metric_alert.critical")
 
@@ -162,7 +165,7 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
     @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
     @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
     def test_broadcast_filters_by_subscription(self, mock_installations, mock_send_webhook):
-        """Only installations subscribed to the event's resource are notified."""
+        """Only installations subscribed to the event are notified."""
         # Create an app that doesn't subscribe to the event resource
         sentry_app_5 = self.create_sentry_app(
             name="App5",
@@ -185,6 +188,27 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
         )
 
         # Only installation_1 should have webhook task queued (subscribes to issue events)
+        mock_send_webhook.delay.assert_called_once_with(
+            self.installation_1.id, "issue.created", payload
+        )
+
+    @patch("sentry.sentry_apps.tasks.sentry_apps.send_resource_change_webhook")
+    @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
+    def test_broadcast_matches_exact_event(self, mock_installations, mock_send_webhook):
+        """Only the installation subscribed to the exact event is notified."""
+        # installation_1 subscribes to issue.created; installation_2 only to
+        # issue.assigned, a sibling event that must not match.
+        mock_installations.return_value = [self.installation_1, self.installation_2]
+
+        payload = {"event": "data"}
+
+        broadcast_webhooks_for_organization(
+            resource_name="issue",
+            event_name="created",
+            organization_id=self.organization.id,
+            payload=payload,
+        )
+
         mock_send_webhook.delay.assert_called_once_with(
             self.installation_1.id, "issue.created", payload
         )
@@ -489,7 +513,13 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
     @patch("sentry.sentry_apps.tasks.sentry_apps.app_service.installations_for_organization")
     def test_broadcast_queues_tasks_asynchronously(self, mock_installations, mock_send_webhook):
         """Test that webhook sending is queued as tasks, not executed synchronously."""
-        mock_installations.return_value = [self.installation_1, self.installation_2]
+        sentry_app = self.create_sentry_app(
+            name="App6", organization=self.organization, events=["issue.created"]
+        )
+        installation = self.create_sentry_app_installation(
+            organization=self.organization, slug=sentry_app.slug
+        )
+        mock_installations.return_value = [self.installation_1, installation]
 
         payload = {"test": "data"}
 
@@ -508,4 +538,4 @@ class BroadcastWebhooksForOrganizationTest(TestCase):
 
         # Verify each installation had a task queued with correct parameters
         mock_send_webhook.delay.assert_any_call(self.installation_1.id, "issue.created", payload)
-        mock_send_webhook.delay.assert_any_call(self.installation_2.id, "issue.created", payload)
+        mock_send_webhook.delay.assert_any_call(installation.id, "issue.created", payload)


### PR DESCRIPTION
When dispatching webhook events, match the exact fired event (plus its legacy issue.archived alias) instead of the whole resource. This is a no-op in prod now, but will matter once we start allowing granular webhook subscriptions in the API / UI. 

Also adds a flag for the future work.

Refs https://linear.app/getsentry/issue/ISWF-2965/more-granular-controls-for-internal-integration-webhook-events