### PR TITLE
ref(pr-metrics): Scope sender and SHA fields to payload types that need them

### DIFF
--- a/src/sentry/pr_metrics/activity_types.py
+++ b/src/sentry/pr_metrics/activity_types.py
@@ -23,10 +23,6 @@ class BaseActivityPayload:
     action: str = ""
     # Login of the account that triggered the webhook action (the
     # sender field in the event payload, not necessarily the PR author).
-    sender_login: str = ""
-    sender_type: SenderType = ""
-    head_sha: str | None = None
-    base_sha: str | None = None
 
 
 @dataclass
@@ -36,6 +32,10 @@ class OpenedPayload(BaseActivityPayload):
     deletions: int = 0
     changed_files: int = 0
     commits: int = 0
+    head_sha: str | None = None
+    base_sha: str | None = None
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -43,18 +43,24 @@ class SynchronizePayload(BaseActivityPayload):
     action: str = "synchronize"
     before_sha: str | None = None  # head SHA before the push
     after_sha: str | None = None  # head SHA after the push
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
 class LabeledPayload(BaseActivityPayload):
     action: str = "labeled"
     label_name: str = ""
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
 class UnlabeledPayload(BaseActivityPayload):
     action: str = "unlabeled"
     label_name: str = ""
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -62,12 +68,16 @@ class ReviewRequestedPayload(BaseActivityPayload):
     action: str = "review_requested"
     # True when a team was requested; False for an individual reviewer.
     is_team_review: bool = False
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
 class ReviewRequestRemovedPayload(BaseActivityPayload):
     action: str = "review_request_removed"
     is_team_review: bool = False
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -76,16 +86,22 @@ class CommentCreatedPayload(BaseActivityPayload):
     author_association: AuthorAssociation = "NONE"
     is_review: bool = False
     review_id: int | None = None
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
 class ConvertedToDraftPayload(BaseActivityPayload):
     action: str = "converted_to_draft"
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
 class ReadyForReviewPayload(BaseActivityPayload):
     action: str = "ready_for_review"
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -93,12 +109,16 @@ class AssignedPayload(BaseActivityPayload):
     action: str = "assigned"
     # Login of the account that was added as an assignee.
     assignee_login: str = ""
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
 class UnassignedPayload(BaseActivityPayload):
     action: str = "unassigned"
     assignee_login: str = ""
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -107,6 +127,8 @@ class ReviewSubmittedPayload(BaseActivityPayload):
     # "approved", "changes_requested", or "commented"
     review_state: str = ""
     review_id: int = 0
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -115,6 +137,8 @@ class ReviewThreadPayload(BaseActivityPayload):
     # GitHub node_id of the review thread (the thread object has no numeric id).
     thread_id: str = ""
     is_resolved: bool = False
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass
@@ -149,6 +173,8 @@ class ReviewDismissedPayload(BaseActivityPayload):
     # back to the earlier review_submitted row to see what was undone (an approval
     # or a changes-request).
     review_id: int = 0
+    sender_login: str = ""
+    sender_type: SenderType = ""
 
 
 @dataclass

--- a/src/sentry/pr_metrics/activity_types.py
+++ b/src/sentry/pr_metrics/activity_types.py
@@ -21,12 +21,20 @@ class BaseActivityPayload:
     """
 
     action: str = ""
-    # Login of the account that triggered the webhook action (the
-    # sender field in the event payload, not necessarily the PR author).
 
 
 @dataclass
-class OpenedPayload(BaseActivityPayload):
+class SenderMixin:
+    """Mixin for payload types that record who triggered the webhook action."""
+
+    # Login of the account that triggered the webhook action (the
+    # sender field in the event payload, not necessarily the PR author).
+    sender_login: str = ""
+    sender_type: SenderType = ""
+
+
+@dataclass
+class OpenedPayload(BaseActivityPayload, SenderMixin):
     action: str = "opened"
     additions: int = 0
     deletions: int = 0
@@ -34,111 +42,85 @@ class OpenedPayload(BaseActivityPayload):
     commits: int = 0
     head_sha: str | None = None
     base_sha: str | None = None
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class SynchronizePayload(BaseActivityPayload):
+class SynchronizePayload(BaseActivityPayload, SenderMixin):
     action: str = "synchronize"
     before_sha: str | None = None  # head SHA before the push
     after_sha: str | None = None  # head SHA after the push
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class LabeledPayload(BaseActivityPayload):
+class LabeledPayload(BaseActivityPayload, SenderMixin):
     action: str = "labeled"
     label_name: str = ""
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class UnlabeledPayload(BaseActivityPayload):
+class UnlabeledPayload(BaseActivityPayload, SenderMixin):
     action: str = "unlabeled"
     label_name: str = ""
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class ReviewRequestedPayload(BaseActivityPayload):
+class ReviewRequestedPayload(BaseActivityPayload, SenderMixin):
     action: str = "review_requested"
     # True when a team was requested; False for an individual reviewer.
     is_team_review: bool = False
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class ReviewRequestRemovedPayload(BaseActivityPayload):
+class ReviewRequestRemovedPayload(BaseActivityPayload, SenderMixin):
     action: str = "review_request_removed"
     is_team_review: bool = False
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class CommentCreatedPayload(BaseActivityPayload):
+class CommentCreatedPayload(BaseActivityPayload, SenderMixin):
     action: str = "comment_created"
     author_association: AuthorAssociation = "NONE"
     is_review: bool = False
     review_id: int | None = None
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class ConvertedToDraftPayload(BaseActivityPayload):
+class ConvertedToDraftPayload(BaseActivityPayload, SenderMixin):
     action: str = "converted_to_draft"
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class ReadyForReviewPayload(BaseActivityPayload):
+class ReadyForReviewPayload(BaseActivityPayload, SenderMixin):
     action: str = "ready_for_review"
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class AssignedPayload(BaseActivityPayload):
+class AssignedPayload(BaseActivityPayload, SenderMixin):
     action: str = "assigned"
     # Login of the account that was added as an assignee.
     assignee_login: str = ""
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class UnassignedPayload(BaseActivityPayload):
+class UnassignedPayload(BaseActivityPayload, SenderMixin):
     action: str = "unassigned"
     assignee_login: str = ""
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class ReviewSubmittedPayload(BaseActivityPayload):
+class ReviewSubmittedPayload(BaseActivityPayload, SenderMixin):
     action: str = ""
     # "approved", "changes_requested", or "commented"
     review_state: str = ""
     review_id: int = 0
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
-class ReviewThreadPayload(BaseActivityPayload):
+class ReviewThreadPayload(BaseActivityPayload, SenderMixin):
     action: str = ""
     # GitHub node_id of the review thread (the thread object has no numeric id).
     thread_id: str = ""
     is_resolved: bool = False
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass
@@ -166,15 +148,13 @@ class CheckRunCompletedPayload(BaseActivityPayload):
 
 
 @dataclass
-class ReviewDismissedPayload(BaseActivityPayload):
+class ReviewDismissedPayload(BaseActivityPayload, SenderMixin):
     action: str = "dismissed"
     # Numeric id of the dismissed review. The dismissed payload reports the review
     # state only as "dismissed", so the id is what lets the judge correlate this
     # back to the earlier review_submitted row to see what was undone (an approval
     # or a changes-request).
     review_id: int = 0
-    sender_login: str = ""
-    sender_type: SenderType = ""
 
 
 @dataclass

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -685,13 +685,9 @@ def handle_check_suite(
         return
 
     check_suite = event.get("check_suite") or {}
-    sender = event.get("sender") or {}
     app = check_suite.get("app") or {}
     payload = asdict(
         CheckSuiteCompletedPayload(
-            sender_login=sender.get("login", ""),
-            sender_type=sender.get("type", ""),
-            head_sha=check_suite.get("head_sha"),
             conclusion=check_suite.get("conclusion") or "",
             app_slug=app.get("slug", ""),
             check_runs_count=check_suite.get("latest_check_runs_count") or 0,
@@ -731,13 +727,9 @@ def handle_check_run(
         return
 
     check_run = event.get("check_run") or {}
-    sender = event.get("sender") or {}
     app = check_run.get("app") or {}
     payload = asdict(
         CheckRunCompletedPayload(
-            sender_login=sender.get("login", ""),
-            sender_type=sender.get("type", ""),
-            head_sha=check_run.get("head_sha"),
             check_name=check_run.get("name", ""),
             conclusion=check_run.get("conclusion") or "",
             app_slug=app.get("slug", ""),
@@ -1156,18 +1148,18 @@ def _build_activity_payload(
     base = pull_request.get("base") or {}
     sender = event.get("sender") or pull_request.get("user") or {}
 
-    base_kw: dict[str, Any] = dict(
+    sender_kw: dict[str, Any] = dict(
         sender_login=sender.get("login", ""),
         sender_type=sender.get("type", ""),
-        head_sha=head.get("sha"),
-        base_sha=base.get("sha"),
     )
 
     match action:
         case "opened":
             return asdict(
                 OpenedPayload(
-                    **base_kw,
+                    **sender_kw,
+                    head_sha=head.get("sha"),
+                    base_sha=base.get("sha"),
                     additions=pull_request.get("additions", 0),
                     deletions=pull_request.get("deletions", 0),
                     changed_files=pull_request.get("changed_files", 0),
@@ -1177,51 +1169,49 @@ def _build_activity_payload(
         case "synchronize":
             return asdict(
                 SynchronizePayload(
-                    **base_kw,
+                    **sender_kw,
                     before_sha=event.get("before"),
                     after_sha=event.get("after"),
                 )
             )
         case "labeled":
             label = event.get("label") or {}
-            return asdict(LabeledPayload(**base_kw, label_name=(label.get("name") or "")))
+            return asdict(LabeledPayload(**sender_kw, label_name=(label.get("name") or "")))
         case "unlabeled":
             label = event.get("label") or {}
-            return asdict(UnlabeledPayload(**base_kw, label_name=(label.get("name") or "")))
+            return asdict(UnlabeledPayload(**sender_kw, label_name=(label.get("name") or "")))
         case "review_requested":
             return asdict(
                 ReviewRequestedPayload(
-                    **base_kw, is_team_review=event.get("requested_team") is not None
+                    **sender_kw, is_team_review=event.get("requested_team") is not None
                 )
             )
         case "review_request_removed":
             return asdict(
                 ReviewRequestRemovedPayload(
-                    **base_kw, is_team_review=event.get("requested_team") is not None
+                    **sender_kw, is_team_review=event.get("requested_team") is not None
                 )
             )
         case "assigned":
             assignee = event.get("assignee") or {}
-            return asdict(AssignedPayload(**base_kw, assignee_login=assignee.get("login", "")))
+            return asdict(AssignedPayload(**sender_kw, assignee_login=assignee.get("login", "")))
         case "unassigned":
             assignee = event.get("assignee") or {}
-            return asdict(UnassignedPayload(**base_kw, assignee_login=assignee.get("login", "")))
+            return asdict(UnassignedPayload(**sender_kw, assignee_login=assignee.get("login", "")))
         case "converted_to_draft":
-            return asdict(ConvertedToDraftPayload(**base_kw))
+            return asdict(ConvertedToDraftPayload(**sender_kw))
         case "ready_for_review":
-            return asdict(ReadyForReviewPayload(**base_kw))
+            return asdict(ReadyForReviewPayload(**sender_kw))
         case "auto_merge_enabled":
             auto_merge = pull_request.get("auto_merge") or {}
             return asdict(
-                AutoMergeEnabledPayload(
-                    **base_kw, merge_method=auto_merge.get("merge_method") or ""
-                )
+                AutoMergeEnabledPayload(merge_method=auto_merge.get("merge_method") or "")
             )
         case "auto_merge_disabled":
-            return asdict(AutoMergeDisabledPayload(**base_kw))
+            return asdict(AutoMergeDisabledPayload())
         case "enqueued":
-            return asdict(EnqueuedPayload(**base_kw))
+            return asdict(EnqueuedPayload())
         case "dequeued":
-            return asdict(DequeuedPayload(**base_kw, reason=event.get("reason") or ""))
+            return asdict(DequeuedPayload(reason=event.get("reason") or ""))
         case _:
             raise ValueError(f"No payload builder for action {action!r}")

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -794,7 +794,7 @@ class HandleWebhookForPrMetricsActivityTest(TestCase):
         assert activity.event_type == PullRequestActivityType.UNASSIGNED
         assert activity.payload["assignee_login"] == "dev"
 
-    # --- sender_type in base payload ---
+    # --- sender_type in opened payload ---
 
     def test_bot_sender_type_stored_in_payload(self) -> None:
         self._call(action="opened", extra_event={"sender": {"login": "testbot", "type": "Bot"}})
@@ -1527,8 +1527,6 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
         assert activity.payload["conclusion"] == "success"
         assert activity.payload["app_slug"] == "github-actions"
         assert activity.payload["check_runs_count"] == 6
-        assert activity.payload["head_sha"] == "headsha1"
-        assert activity.payload["sender_type"] == "Bot"
 
     def test_check_suite_non_completed_action_skipped(self) -> None:
         for action in ("requested", "rerequested"):
@@ -1618,7 +1616,6 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
         assert activity.payload["check_name"] == "lint"
         assert activity.payload["conclusion"] == "failure"
         assert activity.payload["app_slug"] == "github-actions"
-        assert activity.payload["head_sha"] == "headsha1"
 
     def test_check_run_non_completed_action_skipped(self) -> None:
         for action in ("created", "rerequested", "requested_action"):


### PR DESCRIPTION
Reduces the size of `PullRequestActivity` rows by removing fields from the stored JSON payload that specific event types don't need. `sender_login`, `sender_type`, `head_sha`, and `base_sha` are moved out of the base payload class and into only the individual payload types that actually use them.

Refs CORE-265