### PR TITLE
fix(docs): correct parameter names in docstrings (3 locations)

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -418,7 +418,7 @@ class FeatureManager(RegisteredFeatureManager):
         available, or falling back to individual checks.
 
         Args:
-            feature_names: List of feature names to check
+            feature_name: Feature name to check
             organizations: List of organizations to check the features for
 
         Returns:

--- a/src/sentry/seer/math.py
+++ b/src/sentry/seer/math.py
@@ -26,7 +26,7 @@ def entropy(xs: list[float]) -> float:
         H = -sum(p(x) * log2(p(x)))
 
     Parameters:
-        probabilities: A list of non-negative floating point values which sum to 1.
+        xs: A list of non-negative floating point values which sum to 1.
     """
     total = sum(xs)
 

--- a/src/sentry/uptime/endpoints/organization_uptime_stats.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_stats.py
@@ -179,8 +179,6 @@ class OrganizationUptimeStatsEndpoint(OrganizationEndpoint, StatsMixin):
 
         Args:
             response: The EAP RPC TimeSeriesResponse
-            subscription_key: The attribute name for subscription ID ("uptime_subscription_id" or "subscription_id")
-            epoch_cutoff: Optional cutoff timestamp for data
         """
         formatted_data: dict[str, dict[int, dict[str, int]]] = {}
 


### PR DESCRIPTION
## Summary

Fixes 3 locations where docstring parameter names don't match the actual function signatures:

| File | Function | Wrong | Correct |
|------|----------|-------|---------|
| `src/sentry/seer/math.py` | `entropy()` | `probabilities` | `xs` |
| `src/sentry/features/manager.py` | `batch_has_for_organizations()` | `feature_names` | `feature_name` |
| `src/sentry/uptime/endpoints/organization_uptime_stats.py` | `_format_response()` | stale `subscription_key` + `epoch_cutoff` doc entries | removed (params no longer exist in signature) |

No logic changes - docstrings only.