### PR TITLE
fix(dashboards): Stop chart drag-to-zoom selecting the wrong time range

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -89,11 +89,6 @@ export interface TimeSeriesWidgetVisualizationProps extends Partial<LoadableChar
   legendSelection?: LegendSelection;
 
   /**
-   * Whether new options fully replace previous chart options.
-   */
-  notMerge?: boolean;
-
-  /**
    * Callback that returns an updated `LegendSelection` after a user manipulations the selection via the legend
    */
   onLegendSelectionChange?: (selection: LegendSelection) => void;
@@ -615,7 +610,21 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         <BaseChart
           ref={mergeRefs(props.ref, props.chartRef, chartRef, handleChartRef)}
           autoHeightResize
-          notMerge={props.notMerge}
+          // `notMerge` should always be `false`. i.e., ECharts should be
+          // allowed to _merge_ the incoming options when they change. Note
+          // `replaceMerge` below which ensures that the critical components
+          // like the series and the axes are merged using the "replace"
+          // algorithm, not the "normal" algorithm.
+          //
+          // Under `notMerge`, every data refresh does a full ECharts re-init that
+          // destroys and re-creates the toolbox dataZoom "select" component. In
+          // ECharts 6.1 that rebuild re-emits a stale `dataZoom` event, so a
+          // single drag-to-zoom cascades into repeated refetches that settle on
+          // the wrong time range. See apache/echarts#21661.
+          //
+          // To guard against this, we allow ECharts to preserve the
+          // configuration of the toolbox, which prevents these stale fires.
+          notMerge={false}
           replaceMerge={['series', 'xAxis', 'yAxis']}
           series={allSeries}
           grid={{

--- a/static/app/views/explore/components/chart/chartVisualization.tsx
+++ b/static/app/views/explore/components/chart/chartVisualization.tsx
@@ -25,7 +25,6 @@ interface ChartVisualizationProps {
   chartInfo: ChartInfo;
   chartRef?: Ref<ReactEchartsRef>;
   chartXRangeSelection?: Partial<ChartXRangeSelectionProps>;
-  notMerge?: boolean;
 }
 
 export function useChartVisualizationPlottables(chartInfo: ChartInfo) {
@@ -63,7 +62,6 @@ export function ChartVisualization({
   chartXRangeSelection,
   chartInfo,
   chartRef,
-  notMerge,
 }: ChartVisualizationProps) {
   const plottables = useChartVisualizationPlottables(chartInfo);
   const previousPlottables = usePrevious(
@@ -115,7 +113,6 @@ export function ChartVisualization({
         ref={chartRef}
         plottables={activePlottables}
         chartXRangeSelection={chartXRangeSelection}
-        notMerge={notMerge}
       />
     </StyledTransparentLoadingMask>
   );

--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -36,7 +36,6 @@ import {
   useChartVisualizationPlottables,
 } from 'sentry/views/explore/components/chart/chartVisualization';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
-import {useLogsAutoRefreshEnabled} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {useLogsPageDataQueryResult} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {CHART_TYPE_TO_DISPLAY_TYPE} from 'sentry/views/explore/hooks/useAddToDashboard';
@@ -128,7 +127,6 @@ function Graph({
   visualize,
 }: GraphProps) {
   const isShortViewport = useIsShortViewport();
-  const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const {isEmpty: tableIsEmpty, isPending: tableIsPending} = useLogsPageDataQueryResult();
 
   const aggregate = visualize.yAxis;
@@ -181,7 +179,6 @@ function Graph({
         !visualize.visible && plottablesCanBeVisualized(plottables) ? (
           <TimeSeriesWidgetVisualization
             plottables={plottables}
-            notMerge={false}
             showLegend="never"
             showXAxis="never"
             showYAxis="never"
@@ -263,11 +260,7 @@ function Graph({
       Actions={Actions}
       Visualization={
         visualize.visible && (
-          <ChartVisualization
-            key={chartRemountKey}
-            chartInfo={chartInfo}
-            notMerge={!autorefreshEnabled}
-          />
+          <ChartVisualization key={chartRemountKey} chartInfo={chartInfo} />
         )
       }
       Footer={

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -219,7 +219,7 @@ function Graph({
               )}
             />
           ) : showChart ? (
-            <ChartVisualization chartInfo={chartInfo} notMerge={false} />
+            <ChartVisualization chartInfo={chartInfo} />
           ) : undefined
         }
         Footer={

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -217,7 +217,6 @@ function Chart({
         !visualize.visible && plottablesCanBeVisualized(plottables) ? (
           <TimeSeriesWidgetVisualization
             plottables={plottables}
-            notMerge={false}
             showLegend="never"
             showXAxis="never"
             showYAxis="never"


### PR DESCRIPTION
Dragging to zoom on a dashboard time-series widget could snap the global time filter to the wrong (collapsed) range — e.g. a ~2h selection landing on ~1 minute.

Two related bugs in Dashboards time series chart navigation

1. Dragging to zoom creates weird opaque rectangles
2. Drag-to-zoom seems to zoom to incorrect range if many zooms are done without reloading

It looks like the root cause is [apache/echarts#21661](https://github.com/apache/echarts/issues/21661), in which re-mounting a chart reinitiates the zoom toolbox, which weirdly re-fires old zoom events? Truly bizarre. To guard against this, allowing `notMerge=false` makes sure that ECharts doesn't do a full re-init of the toolbox, it just updates it if it changed (it didn't), which prevents this weird re-initialization loop.

I worked through this with Claude for a while, and I'm convinced that the solution works. Since `notMerge` is able to cause broken UI, I removed that prop completely.

This is the same root cause as LOGS-901.

Fixes DAIN-1753

<details>
<summary>Investigation notes</summary>

Verified live with temporary console instrumentation on the repro dashboard (single time-series widget)

**Repro:** drag-zoom (~2h) → dashboard **Cancel** → drag-zoom again → second selection collapses to a wrong, tiny range and the selection rectangle looks more opaque.

**Two theories were disproven by the logs, not assumed:**
- *Orphaned ECharts "cover" SVGs stacking* (the sibling LOGS-901 hypothesis): the brush controller's tracked covers always equalled its mounted covers (`0/0` or `1/1`) — no orphans.
- *Timezone offset*: would corrupt the first drag and shift by whole hours, not collapse the second drag to ~1 min.

**What the logs actually showed:** a single drag fired `handleDataZoom` 3–6 times, each with a **different `from: toolbox-feature_NNN` uid climbing by +26** and a drifting range (`10 → 126 → 126 → 126 → 12` min); the **last write won** and it was the stale collapsed one.

- Not leaked listeners: echarts-for-react `unbindEvents()`/`bindEvents()` on every update, and the events had different `from`/ranges (a single event to N stale listeners would be identical N times). These are N genuinely distinct dispatches.
- The +26 uid jump = the toolbox feature being rebuilt from scratch each time = full `notMerge` re-init.
- Shape is a feedback loop: drag → `setPeriod` → URL/page-filter change → widget re-render → `setOption(notMerge:true)` full re-init → toolbox dataZoom re-emits a `dataZoom` → `setPeriod` → … until it settles on a drifted/collapsed range.

**Fix confirmation:** with `notMerge={false}`, each drag fires `handleDataZoom` exactly once, the `from` uid stays stable, and both drags land the correct ~2h range (117 / 119 min).

**Upstream:** [apache/echarts#21661](https://github.com/apache/echarts/issues/21661) (open, "pending") is the same regression; [#21644](https://github.com/apache/echarts/issues/21644)/[#21669](https://github.com/apache/echarts/pull/21669) are related. No merged upstream fix exists, so this is a client-side mitigation.

**Blast radius:** dashboards, insights, and all explore time-series charts now merge (they shared the latent bug; metrics/spans were already on `notMerge={false}`).
</details>
