### PR TITLE
ref: Remove usage exceeded flag from frontend

### DIFF
--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -38,7 +38,6 @@ const getRow = (row: Subscription) => [
             </span>
           )}
         </small>
-        {row.usageExceeded && <Tag variant="warning">Capacity Limit</Tag>}
         {row.isSuspended && (
           <Tooltip title={row.suspensionReason}>
             <Tag variant="danger">Suspended</Tag>
@@ -156,13 +155,6 @@ export function CustomerGrid(props: Props) {
         },
         suspended: {
           name: 'Suspended',
-          options: [
-            ['0', 'No'],
-            ['1', 'Yes'],
-          ],
-        },
-        usageExceeded: {
-          name: 'Usage Exceeded',
           options: [
             ['0', 'No'],
             ['1', 'Yes'],

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -331,7 +331,6 @@ export function CustomerDetails() {
     localityMap[organization?.links.regionUrl || 'unknown'] ?? 'unknown';
 
   const badges: BadgeItem[] = [
-    {name: 'Capacity Limit', level: 'warning', visible: subscription.usageExceeded},
     {
       name: 'Suspended',
       level: 'danger',

--- a/static/gsAdmin/views/overview.tsx
+++ b/static/gsAdmin/views/overview.tsx
@@ -127,7 +127,6 @@ const getCustomerRow = (row: any) => [
             </span>
           )}
         </small>
-        {row.usageExceeded && <Tag variant="warning">Capacity Limit</Tag>}
         {row.isSuspended && (
           <Tooltip title={row.suspensionReason}>
             <Tag variant="danger">Suspended</Tag>

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -138,21 +138,6 @@ describe('GSBanner', () => {
     expect(screen.getByText('Contact Support')).toBeInTheDocument();
   });
 
-  it('renders usage exceeded modal', async () => {
-    const organization = OrganizationFixture({slug: 'exceeded'});
-    SubscriptionStore.set(
-      organization.slug,
-      SubscriptionFixture({organization, usageExceeded: true})
-    );
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-    });
-    renderGlobalModal();
-
-    expect(await screen.findByTestId('modal-usage-exceeded')).toBeInTheDocument();
-  });
-
   it('opens the trialEndingModal within 3 days of ending', async () => {
     const now = moment();
     const organization = OrganizationFixture({

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -55,7 +55,6 @@ import {
 import {
   getContractDaysLeft,
   getProductTrial,
-  getTrialLength,
   hasPartnerMigrationFeature,
   hasPerformance,
   isBusinessTrial,
@@ -70,7 +69,6 @@ import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
 import {withPromotions} from 'getsentry/utils/withPromotions';
 
 enum ModalType {
-  USAGE_EXCEEDED = 'usage-exceeded',
   PAST_DUE = 'past-due',
 }
 
@@ -156,7 +154,6 @@ function SuspensionModal({
 type NoticeModalProps = ModalRenderProps & {
   billingPermissions: boolean;
   organization: Organization;
-  subscription: Subscription;
   whichModal: ModalType;
 };
 
@@ -165,7 +162,6 @@ function NoticeModal({
   Body,
   Footer,
   closeModal,
-  subscription,
   organization,
   whichModal,
   billingPermissions,
@@ -209,14 +205,6 @@ function NoticeModal({
   let primaryButtonMessage: React.ReactNode;
 
   switch (whichModal) {
-    case ModalType.USAGE_EXCEEDED:
-      title = t('Usage exceeded');
-      body = t(
-        'Your organization has depleted its event capacity for the current usage period and is currently not receiving new events.'
-      );
-      link = normalizeUrl(`/settings/${organization.slug}/billing/overview/`);
-      primaryButtonMessage = t('Continue');
-      break;
     case ModalType.PAST_DUE:
       title = t('Unable to bill your account');
       body = billingPermissions
@@ -236,25 +224,6 @@ function NoticeModal({
         : t('See Who Can Update');
       break;
     default:
-  }
-
-  if (subscription.usageExceeded) {
-    if (subscription.isFree) {
-      subText = subscription.canTrial
-        ? t(
-            `Not yet ready to upgrade? You can start a free %s-day trial with
-               unlimited events to better understand your usage.`,
-            getTrialLength(organization)
-          )
-        : t('To ensure uninterrupted service, upgrade your subscription.');
-    } else {
-      subText = tct(
-        'To ensure uninterrupted service, upgrade your subscription or increase your [budgetTerm] spend limit.',
-        {
-          budgetTerm: subscription.planDetails.budgetTerm,
-        }
-      );
-    }
   }
 
   return (
@@ -500,20 +469,10 @@ class GSBanner extends Component<Props, State> {
   tryTriggerNoticeModal() {
     const {organization, subscription} = this.props;
 
-    const whichModal = subscription.usageExceeded
-      ? ModalType.USAGE_EXCEEDED
-      : subscription.isPastDue && subscription.canSelfServe
-        ? ModalType.PAST_DUE
-        : null;
+    const whichModal =
+      subscription.isPastDue && subscription.canSelfServe ? ModalType.PAST_DUE : null;
 
     if (whichModal === null) {
-      return;
-    }
-    // Only show USAGE_EXCEEDED or PAST_DUE for members
-    if (
-      !this.hasBillingPerms &&
-      !(ModalType.USAGE_EXCEEDED || whichModal === ModalType.PAST_DUE)
-    ) {
       return;
     }
 
@@ -525,7 +484,6 @@ class GSBanner extends Component<Props, State> {
     }
 
     const modalAnalytics = {
-      [ModalType.USAGE_EXCEEDED]: 'usage_exceeded_modal.seen',
       [ModalType.PAST_DUE]: 'past_due_modal.seen',
     } as const;
 
@@ -555,10 +513,7 @@ class GSBanner extends Component<Props, State> {
 
     openModal(
       props => (
-        <NoticeModal
-          {...props}
-          {...{organization, subscription, whichModal, billingPermissions}}
-        />
+        <NoticeModal {...props} {...{organization, whichModal, billingPermissions}} />
       ),
       {onClose}
     );

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -372,10 +372,6 @@ export type Subscription = {
   trialEnd: string | null;
   trialPlan: string | null;
   type: BillingType;
-  /**
-   * All quotas available on the plan are exceeded
-   */
-  usageExceeded: boolean;
   // Seats
   usedLicenses: number;
   acv?: number;

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -249,7 +249,6 @@ type GetsentryEventParameters = {
   'upgrade_now.modal.viewed': UpdateProps & {
     has_price_change: undefined | boolean;
   };
-  'usage_exceeded_modal.seen': HasSub;
 };
 
 export type AM2UpdateSurfaces =
@@ -295,7 +294,6 @@ const GETSENTRY_EVENT_MAP: Record<GetsentryEventKey, string> = {
   'performance.quota_exceeded_alert.displayed':
     'Performance: Quota Exceeded Alert Displayed',
   'trial_ended_notice.dismissed_understood': 'Trial Ended Notice: Dismissed understood',
-  'usage_exceeded_modal.seen': 'Usage Exceeded Modal Seen',
   'past_due_modal.seen': 'Past Due Modal Seen',
   'deactivated_member_alert.snoozed': 'Deactivated Member Alert: Snoozed',
   'deactivated_member_alert.upgrade_link_clicked':

--- a/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
@@ -46,34 +46,11 @@ describe('Subscription > UsageAlert', () => {
     expect(screen.getByLabelText('Request Additional Quota')).toBeInTheDocument();
   });
 
-  it('renders an upgrade CTA for mm2_b usage exceeded', () => {
-    const organization = OrganizationFixture({access: ['org:billing']});
-    const subscription = SubscriptionFixture({
-      organization,
-      plan: 'mm2_b_100k',
-      usageExceeded: true,
-      // TODO: Add "categories" when mmx plans have error BillingMetricHistory
-    });
-
-    render(<UsageAlert subscription={subscription} usage={emptyUsage} />, {
-      organization,
-    });
-
-    expect(screen.getByTestId('usage-exceeded-alert')).toBeInTheDocument();
-    expect(screen.getByText('Usage Exceeded')).toBeInTheDocument();
-    expect(
-      screen.getByText(textWithMarkupMatcher(/errors capacity/))
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText('Upgrade Plan')).toBeInTheDocument();
-    expect(screen.queryByTestId('projected-overage-alert')).not.toBeInTheDocument();
-  });
-
   it('renders am1_f usage exceeded errors with trial', () => {
     const organization = OrganizationFixture({access: ['org:billing']});
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_f',
-      usageExceeded: false,
       categories: {
         errors: MetricHistoryFixture({usageExceeded: true}),
       },
@@ -100,7 +77,6 @@ describe('Subscription > UsageAlert', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_team',
-      usageExceeded: false,
       categories: {
         errors: MetricHistoryFixture({
           category: DataCategory.ERRORS,
@@ -133,7 +109,6 @@ describe('Subscription > UsageAlert', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am2_team',
-      usageExceeded: false,
       categories: {
         errors: MetricHistoryFixture({
           usageExceeded: true,
@@ -166,7 +141,6 @@ describe('Subscription > UsageAlert', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am1_team',
-      usageExceeded: false,
       categories: {
         errors: MetricHistoryFixture({
           usageExceeded: true,
@@ -215,7 +189,6 @@ describe('Subscription > UsageAlert', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: plan_id,
-      usageExceeded: true,
       categories: subCategories,
       canTrial: false,
     });
@@ -256,7 +229,6 @@ describe('Subscription > UsageAlert', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: plan_id,
-      usageExceeded: true,
       categories: subCategories,
       canTrial: false,
     });
@@ -297,7 +269,6 @@ describe('Subscription > UsageAlert', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: plan_id,
-      usageExceeded: true,
       categories: subCategories,
       canTrial: false,
     });
@@ -361,7 +332,6 @@ describe('Subscription > UsageAlert', () => {
           subscription={{
             ...subscription,
             plan: 'am1_f',
-            usageExceeded: false,
             categories: {
               errors: MetricHistoryFixture({
                 usageExceeded: true,

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -250,10 +250,9 @@ export function UsageAlert({subscription, usage}: Props) {
     return null;
   }
 
-  const hasExceeded =
-    Object.values(subscription.categories).some(({usageExceeded}) => usageExceeded) ||
-    // TODO: Remove when mmx plans have error BillingMetricHistory
-    subscription.usageExceeded;
+  const hasExceeded = Object.values(subscription.categories).some(
+    ({usageExceeded}) => usageExceeded
+  );
   const projectedOverages = getProjectedOverages();
   const hasOverage = hasExceeded || !!projectedOverages.length;
 

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -139,7 +139,6 @@ export function SubscriptionFixture(props: Props): TSubscription {
     canTrial: true,
     slug: organization.slug,
     pendingChanges: null,
-    usageExceeded: false,
     name: organization.name,
     billingInterval: planDetails.billingInterval || 'monthly',
     dateJoined: '2018-09-10T23:58:10.167Z',


### PR DESCRIPTION
This flag was only set if all categories had exceeded usage. In practice that was only happening for legacy mm plans. Those are all partner plans which can't manage their subscription anyways so would hide the alert telling them to upgrade. There was one place where a modal would still show up driven by this flag, but arguably that is a better UX to remove anyways.