### PR TITLE
fix(deps): Raise api-docs form-data override floor to 4.0.6 (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/api-docs/package.json
+++ b/api-docs/package.json
@@ -25,7 +25,7 @@
   "pnpm": {
     "overrides": {
       "lodash": ">=4.18.1",
-      "form-data": ">=4.0.2",
+      "form-data": ">=4.0.6",
       "glob>minimatch": "5.1.9"
     }
   }

--- a/api-docs/pnpm-lock.yaml
+++ b/api-docs/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   lodash: '>=4.18.1'
-  form-data: '>=4.0.2'
+  form-data: '>=4.0.6'
   glob>minimatch: 5.1.9
 
 importers:
@@ -276,8 +276,8 @@ packages:
   foreach@2.0.6:
     resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@2.1.2:
@@ -342,6 +342,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   heap@0.2.7:
@@ -820,7 +824,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es5-ext@0.10.64:
     dependencies:
@@ -895,12 +899,12 @@ snapshots:
 
   foreach@2.0.6: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formidable@2.1.2:
@@ -932,7 +936,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -974,9 +978,13 @@ snapshots:
 
   has-tostringtag@1.0.2:
     dependencies:
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -1234,7 +1242,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.3.7
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 2.1.2
       methods: 1.1.2
       mime: 2.6.0


### PR DESCRIPTION
Resolves Dependabot alert #585 (GHSA-hmw2-7cc7-3qxx / CVE-2026-12143, high) in the `api-docs` project.

`form-data` 4.0.0–4.0.5 concatenates multipart field names and the `filename` option into the `Content-Disposition` header without escaping CR/LF/`"`, allowing CRLF injection. Fixed in 4.0.6.

In `api-docs`, form-data is transitive via `json-refs@3.0.15 → superagent@7.1.6 → form-data`. `json-refs` is already at its latest published version and `superagent` 7.x is deprecated, so there is no dependent to bump. `api-docs` already carried a `form-data` override, but its floor (`>=4.0.2`) still permitted the vulnerable 4.0.5 — this raises it to `>=4.0.6`, which re-resolves form-data to 4.0.6 and prevents future regression.

This is the `api-docs/pnpm-lock.yaml` counterpart to the root-lockfile form-data fix (alert #589); the two lockfiles are independent pnpm projects.

Refs GHSA-hmw2-7cc7-3qxx