### PR TITLE
chore(docs): Update 'alert rule action' from user-facing text to 'alert action'

### DIFF
--- a/src/sentry/apidocs/examples/integration_examples.py
+++ b/src/sentry/apidocs/examples/integration_examples.py
@@ -34,14 +34,7 @@ class IntegrationExamples:
                         "canAdd": True,
                         "canDisable": False,
                         "features": ["alert-rule", "chat-unfurl"],
-                        "aspects": {
-                            "alerts": [
-                                {
-                                    "type": "info",
-                                    "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
-                                }
-                            ]
-                        },
+                        "aspects": {},
                     },
                     "configOrganization": [],
                     "configData": {"installationType": "born_as_bot"},
@@ -87,14 +80,7 @@ class IntegrationExamples:
                     "canAdd": True,
                     "canDisable": False,
                     "features": ["alert-rule", "chat-unfurl"],
-                    "aspects": {
-                        "alerts": [
-                            {
-                                "type": "info",
-                                "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
-                            }
-                        ]
-                    },
+                    "aspects": {},
                 },
                 "configOrganization": [],
                 "configData": {"installationType": "born_as_bot"},
@@ -550,14 +536,7 @@ class IntegrationExamples:
                             "noun": "Installation",
                             "issue_url": "https://github.com/getsentry/sentry/issues/new?assignees=&labels=Component:%20Integrations&template=bug.yml&title=PagerDuty%20Integration%20Problem",
                             "source_url": "https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/pagerduty",
-                            "aspects": {
-                                "alerts": [
-                                    {
-                                        "type": "info",
-                                        "text": "The PagerDuty integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to PagerDuty you must create a rule using the PagerDuty action in your project settings.",
-                                    }
-                                ]
-                            },
+                            "aspects": {},
                         },
                         "canAdd": True,
                         "canDisable": False,
@@ -583,14 +562,7 @@ class IntegrationExamples:
                             "noun": "Workspace",
                             "issue_url": "https://github.com/getsentry/sentry/issues/new?assignees=&labels=Component:%20Integrations&template=bug.yml&title=Slack%20Integration%20Problem",
                             "source_url": "https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/slack",
-                            "aspects": {
-                                "alerts": [
-                                    {
-                                        "type": "info",
-                                        "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
-                                    }
-                                ]
-                            },
+                            "aspects": {},
                         },
                         "canAdd": True,
                         "canDisable": False,

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -59,11 +59,6 @@ FEATURES = [
     ),
 ]
 
-setup_alert = {
-    "type": "info",
-    "text": "The PagerDuty integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to PagerDuty you must create a rule using the PagerDuty action in your project settings.",
-}
-
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
     features=FEATURES,
@@ -71,7 +66,7 @@ metadata = IntegrationMetadata(
     noun=_("Installation"),
     issue_url="https://github.com/getsentry/sentry/issues/new?assignees=&labels=Component:%20Integrations&template=bug.yml&title=PagerDuty%20Integration%20Problem",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/pagerduty",
-    aspects={"alerts": [setup_alert]},
+    aspects={},
 )
 
 

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -70,11 +70,6 @@ FEATURES = [
     ),
 ]
 
-setup_alert = {
-    "type": "info",
-    "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
-}
-
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
     features=FEATURES,
@@ -82,7 +77,7 @@ metadata = IntegrationMetadata(
     noun=_("Workspace"),
     issue_url="https://github.com/getsentry/sentry/issues/new?assignees=&labels=Component:%20Integrations&template=bug.yml&title=Slack%20Integration%20Problem",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/slack",
-    aspects={"alerts": [setup_alert]},
+    aspects={},
 )
 
 

--- a/src/sentry/rules/actions/sentry_apps/notify_event.py
+++ b/src/sentry/rules/actions/sentry_apps/notify_event.py
@@ -82,7 +82,7 @@ class NotifyEventSentryAppAction(SentryAppEventAction):
                 return component
 
         raise ValidationError(
-            f"Alert Rule Actions are not enabled for the {sentry_app_name} integration."
+            f"Alert Actions are not enabled for the {sentry_app_name} integration."
         )
 
     def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -329,7 +329,7 @@ class SentryAppParser(Serializer):
                 # also check that we don't have the alert rule enabled
                 if get_current_value("isAlertable"):
                     raise ValidationError(
-                        {"webhookUrl": "webhookUrl required if alert rule action is enabled"}
+                        {"webhookUrl": "webhookUrl required if alert action is enabled"}
                     )
             else:
                 raise ValidationError({"webhookUrl": "webhookUrl required for public integrations"})

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -91,7 +91,7 @@ describe('Sentry Application Details', () => {
 
       await userEvent.click(screen.getByRole('textbox', {name: 'Schema'}));
       await userEvent.paste('{}');
-      await userEvent.click(screen.getByRole('checkbox', {name: 'Alert Rule Action'}));
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Alert Action'}));
 
       await selectEvent.select(screen.getByRole('textbox', {name: 'Member'}), 'Admin');
       await selectEvent.select(
@@ -485,9 +485,9 @@ describe('Sentry Application Details', () => {
     it('removing webhookURL unsets isAlertable and changes webhookDisabled to true', async () => {
       renderComponent();
       await screen.findByRole('button', {name: 'Save Changes'});
-      expect(screen.getByRole('checkbox', {name: 'Alert Rule Action'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'Alert Action'})).toBeChecked();
       await userEvent.clear(screen.getByRole('textbox', {name: 'Webhook URL'}));
-      expect(screen.getByRole('checkbox', {name: 'Alert Rule Action'})).not.toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'Alert Action'})).not.toBeChecked();
     });
   });
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -750,9 +750,9 @@ function SentryApplicationForm({
         <form.AppField name="isAlertable">
           {field => (
             <field.Layout.Row
-              label={t('Alert Rule Action')}
+              label={t('Alert Action')}
               hintText={tct(
-                'If enabled, this integration will be available in Issue Alert rules and Metric Alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learnMore:here].',
+                'If enabled, this integration will be available as an action in alerts in Sentry. The notification destination is the Webhook URL specified above. More on actions [learnMore:here].',
                 {
                   learnMore: (
                     <ExternalLink href="https://docs.sentry.io/product/alerts-notifications/notifications/" />
@@ -767,7 +767,7 @@ function SentryApplicationForm({
                     onChange={field.handleChange}
                     disabled={
                       webhookDisabled
-                        ? t('Cannot enable alert rule action without a webhook url')
+                        ? t('Cannot enable alert action without a webhook url')
                         : false
                     }
                   />

--- a/tests/js/fixtures/organizationIntegrations.ts
+++ b/tests/js/fixtures/organizationIntegrations.ts
@@ -17,14 +17,7 @@ export function OrganizationIntegrationsFixture(
       canAdd: true,
       canDisable: false,
       features: ['alert-rule', 'chat-unfurl'],
-      aspects: {
-        alerts: [
-          {
-            variant: 'info',
-            text: 'The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.',
-          },
-        ],
-      },
+      aspects: {},
     },
     configOrganization: [],
     configData: {

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -723,9 +723,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         response = self.get_error_response(
             self.internal_integration.slug, isAlertable=True, status_code=400
         )
-        assert response.data == {
-            "webhookUrl": ["webhookUrl required if alert rule action is enabled"]
-        }
+        assert response.data == {"webhookUrl": ["webhookUrl required if alert action is enabled"]}
 
     @override_options({"staff.ga-rollout": True})
     def test_set_allowed_origins(self) -> None:


### PR DESCRIPTION
Specifically for the integration platform, not touching the schema or anything yet, we can always do that later if we choose. Also avoided all the models and variables that still reference rules, only touching user facing stuff.

Requires https://github.com/getsentry/sentry-docs/pull/18631 (kinda)