### PR TITLE
feat(sentry-apps): accept granular webhook events on the API

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -44,6 +44,7 @@ from sentry.sentry_apps.installations import SentryAppInstallationNotifier
 from sentry.sentry_apps.logic import SentryAppUpdater
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
+from sentry.sentry_apps.utils.webhooks import has_granular_events
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.audit import create_audit_entry
@@ -150,6 +151,24 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 {
                     "non_field_errors": [
                         "Your organization does not have access to the 'error' resource subscription."
+                    ]
+                },
+                status=403,
+            )
+
+        if (
+            owner_context
+            and has_granular_events(request.data.get("events"))
+            and not features.has(
+                "organizations:sentry-apps-granular-events",
+                owner_context.organization,
+                actor=request.user,
+            )
+        ):
+            return Response(
+                {
+                    "non_field_errors": [
+                        "Your organization does not have access to per-event webhook subscriptions."
                     ]
                 },
                 status=403,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
@@ -26,6 +26,7 @@ from sentry.sentry_apps.api.serializers.sentry_app import (
 )
 from sentry.sentry_apps.logic import SentryAppCreator
 from sentry.sentry_apps.models.sentry_app import SentryApp
+from sentry.sentry_apps.utils.webhooks import has_granular_events
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -104,6 +105,18 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
                 {
                     "non_field_errors": [
                         "Your organization does not have access to the 'error' resource subscription."
+                    ]
+                },
+                status=403,
+            )
+
+        if has_granular_events(request.data.get("events")) and not features.has(
+            "organizations:sentry-apps-granular-events", organization, actor=request.user
+        ):
+            return Response(
+                {
+                    "non_field_errors": [
+                        "Your organization does not have access to per-event webhook subscriptions."
                     ]
                 },
                 status=403,

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -12,7 +12,11 @@ from sentry.apidocs.parameters import build_typed_list
 from sentry.integrations.models.integration_feature import Feature
 from sentry.models.apiscopes import ApiScopes
 from sentry.sentry_apps.api.parsers.schema import validate_ui_element_schema
-from sentry.sentry_apps.models.sentry_app import REQUIRED_EVENT_PERMISSIONS, UUID_CHARS_IN_SLUG
+from sentry.sentry_apps.models.sentry_app import (
+    UUID_CHARS_IN_SLUG,
+    VALID_EVENTS,
+    required_scope_for_subscription,
+)
 from sentry.sentry_apps.utils.webhooks import VALID_EVENT_RESOURCES
 from sentry.utils.display_name_filter import is_spam_display_name
 
@@ -64,11 +68,11 @@ class EventListField(serializers.Field):
         if data is None:
             return
 
-        if not set(data).issubset(VALID_EVENT_RESOURCES):
+        # Individual events (vs whole resources) are flag-gated at the endpoint.
+        valid = set(VALID_EVENT_RESOURCES) | set(VALID_EVENTS)
+        if not set(data).issubset(valid):
             raise ValidationError(
-                "Invalid event subscription: {}".format(
-                    ", ".join(set(data).difference(VALID_EVENT_RESOURCES))
-                )
+                "Invalid event subscription: {}".format(", ".join(set(data).difference(valid)))
             )
         return data
 
@@ -310,11 +314,13 @@ class SentryAppParser(Serializer):
     def validate(self, attrs):
         # validates events against scopes
         if attrs.get("scopes"):
-            for resource in attrs.get("events", []):
-                needed_scope = REQUIRED_EVENT_PERMISSIONS[resource]
+            for subscription in attrs.get("events", []):
+                needed_scope = required_scope_for_subscription(subscription)
                 if needed_scope not in attrs["scopes"]:
                     raise ValidationError(
-                        {"events": f"{resource} webhooks require the {needed_scope} permission."}
+                        {
+                            "events": f"{subscription} webhooks require the {needed_scope} permission."
+                        }
                     )
 
         get_current_value = self.get_current_value_wrapper(attrs)

--- a/src/sentry/sentry_apps/logic.py
+++ b/src/sentry/sentry_apps/logic.py
@@ -40,10 +40,10 @@ from sentry.sentry_apps.metrics import (
 )
 from sentry.sentry_apps.models.sentry_app import (
     MASKED_VALUE,
-    REQUIRED_EVENT_PERMISSIONS,
     UUID_CHARS_IN_SLUG,
     SentryApp,
     default_uuid,
+    required_scope_for_subscription,
 )
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
@@ -206,7 +206,7 @@ class SentryAppUpdater:
     def _update_events(self) -> None:
         if self.events is not None:
             for event in self.events:
-                needed_scope = REQUIRED_EVENT_PERMISSIONS[event]
+                needed_scope = required_scope_for_subscription(event)
                 if needed_scope not in self.sentry_app.scope_list:
                     raise ParseError(
                         detail=f"{event} webhooks require the {needed_scope} permission."

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -32,7 +32,7 @@ from sentry.db.models.paranoia import ParanoidManager, ParanoidModel
 from sentry.hybridcloud.models.outbox import ControlOutbox, outbox_context
 from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
 from sentry.models.apiscopes import HasApiScopes
-from sentry.sentry_apps.utils.webhooks import EVENT_EXPANSION
+from sentry.sentry_apps.utils.webhooks import EVENT_EXPANSION, resource_of
 from sentry.types.cell import find_all_cell_names, find_cells_for_sentry_app
 from sentry.utils import metrics
 
@@ -52,6 +52,13 @@ REQUIRED_EVENT_PERMISSIONS = {
 # EVENT_EXPANSION above. This list is likely a subset of all valid ServiceHook
 # events.
 VALID_EVENTS = tuple(itertools.chain(*EVENT_EXPANSION.values()))
+
+
+def required_scope_for_subscription(subscription: str) -> str:
+    """The API scope a subscription (a resource or one of its events) requires."""
+    resource = resource_of(subscription) or subscription
+    return REQUIRED_EVENT_PERMISSIONS[resource]
+
 
 MASKED_VALUE = "*" * 64
 

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -136,6 +136,11 @@ def resource_of(event: str) -> SentryAppResourceType | None:
     return EVENT_TO_RESOURCE.get(event)
 
 
+def has_granular_events(events: Collection[str] | None) -> bool:
+    """Whether any entry is an individual event rather than a whole resource."""
+    return any(event in EVENT_TO_RESOURCE for event in events or ())
+
+
 def is_subscribed(stored_events: Collection[str], event: str) -> bool:
     """
     Whether a stored subscription covers a fired event.

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -606,6 +606,19 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             status_code=200,
         )
 
+    @with_feature("organizations:sentry-apps-granular-events")
+    @override_options({"staff.ga-rollout": True})
+    def test_can_add_granular_events_with_flag(self) -> None:
+        app = self.create_sentry_app(name="SampleApp", organization=self.organization)
+        self.get_success_response(
+            app.slug,
+            events=["issue.resolved"],
+            scopes=("event:read",),
+            status_code=200,
+        )
+        # Stored verbatim, not expanded to the whole issue resource.
+        assert SentryApp.objects.get(id=app.id).events == ["issue.resolved"]
+
     @override_options({"staff.ga-rollout": True})
     def test_staff_can_mutate_scopes(self) -> None:
         self.login_as(user=self.staff_user, staff=True)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -699,6 +699,23 @@ class PostSentryAppsTest(SentryAppsTest):
                 ]
             }
 
+    @with_feature("organizations:sentry-apps-granular-events")
+    def test_can_create_with_granular_events_with_flag(self) -> None:
+        response = self.get_success_response(
+            **self.get_data(events=("issue.resolved",)), status_code=201
+        )
+        sentry_app = SentryApp.objects.get(slug=response.data["slug"])
+        # Stored verbatim, not expanded to the whole issue resource.
+        assert sentry_app.events == ["issue.resolved"]
+
+    @with_feature("organizations:sentry-apps-granular-events")
+    def test_granular_event_requires_resource_scope(self) -> None:
+        data = self.get_data(events=("issue.resolved",), scopes=("project:read",))
+        response = self.get_error_response(**data, status_code=400)
+        assert response.data == {
+            "events": ["issue.resolved webhooks require the event:read permission."]
+        }
+
     def test_allows_empty_schema(self) -> None:
         self.get_success_response(**self.get_data(shema={}), status_code=201)
 

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -5,7 +5,12 @@ import pytest
 
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
-from sentry.sentry_apps.utils.webhooks import SentryAppResourceType, is_subscribed, resource_of
+from sentry.sentry_apps.utils.webhooks import (
+    SentryAppResourceType,
+    has_granular_events,
+    is_subscribed,
+    resource_of,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -17,6 +22,14 @@ def test_resource_of() -> None:
     # Events outside the subscribable taxonomy (e.g. alerts) resolve to None.
     assert resource_of("metric_alert.critical") is None
     assert resource_of("bogus.thing") is None
+
+
+def test_has_granular_events() -> None:
+    assert has_granular_events(["issue.resolved"])
+    assert has_granular_events(["issue", "issue.resolved"])
+    assert not has_granular_events(["issue", "error"])
+    assert not has_granular_events([])
+    assert not has_granular_events(None)
 
 
 def test_is_subscribed_matches_exact_event() -> None:


### PR DESCRIPTION
Allow the sentry app endpoint to accept individual events (e.g. `issue.resolved`) as well as entire resources (e.g. `issue`), behind a feature flag. The read serializer still consolidates events to resources; exposing the exact stored list is a follow up.