### PR TITLE
ref(pr-metrics): Add observability for dropped delegated-agent attribution

### DIFF
--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -258,6 +258,21 @@ class CursorWebhookEndpoint(Endpoint):
                     "cursor_webhook.pr_attribution_failed",
                     extra={"agent_id": agent_id, "pr_url": pr_url},
                 )
+        elif status == CodingAgentStatus.COMPLETED:
+            # A completed agent that we did not attribute is otherwise invisible: the
+            # webhook arrived and the agent finished, but one of the remaining gates
+            # dropped it silently, leaving no SEER_DELEGATED_CURSOR row and no trace of
+            # why. Log which gate blocked so these are diagnosable from logs alone.
+            logger.info(
+                "cursor_webhook.attribution_skipped",
+                extra={
+                    "agent_id": agent_id,
+                    "pr_url": pr_url,
+                    "repo_full_name": repo_full_name,
+                    "known_to_seer": known_to_seer,
+                    "has_pr_url": bool(pr_url),
+                },
+            )
 
     def _validate_pr_url(self, pr_url: str, repo_full_name: str) -> bool:
         """Validates that the URL points to the expected repo."""
@@ -282,6 +297,7 @@ class CursorWebhookEndpoint(Endpoint):
                 "agent_id": agent_id,
                 "status": status.value,
                 "has_result": result is not None,
+                "known_to_seer": known_to_seer,
             },
         )
         return known_to_seer

--- a/src/sentry/seer/agent/coding_agent_handoff.py
+++ b/src/sentry/seer/agent/coding_agent_handoff.py
@@ -218,6 +218,11 @@ def launch_coding_agents(
             "run_id": run_id,
             "repos_succeeded": len(successes),
             "repos_failed": len(failures),
+            # The launched agent ids are the only join key between this run and the
+            # provider webhooks that later report completion (keyed on agent_id). Seer's
+            # handoff record carries run_id but no agent_id, so without this a webhook's
+            # attribution outcome cannot be traced back to the run that launched it.
+            "agent_ids": [state.id for state in states_to_store],
         },
     )
 

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -72,6 +72,15 @@ class TestCursorWebhook(APITestCase):
             "summary": summary,
         }
 
+    def _skip_log_extra(self, mock_logger: Any) -> dict[str, Any]:
+        calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and c.args[0] == "cursor_webhook.attribution_skipped"
+        ]
+        assert len(calls) == 1
+        return calls[0].kwargs["extra"]
+
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_happy_path_finished(self, mock_update_state):
         mock_update_state.return_value = True
@@ -164,6 +173,32 @@ class TestCursorWebhook(APITestCase):
 
         assert response.status_code == 204
         assert not PullRequestAttribution.objects.exists()
+
+    @patch("sentry.integrations.cursor.webhooks.handler.logger")
+    @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
+    def test_completed_without_attribution_logs_skip_reason(self, mock_update_state, mock_logger):
+        # A completed agent that we don't attribute must leave a breadcrumb naming the
+        # gate that blocked it, otherwise a missing SEER_DELEGATED_CURSOR row is invisible.
+        self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
+
+        # Seer didn't recognize the agent: known_to_seer=False, but a PR is present.
+        mock_update_state.return_value = False
+        body = orjson.dumps(self._build_status_payload(status="FINISHED"))
+        with self.feature("organizations:pr-metrics-attribution"):
+            assert self._post_with_headers(body, self._signed_headers(body)).status_code == 204
+        extra = self._skip_log_extra(mock_logger)
+        assert extra["known_to_seer"] is False
+        assert extra["has_pr_url"] is True
+
+        # Seer knew the agent but there's no PR to attribute: known_to_seer=True, pr_url absent.
+        mock_logger.reset_mock()
+        mock_update_state.return_value = True
+        body = orjson.dumps(self._build_status_payload(status="FINISHED", pr_url=None))
+        with self.feature("organizations:pr-metrics-attribution"):
+            assert self._post_with_headers(body, self._signed_headers(body)).status_code == 204
+        extra = self._skip_log_extra(mock_logger)
+        assert extra["known_to_seer"] is True
+        assert extra["has_pr_url"] is False
 
     @patch("sentry.integrations.cursor.webhooks.handler.update_coding_agent_state")
     def test_finished_records_no_attribution_when_flag_disabled(self, mock_update_state):


### PR DESCRIPTION
Adds a few logs to the Cursor delegated-agent attribution path so we can tell why some completed agents don't get attributed.

The completion webhook silently skips attribution when one of its guards fails, so today there's no way to see whether it was `known_to_seer`, a missing PR URL, or the webhook not matching a run. This logs the blocking gate and adds a `run_id -> agent_id` join key on the launch log. No behavior change.