### PR TITLE
ref(billing): Remove dead overage-warning banner code

### DIFF
--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -13,7 +13,6 @@ import {Flex, Grid} from '@sentry/scraps/layout';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
-import type {PromptData} from 'sentry/actionCreators/prompts';
 import {
   batchedPromptsCheck,
   promptsCheck,
@@ -39,7 +38,6 @@ import {
   openTrialEndingModal,
 } from 'getsentry/actionCreators/modal';
 import type {EventType} from 'getsentry/components/addEventsCTA';
-import AddEventsCTA from 'getsentry/components/addEventsCTA';
 import {ProductTrialAlert} from 'getsentry/components/productTrial/productTrialAlert';
 import {getProductForPath} from 'getsentry/components/productTrial/productTrialPaths';
 import {makeLinkToOwnersAndBillingMembers} from 'getsentry/components/profiling/alerts';
@@ -88,8 +86,6 @@ function objectFromBilledCategories(callback: (c: BilledDataCategoryInfo) => any
     {} as Record<EventType, any>
   );
 }
-
-const ALERTS_OFF = objectFromBilledCategories(() => false);
 
 type SuspensionModalProps = ModalRenderProps & {
   organization: Organization;
@@ -267,8 +263,6 @@ type Props = {
 
 type State = {
   deactivatedMemberDismissed: boolean;
-  overageAlertDismissed: Record<EventType, boolean>;
-  overageWarningDismissed: Record<EventType, boolean>;
   productTrialDismissed: Record<EventType, boolean>;
 };
 
@@ -276,8 +270,6 @@ class GSBanner extends Component<Props, State> {
   // assume dismissed until we've checked the backend
   state: State = {
     deactivatedMemberDismissed: true,
-    overageAlertDismissed: objectFromBilledCategories(() => true),
-    overageWarningDismissed: objectFromBilledCategories(() => true),
     productTrialDismissed: objectFromBilledCategories(() => true),
   };
   async componentDidMount() {
@@ -295,23 +287,6 @@ class GSBanner extends Component<Props, State> {
       this.tryTriggerPartnerPlanEndingModal();
     }
     await this.checkPrompts();
-
-    // must happen after prompts check
-    if (this.overageAlertType !== null) {
-      const {organization, subscription} = this.props;
-      const isWarning = this.overageAlertType === 'warning';
-      const eventTypes = Object.entries(
-        isWarning ? this.overageWarningActive : this.overageAlertActive
-      )
-        .filter(([_, value]) => value)
-        .map(([key, _]) => key as EventType);
-      trackGetsentryAnalytics('quota_alert.alert_displayed', {
-        organization,
-        subscription,
-        event_types: eventTypes.sort().join(','),
-        is_warning: isWarning,
-      });
-    }
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -585,8 +560,6 @@ class GSBanner extends Component<Props, State> {
       return;
     }
 
-    const category_overage_prompts: string[] = [];
-    const category_warning_prompts: string[] = [];
     const category_product_trial_prompts: string[] = [];
 
     Object.values(BILLED_DATA_CATEGORY_INFO)
@@ -597,8 +570,6 @@ class GSBanner extends Component<Props, State> {
       )
       .forEach(categoryInfo => {
         const snakeCasePlural = snakeCase(categoryInfo.plural);
-        category_overage_prompts.push(`${snakeCasePlural}_overage_alert`);
-        category_warning_prompts.push(`${snakeCasePlural}_warning_alert`);
         if (categoryInfo.canProductTrial) {
           category_product_trial_prompts.push(`${snakeCasePlural}_product_trial_alert`);
         }
@@ -610,12 +581,6 @@ class GSBanner extends Component<Props, State> {
         [
           'deactivated_member_alert',
 
-          // overage alerts
-          ...category_overage_prompts,
-
-          // warning alerts
-          ...category_warning_prompts,
-
           // product trial alerts
           ...category_product_trial_prompts,
         ],
@@ -624,34 +589,10 @@ class GSBanner extends Component<Props, State> {
         }
       );
 
-      // overage notifications should get reset when ondemand period ends
-      const promptIsDismissedForBillingPeriod = (prompt: PromptData) => {
-        const {snoozedTime, dismissedTime} = prompt || {};
-        // TODO: dismissed prompt should always return false
-        const time = snoozedTime || dismissedTime;
-        if (!time) {
-          return false;
-        }
-        const onDemandPeriodEnd = new Date(subscription.onDemandPeriodEnd);
-        onDemandPeriodEnd.setHours(23, 59, 59);
-        return time <= onDemandPeriodEnd.getTime() / 1000;
-      };
-
       this.setState({
         // not billing related prompt checks
         deactivatedMemberDismissed: promptIsDismissed(
           checkResults.deactivated_member_alert!
-        ),
-        // billing period related prompt checks
-        overageAlertDismissed: objectFromBilledCategories(c =>
-          promptIsDismissedForBillingPeriod(
-            checkResults[`${snakeCase(c.plural)}_overage_alert`]!
-          )
-        ),
-        overageWarningDismissed: objectFromBilledCategories(c =>
-          promptIsDismissedForBillingPeriod(
-            checkResults[`${snakeCase(c.plural)}_warning_alert`]!
-          )
         ),
         productTrialDismissed: objectFromBilledCategories(c =>
           trialPromptIsDismissed(
@@ -664,98 +605,6 @@ class GSBanner extends Component<Props, State> {
       // let check fail but capture exception
       Sentry.captureException(error);
     }
-  }
-
-  get overageAlertActive(): Record<EventType, boolean> {
-    const {subscription} = this.props;
-    return objectFromBilledCategories(
-      c =>
-        !this.state.overageAlertDismissed[c.singular as EventType] &&
-        !!subscription.categories[c.plural]?.usageExceeded
-    );
-  }
-
-  get overageWarningActive(): Record<EventType, boolean> {
-    const {subscription} = this.props;
-    // disable warnings if org has PAYG
-    if (subscription.onDemandMaxSpend > 0) {
-      return ALERTS_OFF;
-    }
-    return objectFromBilledCategories(
-      c =>
-        !this.state.overageWarningDismissed[c.singular as EventType] &&
-        !!subscription.categories[c.plural]?.sentUsageWarning
-    );
-  }
-
-  // Returns true for overage alert, false for overage warning, and null if we don't show anything.
-  get overageAlertType(): 'critical' | 'warning' | null {
-    const {subscription} = this.props;
-    if (!hasPerformance(subscription.planDetails)) {
-      return null;
-    }
-    if (!subscription.canSelfServe) {
-      return null;
-    }
-    if (Object.values(this.overageAlertActive).some(Boolean)) {
-      return 'critical';
-    }
-
-    if (Object.values(this.overageWarningActive).some(Boolean)) {
-      return 'warning';
-    }
-    return null;
-  }
-
-  renderOverageAlertPrimaryCTA(eventTypes: EventType[], isWarning: boolean) {
-    const {subscription, organization} = this.props;
-
-    // can't use as const with ternary
-    const notificationType = isWarning ? 'overage_warning' : 'overage_critical';
-
-    const props = {
-      organization,
-      subscription,
-      eventTypes,
-      notificationType,
-      referrer: `overage-alert-${eventTypes.join('-')}`,
-      source: isWarning ? 'quota-warning' : 'quota-overage',
-      handleRequestSent: () => this.handleOverageSnooze(eventTypes, isWarning),
-    } as const;
-
-    return <AddEventsCTA {...props} />;
-  }
-
-  handleOverageSnooze(eventTypes: EventType[], isWarning: boolean) {
-    const {organization, api} = this.props;
-    const dismissState = isWarning
-      ? this.state.overageWarningDismissed
-      : this.state.overageAlertDismissed;
-
-    for (const eventType of eventTypes) {
-      if (dismissState[eventType]) {
-        // This type of event is already dismissed. Skip.
-        continue;
-      }
-      const key = isWarning ? 'warning' : 'overage';
-
-      const featureMap = objectFromBilledCategories(
-        c => `${snakeCase(c.plural)}_${key}_alert`
-      );
-
-      promptsUpdate(api, {
-        organization,
-        feature: featureMap[eventType],
-        status: 'snoozed',
-      });
-    }
-
-    const dismissedState = objectFromBilledCategories(() => true);
-    // Suppress all warnings and alerts
-    this.setState({
-      overageAlertDismissed: dismissedState,
-      overageWarningDismissed: dismissedState,
-    });
   }
 
   handleSnoozeMemberDeactivatedAlert = () => {
@@ -944,15 +793,6 @@ class GSBanner extends Component<Props, State> {
     }
 
     const productTrialAlerts = this.renderProductTrialAlerts();
-
-    const overageAlertType = this.overageAlertType;
-    if (overageAlertType !== null) {
-      return (
-        <Fragment>
-          {productTrialAlerts && productTrialAlerts.length > 0 && productTrialAlerts}
-        </Fragment>
-      );
-    }
 
     const {membersDeactivatedFromLimit} = subscription;
     const isOverMemberLimit = membersDeactivatedFromLimit > 0;

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -757,7 +757,6 @@ export type BillingMetricHistory = {
   paygCpe: number | null;
   prepaid: number;
   reserved: number | null;
-  sentUsageWarning: boolean;
   // TODO(isabella): Make SoftCapType an enum
   softCapType: 'ON_DEMAND' | 'TRUE_FORWARD' | null;
   usage: number;

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1022,7 +1022,6 @@ export function normalizeMetricHistory(
       customPrice: null,
       order: 0,
       paygCpe: null,
-      sentUsageWarning: false,
       softCapType: null,
       usageExceeded: false,
     }

--- a/tests/js/getsentry-test/fixtures/metricHistory.ts
+++ b/tests/js/getsentry-test/fixtures/metricHistory.ts
@@ -22,7 +22,6 @@ export function MetricHistoryFixture(
     onDemandSpendUsed: 0,
     paygCpe: 0,
     onDemandQuantity: 0,
-    sentUsageWarning: false,
     softCapType: null,
     order,
     prepaid: 5_000,


### PR DESCRIPTION
# Human summary:

The function `renderOverageAlertPrimaryCTA` was never called. It's now deleted along with all of the code is used. The `sentUsageWarning` field in the API response was read and used to short circuit the banner rendering code, but just rendered a "product-trial" banner which was the default banner anyways. So that all gets removed.

The only real change is that now analytics events for the usage banners won't fire, but those banners weren't displayed anyways, so analytics for them shouldn't fire.

# AI summary:

## Summary

Removes the overage/usage-warning alert machinery from `gsBanner`, and the now-unread `sentUsageWarning` field from the `BillingMetricHistory` frontend type (plus its default and test fixture). This is a pure dead-code deletion — 163 lines removed, no functionality that was actually reaching users.

## Why this is dead code

The chain of evidence, from the render path outward:

### 1. The warning/overage banner never renders

`gsBanner`'s `render()` computed `overageAlertType` (`'critical' | 'warning' | null`) and, when non-null, **returned only the product-trial alerts** — there was no overage banner in that branch. The component that would have rendered the actual alert, `renderOverageAlertPrimaryCTA` (which returns `<AddEventsCTA />`), **was never called anywhere in the file**. So the entire `overageAlertActive` / `overageWarningActive` / `overageAlertType` cluster fed a banner that had already been removed.

Its only two remaining effects were:
- firing the `quota_alert.alert_displayed` analytics event in `componentDidMount`, and
- an early-return in `render()` that suppressed lower-priority banners (see behavior note below).

Neither puts any overage/warning UI in front of the user.

### 2. `sentUsageWarning` had exactly one reader — the code above

`sentUsageWarning` was read in a single place: `overageWarningActive` in `gsBanner`. With the cluster removed, nothing reads it. After this change, a repo-wide search is clean:

```
$ grep -rn "sentUsageWarning" static/ tests/
(no results)
```

Everything else that mentioned it was declaration/plumbing, not consumption:
- `types/index.tsx` — the type field
- `utils/billing.tsx` — a default in the fallback object
- `tests/js/getsentry-test/fixtures/metricHistory.ts` — a fixture default

### 3. The real over-quota UI uses a different field

The user-facing "you're over quota" surfaces on the subscription page are driven by **`usageExceeded`**, not `sentUsageWarning`:
- `views/subscriptionPage/usageAlert.tsx:158,254`
- `views/subscriptionPage/usageOverview/components/tableRow.tsx:86,227,278,288`

`usageExceeded` is untouched by this PR. `sentUsageWarning` (and its backend sibling `sentUsageExceeded`) are notification-dedup flags, not render inputs.

## What is removed

`static/gsApp/components/gsBanner.tsx`
- Getters `overageAlertActive`, `overageWarningActive`, `overageAlertType`
- Dead methods `renderOverageAlertPrimaryCTA` and `handleOverageSnooze`
- The `quota_alert.alert_displayed` analytics call in `componentDidMount`
- `checkPrompts` fetches for `*_overage_alert` / `*_warning_alert` and the `promptIsDismissedForBillingPeriod` helper that only served them
- State `overageAlertDismissed` / `overageWarningDismissed`
- The `overageAlertType` early-return in `render()`
- Now-orphaned `ALERTS_OFF` const and `AddEventsCTA` / `PromptData` imports

`static/gsApp/types/index.tsx`, `static/gsApp/utils/billing.tsx`, `tests/js/getsentry-test/fixtures/metricHistory.ts`
- The `sentUsageWarning` field / default / fixture entry

## Behavior note

The deleted `render()` early-return suppressed the **member-deactivated banner** whenever `overageAlertType` was non-null. Since no overage banner rendered in its place, that suppression was an accidental leftover of the earlier banner removal. Consequence: an org that is *simultaneously* over its member limit **and** in overage will now see the member-deactivated banner (previously hidden). This is a narrow edge case and arguably the correct behavior. No other rendering changes.

## Explicitly out of scope

The backend `BillingMetricHistory` model fields (`sent_usage_80`, `sent_usage_exceeded`) and the usage-notification pipeline that reads/writes them are **unaffected** — they remain the server-side email-dedup mechanism. This PR only removes dead frontend consumption. The getsentry customer serializer still emits these JSON keys; dropping them there is a possible follow-up.

## Testing

- `gsBanner.spec.tsx` — 33/33 passing
- `usageAlert.spec.tsx` — passing (verifies the `usageExceeded`-driven UI is unaffected)
- ESLint clean on all touched files
