### PR TITLE
feat(explore): Add drag-to-zoom for metrics heat maps in Explore

### DIFF
--- a/static/app/components/charts/pickBoxZoomRange.tsx
+++ b/static/app/components/charts/pickBoxZoomRange.tsx
@@ -1,0 +1,80 @@
+export interface BoxZoomRange {
+  /**
+   * The selected range on the X-axis, in the X-axis's own units (for a `time`
+   * axis, milliseconds since epoch).
+   */
+  xRange: [number, number];
+  /**
+   * The selected range on the Y-axis, in the Y-axis's own units.
+   */
+  yRange: [number, number];
+}
+
+/**
+ * A brush area over a grid with multiple coordinate systems exposes a
+ * `coordRange` per axis-pair combination. ECharts only types the singular
+ * `coordRange`, so reach for the plural one here.
+ */
+export interface BrushArea {
+  coordRange?: number[] | number[][];
+  coordRanges?: number[][][];
+}
+
+/**
+ * Pick the brush selection expressed on the *target* (overlay) axes.
+ *
+ * A brush over a grid with several coordinate systems reports one coordinate
+ * range per axis-pair it touches, in ascending axis-index order. For a heat map
+ * those are `(category, value)`, `(time, category)`, `(time, value)` — so the
+ * all-overlay pair, on the highest-index axes, is the *last* entry. ECharts
+ * doesn't label entries by axis, so we rely on that ordering; if it ever shifts,
+ * a wrong zoom is immediately visible.
+ *
+ * Falls back to the singular `coordRange` for charts with one coordinate system.
+ */
+export function pickBoxZoomRange(area: BrushArea | undefined): BoxZoomRange | null {
+  if (!area) {
+    return null;
+  }
+
+  const {coordRanges} = area;
+  if (Array.isArray(coordRanges) && coordRanges.length > 0) {
+    const overlay = toBoxZoomRange(coordRanges[coordRanges.length - 1]);
+    if (overlay) {
+      return overlay;
+    }
+  }
+
+  return toBoxZoomRange(area.coordRange);
+}
+
+/**
+ * Turn an ECharts `rect` brush coordinate range (`[[xMin, xMax], [yMin, yMax]]`,
+ * in axis units) into sorted x/y ranges, or `null` if it isn't that shape.
+ */
+function toBoxZoomRange(
+  coordRange: number[] | number[][] | undefined
+): BoxZoomRange | null {
+  if (
+    !Array.isArray(coordRange) ||
+    !Array.isArray(coordRange[0]) ||
+    !Array.isArray(coordRange[1]) ||
+    coordRange[0].length !== 2 ||
+    coordRange[1].length !== 2
+  ) {
+    return null;
+  }
+  const [xPair, yPair] = coordRange;
+  if (
+    typeof xPair[0] !== 'number' ||
+    typeof xPair[1] !== 'number' ||
+    typeof yPair[0] !== 'number' ||
+    typeof yPair[1] !== 'number'
+  ) {
+    return null;
+  }
+  return {
+    xRange: [Math.min(xPair[0], xPair[1]), Math.max(xPair[0], xPair[1])],
+    yRange: [Math.min(yPair[0], yPair[1]), Math.max(yPair[0], yPair[1])],
+  };
+}

--- a/static/app/components/charts/pickBoxZoomRange.tsx
+++ b/static/app/components/charts/pickBoxZoomRange.tsx
@@ -1,3 +1,5 @@
+import type {EChartBrushArea} from 'sentry/types/echarts';
+
 export interface BoxZoomRange {
   /**
    * The selected range on the X-axis, in the X-axis's own units (for a `time`
@@ -8,16 +10,6 @@ export interface BoxZoomRange {
    * The selected range on the Y-axis, in the Y-axis's own units.
    */
   yRange: [number, number];
-}
-
-/**
- * A brush area over a grid with multiple coordinate systems exposes a
- * `coordRange` per axis-pair combination. ECharts only types the singular
- * `coordRange`, so reach for the plural one here.
- */
-export interface BrushArea {
-  coordRange?: number[] | number[][];
-  coordRanges?: number[][][];
 }
 
 /**
@@ -34,10 +26,10 @@ export interface BrushArea {
  *
  * Returns `null` for a selection that collapses on either axis (a click, or a
  * purely vertical/horizontal drag): a zero-width span isn't a zoom, and would
- * resolve to an empty range (e.g. `value:>=x value:<x`, matching nothing).
+ * resolve to an empty range (e.g., `value:>=x value:<x`, matching nothing).
  * Any selection with positive extent on both axes is allowed.
  */
-export function pickBoxZoomRange(area: BrushArea | undefined): BoxZoomRange | null {
+export function pickBoxZoomRange(area: EChartBrushArea | undefined): BoxZoomRange | null {
   if (!area) {
     return null;
   }
@@ -45,8 +37,8 @@ export function pickBoxZoomRange(area: BrushArea | undefined): BoxZoomRange | nu
   const {coordRanges} = area;
   const range =
     (Array.isArray(coordRanges) && coordRanges.length > 0
-      ? toBoxZoomRange(coordRanges[coordRanges.length - 1])
-      : null) ?? toBoxZoomRange(area.coordRange);
+      ? coordRangeToBoxZoomRange(coordRanges[coordRanges.length - 1])
+      : null) ?? coordRangeToBoxZoomRange(area.coordRange);
 
   if (
     !range ||
@@ -62,7 +54,7 @@ export function pickBoxZoomRange(area: BrushArea | undefined): BoxZoomRange | nu
  * Turn an ECharts `rect` brush coordinate range (`[[xMin, xMax], [yMin, yMax]]`,
  * in axis units) into sorted x/y ranges, or `null` if it isn't that shape.
  */
-function toBoxZoomRange(
+function coordRangeToBoxZoomRange(
   coordRange: number[] | number[][] | undefined
 ): BoxZoomRange | null {
   if (

--- a/static/app/components/charts/pickBoxZoomRange.tsx
+++ b/static/app/components/charts/pickBoxZoomRange.tsx
@@ -31,6 +31,11 @@ export interface BrushArea {
  * a wrong zoom is immediately visible.
  *
  * Falls back to the singular `coordRange` for charts with one coordinate system.
+ *
+ * Returns `null` for a selection that collapses on either axis (a click, or a
+ * purely vertical/horizontal drag): a zero-width span isn't a zoom, and would
+ * resolve to an empty range (e.g. `value:>=x value:<x`, matching nothing).
+ * Any selection with positive extent on both axes is allowed.
  */
 export function pickBoxZoomRange(area: BrushArea | undefined): BoxZoomRange | null {
   if (!area) {
@@ -38,14 +43,19 @@ export function pickBoxZoomRange(area: BrushArea | undefined): BoxZoomRange | nu
   }
 
   const {coordRanges} = area;
-  if (Array.isArray(coordRanges) && coordRanges.length > 0) {
-    const overlay = toBoxZoomRange(coordRanges[coordRanges.length - 1]);
-    if (overlay) {
-      return overlay;
-    }
-  }
+  const range =
+    (Array.isArray(coordRanges) && coordRanges.length > 0
+      ? toBoxZoomRange(coordRanges[coordRanges.length - 1])
+      : null) ?? toBoxZoomRange(area.coordRange);
 
-  return toBoxZoomRange(area.coordRange);
+  if (
+    !range ||
+    range.xRange[0] === range.xRange[1] ||
+    range.yRange[0] === range.yRange[1]
+  ) {
+    return null;
+  }
+  return range;
 }
 
 /**

--- a/static/app/components/charts/useChartBoxZoom.tsx
+++ b/static/app/components/charts/useChartBoxZoom.tsx
@@ -1,0 +1,144 @@
+import {useCallback, useMemo} from 'react';
+import type {BrushComponentOption, ToolboxComponentOption} from 'echarts';
+
+import {ToolBox} from 'sentry/components/charts/components/toolBox';
+import {
+  pickBoxZoomRange,
+  type BoxZoomRange,
+} from 'sentry/components/charts/pickBoxZoomRange';
+import type {
+  ECharts,
+  EChartBrushEndHandler,
+  EChartBrushStartHandler,
+  EChartFinishedHandler,
+} from 'sentry/types/echarts';
+
+export type {BoxZoomRange};
+
+interface UseChartBoxZoomProps {
+  /**
+   * Called once on mouse-up with the selected x/y ranges of the dragged box.
+   */
+  onZoom: (range: BoxZoomRange) => void;
+  /**
+   * When true, drag-to-zoom is not installed.
+   */
+  disabled?: boolean;
+  /**
+   * The index of the X-axis the brush maps to. Maybe be non-zero depending on
+   * whether the brushed chart adds more axes (especially hidden ones, like Heat
+   * Map)
+   */
+  xAxisIndex?: number;
+  /**
+   * The index of the Y-axis the brush maps to.
+   */
+  yAxisIndex?: number;
+}
+
+interface BoxZoomOptions {
+  brush: BrushComponentOption | undefined;
+  onBrushEnd: EChartBrushEndHandler;
+  onBrushStart: EChartBrushStartHandler;
+  onFinished: EChartFinishedHandler;
+  toolBox: ToolboxComponentOption | undefined;
+}
+
+/**
+ * Drag-to-zoom for cartesian charts where a single drag should select a 2D
+ * region, e.g., heat maps. Uses ECharts' `brush` component.
+ *
+ * Brush mode is a global cursor that ECharts drops on every `setOption`, so the
+ * hook re-arms it on the chart's `finished` event (fires after the initial
+ * render, every data refresh, and each brush clear) — the same approach
+ * `useChartZoom` uses for its dataZoom area-select. Wire the returned
+ * `onFinished` (and `brush`/`toolBox`/`onBrushStart`/`onBrushEnd`) into the chart.
+ */
+export function useChartBoxZoom({
+  onZoom,
+  disabled = false,
+  xAxisIndex = 0,
+  yAxisIndex = 0,
+}: UseChartBoxZoomProps): BoxZoomOptions {
+  const brushOption = useMemo<BrushComponentOption>(
+    () => ({
+      mainType: 'brush',
+      toolbox: ['rect', 'clear'],
+      brushMode: 'single',
+      brushType: 'rect',
+      throttleType: 'debounce',
+      throttleDelay: 100,
+      xAxisIndex,
+      yAxisIndex,
+      brushStyle: {},
+      removeOnClick: false,
+      transformable: false,
+    }),
+    [xAxisIndex, yAxisIndex]
+  );
+
+  const enableBrushMode = useCallback(
+    (chartInstance: ECharts) => {
+      chartInstance.dispatchAction({
+        type: 'takeGlobalCursor',
+        key: 'brush',
+        brushOption,
+      });
+    },
+    [brushOption]
+  );
+
+  const onBrushStart = useCallback<EChartBrushStartHandler>((_evt, chartInstance) => {
+    // Hide the hover tooltip while dragging so it doesn't cover the selection.
+    chartInstance.dispatchAction({type: 'hideTip'});
+    chartInstance.setOption({tooltip: {show: false}}, {silent: true});
+  }, []);
+
+  const onBrushEnd = useCallback<EChartBrushEndHandler>(
+    (evt, chartInstance) => {
+      if (!chartInstance) {
+        return;
+      }
+
+      const range = pickBoxZoomRange(evt.areas[0]);
+
+      // Restore the tooltip and clear the drawn box: the zoom applies once. The
+      // resulting render re-arms brush mode via `onFinished`.
+      chartInstance.setOption({tooltip: {show: true}}, {silent: true});
+      chartInstance.dispatchAction({type: 'brush', areas: []});
+
+      if (range) {
+        onZoom(range);
+      }
+    },
+    [onZoom]
+  );
+
+  // ECharts drops the global brush cursor on every `setOption`, so re-arm it
+  // each time rendering finishes — the initial render, data refreshes, and the
+  // re-render after each brush clears.
+  const onFinished = useCallback<EChartFinishedHandler>(
+    (_props, chartInstance) => {
+      if (!disabled) {
+        enableBrushMode(chartInstance);
+      }
+    },
+    [disabled, enableBrushMode]
+  );
+
+  const toolBox = useMemo<ToolboxComponentOption | undefined>(() => {
+    if (disabled) {
+      return;
+    }
+    // Hidden: we enable brush selection programmatically via `takeGlobalCursor`.
+    return ToolBox({show: false}, {brush: {type: ['rect']}});
+  }, [disabled]);
+
+  return {
+    brush: disabled ? undefined : brushOption,
+    onBrushEnd,
+    onBrushStart,
+    onFinished,
+    toolBox,
+  };
+}

--- a/static/app/components/charts/useChartBoxZoom.tsx
+++ b/static/app/components/charts/useChartBoxZoom.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import type {BrushComponentOption, ToolboxComponentOption} from 'echarts';
 
 import {ToolBox} from 'sentry/components/charts/components/toolBox';
@@ -7,10 +7,9 @@ import {
   type BoxZoomRange,
 } from 'sentry/components/charts/pickBoxZoomRange';
 import type {
-  ECharts,
   EChartBrushEndHandler,
   EChartBrushStartHandler,
-  EChartFinishedHandler,
+  EChartChartReadyHandler,
 } from 'sentry/types/echarts';
 
 export type {BoxZoomRange};
@@ -40,7 +39,7 @@ interface BoxZoomOptions {
   brush: BrushComponentOption | undefined;
   onBrushEnd: EChartBrushEndHandler;
   onBrushStart: EChartBrushStartHandler;
-  onFinished: EChartFinishedHandler;
+  onChartReady: EChartChartReadyHandler;
   toolBox: ToolboxComponentOption | undefined;
 }
 
@@ -48,11 +47,13 @@ interface BoxZoomOptions {
  * Drag-to-zoom for cartesian charts where a single drag should select a 2D
  * region, e.g., heat maps. Uses ECharts' `brush` component.
  *
- * Brush mode is a global cursor that ECharts drops on every `setOption`, so the
- * hook re-arms it on the chart's `finished` event (fires after the initial
- * render, every data refresh, and each brush clear) — the same approach
- * `useChartZoom` uses for its dataZoom area-select. Wire the returned
- * `onFinished` (and `brush`/`toolBox`/`onBrushStart`/`onBrushEnd`) into the chart.
+ * The brush is a global cursor that, while active, suppresses the series'
+ * native hover emphasis. So rather than keeping it armed, the hook arms it only
+ * while the mouse button is down (`mousedown` → `mouseup`) — a plain hover keeps
+ * the chart's normal emphasis and tooltip. Arming happens in a capture-phase
+ * `mousedown` listener so the cursor is set before ECharts handles the event and
+ * can still capture that drag. Wire the returned `onChartReady` (and
+ * `brush`/`toolBox`/`onBrushStart`/`onBrushEnd`) into the chart.
  */
 export function useChartBoxZoom({
   onZoom,
@@ -60,6 +61,8 @@ export function useChartBoxZoom({
   xAxisIndex = 0,
   yAxisIndex = 0,
 }: UseChartBoxZoomProps): BoxZoomOptions {
+  const cleanupRef = useRef<(() => void) | null>(null);
+
   const brushOption = useMemo<BrushComponentOption>(
     () => ({
       mainType: 'brush',
@@ -75,17 +78,6 @@ export function useChartBoxZoom({
       transformable: false,
     }),
     [xAxisIndex, yAxisIndex]
-  );
-
-  const enableBrushMode = useCallback(
-    (chartInstance: ECharts) => {
-      chartInstance.dispatchAction({
-        type: 'takeGlobalCursor',
-        key: 'brush',
-        brushOption,
-      });
-    },
-    [brushOption]
   );
 
   const onBrushStart = useCallback<EChartBrushStartHandler>((_evt, chartInstance) => {
@@ -104,8 +96,7 @@ export function useChartBoxZoom({
       // zero-width drag on either axis), so those don't fire a zoom.
       const range = pickBoxZoomRange(evt.areas[0]);
 
-      // Restore the tooltip and clear the drawn box: the zoom applies once. The
-      // resulting render re-arms brush mode via `onFinished`.
+      // Restore the tooltip and clear the drawn box: the zoom applies once.
       chartInstance.setOption({tooltip: {show: true}}, {silent: true});
       chartInstance.dispatchAction({type: 'brush', areas: []});
 
@@ -116,17 +107,57 @@ export function useChartBoxZoom({
     [onZoom]
   );
 
-  // ECharts drops the global brush cursor on every `setOption`, so re-arm it
-  // each time rendering finishes — the initial render, data refreshes, and the
-  // re-render after each brush clears.
-  const onFinished = useCallback<EChartFinishedHandler>(
-    (_props, chartInstance) => {
-      if (!disabled) {
-        enableBrushMode(chartInstance);
+  const onChartReady = useCallback<EChartChartReadyHandler>(
+    chartInstance => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+
+      if (disabled) {
+        return;
       }
+
+      const dom = chartInstance.getDom();
+      let armed = false;
+      let frame: number | null = null;
+
+      const arm = () => {
+        chartInstance.dispatchAction({
+          type: 'takeGlobalCursor',
+          key: 'brush',
+          brushOption,
+        });
+        armed = true;
+      };
+
+      const disarm = () => {
+        if (!armed) {
+          return;
+        }
+        armed = false;
+        // Defer past the synchronous `brushend` this same mouseup fires, then
+        // clear the global cursor so hovering shows normal emphasis again.
+        frame = requestAnimationFrame(() => {
+          chartInstance.dispatchAction({type: 'takeGlobalCursor'});
+        });
+      };
+
+      // Arm on press (capture phase, so the cursor is set before ECharts handles
+      // the mousedown and can capture this drag); disarm on release.
+      dom.addEventListener('mousedown', arm, true);
+      document.addEventListener('mouseup', disarm);
+
+      cleanupRef.current = () => {
+        dom.removeEventListener('mousedown', arm, true);
+        document.removeEventListener('mouseup', disarm);
+        if (frame !== null) {
+          cancelAnimationFrame(frame);
+        }
+      };
     },
-    [disabled, enableBrushMode]
+    [disabled, brushOption]
   );
+
+  useEffect(() => () => cleanupRef.current?.(), []);
 
   const toolBox = useMemo<ToolboxComponentOption | undefined>(() => {
     if (disabled) {
@@ -140,7 +171,7 @@ export function useChartBoxZoom({
     brush: disabled ? undefined : brushOption,
     onBrushEnd,
     onBrushStart,
-    onFinished,
+    onChartReady,
     toolBox,
   };
 }

--- a/static/app/components/charts/useChartBoxZoom.tsx
+++ b/static/app/components/charts/useChartBoxZoom.tsx
@@ -100,14 +100,17 @@ export function useChartBoxZoom({
         return;
       }
 
-      const range = pickBoxZoomRange(evt.areas[0]);
+      const area = evt.areas[0];
+      const range = pickBoxZoomRange(area);
 
       // Restore the tooltip and clear the drawn box: the zoom applies once. The
       // resulting render re-arms brush mode via `onFinished`.
       chartInstance.setOption({tooltip: {show: true}}, {silent: true});
       chartInstance.dispatchAction({type: 'brush', areas: []});
 
-      if (range) {
+      // Ignore selections too small to be an intentional drag (a stray click or
+      // tiny nudge) — they'd resolve to an empty range on the collapsed axis.
+      if (range && isIntentionalDrag(area?.range)) {
         onZoom(range);
       }
     },
@@ -141,4 +144,32 @@ export function useChartBoxZoom({
     onFinished,
     toolBox,
   };
+}
+
+/**
+ * A drag smaller than this on either axis (in pixels) is treated as a stray
+ * click or nudge rather than a zoom.
+ */
+const MIN_BRUSH_SIZE_PX = 5;
+
+/**
+ * Whether the brush's pixel `range` (`[[x0, x1], [y0, y1]]`) is large enough on
+ * both axes to count as an intentional drag. Unmeasurable shapes pass through so
+ * we never block a real zoom.
+ */
+function isIntentionalDrag(range: number[] | number[][] | undefined): boolean {
+  if (!Array.isArray(range) || !Array.isArray(range[0]) || !Array.isArray(range[1])) {
+    return true;
+  }
+  const [x0, x1] = range[0];
+  const [y0, y1] = range[1];
+  if (
+    typeof x0 !== 'number' ||
+    typeof x1 !== 'number' ||
+    typeof y0 !== 'number' ||
+    typeof y1 !== 'number'
+  ) {
+    return true;
+  }
+  return Math.abs(x1 - x0) >= MIN_BRUSH_SIZE_PX && Math.abs(y1 - y0) >= MIN_BRUSH_SIZE_PX;
 }

--- a/static/app/components/charts/useChartBoxZoom.tsx
+++ b/static/app/components/charts/useChartBoxZoom.tsx
@@ -17,12 +17,9 @@ export type {BoxZoomRange};
 interface UseChartBoxZoomProps {
   /**
    * Called once on mouse-up with the selected x/y ranges of the dragged box.
+   * When omitted, drag-to-zoom is not installed.
    */
-  onZoom: (range: BoxZoomRange) => void;
-  /**
-   * When true, drag-to-zoom is not installed.
-   */
-  disabled?: boolean;
+  onZoom?: (range: BoxZoomRange) => void;
   /**
    * The index of the X-axis the brush maps to. Maybe be non-zero depending on
    * whether the brushed chart adds more axes (especially hidden ones, like Heat
@@ -57,7 +54,6 @@ interface BoxZoomOptions {
  */
 export function useChartBoxZoom({
   onZoom,
-  disabled = false,
   xAxisIndex = 0,
   yAxisIndex = 0,
 }: UseChartBoxZoomProps): BoxZoomOptions {
@@ -101,7 +97,7 @@ export function useChartBoxZoom({
       chartInstance.dispatchAction({type: 'brush', areas: []});
 
       if (range) {
-        onZoom(range);
+        onZoom?.(range);
       }
     },
     [onZoom]
@@ -112,7 +108,7 @@ export function useChartBoxZoom({
       cleanupRef.current?.();
       cleanupRef.current = null;
 
-      if (disabled) {
+      if (!onZoom) {
         return;
       }
 
@@ -154,21 +150,21 @@ export function useChartBoxZoom({
         }
       };
     },
-    [disabled, brushOption]
+    [onZoom, brushOption]
   );
 
   useEffect(() => () => cleanupRef.current?.(), []);
 
   const toolBox = useMemo<ToolboxComponentOption | undefined>(() => {
-    if (disabled) {
+    if (!onZoom) {
       return;
     }
     // Hidden: we enable brush selection programmatically via `takeGlobalCursor`.
     return ToolBox({show: false}, {brush: {type: ['rect']}});
-  }, [disabled]);
+  }, [onZoom]);
 
   return {
-    brush: disabled ? undefined : brushOption,
+    brush: onZoom ? brushOption : undefined,
     onBrushEnd,
     onBrushStart,
     onChartReady,

--- a/static/app/components/charts/useChartBoxZoom.tsx
+++ b/static/app/components/charts/useChartBoxZoom.tsx
@@ -100,17 +100,16 @@ export function useChartBoxZoom({
         return;
       }
 
-      const area = evt.areas[0];
-      const range = pickBoxZoomRange(area);
+      // `pickBoxZoomRange` returns null for a degenerate selection (a click or a
+      // zero-width drag on either axis), so those don't fire a zoom.
+      const range = pickBoxZoomRange(evt.areas[0]);
 
       // Restore the tooltip and clear the drawn box: the zoom applies once. The
       // resulting render re-arms brush mode via `onFinished`.
       chartInstance.setOption({tooltip: {show: true}}, {silent: true});
       chartInstance.dispatchAction({type: 'brush', areas: []});
 
-      // Ignore selections too small to be an intentional drag (a stray click or
-      // tiny nudge) — they'd resolve to an empty range on the collapsed axis.
-      if (range && isIntentionalDrag(area?.range)) {
+      if (range) {
         onZoom(range);
       }
     },
@@ -144,32 +143,4 @@ export function useChartBoxZoom({
     onFinished,
     toolBox,
   };
-}
-
-/**
- * A drag smaller than this on either axis (in pixels) is treated as a stray
- * click or nudge rather than a zoom.
- */
-const MIN_BRUSH_SIZE_PX = 5;
-
-/**
- * Whether the brush's pixel `range` (`[[x0, x1], [y0, y1]]`) is large enough on
- * both axes to count as an intentional drag. Unmeasurable shapes pass through so
- * we never block a real zoom.
- */
-function isIntentionalDrag(range: number[] | number[][] | undefined): boolean {
-  if (!Array.isArray(range) || !Array.isArray(range[0]) || !Array.isArray(range[1])) {
-    return true;
-  }
-  const [x0, x1] = range[0];
-  const [y0, y1] = range[1];
-  if (
-    typeof x0 !== 'number' ||
-    typeof x1 !== 'number' ||
-    typeof y0 !== 'number' ||
-    typeof y1 !== 'number'
-  ) {
-    return true;
-  }
-  return Math.abs(x1 - x0) >= MIN_BRUSH_SIZE_PX && Math.abs(y1 - y0) >= MIN_BRUSH_SIZE_PX;
 }

--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -162,11 +162,19 @@ export type EChartFinishedHandler = EChartEventHandler<Record<string, unknown>>;
 
 export type EChartRenderedHandler = EChartEventHandler<Record<string, unknown>>;
 
-type EchartBrushAreas = Array<{
+export type EChartBrushArea = {
   coordRange: number[] | number[][];
   panelId: string;
   range: number[] | number[][];
-}>;
+  /**
+   * On a grid with multiple coordinate systems, the brush reports one
+   * coordinate range per axis-pair it touches. ECharts' own types only cover
+   * the singular `coordRange`, so this plural field is declared here.
+   */
+  coordRanges?: number[][][];
+};
+
+type EchartBrushAreas = EChartBrushArea[];
 
 export type EChartBrushStartHandler = EChartEventHandler<{
   areas: EchartBrushAreas;

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -478,6 +478,11 @@ function HeatmapSeriesComponent(props: TableComponentProps): React.ReactNode {
 
   return (
     <ChartWrapper autoHeightResize>
+      {/* Drag-to-zoom not implemented in Dashboards because we haven't come up
+      with a sensible behaviour here. The X-axis selection can update the
+      selected date range, but what about the Y-axis? It might update the global
+      filter, but that affects other widgets, is that okay? Or, it might affect
+      just the current widget, but how does the UI react? */}
       <HeatMapWidgetVisualization plottables={[new HeatMap(heatmapResults)]} />
     </ChartWrapper>
   );

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -14,6 +14,10 @@ import {Text} from '@sentry/scraps/text';
 
 import {BaseChart} from 'sentry/components/charts/baseChart';
 import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
+import {
+  useChartBoxZoom,
+  type BoxZoomRange,
+} from 'sentry/components/charts/useChartBoxZoom';
 import {isChartHovered, truncationFormatter} from 'sentry/components/charts/utils';
 import {CircleIndicator} from 'sentry/components/circleIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -43,6 +47,12 @@ interface HeatMapWidgetVisualizationProps {
    */
   plottables: [HeatMap, ...HeatMapPlottable[]];
   /**
+   * Called when the user drag-selects a region of the heat map. The X-axis
+   * range maps to a time range and the Y-axis range to a value range. When
+   * omitted, drag-to-zoom is disabled.
+   */
+  onZoom?: (context: HeatMapZoomContext) => void;
+  /**
    * Renders extra content in a cell's tooltip. Because ECharts renders the
    * tooltip to an HTML string (no live React handlers), the visualization
    * routes clicks for you: use `data-traces-link="<url>"` for navigations, and
@@ -59,7 +69,7 @@ interface HeatMapWidgetVisualizationProps {
 }
 
 export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProps) {
-  const {plottables, tooltipActionHandlers, renderTooltipActions} = props;
+  const {plottables, tooltipActionHandlers, renderTooltipActions, onZoom} = props;
   const theme = useTheme();
   const renderToString = useRenderToString();
   const navigate = useNavigate();
@@ -116,6 +126,27 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
     document.addEventListener('click', handleTooltipLinksClick);
     return () => document.removeEventListener('click', handleTooltipLinksClick);
   }, [handleTooltipLinksClick]);
+
+  const handleZoom = useCallback(
+    (range: BoxZoomRange) => {
+      onZoom?.({
+        timestampStart: range.xRange[0],
+        timestampEnd: range.xRange[1],
+        valueMin: range.yRange[0],
+        valueMax: range.yRange[1],
+      });
+    },
+    [onZoom]
+  );
+
+  // The heat map's readable time/value axes sit at index 1; index 0 is the
+  // hidden category axis that positions the cells.
+  const {brush, toolBox, onBrushStart, onBrushEnd, onFinished} = useChartBoxZoom({
+    onZoom: handleZoom,
+    disabled: !onZoom,
+    xAxisIndex: 1,
+    yAxisIndex: 1,
+  });
 
   if (!plottablesCanBeVisualized(plottables)) {
     throw new Error(NO_PLOTTABLE_VALUES);
@@ -289,6 +320,11 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         isGroupedByDate
         showTimeInTooltip
         ref={chartRef}
+        brush={brush}
+        toolBox={toolBox}
+        onBrushStart={onBrushStart}
+        onBrushEnd={onBrushEnd}
+        onFinished={onFinished}
         tooltip={{
           show: true,
           enterable: true,
@@ -359,12 +395,23 @@ export const visualMapOptions = (
 };
 
 /**
- * Context for the hovered heat map cell, handed to `renderTooltipActions` so the
- * caller can build its own tooltip actions (e.g. links into Explore).
+ * Bucket bounds of a region of the heat map, in raw axis units: a time span on
+ * the X axis (ms since epoch) and a value span on the Y axis.
  */
-interface HeatMapTooltipContext {
+interface HeatMapBucketBounds {
   timestampEnd: number;
   timestampStart: number;
   valueMax: number;
   valueMin: number;
 }
+
+/**
+ * Context for the hovered heat map cell, handed to `renderTooltipActions` so the
+ * caller can build its own tooltip actions (e.g., link into Explore).
+ */
+type HeatMapTooltipContext = HeatMapBucketBounds;
+
+/**
+ * Context for a drag-selected region, handed to `onZoom`.
+ */
+export type HeatMapZoomContext = HeatMapBucketBounds;

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -142,8 +142,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   // The heat map's readable time/value axes sit at index 1; index 0 is the
   // hidden category axis that positions the cells.
   const {brush, toolBox, onBrushStart, onBrushEnd, onChartReady} = useChartBoxZoom({
-    onZoom: handleZoom,
-    disabled: !onZoom,
+    onZoom: onZoom ? handleZoom : undefined,
     xAxisIndex: 1,
     yAxisIndex: 1,
   });

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -141,7 +141,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
 
   // The heat map's readable time/value axes sit at index 1; index 0 is the
   // hidden category axis that positions the cells.
-  const {brush, toolBox, onBrushStart, onBrushEnd, onFinished} = useChartBoxZoom({
+  const {brush, toolBox, onBrushStart, onBrushEnd, onChartReady} = useChartBoxZoom({
     onZoom: handleZoom,
     disabled: !onZoom,
     xAxisIndex: 1,
@@ -324,7 +324,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         toolBox={toolBox}
         onBrushStart={onBrushStart}
         onBrushEnd={onBrushEnd}
-        onFinished={onFinished}
+        onChartReady={onChartReady}
         tooltip={{
           show: true,
           enterable: true,

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -324,6 +324,7 @@ export function MetricPanel({
                           heatmapResult={heatmapResult}
                           actions={actions}
                           title={title}
+                          queryLabel={queryLabel}
                         />
                       ) : (
                         <MetricsGraph

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -1,9 +1,17 @@
+import {useCallback} from 'react';
 import type {UseQueryResult} from '@tanstack/react-query';
 
+import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import {t} from 'sentry/locale';
+import {getUtcDateString} from 'sentry/utils/dates';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import type {HeatMapSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {WidgetLoadingPanel} from 'sentry/views/dashboards/widgets/common/widgetLoadingPanel';
-import {HeatMapWidgetVisualization} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
+import {
+  HeatMapWidgetVisualization,
+  type HeatMapZoomContext,
+} from 'sentry/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization';
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {WidgetWrapper} from 'sentry/views/explore/metrics/metricGraph/styles';
@@ -14,7 +22,12 @@ import {
   useMetricVisualizes,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {STACKED_GRAPH_HEIGHT} from 'sentry/views/explore/metrics/settings';
+import {
+  useQueryParamsQuery,
+  useSetQueryParamsQuery,
+} from 'sentry/views/explore/queryParams/context';
 import {prettifyAggregation} from 'sentry/views/explore/utils';
+import {setExploreAttributeBounds} from 'sentry/views/explore/utils/setExploreAttributeBounds';
 
 interface MetricsHeatMapProps {
   actions: React.ReactNode;
@@ -27,6 +40,10 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
   const visualizes = useMetricVisualizes();
   const metricLabel = useMetricLabel();
   const metricName = useMetricName();
+  const userQuery = useQueryParamsQuery();
+  const setMetricQuery = useSetQueryParamsQuery();
+  const location = useLocation();
+  const navigate = useNavigate();
 
   const {data: heatMapSeries, isPending, error} = heatmapResult;
 
@@ -35,6 +52,25 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
     visualizes.length > 1
       ? metricName
       : (title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate);
+
+  // Drag-to-zoom: the X span narrows the global page time range, the Y span
+  // replaces the `value` filter so zooming in repeatedly keeps narrowing
+  // instead of stacking contradictory bounds.
+  const handleZoom = useCallback(
+    ({timestampStart, timestampEnd, valueMin, valueMax}: HeatMapZoomContext) => {
+      updateDateTime(
+        {
+          start: getUtcDateString(Math.floor(timestampStart / 60_000) * 60_000),
+          end: getUtcDateString(Math.ceil(timestampEnd / 60_000) * 60_000),
+          period: null,
+        },
+        location,
+        navigate
+      );
+      setMetricQuery(setExploreAttributeBounds(userQuery, 'value', valueMin, valueMax));
+    },
+    [location, navigate, setMetricQuery, userQuery]
+  );
 
   return (
     <WidgetWrapper>
@@ -49,7 +85,10 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
           ) : heatMapSeries.values.length === 0 ? (
             <Widget.WidgetError error={t('No data')} />
           ) : (
-            <HeatMapWidgetVisualization plottables={[new HeatMap(heatMapSeries)]} />
+            <HeatMapWidgetVisualization
+              plottables={[new HeatMap(heatMapSeries)]}
+              onZoom={handleZoom}
+            />
           )
         }
         height={STACKED_GRAPH_HEIGHT}

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -1,7 +1,6 @@
 import {useCallback} from 'react';
 import type {UseQueryResult} from '@tanstack/react-query';
 
-import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import {t} from 'sentry/locale';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -15,17 +14,16 @@ import {
 import {HeatMap} from 'sentry/views/dashboards/widgets/heatMapWidget/plottables/heatMap';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {WidgetWrapper} from 'sentry/views/explore/metrics/metricGraph/styles';
+import {encodeMetricQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {
   useMetricLabel,
   useMetricName,
   useMetricVisualize,
   useMetricVisualizes,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
+import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {STACKED_GRAPH_HEIGHT} from 'sentry/views/explore/metrics/settings';
-import {
-  useQueryParamsQuery,
-  useSetQueryParamsQuery,
-} from 'sentry/views/explore/queryParams/context';
+import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {prettifyAggregation} from 'sentry/views/explore/utils';
 import {setExploreAttributeBounds} from 'sentry/views/explore/utils/setExploreAttributeBounds';
 
@@ -40,8 +38,8 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
   const visualizes = useMetricVisualizes();
   const metricLabel = useMetricLabel();
   const metricName = useMetricName();
-  const userQuery = useQueryParamsQuery();
-  const setMetricQuery = useSetQueryParamsQuery();
+  const queryParams = useQueryParams();
+  const metricQueries = useMultiMetricsQueryParams();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -53,23 +51,39 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
       ? metricName
       : (title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate);
 
-  // Drag-to-zoom: the X span narrows the global page time range, the Y span
-  // replaces the `value` filter so zooming in repeatedly keeps narrowing
-  // instead of stacking contradictory bounds.
+  // Drag-to-zoom: the X span narrows the page time range, the Y span replaces
+  // this metric's `value` filter (so repeated zooms keep narrowing instead of
+  // stacking bounds). Both go in a single `navigate` — separate navigations
+  // would each compute from the same stale location and clobber each other,
+  // dropping the datetime from the URL.
   const handleZoom = useCallback(
     ({timestampStart, timestampEnd, valueMin, valueMax}: HeatMapZoomContext) => {
-      updateDateTime(
+      const newQueryParams = queryParams.replace({
+        query: setExploreAttributeBounds(queryParams.query, 'value', valueMin, valueMax),
+      });
+      const metric = metricQueries
+        .map(metricQuery =>
+          metricQuery.queryParams === queryParams
+            ? encodeMetricQueryParams({...metricQuery, queryParams: newQueryParams})
+            : encodeMetricQueryParams(metricQuery)
+        )
+        .filter(Boolean);
+
+      navigate(
         {
-          start: getUtcDateString(Math.floor(timestampStart / 60_000) * 60_000),
-          end: getUtcDateString(Math.ceil(timestampEnd / 60_000) * 60_000),
-          period: null,
+          ...location,
+          query: {
+            ...location.query,
+            metric,
+            start: getUtcDateString(Math.floor(timestampStart / 60_000) * 60_000),
+            end: getUtcDateString(Math.ceil(timestampEnd / 60_000) * 60_000),
+            statsPeriod: undefined,
+          },
         },
-        location,
-        navigate
+        {preventScrollReset: true}
       );
-      setMetricQuery(setExploreAttributeBounds(userQuery, 'value', valueMin, valueMax));
     },
-    [location, navigate, setMetricQuery, userQuery]
+    [queryParams, metricQueries, location, navigate]
   );
 
   return (

--- a/static/app/views/explore/metrics/metricsHeatMap.tsx
+++ b/static/app/views/explore/metrics/metricsHeatMap.tsx
@@ -23,22 +23,30 @@ import {
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {STACKED_GRAPH_HEIGHT} from 'sentry/views/explore/metrics/settings';
-import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {prettifyAggregation} from 'sentry/views/explore/utils';
 import {setExploreAttributeBounds} from 'sentry/views/explore/utils/setExploreAttributeBounds';
 
 interface MetricsHeatMapProps {
   actions: React.ReactNode;
   heatmapResult: UseQueryResult<HeatMapSeries>;
+  /**
+   * Stable label of this heat map's metric query (e.g., "A"), used to find the
+   * matching row when drag-zooming. See `handleZoom`.
+   */
+  queryLabel: string;
   title?: string;
 }
 
-export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapProps) {
+export function MetricsHeatMap({
+  heatmapResult,
+  actions,
+  title,
+  queryLabel,
+}: MetricsHeatMapProps) {
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const metricLabel = useMetricLabel();
   const metricName = useMetricName();
-  const queryParams = useQueryParams();
   const metricQueries = useMultiMetricsQueryParams();
   const location = useLocation();
   const navigate = useNavigate();
@@ -51,22 +59,42 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
       ? metricName
       : (title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate);
 
-  // Drag-to-zoom: the X span narrows the page time range, the Y span replaces
-  // this metric's `value` filter (so repeated zooms keep narrowing instead of
-  // stacking bounds). Both go in a single `navigate` — separate navigations
-  // would each compute from the same stale location and clobber each other,
-  // dropping the datetime from the URL.
+  // Drag-to-zoom changes two independent URL params at once: this row's `value`
+  // filter (encoded inside the `metric` param) and the page time range
+  // (`start`/`end`/`statsPeriod`). They have to land in a single `navigate`:
+  // two navigations would each rebuild the whole query from the same stale
+  // `location` snapshot and clobber each other, dropping one of the changes.
+  //
+  // So we hand-assemble that one navigation here — re-encode every metric row,
+  // swapping the new `value` bounds into the row this heat map belongs to. That
+  // row is found by its stable label ("A", "B", ...) rather than object
+  // identity, because the metric queries are decoded fresh from the URL on
+  // every render and share no reference across navigations.
+  //
+  // This is more manual than it should be. A URL-state library like Nuqs
+  // (batched, functional param updates) would let a `value`-filter setter and a
+  // datetime setter each update independently and coalesce into one URL write,
+  // removing both the re-encode loop and the label lookup.
   const handleZoom = useCallback(
     ({timestampStart, timestampEnd, valueMin, valueMax}: HeatMapZoomContext) => {
-      const newQueryParams = queryParams.replace({
-        query: setExploreAttributeBounds(queryParams.query, 'value', valueMin, valueMax),
-      });
       const metric = metricQueries
-        .map(metricQuery =>
-          metricQuery.queryParams === queryParams
-            ? encodeMetricQueryParams({...metricQuery, queryParams: newQueryParams})
-            : encodeMetricQueryParams(metricQuery)
-        )
+        .map(metricQuery => {
+          if ((metricQuery.label ?? '') !== queryLabel) {
+            return encodeMetricQueryParams(metricQuery);
+          }
+          const {queryParams} = metricQuery;
+          return encodeMetricQueryParams({
+            ...metricQuery,
+            queryParams: queryParams.replace({
+              query: setExploreAttributeBounds(
+                queryParams.query,
+                'value',
+                valueMin,
+                valueMax
+              ),
+            }),
+          });
+        })
         .filter(Boolean);
 
       navigate(
@@ -83,7 +111,7 @@ export function MetricsHeatMap({heatmapResult, actions, title}: MetricsHeatMapPr
         {preventScrollReset: true}
       );
     },
-    [queryParams, metricQueries, location, navigate]
+    [metricQueries, location, navigate, queryLabel]
   );
 
   return (

--- a/static/app/views/explore/utils/setExploreAttributeBounds.spec.tsx
+++ b/static/app/views/explore/utils/setExploreAttributeBounds.spec.tsx
@@ -1,0 +1,33 @@
+import {setExploreAttributeBounds} from 'sentry/views/explore/utils/setExploreAttributeBounds';
+
+describe('setExploreAttributeBounds', () => {
+  it('sets a range when there is no existing query', () => {
+    expect(setExploreAttributeBounds('', 'value', 100, 200)).toBe(
+      'value:>=100 value:<200'
+    );
+  });
+
+  it('preserves other filters while setting the range', () => {
+    expect(setExploreAttributeBounds('span.op:db', 'value', 100, 200)).toBe(
+      'span.op:db value:>=100 value:<200'
+    );
+  });
+
+  it('replaces an existing range on the same attribute instead of stacking it', () => {
+    expect(setExploreAttributeBounds('value:>=0 value:<1000', 'value', 100, 200)).toBe(
+      'value:>=100 value:<200'
+    );
+  });
+
+  it('only touches the named attribute, leaving other bounds intact', () => {
+    expect(setExploreAttributeBounds('duration:>=0 duration:<5', 'value', 100, 200)).toBe(
+      'duration:>=0 duration:<5 value:>=100 value:<200'
+    );
+  });
+
+  it('works for an arbitrary attribute, not just value', () => {
+    expect(setExploreAttributeBounds('', 'duration', 1.5, 9)).toBe(
+      'duration:>=1.5 duration:<9'
+    );
+  });
+});

--- a/static/app/views/explore/utils/setExploreAttributeBounds.tsx
+++ b/static/app/views/explore/utils/setExploreAttributeBounds.tsx
@@ -1,0 +1,17 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+
+/**
+ * Replace any existing bounds on an attribute in an Explore search query with
+ * the half-open range `[min, max)`
+ */
+export function setExploreAttributeBounds(
+  query: string,
+  attribute: string,
+  min: number,
+  max: number
+): string {
+  const search = new MutableSearch(query);
+  // `shouldEscape` is off so the comparison operators (`>=`, `<`) aren't quoted.
+  search.setFilterValues(attribute, [`>=${min}`, `<${max}`], false);
+  return search.formatString();
+}


### PR DESCRIPTION
**e.g.,**

https://github.com/user-attachments/assets/c189460e-f540-4a03-95ee-e9929ccb184f

This interaction requires _some_ shenanigans because a heatmap series in ECharts uses category axes. Luckily, we plot a value axis for time and value, and we can use _that_ to get the selection bounds!

Dashboards omitted for now, we'll do that separately. Also, would be nice to have a smoother transition rather than the loading spinner, maybe we use the data from the selected region to plot a "loading" state? Anyway, one thing at a time.

Closes DAIN-1744