### PR TITLE
fix(trace): Use primary alias for description

### DIFF
--- a/src/sentry/snuba/spans_rpc.py
+++ b/src/sentry/snuba/spans_rpc.py
@@ -95,7 +95,7 @@ class Spans(rpc_dataset_common.RPCBase):
 
         trace_attributes = [
             "parent_span",
-            "description",
+            "span.description",
             "span.op",
             "span.name",
             "is_transaction",

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -290,7 +290,7 @@ def _serialize_rpc_event(
         duration=event["span.duration"],
         transaction=event["transaction"],
         is_transaction=event["is_transaction"],
-        description=event["description"],
+        description=event["span.description"],
         sdk_name=event["sdk.name"],
         op=event["span.op"],
         name=event["span.name"],

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -573,6 +573,25 @@ class OrganizationEventsTraceEndpointTest(
         assert data[0]["children"][0]["additional_attributes"]["gen_ai.request.model"] == "gpt-4o"
         assert data[0]["children"][0]["additional_attributes"]["gen_ai.usage.total_tokens"] == 100
 
+    def test_with_span_description_in_additional_attrs(self) -> None:
+        self.load_trace()
+        with self.feature(self.FEATURES):
+            response = self.client_get(
+                data={
+                    "timestamp": self.day_ago,
+                    "additional_attributes": [
+                        "span.description",
+                    ],
+                },
+            )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert len(data) == 1
+
+        assert data[0]["additional_attributes"]["span.description"] == "root"
+
+        assert data[0]["children"][0]["additional_attributes"]["span.description"] == "GET gen1-0"
+
     def test_with_target_error(self) -> None:
         start, _ = self.get_start_end_from_day_ago(1000)
         error_data = load_data(


### PR DESCRIPTION
- Because we were using the secondary alias if span.description appeared in the additional_attributes we'd get a keyerror looking for desc