### PR TITLE
chore(relay): Remove relay-dsn-endpoint-override feature flag (frontend)

### DIFF
--- a/static/app/views/settings/organizationRelay/relayWrapper.spec.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.spec.tsx
@@ -194,17 +194,8 @@ describe('RelayWrapper', () => {
   });
 
   describe('relayDsnEndpoint input', () => {
-    it('is hidden without the feature flag', () => {
-      renderComponent();
-
-      expect(
-        screen.queryByRole('textbox', {name: 'DSN Endpoint Override'})
-      ).not.toBeInTheDocument();
-    });
-
-    it('renders the persisted value when the feature flag is on', () => {
+    it('renders the persisted value', () => {
       renderComponent({
-        features: ['relay-dsn-endpoint-override'],
         relayDsnEndpoint: 'https://relay.example.com',
       });
 
@@ -221,7 +212,6 @@ describe('RelayWrapper', () => {
       });
 
       renderComponent({
-        features: ['relay-dsn-endpoint-override'],
         relayDsnEndpoint: 'https://old-relay.example.com',
       });
 
@@ -249,7 +239,6 @@ describe('RelayWrapper', () => {
       });
 
       renderComponent({
-        features: ['relay-dsn-endpoint-override'],
         relayDsnEndpoint: 'https://relay.example.com',
       });
 
@@ -270,7 +259,6 @@ describe('RelayWrapper', () => {
 
     it('is disabled when user lacks org:write permission', () => {
       renderComponent({
-        features: ['relay-dsn-endpoint-override'],
         access: [],
       });
 
@@ -289,7 +277,7 @@ describe('RelayWrapper', () => {
         method: 'PUT',
       });
 
-      renderComponent({features: ['relay-dsn-endpoint-override']});
+      renderComponent();
 
       const input = screen.getByRole('textbox', {name: 'DSN Endpoint Override'});
       await userEvent.clear(input);

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -74,9 +74,6 @@ export function RelayWrapper() {
   const [relays, setRelays] = useState(organization.trustedRelays ?? []);
 
   const disabled = !organization.access.includes('org:write');
-  const hasRelayDsnEndpointOverrideFeature = organization.features.includes(
-    'relay-dsn-endpoint-override'
-  );
 
   const handleOpenAddDialog = () => {
     openModal(modalProps => (
@@ -162,39 +159,37 @@ export function RelayWrapper() {
             </field.Layout.Row>
           )}
         </AutoSaveForm>
-        {hasRelayDsnEndpointOverrideFeature && (
-          <AutoSaveForm
-            name="relayDsnEndpoint"
-            schema={relayDsnEndpointSchema}
-            initialValue={organization.relayDsnEndpoint ?? ''}
-            mutationOptions={{
-              mutationFn: data =>
-                fetchMutation<Organization>({
-                  url: `/organizations/${organization.slug}/`,
-                  method: 'PUT',
-                  data: {relayDsnEndpoint: data.relayDsnEndpoint},
-                }),
-              onSuccess: updatedOrg => {
-                OrganizationStore.onUpdate(updatedOrg);
-              },
-            }}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('DSN Endpoint Override')}
-                hintText={t(
-                  "Use a Relay base URL when displaying Client Key DSNs. Leave blank to use Sentry's default ingest endpoint."
-                )}
-              >
-                <field.Input
-                  value={field.state.value}
-                  onChange={field.handleChange}
-                  disabled={disabled}
-                />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
-        )}
+        <AutoSaveForm
+          name="relayDsnEndpoint"
+          schema={relayDsnEndpointSchema}
+          initialValue={organization.relayDsnEndpoint ?? ''}
+          mutationOptions={{
+            mutationFn: data =>
+              fetchMutation<Organization>({
+                url: `/organizations/${organization.slug}/`,
+                method: 'PUT',
+                data: {relayDsnEndpoint: data.relayDsnEndpoint},
+              }),
+            onSuccess: updatedOrg => {
+              OrganizationStore.onUpdate(updatedOrg);
+            },
+          }}
+        >
+          {field => (
+            <field.Layout.Row
+              label={t('DSN Endpoint Override')}
+              hintText={t(
+                "Use a Relay base URL when displaying Client Key DSNs. Leave blank to use Sentry's default ingest endpoint."
+              )}
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                disabled={disabled}
+              />
+            </field.Layout.Row>
+          )}
+        </AutoSaveForm>
       </FieldGroup>
       {relays.length === 0 ? (
         <EmptyState />


### PR DESCRIPTION
## Summary

Frontend removal of the `organizations:relay-dsn-endpoint-override` feature flag. The feature has been rolled out, so the DSN endpoint override form always renders on the Relay settings page. Backend removal is in [#118984](https://github.com/getsentry/sentry/pull/118984).

## Changes

- Drop the `relay-dsn-endpoint-override` feature check and unconditionally render the DSN endpoint form in `relayWrapper.tsx`
- Remove the "hidden without feature flag" test and strip `features: ['relay-dsn-endpoint-override']` from the remaining tests in `relayWrapper.spec.tsx`
