### PR TITLE
fix(dashboards): Preserve spans table `timestamp` column in Explore

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -397,6 +397,37 @@ describe('getWidgetExploreUrl', () => {
     expect(url).toBeNull();
   });
 
+  it('preserves timestamp column and sort when opening in explore', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          fields: ['span.description', 'timestamp'],
+          aggregates: [],
+          columns: ['span.description', 'timestamp'],
+          conditions: '',
+          orderby: '-timestamp',
+          name: '',
+        },
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, undefined, selection, organization);
+
+    expectUrl(url).toMatch({
+      path: '/organizations/org-slug/explore/traces/',
+      params: [
+        ['field', 'timestamp'],
+        ['field', 'span.description'],
+        ['interval', '30m'],
+        ['mode', 'samples'],
+        ['sort', '-timestamp'],
+        ['statsPeriod', '14d'],
+        ['project', ''],
+      ],
+    });
+  });
+
   it('adds referrer query parameter if provided', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.LINE,

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -260,16 +260,20 @@ function _getWidgetExploreUrl(
 
   const query = widget.queries[0]!;
 
-  let groupBy: string[] =
+  const columnFields: string[] =
     defined(query.fields) && widget.displayType === DisplayType.TABLE
       ? query.fields.filter(
           field =>
             !isAggregateFieldOrEquation(field) &&
-            field !== 'timestamp' &&
             field !== SpanFields.IS_STARRED_TRANSACTION // starred transactions are not supported in explore
         )
       : query.columns.filter(column => column !== SpanFields.IS_STARRED_TRANSACTION);
-  if (groupBy?.length === 0) {
+
+  let groupBy =
+    widget.displayType === DisplayType.TABLE
+      ? columnFields.filter(field => field !== 'timestamp')
+      : columnFields;
+  if (groupBy.length === 0) {
     // Force the groupBy to be an array with a single empty string
     // so that qs.stringify appends the key to the URL. If the key
     // is not present, the Explore UI will assign a default groupBy
@@ -278,7 +282,7 @@ function _getWidgetExploreUrl(
   }
 
   const yAxisFields = locationQueryParams.yAxes.flatMap(getAggregateArguments);
-  const fields = [...new Set([...groupBy, ...yAxisFields])].filter(Boolean);
+  const fields = [...new Set([...columnFields, ...yAxisFields])].filter(Boolean);
 
   const sortDirection = widget.queries[0]?.orderby?.startsWith('-') ? '-' : '';
   const sortColumn = trimStart(widget.queries[0]?.orderby ?? '', '-');


### PR DESCRIPTION
## Repro
1. Create a Dashboard widget on the Spans dataset with a `timestamp` column.

---
<img width="675" height="698" alt="Screenshot 2026-07-02 at 14 56 39" src="https://github.com/user-attachments/assets/e4b8bfcf-57a2-4bcd-873e-e4c260f8dc2f" />

---

2. Expand the widget and click the `Open in Explore` button
3. Expected a `timestamp` column in the result. Instead, that column is missing:

<img width="1272" height="209" alt="Screenshot 2026-07-02 at 15 02 02" src="https://github.com/user-attachments/assets/53d84739-bf2e-4d91-8d85-f2f29bf5bcf2" />

## Fix
The old code inadvertently excluded `timestamp`. This brings it back by separating the list of columns (where `timestamp` is fine) from the `groupBy` (where `timestamp` is not allowed).