### PR TITLE
feat(pr-metrics): Derive participants_count and reviews_count

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -47,12 +47,21 @@ class PrCloseMetricsEvent(analytics.Event):
     comments_count: int = 0
     review_comments_count: int = 0
     is_assigned: bool = False
+    # Derived from the stored activity log at the terminal event (not the webhook
+    # payload above): ``reviews_count`` = total review submissions;
+    # ``participants_count`` = distinct non-bot senders across the PR's activity.
+    # Only meaningful under ``pr-metrics-activity``; 0 when activity isn't tracked.
+    participants_count: int = 0
+    reviews_count: int = 0
     # The point-in-time attribution snapshot at emit time: a JSON-encoded list of
     # the active (is_valid=True) attributions, each {signal_type, source,
     # signal_details}, ordered by attribution priority (highest-confidence first).
     attributions: str = "[]"
-    # The Seer judge verdict (one of ``PullRequestVerdict``). Null on the no-judge
-    # path and until the judge callback lands a result for a forwarded PR.
+    # The terminal verdict, one of ``PullRequestVerdict``: the deterministic
+    # outcome (``merged_unchanged`` / ``closed_unmerged``) on the no-judge path, or
+    # the Seer judge's verdict on the judge path. Claimed before emit on both paths
+    # (the claim gates emission), so every emitted row carries a verdict — the
+    # ``| None`` is only the column's unset default, not an expected emitted value.
     verdict: str | None = None
     # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
     # "why", a vocabulary shared across judges, not specific to any one. Repeated

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -453,13 +453,12 @@ class PullRequestAttribution(DefaultFieldsModel):
 
 @cell_silo_model
 class PullRequestMetrics(DefaultFieldsModel):
-    """One row per PR holding the webhook-sourced activity counters.
+    """One row per PR holding its metrics — the size/activity counters plus the
+    terminal ``verdict``.
 
     Kept current by the metrics pipeline on each ``pull_request`` webhook and read
-    by the emit/judge path (which, on the Seer callback, has no payload — hence
-    the counts are stored rather than re-derived). ``verdict`` and the Seer-only
-    counters (``participants_count``, ``reviews_count``) are populated later by
-    the judge path, not the webhook.
+    by the emit/judge path — which, on the Seer callback, has no payload, so the
+    values are stored here rather than re-derived at read time.
     """
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -222,11 +222,43 @@ def build_pr_metrics_row(
         comments_count=metrics.comments_count,
         review_comments_count=metrics.review_comments_count,
         is_assigned=metrics.is_assigned,
+        participants_count=metrics.participants_count,
+        reviews_count=metrics.reviews_count,
         attributions=json.dumps(attributions),
         verdict=metrics.verdict,
         diagnosis_labels=list(diagnosis_labels) if diagnosis_labels is not None else None,
         **_conversation_analysis_fields(conversation_analysis),
     )
+
+
+def _activity_derived_counters(pull_request: PullRequest) -> dict[str, int]:
+    """Counters derived from the PR's stored activity log at its terminal event.
+
+    Computed at emit — not on the Seer callback — so both the no-judge and judge
+    paths populate them from data Sentry already holds, independent of whether the
+    PR is judged. Read before ``cleanup_pr_activity_task`` sweeps the activity
+    rows; the results are persisted onto ``PullRequestMetrics`` so a later
+    re-derivation (recovery) reads them off the row, not the deleted activity.
+
+    - ``reviews_count``: total ``REVIEW_SUBMITTED`` rows — every GitHub review
+      submission (a reviewer who submits twice counts twice), not distinct
+      reviewers.
+    - ``participants_count``: distinct non-empty ``sender_login`` across the PR's
+      activity, excluding ``sender_type == "Bot"`` so CI apps and automation don't
+      inflate human participation.
+
+    Both are only meaningful under ``pr-metrics-activity`` (no activity rows → 0).
+    """
+    activities = PullRequestActivity.objects.filter(pull_request=pull_request)
+    reviews_count = activities.filter(event_type=PullRequestActivityType.REVIEW_SUBMITTED).count()
+    participant_logins = {
+        login
+        for login, sender_type in activities.values_list(
+            "payload__sender_login", "payload__sender_type"
+        )
+        if login and sender_type != "Bot"
+    }
+    return {"participants_count": len(participant_logins), "reviews_count": reviews_count}
 
 
 def emit_pr_metrics_row(
@@ -251,6 +283,14 @@ def emit_pr_metrics_row(
     if not attributions:
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return False
+
+    # Derive the activity-sourced counters at the terminal event — before the
+    # activity rows are swept post-emit — and persist them onto the metrics row so
+    # build_pr_metrics_row (and any later re-derivation for recovery) reads the
+    # same final counts. A no-op when Sentry never wrote a metrics row.
+    PullRequestMetrics.objects.filter(pull_request=pull_request).update(
+        **_activity_derived_counters(pull_request)
+    )
 
     close_action: CloseAction = (
         CLOSE_ACTION_MERGED if pull_request.merged_at is not None else CLOSE_ACTION_CLOSED

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -373,9 +373,9 @@ def handle_metrics(
     Kept current on every ``pull_request`` event so the emit path can read the
     counts off the row — the judge path (Seer RPC callback) has no payload to
     derive them from. Registered before ``handle_emission`` so a close/merge
-    reflects the final counts. Gated by the emit flag, the sole consumer; only
-    the webhook-sourced columns are written, leaving the Seer-derived ones
-    (verdict, participants_count, reviews_count) untouched.
+    reflects the final counts. Gated by the emit flag, the sole consumer; it
+    writes only the webhook-sourced counters, leaving the other columns to their
+    own producers.
     """
     pull_request = event.get("pull_request")
     if not pull_request:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -17,6 +17,7 @@ from sentry.models.pullrequest import (
 )
 from sentry.pr_metrics.contracts import PrConversationAnalysis
 from sentry.pr_metrics.emit import (
+    _activity_derived_counters,
     active_attributions,
     build_pr_metrics_row,
     emit_pr_metrics_row,
@@ -516,6 +517,81 @@ class PrMetricsEmissionTest(TestCase):
         emitted = emit_pr_metrics_row(pull_request=self.pull_request)
         assert emitted is False
         assert mock_record.call_count == 0
+
+    # --- _activity_derived_counters (participants_count, reviews_count) ---
+
+    def _activity(
+        self,
+        *,
+        webhook_id: str,
+        event_type: str = PullRequestActivityType.COMMENT_CREATED,
+        sender_login: str = "",
+        sender_type: str = "User",
+    ) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=event_type,
+            payload={"sender_login": sender_login, "sender_type": sender_type},
+        )
+
+    def test_activity_derived_counters_zero_without_activity(self) -> None:
+        assert _activity_derived_counters(self.pull_request) == {
+            "participants_count": 0,
+            "reviews_count": 0,
+        }
+
+    def test_activity_derived_counters_counts_reviews_and_distinct_participants(self) -> None:
+        self._activity(
+            webhook_id="a1", event_type=PullRequestActivityType.OPENED, sender_login="octocat"
+        )
+        self._activity(webhook_id="a2", sender_login="octocat")  # same participant again
+        self._activity(webhook_id="a3", sender_login="reviewer")
+        self._activity(
+            webhook_id="a4",
+            event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+            sender_login="reviewer",
+        )
+        self._activity(
+            webhook_id="a5",
+            event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+            sender_login="reviewer",
+        )
+        assert _activity_derived_counters(self.pull_request) == {
+            "participants_count": 2,  # distinct octocat, reviewer
+            "reviews_count": 2,  # two REVIEW_SUBMITTED rows, not distinct reviewers
+        }
+
+    def test_activity_derived_counters_excludes_bots_and_blank_logins(self) -> None:
+        self._activity(webhook_id="b1", sender_login="human")
+        self._activity(webhook_id="b2", sender_login="dependabot", sender_type="Bot")
+        self._activity(
+            webhook_id="b3", event_type=PullRequestActivityType.SYNCHRONIZED, sender_login=""
+        )
+        assert _activity_derived_counters(self.pull_request) == {
+            "participants_count": 1,  # "human"; bot + blank login excluded
+            "reviews_count": 0,
+        }
+
+    @patch("sentry.analytics.record")
+    def test_emit_persists_and_carries_activity_derived_counts(self, mock_record: Any) -> None:
+        self._track()
+        self._activity(webhook_id="c1", sender_login="octocat")
+        self._activity(
+            webhook_id="c2",
+            event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+            sender_login="reviewer",
+        )
+        emit_pr_metrics_row(pull_request=self.pull_request)
+
+        # Persisted onto the metrics row so recovery re-reads them post-cleanup...
+        row = PullRequestMetrics.objects.get(pull_request=self.pull_request)
+        assert row.participants_count == 2
+        assert row.reviews_count == 1
+        # ...and carried on the emitted analytics row.
+        emitted = mock_record.call_args[0][0]
+        assert emitted.participants_count == 2
+        assert emitted.reviews_count == 1
 
     # --- _commit_shas_from_activity ---
 


### PR DESCRIPTION
## What

Derive the two `PullRequestMetrics` columns that had no producer — `participants_count` and `reviews_count` — from the stored `PullRequestActivity` log at the terminal (close/merge) event, persist them onto the row, and emit them on `PrCloseMetricsEvent`.

- **`reviews_count`** — total `REVIEW_SUBMITTED` activity rows (every review submission; not distinct reviewers).
- **`participants_count`** — distinct non-bot `sender_login` across the PR's activity (bots / CI apps excluded).

Derivation runs at emit, *before* the activity rows are swept post-emit, and is persisted onto the row so both the no-judge and judge paths emit the counts and a later re-derivation (recovery) reads them off the row rather than the deleted activity.

## Why

The two columns were earmarked "Seer-derived" but nothing populated them — they were neither populated nor emitted. Deriving them in Sentry (rather than via a Seer round-trip) means they exist on every tracked PR regardless of whether it's judged. Trade-off: activity-derived counts reflect only the webhooks Sentry received, so a missed delivery undercounts — accepted (completeness over fidelity).

With this, **every `PullRequestMetrics` field is both populated and emitted** — the CORE-236 field audit.

## Also

- Clarify the `PrCloseMetricsEvent.verdict` comment: the verdict is claimed before emit on both paths, so every emitted row carries one — the prior comment wrongly implied null on the no-judge path.
- Drop the stale per-field "producer" enumeration from the model / `handle_metrics` docstrings (it had already gone out of date).

Fixes CORE-236
Refs CORE-223
