### PR TITLE
fix(deps): Bump api-docs picomatch to 2.3.2 for ReDoS (GHSA-c2c7-rcm5-vvqj)

### DIFF
--- a/api-docs/pnpm-lock.yaml
+++ b/api-docs/pnpm-lock.yaml
@@ -520,8 +520,8 @@ packages:
   path-loader@1.0.12:
     resolution: {integrity: sha512-n7oDG8B+k/p818uweWrOixY9/Dsr89o2TkCm6tOTex3fpdo2+BFDgR+KpB37mGKBRsBAlR8CIJMFN0OEy/7hIQ==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   prr@1.0.1:
@@ -688,7 +688,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   argparse@1.0.10:
     dependencies:
@@ -1085,7 +1085,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -1153,7 +1153,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   prr@1.0.1: {}
 


### PR DESCRIPTION
Resolves Dependabot alert #501 (GHSA-c2c7-rcm5-vvqj / CVE-2026-33671, high) in the `api-docs` project.

`picomatch` < 2.3.2 is vulnerable to ReDoS via extglob quantifiers. In `api-docs` it is a transitive devDependency reachable via `sane@5.0.1 → anymatch@3.1.3` / `micromatch@4.0.8`, which declare `picomatch ^2.0.4` and `^2.3.1` respectively — both already satisfied by the patched 2.3.2. `sane` is deprecated and at its latest published version, so there is no dependent to bump; the single `picomatch@2.3.1` copy lingered only because pnpm preserves resolved versions.

This re-resolves it to `2.3.2` in `api-docs/pnpm-lock.yaml` (validated with `pnpm install --lockfile-only`). picomatch has no dependencies, so the change is isolated.

Refs GHSA-c2c7-rcm5-vvqj