### PR TITLE
fix(deps): Bump api-docs fast-uri to 3.1.3 for host confusion (GHSA-v39h-62p7-jpjc)

### DIFF
--- a/api-docs/pnpm-lock.yaml
+++ b/api-docs/pnpm-lock.yaml
@@ -263,8 +263,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -681,7 +681,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -883,7 +883,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.0.3: {}
+  fast-uri@3.1.3: {}
 
   fb-watchman@2.0.2:
     dependencies:


### PR DESCRIPTION
Resolves Dependabot alert #560 (GHSA-v39h-62p7-jpjc / CVE-2026-6322, high) in the `api-docs` project.

`fast-uri` <= 3.1.1 is vulnerable to host confusion via percent-encoded authority delimiters. In `api-docs` it is a transitive devDependency via `openapi-examples-validator@6.0.3 → ajv@8.17.1` (which declares `fast-uri ^3.0.1`).

The range already permits the fix, so this re-resolves the single `fast-uri` instance to `3.1.3` (latest 3.x; 4.x is out of ajv's range). 3.1.3 also covers the related path-traversal advisory (GHSA-q3j6-qgpj-74h6). Validated with `pnpm install --lockfile-only`.

This is the `api-docs/pnpm-lock.yaml` counterpart to the root-lockfile fast-uri fix (alert #559); the two are independent pnpm projects.

Refs GHSA-v39h-62p7-jpjc