### PR TITLE
fix(ourlogs): type-qualify attribute keys built by "Add to filter"

### DIFF
--- a/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTree.tsx
@@ -23,6 +23,7 @@ const INVALID_BRANCH_REGEX = /\.{2,}/;
 
 interface Attribute {
   attribute_key: string;
+  attribute_type: TraceItemResponseAttribute['type'];
   attribute_value: string | number | null;
   original_attribute_key: string;
 }
@@ -145,6 +146,7 @@ function addToAttributeTree(
   // Recurse with a pseudo attribute, e.g. 'model', to create nesting structure
   const pseudoAttribute = {
     attribute_key: branch,
+    attribute_type: attribute.attribute_type,
     attribute_value: attribute.attribute_value,
     original_attribute_key: attribute.original_attribute_key,
   };
@@ -462,6 +464,7 @@ function getAttribute(
 
   return {
     attribute_key: prettifyAttributeName(attribute.name),
+    attribute_type: attribute.type,
     attribute_value: attributeValue,
     original_attribute_key: getAdjustedAttributeKey
       ? getAdjustedAttributeKey(attribute)

--- a/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.spec.tsx
+++ b/static/app/views/explore/components/traceItemAttributes/attributesTreeValue.spec.tsx
@@ -22,6 +22,7 @@ describe('AttributesTreeValue', () => {
       value: 'test-value',
       originalAttribute: {
         attribute_key: 'test.key',
+        attribute_type: 'str' as const,
         attribute_value: 'test-value',
         original_attribute_key: 'test.key',
       },

--- a/static/app/views/explore/logs/useLogAttributesTreeActions.spec.tsx
+++ b/static/app/views/explore/logs/useLogAttributesTreeActions.spec.tsx
@@ -1,0 +1,171 @@
+import {useMemo, type ReactNode} from 'react';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {useLogAttributesTreeActions} from 'sentry/views/explore/logs/useLogAttributesTreeActions';
+import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
+import {defaultCursor} from 'sentry/views/explore/queryParams/cursor';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+
+const mockSetQueryParams = jest.fn();
+
+function mockAttributes() {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/trace-items/attributes/',
+    method: 'GET',
+    body: [
+      {
+        attributeType: 'number',
+        key: 'tags[message.parameter.StatusCode,number]',
+        name: 'message.parameter.StatusCode',
+      },
+      {attributeType: 'number', key: 'payload_size', name: 'payload_size'},
+      {
+        attributeType: 'boolean',
+        key: 'tags[activity_object_created,boolean]',
+        name: 'activity_object_created',
+      },
+      {attributeType: 'string', key: 'message.parameter.0', name: 'message.parameter.0'},
+    ],
+  });
+}
+
+function Wrapper({children}: {children: ReactNode}) {
+  const queryParams = useMemo(
+    () =>
+      new ReadableQueryParams({
+        aggregateCursor: defaultCursor(),
+        aggregateFields: [],
+        aggregateSortBys: [],
+        cursor: defaultCursor(),
+        extrapolate: true,
+        fields: ['timestamp', 'message'],
+        mode: Mode.SAMPLES,
+        query: '',
+        sortBys: [],
+      }),
+    []
+  );
+
+  return (
+    <QueryParamsContextProvider
+      isUsingDefaultFields={false}
+      queryParams={queryParams}
+      setQueryParams={mockSetQueryParams}
+      shouldManageFields={false}
+    >
+      {children}
+    </QueryParamsContextProvider>
+  );
+}
+
+function renderActions() {
+  return renderHookWithProviders(() => useLogAttributesTreeActions({embedded: false}), {
+    additionalWrapper: Wrapper,
+  });
+}
+
+function addToFilter(
+  actions: ReturnType<ReturnType<typeof renderActions>['result']['current']>
+) {
+  actions.find(action => action.key === 'search-for-value')?.onAction?.();
+}
+
+describe('useLogAttributesTreeActions', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    mockAttributes();
+    mockSetQueryParams.mockClear();
+  });
+
+  it('builds a tags[name,number] filter for a custom numeric attribute', async () => {
+    const {result} = renderActions();
+
+    const content: AttributesTreeContent = {
+      originalAttribute: {
+        attribute_key: 'message.parameter.StatusCode',
+        attribute_type: 'int',
+        attribute_value: 200,
+        original_attribute_key: 'sentry.message.parameter.StatusCode',
+      },
+      subtree: {},
+      value: 200,
+    };
+
+    await waitFor(() => {
+      addToFilter(result.current(content));
+      expect(mockSetQueryParams).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          query: 'tags[message.parameter.StatusCode,number]:200',
+        })
+      );
+    });
+  });
+
+  it('keeps the plain key for a known numeric field', async () => {
+    const {result} = renderActions();
+
+    const content: AttributesTreeContent = {
+      originalAttribute: {
+        attribute_key: 'payload_size',
+        attribute_type: 'int',
+        attribute_value: 5,
+        original_attribute_key: 'payload_size',
+      },
+      subtree: {},
+      value: 5,
+    };
+
+    await waitFor(() => {
+      addToFilter(result.current(content));
+      expect(mockSetQueryParams).toHaveBeenLastCalledWith(
+        expect.objectContaining({query: 'payload_size:5'})
+      );
+    });
+  });
+
+  it('builds a tags[name,boolean] filter for a boolean attribute', async () => {
+    const {result} = renderActions();
+
+    const content: AttributesTreeContent = {
+      originalAttribute: {
+        attribute_key: 'activity_object_created',
+        attribute_type: 'bool',
+        attribute_value: 'true',
+        original_attribute_key: 'activity_object_created',
+      },
+      subtree: {},
+      value: 'true',
+    };
+
+    await waitFor(() => {
+      addToFilter(result.current(content));
+      expect(mockSetQueryParams).toHaveBeenLastCalledWith(
+        expect.objectContaining({query: 'tags[activity_object_created,boolean]:true'})
+      );
+    });
+  });
+
+  it('keeps the plain key for a string value', () => {
+    const {result} = renderActions();
+
+    const content: AttributesTreeContent = {
+      originalAttribute: {
+        attribute_key: 'message.parameter.0',
+        attribute_type: 'str',
+        attribute_value: '18446744073709551615',
+        original_attribute_key: 'sentry.message.parameter.0',
+      },
+      subtree: {},
+      value: '18446744073709551615',
+    };
+
+    addToFilter(result.current(content));
+
+    expect(mockSetQueryParams).toHaveBeenLastCalledWith(
+      expect.objectContaining({query: 'sentry.message.parameter.0:18446744073709551615'})
+    );
+  });
+});

--- a/static/app/views/explore/logs/useLogAttributesTreeActions.tsx
+++ b/static/app/views/explore/logs/useLogAttributesTreeActions.tsx
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
 import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {useLogItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {useLogsSidebar} from 'sentry/views/explore/logs/logsSidebarContext';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {
@@ -14,6 +15,7 @@ import {
   useSetQueryParamsSearch,
 } from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {resolveAttributeFilterKey} from 'sentry/views/explore/utils';
 
 export function useLogAttributesTreeActions({embedded}: {embedded: boolean}) {
   const setLogsSearch = useSetQueryParamsSearch();
@@ -23,6 +25,8 @@ export function useLogAttributesTreeActions({embedded}: {embedded: boolean}) {
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
   const sidebar = useLogsSidebar();
+  const {attributes: numberAttributes} = useLogItemAttributes({}, 'number');
+  const {attributes: booleanAttributes} = useLogItemAttributes({}, 'boolean');
 
   const addSearchFilter = useCallback(
     (content: AttributesTreeContent, negated?: boolean) => {
@@ -30,14 +34,18 @@ export function useLogAttributesTreeActions({embedded}: {embedded: boolean}) {
       if (!originalAttribute) {
         return;
       }
+      const key = resolveAttributeFilterKey({
+        name: originalAttribute.attribute_key,
+        fallbackKey: originalAttribute.original_attribute_key,
+        type: originalAttribute.attribute_type,
+        numberAttributes,
+        booleanAttributes,
+      });
       const newSearch = search.copy();
-      newSearch.addFilterValue(
-        `${negated ? '!' : ''}${originalAttribute.original_attribute_key}`,
-        String(content.value)
-      );
+      newSearch.addFilterValue(`${negated ? '!' : ''}${key}`, String(content.value));
       setLogsSearch(newSearch);
     },
-    [setLogsSearch, search]
+    [setLogsSearch, search, numberAttributes, booleanAttributes]
   );
 
   const addColumn = useCallback(

--- a/static/app/views/explore/metrics/useMetricAttributesTreeActions.spec.tsx
+++ b/static/app/views/explore/metrics/useMetricAttributesTreeActions.spec.tsx
@@ -1,6 +1,6 @@
 import {useMemo, type ReactNode} from 'react';
 
-import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {
@@ -48,6 +48,12 @@ function Wrapper({children}: {children: ReactNode}) {
 
 describe('useMetricAttributesTreeActions', () => {
   beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      method: 'GET',
+      body: [{attributeType: 'number', key: 'tags[latency,number]', name: 'latency'}],
+    });
     mockSetQueryParams.mockClear();
   });
 
@@ -59,6 +65,7 @@ describe('useMetricAttributesTreeActions', () => {
     const content: AttributesTreeContent = {
       originalAttribute: {
         attribute_key: 'release',
+        attribute_type: 'str',
         attribute_value: '1.0.0',
         original_attribute_key: 'release',
       },
@@ -72,6 +79,57 @@ describe('useMetricAttributesTreeActions', () => {
       'Add to filter',
       'Exclude this value',
     ]);
+  });
+
+  it('builds a tags[name,number] filter when a custom numeric attribute matches', async () => {
+    const {result} = renderHookWithProviders(useMetricAttributesTreeActions, {
+      additionalWrapper: Wrapper,
+    });
+
+    const content: AttributesTreeContent = {
+      originalAttribute: {
+        attribute_key: 'latency',
+        attribute_type: 'int',
+        attribute_value: 5,
+        original_attribute_key: 'latency',
+      },
+      subtree: {},
+      value: 5,
+    };
+
+    await waitFor(() => {
+      result
+        .current(content)
+        .find(action => action.key === 'search-for-value')
+        ?.onAction?.();
+      expect(mockSetQueryParams).toHaveBeenLastCalledWith(
+        expect.objectContaining({query: 'tags[latency,number]:5'})
+      );
+    });
+  });
+
+  it('builds a plain filter when the attribute is a string value', () => {
+    const {result} = renderHookWithProviders(useMetricAttributesTreeActions, {
+      additionalWrapper: Wrapper,
+    });
+
+    const content: AttributesTreeContent = {
+      originalAttribute: {
+        attribute_key: 'release',
+        attribute_type: 'str',
+        attribute_value: '1.0.0',
+        original_attribute_key: 'release',
+      },
+      subtree: {},
+      value: '1.0.0',
+    };
+
+    const actions = result.current(content);
+    actions.find(action => action.key === 'search-for-value')?.onAction?.();
+
+    expect(mockSetQueryParams).toHaveBeenCalledWith(
+      expect.objectContaining({query: 'release:1.0.0'})
+    );
   });
 
   it('returns no actions when originalAttribute is missing', () => {

--- a/static/app/views/explore/metrics/useMetricAttributesTreeActions.tsx
+++ b/static/app/views/explore/metrics/useMetricAttributesTreeActions.tsx
@@ -3,10 +3,14 @@ import {useCallback} from 'react';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t} from 'sentry/locale';
 import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {useTraceMetricItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {useAddSearchFilter} from 'sentry/views/explore/queryParams/context';
+import {resolveAttributeFilterKey} from 'sentry/views/explore/utils';
 
 export function useMetricAttributesTreeActions() {
   const addSearchFilter = useAddSearchFilter();
+  const {attributes: numberAttributes} = useTraceMetricItemAttributes({}, 'number');
+  const {attributes: booleanAttributes} = useTraceMetricItemAttributes({}, 'boolean');
 
   const addAttributeSearchFilter = useCallback(
     (content: AttributesTreeContent, negated?: boolean) => {
@@ -16,12 +20,18 @@ export function useMetricAttributesTreeActions() {
       }
 
       addSearchFilter({
-        key: originalAttribute.original_attribute_key,
+        key: resolveAttributeFilterKey({
+          name: originalAttribute.attribute_key,
+          fallbackKey: originalAttribute.original_attribute_key,
+          type: originalAttribute.attribute_type,
+          numberAttributes,
+          booleanAttributes,
+        }),
         value: String(content.value),
         negated,
       });
     },
-    [addSearchFilter]
+    [addSearchFilter, numberAttributes, booleanAttributes]
   );
 
   return (content: AttributesTreeContent) => {

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -8,6 +8,7 @@ import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {
   findSuggestedColumns,
   removeHiddenKeys,
+  resolveAttributeFilterKey,
   viewSamplesTarget,
 } from 'sentry/views/explore/utils';
 
@@ -379,5 +380,89 @@ describe('removeHiddenKeys', () => {
     };
 
     expect(removeHiddenKeys(tags, ['project_id'])).toEqual(tags);
+  });
+});
+
+describe('resolveAttributeFilterKey', () => {
+  const numberAttributes: TagCollection = {
+    // custom numeric attribute — keyed by its explicit form
+    'tags[message.parameter.StatusCode,number]': {
+      key: 'tags[message.parameter.StatusCode,number]',
+      name: 'message.parameter.StatusCode',
+      kind: FieldKind.MEASUREMENT,
+    },
+    // known numeric field — keyed plainly
+    payload_size: {
+      key: 'payload_size',
+      name: 'payload_size',
+      kind: FieldKind.MEASUREMENT,
+    },
+  };
+  const booleanAttributes: TagCollection = {
+    'tags[activity_object_created,boolean]': {
+      key: 'tags[activity_object_created,boolean]',
+      name: 'activity_object_created',
+      kind: FieldKind.BOOLEAN,
+    },
+  };
+
+  it('returns the explicit key when a custom numeric attribute matches', () => {
+    const result = resolveAttributeFilterKey({
+      name: 'message.parameter.StatusCode',
+      fallbackKey: 'sentry.message.parameter.StatusCode',
+      type: 'int',
+      numberAttributes,
+      booleanAttributes,
+    });
+
+    expect(result).toBe('tags[message.parameter.StatusCode,number]');
+  });
+
+  it('returns the plain key when a known numeric field matches', () => {
+    const result = resolveAttributeFilterKey({
+      name: 'payload_size',
+      fallbackKey: 'payload_size',
+      type: 'int',
+      numberAttributes,
+      booleanAttributes,
+    });
+
+    expect(result).toBe('payload_size');
+  });
+
+  it('returns the explicit key when a boolean attribute matches', () => {
+    const result = resolveAttributeFilterKey({
+      name: 'activity_object_created',
+      fallbackKey: 'activity_object_created',
+      type: 'bool',
+      numberAttributes,
+      booleanAttributes,
+    });
+
+    expect(result).toBe('tags[activity_object_created,boolean]');
+  });
+
+  it('returns the fallback key when the numeric attribute is not in the collection', () => {
+    const result = resolveAttributeFilterKey({
+      name: 'observed_timestamp',
+      fallbackKey: 'observed_timestamp',
+      type: 'float',
+      numberAttributes,
+      booleanAttributes,
+    });
+
+    expect(result).toBe('observed_timestamp');
+  });
+
+  it('returns the fallback key when the value is a string', () => {
+    const result = resolveAttributeFilterKey({
+      name: 'message.parameter.0',
+      fallbackKey: 'sentry.message.parameter.0',
+      type: 'str',
+      numberAttributes,
+      booleanAttributes,
+    });
+
+    expect(result).toBe('sentry.message.parameter.0');
   });
 });

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -47,6 +47,7 @@ import {
 import type {
   TraceItemAttributeMeta,
   TraceItemDetailsMeta,
+  TraceItemResponseAttribute,
 } from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {getLogsUrlFromSavedQueryUrl} from 'sentry/views/explore/logs/utils';
 import {getMetricsUrlFromSavedQueryUrl} from 'sentry/views/explore/metrics/utils';
@@ -660,6 +661,44 @@ export const removeHiddenKeys = (
   }
   return result;
 };
+
+// An untyped attribute key resolves to the string variant on the backend, but an
+// attribute can exist as both a string and a number/boolean at once, so a numeric or
+// boolean value filtered by its plain name targets the wrong (often nonexistent) string
+// variant and validates as "Unknown attribute". Look the attribute up in the
+// type-appropriate collection and use its authoritative key (plain for known fields,
+// tags[name,type] for custom attributes). Falls back to the plain key when not found, so
+// known fields and strings are left untouched.
+export function resolveAttributeFilterKey({
+  name,
+  fallbackKey,
+  type,
+  numberAttributes,
+  booleanAttributes,
+}: {
+  booleanAttributes: TagCollection;
+  fallbackKey: string;
+  name: string;
+  numberAttributes: TagCollection;
+  type: TraceItemResponseAttribute['type'];
+}): string {
+  const collection =
+    type === 'int' || type === 'float'
+      ? numberAttributes
+      : type === 'bool'
+        ? booleanAttributes
+        : undefined;
+
+  if (collection) {
+    for (const attribute of Object.values(collection)) {
+      if (attribute.name === name) {
+        return attribute.key;
+      }
+    }
+  }
+
+  return fallbackKey;
+}
 
 export function getSavedQueryTraceItemUrl({
   savedQuery,


### PR DESCRIPTION
## Summary

`Add to filter` / `Exclude this value` on a log (or metric) attribute built the search with the **plain, untyped** attribute key. The backend resolves an untyped key to the *string* variant, but numeric and boolean attributes — including numeric `message.parameter.*` values — frequently exist **only** as a number/boolean attribute. So the generated query (`message.parameter.StatusCode:200`) targeted a nonexistent string attribute, `/events/validate/` returned `Unknown attribute`, and the search token rendered as invalid — even though the user got there by clicking the value.

The fix resolves the key from the attribute collections instead of synthesizing it: look the clicked attribute up by display name in the type-appropriate collection and use its **authoritative key** — plain for known fields (`payload_size`, `severity_number`), `tags[name,type]` for custom attributes. It falls back to the plain key when the attribute isn't found, so known fields and string values are untouched and no existing filter regresses. No backend change.

This also explains the intermittency in the issue thread: a *string* param only breaks while it exists solely as a number attribute; once the same param is later ingested as a string too, the untyped query resolves and it "starts working." A number-only or boolean-only param reproduces it every time.

> Note: an earlier revision of this branch naively wrapped every numeric value in `tags[...,number]`, which regressed known numeric fields like `payload_size` / `observed_timestamp` (they're valid plain but 400 as `tags[...]`). The collection-lookup approach above avoids that by construction.

## Repro (before this change)

On current production (the fix isn't deployed there yet), or on `master` with this branch stashed:

1. Open **Explore → Logs** and pick a time range with data.
2. Find a log whose message has a **numeric** interpolated parameter (e.g. a `StatusCode`, `count`, `bytes`, or latency-style value). Click the row to open the attribute detail tree.
3. In the tree, find the `message.parameter.<numeric-param>` row and click **Add to filter** from its actions.
4. **Bug:** the search bar receives `message.parameter.<param>:<value>` and the token turns red / invalid ("not a supported search key"), despite being built by clicking the value.
5. **With this change:** the same click produces `tags[message.parameter.<param>,number]:<value>`, which validates and returns results. Boolean-only attributes behave the same way (`tags[key,boolean]`). Known fields (`payload_size`, etc.) keep their plain key.

Quick deterministic check of the underlying cause via the validate endpoint (org with numeric log params):

- `message.parameter.StatusCode:200` → `400` `valid:false` `"Unknown attribute"`
- `tags[message.parameter.StatusCode,number]:200` → `200` `valid:true`
- `payload_size:5` → `200` `valid:true`; `tags[payload_size,number]:5` → `400` (why known fields must stay plain)

Refs LOGS-278
