### PR TITLE
fix(deps): Dedupe minimatch 3.1.2 to 3.1.5 for ReDoS (GHSA-7r86-cg39-jmmj)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7138,9 +7138,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -9979,7 +9976,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -9998,7 +9995,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.0
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -14571,7 +14568,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -14654,7 +14651,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -14772,7 +14769,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -16919,10 +16916,6 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
-
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.11
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
Resolves Dependabot alert #476 (GHSA-7r86-cg39-jmmj / CVE-2026-27903, high).

`minimatch` < 3.1.3 is vulnerable to ReDoS via combinatorial backtracking in `matchOne()` when a pattern has multiple non-adjacent `**` segments. It is a transitive devDependency of the eslint toolchain — eslint core, `@eslint/config-array`, `@eslint/eslintrc`, `eslint-plugin-import`, and `eslint-plugin-react`.

All of those declare `minimatch: ^3.1.2`, a range **already satisfied by the patched 3.1.5** that other packages in the tree resolve to. `eslint-plugin-import` and `eslint-plugin-react` are already at their latest published versions and still pin `^3.1.2`, so no dependency bump removes the vulnerable copy. Rather than add a lockfile override, this repoints the five consumers of `minimatch@3.1.2` onto the existing `3.1.5` and drops the now-orphaned 3.1.2 entry. `pnpm install --lockfile-only` validates the result.

This handles the 3.x alert only. The separate `minimatch@9.0.1` ReDoS (alert #468, GHSA-3ppc-4f35-3m26) is fixed in its own PR by bumping js-beautify.

Refs GHSA-7r86-cg39-jmmj