### PR TITLE
perf(issue-search): Skip zero-weight signal queries in recommended_v2

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1020,6 +1020,16 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
             + newness_weight * newness
         )
 
+    # A signal whose weight is zeroed via options can't affect the score, so don't
+    # register its resolver and its query never runs. assignment_weight scales both
+    # viewer-relevance signals.
+    signal_resolvers: dict[str, Callable[[Any, Organization, list[int]], dict[int, Any]]] = {}
+    if assignment_weight:
+        signal_resolvers["assignment"] = resolve_assignment_signal
+        signal_resolvers["suspect_commit"] = resolve_suspect_commit_signal
+    if agent_weight:
+        signal_resolvers["agent"] = resolve_issue_agent_signal
+
     return PostgresSortStrategy(
         postgres_fields={
             "fixability": "seer_fixability_score",
@@ -1027,11 +1037,7 @@ def recommended_v2_strategy() -> PostgresSortStrategy:
             "first_seen": "first_seen",
         },
         snuba_aggregations=["recommended"],
-        signal_resolvers={
-            "assignment": resolve_assignment_signal,
-            "suspect_commit": resolve_suspect_commit_signal,
-            "agent": resolve_issue_agent_signal,
-        },
+        signal_resolvers=signal_resolvers,
         score_fn=score_fn,
         # If a boost calculation ever fails, keep the issue in the stream ranked by its
         # base Snuba recommended score rather than dropping it.

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -580,6 +580,13 @@ class TestDefaultPostgresSortStrategies(TestCase):
         assert strategy.exclude_null_postgres is False
         assert set(strategy.signal_resolvers) == {"assignment", "suspect_commit", "agent"}
 
+    def test_recommended_v2_zero_weight_drops_signal_resolver(self):
+        # A zeroed weight can't affect the score, so the strategy must not pay for that
+        # signal's query.
+        with self.options({"snuba.search.recommended.agent-weight": 0.0}):
+            strategy = PostgresSnubaQueryExecutor().postgres_sort_strategies["recommended_v2"]
+        assert set(strategy.signal_resolvers) == {"assignment", "suspect_commit"}
+
     def test_progress_registered(self):
         strategies = PostgresSnubaQueryExecutor().postgres_sort_strategies
         strategy = strategies["progress"]


### PR DESCRIPTION
A signal whose weight option is zeroed can't affect the score, so `recommended_v2_strategy()` now only registers resolvers with a non-zero weight and the pipeline never runs their queries — the same way `_execute_postgres_sort` already skips the Snuba stage for strategies without aggregations.

This turns the weight options into a runtime kill switch: any signal's query can be disabled without a deploy by zeroing its weight. `assignment-weight` gates both viewer-relevance signals (`assignment` and `suspect_commit`) since it scales both in `score_fn`.