### PR TITLE
feat(onboarding-multi-platform-detection): Updating UI for multiple detected platforms

### DIFF
--- a/static/app/views/onboarding/components/scmPlatformCard.tsx
+++ b/static/app/views/onboarding/components/scmPlatformCard.tsx
@@ -2,6 +2,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {getPlatformKind, type PlatformKind} from 'sentry/data/platformKinds';
 import {t} from 'sentry/locale';
@@ -40,9 +41,11 @@ export function ScmPlatformCard({
             <PlatformIcon platform={platform} size={28} />
           </Flex>
           <Stack maxWidth="100%" flexShrink={1} flexGrow={1} overflow="hidden">
-            <Text bold textWrap="nowrap" ellipsis>
-              {name}
-            </Text>
+            <Tooltip title={name} showOnlyOnOverflow skipWrapper>
+              <Text bold textWrap="nowrap" ellipsis>
+                {name}
+              </Text>
+            </Tooltip>
             <Text variant="muted" size="sm" textWrap="nowrap" ellipsis>
               {KIND_LABELS[getPlatformKind(platform, type)]}
             </Text>

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -385,7 +385,7 @@ export function ScmPlatformFeaturesCore({
               'screen:xs': '1fr',
               'screen:md':
                 resolvedPlatforms.length < 3
-                  ? `repeat(${resolvedPlatforms.length}, .5fr)`
+                  ? 'repeat(2, minmax(0, 1fr))'
                   : 'repeat(3, minmax(0, 1fr))',
             }}
             width="100%"

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -383,7 +383,13 @@ export function ScmPlatformFeaturesCore({
           <Grid
             columns={{
               'screen:xs': '1fr',
-              'screen:md': `repeat(${resolvedPlatforms.length}, .5fr)`,
+              // Below 3 detections there's enough space to keep the original
+              // .5fr-per-card sizing; at 3+ switch to a fixed 3-column grid
+              // so extra cards wrap to new rows instead of cramming into one.
+              'screen:md':
+                resolvedPlatforms.length < 3
+                  ? `repeat(${resolvedPlatforms.length}, .5fr)`
+                  : 'repeat(3, minmax(0, 1fr))',
             }}
             width="100%"
             justify="start"

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -383,9 +383,6 @@ export function ScmPlatformFeaturesCore({
           <Grid
             columns={{
               'screen:xs': '1fr',
-              // Below 3 detections there's enough space to keep the original
-              // .5fr-per-card sizing; at 3+ switch to a fixed 3-column grid
-              // so extra cards wrap to new rows instead of cramming into one.
               'screen:md':
                 resolvedPlatforms.length < 3
                   ? `repeat(${resolvedPlatforms.length}, .5fr)`


### PR DESCRIPTION
- Preserved current layout for < 3 detections, 3 columns wrapped to next rows, for anything else
- Added tooltip on truncation

Before: 
<img width="690" height="288" alt="Screenshot 2026-07-02 at 12 46 32 PM" src="https://github.com/user-attachments/assets/b805b718-e975-49cb-96f5-8ad560045480" />

After: 
<img width="812" height="298" alt="Screenshot 2026-07-02 at 12 22 36 PM" src="https://github.com/user-attachments/assets/adbe7584-bace-41d9-8fe9-6904dd27341c" />

Other examples:
<img width="790" height="293" alt="Screenshot 2026-07-02 at 12 24 03 PM" src="https://github.com/user-attachments/assets/39aacb41-48be-443f-a962-08df2e239163" />
<img width="793" height="343" alt="Screenshot 2026-07-02 at 12 26 35 PM" src="https://github.com/user-attachments/assets/75d080ad-4e1f-48cd-97d5-83c93c6ee2ed" />
<img width="770" height="345" alt="Screenshot 2026-07-02 at 12 33 06 PM" src="https://github.com/user-attachments/assets/1e350e90-7490-4dcd-bde6-3e45e9d90844" />

