### PR TITLE
ref(features): Remove unused `organizations:profiling-beta` flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -219,8 +219,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Enabled for those orgs who participated in the profiling Beta program
-    manager.add("organizations:profiling-beta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enables dropping of profiles that may come from buggy sdks
     manager.add("organizations:profiling-reject-sdks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable global suspect functions in profiling


### PR DESCRIPTION
Remove the `organizations:profiling-beta` feature flag registration. The flag is dead — no `features.has("organizations:profiling-beta")` call in sentry or getsentry and no frontend usage. It was an `INTERNAL`-strategy flag (never in flagpole/the options-automator).

Its only backing code, `ProfilingBetaFeatureHandler` in getsentry, is removed in getsentry/getsentry#20922. Merge that PR first; this registration removal follows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMyfp9qHNrpjJdjxvNVun6)_