### PR TITLE
feat(weekly-report): Update notification page for project customization

### DIFF
--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -59,7 +59,7 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
   reports: {
     title: t('Weekly Reports'),
     description: t(
-      "Reports contain a summary of what's happened within the organization."
+      "Reports contain a summary of what's happened within the organization. Customize the report to include projects relevant to you."
     ),
     type: 'select',
     // API only saves organizations that have this disabled, so we should default to "On"

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -227,8 +227,10 @@ export function NotificationSettingsByEntity({
         ]
       : entityOptions;
 
+  const Wrapper = entityType === 'project' ? MinHeight : Fragment;
+
   return (
-    <MinHeight>
+    <Wrapper>
       <Panel>
         <StyledPanelHeader>
           {entityType === 'project' ? (
@@ -297,7 +299,7 @@ export function NotificationSettingsByEntity({
           </Fragment>
         )}
       </Panel>
-    </MinHeight>
+    </Wrapper>
   );
 }
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -227,10 +227,8 @@ export function NotificationSettingsByEntity({
         ]
       : entityOptions;
 
-  const Wrapper = entityType === 'project' ? MinHeight : Fragment;
-
   return (
-    <Wrapper>
+    <MinHeight>
       <Panel>
         <StyledPanelHeader>
           {entityType === 'project' ? (
@@ -299,7 +297,7 @@ export function NotificationSettingsByEntity({
           </Fragment>
         )}
       </Panel>
-    </Wrapper>
+    </MinHeight>
   );
 }
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -36,6 +36,7 @@ import {NotificationSettingsByEntity} from './notificationSettingsByEntity';
 import type {Identity} from './types';
 import {UnlinkedAlert} from './unlinkedAlert';
 import {isGroupedByProject} from './utils';
+import {WeeklyReportProjectExclusions} from './weeklyReportProjectExclusions';
 
 type Props = {
   notificationType: string; // TODO(steve)? type better
@@ -423,15 +424,17 @@ export function NotificationSettingsByType({notificationType}: Props) {
       <SentryDocumentTitle title={title} />
       <SettingsPageHeader title={title} />
       {description && <TextBlock>{description}</TextBlock>}
-      <FieldGroup
-        title={
-          isGroupedByProject(notificationType)
-            ? t('All Projects')
-            : t('All Organizations')
-        }
-      >
-        {notificationType === 'quota' ? renderQuotaFields() : renderDefaultField()}
-      </FieldGroup>
+      {notificationType !== 'reports' && (
+        <FieldGroup
+          title={
+            isGroupedByProject(notificationType)
+              ? t('All Projects')
+              : t('All Organizations')
+          }
+        >
+          {notificationType === 'quota' ? renderQuotaFields() : renderDefaultField()}
+        </FieldGroup>
+      )}
       {notificationType !== 'reports' && notificationType !== 'brokenMonitors' ? (
         <FieldGroup title={t('Delivery Method')}>
           <AutoSaveForm
@@ -466,15 +469,29 @@ export function NotificationSettingsByType({notificationType}: Props) {
           </AutoSaveForm>
         </FieldGroup>
       ) : null}
-      <NotificationSettingsByEntity
-        notificationType={notificationType}
-        notificationOptions={notificationOptions}
-        organizations={organizations}
-        handleRemoveNotificationOption={id => removeNotificationMutation.mutate(id)}
-        handleAddNotificationOption={option => addNotificationMutation.mutate(option)}
-        handleEditNotificationOption={option => deleteNotificationMutation.mutate(option)}
-        entityType={entityType}
-      />
+      {notificationType === 'reports' ? (
+        <WeeklyReportProjectExclusions
+          organizations={organizations}
+          notificationOptions={notificationOptions}
+          handleRemoveNotificationOption={id => removeNotificationMutation.mutate(id)}
+          handleAddNotificationOption={option => addNotificationMutation.mutate(option)}
+          handleEditNotificationOption={option =>
+            deleteNotificationMutation.mutate(option)
+          }
+        />
+      ) : (
+        <NotificationSettingsByEntity
+          notificationType={notificationType}
+          notificationOptions={notificationOptions}
+          organizations={organizations}
+          handleRemoveNotificationOption={id => removeNotificationMutation.mutate(id)}
+          handleAddNotificationOption={option => addNotificationMutation.mutate(option)}
+          handleEditNotificationOption={option =>
+            deleteNotificationMutation.mutate(option)
+          }
+          entityType={entityType}
+        />
+      )}
     </Fragment>
   );
 }

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
@@ -24,6 +24,13 @@ describe('WeeklyReportProjectExclusions', () => {
       ...ConfigStore.get('customerDomain')!,
       subdomain: organization.slug,
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: OrganizationFixture({
+        ...organization,
+        features: ['weekly-report-project-exclusions'],
+      }),
+    });
   });
 
   afterEach(() => {
@@ -347,15 +354,14 @@ describe('WeeklyReportProjectExclusions', () => {
     expect(handleRemove).toHaveBeenCalledWith('42');
   });
 
-  it('does not show project toggles when exclusions endpoint returns 404', async () => {
+  it('does not show project toggles when feature flag is disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: OrganizationFixture({...organization, features: []}),
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,
       body: [projectA],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
-      statusCode: 404,
-      body: {},
     });
 
     render(

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
@@ -394,7 +394,7 @@ describe('WeeklyReportProjectExclusions', () => {
       });
     });
 
-    it('shows first 20 projects and pagination controls', async () => {
+    it('shows first 15 projects and pagination controls', async () => {
       render(
         <WeeklyReportProjectExclusions
           organizations={[organization]}
@@ -407,9 +407,9 @@ describe('WeeklyReportProjectExclusions', () => {
       });
 
       const checkboxes = screen.getAllByRole('checkbox');
-      expect(checkboxes).toHaveLength(20);
+      expect(checkboxes).toHaveLength(15);
 
-      expect(screen.getByText('1-20 of 25')).toBeInTheDocument();
+      expect(screen.getByText('1-15 of 25')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
       expect(screen.getByRole('button', {name: 'Next'})).toBeEnabled();
     });
@@ -429,17 +429,17 @@ describe('WeeklyReportProjectExclusions', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
       const checkboxes = screen.getAllByRole('checkbox');
-      expect(checkboxes).toHaveLength(5);
+      expect(checkboxes).toHaveLength(10);
 
-      expect(screen.getByText('21-25 of 25')).toBeInTheDocument();
+      expect(screen.getByText('16-25 of 25')).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Previous'})).toBeEnabled();
       expect(screen.getByRole('button', {name: 'Next'})).toBeDisabled();
     });
 
-    it('does not show pagination for 20 or fewer projects', async () => {
+    it('does not show pagination for 15 or fewer projects', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/projects/`,
-        body: manyProjects.slice(0, 20),
+        body: manyProjects.slice(0, 15),
       });
 
       render(

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
@@ -373,4 +373,88 @@ describe('WeeklyReportProjectExclusions', () => {
       })
     ).not.toBeInTheDocument();
   });
+
+  describe('pagination', () => {
+    const manyProjects = Array.from({length: 25}, (_, i) =>
+      ProjectFixture({
+        id: String(i + 1),
+        slug: `project-${String(i + 1).padStart(2, '0')}`,
+        organization,
+      })
+    );
+
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: manyProjects,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+        body: [],
+      });
+    });
+
+    it('shows first 20 projects and pagination controls', async () => {
+      render(
+        <WeeklyReportProjectExclusions
+          organizations={[organization]}
+          {...defaultNotificationProps}
+        />
+      );
+
+      await screen.findByRole('checkbox', {
+        name: 'Toggle weekly report for project-01',
+      });
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(20);
+
+      expect(screen.getByText('1-20 of 25')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Previous'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Next'})).toBeEnabled();
+    });
+
+    it('navigates to second page', async () => {
+      render(
+        <WeeklyReportProjectExclusions
+          organizations={[organization]}
+          {...defaultNotificationProps}
+        />
+      );
+
+      await screen.findByRole('checkbox', {
+        name: 'Toggle weekly report for project-01',
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(5);
+
+      expect(screen.getByText('21-25 of 25')).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Previous'})).toBeEnabled();
+      expect(screen.getByRole('button', {name: 'Next'})).toBeDisabled();
+    });
+
+    it('does not show pagination for 20 or fewer projects', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: manyProjects.slice(0, 20),
+      });
+
+      render(
+        <WeeklyReportProjectExclusions
+          organizations={[organization]}
+          {...defaultNotificationProps}
+        />
+      );
+
+      await screen.findByRole('checkbox', {
+        name: 'Toggle weekly report for project-01',
+      });
+
+      expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Next'})).not.toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
@@ -1,0 +1,376 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
+
+import {ConfigStore} from 'sentry/stores/configStore';
+import {WeeklyReportProjectExclusions} from 'sentry/views/settings/account/notifications/weeklyReportProjectExclusions';
+
+describe('WeeklyReportProjectExclusions', () => {
+  const organization = OrganizationFixture();
+  const projectA = ProjectFixture({id: '1', slug: 'project-a', organization});
+  const projectB = ProjectFixture({id: '2', slug: 'project-b', organization});
+
+  const defaultNotificationProps = {
+    notificationOptions: [],
+    handleAddNotificationOption: jest.fn(),
+    handleEditNotificationOption: jest.fn(),
+    handleRemoveNotificationOption: jest.fn(),
+  };
+
+  beforeEach(() => {
+    ConfigStore.set('customerDomain', {
+      ...ConfigStore.get('customerDomain')!,
+      subdomain: organization.slug,
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('renders all projects with switches ON when no exclusions', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA, projectB],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    const switchA = await screen.findByRole('checkbox', {
+      name: 'Toggle weekly report for project-a',
+    });
+    const switchB = screen.getByRole('checkbox', {
+      name: 'Toggle weekly report for project-b',
+    });
+    expect(switchA).toBeChecked();
+    expect(switchB).toBeChecked();
+  });
+
+  it('renders excluded projects with switches OFF', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA, projectB],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [{id: '100', projectId: '1', projectSlug: 'project-a', dateAdded: ''}],
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    const switchA = await screen.findByRole('checkbox', {
+      name: 'Toggle weekly report for project-a',
+    });
+    const switchB = screen.getByRole('checkbox', {
+      name: 'Toggle weekly report for project-b',
+    });
+    expect(switchA).not.toBeChecked();
+    expect(switchB).toBeChecked();
+  });
+
+  it('sends PUT with project added to exclusions when toggling OFF', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA, projectB],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+    const putMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      method: 'PUT',
+      statusCode: 204,
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    const switchA = await screen.findByRole('checkbox', {
+      name: 'Toggle weekly report for project-a',
+    });
+    await userEvent.click(switchA);
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {projectIds: [1]},
+        })
+      );
+    });
+  });
+
+  it('sends PUT with project removed from exclusions when toggling ON', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA, projectB],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [
+        {id: '100', projectId: '1', projectSlug: 'project-a', dateAdded: ''},
+        {id: '101', projectId: '2', projectSlug: 'project-b', dateAdded: ''},
+      ],
+    });
+    const putMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      method: 'PUT',
+      statusCode: 204,
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    const switchA = await screen.findByRole('checkbox', {
+      name: 'Toggle weekly report for project-a',
+    });
+    await userEvent.click(switchA);
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {projectIds: [2]},
+        })
+      );
+    });
+  });
+
+  it('shows empty state when no organization is selected', () => {
+    const orgA = OrganizationFixture({id: '1', slug: 'org-a', name: 'Org A'});
+    const orgB = OrganizationFixture({id: '2', slug: 'org-b', name: 'Org B'});
+    ConfigStore.set('customerDomain', {
+      ...ConfigStore.get('customerDomain')!,
+      subdomain: '',
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[orgA, orgB]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    expect(screen.getByText('Select an organization to continue')).toBeInTheDocument();
+  });
+
+  it('shows no projects found when org has no projects', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    expect(await screen.findByText('No projects found')).toBeInTheDocument();
+  });
+
+  it('shows warning when all projects are excluded', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA, projectB],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [
+        {id: '100', projectId: '1', projectSlug: 'project-a', dateAdded: ''},
+        {id: '101', projectId: '2', projectSlug: 'project-b', dateAdded: ''},
+      ],
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    expect(
+      await screen.findByText(
+        "You won't receive a weekly report for this organization if all projects are excluded."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows org-level dropdown that defaults to On', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    expect(await screen.findByText('On')).toBeInTheDocument();
+  });
+
+  it('hides project toggles when org report is off', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        notificationOptions={[
+          {
+            id: '1',
+            type: 'reports',
+            scopeType: 'organization',
+            scopeIdentifier: organization.id,
+            value: 'never',
+          },
+        ]}
+        handleAddNotificationOption={jest.fn()}
+        handleEditNotificationOption={jest.fn()}
+        handleRemoveNotificationOption={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText('Off')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('checkbox', {
+        name: 'Toggle weekly report for project-a',
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls handleAddNotificationOption when switching org report to Off', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+
+    const handleAdd = jest.fn();
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+        handleAddNotificationOption={handleAdd}
+      />
+    );
+
+    await selectEvent.select(await screen.findByText('On'), 'Off');
+
+    expect(handleAdd).toHaveBeenCalledWith({
+      type: 'reports',
+      scopeType: 'organization',
+      scopeIdentifier: organization.id,
+      value: 'never',
+    });
+  });
+
+  it('calls handleRemoveNotificationOption when switching org report to On', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      body: [],
+    });
+
+    const handleRemove = jest.fn();
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        notificationOptions={[
+          {
+            id: '42',
+            type: 'reports',
+            scopeType: 'organization',
+            scopeIdentifier: organization.id,
+            value: 'never',
+          },
+        ]}
+        handleAddNotificationOption={jest.fn()}
+        handleEditNotificationOption={jest.fn()}
+        handleRemoveNotificationOption={handleRemove}
+      />
+    );
+
+    await selectEvent.select(await screen.findByText('Off'), 'On');
+
+    expect(handleRemove).toHaveBeenCalledWith('42');
+  });
+
+  it('does not show project toggles when exclusions endpoint returns 404', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [projectA],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/weekly-report-project-exclusions/`,
+      statusCode: 404,
+      body: {},
+    });
+
+    render(
+      <WeeklyReportProjectExclusions
+        organizations={[organization]}
+        {...defaultNotificationProps}
+      />
+    );
+
+    expect(await screen.findByText('On')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('checkbox', {
+        name: 'Toggle weekly report for project-a',
+      })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
@@ -1,0 +1,384 @@
+import {Fragment} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useMutation} from '@tanstack/react-query';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Select} from '@sentry/scraps/select';
+import {Switch} from '@sentry/scraps/switch';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
+import {IdBadge} from 'sentry/components/idBadge';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelBody} from 'sentry/components/panels/panelBody';
+import {PanelHeader} from 'sentry/components/panels/panelHeader';
+import {t} from 'sentry/locale';
+import {ConfigStore} from 'sentry/stores/configStore';
+import type {OrganizationSummary} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {fetchMutation, setApiQueryData} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+import type {NotificationOptionsObject} from './constants';
+import {OrganizationSelectHeader} from './organizationSelectHeader';
+
+interface WeeklyReportProjectExclusionsProps {
+  handleAddNotificationOption: (option: Omit<NotificationOptionsObject, 'id'>) => void;
+  handleEditNotificationOption: (option: NotificationOptionsObject) => void;
+  handleRemoveNotificationOption: (id: string) => void;
+  notificationOptions: NotificationOptionsObject[];
+  organizations: OrganizationSummary[];
+}
+
+interface Exclusion {
+  dateAdded: string;
+  id: string;
+  projectId: string;
+  projectSlug: string;
+}
+
+function exclusionsApiOptions(
+  orgSlug: string | typeof skipToken,
+  regionUrl: string | undefined
+) {
+  return apiOptions.as<Exclusion[]>()(
+    '/organizations/$organizationIdOrSlug/weekly-report-project-exclusions/',
+    {
+      path: orgSlug === skipToken ? skipToken : {organizationIdOrSlug: orgSlug},
+      host: regionUrl,
+      staleTime: 30_000,
+    }
+  );
+}
+
+export function WeeklyReportProjectExclusions({
+  organizations,
+  notificationOptions,
+  handleAddNotificationOption,
+  handleEditNotificationOption,
+  handleRemoveNotificationOption,
+}: WeeklyReportProjectExclusionsProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const customerDomain = ConfigStore.get('customerDomain');
+  const orgFromSubdomain = organizations.find(
+    ({slug}) => slug === customerDomain?.subdomain
+  )?.id;
+
+  const orgId =
+    (location.query?.organizationId as string | undefined) ??
+    orgFromSubdomain ??
+    (organizations.length === 1 ? organizations[0]?.id : undefined);
+  let organization = organizations.find(({id}) => id === orgId);
+
+  if (!organization && organizations.length === 1) {
+    organization = organizations[0];
+  }
+
+  const {
+    data: projects,
+    isPending: projectsPending,
+    isError: projectsError,
+    refetch: refetchProjects,
+  } = useQuery({
+    ...apiOptions.as<Project[]>()('/organizations/$organizationIdOrSlug/projects/', {
+      path: organization ? {organizationIdOrSlug: organization.slug} : skipToken,
+      host: organization?.links?.regionUrl,
+      query: {
+        all_projects: '1',
+        collapse: ['latestDeploys', 'unusedFeatures'],
+      },
+      staleTime: Infinity,
+    }),
+  });
+
+  const exclusionsOpts = exclusionsApiOptions(
+    organization?.slug ?? skipToken,
+    organization?.links?.regionUrl
+  );
+
+  const {
+    data: exclusions,
+    isPending: exclusionsPending,
+    isError: exclusionsError,
+    error: exclusionsErrorObj,
+    refetch: refetchExclusions,
+  } = useQuery({
+    ...exclusionsOpts,
+    retry: (failureCount, error) => {
+      if (error instanceof RequestError && error.status === 404) {
+        return false;
+      }
+      return failureCount < 3;
+    },
+  });
+
+  const featureDisabled =
+    exclusionsError &&
+    exclusionsErrorObj instanceof RequestError &&
+    exclusionsErrorObj.status === 404;
+
+  const excludedProjectIds = new Set((exclusions ?? []).map(exc => exc.projectId));
+
+  const toggleMutation = useMutation({
+    mutationFn: (newExcludedIds: string[]) =>
+      fetchMutation({
+        method: 'PUT',
+        url: `/organizations/${organization!.slug}/weekly-report-project-exclusions/`,
+        options: {host: organization!.links?.regionUrl},
+        data: {projectIds: newExcludedIds.map(Number)},
+      }),
+    onMutate: (newExcludedIds: string[]) => {
+      const previousExclusions = queryClient.getQueryData(exclusionsOpts.queryKey);
+      setApiQueryData(
+        queryClient,
+        exclusionsOpts.queryKey,
+        newExcludedIds.map(id => ({
+          id,
+          projectId: id,
+          projectSlug: '',
+          dateAdded: '',
+        }))
+      );
+      return {previousExclusions};
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousExclusions) {
+        queryClient.setQueryData(exclusionsOpts.queryKey, context.previousExclusions);
+      }
+      addErrorMessage(t('Unable to update weekly report project exclusions'));
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey: exclusionsOpts.queryKey});
+    },
+  });
+
+  const handleToggle = (projectId: string) => {
+    const newExcluded = new Set(excludedProjectIds);
+    if (newExcluded.has(projectId)) {
+      newExcluded.delete(projectId);
+    } else {
+      newExcluded.add(projectId);
+    }
+    toggleMutation.mutate([...newExcluded]);
+  };
+
+  const handleOrgChange = (organizationId: string) => {
+    navigate(
+      {
+        ...location,
+        query: {organizationId},
+      },
+      {replace: true}
+    );
+  };
+
+  const userDefault = notificationOptions.find(
+    o => o.type === 'reports' && o.scopeType === 'user'
+  );
+  const defaultEnabled = userDefault ? userDefault.value === 'always' : true;
+
+  const orgOverride = organization
+    ? notificationOptions.find(
+        o =>
+          o.type === 'reports' &&
+          o.scopeType === 'organization' &&
+          o.scopeIdentifier === organization.id
+      )
+    : undefined;
+  const reportEnabled = orgOverride ? orgOverride.value === 'always' : defaultEnabled;
+
+  const handleReportToggle = () => {
+    if (!organization) {
+      return;
+    }
+    if (orgOverride) {
+      if (reportEnabled) {
+        handleEditNotificationOption({...orgOverride, value: 'never'});
+      } else {
+        handleRemoveNotificationOption(orgOverride.id);
+      }
+    } else {
+      handleAddNotificationOption({
+        type: 'reports',
+        scopeType: 'organization',
+        scopeIdentifier: organization.id,
+        value: 'never',
+      });
+    }
+  };
+
+  const isPending = !featureDisabled && (projectsPending || exclusionsPending);
+  const isError = !featureDisabled && (projectsError || exclusionsError);
+
+  const sortedProjects = [...(projects ?? [])]
+    .filter(project => project.isMember)
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+
+  const allExcluded =
+    sortedProjects.length > 0 &&
+    sortedProjects.every(p => excludedProjectIds.has(String(p.id)));
+
+  return (
+    <Fragment>
+      <Panel>
+        <StyledPanelHeader>
+          <OrganizationSelectHeader
+            organizations={organizations}
+            organizationId={orgId}
+            handleOrgChange={handleOrgChange}
+          />
+          {organization && (
+            <Select
+              value={reportEnabled ? 'always' : 'never'}
+              options={[
+                {value: 'always', label: t('On')},
+                {value: 'never', label: t('Off')},
+              ]}
+              onChange={({value}: {value: string}) => {
+                if ((value === 'always') === reportEnabled) {
+                  return;
+                }
+                handleReportToggle();
+              }}
+              aria-label={t('Toggle weekly report for %s', organization.name)}
+            />
+          )}
+        </StyledPanelHeader>
+        {organization ? (
+          <Fragment>
+            {reportEnabled && (
+              <Fragment>
+                {projectsPending && (
+                  <PanelBody>
+                    <LoadingIndicator />
+                  </PanelBody>
+                )}
+                {projectsError && (
+                  <PanelBody>
+                    <LoadingError onRetry={refetchProjects} />
+                  </PanelBody>
+                )}
+                {!featureDisabled && isPending && !projectsPending && (
+                  <PanelBody>
+                    <LoadingIndicator />
+                  </PanelBody>
+                )}
+                {!featureDisabled && isError && !projectsError && (
+                  <PanelBody>
+                    <LoadingError
+                      onRetry={() => {
+                        refetchProjects();
+                        refetchExclusions();
+                      }}
+                    />
+                  </PanelBody>
+                )}
+                {!projectsPending && !projectsError && (
+                  <Fragment>
+                    {!featureDisabled && allExcluded && (
+                      <StyledAlert variant="warning">
+                        {t(
+                          "You won't receive a weekly report for this organization if all projects are excluded."
+                        )}
+                      </StyledAlert>
+                    )}
+                    <DisabledOverlay disabled={featureDisabled}>
+                      <StyledPanelBody>
+                        {sortedProjects.length === 0 ? (
+                          <EmptyStateWarning withIcon={false}>
+                            {t('No projects found')}
+                          </EmptyStateWarning>
+                        ) : (
+                          sortedProjects.map(project => (
+                            <Item key={project.id}>
+                              <IdBadge
+                                project={project}
+                                avatarSize={20}
+                                avatarProps={{consistentWidth: true}}
+                                disableLink
+                              />
+                              <Switch
+                                size="lg"
+                                checked={
+                                  featureDisabled ||
+                                  !excludedProjectIds.has(String(project.id))
+                                }
+                                disabled={featureDisabled}
+                                onChange={() => handleToggle(String(project.id))}
+                                aria-label={t(
+                                  'Toggle weekly report for %s',
+                                  project.slug
+                                )}
+                              />
+                            </Item>
+                          ))
+                        )}
+                      </StyledPanelBody>
+                    </DisabledOverlay>
+                  </Fragment>
+                )}
+              </Fragment>
+            )}
+          </Fragment>
+        ) : (
+          <PanelBody>
+            <EmptyStateWarning withIcon={false}>
+              {t('Select an organization to continue')}
+            </EmptyStateWarning>
+          </PanelBody>
+        )}
+      </Panel>
+    </Fragment>
+  );
+}
+
+const StyledAlert = styled(Alert)`
+  margin: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
+  margin-bottom: 0;
+`;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  flex-wrap: wrap;
+  gap: ${p => p.theme.space.md};
+  & > form {
+    flex-grow: 1;
+  }
+  & > div:last-child {
+    min-width: 80px;
+    flex-shrink: 0;
+    font-weight: ${p => p.theme.font.weight.sans.regular};
+    text-transform: none;
+  }
+`;
+
+const DisabledOverlay = styled('div')<{disabled: boolean}>`
+  ${p =>
+    p.disabled &&
+    css`
+      opacity: 0.6;
+      pointer-events: none;
+    `}
+`;
+
+const StyledPanelBody = styled(PanelBody)`
+  & > div:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const Item = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
+`;

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
@@ -300,7 +300,7 @@ export function WeeklyReportProjectExclusions({
                     />
                   </PanelBody>
                 )}
-                {!projectsPending && !projectsError && (
+                {!isPending && !isError && !projectsPending && !projectsError && (
                   <Fragment>
                     {!featureDisabled && allExcluded && (
                       <StyledAlert variant="warning">

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
@@ -1,8 +1,7 @@
 import {Fragment, useEffect, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
-import {useMutation} from '@tanstack/react-query';
+import {skipToken, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, ButtonBar} from '@sentry/scraps/button';
@@ -10,7 +9,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Switch} from '@sentry/scraps/switch';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -21,11 +20,10 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {OrganizationSummary} from 'sentry/types/organization';
+import type {Organization, OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import {fetchMutation, setApiQueryData} from 'sentry/utils/queryClient';
-import {RequestError} from 'sentry/utils/requestError/requestError';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
@@ -84,15 +82,25 @@ export function WeeklyReportProjectExclusions({
     (location.query?.organizationId as string | undefined) ??
     orgFromSubdomain ??
     (organizations.length === 1 ? organizations[0]?.id : undefined);
-  let organization = organizations.find(({id}) => id === orgId);
-
-  if (!organization && organizations.length === 1) {
-    organization = organizations[0];
-  }
+  const organization = organizations.find(({id}) => id === orgId);
 
   useEffect(() => {
     setCurrentPage(0);
   }, [organization?.id]);
+
+  const {data: orgDetails, isPending: orgDetailsPending} = useQuery({
+    ...apiOptions.as<Organization>()('/organizations/$organizationIdOrSlug/', {
+      path: organization ? {organizationIdOrSlug: organization.slug} : skipToken,
+      host: organization?.links?.regionUrl,
+      query: {include_feature_flags: 1},
+      staleTime: 30_000,
+    }),
+  });
+
+  const featureEnabled = orgDetails?.features.includes(
+    'weekly-report-project-exclusions'
+  );
+  const featureDisabled = orgDetails !== undefined && !featureEnabled;
 
   const {
     data: projects,
@@ -112,7 +120,7 @@ export function WeeklyReportProjectExclusions({
   });
 
   const exclusionsOpts = exclusionsApiOptions(
-    organization?.slug ?? skipToken,
+    featureEnabled ? (organization?.slug ?? skipToken) : skipToken,
     organization?.links?.regionUrl
   );
 
@@ -120,22 +128,10 @@ export function WeeklyReportProjectExclusions({
     data: exclusions,
     isPending: exclusionsPending,
     isError: exclusionsError,
-    error: exclusionsErrorObj,
     refetch: refetchExclusions,
   } = useQuery({
     ...exclusionsOpts,
-    retry: (failureCount, error) => {
-      if (error instanceof RequestError && error.status === 404) {
-        return false;
-      }
-      return failureCount < 3;
-    },
   });
-
-  const featureDisabled =
-    exclusionsError &&
-    exclusionsErrorObj instanceof RequestError &&
-    exclusionsErrorObj.status === 404;
 
   const excludedProjectIds = new Set((exclusions ?? []).map(exc => exc.projectId));
 
@@ -149,17 +145,19 @@ export function WeeklyReportProjectExclusions({
       }),
     onMutate: (newExcludedIds: string[]) => {
       const previousExclusions = queryClient.getQueryData(exclusionsOpts.queryKey);
-      setApiQueryData(
-        queryClient,
-        exclusionsOpts.queryKey,
-        newExcludedIds.map(id => ({
+      queryClient.setQueryData(exclusionsOpts.queryKey, {
+        json: newExcludedIds.map(id => ({
           id,
           projectId: id,
           projectSlug: '',
           dateAdded: '',
-        }))
-      );
+        })),
+        headers: {},
+      });
       return {previousExclusions};
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('Updated weekly report project exclusions'));
     },
     onError: (_error, _variables, context) => {
       if (context?.previousExclusions) {
@@ -227,8 +225,9 @@ export function WeeklyReportProjectExclusions({
     }
   };
 
-  const isPending = !featureDisabled && (projectsPending || exclusionsPending);
-  const isError = !featureDisabled && (projectsError || exclusionsError);
+  const isPending =
+    orgDetailsPending || projectsPending || (!featureDisabled && exclusionsPending);
+  const isError = projectsError || (!featureDisabled && exclusionsError);
 
   const sortedProjects = [...(projects ?? [])]
     .filter(project => project.isMember)

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
@@ -1,10 +1,12 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Button, ButtonBar} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Switch} from '@sentry/scraps/switch';
 
@@ -16,7 +18,8 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
-import {t} from 'sentry/locale';
+import {IconChevron} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -36,6 +39,8 @@ interface WeeklyReportProjectExclusionsProps {
   notificationOptions: NotificationOptionsObject[];
   organizations: OrganizationSummary[];
 }
+
+const PAGE_SIZE = 15;
 
 interface Exclusion {
   dateAdded: string;
@@ -68,6 +73,7 @@ export function WeeklyReportProjectExclusions({
   const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [currentPage, setCurrentPage] = useState(0);
 
   const customerDomain = ConfigStore.get('customerDomain');
   const orgFromSubdomain = organizations.find(
@@ -83,6 +89,10 @@ export function WeeklyReportProjectExclusions({
   if (!organization && organizations.length === 1) {
     organization = organizations[0];
   }
+
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [organization?.id]);
 
   const {
     data: projects,
@@ -228,6 +238,13 @@ export function WeeklyReportProjectExclusions({
     sortedProjects.length > 0 &&
     sortedProjects.every(p => excludedProjectIds.has(String(p.id)));
 
+  const totalPages = Math.ceil(sortedProjects.length / PAGE_SIZE);
+  const paginatedProjects = sortedProjects.slice(
+    currentPage * PAGE_SIZE,
+    (currentPage + 1) * PAGE_SIZE
+  );
+  const showPagination = sortedProjects.length > PAGE_SIZE;
+
   return (
     <Fragment>
       <Panel>
@@ -299,7 +316,7 @@ export function WeeklyReportProjectExclusions({
                             {t('No projects found')}
                           </EmptyStateWarning>
                         ) : (
-                          sortedProjects.map(project => (
+                          paginatedProjects.map(project => (
                             <Item key={project.id}>
                               <IdBadge
                                 project={project}
@@ -325,6 +342,36 @@ export function WeeklyReportProjectExclusions({
                         )}
                       </StyledPanelBody>
                     </DisabledOverlay>
+                    {showPagination && (
+                      <Flex justify="end" align="center" margin="lg xl">
+                        <PaginationCaption>
+                          {tct('[start]-[end] of [total]', {
+                            start: currentPage * PAGE_SIZE + 1,
+                            end: Math.min(
+                              (currentPage + 1) * PAGE_SIZE,
+                              sortedProjects.length
+                            ),
+                            total: sortedProjects.length,
+                          })}
+                        </PaginationCaption>
+                        <ButtonBar>
+                          <Button
+                            icon={<IconChevron direction="left" />}
+                            aria-label={t('Previous')}
+                            size="sm"
+                            disabled={currentPage === 0}
+                            onClick={() => setCurrentPage(p => p - 1)}
+                          />
+                          <Button
+                            icon={<IconChevron direction="right" />}
+                            aria-label={t('Next')}
+                            size="sm"
+                            disabled={currentPage >= totalPages - 1}
+                            onClick={() => setCurrentPage(p => p + 1)}
+                          />
+                        </ButtonBar>
+                      </Flex>
+                    )}
                   </Fragment>
                 )}
               </Fragment>
@@ -381,4 +428,10 @@ const Item = styled('div')`
   align-items: center;
   justify-content: space-between;
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
+`;
+
+const PaginationCaption = styled('span')`
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.md};
+  margin-right: ${p => p.theme.space.xl};
 `;

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
@@ -97,10 +97,8 @@ export function WeeklyReportProjectExclusions({
     }),
   });
 
-  const featureEnabled = orgDetails?.features.includes(
-    'weekly-report-project-exclusions'
-  );
-  const featureDisabled = orgDetails !== undefined && !featureEnabled;
+  const featureEnabled =
+    orgDetails?.features.includes('weekly-report-project-exclusions') ?? false;
 
   const {
     data: projects,
@@ -120,7 +118,7 @@ export function WeeklyReportProjectExclusions({
   });
 
   const exclusionsOpts = exclusionsApiOptions(
-    featureEnabled ? (organization?.slug ?? skipToken) : skipToken,
+    orgDetails && featureEnabled ? (organization?.slug ?? skipToken) : skipToken,
     organization?.links?.regionUrl
   );
 
@@ -226,8 +224,8 @@ export function WeeklyReportProjectExclusions({
   };
 
   const isPending =
-    orgDetailsPending || projectsPending || (!featureDisabled && exclusionsPending);
-  const isError = projectsError || (!featureDisabled && exclusionsError);
+    orgDetailsPending || projectsPending || (featureEnabled && exclusionsPending);
+  const isError = projectsError || (featureEnabled && exclusionsError);
 
   const sortedProjects = [...(projects ?? [])]
     .filter(project => project.isMember)
@@ -284,12 +282,12 @@ export function WeeklyReportProjectExclusions({
                     <LoadingError onRetry={refetchProjects} />
                   </PanelBody>
                 )}
-                {!featureDisabled && isPending && !projectsPending && (
+                {featureEnabled && isPending && !projectsPending && (
                   <PanelBody>
                     <LoadingIndicator />
                   </PanelBody>
                 )}
-                {!featureDisabled && isError && !projectsError && (
+                {featureEnabled && isError && !projectsError && (
                   <PanelBody>
                     <LoadingError
                       onRetry={() => {
@@ -301,14 +299,14 @@ export function WeeklyReportProjectExclusions({
                 )}
                 {!isPending && !isError && !projectsPending && !projectsError && (
                   <Fragment>
-                    {!featureDisabled && allExcluded && (
+                    {featureEnabled && allExcluded && (
                       <StyledAlert variant="warning">
                         {t(
                           "You won't receive a weekly report for this organization if all projects are excluded."
                         )}
                       </StyledAlert>
                     )}
-                    <DisabledOverlay disabled={featureDisabled}>
+                    <DisabledOverlay disabled={!featureEnabled}>
                       <StyledPanelBody>
                         {sortedProjects.length === 0 ? (
                           <EmptyStateWarning withIcon={false}>
@@ -326,10 +324,10 @@ export function WeeklyReportProjectExclusions({
                               <Switch
                                 size="lg"
                                 checked={
-                                  featureDisabled ||
+                                  !featureEnabled ||
                                   !excludedProjectIds.has(String(project.id))
                                 }
-                                disabled={featureDisabled}
+                                disabled={!featureEnabled}
                                 onChange={() => handleToggle(String(project.id))}
                                 aria-label={t(
                                   'Toggle weekly report for %s',


### PR DESCRIPTION
Resolves [ID-1659](https://linear.app/getsentry/issue/ID-1659/update-notification-page-to-support-project-exclusion-in-weekly-report)

Before and after images in the linear issue! To test, go to `/settings/account/notifications/reports/`

Goal: update notification page to allow users to choose which projects they want to include in the weekly digest. Gated behind feature flag `organizations:weekly-report-project-exclusions`

**Changes**
- Add WeeklyReportProjectExclusions component that renders per-project toggle switches on the Account > Notifications > Weekly Reports fine-tune page
- Integrate org-level on/off dropdown into the panel header, replacing the separate "All Organizations" FieldGroup for reports
- Add client-side pagination (15 per page) for users with many projects
- Handle orgs without the feature flag (grayed-out, non-interactive toggles)
- Show warning when all projects are excluded (no report will be generated)
- Update reports description to mention project customization