### PR TITLE
fix(deps): Bump fast-uri to 3.1.3 for path traversal (GHSA-q3j6-qgpj-74h6)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5725,8 +5725,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -13281,7 +13281,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -14900,7 +14900,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.3: {}
+  fast-uri@3.1.3: {}
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
Resolves Dependabot alert #559 (GHSA-q3j6-qgpj-74h6 / CVE-2026-6321, high).

`fast-uri` <= 3.1.0 is vulnerable to path traversal via percent-encoded dot segments. It is a transitive devDependency via `ajv@8.17.1` (which declares `fast-uri ^3.0.1`), pulled in through the webpack/stylelint build toolchain (mdx-js/loader, css-loader, html-webpack-plugin, stylelint, etc. — all share the one ajv instance).

The range already permits the fix, so this re-resolves the single `fast-uri` instance to `3.1.3` (the latest 3.x). 3.1.3 also covers the related host-confusion advisory (GHSA-v39h-62p7-jpjc, ≥3.1.2). 4.x is out of range for ajv's `^3.0.1`. Validated with `pnpm install --lockfile-only`.

Refs GHSA-q3j6-qgpj-74h6