### PR TITLE
feat(seer): Allow custom questions on the org Seer runs endpoint

### DIFF
--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -7,9 +7,18 @@ from sentry.api.serializers import Serializer, register
 from sentry.seer.models.run import SeerAgentRun, SeerRun
 
 
+# Within a run, outputs are ordered to match the questions that produced them
+# (built-in set first, then user questions in request order), so callers
+# correlate answers positionally; ``key`` and ``hash`` are just metadata.
 class RunQuestionOutput(TypedDict):
+    # Stable key for built-in questions; a synthetic ``user_<n>`` for user ones.
     key: str
+    # Short digest of the question text, always present.
+    hash: str
+    # The one-shot's markdown answer.
     answer: str
+    # The question text, echoed back only for user-supplied questions.
+    question: NotRequired[str]
 
 
 class SeerRunResponse(TypedDict):
@@ -24,7 +33,8 @@ class SeerRunResponse(TypedDict):
     projectId: str | None
     groupId: str | None
     # One-shot outputs (question answers), injected by the endpoint when
-    # ?outputs is passed; the serializer itself never populates them.
+    # ?expand=questions and/or ?question= is passed; the serializer itself never
+    # populates them.
     outputs: NotRequired[list[RunQuestionOutput]]
 
 

--- a/src/sentry/seer/endpoints/organization_seer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_runs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
 
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -34,6 +35,15 @@ from sentry.seer.runs_query import filtered_runs_queryset
 
 MAX_USER_QUESTIONS = 5
 MAX_QUESTION_LENGTH = 4096
+
+
+def _as_str_list(value: object) -> list[str]:
+    """Coerce a JSON value into a list of strings (``None`` → empty, scalar → singleton)."""
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [v for v in value if isinstance(v, str)]
+    return []
 
 
 def _fetch_run_outputs(
@@ -74,6 +84,7 @@ def _fetch_run_outputs(
 class OrganizationSeerRunsPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read"],
+        "POST": ["org:read"],
     }
 
 
@@ -81,6 +92,7 @@ class OrganizationSeerRunsPermission(OrganizationPermission):
 class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
@@ -103,7 +115,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
                 one-shot outputs for the built-in question set on each run
                 (requires the ``seer-run-questions`` feature).
             question: Optional repeatable free-text question (also requires the
-                feature). At most ``MAX_CUSTOM_QUESTIONS`` may be passed.
+                feature). At most ``MAX_USER_QUESTIONS`` may be passed.
 
         ``expand=questions`` and ``question`` are additive: you may request the
         built-in set, user questions, both, or neither. Each run's ``outputs``
@@ -112,6 +124,48 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
         correlate answers positionally. The per-output ``key`` and ``hash`` are
         supplementary metadata, not the primary correlation key.
         """
+        start, end = get_date_range_from_params(request.GET, optional=True)
+        return self._list_runs(
+            request,
+            organization,
+            query=request.GET.get("query", "").strip(),
+            expand=request.GET.getlist("expand"),
+            questions=request.GET.getlist("question"),
+            start=start,
+            end=end,
+        )
+
+    def post(self, request: Request, organization: Organization) -> Response:
+        """
+        Same as ``GET`` but reads its parameters (``query``, ``expand``,
+        ``question``, and date range) from a JSON body. Prefer this when asking
+        many or long questions that don't fit comfortably in a query string.
+        Pagination (``cursor``) is still read from the query string.
+        """
+        data = request.data if isinstance(request.data, dict) else {}
+        query = data.get("query", "")
+        start, end = get_date_range_from_params(data, optional=True)
+        return self._list_runs(
+            request,
+            organization,
+            query=query.strip() if isinstance(query, str) else "",
+            expand=_as_str_list(data.get("expand")),
+            questions=_as_str_list(data.get("question")),
+            start=start,
+            end=end,
+        )
+
+    def _list_runs(
+        self,
+        request: Request,
+        organization: Organization,
+        *,
+        query: str,
+        expand: Sequence[str],
+        questions: Sequence[str],
+        start: datetime | None,
+        end: datetime | None,
+    ) -> Response:
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
         if not has_access:
             raise PermissionDenied(error)
@@ -123,8 +177,8 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
         user_questions: list[str] = []
         include_builtin = False
         if feature_enabled:
-            include_builtin = "questions" in request.GET.getlist("expand")
-            user_questions = [q.strip() for q in request.GET.getlist("question") if q.strip()]
+            include_builtin = "questions" in expand
+            user_questions = [q.strip() for q in questions if q.strip()]
             if len(user_questions) > MAX_USER_QUESTIONS:
                 return Response(
                     {"detail": f"At most {MAX_USER_QUESTIONS} questions may be supplied."},
@@ -138,21 +192,16 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
 
         # The built-in set (expand=questions) and user questions are additive.
         # Built-ins come first so outputs stay ordered.
-        questions: list[Question] = []
+        run_questions: list[Question] = []
         if include_builtin:
-            questions.extend(QUESTIONS)
+            run_questions.extend(QUESTIONS)
         if user_questions:
-            questions.extend(build_user_questions(user_questions))
-        include_outputs = bool(questions)
+            run_questions.extend(build_user_questions(user_questions))
+        include_outputs = bool(run_questions)
 
-        query = request.GET.get("query", "").strip()
         accessible_project_ids = [
             p.id for p in self.get_projects(request, organization, include_all_accessible=True)
         ]
-
-        # get_date_range_from_params raises InvalidParams (a DRF ParseError) on
-        # bad date params, which DRF renders as a 400 on its own.
-        start, end = get_date_range_from_params(request.GET, optional=True)
 
         try:
             queryset = filtered_runs_queryset(
@@ -174,7 +223,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
                 outputs_by_run_id = _fetch_run_outputs(
                     runs,
                     organization,
-                    questions=questions,
+                    questions=run_questions,
                     user_id=request.user.id,
                 )
                 for run, data in zip(runs, serialized):

--- a/src/sentry/seer/endpoints/organization_seer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_runs.py
@@ -23,14 +23,24 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.seer.agent.client_utils import has_seer_agent_access_with_detail
 from sentry.seer.models.run import SeerRun, SeerRunType
-from sentry.seer.run_questions import get_run_questions
+from sentry.seer.run_questions import (
+    QUESTIONS,
+    Question,
+    RunQuestion,
+    build_user_questions,
+    get_run_questions,
+)
 from sentry.seer.runs_query import filtered_runs_queryset
+
+MAX_USER_QUESTIONS = 5
+MAX_QUESTION_LENGTH = 4096
 
 
 def _fetch_run_outputs(
     runs: Sequence[SeerRun],
     organization: Organization,
     *,
+    questions: Sequence[Question],
     user_id: int | None,
 ) -> dict[int, list[RunQuestionOutput]]:
     qualifying = [
@@ -44,13 +54,19 @@ def _fetch_run_outputs(
     answers_by_state_id = get_run_questions(
         [run.seer_run_state_id for run in qualifying],
         organization,
+        questions=questions,
         user_id=user_id,
     )
+
+    def to_output(q: RunQuestion) -> RunQuestionOutput:
+        output: RunQuestionOutput = {"key": q["key"], "hash": q["hash"], "answer": q["answer"]}
+        # Echo the prompt back only for user questions; built-in prompts are internal.
+        if q["user_supplied"]:
+            output["question"] = q["question"]
+        return output
+
     return {
-        run.id: [
-            {"key": q["key"], "answer": q["answer"]}
-            for q in answers_by_state_id.get(run.seer_run_state_id, [])
-        ]
+        run.id: [to_output(q) for q in answers_by_state_id.get(run.seer_run_state_id, [])]
         for run in qualifying
     }
 
@@ -83,16 +99,51 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             query: Optional structured search string. Supports ``source``, ``type``,
                 ``project``, ``is:agent``/``!is:agent``, ``is:mine``/``!is:mine``,
                 and free-text title search.
-            outputs: Optional boolean flag. When present, include one-shot outputs
-                per run (requires the ``seer-run-questions`` feature).
+            expand: Optional repeatable flag. Pass ``expand=questions`` to include
+                one-shot outputs for the built-in question set on each run
+                (requires the ``seer-run-questions`` feature).
+            question: Optional repeatable free-text question (also requires the
+                feature). At most ``MAX_CUSTOM_QUESTIONS`` may be passed.
+
+        ``expand=questions`` and ``question`` are additive: you may request the
+        built-in set, user questions, both, or neither. Each run's ``outputs``
+        list is returned in question order — the built-in set first (when
+        expanded), then the ``question`` params in the order supplied — so
+        correlate answers positionally. The per-output ``key`` and ``hash`` are
+        supplementary metadata, not the primary correlation key.
         """
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
         if not has_access:
             raise PermissionDenied(error)
 
-        include_outputs = "outputs" in request.GET and features.has(
+        feature_enabled = features.has(
             "organizations:seer-run-questions", organization, actor=request.user
         )
+
+        user_questions: list[str] = []
+        include_builtin = False
+        if feature_enabled:
+            include_builtin = "questions" in request.GET.getlist("expand")
+            user_questions = [q.strip() for q in request.GET.getlist("question") if q.strip()]
+            if len(user_questions) > MAX_USER_QUESTIONS:
+                return Response(
+                    {"detail": f"At most {MAX_USER_QUESTIONS} questions may be supplied."},
+                    status=400,
+                )
+            if any(len(q) > MAX_QUESTION_LENGTH for q in user_questions):
+                return Response(
+                    {"detail": f"Questions may be at most {MAX_QUESTION_LENGTH} characters."},
+                    status=400,
+                )
+
+        # The built-in set (expand=questions) and user questions are additive.
+        # Built-ins come first so outputs stay ordered.
+        questions: list[Question] = []
+        if include_builtin:
+            questions.extend(QUESTIONS)
+        if user_questions:
+            questions.extend(build_user_questions(user_questions))
+        include_outputs = bool(questions)
 
         query = request.GET.get("query", "").strip()
         accessible_project_ids = [
@@ -120,7 +171,12 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
         def on_results(runs: Sequence[SeerRun]) -> list[SeerRunResponse]:
             serialized: list[SeerRunResponse] = serialize(runs, request.user, SeerRunSerializer())
             if include_outputs:
-                outputs_by_run_id = _fetch_run_outputs(runs, organization, user_id=request.user.id)
+                outputs_by_run_id = _fetch_run_outputs(
+                    runs,
+                    organization,
+                    questions=questions,
+                    user_id=request.user.id,
+                )
                 for run, data in zip(runs, serialized):
                     data["outputs"] = outputs_by_run_id.get(run.id, [])
             return serialized

--- a/src/sentry/seer/run_questions.py
+++ b/src/sentry/seer/run_questions.py
@@ -82,13 +82,7 @@ QUESTIONS: tuple[Question, ...] = (
 
 
 def question_hash(question: str) -> str:
-    """Stable short digest of a question's text.
-
-    Used both as the Redis cache key suffix and as the ``hash`` echoed back on
-    each output so the frontend can correlate an answer with the question it
-    sent regardless of the (possibly synthetic) ``key``.
-    """
-    return hashlib.sha1(question.encode("utf-8")).hexdigest()[:8]
+    return hashlib.sha1(question.encode("utf-8")).hexdigest()
 
 
 def build_user_questions(questions: Sequence[str]) -> list[Question]:

--- a/src/sentry/seer/run_questions.py
+++ b/src/sentry/seer/run_questions.py
@@ -42,6 +42,7 @@ class Question:
     key: str
     # The prompt sent to the one-shot.
     question: str
+    user_supplied: bool = False
 
 
 class RunQuestion(TypedDict):
@@ -49,8 +50,11 @@ class RunQuestion(TypedDict):
     key: str
     # The prompt sent to the one-shot.
     question: str
+    # Digest of the question text; stable for a given prompt regardless of key.
+    hash: str
     # The one-shot's markdown answer, or "" when unavailable.
     answer: str
+    user_supplied: bool
 
 
 # For now define the questions here so they are easy to iterate on.
@@ -77,9 +81,28 @@ QUESTIONS: tuple[Question, ...] = (
 )
 
 
+def question_hash(question: str) -> str:
+    """Stable short digest of a question's text.
+
+    Used both as the Redis cache key suffix and as the ``hash`` echoed back on
+    each output so the frontend can correlate an answer with the question it
+    sent regardless of the (possibly synthetic) ``key``.
+    """
+    return hashlib.sha1(question.encode("utf-8")).hexdigest()[:8]
+
+
+def build_user_questions(questions: Sequence[str]) -> list[Question]:
+    """Wrap user-supplied question strings as ``Question`` objects.
+
+    They have no stable identifier, so we mint a positional ``user_<index>`` key.
+    """
+    return [
+        Question(key=f"user_{i}", question=q, user_supplied=True) for i, q in enumerate(questions)
+    ]
+
+
 def _answer_cache_key(organization: Organization, run_id: int, question: str) -> str:
-    digest = hashlib.sha1(question.encode("utf-8")).hexdigest()[:8]
-    return f"seer-run-question-v1:{organization.id}:{run_id}:{digest}"
+    return f"seer-run-question-v1:{organization.id}:{run_id}:{question_hash(question)}"
 
 
 def _get_answer(
@@ -127,17 +150,21 @@ def get_run_questions(
     run_ids: Sequence[int],
     organization: Organization,
     *,
+    questions: Sequence[Question] = QUESTIONS,
     user_id: int | None = None,
     timeout: int | float | None = None,
 ) -> dict[int, list[RunQuestion]]:
-    """Answer ``QUESTIONS`` about each run in ``run_ids``.
+    """Answer ``questions`` about each run in ``run_ids``.
+
+    Defaults to the built-in ``QUESTIONS`` set; callers may pass a user-supplied
+    set (e.g. from :func:`build_user_questions`) to answer arbitrary prompts.
 
     Every (run, question) pair is answered concurrently in a single shared pool,
     so multiple runs parallelize with each other as well as across questions.
-    Returns a mapping from run id to its answers in ``QUESTIONS`` order.
+    Returns a mapping from run id to its answers in ``questions`` order.
     """
     unique_run_ids = list(dict.fromkeys(run_ids))
-    tasks = [(run_id, question) for run_id in unique_run_ids for question in QUESTIONS]
+    tasks = [(run_id, question) for run_id in unique_run_ids for question in questions]
 
     with ContextPropagatingThreadPoolExecutor(max_workers=_MAX_WORKERS) as executor:
         answers = list(
@@ -152,6 +179,12 @@ def get_run_questions(
     result: dict[int, list[RunQuestion]] = {run_id: [] for run_id in unique_run_ids}
     for (run_id, question), answer in zip(tasks, answers):
         result[run_id].append(
-            {"key": question.key, "question": question.question, "answer": answer}
+            {
+                "key": question.key,
+                "question": question.question,
+                "hash": question_hash(question.question),
+                "answer": answer,
+                "user_supplied": question.user_supplied,
+            }
         )
     return result

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -570,6 +570,67 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             status_code=400,
         )
 
+    def test_post_lists_runs(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=1
+        )
+
+        response = self.get_success_response(self.organization.slug, method="post")
+
+        assert [r["id"] for r in response.data] == [str(run.uuid)]
+        assert "outputs" not in response.data[0]
+
+    @with_feature("organizations:seer-run-questions")
+    def test_post_builtin_and_user_questions_are_additive(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+        user_questions = ["What broke?", "Who is affected?"]
+
+        def fake_oneshot(
+            oneshot_id: str, payload: Mapping[str, Any], organization: Any, **kwargs: Any
+        ) -> dict[str, str]:
+            return {"answer": f"answer to: {payload['question']}"}
+
+        with patch("sentry.seer.run_questions.run_oneshot", side_effect=fake_oneshot) as mock_run:
+            response = self.get_success_response(
+                self.organization.slug,
+                method="post",
+                expand=["questions"],
+                question=user_questions,
+            )
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        assert [o["key"] for o in row["outputs"]] == [
+            *(q.key for q in QUESTIONS),
+            "user_0",
+            "user_1",
+        ]
+        assert [o["question"] for o in row["outputs"][len(QUESTIONS) :]] == user_questions
+        assert mock_run.call_count == len(QUESTIONS) + len(user_questions)
+
+    @with_feature("organizations:seer-run-questions")
+    def test_post_too_many_questions_returns_400(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            method="post",
+            question=[f"q{i}" for i in range(6)],
+            status_code=400,
+        )
+
+    def test_post_questions_require_feature(self) -> None:
+        self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            response = self.get_success_response(
+                self.organization.slug, method="post", question=["What broke?"]
+            )
+
+        assert "outputs" not in response.data[0]
+        assert mock_run.call_count == 0
+
 
 class OrganizationSeerRunsEndpointAccessTest(APITestCase):
     endpoint = "sentry-api-0-organization-seer-runs"

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry.seer.models.run import SeerRunType
-from sentry.seer.run_questions import QUESTIONS
+from sentry.seer.run_questions import QUESTIONS, question_hash
 from sentry.seer.runs_query import filtered_runs_queryset
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -341,7 +341,9 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
                 last_triggered_at=before_now(minutes=i),
             )
 
-        response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"expand": "questions"}
+        )
 
         assert len(response.data) == 10
         assert 'rel="next"; results="true"' in response.headers["Link"]
@@ -354,8 +356,8 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
                 last_triggered_at=before_now(minutes=i),
             )
 
-        # Without ?outputs the small default doesn't apply, so all runs fit on
-        # the first page.
+        # Without expanded questions the small default doesn't apply, so all runs
+        # fit on the first page.
         response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 11
@@ -386,9 +388,11 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             organization=self.organization, user_id=self.user.id, seer_run_state_id=1
         )
 
-        # Feature off: the flag is ignored, no one-shot calls, no outputs field.
+        # Feature off: expand=questions is ignored, no one-shot calls, no outputs.
         with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
-            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "questions"}
+            )
 
         assert "outputs" not in response.data[0]
         assert mock_run.call_count == 0
@@ -405,7 +409,9 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             return {"answer": f"answer to: {payload['question']}"}
 
         with patch("sentry.seer.run_questions.run_oneshot", side_effect=fake_oneshot) as mock_run:
-            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "questions"}
+            )
 
         row = next(r for r in response.data if r["id"] == str(run.uuid))
         assert [q["key"] for q in row["outputs"]] == [q.key for q in QUESTIONS]
@@ -413,6 +419,37 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             f"answer to: {q.question}" for q in QUESTIONS
         ]
         assert mock_run.call_count == len(QUESTIONS)
+
+    @with_feature("organizations:seer-run-questions")
+    def test_builtin_and_user_questions_are_additive(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+        user_questions = ["What broke?", "Who is affected?"]
+
+        def fake_oneshot(
+            oneshot_id: str, payload: Mapping[str, Any], organization: Any, **kwargs: Any
+        ) -> dict[str, str]:
+            return {"answer": f"answer to: {payload['question']}"}
+
+        with patch("sentry.seer.run_questions.run_oneshot", side_effect=fake_oneshot) as mock_run:
+            response = self.get_success_response(
+                self.organization.slug,
+                qs_params={"expand": "questions", "question": user_questions},
+            )
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        # Built-in questions come first (no echoed prompt), then the user ones in
+        # request order (with their prompt echoed).
+        assert [o["key"] for o in row["outputs"]] == [
+            *(q.key for q in QUESTIONS),
+            "user_0",
+            "user_1",
+        ]
+        for output in row["outputs"][: len(QUESTIONS)]:
+            assert "question" not in output
+        assert [o["question"] for o in row["outputs"][len(QUESTIONS) :]] == user_questions
+        assert mock_run.call_count == len(QUESTIONS) + len(user_questions)
 
     @with_feature("organizations:seer-run-questions")
     def test_outputs_skips_non_explorer_runs(self) -> None:
@@ -424,7 +461,9 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         )
 
         with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
-            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "questions"}
+            )
 
         row = next(r for r in response.data if r["id"] == str(pr_review.uuid))
         # Non-explorer runs carry an empty list and trigger no one-shot calls.
@@ -438,11 +477,98 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         )
 
         with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
-            response = self.get_success_response(self.organization.slug, qs_params={"outputs": "1"})
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "questions"}
+            )
 
         row = next(r for r in response.data if r["id"] == str(run.uuid))
         assert row["outputs"] == []
         assert mock_run.call_count == 0
+
+    @with_feature("organizations:seer-run-questions")
+    def test_builtin_outputs_include_hash_and_omit_question(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+
+        with patch(
+            "sentry.seer.run_questions.run_oneshot",
+            return_value={"answer": "an answer"},
+        ):
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"expand": "questions"}
+            )
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        for output, builtin in zip(row["outputs"], QUESTIONS):
+            assert output["hash"] == question_hash(builtin.question)
+            # Built-in questions don't echo their prompt text.
+            assert "question" not in output
+
+    @with_feature("organizations:seer-run-questions")
+    def test_user_questions_without_expand_are_user_only(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+        questions = ["What broke?", "Who is affected?"]
+
+        def fake_oneshot(
+            oneshot_id: str, payload: Mapping[str, Any], organization: Any, **kwargs: Any
+        ) -> dict[str, str]:
+            return {"answer": f"answer to: {payload['question']}"}
+
+        with patch("sentry.seer.run_questions.run_oneshot", side_effect=fake_oneshot) as mock_run:
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"question": questions}
+            )
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        # Without expand=questions the built-in set is not included, so only the
+        # supplied questions are answered.
+        assert [o["key"] for o in row["outputs"]] == ["user_0", "user_1"]
+        assert [o["question"] for o in row["outputs"]] == questions
+        assert [o["hash"] for o in row["outputs"]] == [question_hash(q) for q in questions]
+        assert [o["answer"] for o in row["outputs"]] == [f"answer to: {q}" for q in questions]
+        assert mock_run.call_count == len(questions)
+
+    @with_feature("organizations:seer-run-questions")
+    def test_user_questions_strip_and_ignore_blanks(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+
+        with patch(
+            "sentry.seer.run_questions.run_oneshot",
+            return_value={"answer": "an answer"},
+        ) as mock_run:
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"question": ["  What broke?  ", "   "]}
+            )
+
+        row = next(r for r in response.data if r["id"] == str(run.uuid))
+        assert [o["question"] for o in row["outputs"]] == ["What broke?"]
+        assert mock_run.call_count == 1
+
+    def test_user_questions_require_feature(self) -> None:
+        self.create_seer_run(
+            organization=self.organization, user_id=self.user.id, seer_run_state_id=99
+        )
+
+        with patch("sentry.seer.run_questions.run_oneshot") as mock_run:
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"question": "What broke?"}
+            )
+
+        assert "outputs" not in response.data[0]
+        assert mock_run.call_count == 0
+
+    @with_feature("organizations:seer-run-questions")
+    def test_too_many_questions_returns_400(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"question": [f"q{i}" for i in range(6)]},
+            status_code=400,
+        )
 
 
 class OrganizationSeerRunsEndpointAccessTest(APITestCase):


### PR DESCRIPTION
Extends the organization Seer runs list endpoint (`GET /organizations/{org}/seer/runs/`) to accept caller-supplied questions instead of only the built-in set.
Also replace `output=1` with `expand=questions` - to better match the other endpoints.

This allows for easier prototyping of new summaries of Autofix and other agent runs via `pnpm dev-ui`.
Both paths remain gated on the `organizations:seer-run-questions` feature preventing
external users from using this at the moment.

As previously the intention is that once we decide the final summaries the questions/prompts get migrated into
`getsentry/seer` where they can be easily evaled.

Agent transcript: https://claudescope.sentry.dev/share/NBqu4BjRjcZW7DvRgpHXAizTuhZoe9JVU45HbjLyGP4