### PR TITLE
feat(sentry-apps): expose exact event subscriptions as webhookEvents

### DIFF
--- a/src/sentry/apidocs/examples/sentry_app_examples.py
+++ b/src/sentry/apidocs/examples/sentry_app_examples.py
@@ -18,6 +18,13 @@ class SentryAppExamples:
                     }
                 ],
                 "events": ["issue"],
+                "webhookEvents": [
+                    "issue.assigned",
+                    "issue.created",
+                    "issue.ignored",
+                    "issue.resolved",
+                    "issue.unresolved",
+                ],
                 "isAlertable": False,
                 "isDisabled": False,
                 "metadata": "",
@@ -59,6 +66,13 @@ class SentryAppExamples:
                     }
                 ],
                 "events": ["issue"],
+                "webhookEvents": [
+                    "issue.assigned",
+                    "issue.created",
+                    "issue.ignored",
+                    "issue.resolved",
+                    "issue.unresolved",
+                ],
                 "isAlertable": False,
                 "isDisabled": False,
                 "metadata": "",
@@ -118,6 +132,13 @@ class SentryAppExamples:
                         }
                     ],
                     "events": ["issue"],
+                    "webhookEvents": [
+                        "issue.assigned",
+                        "issue.created",
+                        "issue.ignored",
+                        "issue.resolved",
+                        "issue.unresolved",
+                    ],
                     "isAlertable": False,
                     "isDisabled": False,
                     "metadata": "",
@@ -142,7 +163,8 @@ class SentryAppExamples:
                     "allowedOrigins": [],
                     "author": "ACME Corp",
                     "avatars": [],
-                    "events": ["issue", "event"],
+                    "events": ["issue"],
+                    "webhookEvents": ["issue.resolved"],
                     "isAlertable": False,
                     "isDisabled": False,
                     "metadata": "",

--- a/src/sentry/sentry_apps/api/serializers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app.py
@@ -48,7 +48,12 @@ class OwnerResponseField(TypedDict):
 class SentryAppSerializerResponse(TypedDict):
     allowedOrigins: list[str]
     avatars: list[SentryAppAvatarSerializerResponse]
+    # Webhook subscriptions were originally to whole resources ("issue") but can
+    # now also be to individual events ("issue.resolved"). `events` keeps the
+    # original resource-level view by consolidating the stored events;
+    # `webhookEvents` is the exact stored list.
     events: set[str]
+    webhookEvents: list[str]
     featureData: list[str]
     isAlertable: bool
     metadata: str
@@ -146,6 +151,7 @@ class SentryAppSerializer(Serializer):
                 serializer=ResponseSentryAppAvatarSerializer(),
             ),
             events=consolidate_events(obj.events),
+            webhookEvents=sorted(obj.events),
             featureData=[],
             isAlertable=obj.is_alertable,
             isDisabled=obj.is_disabled,

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_apps.py
@@ -46,6 +46,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
                     "slug": self.unpublished_app.slug,
                     "scopes": [],
                     "events": [],
+                    "webhookEvents": [],
                     "uuid": self.unpublished_app.uuid,
                     "status": self.unpublished_app.get_status_display(),
                     "webhookUrl": self.unpublished_app.webhook_url,

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -135,6 +135,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             "slug": self.published_app.slug,
             "scopes": [],
             "events": set(),
+            "webhookEvents": [],
             "status": self.published_app.get_status_display(),
             "uuid": self.published_app.uuid,
             "webhookUrl": "https://newurl.com",

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -119,6 +119,7 @@ class SentryAppsTest(APITestCase):
             "clientId": sentry_app.application.client_id,
             "clientSecret": sentry_app.application.client_secret,
             "events": [],
+            "webhookEvents": [],
             "featureData": [],
             "isAlertable": sentry_app.is_alertable,
             "isDisabled": sentry_app.is_disabled,

--- a/tests/sentry/sentry_apps/api/serializers/test_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/serializers/test_sentry_app.py
@@ -34,6 +34,21 @@ class SentryAppSerializerTest(TestCase):
         assert result["scopes"] == ["org:write", "team:admin"]
         assert result.get("clientSecret") is None
 
+    def test_webhook_events_are_faithful(self) -> None:
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        sentry_app = self.create_sentry_app(
+            name="Granular App",
+            organization=organization,
+            scopes=("event:read",),
+            events=["issue.resolved"],
+        )
+        result = serialize(sentry_app, None, SentryAppSerializer(), access=None)
+
+        # events consolidates to the resource; webhookEvents is the exact list.
+        assert result["events"] == {"issue"}
+        assert result["webhookEvents"] == ["issue.resolved"]
+
     def test_internal_app(self) -> None:
         user = self.create_user()
         org = self.create_organization(owner=user)


### PR DESCRIPTION
We store webhook subscriptions like `['issue.created', 'issue.resolved', ...]`, even though we only allow subscriptions to entire resources (such as 'issue'). In https://github.com/getsentry/sentry/pull/118932, we allowed the API to accept more granular subscriptions, so (with the flag on) we can store subscriptions like `['issue.created']`. In https://github.com/getsentry/sentry/pull/118923, we changed dispatch logic such that we can handle these more granular subscriptions. Now, we have to allow users to actually modify their subscriptions to be more granular — right now, the API endpoint only returns e.g. 'issues', rather than the full list of events. To show these subscriptions in the frontend precisely, we'll send `webhookEvents` on the API endpoint, which will contain the full list of subscribed events.