### PR TITLE
feat(github): handle new_permissions_accepted installation webhook

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -731,6 +731,72 @@ INSTALLATION_DELETE_EVENT_EXAMPLE = """{
   }
 }"""
 
+INSTALLATION_NEW_PERMISSIONS_EVENT_EXAMPLE = """{
+  "action": "new_permissions_accepted",
+  "installation": {
+    "id": 2,
+    "client_id": "Iv1.abc123",
+    "account": {
+      "login": "octocat",
+      "id": 1,
+      "node_id": "MDQ6VXNlcjE=",
+      "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/octocat",
+      "html_url": "https://github.com/octocat",
+      "type": "User",
+      "user_view_type": "public",
+      "site_admin": false
+    },
+    "repository_selection": "all",
+    "access_tokens_url": "https://api.github.com/app/installations/2/access_tokens",
+    "repositories_url": "https://api.github.com/installation/repositories",
+    "html_url": "https://github.com/settings/installations/2",
+    "app_id": 123,
+    "app_slug": "octocat-app",
+    "target_id": 1,
+    "target_type": "User",
+    "permissions": {
+      "actions": "read",
+      "administration": "read",
+      "checks": "write",
+      "contents": "write",
+      "issues": "write",
+      "metadata": "read",
+      "pull_requests": "write",
+      "repository_hooks": "write",
+      "statuses": "write"
+    },
+    "events": [
+      "check_suite",
+      "issues",
+      "issue_comment",
+      "pull_request",
+      "pull_request_review",
+      "push"
+    ],
+    "created_at": "2019-01-01T08:56:55.000-04:00",
+    "updated_at": "2019-01-02T12:16:12.000-04:00",
+    "single_file_name": null,
+    "has_multiple_single_files": false,
+    "single_file_paths": [],
+    "suspended_by": null,
+    "suspended_at": null
+  },
+  "sender": {
+    "login": "octocat",
+    "id": 1,
+    "node_id": "MDQ6VXNlcjE=",
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/octocat",
+    "html_url": "https://github.com/octocat",
+    "type": "User",
+    "user_view_type": "public",
+    "site_admin": false
+  }
+}"""
+
 INSTALLATION_REPO_EVENT = """{
   "action": "added",
   "installation": {

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import calendar
 import datetime
-import logging
 import time
 from urllib.parse import urlparse
 
@@ -10,8 +9,6 @@ from rest_framework.response import Response
 
 from sentry import options
 from sentry.utils import jwt
-
-logger = logging.getLogger(__name__)
 
 
 def get_jwt(github_id: str | None = None, github_private_key: str | None = None) -> str:

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -28,6 +28,7 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.identity.services.identity.service import identity_service
 from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.github.client import GitHubApiClient
 from sentry.integrations.github.webhook_types import (
     GITHUB_WEBHOOK_TYPE_HEADER_KEY,
     GithubWebhookType,
@@ -466,6 +467,10 @@ class InstallationEventWebhook(GitHubWebhook):
             data = GitHubIntegrationProvider().build_integration(state)
             ensure_integration(IntegrationProviderSlug.GITHUB.value, data)
 
+        if event["action"] == "new_permissions_accepted":
+            self._handle_new_permissions_accepted(event, **kwargs)
+            return
+
         if event["action"] == "deleted":
             external_id = event["installation"]["id"]
             if host := kwargs.get("host"):
@@ -494,6 +499,65 @@ class InstallationEventWebhook(GitHubWebhook):
                         "external_id": str(external_id),
                     },
                 )
+
+    def _handle_new_permissions_accepted(
+        self, event: Mapping[str, Any], **kwargs: Any
+    ) -> None:
+        external_id = event["installation"]["id"]
+        if host := kwargs.get("host"):
+            external_id = "{}:{}".format(host, event["installation"]["id"])
+
+        result = integration_service.organization_contexts(
+            provider=self.provider,
+            external_id=external_id,
+        )
+        integration = result.integration
+        if integration is None:
+            logger.warning(
+                "github.new-permissions-missing-integration",
+                extra={
+                    "action": event["action"],
+                    "installation_name": event["installation"]["account"]["login"],
+                    "external_id": str(external_id),
+                },
+            )
+            return
+
+        # Expire the stored access token so the refresh below persists the
+        # permissions GitHub returns with the newly scoped token.
+        metadata = {
+            **integration.metadata,
+            "access_token": None,
+            "expires_at": None,
+        }
+        updated = integration_service.update_integration(
+            integration_id=integration.id, metadata=metadata
+        )
+        if updated is None:
+            logger.warning(
+                "github.new-permissions-integration-update-failed",
+                extra={"integration_id": integration.id, "external_id": str(external_id)},
+            )
+            return
+
+        logger.info(
+            "InstallationEventWebhook._handle_new_permissions_accepted",
+            extra={
+                "external_id": str(external_id),
+                "integration_id": integration.id,
+            },
+        )
+
+        # Eagerly refresh the token so it's valid immediately and the stored
+        # permissions are confirmed against GitHub. Non-fatal: the token also
+        # refreshes lazily on the next request if this fails.
+        try:
+            GitHubApiClient(integration=updated).get_access_token()
+        except Exception:
+            logger.exception(
+                "github.new-permissions-token-refresh-failed",
+                extra={"integration_id": integration.id, "external_id": str(external_id)},
+            )
 
     def _handle_organization_deletion(
         self,

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -28,7 +28,7 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.constants import EXTENSION_LANGUAGE_MAP, ObjectStatus
 from sentry.identity.services.identity.service import identity_service
 from sentry.integrations.base import IntegrationDomain
-from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.github.client import GitHubApiClient, GitHubBaseClient
 from sentry.integrations.github.webhook_types import (
     GITHUB_WEBHOOK_TYPE_HEADER_KEY,
     GithubWebhookType,
@@ -550,12 +550,15 @@ class InstallationEventWebhook(GitHubWebhook):
         # permissions are confirmed against GitHub. Non-fatal: the token also
         # refreshes lazily on the next request if this fails.
         try:
-            GitHubApiClient(integration=updated).get_access_token()
+            self._get_token_refresh_client(updated).get_access_token()
         except Exception:
             logger.exception(
                 "github.new-permissions-token-refresh-failed",
                 extra={"integration_id": integration.id, "external_id": str(external_id)},
             )
+
+    def _get_token_refresh_client(self, integration: RpcIntegration) -> GitHubBaseClient:
+        return GitHubApiClient(integration=integration)
 
     def _handle_organization_deletion(
         self,

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -500,9 +500,7 @@ class InstallationEventWebhook(GitHubWebhook):
                     },
                 )
 
-    def _handle_new_permissions_accepted(
-        self, event: Mapping[str, Any], **kwargs: Any
-    ) -> None:
+    def _handle_new_permissions_accepted(self, event: Mapping[str, Any], **kwargs: Any) -> None:
         external_id = event["installation"]["id"]
         if host := kwargs.get("host"):
             external_id = "{}:{}".format(host, event["installation"]["id"])

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -19,6 +19,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationDomain
+from sentry.integrations.github.client import GitHubBaseClient
 from sentry.integrations.github.webhook import (
     GitHubWebhook,
     InstallationEventWebhook,
@@ -29,6 +30,7 @@ from sentry.integrations.github.webhook import (
     get_github_external_id,
 )
 from sentry.integrations.github.webhook_types import GithubWebhookType
+from sentry.integrations.github_enterprise.client import GitHubEnterpriseApiClient
 from sentry.integrations.utils.metrics import IntegrationWebhookEvent
 from sentry.integrations.utils.scope import clear_organization_info
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
@@ -113,7 +115,17 @@ class GitHubEnterpriseWebhook:
 
 
 class GitHubEnterpriseInstallationEventWebhook(GitHubEnterpriseWebhook, InstallationEventWebhook):
-    pass
+    def _get_token_refresh_client(self, integration: RpcIntegration) -> GitHubBaseClient:
+        metadata = integration.metadata
+        installation = metadata["installation"]
+        return GitHubEnterpriseApiClient(
+            base_url=metadata["domain_name"].split("/")[0],
+            integration=integration,
+            app_id=installation["id"],
+            private_key=installation["private_key"],
+            verify_ssl=installation["verify_ssl"],
+            org_integration_id=None,
+        )
 
 
 class GitHubEnterpriseInstallationRepositoriesEventWebhook(

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -10,6 +10,7 @@ from fixtures.github import (
     INSTALLATION_API_RESPONSE,
     INSTALLATION_DELETE_EVENT_EXAMPLE,
     INSTALLATION_EVENT_EXAMPLE,
+    INSTALLATION_NEW_PERMISSIONS_EVENT_EXAMPLE,
     ISSUES_ASSIGNED_EVENT_EXAMPLE,
     ISSUES_CLOSED_EVENT_EXAMPLE,
     ISSUES_REOPENED_EVENT_EXAMPLE,
@@ -341,6 +342,121 @@ class InstallationDeleteEventWebhookTest(APITestCase):
         assert integration.external_id == "2"
         assert integration.name == "octocat"
         assert integration.status == ObjectStatus.DISABLED
+
+
+@control_silo_test
+class InstallationNewPermissionsEventWebhookTest(APITestCase):
+    base_url = "https://api.github.com"
+
+    def setUp(self) -> None:
+        self.url = "/extensions/github/webhook/"
+        self.secret = "b3002c3e321d4b7880360d397db2ccfd"
+        options.set("github-app.webhook-secret", self.secret)
+
+    def _post(self) -> int:
+        body = INSTALLATION_NEW_PERMISSIONS_EVENT_EXAMPLE
+        sig1 = GitHubIntegrationsWebhookEndpoint.compute_signature(
+            "sha1", body.encode(), self.secret
+        )
+        sig256 = GitHubIntegrationsWebhookEndpoint.compute_signature(
+            "sha256", body.encode(), self.secret
+        )
+        response = self.client.post(
+            path=self.url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="installation",
+            HTTP_X_HUB_SIGNATURE=f"sha1={sig1}",
+            HTTP_X_HUB_SIGNATURE_256=f"sha256={sig256}",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        return response.status_code
+
+    def _add_refresh_response(self) -> None:
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/2/access_tokens",
+            json={
+                "token": "new-token",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "permissions": {"contents": "write", "pull_requests": "write"},
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+    @responses.activate
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def test_refreshes_token_and_persists_permissions(self, get_jwt: MagicMock) -> None:
+        # A token that is still valid (well in the future) so the only reason a
+        # refresh happens is that the handler expired it. Confirms we ALWAYS refresh.
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(hours=1)
+        integration = self.create_integration(
+            name="octocat",
+            organization=self.organization,
+            external_id="2",
+            provider="github",
+            metadata={
+                "access_token": "old-token",
+                "expires_at": future_expires.isoformat(),
+                "permissions": {"contents": "read"},
+            },
+        )
+        self._add_refresh_response()
+
+        assert self._post() == 204
+
+        # The refresh endpoint was hit even though the stored token was unexpired.
+        assert len(responses.calls) == 1
+        assert "access_tokens" in responses.calls[0].request.url
+
+        integration = Integration.objects.get(external_id="2")
+        assert integration.metadata["access_token"] == "new-token"
+        assert integration.metadata["expires_at"] == "2099-01-01T00:00:00"
+        # Permissions returned with the refreshed token are persisted as a side effect.
+        assert integration.metadata["permissions"] == {
+            "contents": "write",
+            "pull_requests": "write",
+        }
+
+    @responses.activate
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def test_missing_integration_is_noop(self, get_jwt: MagicMock) -> None:
+        self._add_refresh_response()
+
+        # No integration exists for external_id "2".
+        assert self._post() == 204
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def test_token_refresh_failure_is_non_fatal(self, get_jwt: MagicMock) -> None:
+        future_expires = datetime.now().replace(microsecond=0) + timedelta(hours=1)
+        self.create_integration(
+            name="octocat",
+            organization=self.organization,
+            external_id="2",
+            provider="github",
+            metadata={
+                "access_token": "old-token",
+                "expires_at": future_expires.isoformat(),
+                "permissions": {"contents": "read"},
+            },
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/2/access_tokens",
+            status=500,
+        )
+
+        # A failed refresh must not surface an error to GitHub.
+        assert self._post() == 204
+
+        # The token was expired prior to the (failed) refresh; it stays expired so
+        # the next request will retry the refresh lazily.
+        integration = Integration.objects.get(external_id="2")
+        assert integration.metadata["access_token"] is None
+        assert integration.metadata["expires_at"] is None
 
 
 @control_silo_test


### PR DESCRIPTION
we need to deploy this webhook handler before we make any app changes so we can make sure the permissions in the integration metadata is always up to date

by deploying this change first we make sure that when we release a app permission change, we'll know _for sure_ whether the app permissions request was accepted or not

if we deploy this after we request new permissions, it's possible users accept the new perms before we start handling the webhooks, and we have to rely on adhoc github api calls to know whether the installation has been updated vs. being able to rely on the perms in the DB

closes CORE-270