### PR TITLE
ref(utils): Rollout comparator comment and test tweaks

### DIFF
--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -31,7 +31,8 @@ class SafeRolloutComparator:
     counts as a "reasonable" (close enough) match is definable by providing a comparison function.)
     Once a callsite looks correct enough, you can switch the code behavior to actually use the data
     from the experimental branch by adding the callsite indentifier to the "use experimental data"
-    allowlist option provided by the class.
+    allowlist option provided by the class. It's also possible to run the comparison separate from
+    choosing which data to use, by using the `compare` method.
 
     The flow is generally:
       1. Set up your `SafeRolloutComparator` subclass (in Sentry) & options (in options automator).
@@ -71,6 +72,16 @@ class SafeRolloutComparator:
             )
         else:
             data = control_data
+    ```
+
+    In options-automator:
+    ```
+    dynamic.saferollouts.some_new_feature.should_eval_experimental: True
+    dynamic.saferollouts.some_new_feature.callsite_experiment_sample_rate:
+      { "some.module.path.some_function": 0.0001 }
+    dynamic.saferollouts.some_new_feature.eval_experimental_sample_rate: 0.0001 # Fallback rate
+    dynamic.saferollouts.some_new_feature.mismatch_log_callsite_allowlist:
+      ["*"] # Log mismatches for all callsites
     ```
     """
 
@@ -112,9 +123,9 @@ class SafeRolloutComparator:
     @classmethod
     def _callsite_experiment_blocklist_option(cls) -> str:
         """
-        This is the callsite-level experimemt rollout option. If the option value contains a
-        callsite, the `should_check_experiment` function will return False. (This is useful if you
-        see one callsite in particular start throwing.) Defaults to an empty list.
+        This is a list containing callsites for which the experiment shouldn't be run; if the option
+        value contains a callsite, the `should_check_experiment` function will return False. (This
+        is useful if you see one callsite in particular start throwing.) Defaults to an empty list.
         """
         return f"dynamic.saferollouts.{cls.ROLLOUT_NAME}.eval_callsite_blocklist"
 
@@ -333,10 +344,11 @@ class SafeRolloutComparator:
             should pass "both".
         * is_experimental_data_nullish: Whether the result is a "null result" (e.g. empty array).
             This helps to determine whether a "match" is significant.
-        * reasonable_match_comparator: Optional predicate for semantic correctness, returning True
-            if the data is "reasonably the same" and False otherwise. An example might be checking
-            whether the experimental data is a subset of the control data (useful in case of
-            migrating something where you don't yet have full retention in the experimental branch).
+        * reasonable_match_comparator: Optional function to determine if the control data and
+            experimental data are "reasonably the same." An example might be checking whether the
+            experimental data is a subset of the control data (useful in case of migrating something
+            where you don't yet have full retention in the experimental branch). If not provided, no
+            "reasonable match" comparison will be performed.
         * debug_context: Optional structured metadata included on mismatch logs.
         * data_serializer: Optional serializer for control/experimental payloads in logs. Defaults
             to `_default_serialize_for_log`.

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from sentry import options
 from sentry.options import all as all_options
 from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -32,7 +33,7 @@ class SafeRolloutComparatorTestCase(TestCase):
         # We need to instantiate the comparator class in order for the options to be registered
         TestRolloutComparator()
 
-    def test_options_registered(self) -> None:
+    def test_all_options_registered(self) -> None:
         option_names = [o.name for o in all_options()]
 
         assert TEST_SHOULD_RUN_EXPERIMENT_OPTION in option_names
@@ -42,35 +43,22 @@ class SafeRolloutComparatorTestCase(TestCase):
         assert TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION in option_names
         assert TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION in option_names
 
-    def test_return_as_expected(self) -> None:
+    def test_experiment_enablement(self) -> None:
         with override_options({TEST_SHOULD_RUN_EXPERIMENT_OPTION: False}):
+            assert options.get(TEST_EXPERIMENT_SAMPLE_RATE_OPTION) == 1.0
+            assert options.get(TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION) == []
+            # Even though the sample rate is 100% (the default), and the callsite isn't blocklisted,
+            # the experiment won't run
             assert TestRolloutComparator.should_check_experiment("test_1") is False
 
-        with override_options(
-            {
-                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
-            }
-        ):
+        with override_options({TEST_SHOULD_RUN_EXPERIMENT_OPTION: True}):
             assert TestRolloutComparator.should_check_experiment("test_2") is True
-            assert TestRolloutComparator.should_check_experiment("test_blocked") is False
 
-        with override_options(
-            {
-                TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: [],
-                TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: ["test_allowed"],
-            }
-        ):
-            assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_3") == "ctl"
-            assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_allowed") == "exp"
-
-    def test_eval_experimental_sample_rate(self) -> None:
+    def test_experiment_sample_rate(self) -> None:
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
                 TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 0.5,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
             }
         ):
             with patch("sentry.utils.rollout.random.random", return_value=0.3):
@@ -95,7 +83,6 @@ class SafeRolloutComparatorTestCase(TestCase):
                     "all_dogs_are_good": True,  # invalid value
                     "roll_over": "good_dog",  # invalid value
                 },
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
             }
         ):
             # Value which passes both the general and valid callsite-specific rates
@@ -119,30 +106,20 @@ class SafeRolloutComparatorTestCase(TestCase):
                 assert TestRolloutComparator.should_check_experiment("all_dogs_are_good") is False
                 assert TestRolloutComparator.should_check_experiment("roll_over") is False
 
-    def test_eval_experimental_respects_blocklist(self) -> None:
+    def test_experiment_callsite_blocklist(self) -> None:
         with override_options(
             {
                 TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
                 TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: ["test_blocked"],
             }
         ):
+            assert options.get(TEST_EXPERIMENT_SAMPLE_RATE_OPTION) == 1.0
             # Even with 100% sample rate, blocklisted callsites should be blocked
             assert TestRolloutComparator.should_check_experiment("test_blocked") is False
             # Non-blocklisted callsites should still work
             assert TestRolloutComparator.should_check_experiment("test_not_blocked") is True
 
-    def test_eval_experimental_sample_rate_respects_eval_disabled(self) -> None:
-        with override_options(
-            {
-                TEST_SHOULD_RUN_EXPERIMENT_OPTION: False,
-                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
-            }
-        ):
-            assert TestRolloutComparator.should_check_experiment("test_disabled") is False
-
-    def test_should_log_mismatch_allowlist(self) -> None:
+    def test_mismatch_logging_allowlist(self) -> None:
         with override_options({TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: []}):
             assert TestRolloutComparator._should_log_mismatch("callsite") is False
 
@@ -154,20 +131,24 @@ class SafeRolloutComparatorTestCase(TestCase):
             assert TestRolloutComparator._should_log_mismatch("callsite") is True
             assert TestRolloutComparator._should_log_mismatch("other") is True
 
-    @patch("sentry.utils.rollout.SafeRolloutComparator.check_and_choose")
-    def test_check_and_choose_with_timings_forwards_debug_args(
-        self, check_and_choose: MagicMock
-    ) -> None:
-        check_and_choose.return_value = "control"
-        serializer = lambda value: {"value": str(value)}
-
+    def test_experimental_data_use(self) -> None:
         with override_options(
             {
-                TEST_SHOULD_RUN_EXPERIMENT_OPTION: True,
-                TEST_EXPERIMENT_SAMPLE_RATE_OPTION: 1.0,
-                TEST_CALLSITE_EXPERIMENT_BLOCKLIST_OPTION: [],
+                TEST_CALLSITE_USE_EXPERIMENTAL_DATA_ALLOWLIST_OPTION: ["known_good_callsite"],
             }
         ):
+            assert TestRolloutComparator.check_and_choose("ctl", "exp", "test_3") == "ctl"
+            assert (
+                TestRolloutComparator.check_and_choose("ctl", "exp", "known_good_callsite") == "exp"
+            )
+
+    @patch("sentry.utils.rollout.SafeRolloutComparator.check_and_choose", return_value="control")
+    def test_check_and_choose_with_timings_forwards_debug_args(
+        self, mock_check_and_choose: MagicMock
+    ) -> None:
+        serializer = lambda value: {"value": str(value)}
+
+        with override_options({TEST_SHOULD_RUN_EXPERIMENT_OPTION: True}):
             TestRolloutComparator.check_and_choose_with_timings(
                 control_data_func=lambda: "control",
                 experimental_data_func=lambda: "experimental",
@@ -176,6 +157,6 @@ class SafeRolloutComparatorTestCase(TestCase):
                 data_serializer=serializer,
             )
 
-        assert check_and_choose.called
-        assert check_and_choose.call_args.kwargs["debug_context"] == {"x": "y"}
-        assert check_and_choose.call_args.kwargs["data_serializer"] is serializer
+        assert mock_check_and_choose.called
+        assert mock_check_and_choose.call_args.kwargs["debug_context"] == {"x": "y"}
+        assert mock_check_and_choose.call_args.kwargs["data_serializer"] is serializer


### PR DESCRIPTION
This is a collection of small refactors to comments and tests for the `SafeRolloutComparator` utility, extracted from an upcoming PR to make it easier to review. No behavior changes.