### PR TITLE
chore(relay): Remove relay-dsn-endpoint-override feature flag (backend)

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -465,16 +465,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def validate_relayDsnEndpoint(self, value: str | None) -> str | None:
-        organization = self.context["organization"]
-        request = self.context["request"]
-
-        if not features.has(
-            "organizations:relay-dsn-endpoint-override", organization, actor=request.user
-        ):
-            raise serializers.ValidationError(
-                "Organization does not have the Relay DSN endpoint override feature enabled."
-            )
-
         if value is None:
             return None
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -210,8 +210,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables configuring a Relay base URL for displayed Client Key DSNs
-    manager.add("organizations:relay-dsn-endpoint-override", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay
     manager.add("organizations:relay-playstation-ingestion", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable the new apiFetch implementation that uses cell fetch.

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1264,7 +1264,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         assert response.data["relayDsnEndpoint"] == "https://relay.example.com/ingest"
 
-    @with_feature("organizations:relay-dsn-endpoint-override")
     def test_relay_dsn_endpoint_accepts_valid_write(self) -> None:
         response = self.get_success_response(
             self.organization.slug,
@@ -1276,7 +1275,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         )
         assert response.data["relayDsnEndpoint"] == "https://relay.example.com/ingest"
 
-    @with_feature("organizations:relay-dsn-endpoint-override")
     def test_relay_dsn_endpoint_blank_clears_value(self) -> None:
         self.organization.update_option(
             "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
@@ -1287,7 +1285,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
         assert response.data["relayDsnEndpoint"] is None
 
-    @with_feature("organizations:relay-dsn-endpoint-override")
     def test_relay_dsn_endpoint_null_clears_value(self) -> None:
         self.organization.update_option(
             "sentry:relay_dsn_endpoint", "https://relay.example.com/ingest"
@@ -1297,18 +1294,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
         assert response.data["relayDsnEndpoint"] is None
-
-    def test_relay_dsn_endpoint_rejects_write_without_feature(self) -> None:
-        response = self.get_error_response(
-            self.organization.slug,
-            status_code=400,
-            relayDsnEndpoint="https://relay.example.com/ingest",
-        )
-
-        assert response.data["relayDsnEndpoint"] == [
-            "Organization does not have the Relay DSN endpoint override feature enabled."
-        ]
-        assert self.organization.get_option("sentry:relay_dsn_endpoint") is None
 
     def test_relay_dsn_endpoint_rejects_invalid_url(self) -> None:
         relay_dsn_endpoints = [
@@ -1320,16 +1305,15 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "https://relay.example.com#fragment",
         ]
 
-        with self.feature("organizations:relay-dsn-endpoint-override"):
-            for relay_dsn_endpoint in relay_dsn_endpoints:
-                with self.subTest(relay_dsn_endpoint=relay_dsn_endpoint):
-                    response = self.get_error_response(
-                        self.organization.slug,
-                        status_code=400,
-                        relayDsnEndpoint=relay_dsn_endpoint,
-                    )
+        for relay_dsn_endpoint in relay_dsn_endpoints:
+            with self.subTest(relay_dsn_endpoint=relay_dsn_endpoint):
+                response = self.get_error_response(
+                    self.organization.slug,
+                    status_code=400,
+                    relayDsnEndpoint=relay_dsn_endpoint,
+                )
 
-                    assert response.data["relayDsnEndpoint"] == [ERR_RELAY_DSN_ENDPOINT_INVALID]
+                assert response.data["relayDsnEndpoint"] == [ERR_RELAY_DSN_ENDPOINT_INVALID]
 
     @with_feature("organizations:dynamic-sampling-custom")
     def test_target_sample_rate_range(self) -> None:


### PR DESCRIPTION
## Summary

Backend removal of the `organizations:relay-dsn-endpoint-override` feature flag. The feature has been rolled out, so the flag registration, endpoint gate, and test decorators are no longer needed. The relay DSN endpoint override is now accepted for all organizations.

Frontend removal is in a separate PR.

## Changes

- Remove flag registration from `src/sentry/features/temporary.py`
- Remove flag check in `validate_relayDsnEndpoint` on the organization details endpoint
- Drop `@with_feature` decorators and the "rejects without feature" test in `test_organization_details.py`
