### PR TITLE
feat(seer-activity): Better communicate incompatible alerts

### DIFF
--- a/static/app/views/automations/hooks/utils.spec.tsx
+++ b/static/app/views/automations/hooks/utils.spec.tsx
@@ -412,4 +412,198 @@ describe('findConflictingConditions', () => {
       conflictReason: 'Delete duplicate triggers to continue.',
     });
   });
+
+  describe('Seer activity trigger incompatibilities', () => {
+    const seerTriggers: DataConditionGroup = {
+      id: 'triggers',
+      logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+      conditions: [
+        {
+          id: '1',
+          type: DataConditionType.SEER_ACTIVITY_TRIGGER,
+          comparison: ['rca_completed'],
+        },
+      ],
+    };
+
+    it('flags event attribute filters as incompatible with Seer activity triggers', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ALL,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {
+          actionFilter1: new Set(['2']),
+        },
+        conflictReason:
+          'The conditions highlighted in red are not compatible with Seer activity triggers.',
+      });
+    });
+
+    it('flags tagged event, level, and release filters as incompatible', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ALL,
+          conditions: [
+            {id: '2', type: DataConditionType.TAGGED_EVENT, comparison: {}},
+            {id: '3', type: DataConditionType.LEVEL, comparison: {}},
+            {id: '4', type: DataConditionType.LATEST_RELEASE, comparison: true},
+            {
+              id: '5',
+              type: DataConditionType.LATEST_ADOPTED_RELEASE,
+              comparison: {},
+            },
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {
+          actionFilter1: new Set(['2', '3', '4', '5']),
+        },
+        conflictReason:
+          'The conditions highlighted in red are not compatible with Seer activity triggers.',
+      });
+    });
+
+    it('flags frequency (slow) conditions as incompatible', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ALL,
+          conditions: [
+            {
+              id: '2',
+              type: DataConditionType.EVENT_FREQUENCY_COUNT,
+              comparison: {value: 10},
+            },
+            {
+              id: '3',
+              type: DataConditionType.PERCENT_SESSIONS_COUNT,
+              comparison: {value: 5},
+            },
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {
+          actionFilter1: new Set(['2', '3']),
+        },
+        conflictReason:
+          'The conditions highlighted in red are not compatible with Seer activity triggers.',
+      });
+    });
+
+    it('allows compatible issue attribute filters with Seer activity triggers', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ALL,
+          conditions: [
+            {
+              id: '2',
+              type: DataConditionType.AGE_COMPARISON,
+              comparison: {comparison_type: AgeComparison.OLDER, value: 10},
+            },
+            {
+              id: '3',
+              type: DataConditionType.ASSIGNED_TO,
+              comparison: {targetType: 'Unassigned'},
+            },
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {},
+        conflictReason: null,
+      });
+    });
+
+    it('clears conflicts with ANY logic when at least one condition is compatible', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+            {
+              id: '3',
+              type: DataConditionType.AGE_COMPARISON,
+              comparison: {comparison_type: AgeComparison.OLDER, value: 10},
+            },
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {},
+        conflictReason: null,
+      });
+    });
+
+    it('flags conflicts with ANY logic when all conditions are incompatible', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+            {id: '3', type: DataConditionType.TAGGED_EVENT, comparison: {}},
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {
+          actionFilter1: new Set(['2', '3']),
+        },
+        conflictReason:
+          'The conditions highlighted in red are not compatible with Seer activity triggers.',
+      });
+    });
+
+    it('does not flag Seer incompatibilities when there is no Seer activity trigger', () => {
+      const triggers: DataConditionGroup = {
+        id: 'triggers',
+        logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+        conditions: [
+          {
+            id: '1',
+            type: DataConditionType.FIRST_SEEN_EVENT,
+            comparison: {},
+          },
+        ],
+      };
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ALL,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(triggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {},
+        conflictReason: null,
+      });
+    });
+  });
 });

--- a/static/app/views/automations/hooks/utils.spec.tsx
+++ b/static/app/views/automations/hooks/utils.spec.tsx
@@ -622,6 +622,50 @@ describe('findConflictingConditions', () => {
       });
     });
 
+    it('does not flag event-required conditions with NONE logic since they evaluate to false', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.NONE,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+            {id: '3', type: DataConditionType.TAGGED_EVENT, comparison: {}},
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {},
+        conflictReason: null,
+      });
+    });
+
+    it('still flags slow conditions with NONE logic since they are silently skipped', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.NONE,
+          conditions: [
+            {
+              id: '2',
+              type: DataConditionType.EVENT_FREQUENCY_COUNT,
+              comparison: {value: 10},
+            },
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {
+          actionFilter1: new Set(['2']),
+        },
+        conflictReason:
+          'The conditions highlighted in red are not compatible with Seer activity triggers.',
+      });
+    });
+
     it('does not flag Seer incompatibilities when there is no Seer activity trigger', () => {
       const triggers: DataConditionGroup = {
         id: 'triggers',

--- a/static/app/views/automations/hooks/utils.spec.tsx
+++ b/static/app/views/automations/hooks/utils.spec.tsx
@@ -577,6 +577,51 @@ describe('findConflictingConditions', () => {
       });
     });
 
+    it('clears conflicts with legacy ANY logic when at least one condition is compatible', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ANY,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+            {
+              id: '3',
+              type: DataConditionType.AGE_COMPARISON,
+              comparison: {comparison_type: AgeComparison.OLDER, value: 10},
+            },
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {},
+        conflictReason: null,
+      });
+    });
+
+    it('flags conflicts with legacy ANY logic when all conditions are incompatible', () => {
+      const actionFilters = [
+        {
+          id: 'actionFilter1',
+          logicType: DataConditionGroupLogicType.ANY,
+          conditions: [
+            {id: '2', type: DataConditionType.EVENT_ATTRIBUTE, comparison: {}},
+            {id: '3', type: DataConditionType.TAGGED_EVENT, comparison: {}},
+          ],
+        },
+      ];
+
+      const result = findConflictingConditions(seerTriggers, actionFilters);
+      expect(result).toEqual({
+        conflictingConditionGroups: {
+          actionFilter1: new Set(['2', '3']),
+        },
+        conflictReason:
+          'The conditions highlighted in red are not compatible with Seer activity triggers.',
+      });
+    });
+
     it('does not flag Seer incompatibilities when there is no Seer activity trigger', () => {
       const triggers: DataConditionGroup = {
         id: 'triggers',

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -207,6 +207,8 @@ const slowConditions = new Set<DataConditionType>([
   DataConditionType.EVENT_FREQUENCY_PERCENT,
   DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
   DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+  DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_COUNT,
+  DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_WITH_CONDITIONS_PERCENT,
   DataConditionType.PERCENT_SESSIONS_COUNT,
   DataConditionType.PERCENT_SESSIONS_PERCENT,
 ]);
@@ -306,23 +308,25 @@ function findConflictingPriorityConditions(
   return conflictingConditions;
 }
 
+const ANY_LOGIC_TYPES = new Set([
+  DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+  DataConditionGroupLogicType.ANY,
+]);
+
 function findSeerActivityIncompatibleConditions(
   conditionGroup: DataConditionGroup
 ): Set<string> {
-  const allIncompatibleConditions = new Set([
-    ...eventRequiredConditions,
-    ...slowConditions,
-  ]);
-  const anyLogicTypes = new Set([
-    DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
-    DataConditionGroupLogicType.ANY,
-  ]);
+  const incompatibleSet =
+    conditionGroup.logicType === DataConditionGroupLogicType.NONE
+      ? slowConditions
+      : slowConditions.union(eventRequiredConditions);
+
   const incompatibleConditions = conditionGroup.conditions.filter(c =>
-    allIncompatibleConditions.has(c.type)
+    incompatibleSet.has(c.type)
   );
   // With ANY logic, if at least one condition is compatible, the filter can still pass
   if (
-    anyLogicTypes.has(conditionGroup.logicType) &&
+    ANY_LOGIC_TYPES.has(conditionGroup.logicType) &&
     incompatibleConditions.length !== conditionGroup.conditions.length
   ) {
     return new Set<string>();

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -189,7 +189,7 @@ const frequencyTypes = new Set<DataConditionType>([
  * (like Seer activity) pass an Activity object, so these filters always
  * return false and will block the workflow if the logic type is ALL.
  */
-const eventRequiredFilters = new Set<DataConditionType>([
+const eventRequiredConditions = new Set<DataConditionType>([
   DataConditionType.EVENT_ATTRIBUTE,
   DataConditionType.TAGGED_EVENT,
   DataConditionType.LEVEL,
@@ -202,7 +202,7 @@ const eventRequiredFilters = new Set<DataConditionType>([
  * cannot be enqueued for delayed evaluation, so these conditions are
  * silently skipped.
  */
-const slowConditionTypes = new Set<DataConditionType>([
+const slowConditions = new Set<DataConditionType>([
   DataConditionType.EVENT_FREQUENCY_COUNT,
   DataConditionType.EVENT_FREQUENCY_PERCENT,
   DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
@@ -309,26 +309,26 @@ function findConflictingPriorityConditions(
 function findSeerActivityIncompatibleConditions(
   conditionGroup: DataConditionGroup
 ): Set<string> {
-  const incompatible = new Set<string>();
-
-  for (const condition of conditionGroup.conditions) {
-    if (
-      eventRequiredFilters.has(condition.type) ||
-      slowConditionTypes.has(condition.type)
-    ) {
-      incompatible.add(condition.id);
-    }
-  }
-
+  const allIncompatibleConditions = new Set([
+    ...eventRequiredConditions,
+    ...slowConditions,
+  ]);
+  const anyLogicTypes = new Set([
+    DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
+    DataConditionGroupLogicType.ANY,
+  ]);
+  const incompatibleConditions = conditionGroup.conditions.filter(c =>
+    allIncompatibleConditions.has(c.type)
+  );
   // With ANY logic, if at least one condition is compatible, the filter can still pass
   if (
-    conditionGroup.logicType === DataConditionGroupLogicType.ANY_SHORT_CIRCUIT &&
-    incompatible.size !== conditionGroup.conditions.length
+    anyLogicTypes.has(conditionGroup.logicType) &&
+    incompatibleConditions.length !== conditionGroup.conditions.length
   ) {
     return new Set<string>();
   }
 
-  return incompatible;
+  return new Set<string>(incompatibleConditions.map(c => c.id));
 }
 
 function findDuplicateTriggerConditions(triggers: DataConditionGroup): Set<string> {

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -138,6 +138,32 @@ export function findConflictingConditions(
     };
   }
 
+  // Check for action filters incompatible with Seer activity triggers
+  const hasSeerActivityTrigger = triggers.conditions.some(
+    c => c.type === DataConditionType.SEER_ACTIVITY_TRIGGER
+  );
+  if (!hasSeerActivityTrigger) {
+    const seerConflictingActionFilters: Record<string, Set<string>> = {};
+    let hasSeerConflicts = false;
+
+    for (const actionFilter of actionFilters) {
+      const conflicts = findSeerActivityIncompatibleConditions(actionFilter);
+      if (conflicts.size > 0) {
+        hasSeerConflicts = true;
+        seerConflictingActionFilters[actionFilter.id] = conflicts;
+      }
+    }
+
+    if (hasSeerConflicts) {
+      return {
+        conflictingConditionGroups: seerConflictingActionFilters,
+        conflictReason: t(
+          'The conditions highlighted in red are not compatible with Seer activity triggers.'
+        ),
+      };
+    }
+  }
+
   return {
     conflictingConditionGroups: {},
     conflictReason: null,
@@ -156,6 +182,33 @@ const frequencyTypes = new Set<DataConditionType>([
   DataConditionType.EVENT_FREQUENCY_PERCENT,
   DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
   DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+]);
+
+/**
+ * Filters that require a GroupEvent to evaluate. Activity-based triggers
+ * (like Seer activity) pass an Activity object, so these filters always
+ * return false and will block the workflow if the logic type is ALL.
+ */
+const eventRequiredFilters = new Set<DataConditionType>([
+  DataConditionType.EVENT_ATTRIBUTE,
+  DataConditionType.TAGGED_EVENT,
+  DataConditionType.LEVEL,
+  DataConditionType.LATEST_RELEASE,
+  DataConditionType.LATEST_ADOPTED_RELEASE,
+]);
+
+/**
+ * Slow conditions that require Snuba queries. Activity-based triggers
+ * cannot be enqueued for delayed evaluation, so these conditions are
+ * silently skipped.
+ */
+const slowConditionTypes = new Set<DataConditionType>([
+  DataConditionType.EVENT_FREQUENCY_COUNT,
+  DataConditionType.EVENT_FREQUENCY_PERCENT,
+  DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_COUNT,
+  DataConditionType.EVENT_UNIQUE_USER_FREQUENCY_PERCENT,
+  DataConditionType.PERCENT_SESSIONS_COUNT,
+  DataConditionType.PERCENT_SESSIONS_PERCENT,
 ]);
 
 function findFirstSeenEventConflictingConditions(
@@ -251,6 +304,31 @@ function findConflictingPriorityConditions(
   }
 
   return conflictingConditions;
+}
+
+function findSeerActivityIncompatibleConditions(
+  conditionGroup: DataConditionGroup
+): Set<string> {
+  const incompatible = new Set<string>();
+
+  for (const condition of conditionGroup.conditions) {
+    if (
+      eventRequiredFilters.has(condition.type) ||
+      slowConditionTypes.has(condition.type)
+    ) {
+      incompatible.add(condition.id);
+    }
+  }
+
+  // With ANY logic, if at least one condition is compatible, the filter can still pass
+  if (
+    conditionGroup.logicType === DataConditionGroupLogicType.ANY_SHORT_CIRCUIT &&
+    incompatible.size !== conditionGroup.conditions.length
+  ) {
+    return new Set<string>();
+  }
+
+  return incompatible;
 }
 
 function findDuplicateTriggerConditions(triggers: DataConditionGroup): Set<string> {

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -142,7 +142,7 @@ export function findConflictingConditions(
   const hasSeerActivityTrigger = triggers.conditions.some(
     c => c.type === DataConditionType.SEER_ACTIVITY_TRIGGER
   );
-  if (!hasSeerActivityTrigger) {
+  if (hasSeerActivityTrigger) {
     const seerConflictingActionFilters: Record<string, Set<string>> = {};
     let hasSeerConflicts = false;
 


### PR DESCRIPTION
Some attributes and filters will never fire when connected to a Seer activity alert, so we should warn about those.
<img width="927" height="535" alt="image" src="https://github.com/user-attachments/assets/fae2c1cb-b293-41e0-852d-211a03aa6890" />
