### PR TITLE
style(onboarding): tablet, mobile style fixes for scm onboarding

### DIFF
--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -142,7 +142,7 @@ export function NewWelcomeUI(props: StepProps) {
     <MotionContainer width="100%" margin="0 auto" maxWidth="900px" position="relative">
       <MotionFlex direction="column" align="center" {...STAGGER_CONTAINER}>
         <WelcomeBackgroundNewUi />
-        <Stack gap="3xl" align={hasScmOnboarding ? 'start' : 'center'} width="100%">
+        <Stack gap="3xl" align="center" width="100%">
           <MotionStack gap="md" {...ONBOARDING_WELCOME_STAGGER_ITEM} width="100%">
             {hasScmOnboarding ? (
               <Stack gap="lg">
@@ -194,8 +194,9 @@ export function NewWelcomeUI(props: StepProps) {
           </MotionStack>
 
           <MotionGrid
-            columns={{'screen:xs': '1fr', 'screen:md': 'repeat(3, 1fr)'}}
+            columns={{'screen:xs': '1fr', 'screen:sm': 'repeat(3, 1fr)'}}
             gap="3xl"
+            width="100%"
             {...ONBOARDING_WELCOME_STAGGER_ITEM}
             border="muted"
             background="secondary"

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -36,7 +36,7 @@ export function ScmFeatureSelectionCards({
           </Heading>
           {availableFeatures.length > 1 ? (
             <Container>
-              <Text size="sm" variant="secondary" ellipsis>
+              <Text size="sm" variant="secondary">
                 {t('Choose one or more')}
               </Text>
             </Container>

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -1,4 +1,4 @@
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -28,14 +28,18 @@ export function ScmFeatureSelectionCards({
   isOnboarding,
 }: ScmFeatureSelectionCardsProps) {
   return (
-    <Stack gap="xl" width="100%" justify="center">
+    <Stack gap="lg" width="100%" justify="center">
       {isOnboarding ? (
-        <Flex justify="between" align="center">
-          <Heading as="h4">{t('What do you want to instrument?')}</Heading>
+        <Flex justify="between" align="center" gap="md">
+          <Heading as="h4" ellipsis>
+            {t('What do you want to instrument?')}
+          </Heading>
           {availableFeatures.length > 1 ? (
-            <Text size="sm" variant="secondary">
-              {t('Choose one or more')}
-            </Text>
+            <Container>
+              <Text size="sm" variant="secondary" ellipsis>
+                {t('Choose one or more')}
+              </Text>
+            </Container>
           ) : null}
         </Flex>
       ) : null}

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -36,7 +36,7 @@ export function ScmFeatureSelectionCards({
           </Heading>
           {availableFeatures.length > 1 ? (
             <Container>
-              <Text size="sm" variant="secondary">
+              <Text size="sm" variant="secondary" wrap="nowrap">
                 {t('Choose one or more')}
               </Text>
             </Container>

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -366,12 +366,10 @@ export function ScmPlatformFeaturesCore({
       <Flex
         justify="between"
         align={{'screen:xs': 'start', 'screen:sm': 'center'}}
-        maxWidth="100%"
-        minWidth="0%"
         gap="md"
         direction={{'screen:xs': 'column', 'screen:sm': 'row'}}
       >
-        <Flex align="center" gap="sm" maxWidth="100%" minWidth="0%" flexShrink={1}>
+        <Flex align="center" gap="sm">
           <Flex flexShrink={0}>
             <IconBroadcast size="sm" />
           </Flex>

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -373,9 +373,7 @@ export function ScmPlatformFeaturesCore({
           <Flex flexShrink={0}>
             <IconBroadcast size="sm" />
           </Flex>
-          <Heading as="h4" ellipsis>
-            {t('Auto-detected from your repository')}
-          </Heading>
+          <Heading as="h4">{t('Auto-detected from your repository')}</Heading>
         </Flex>
         <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
           {isDetecting

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -378,11 +378,9 @@ export function ScmPlatformFeaturesCore({
           </Heading>
         </Flex>
         <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
-          <Text ellipsis variant="inherit">
-            {isDetecting
-              ? t('Skip detection and select manually')
-              : t("Doesn't look right? Change platform")}
-          </Text>
+          {isDetecting
+            ? t('Skip detection and select manually')
+            : t("Doesn't look right? Change platform")}
         </Button>
       </Flex>
       <Stack gap="lg" width="100%">

--- a/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
+++ b/static/app/views/onboarding/components/scmPlatformFeaturesCore.tsx
@@ -360,18 +360,31 @@ export function ScmPlatformFeaturesCore({
       key="detected"
       initial={{opacity: 0}}
       animate={{opacity: 1}}
-      gap="md"
+      gap="lg"
       width="100%"
     >
-      <Flex justify="between" align="center">
-        <Flex align="center" gap="sm">
-          <IconBroadcast size="sm" />
-          <Heading as="h4">{t('Auto-detected from your repository')}</Heading>
+      <Flex
+        justify="between"
+        align={{'screen:xs': 'start', 'screen:sm': 'center'}}
+        maxWidth="100%"
+        minWidth="0%"
+        gap="md"
+        direction={{'screen:xs': 'column', 'screen:sm': 'row'}}
+      >
+        <Flex align="center" gap="sm" maxWidth="100%" minWidth="0%" flexShrink={1}>
+          <Flex flexShrink={0}>
+            <IconBroadcast size="sm" />
+          </Flex>
+          <Heading as="h4" ellipsis>
+            {t('Auto-detected from your repository')}
+          </Heading>
         </Flex>
         <Button size="xs" variant="link" onClick={handleChangePlatformClick}>
-          {isDetecting
-            ? t('Skip detection and select manually')
-            : t("Doesn't look right? Change platform")}
+          <Text ellipsis variant="inherit">
+            {isDetecting
+              ? t('Skip detection and select manually')
+              : t("Doesn't look right? Change platform")}
+          </Text>
         </Button>
       </Flex>
       <Stack gap="lg" width="100%">

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -600,6 +600,7 @@ const OnboardingContainer = styled('div')<{
   display: flex;
   flex-direction: column;
   position: relative;
+  overflow-x: hidden;
   background: ${p => p.theme.tokens.background.primary};
   padding: ${p => (p.hasScmOnboarding ? '60px' : '120px')} ${p => p.theme.space['2xl']};
   width: 100%;

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -171,7 +171,7 @@ export function ScmPlatformFeatures({
 
   return (
     <Stack align="center" gap="2xl" flexGrow={1}>
-      <Stack gap="3xl" maxWidth={SCM_STEP_CONTENT_WIDTH}>
+      <Stack gap="3xl" maxWidth={`min(${SCM_STEP_CONTENT_WIDTH}, 100%)`}>
         <Heading as="h2" size="4xl">
           {t('Create your first project')}
         </Heading>


### PR DESCRIPTION
- `scmPlatformFeaturesCore.tsx`: the "Auto-detected from your repository" header row now stacks into a column on the smallest breakpoint and stays a row above it, the heading truncates with an ellipsis, and the broadcast icon no longer shrinks.
- `scmFeatureSelectionCards.tsx`: the "What do you want to instrument?" heading and the "Choose one or more" hint both truncate, with a gap added between them.
- `newWelcome.tsx`: the welcome content always centers, and the benefits grid switches to three columns one breakpoint earlier while filling the available width.
- `scmPlatformFeatures.tsx`: the step content width is capped at the viewport so it cannot exceed 100%.
- `onboarding.tsx`: clip horizontal overflow on the SCM onboarding container so the off-canvas welcome background images cannot add horizontal scroll on narrow viewports.


| before | after |
| --- | --- |
| <img width="375" height="667" alt="Screenshot 2026-07-02 at 3 52 35 PM" src="https://github.com/user-attachments/assets/57720c70-e820-4137-b547-05991e4bdc72" /> | <img width="376" height="666" alt="Screenshot 2026-07-02 at 3 50 35 PM" src="https://github.com/user-attachments/assets/49eb6efc-e97c-4d66-aeab-48ce82a74048" /> | 
| <img width="918" height="1106" alt="Screenshot 2026-07-02 at 4 00 17 PM" src="https://github.com/user-attachments/assets/fc851558-6d29-4d34-8cbf-0a77893ed7de" /> | <img width="916" height="1106" alt="Screenshot 2026-07-02 at 4 00 36 PM" src="https://github.com/user-attachments/assets/406c0db3-36a3-420d-9b88-6a09d5291a68" /> |


