### PR TITLE
fix(sentry apps): Restrict access to external issue actions without correct scope

### DIFF
--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -462,7 +462,7 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
 
 class SentryAppInstallationExternalIssuePermission(SentryAppInstallationPermission):
     scope_map = {
-        "POST": ("event:read", "event:write", "event:admin"),
+        "POST": ("event:write", "event:admin"),
         "DELETE": ("event:admin",),
     }
 

--- a/src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_external_issue_actions.py
@@ -6,7 +6,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import control_silo_endpoint
 from sentry.api.serializers import serialize
-from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationBaseEndpoint
+from sentry.sentry_apps.api.bases.sentryapps import SentryAppInstallationExternalIssueBaseEndpoint
 from sentry.sentry_apps.api.serializers.platform_external_issue import (
     PlatformExternalIssueSerializer,
 )
@@ -24,7 +24,9 @@ class SentryAppInstallationExternalIssueActionsSerializer(serializers.Serializer
 
 
 @control_silo_endpoint
-class SentryAppInstallationExternalIssueActionsEndpoint(SentryAppInstallationBaseEndpoint):
+class SentryAppInstallationExternalIssueActionsEndpoint(
+    SentryAppInstallationExternalIssueBaseEndpoint
+):
     owner = ApiOwner.INTEGRATION_PLATFORM
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -132,6 +132,68 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         assert response.status_code == 400
         assert "uri" in response.data
 
+    def _set_up_token(self, scopes: list[str]):
+        scoped_app = self.create_sentry_app(
+            name="Scoped", organization=self.org, webhook_url="https://example.com", scopes=scopes
+        )
+        scoped_install = self.create_sentry_app_installation(
+            organization=self.org, slug=scoped_app.slug, user=self.user
+        )
+        token = self.create_internal_integration_token(install=scoped_install, user=self.user)
+        url = reverse(
+            "sentry-api-0-sentry-app-installation-external-issue-actions",
+            args=[scoped_install.uuid],
+        )
+        return token, url
+
+    def test_rejects_token_without_event_scope(self) -> None:
+        token, url = self._set_up_token(["org:integrations"])
+        response = self.client.post(
+            url,
+            data={
+                "groupId": self.group.id,
+                "action": "create",
+                "fields": {"title": "Hello"},
+                "uri": "/create-issues",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+        assert response.status_code == 403
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
+    @responses.activate
+    def test_creates_external_issue_with_event_scope(self) -> None:
+        token, url = self._set_up_token(["event:write"])
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/create-issues",
+            json={
+                "project": "ProjectName",
+                "webUrl": "https://example.com/project/issue-id",
+                "identifier": "issue-1",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        response = self.client.post(
+            url,
+            data={
+                "groupId": self.group.id,
+                "action": "create",
+                "fields": {"title": "Hello"},
+                "uri": "/create-issues",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 200
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
     def test_rejects_group_from_inaccessible_project(self) -> None:
         with assume_test_silo_mode_of(Organization):
             self.org.flags.allow_joinleave = False

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -163,6 +163,23 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         with assume_test_silo_mode_of(PlatformExternalIssue):
             assert not PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
 
+    def test_rejects_token_with_only_read_scope(self) -> None:
+        token, url = self._set_up_token(["event:read"])
+        response = self.client.post(
+            url,
+            data={
+                "groupId": self.group.id,
+                "action": "create",
+                "fields": {"title": "Hello"},
+                "uri": "/create-issues",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+        assert response.status_code == 403
+        with assume_test_silo_mode_of(PlatformExternalIssue):
+            assert not PlatformExternalIssue.objects.filter(group_id=self.group.id).exists()
+
     @responses.activate
     def test_creates_external_issue_with_event_scope(self) -> None:
         token, url = self._set_up_token(["event:write"])

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -1,6 +1,7 @@
 import responses
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
 from sentry.models.organization import Organization
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.testutils.cases import APITestCase
@@ -132,7 +133,7 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         assert response.status_code == 400
         assert "uri" in response.data
 
-    def _set_up_token(self, scopes: list[str]):
+    def _set_up_token(self, scopes: list[str]) -> tuple[ApiToken, str]:
         scoped_app = self.create_sentry_app(
             name="Scoped", organization=self.org, webhook_url="https://example.com", scopes=scopes
         )


### PR DESCRIPTION
Fix so that the sentry app external issue actions POST method rejects requests if the token doesn't have the `event:write` scope. 