### PR TITLE
chore: Cleanup unused/deprecated forceAppendRawQuerySting param

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1187,10 +1187,7 @@ export class EventView {
   }
 
   // Takes an EventView instance and converts it into the format required for the events API
-  getEventsAPIPayload(
-    location: Location,
-    forceAppendRawQueryString?: string
-  ): EventQuery & LocationQuery {
+  getEventsAPIPayload(location: Location): EventQuery & LocationQuery {
     // pick only the query strings that we care about
     const picked = pickRelevantLocationQueryStrings(location);
 
@@ -1208,10 +1205,7 @@ export class EventView {
     const project = this.project.map(String);
     const environment = this.environment as string[];
 
-    let queryString = this.getQueryWithAdditionalConditions();
-    if (forceAppendRawQueryString) {
-      queryString += ' ' + forceAppendRawQueryString;
-    }
+    const queryString = this.getQueryWithAdditionalConditions();
 
     // generate event query
     const eventQuery = Object.assign(

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -71,11 +71,6 @@ type BaseDiscoverQueryProps = {
    */
   cursor?: string;
   /**
-   * Appends a raw string to query to be able to sidestep the tokenizer.
-   * @deprecated
-   */
-  forceAppendRawQueryString?: string;
-  /**
    * Record limit to get.
    */
   limit?: number;
@@ -366,19 +361,11 @@ export async function doDiscoverQuery<T>(
 }
 
 function getPayload<T, P>(props: Props<T, P>) {
-  const {
-    cursor,
-    limit,
-    noPagination,
-    referrer,
-    getRequestPayload,
-    eventView,
-    location,
-    forceAppendRawQueryString,
-  } = props;
+  const {cursor, limit, noPagination, referrer, getRequestPayload, eventView, location} =
+    props;
   const payload = getRequestPayload
     ? getRequestPayload(props)
-    : eventView.getEventsAPIPayload(location, forceAppendRawQueryString);
+    : eventView.getEventsAPIPayload(location);
 
   if (cursor !== undefined) {
     payload.cursor = cursor;


### PR DESCRIPTION
Fixes [FRONTEND-TSC-8Q](https://sentry.sentry.io/issues/7585611578/)