### PR TITLE
fix(explore): Allow agent filter in saved query serializer

### DIFF
--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -124,6 +124,7 @@ class ExploreSavedQueryModelSerializer(Serializer[ExploreSavedQueryResponse]):
             "end",
             "interval",
             "crossEvents",
+            "agent",
         ]
         data: ExploreSavedQueryResponse = {
             "id": str(obj.id),

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -219,6 +219,12 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
         max_length=MAX_CROSS_EVENT_QUERIES,
         help_text="Optional cross-event queries across event types. Max 2 entries.",
     )
+    agent = ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_null=True,
+        help_text="Agent names to filter conversations by.",
+    )
     query = ListField(child=QuerySerializer(), required=True, min_length=1)
 
     def validate_projects(self, projects):
@@ -236,6 +242,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
             "end",
             "interval",
             "crossEvents",
+            "agent",
         ]
 
         inner_query_keys = [

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_ai_conversations.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_ai_conversations.py
@@ -91,6 +91,29 @@ class ExploreSavedQueryAIConversationsTest(APITestCase):
             starred=True,
         ).exists()
 
+    def test_post_preserves_agent_filter(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.list_url,
+                {
+                    "name": "Agent-filtered query",
+                    "projects": [self.project.id],
+                    "dataset": "ai_conversations",
+                    "range": "24h",
+                    "agent": ["my-agent", "other-agent"],
+                    "query": [{"fields": [], "mode": "samples"}],
+                },
+            )
+
+        assert response.status_code == 201, response.content
+        assert response.data["agent"] == ["my-agent", "other-agent"]
+
+        # Verify round-trip through detail endpoint
+        with self.feature(self.features):
+            detail = self.client.get(self._detail_url(int(response.data["id"])))
+        assert detail.status_code == 200
+        assert detail.data["agent"] == ["my-agent", "other-agent"]
+
     # ── Read ────────────────────────────────────────────────────────────
 
     def test_get_returns_ai_conversations_query(self) -> None:


### PR DESCRIPTION
Add `agent` field to the saved query serializer so conversations saved queries can persist and restore the selected agent filter.

- Input serializer: new `agent` ListField (optional list of strings) + added to `query_keys` so it's stored in the JSON
- Output serializer: added to `query_keys` so it's returned in API responses
- Test: round-trip through create and detail endpoints

Contributes to TET-2552