### PR TITLE
feat(spans): Create a task for process segment

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -945,6 +945,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.seer.entrypoints.slack.tasks",
     "sentry.snuba.query_subscriptions.run",
     "sentry.snuba.tasks",
+    "sentry.spans.consumers.process_segments.tasks",
     "sentry.tasks.activity",
     "sentry.tasks.assemble",
     "sentry.tasks.auth.auth",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2998,12 +2998,6 @@ register(
     default=0.0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Segments consumer
-register(
-    "spans.process-segments.consumer.enable",
-    default=True,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 register(
     "spans.process-segments.detect-performance-problems.enable",
     default=False,

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -156,9 +156,6 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
 
 
 def _process_segment_bytes(segment_bytes: bytes, skip_produce: bool = False) -> list[KafkaPayload]:
-    if not options.get("spans.process-segments.consumer.enable"):
-        return []
-
     segment = orjson.loads(segment_bytes)
     skip_enrichment = segment.get("skip_enrichment", False)
     processed = process_segment(

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -168,9 +168,6 @@ def _process_segment_bytes(segment_bytes: bytes, skip_produce: bool = False) -> 
 def _process_message(
     message: Message[KafkaPayload], skip_produce: bool = False
 ) -> list[Value[KafkaPayload]]:
-    if not options.get("spans.process-segments.consumer.enable"):
-        return []
-
     assert isinstance(message.value, BrokerValue)
 
     try:

--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import datetime
 from functools import partial
 
 import orjson
@@ -156,6 +155,19 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         self.pool.close()
 
 
+def _process_segment_bytes(segment_bytes: bytes, skip_produce: bool = False) -> list[KafkaPayload]:
+    if not options.get("spans.process-segments.consumer.enable"):
+        return []
+
+    segment = orjson.loads(segment_bytes)
+    skip_enrichment = segment.get("skip_enrichment", False)
+    processed = process_segment(
+        segment["spans"], skip_produce=skip_produce, skip_enrichment=skip_enrichment
+    )
+    processed = _check_span_duplicates(processed)
+    return [_serialize_payload(span) for span in processed]
+
+
 def _process_message(
     message: Message[KafkaPayload], skip_produce: bool = False
 ) -> list[Value[KafkaPayload]]:
@@ -166,32 +178,25 @@ def _process_message(
 
     try:
         value = message.payload.value
-        segment = orjson.loads(value)
-        skip_enrichment = segment.get("skip_enrichment", False)
-        processed = process_segment(
-            segment["spans"], skip_produce=skip_produce, skip_enrichment=skip_enrichment
-        )
-        processed = _check_span_duplicates(processed)
-        return [_serialize_payload(span, message.timestamp) for span in processed]
+        return [
+            Value(payload, {}, message.timestamp)
+            for payload in _process_segment_bytes(value, skip_produce=skip_produce)
+        ]
     except Exception:
         logger.exception("segments.invalid-message")
         raise InvalidMessage(message.value.partition, message.value.offset)
 
 
-def _serialize_payload(span: CompatibleSpan, timestamp: datetime | None) -> Value[KafkaPayload]:
+def _serialize_payload(span: CompatibleSpan) -> KafkaPayload:
     item = convert_span_to_item(span)
 
-    return Value(
-        KafkaPayload(
-            None,
-            item.SerializeToString(),
-            [
-                ("item_type", str(item.item_type).encode("ascii")),
-                ("project_id", str(span["project_id"]).encode("ascii")),
-            ],
-        ),
-        {},
-        timestamp,
+    return KafkaPayload(
+        None,
+        item.SerializeToString(),
+        [
+            ("item_type", str(item.item_type).encode("ascii")),
+            ("project_id", str(span["project_id"]).encode("ascii")),
+        ],
     )
 
 

--- a/src/sentry/spans/consumers/process_segments/tasks.py
+++ b/src/sentry/spans/consumers/process_segments/tasks.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from functools import partial
+
+from arroyo import Topic as ArroyoTopic
+from taskbroker_client.constants import CompressionType
+
+from sentry.conf.types.kafka_definition import Topic
+from sentry.silo.base import SiloMode
+from sentry.spans.consumers.process_segments.factory import _process_segment_bytes
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import spans_process_segments_tasks
+from sentry.taskworker.producer import get_task_producer
+from sentry.utils.arroyo_producer import get_arroyo_producer
+from sentry.utils.kafka_config import get_topic_definition
+
+PROCESS_SEGMENT_TASK_NAME = "sentry.spans.process_segments.process_segment"
+
+
+def _get_snuba_items_producer(name: str = "sentry.spans.process_segments.snuba_items"):
+    return get_arroyo_producer(
+        name,
+        Topic.SNUBA_ITEMS,
+    )
+
+
+_snuba_items_task_producer_name = "sentry.spans.process_segments.snuba_items_taskproducer"
+_snuba_items_task_producer = get_task_producer(
+    producer_name=_snuba_items_task_producer_name,
+    producer_factory=partial(_get_snuba_items_producer, name=_snuba_items_task_producer_name),
+)
+_snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"])
+
+
+@instrumented_task(
+    name=PROCESS_SEGMENT_TASK_NAME,
+    namespace=spans_process_segments_tasks,
+    at_most_once=True,
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+)
+def process_segment_task(segment_bytes: bytes) -> None:
+    for payload in _process_segment_bytes(segment_bytes):
+        _snuba_items_task_producer.produce(_snuba_items_topic, payload)

--- a/src/sentry/spans/consumers/process_segments/tasks.py
+++ b/src/sentry/spans/consumers/process_segments/tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import partial
 
 from arroyo import Topic as ArroyoTopic
+from arroyo.backends.kafka import KafkaProducer
 from taskbroker_client.constants import CompressionType
 
 from sentry.conf.types.kafka_definition import Topic
@@ -14,10 +15,10 @@ from sentry.taskworker.producer import get_task_producer
 from sentry.utils.arroyo_producer import get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
 
-PROCESS_SEGMENT_TASK_NAME = "sentry.spans.process_segments.process_segment"
 
-
-def _get_snuba_items_producer(name: str = "sentry.spans.process_segments.snuba_items"):
+def _get_snuba_items_producer(
+    name: str = "sentry.spans.process_segments.snuba_items",
+) -> KafkaProducer:
     return get_arroyo_producer(
         name,
         Topic.SNUBA_ITEMS,
@@ -33,7 +34,7 @@ _snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_t
 
 
 @instrumented_task(
-    name=PROCESS_SEGMENT_TASK_NAME,
+    name="sentry.spans.process_segments.process_segment",
     namespace=spans_process_segments_tasks,
     at_most_once=True,
     compression_type=CompressionType.ZSTD,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -92,6 +92,11 @@ ingest_transactions_tasks = app.taskregistry.create_namespace(
     app_feature="transactions",
 )
 
+spans_process_segments_tasks = app.taskregistry.create_namespace(
+    "spans.process_segments",
+    app_feature="transactions",
+)
+
 ingest_attachments_tasks = app.taskregistry.create_namespace(
     "ingest.attachments",
     app_feature="attachments",

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -11,7 +11,9 @@ from sentry.spans.consumers.process_segments.convert import convert_span_to_item
 from sentry.spans.consumers.process_segments.factory import (
     DetectPerformanceIssuesStrategyFactory,
     _check_span_duplicates,
+    _process_message,
 )
+from sentry.spans.consumers.process_segments.tasks import process_segment_task
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 from sentry.utils import json
@@ -53,7 +55,12 @@ def test_segment_deserialized_correctly(mock_process_segment: mock.MagicMock) ->
         skip_produce=False,
     )
 
-    with mock.patch.object(factory, "producer", new=mock.Mock()) as mock_producer:
+    with (
+        mock.patch.object(factory, "producer", new=mock.Mock()) as mock_producer,
+        mock.patch(
+            "sentry.spans.consumers.process_segments.tasks._snuba_items_task_producer"
+        ) as mock_task_producer,
+    ):
         strategy = factory.create_with_partitions(
             commit=mock_commit,
             partitions={},
@@ -99,6 +106,7 @@ def test_segment_deserialized_correctly(mock_process_segment: mock.MagicMock) ->
 
         assert mock_producer.produce.call_count == 2
         assert mock_producer.produce.call_args.args[0] == ArroyoTopic("snuba-items")
+        mock_task_producer.produce.assert_not_called()
 
         payload = mock_producer.produce.call_args.args[1]
         span_item = TraceItem.FromString(payload.value)
@@ -107,6 +115,77 @@ def test_segment_deserialized_correctly(mock_process_segment: mock.MagicMock) ->
         headers = {k: v for k, v in payload.headers}
         assert headers["item_type"] == b"1"
         assert headers["project_id"] == b"1"
+
+
+@override_options({"spans.process-segments.consumer.enable": True})
+@mock.patch(
+    "sentry.spans.consumers.process_segments.factory._check_span_duplicates",
+    side_effect=lambda spans: spans,
+)
+@mock.patch(
+    "sentry.spans.consumers.process_segments.factory.process_segment",
+    side_effect=lambda x, **kwargs: x,
+)
+def test_process_segment_task_matches_consumer_output(
+    mock_process_segment: mock.MagicMock,
+    mock_check_span_duplicates: mock.MagicMock,
+) -> None:
+    topic = ArroyoTopic(get_topic_definition(Topic.BUFFERED_SEGMENTS)["real_topic_name"])
+    partition = Partition(topic, 0)
+    span_data = build_mock_span(project_id=1, is_segment=True)
+    segment_data = {"spans": [span_data]}
+    segment_bytes = json.dumps(segment_data).encode("utf-8")
+
+    consumer_values = _process_message(
+        Message(
+            BrokerValue(
+                KafkaPayload(b"key", segment_bytes, []),
+                partition,
+                1,
+                datetime.now(),
+            )
+        )
+    )
+    consumer_payloads = [value.payload for value in consumer_values]
+
+    with mock.patch(
+        "sentry.spans.consumers.process_segments.tasks._snuba_items_task_producer"
+    ) as mock_producer:
+        process_segment_task(segment_bytes)
+
+    assert mock_process_segment.call_count == 2
+    assert mock_process_segment.call_args.args[0] == segment_data["spans"]
+    assert mock_check_span_duplicates.call_count == 2
+
+    mock_producer.produce.assert_called_once()
+    assert mock_producer.produce.call_args.args[0] == ArroyoTopic("snuba-items")
+
+    task_payloads = [call.args[1] for call in mock_producer.produce.call_args_list]
+    assert task_payloads == consumer_payloads
+
+    payload = task_payloads[0]
+    span_item = TraceItem.FromString(payload.value)
+    assert span_item == convert_span_to_item(span_data)
+
+    headers = {k: v for k, v in payload.headers}
+    assert headers["item_type"] == b"1"
+    assert headers["project_id"] == b"1"
+
+
+@override_options({"spans.process-segments.consumer.enable": False})
+@mock.patch("sentry.spans.consumers.process_segments.factory.process_segment")
+def test_process_segment_task_respects_consumer_enable_option(
+    mock_process_segment: mock.MagicMock,
+) -> None:
+    segment_data = {"spans": [build_mock_span(project_id=1, is_segment=True)]}
+
+    with mock.patch(
+        "sentry.spans.consumers.process_segments.tasks._snuba_items_task_producer"
+    ) as mock_producer:
+        process_segment_task(json.dumps(segment_data).encode("utf-8"))
+
+    mock_process_segment.assert_not_called()
+    mock_producer.produce.assert_not_called()
 
 
 class TestCheckSpanDuplicates:

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -31,7 +31,6 @@ def build_mock_message(data, topic=None):
 
 @override_options(
     {
-        "spans.process-segments.consumer.enable": True,
         "spans.process-segments.dedupe-ttl": 0,
         "spans.process-segments.dedupe-filter-enable": False,
     }
@@ -117,7 +116,6 @@ def test_segment_deserialized_correctly(mock_process_segment: mock.MagicMock) ->
         assert headers["project_id"] == b"1"
 
 
-@override_options({"spans.process-segments.consumer.enable": True})
 @mock.patch(
     "sentry.spans.consumers.process_segments.factory._check_span_duplicates",
     side_effect=lambda spans: spans,

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -172,22 +172,6 @@ def test_process_segment_task_matches_consumer_output(
     assert headers["project_id"] == b"1"
 
 
-@override_options({"spans.process-segments.consumer.enable": False})
-@mock.patch("sentry.spans.consumers.process_segments.factory.process_segment")
-def test_process_segment_task_respects_consumer_enable_option(
-    mock_process_segment: mock.MagicMock,
-) -> None:
-    segment_data = {"spans": [build_mock_span(project_id=1, is_segment=True)]}
-
-    with mock.patch(
-        "sentry.spans.consumers.process_segments.tasks._snuba_items_task_producer"
-    ) as mock_producer:
-        process_segment_task(json.dumps(segment_data).encode("utf-8"))
-
-    mock_process_segment.assert_not_called()
-    mock_producer.produce.assert_not_called()
-
-
 class TestCheckSpanDuplicates:
     @override_options({"spans.process-segments.dedupe-ttl": 0})
     def test_disabled_when_ttl_is_zero(self):


### PR DESCRIPTION
Refs STREAM-1301

Creates a task to port the segments consumers to taskbroker. The task accepts the serialized segment payload and emits the same `snuba-items` payloads as the existing Kafka consumer path using TaskProducer.

The existing consumer path remains unchanged operationally and still produces through the Arroyo producer. 

The `_process_message` function is also refactored to use the new shared `_process_segment_bytes` logic.

The rollout of this task in the spans buffer will be done in a followup PR.