### PR TITLE
feat(sdk-crashes): add is_anr_or_apphang tag to sdk crash monitoring metrics

### DIFF
--- a/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
+++ b/src/sentry/utils/sdk_crashes/sdk_crash_detection.py
@@ -66,7 +66,12 @@ class SDKCrashDetection:
         if not sdk_name or not sdk_version:
             return None
 
-        metric_tags = {"sdk_name": sdk_name, "sdk_version": sdk_version}
+        mechanism = get_path(event.data, "exception", "values", -1, "mechanism", "type")
+        metric_tags = {
+            "sdk_name": sdk_name,
+            "sdk_version": sdk_version,
+            "is_anr_or_apphang": "true" if mechanism in ("ANR", "AppExitInfo") else "false",
+        }
         sdk_detectors = list(map(lambda config: SDKCrashDetector(config=config), configs))
 
         num_supported_detectors = sum(

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -284,6 +284,23 @@ def test_should_increment_counters_for_sdk_crash(incr, sdk_crash_reporter, store
 @pytest.mark.snuba
 @patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
 @patch("sentry.utils.metrics.incr")
+def test_anr_event_tags_is_anr_or_apphang_true(incr, sdk_crash_reporter, store_event) -> None:
+    event_data = get_crash_event()
+    set_path(event_data, "exception", "values", -1, "mechanism", "type", value="ANR")
+    event = store_event(data=event_data)
+
+    sdk_crash_detection.detect_sdk_crash(event=event, configs=build_sdk_configs())
+
+    incr.assert_any_call(
+        "post_process.sdk_crash_monitoring.sdk_event",
+        tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0", "is_anr_or_apphang": "true"},
+    )
+
+
+@django_db_all
+@pytest.mark.snuba
+@patch("sentry.utils.sdk_crashes.sdk_crash_detection.sdk_crash_detection.sdk_crash_reporter")
+@patch("sentry.utils.metrics.incr")
 def test_should_only_increment_detecting_counter_for_non_crash_event(
     incr, sdk_crash_reporter, store_event
 ):

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -286,7 +286,7 @@ def test_should_increment_counters_for_sdk_crash(incr, sdk_crash_reporter, store
 @patch("sentry.utils.metrics.incr")
 def test_anr_event_tags_is_anr_or_apphang_true(incr, sdk_crash_reporter, store_event) -> None:
     event_data = get_crash_event()
-    set_path(event_data, "exception", "values", -1, "mechanism", "type", value="ANR")
+    event_data["exception"]["values"][-1]["mechanism"]["type"] = "ANR"
     event = store_event(data=event_data)
 
     sdk_crash_detection.detect_sdk_crash(event=event, configs=build_sdk_configs())

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -286,7 +286,7 @@ def test_should_increment_counters_for_sdk_crash(incr, sdk_crash_reporter, store
 @patch("sentry.utils.metrics.incr")
 def test_anr_event_tags_is_anr_or_apphang_true(incr, sdk_crash_reporter, store_event) -> None:
     event_data = get_crash_event()
-    event_data["exception"]["values"][-1]["mechanism"]["type"] = "ANR"
+    set_path(event_data, "exception", "values", 0, "mechanism", "type", value="ANR")
     event = store_event(data=event_data)
 
     sdk_crash_detection.detect_sdk_crash(event=event, configs=build_sdk_configs())

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -97,7 +97,7 @@ class PerformanceEventTestMixin(BaseSDKCrashDetectionMixin, SnubaTestCase):
 
         incr.assert_called_with(
             "post_process.sdk_crash_monitoring.sdk_event",
-            tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+            tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0", "is_anr_or_apphang": "false"},
         )
 
         # Ensure that no counter is incremented
@@ -253,15 +253,27 @@ def test_should_increment_counters_for_sdk_crash(incr, sdk_crash_reporter, store
         [
             call(
                 "post_process.sdk_crash_monitoring.sdk_event",
-                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+                tags={
+                    "sdk_name": "sentry.cocoa",
+                    "sdk_version": "8.2.0",
+                    "is_anr_or_apphang": "false",
+                },
             ),
             call(
                 "post_process.sdk_crash_monitoring.detecting_sdk_crash",
-                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+                tags={
+                    "sdk_name": "sentry.cocoa",
+                    "sdk_version": "8.2.0",
+                    "is_anr_or_apphang": "false",
+                },
             ),
             call(
                 "post_process.sdk_crash_monitoring.sdk_crash_detected",
-                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+                tags={
+                    "sdk_name": "sentry.cocoa",
+                    "sdk_version": "8.2.0",
+                    "is_anr_or_apphang": "false",
+                },
             ),
         ],
         any_order=True,
@@ -286,11 +298,19 @@ def test_should_only_increment_detecting_counter_for_non_crash_event(
         [
             call(
                 "post_process.sdk_crash_monitoring.sdk_event",
-                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+                tags={
+                    "sdk_name": "sentry.cocoa",
+                    "sdk_version": "8.2.0",
+                    "is_anr_or_apphang": "false",
+                },
             ),
             call(
                 "post_process.sdk_crash_monitoring.detecting_sdk_crash",
-                tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+                tags={
+                    "sdk_name": "sentry.cocoa",
+                    "sdk_version": "8.2.0",
+                    "is_anr_or_apphang": "false",
+                },
             ),
         ],
         any_order=True,
@@ -341,7 +361,7 @@ def test_should_increment_counter_for_non_crash_event(
 
     incr.assert_called_with(
         "post_process.sdk_crash_monitoring.sdk_event",
-        tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0"},
+        tags={"sdk_name": "sentry.cocoa", "sdk_version": "8.2.0", "is_anr_or_apphang": "false"},
     )
 
     # Ensure that no counter is incremented

--- a/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
+++ b/tests/sentry/utils/sdk_crashes/test_sdk_crash_detection.py
@@ -286,7 +286,7 @@ def test_should_increment_counters_for_sdk_crash(incr, sdk_crash_reporter, store
 @patch("sentry.utils.metrics.incr")
 def test_anr_event_tags_is_anr_or_apphang_true(incr, sdk_crash_reporter, store_event) -> None:
     event_data = get_crash_event()
-    set_path(event_data, "exception", "values", 0, "mechanism", "type", value="ANR")
+    event_data["exception"]["values"][0]["mechanism"]["type"] = "ANR"  # type: ignore[index]
     event = store_event(data=event_data)
 
     sdk_crash_detection.detect_sdk_crash(event=event, configs=build_sdk_configs())


### PR DESCRIPTION
## Summary

Adds a low-cardinality `is_anr_or_apphang` tag to all three `post_process.sdk_crash_monitoring.*` metrics (`sdk_event`, `detecting_sdk_crash`, `sdk_crash_detected`).

The tag is `"true"` when the exception mechanism type is `ANR` or `AppExitInfo`, `"false"` otherwise. Filterable in DataDog as `is_anr_or_apphang:true`.

## Motivation

Android ANR events inflate the SDK crash rate dashboard, making stable releases look problematic. A previous iteration tagged the raw `mechanism` type, but that has unbounded cardinality and would increase the DataDog bill. A boolean tag gives us the filtering we need (crashes vs ANRs) at cardinality 2.

## Changes

- `sdk_crash_detection.py`: extract `mechanism.type` from the event, emit `is_anr_or_apphang` tag
- `test_sdk_crash_detection.py`: update metric tag assertions

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC089VFRB8N9%3A1783066202.596519/?project=4510944073809921)

<!-- junior-session-footer:end -->