### PR TITLE
fix(alerts): Scope lookup to project in path

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -60,26 +60,26 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
             method_flag is not None and features.has(method_flag, project.organization)
         )
         if use_workflow_engine:
-            try:
-                arw = AlertRuleWorkflow.objects.get(
-                    rule_id=rule_id,
-                    workflow__organization=project.organization,
-                    workflow__status=ObjectStatus.ACTIVE,
-                    workflow__detectorworkflow__detector__project=project,
-                )
+            arw = AlertRuleWorkflow.objects.filter(
+                rule_id=rule_id,
+                workflow__organization=project.organization,
+                workflow__status=ObjectStatus.ACTIVE,
+                workflow__detectorworkflow__detector__project=project,
+            ).first()
+            if arw is not None:
                 kwargs["rule"] = arw.workflow
-            except AlertRuleWorkflow.DoesNotExist:
+            else:
                 # XXX: this means the workflow was single written and has no ARW or related Rule object
-                try:
-                    workflow_id = get_object_id_from_fake_id(int(rule_id))
-                    kwargs["rule"] = Workflow.objects.get(
-                        id=workflow_id,
-                        organization=project.organization,
-                        status=ObjectStatus.ACTIVE,
-                        detectorworkflow__detector__project=project,
-                    )
-                except (AlertRuleWorkflow.DoesNotExist, Workflow.DoesNotExist):
+                workflow_id = get_object_id_from_fake_id(int(rule_id))
+                workflow = Workflow.objects.filter(
+                    id=workflow_id,
+                    organization=project.organization,
+                    status=ObjectStatus.ACTIVE,
+                    detectorworkflow__detector__project=project,
+                ).first()
+                if workflow is None:
                     raise ResourceDoesNotExist
+                kwargs["rule"] = workflow
 
             return args, kwargs
 

--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -65,6 +65,7 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
                     rule_id=rule_id,
                     workflow__organization=project.organization,
                     workflow__status=ObjectStatus.ACTIVE,
+                    workflow__detectorworkflow__detector__project=project,
                 )
                 kwargs["rule"] = arw.workflow
             except AlertRuleWorkflow.DoesNotExist:
@@ -75,6 +76,7 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
                         id=workflow_id,
                         organization=project.organization,
                         status=ObjectStatus.ACTIVE,
+                        detectorworkflow__detector__project=project,
                     )
                 except (AlertRuleWorkflow.DoesNotExist, Workflow.DoesNotExist):
                     raise ResourceDoesNotExist

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -11,6 +11,7 @@ from slack_sdk.web.slack_response import SlackResponse
 
 from sentry.analytics.events.rule_reenable import RuleReenableEdit
 from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.integrations.slack.utils.channel import strip_channel_name
@@ -182,7 +183,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
             }
         ]
         # create single written workflow
-        self.detector = self.create_detector()
+        self.detector = self.create_detector(project=self.project)
         self.workflow_triggers = self.create_data_condition_group()
         self.workflow = self.create_workflow(
             when_condition_group=self.workflow_triggers,
@@ -248,6 +249,40 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
 
     def test_non_existing_rule(self) -> None:
         self.get_error_response(self.organization.slug, self.project.slug, 12345, status_code=404)
+
+    def test_cannot_get_other_project_workflow_rule(self) -> None:
+        """
+        Test that a user with access to project A but not project B must not be able to
+        reach project B's workflow-backed rule by using project A's slug in the
+        URL together with project B's rule id
+        """
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],  # self.team owns self.project (project A), not project B
+        )
+        self.login_as(member_user)
+
+        other_project = self.create_project(organization=self.organization)
+
+        # Dual-written rule in project B (resolved via AlertRuleWorkflow.rule_id).
+        other_rule = self.create_project_rule(project=other_project)
+        self.get_error_response(
+            self.organization.slug, self.project.slug, other_rule.id, status_code=404
+        )
+
+        # Single-written workflow in project B (resolved via the fake workflow id).
+        other_detector = self.create_detector(project=other_project)
+        other_workflow = self.create_workflow(organization=self.organization)
+        self.create_detector_workflow(detector=other_detector, workflow=other_workflow)
+        fake_other_workflow_id = get_fake_id_from_object_id(other_workflow.id)
+        self.get_error_response(
+            self.organization.slug, self.project.slug, fake_other_workflow_id, status_code=404
+        )
 
     @freeze_time()
     def test_last_triggered(self) -> None:
@@ -1548,6 +1583,63 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not Workflow.objects.filter(id=workflow.id).exists()
         other_rule.refresh_from_db()
         assert other_rule.status == ObjectStatus.ACTIVE
+
+    def test_cannot_delete_other_project_workflow_rule(self) -> None:
+        """
+        Test that a user with access to project A but not project B must not be able to
+        delete project B's workflow-backed rule via project A's slug
+        """
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role="member",
+            teams=[self.team],  # self.team owns self.project (project A), not project B
+        )
+        self.login_as(member_user)
+
+        other_project = self.create_project(organization=self.organization)
+
+        # Dual-written rule in project B (resolved via AlertRuleWorkflow.rule_id).
+        other_rule = self.create_project_rule(project=other_project)
+        other_workflow = AlertRuleWorkflow.objects.get(rule_id=other_rule.id).workflow
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            other_rule.id,
+            method="delete",
+            status_code=404,
+        )
+        other_rule.refresh_from_db()
+        other_workflow.refresh_from_db()
+        assert other_rule.status == ObjectStatus.ACTIVE
+        assert other_workflow.status == ObjectStatus.ACTIVE
+        assert not CellScheduledDeletion.objects.filter(
+            model_name="Workflow", object_id=other_workflow.id
+        ).exists()
+        assert not CellScheduledDeletion.objects.filter(
+            model_name="Rule", object_id=other_rule.id
+        ).exists()
+
+        # Single-written workflow in project B (resolved via the fake workflow id).
+        other_detector = self.create_detector(project=other_project)
+        single_written_workflow = self.create_workflow(organization=self.organization)
+        self.create_detector_workflow(detector=other_detector, workflow=single_written_workflow)
+        fake_other_workflow_id = get_fake_id_from_object_id(single_written_workflow.id)
+        self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            fake_other_workflow_id,
+            method="delete",
+            status_code=404,
+        )
+        single_written_workflow.refresh_from_db()
+        assert single_written_workflow.status == ObjectStatus.ACTIVE
+        assert not CellScheduledDeletion.objects.filter(
+            model_name="Workflow", object_id=single_written_workflow.id
+        ).exists()
 
 
 class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):


### PR DESCRIPTION
Scope the alertruleworkflow or workflow lookup to the project passed in that path to prevent any access from a user without access to that project.