### PR TITLE
feat(seer): accept viewer context auth on the Seer RPC endpoint

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -297,10 +297,13 @@ class SeerRpcViewerContextAuthentication(BaseAuthentication):
             return None
 
         vc = viewer_context_from_header(header)
-        if vc is None:
-            # Present but unverifiable — fall through (do not raise) so a valid
-            # HMAC on the same request can still win, and otherwise the endpoint
-            # denies via _is_authorized.
+        if vc is None or vc.organization_id is None:
+            # Reject a viewer context that is unverifiable OR carries no
+            # organization: every seer RPC call acts on behalf of an org, so a
+            # VC used for auth MUST name one. We fall through (do not raise) so a
+            # valid HMAC on the same request can still win; otherwise the
+            # endpoint denies via _is_authorized. This guarantees every
+            # VC-authenticated call carries an attested org to enforce against.
             return None
 
         user: Any = AnonymousUser()

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -14,6 +14,7 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.timestamp_pb2 import Timestamp as ProtobufTimestamp
 from pydantic import BaseModel
 from requests.exceptions import RequestException
+from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import (
     APIException,
     AuthenticationFailed,
@@ -170,11 +171,15 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.snuba.referrer import Referrer
 from sentry.users.services.user.service import user_service
-from sentry.utils import snuba_rpc
+from sentry.utils import metrics, snuba_rpc
 from sentry.utils.env import in_test_environment
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 from sentry.utils.tracing import start_span
-from sentry.viewer_context import get_viewer_context, observe_viewer_context_propagation
+from sentry.viewer_context import (
+    get_viewer_context,
+    observe_viewer_context_propagation,
+    viewer_context_from_header,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +206,9 @@ def compare_signature(url: str, body: bytes, signature: str) -> bool:
 
     Once a key has been able to validate the signature other keys will
     not be attempted. We should only have multiple keys during key rotations.
+
+    DEPRECATED: part of the HMAC RPC auth mechanism being retired in favor of
+    signed ``X-Viewer-Context`` (see ``SeerRpcSignatureAuthentication``).
     """
     if not settings.SEER_RPC_SHARED_SECRET:
         raise RpcAuthenticationSetupException(
@@ -240,6 +248,14 @@ class SeerRpcSignatureAuthentication(StandardAuthentication):
     """
     Authentication for seer RPC requests.
     Requests are sent with an HMAC signed by a shared private key.
+
+    DEPRECATED: this HMAC mechanism (backed by ``SEER_RPC_SHARED_SECRET``) is
+    slated for removal. Seer↔Sentry auth is consolidating onto the signed
+    ``X-Viewer-Context`` header (see ``SeerRpcViewerContextAuthentication``).
+    Removal order: (1) this endpoint accepts viewer context [done],
+    (2) Seer stops sending ``Rpcsignature``, (3) delete this class +
+    ``compare_signature``, (4) retire ``SEER_RPC_SHARED_SECRET`` (only after
+    step 2 — an inbound signature with the secret unset raises).
     """
 
     token_name = b"rpcsignature"
@@ -258,6 +274,54 @@ class SeerRpcSignatureAuthentication(StandardAuthentication):
         return (AnonymousUser(), token)
 
 
+@AuthenticationSiloLimit(SiloMode.CONTROL, SiloMode.CELL)
+class SeerRpcViewerContextAuthentication(BaseAuthentication):
+    """
+    Authentication for seer RPC requests via a signed ``X-Viewer-Context`` JWT.
+
+    A co-equal alternative to :class:`SeerRpcSignatureAuthentication` (HMAC). The
+    JWT is verified with ``SEER_API_SHARED_SECRET`` using the shared
+    ``sentry.viewer_context`` verification logic — the same trust envelope the
+    rest of the Sentry API already relies on.
+
+    Unlike the REST ``ViewerContextAuthentication``, this accepts org-only
+    contexts (no ``user_id``) — the common near-term case for RPC callers — and
+    returns a truthy ``auth`` value so the endpoint's ``_is_authorized`` gate
+    passes. The user is resolved opportunistically when a ``user_id`` is present.
+    """
+
+    def authenticate(self, request: Request) -> tuple[Any, Any] | None:
+        header = request.META.get("HTTP_X_VIEWER_CONTEXT")
+        if not header:
+            # No viewer context: leave authentication to the HMAC authenticator.
+            return None
+
+        vc = viewer_context_from_header(header)
+        if vc is None:
+            # Present but unverifiable — fall through (do not raise) so a valid
+            # HMAC on the same request can still win, and otherwise the endpoint
+            # denies via _is_authorized.
+            return None
+
+        user: Any = AnonymousUser()
+        if vc.user_id is not None:
+            resolved = user_service.get_user(user_id=vc.user_id)
+            if resolved is not None:
+                user = resolved
+
+        sentry_sdk.get_isolation_scope().set_tag("seer_rpc_viewer_context_auth", True)
+
+        # Stash the verified context so the org-binding guard reads the signed
+        # value directly. (The middleware contextvar can drop organization_id when
+        # it resolves the user and prefers the request context, so it is not a
+        # reliable source for the binding check.)
+        setattr(request, "_seer_rpc_viewer_context", vc)
+
+        # Return the raw header as a truthy ``auth`` so ``_is_authorized`` passes,
+        # mirroring the HMAC authenticator's (user, token) shape.
+        return (user, header)
+
+
 @internal_cell_silo_endpoint
 class SeerRpcServiceEndpoint(Endpoint):
     """
@@ -269,17 +333,48 @@ class SeerRpcServiceEndpoint(Endpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.ML_AI
-    authentication_classes = (SeerRpcSignatureAuthentication,)
+    # HMAC is listed first so it wins when a caller sends both credentials
+    # (Seer sends both today), keeping this a no-op at rollout. The viewer
+    # context authenticator only engages when there is no valid Rpcsignature.
+    authentication_classes = (
+        SeerRpcSignatureAuthentication,
+        SeerRpcViewerContextAuthentication,
+    )
     permission_classes = ()
     enforce_rate_limit = False
 
     @sentry_sdk.trace
     def _is_authorized(self, request: Request) -> bool:
-        if request.auth and isinstance(
-            request.successful_authenticator, SeerRpcSignatureAuthentication
-        ):
-            return True
-        return False
+        return bool(request.auth) and isinstance(
+            request.successful_authenticator,
+            (SeerRpcSignatureAuthentication, SeerRpcViewerContextAuthentication),
+        )
+
+    def _enforce_viewer_context_org_binding(
+        self, request: Request, arguments: dict[str, Any]
+    ) -> None:
+        """Bind a viewer-context-authenticated call to the signed context's org.
+
+        This endpoint has no per-org access control — ``org_id`` is a trusted
+        argument. That is safe for HMAC callers (only Seer holds the secret), but
+        as viewer-context auth generalizes to any caller, an unforgeable VC for
+        org A must not be usable to read org B. HMAC calls keep god-mode.
+        """
+        if not isinstance(request.successful_authenticator, SeerRpcViewerContextAuthentication):
+            return
+
+        arg_org_id = arguments.get("org_id", arguments.get("organization_id"))
+        if arg_org_id is None:
+            return
+
+        vc = getattr(request, "_seer_rpc_viewer_context", None)
+        vc_org_id = vc.organization_id if vc is not None else None
+        if vc_org_id is None or int(arg_org_id) != int(vc_org_id):
+            metrics.incr(
+                "seer.rpc.viewer_context_org_binding",
+                tags={"outcome": "mismatch"},
+            )
+            raise PermissionDenied("Viewer context organization does not match request")
 
     @sentry_sdk.trace
     def _dispatch_to_local_method(self, method_name: str, arguments: dict[str, Any]) -> Any:
@@ -323,6 +418,8 @@ class SeerRpcServiceEndpoint(Endpoint):
             raise ParseError from e
         if not isinstance(arguments, dict):
             raise ParseError
+
+        self._enforce_viewer_context_org_binding(request, arguments)
 
         try:
             result = self._dispatch_to_local_method(method_name, arguments)

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -367,9 +367,16 @@ class SeerRpcServiceEndpoint(Endpoint):
         if arg_org_id is None:
             return
 
+        # ``arg_org_id`` is caller-supplied and only validated to live under a
+        # dict; coerce defensively so malformed input is a 400, not a 500.
+        try:
+            arg_org_id = int(arg_org_id)
+        except (TypeError, ValueError):
+            raise ParseError("Invalid organization id")
+
         vc = getattr(request, "_seer_rpc_viewer_context", None)
         vc_org_id = vc.organization_id if vc is not None else None
-        if vc_org_id is None or int(arg_org_id) != int(vc_org_id):
+        if vc_org_id is None or arg_org_id != int(vc_org_id):
             metrics.incr(
                 "seer.rpc.viewer_context_org_binding",
                 tags={"outcome": "mismatch"},

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -48,6 +48,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of, cell_silo_test
 from sentry.users.models.identity import Identity
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
+from sentry.viewer_context import ActorType, ViewerContext, encode_viewer_context
 
 TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
 
@@ -2028,3 +2029,121 @@ class TestRecordPrAttribution(APITestCase):
 
         assert result == {"attribution_id": None}
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
+
+
+@override_settings(SEER_RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])
+@override_settings(SEER_API_SHARED_SECRET="viewer-context-test-secret")
+class TestSeerRpcViewerContextAuth(APITestCase):
+    """The Seer RPC endpoint accepts a signed X-Viewer-Context JWT as a co-equal
+    credential to the HMAC Rpcsignature."""
+
+    @staticmethod
+    def _get_path(method_name: str) -> str:
+        return reverse(
+            "sentry-api-0-seer-rpc-service",
+            kwargs={"method_name": method_name},
+        )
+
+    def _hmac_header(self, path: str, data: dict[str, Any]) -> str:
+        body = orjson.dumps(data).decode()
+        return f"rpcsignature {generate_request_signature(path, body.encode())}"
+
+    def _vc_header(self, *, organization_id: int | None, user_id: int | None = None) -> str:
+        vc = ViewerContext(
+            organization_id=organization_id,
+            user_id=user_id,
+            actor_type=ActorType.USER,
+        )
+        return encode_viewer_context(vc)
+
+    def test_org_only_viewer_context_authenticates(self) -> None:
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=org.id),
+        )
+        assert response.status_code == 200
+        assert "features" in response.data
+
+    def test_user_scoped_viewer_context_authenticates(self) -> None:
+        org = self.create_organization(owner=self.user)
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=org.id, user_id=self.user.id),
+        )
+        assert response.status_code == 200
+
+    def test_invalid_viewer_context_signature_denied(self) -> None:
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT="invalid.jwt.token",
+        )
+        assert response.status_code == 403
+
+    def test_no_credentials_denied(self) -> None:
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(path, data=data)
+        assert response.status_code == 403
+
+    def test_hmac_only_still_authenticates(self) -> None:
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_AUTHORIZATION=self._hmac_header(path, data),
+        )
+        assert response.status_code == 200
+
+    def test_hmac_takes_precedence_and_is_not_org_bound(self) -> None:
+        # Valid HMAC + a viewer context scoped to a DIFFERENT org. If the viewer
+        # context authenticator had won, the org-binding guard would reject the
+        # mismatch (403). A 200 proves HMAC won and skipped the binding check.
+        org = self.create_organization()
+        other_org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_AUTHORIZATION=self._hmac_header(path, data),
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=other_org.id),
+        )
+        assert response.status_code == 200
+
+    def test_viewer_context_org_binding_matches(self) -> None:
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=org.id),
+        )
+        assert response.status_code == 200
+
+    def test_viewer_context_org_binding_mismatch_denied(self) -> None:
+        org = self.create_organization()
+        other_org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        # Argument targets `org`, but the signed viewer context is for `other_org`.
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=other_org.id),
+        )
+        assert response.status_code == 403

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -2068,6 +2068,28 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         assert response.status_code == 200
         assert "features" in response.data
 
+    def test_org_only_viewer_context_scopes_to_the_arg_org(self) -> None:
+        # An org-only viewer context (no user_id — e.g. an org background job or,
+        # later, a service-account viewer) must dispatch and return data scoped to
+        # the org passed in args. org_id reaches the method via request args, not
+        # auth, so filtering is unchanged; the org-binding guard only requires the
+        # arg org to equal the signed context's org.
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        other_org = self.create_organization()
+        self.create_project(organization=other_org)
+
+        path = self._get_path("get_organization_projects")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=org.id),
+        )
+        assert response.status_code == 200
+        returned_ids = {p["id"] for p in response.data["projects"]}
+        assert returned_ids == {project.id}
+
     def test_user_scoped_viewer_context_authenticates(self) -> None:
         org = self.create_organization(owner=self.user)
         path = self._get_path("get_organization_features")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -2119,6 +2119,19 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         response = self.client.post(path, data=data)
         assert response.status_code == 403
 
+    def test_malformed_org_id_arg_is_bad_request_not_server_error(self) -> None:
+        # A non-numeric org_id on the viewer-context path must 400, not 500 —
+        # the org-binding guard coerces caller-supplied input defensively.
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": "not-a-number"}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=org.id),
+        )
+        assert response.status_code == 400
+
     def test_hmac_only_still_authenticates(self) -> None:
         org = self.create_organization()
         path = self._get_path("get_organization_features")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -2173,6 +2173,35 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         )
         assert response.status_code == 200
 
+    def test_hmac_works_with_empty_viewer_context_header(self) -> None:
+        # Invariant: an HMAC-authenticated request behaves as it does today no
+        # matter the X-Viewer-Context header. An empty header is inert — once
+        # HMAC succeeds the VC authenticator is never consulted.
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_AUTHORIZATION=self._hmac_header(path, data),
+            HTTP_X_VIEWER_CONTEXT="",
+        )
+        assert response.status_code == 200
+
+    def test_hmac_works_with_malformed_viewer_context_header(self) -> None:
+        # Same invariant: a malformed/garbage VC header does not affect an
+        # HMAC-authenticated request.
+        org = self.create_organization()
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_AUTHORIZATION=self._hmac_header(path, data),
+            HTTP_X_VIEWER_CONTEXT="not-a-valid-jwt",
+        )
+        assert response.status_code == 200
+
     def test_viewer_context_org_binding_matches(self) -> None:
         org = self.create_organization()
         path = self._get_path("get_organization_features")

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -2068,6 +2068,20 @@ class TestSeerRpcViewerContextAuth(APITestCase):
         assert response.status_code == 200
         assert "features" in response.data
 
+    def test_org_less_viewer_context_is_rejected(self) -> None:
+        # A validly-signed but org-less viewer context carries no org to enforce
+        # against, so it must not authenticate on signature alone. Every seer RPC
+        # call acts on behalf of an organization.
+        org = self.create_organization(owner=self.user)
+        path = self._get_path("get_organization_features")
+        data: dict[str, Any] = {"args": {"org_id": org.id}, "meta": {}}
+        response = self.client.post(
+            path,
+            data=data,
+            HTTP_X_VIEWER_CONTEXT=self._vc_header(organization_id=None, user_id=self.user.id),
+        )
+        assert response.status_code == 403
+
     def test_org_only_viewer_context_scopes_to_the_arg_org(self) -> None:
         # An org-only viewer context (no user_id — e.g. an org background job or,
         # later, a service-account viewer) must dispatch and return data scoped to


### PR DESCRIPTION
The Seer RPC endpoint (`SeerRpcServiceEndpoint`) authenticates with a bespoke HMAC signature (`SEER_RPC_SHARED_SECRET`), separate from the `X-Viewer-Context` JWT the rest of the Sentry API already accepts. This teaches the endpoint to accept a signed viewer context as a co-equal credential so Seer↔Sentry auth can consolidate onto viewer context and the RPC-specific secret can be retired.

HMAC is checked first and is unchanged, so this is a no-op at rollout (Seer sends both headers today). Org-only viewer contexts authenticate now; when a call authenticates via viewer context, its `org_id` argument is bound to the signed context's organization. The HMAC path is annotated as deprecated pending a follow-up removal.