### PR TITLE
feat(utils): Add exact match callback option to rollout comparator

### DIFF
--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -28,7 +28,9 @@ class SafeRolloutComparator:
 
     In particular, it can (with callsite-by-callsite granularity) help to track rate at which the
     experimental branch both exactly matches and "reasonably" matches the control branch. (What
-    counts as a "reasonable" (close enough) match is definable by providing a comparison function.)
+    counts as an exact match and as a "reasonable" (close enough) match is definable by providing a
+    callback for each comparison.)
+
     Once a callsite looks correct enough, you can switch the code behavior to actually use the data
     from the experimental branch by adding the callsite indentifier to the "use experimental data"
     allowlist option provided by the class. It's also possible to run the comparison separate from
@@ -323,6 +325,7 @@ class SafeRolloutComparator:
         callsite: str,
         source_of_truth: SourceOfTruth = "neither",
         is_experimental_data_nullish: bool | None = None,
+        exact_match_comparator: Callable[[TData, TData], bool] | None = None,
         reasonable_match_comparator: Callable[[TData, TData], bool] | None = None,
         debug_context: dict[str, Any] | None = None,
         data_serializer: Callable[[TData], Any] | None = None,
@@ -344,6 +347,8 @@ class SafeRolloutComparator:
             should pass "both".
         * is_experimental_data_nullish: Whether the result is a "null result" (e.g. empty array).
             This helps to determine whether a "match" is significant.
+        * exact_match_comparator: Optional function to determine if the control data and
+            experimental data are considered a match. If not provided, strict equality will be used.
         * reasonable_match_comparator: Optional function to determine if the control data and
             experimental data are "reasonably the same." An example might be checking whether the
             experimental data is a subset of the control data (useful in case of migrating something
@@ -367,12 +372,24 @@ class SafeRolloutComparator:
         if is_experimental_data_nullish is not None:
             tags["is_null_result"] = str(is_experimental_data_nullish)
 
+        if exact_match_comparator is not None:
+            try:
+                is_exact_match = exact_match_comparator(control_data, experimental_data)
+            except Exception:
+                logger.exception(
+                    "saferollout.exact_match_comparator_error",
+                    extra={"rollout_name": cls.ROLLOUT_NAME, "callsite": callsite},
+                )
+                is_exact_match = control_data == experimental_data
+            else:
+                tags["exact_match"] = str(is_exact_match)
+
         if reasonable_match_comparator is not None:
             try:
                 is_reasonable_match = reasonable_match_comparator(control_data, experimental_data)
             except Exception:
                 logger.exception(
-                    "saferollout.comparator_error",
+                    "saferollout.reasonable_match_comparator_error",
                     extra={"rollout_name": cls.ROLLOUT_NAME, "callsite": callsite},
                 )
                 is_reasonable_match = None
@@ -417,6 +434,7 @@ class SafeRolloutComparator:
         experimental_data: TData,
         callsite: str,
         is_experimental_data_nullish: bool | None = None,
+        exact_match_comparator: Callable[[TData, TData], bool] | None = None,
         reasonable_match_comparator: Callable[[TData, TData], bool] | None = None,
         debug_context: dict[str, Any] | None = None,
         data_serializer: Callable[[TData], Any] | None = None,
@@ -435,6 +453,7 @@ class SafeRolloutComparator:
             callsite=callsite,
             source_of_truth="experimental" if use_experimental_data else "control",
             is_experimental_data_nullish=is_experimental_data_nullish,
+            exact_match_comparator=exact_match_comparator,
             reasonable_match_comparator=reasonable_match_comparator,
             debug_context=debug_context,
             data_serializer=data_serializer,
@@ -449,6 +468,7 @@ class SafeRolloutComparator:
         experimental_data_func: Callable[[], TData],
         callsite: str,
         null_result_determiner: Callable[[TData], bool] | None = None,
+        exact_match_comparator: Callable[[TData, TData], bool] | None = None,
         reasonable_match_comparator: Callable[[TData, TData], bool] | None = None,
         debug_context: dict[str, Any] | None = None,
         data_serializer: Callable[[TData], Any] | None = None,
@@ -497,6 +517,7 @@ class SafeRolloutComparator:
             experimental_data=experimental_data,
             callsite=callsite,
             is_experimental_data_nullish=is_experimental_data_nullish,
+            exact_match_comparator=exact_match_comparator,
             reasonable_match_comparator=reasonable_match_comparator,
             debug_context=debug_context,
             data_serializer=data_serializer,

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -142,6 +142,55 @@ class SafeRolloutComparatorTestCase(TestCase):
                 TestRolloutComparator.check_and_choose("ctl", "exp", "known_good_callsite") == "exp"
             )
 
+    def test_comparator_use(self) -> None:
+        exact_matcher = lambda control, exp: exp["dogs"] == control["dogs"]
+        close_matcher = lambda control, exp: exp["dogs"].issubset(control["dogs"])
+        expected_tags = {
+            "rollout_name": "test_rollout",
+            "callsite": "dogs_are_great",
+            "source_of_truth": "neither",
+        }
+
+        with patch("sentry.utils.rollout.metrics.incr") as mock_metrics_incr:
+            TestRolloutComparator.compare(
+                control_data={"dogs": {"maisey"}},
+                experimental_data={"dogs": {"maisey"}},
+                callsite="dogs_are_great",
+                exact_match_comparator=exact_matcher,
+            )
+            mock_metrics_incr.assert_called_with(
+                "SafeRolloutComparator.compare",
+                sample_rate=0.1,
+                tags={**expected_tags, "exact_match": "True"},
+            )
+
+        with patch("sentry.utils.rollout.metrics.incr") as mock_metrics_incr:
+            TestRolloutComparator.compare(
+                control_data={"dogs": {"charlie"}},
+                experimental_data={"dogs": {"maisey"}},
+                callsite="dogs_are_great",
+                exact_match_comparator=exact_matcher,
+            )
+            mock_metrics_incr.assert_called_with(
+                "SafeRolloutComparator.compare",
+                sample_rate=0.1,
+                tags={**expected_tags, "exact_match": "False"},
+            )
+
+        with patch("sentry.utils.rollout.metrics.incr") as mock_metrics_incr:
+            TestRolloutComparator.compare(
+                control_data={"dogs": {"charlie", "maisey"}},
+                experimental_data={"dogs": {"maisey"}},
+                callsite="dogs_are_great",
+                exact_match_comparator=exact_matcher,
+                reasonable_match_comparator=close_matcher,
+            )
+            mock_metrics_incr.assert_called_with(
+                "SafeRolloutComparator.compare",
+                sample_rate=0.1,
+                tags={**expected_tags, "exact_match": "False", "reasonable_match": "True"},
+            )
+
     @patch("sentry.utils.rollout.SafeRolloutComparator.check_and_choose", return_value="control")
     def test_check_and_choose_with_timings_forwards_debug_args(
         self, mock_check_and_choose: MagicMock


### PR DESCRIPTION
The `SafeRolloutComparator` utility includes the option to specify a callback to use when determining whether the control and experimental data are "reasonably the same," but it doesn't offer the same flexibility for checking for exact matches (it just runs a strict equality check on the two values it's passed). This PR changes that by adding a comparable callback option for testing if the new and old data match exactly.

(This came up in the process of testing the new span-first issue detectors. We're comparing the problems they generate to problems generated by the existing detectors, to make sure they're giving the same results, and the actual comparison is being done by checking problem fingerprints, so that's what we're currently passing to the comparator's `compare` method. But that means that in the small handful of cases so far where we've seen a mismatch, all the logs show is the two different fingerprint lists - not very helpful for debugging. Really what we need is to log the full `PerformanceProblem` objects, but if we pass those to `compare` instead, we'll then be running a strict equality check on the objects, not their fingerprints. Hence the need for this option.)