### PR TITLE
fix(deps): Bump defu to 6.1.7 for prototype pollution (GHSA-737v-mqg7-c878)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5122,8 +5122,8 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -11147,7 +11147,7 @@ snapshots:
 
   '@r4ai/remark-callout@0.6.2':
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       unist-util-visit: 5.0.0
 
   '@react-aria/button@3.14.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -14039,7 +14039,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   delayed-stream@1.0.0: {}
 


### PR DESCRIPTION
Resolves Dependabot alert #531 (GHSA-737v-mqg7-c878 / CVE-2026-35209, high).

`defu` <= 6.1.4 is vulnerable to prototype pollution: a `__proto__` key in the first argument to `defu()` overrides intended defaults in the merged result. Fixed in 6.1.5.

`defu` is a transitive devDependency reachable only through `@r4ai/remark-callout@0.6.2`, which declares `defu: ^6.1.4` — a range already satisfied by the patched line. remark-callout is at its latest published version and still uses `^6.1.4`, so no dependency bump moves it; the single `defu@6.1.4` copy lingered only because pnpm preserves resolved versions. This re-resolves it to `6.1.7` in the lockfile (validated with `pnpm install --lockfile-only`) instead of adding an override. defu has no dependencies, so the change is isolated.

Refs GHSA-737v-mqg7-c878