### PR TITLE
Add copy attribute for filter action

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.spec.tsx
@@ -1,12 +1,80 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {
+  getAttributeFilterSearch,
+  getTraceAttributesTreeActions,
+  getTraceKeyValueActions,
   getTraceIssueSeverityClassName,
   parseJsonWithFix,
+  TraceDrawerActionValueKind,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {
   makeEAPError,
   makeEAPOccurrence,
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
+
+describe('getAttributeFilterSearch', () => {
+  it('formats an attribute key and value as a search filter', () => {
+    expect(getAttributeFilterSearch('http.request.method', 'GET')).toBe(
+      'http.request.method:GET'
+    );
+  });
+
+  it('quotes attribute values that need query escaping', () => {
+    expect(getAttributeFilterSearch('span.description', 'GET /api/users')).toBe(
+      'span.description:"GET /api/users"'
+    );
+  });
+});
+
+describe('getTraceAttributesTreeActions', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {writeText: jest.fn().mockResolvedValue('')},
+    });
+  });
+
+  it('copies the attribute as a formatted filter', () => {
+    const actions = getTraceAttributesTreeActions({
+      location: LocationFixture(),
+      organization: OrganizationFixture({features: []}),
+    })({
+      subtree: {},
+      value: 'GET /api/users',
+      originalAttribute: {
+        attribute_key: 'description',
+        attribute_value: 'GET /api/users',
+        original_attribute_key: 'span.description',
+      },
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.label).toBe('Copy attribute for filter');
+
+    actions[0]?.onAction?.();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'span.description:"GET /api/users"'
+    );
+  });
+});
+
+describe('getTraceKeyValueActions', () => {
+  it('adds a copy-filter action for attribute values', () => {
+    const actions = getTraceKeyValueActions({
+      location: LocationFixture(),
+      organization: OrganizationFixture({features: []}),
+      rowKey: 'span.description',
+      rowValue: 'GET /api/users',
+      kind: TraceDrawerActionValueKind.ATTRIBUTE,
+    });
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.label).toBe('Copy attribute for filter');
+  });
+});
 
 describe('parseJsonWithFix', () => {
   it('parses valid JSON without fixing', () => {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -135,7 +135,7 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
   if (
     !defined(rowValue) ||
     !defined(rowKey) ||
-    !['string', 'number'].includes(typeof rowValue)
+    (typeof rowValue !== 'string' && typeof rowValue !== 'number')
   ) {
     return [];
   }
@@ -177,7 +177,6 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
         location,
         projectIds,
         rowKey,
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         rowValue.toString(),
         TraceDrawerActionKind.INCLUDE
       ),
@@ -190,7 +189,6 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
         location,
         projectIds,
         rowKey,
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
         rowValue.toLocaleString(),
         TraceDrawerActionKind.EXCLUDE
       ),
@@ -221,7 +219,6 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
           location,
           projectIds,
           rowKey,
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
           rowValue.toString(),
           TraceDrawerActionKind.GREATER_THAN
         ),
@@ -234,7 +231,6 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
           location,
           projectIds,
           rowKey,
-          // eslint-disable-next-line @typescript-eslint/no-base-to-string
           rowValue.toString(),
           TraceDrawerActionKind.LESS_THAN
         ),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -9,6 +9,7 @@ import type {Organization} from 'sentry/types/organization';
 import {defined} from 'sentry/utils/defined';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import {
   SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS,
@@ -112,6 +113,12 @@ export function sortAttributes(attributes: TraceItemResponseAttribute[]) {
   });
 }
 
+export function getAttributeFilterSearch(rowKey: string, rowValue: string | number) {
+  const search = new MutableSearch('');
+  search.addFilterValue(rowKey, rowValue.toString());
+  return search.formatString();
+}
+
 export type KeyValueActionParams = {
   location: Location;
   organization: Organization;
@@ -126,12 +133,27 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
   const hasExploreEnabled = organization.features.includes('visibility-explore-view');
 
   if (
-    !hasExploreEnabled ||
     !defined(rowValue) ||
     !defined(rowKey) ||
     !['string', 'number'].includes(typeof rowValue)
   ) {
     return [];
+  }
+
+  const copyAttributeFilterAction: MenuItemProps | null =
+    kind === TraceDrawerActionValueKind.ATTRIBUTE
+      ? {
+          key: 'copy-attribute-filter',
+          label: t('Copy attribute for filter'),
+          onAction: () =>
+            copyToClipboard(getAttributeFilterSearch(rowKey, rowValue), {
+              successMessage: t('Attribute filter copied to clipboard'),
+            }),
+        }
+      : null;
+
+  if (!hasExploreEnabled) {
+    return copyAttributeFilterAction ? [copyAttributeFilterAction] : [];
   }
 
   // We assume that tags, measurements and additional data (span.data) are dynamic lists of searchable keys in explore.
@@ -220,7 +242,9 @@ export function getTraceKeyValueActions(params: KeyValueActionParams): MenuItemP
     );
   }
 
-  return dropdownOptions;
+  return copyAttributeFilterAction
+    ? [...dropdownOptions, copyAttributeFilterAction]
+    : dropdownOptions;
 }
 
 export function getTraceAttributesTreeActions(
@@ -229,13 +253,13 @@ export function getTraceAttributesTreeActions(
   return (content: AttributesTreeContent) => {
     const rowKey = content.originalAttribute?.original_attribute_key;
     const rowValue = content.value;
-    if (!rowKey || !rowValue) {
+    if (!rowKey || !defined(rowValue)) {
       return [];
     }
 
     return getTraceKeyValueActions({
       rowKey,
-      rowValue: content.value,
+      rowValue,
       kind: TraceDrawerActionValueKind.ATTRIBUTE,
       projectIds: params.projectIds,
       location: params.location,


### PR DESCRIPTION
This PR adds a "copy attribute for filter" option to trace span attribute actions and formats copied filters through `MutableSearch` so values are ready for the query builder. 

Closes: EXP-1078

Example - Copies `span.name:ui.react.update` to clipboard:
<img width="568" height="263" alt="Screenshot 2026-07-03 at 07 44 08" src="https://github.com/user-attachments/assets/eeb332b0-9e45-4835-9bd5-e45b3771707a" />