### PR TITLE
feat(dashboards): Add (no value) option to global filters

### DIFF
--- a/static/app/utils/discover/emptyFieldValues.tsx
+++ b/static/app/utils/discover/emptyFieldValues.tsx
@@ -2,9 +2,11 @@ import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 
+export const EMPTY_VALUE_LABEL = t('(no value)');
+
 export const emptyValue = (
   <Text as="span" variant="muted">
-    {t('(no value)')}
+    {EMPTY_VALUE_LABEL}
   </Text>
 );
 export const emptyStringValue = (

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -265,6 +265,34 @@ describe('FilterSelector', () => {
     });
   });
 
+  it('collapses "contains" to "is" when only "(no value)" is selected', async () => {
+    render(
+      <FilterSelector
+        globalFilter={mockGlobalFilter}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    const button = screen.getByRole('button', {
+      name: `${mockGlobalFilter.tag.key} contains All`,
+    });
+    await userEvent.click(button);
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select (no value)'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(mockOnUpdateFilter).toHaveBeenCalledWith({
+      ...mockGlobalFilter,
+      value: '!has:browser',
+    });
+
+    const trigger = screen.getByRole('button', {name: /browser/});
+    expect(trigger).not.toHaveTextContent('contains');
+    expect(trigger).toHaveTextContent('(no value)');
+  });
+
   it('rewrites the value without corrupting the query when editing a combined value + "(no value)" filter', async () => {
     render(
       <FilterSelector

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -265,8 +265,8 @@ describe('FilterSelector', () => {
     });
   });
 
-  it('collapses "contains" to "is" when only "(no value)" is selected', async () => {
-    render(
+  it('collapses "contains" to "is" when only "(no value)" is persisted', async () => {
+    const {rerender} = render(
       <FilterSelector
         globalFilter={mockGlobalFilter}
         searchBarData={mockSearchBarData}
@@ -288,8 +288,18 @@ describe('FilterSelector', () => {
       value: '!has:browser',
     });
 
+    // Simulate the parent persisting the emitted value back into the filter.
+    rerender(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: '!has:browser'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
     const trigger = screen.getByRole('button', {name: /browser/});
-    expect(trigger).not.toHaveTextContent('contains');
+    await waitFor(() => expect(trigger).not.toHaveTextContent('contains'));
     expect(trigger).toHaveTextContent('(no value)');
   });
 

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -219,6 +219,52 @@ describe('FilterSelector', () => {
     expect(screen.getByRole('gridcell', {name: /Northern Europe/})).toBeInTheDocument();
   });
 
+  it('keeps the "is" operator when switching from "(no value)" to a real value', async () => {
+    render(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: '!has:browser'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    const button = screen.getByRole('button', {name: /browser/});
+    await userEvent.click(button);
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select (no value)'}));
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(mockOnUpdateFilter).toHaveBeenCalledWith({
+      ...mockGlobalFilter,
+      value: 'browser:firefox',
+    });
+  });
+
+  it('keeps the "is not" operator when switching from "(no value)" to a real value', async () => {
+    render(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: 'has:browser'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    const button = screen.getByRole('button', {name: /browser/});
+    await userEvent.click(button);
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select (no value)'}));
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    expect(mockOnUpdateFilter).toHaveBeenCalledWith({
+      ...mockGlobalFilter,
+      value: '!browser:firefox',
+    });
+  });
+
   it('allows searching for values over 70 characters', async () => {
     // Create a long transaction name that exceeds 70 characters
     const longValue =
@@ -246,8 +292,8 @@ describe('FilterSelector', () => {
 
     // Wait for options to load - both values should be visible initially
     expect(await screen.findByText(shortValue)).toBeInTheDocument();
-    // Verify we have 2 checkboxes (one for each option)
-    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+    // Two tag values plus the prepended "(no value)" option
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
 
     // Search for the entire long value to test that search works on the full textValue
     // even though the displayed label is truncated at 70 characters

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -289,7 +289,6 @@ describe('FilterSelector', () => {
   });
 
   it('intersects (AND) a value with "(no value)" when the operator is negated', async () => {
-    // `has:browser` reopens as "(no value)" selected with the "is not" operator.
     render(
       <FilterSelector
         globalFilter={{...mockGlobalFilter, value: 'has:browser'}}
@@ -306,42 +305,13 @@ describe('FilterSelector', () => {
       await screen.findByRole('checkbox', {name: 'Select (no value)'})
     ).toBeChecked();
 
-    // Keep "(no value)" selected and also exclude firefox.
     await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
 
-    // Must AND (exclude both), not OR (which would show everything).
     expect(mockOnUpdateFilter).toHaveBeenCalledWith({
       ...mockGlobalFilter,
       value: '(!browser:firefox AND has:browser)',
     });
-  });
-
-  it('resyncs the operator when the saved filter flips has: <-> !has: externally', async () => {
-    const {rerender} = render(
-      <FilterSelector
-        globalFilter={{...mockGlobalFilter, value: '!has:browser'}}
-        searchBarData={mockSearchBarData}
-        onUpdateFilter={mockOnUpdateFilter}
-        onRemoveFilter={mockOnRemoveFilter}
-      />
-    );
-
-    // External update flips !has: -> has: on the same tag (values unchanged).
-    rerender(
-      <FilterSelector
-        globalFilter={{...mockGlobalFilter, value: 'has:browser'}}
-        searchBarData={mockSearchBarData}
-        onUpdateFilter={mockOnUpdateFilter}
-        onRemoveFilter={mockOnRemoveFilter}
-      />
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: /browser/}));
-
-    // Saved value is `has:browser`, so the operator must read "is not", not the
-    // stale "is" from the initial render.
-    expect((await screen.findAllByText('is not')).length).toBeGreaterThan(0);
   });
 
   it('allows searching for values over 70 characters', async () => {

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -288,6 +288,62 @@ describe('FilterSelector', () => {
     expect(emittedValue).toBe('(browser:[chrome,firefox] OR !has:browser)');
   });
 
+  it('intersects (AND) a value with "(no value)" when the operator is negated', async () => {
+    // `has:browser` reopens as "(no value)" selected with the "is not" operator.
+    render(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: 'has:browser'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    const button = screen.getByRole('button', {name: /browser/});
+    await userEvent.click(button);
+
+    expect(
+      await screen.findByRole('checkbox', {name: 'Select (no value)'})
+    ).toBeChecked();
+
+    // Keep "(no value)" selected and also exclude firefox.
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    // Must AND (exclude both), not OR (which would show everything).
+    expect(mockOnUpdateFilter).toHaveBeenCalledWith({
+      ...mockGlobalFilter,
+      value: '(!browser:firefox AND has:browser)',
+    });
+  });
+
+  it('resyncs the operator when the saved filter flips has: <-> !has: externally', async () => {
+    const {rerender} = render(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: '!has:browser'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    // External update flips !has: -> has: on the same tag (values unchanged).
+    rerender(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: 'has:browser'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /browser/}));
+
+    // Saved value is `has:browser`, so the operator must read "is not", not the
+    // stale "is" from the initial render.
+    expect((await screen.findAllByText('is not')).length).toBeGreaterThan(0);
+  });
+
   it('allows searching for values over 70 characters', async () => {
     // Create a long transaction name that exceeds 70 characters
     const longValue =

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -288,7 +288,6 @@ describe('FilterSelector', () => {
       value: '!has:browser',
     });
 
-    // Simulate the parent persisting the emitted value back into the filter.
     rerender(
       <FilterSelector
         globalFilter={{...mockGlobalFilter, value: '!has:browser'}}
@@ -349,6 +348,87 @@ describe('FilterSelector', () => {
     expect(mockOnUpdateFilter).toHaveBeenCalledWith({
       ...mockGlobalFilter,
       value: '(!browser:firefox AND has:browser)',
+    });
+  });
+
+  describe('emits the correct query for each operator + "(no value)" combination', () => {
+    async function openSelector() {
+      await userEvent.click(screen.getByRole('button', {name: /browser/}));
+    }
+
+    async function selectOperator(target: string, current = 'contains') {
+      await userEvent.click(screen.getByRole('button', {name: current}));
+      await userEvent.click(await screen.findByRole('menuitemradio', {name: target}));
+    }
+
+    async function selectNoValue() {
+      await userEvent.click(screen.getByRole('checkbox', {name: 'Select (no value)'}));
+    }
+
+    async function apply() {
+      await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    }
+
+    function lastEmittedValue() {
+      return mockOnUpdateFilter.mock.calls.at(-1)?.[0]?.value as string;
+    }
+
+    describe('with no existing value', () => {
+      it.each([
+        ['is', '!has:browser'],
+        ['is not', 'has:browser'],
+        ['contains', '!has:browser'],
+        ['does not contain', 'has:browser'],
+      ])('%s + (no value) -> %s', async (operator, expected) => {
+        render(
+          <FilterSelector
+            globalFilter={mockGlobalFilter}
+            searchBarData={mockSearchBarData}
+            onUpdateFilter={mockOnUpdateFilter}
+            onRemoveFilter={mockOnRemoveFilter}
+          />
+        );
+
+        await openSelector();
+        if (operator !== 'contains') {
+          await selectOperator(operator);
+        }
+        await selectNoValue();
+        await apply();
+
+        expect(lastEmittedValue()).toBe(expected);
+      });
+    });
+
+    describe('with an existing value', () => {
+      it.each([
+        ['is', '(browser:firefox OR !has:browser)'],
+        ['is not', '(!browser:firefox AND has:browser)'],
+        ['contains', `(browser:${WildcardOperators.CONTAINS}firefox OR !has:browser)`],
+        [
+          'does not contain',
+          `(!browser:${WildcardOperators.CONTAINS}firefox AND has:browser)`,
+        ],
+      ])('%s value + (no value) -> %s', async (operator, expected) => {
+        render(
+          <FilterSelector
+            globalFilter={mockGlobalFilter}
+            searchBarData={mockSearchBarData}
+            onUpdateFilter={mockOnUpdateFilter}
+            onRemoveFilter={mockOnRemoveFilter}
+          />
+        );
+
+        await openSelector();
+        if (operator !== 'contains') {
+          await selectOperator(operator);
+        }
+        await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
+        await selectNoValue();
+        await apply();
+
+        expect(lastEmittedValue()).toBe(expected);
+      });
     });
   });
 

--- a/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.spec.tsx
@@ -265,6 +265,29 @@ describe('FilterSelector', () => {
     });
   });
 
+  it('rewrites the value without corrupting the query when editing a combined value + "(no value)" filter', async () => {
+    render(
+      <FilterSelector
+        globalFilter={{...mockGlobalFilter, value: '(browser:chrome OR !has:browser)'}}
+        searchBarData={mockSearchBarData}
+        onUpdateFilter={mockOnUpdateFilter}
+        onRemoveFilter={mockOnRemoveFilter}
+      />
+    );
+
+    const button = screen.getByRole('button', {name: /browser/});
+    await userEvent.click(button);
+
+    expect(await screen.findByRole('checkbox', {name: 'Select chrome'})).toBeChecked();
+    expect(screen.getByRole('checkbox', {name: 'Select (no value)'})).toBeChecked();
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'Select firefox'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+
+    const emittedValue = mockOnUpdateFilter.mock.calls.at(-1)?.[0]?.value as string;
+    expect(emittedValue).toBe('(browser:[chrome,firefox] OR !has:browser)');
+  });
+
   it('allows searching for values over 70 characters', async () => {
     // Create a long transaction name that exceeds 70 characters
     const longValue =

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -14,7 +14,6 @@ import {
 } from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
-import {Text} from '@sentry/scraps/text';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -37,6 +36,7 @@ import {
 import {TermOperator} from 'sentry/components/searchSyntax/parser';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {emptyValue, EMPTY_VALUE_LABEL} from 'sentry/utils/discover/emptyFieldValues';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import {middleEllipsis} from 'sentry/utils/string/middleEllipsis';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
@@ -229,38 +229,31 @@ export function FilterSelector({
   const {data: fetchedFilterValues, isFetching} = queryResult;
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    const buildNoValueOption = (): SelectOption<string> | null => {
-      if (!NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)) {
-        return null;
-      }
-      const noValueLabel = t('(no value)');
-      const noValueOption: SelectOption<string> = {
-        label: <Text variant="muted">{noValueLabel}</Text>,
-        textValue: noValueLabel,
-        value: NO_VALUE_SENTINEL,
-      };
-      if (canSelectMultipleValues) {
-        noValueOption.leadingItems = ({isSelected}: {isSelected: boolean}) => (
-          <Checkbox
-            checked={isSelected}
-            onChange={() => toggleOptionRef.current?.(NO_VALUE_SENTINEL)}
-            aria-label={t('Select %s', noValueLabel)}
-            tabIndex={-1}
-          />
-        );
-      }
-      return noValueOption;
-    };
+    const noValueOption: SelectOption<string> | null = NO_VALUE_SUPPORTED_OPERATORS.has(
+      stagedOperator
+    )
+      ? {
+          label: emptyValue,
+          textValue: EMPTY_VALUE_LABEL,
+          value: NO_VALUE_SENTINEL,
+          ...(canSelectMultipleValues
+            ? {
+                leadingItems: ({isSelected}: {isSelected: boolean}) => (
+                  <Checkbox
+                    checked={isSelected}
+                    onChange={() => toggleOptionRef.current?.(NO_VALUE_SENTINEL)}
+                    aria-label={t('Select %s', EMPTY_VALUE_LABEL)}
+                    tabIndex={-1}
+                  />
+                ),
+              }
+            : {}),
+        }
+      : null;
 
     const prependNoValueOption = (
       opts: Array<SelectOption<string>>
-    ): Array<SelectOption<string>> => {
-      const noValueOption = buildNoValueOption();
-      if (noValueOption) {
-        opts.unshift(noValueOption);
-      }
-      return opts;
-    };
+    ): Array<SelectOption<string>> => (noValueOption ? [noValueOption, ...opts] : opts);
 
     if (predefinedValues && !canSelectMultipleValues) {
       const predefinedOptions: Array<SelectOption<string>> = predefinedValues.flatMap(

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -45,8 +45,7 @@ import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
 import {FilterSelectorTrigger} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
 import {
   buildNoValueFilterQuery,
-  classifyFilterValue,
-  getFieldDefinitionForDataset,
+  deriveFilterState,
   getFilterToken,
   NO_VALUE_SENTINEL,
   NO_VALUE_SUPPORTED_OPERATORS,
@@ -82,73 +81,49 @@ export function FilterSelector({
   const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
   const stagedValueRef = useRef<string[]>([]);
 
-  const {fieldDefinition, filterToken, mode, noValueOperator} = useMemo(() => {
-    const fieldDef = getFieldDefinitionForDataset(globalFilter.tag, globalFilter.dataset);
+  const {fieldDefinition, filterToken, noValueToken} = useMemo(
+    () => deriveFilterState(globalFilter),
+    [globalFilter]
+  );
 
-    const allTokens = globalFilter.value
-      ? parseFilterValue(globalFilter.value, globalFilter)
-      : [];
-    const parsed = classifyFilterValue(allTokens);
+  // Effectively a filter token with a fallback to an empty placeholder when the filterToken is empty/has 'no value'.
+  const pickerToken = useMemo(
+    () => filterToken ?? getFilterToken({...globalFilter, value: ''}, fieldDefinition),
+    [filterToken, globalFilter, fieldDefinition]
+  );
 
-    switch (parsed.mode) {
-      case 'valueAndNoValue':
-        return {
-          fieldDefinition: fieldDef,
-          filterToken: parsed.valueFilterToken,
-          mode: parsed.mode,
-          noValueOperator: null,
-        };
-      case 'noValue':
-        return {
-          fieldDefinition: fieldDef,
-          filterToken: getFilterToken({...globalFilter, value: ''}, fieldDef),
-          mode: parsed.mode,
-          noValueOperator: parsed.noValueOperator,
-        };
-      case 'value':
-      case 'empty':
-      default:
-        return {
-          fieldDefinition: fieldDef,
-          filterToken: getFilterToken(globalFilter, fieldDef),
-          mode: parsed.mode,
-          noValueOperator: null,
-        };
-    }
-  }, [globalFilter]);
-
-  // Get initial selected values from the filter token
+  // Get initial selected values from the tokens
   const initialValues = useMemo(() => {
-    if (!filterToken) {
-      return [];
-    }
-
-    const tokenForParsing =
-      mode === 'value' || mode === 'valueAndNoValue' ? filterToken : null;
-    const initialValue = tokenForParsing
-      ? getInitialInputValue(tokenForParsing, true)
-      : '';
+    const initialValue = filterToken ? getInitialInputValue(filterToken, true) : '';
 
     const selectedValues = getSelectedValuesFromText(initialValue);
     const values = selectedValues.map(item => item.value);
 
-    if (mode === 'noValue' || mode === 'valueAndNoValue') {
+    if (noValueToken) {
       values.push(NO_VALUE_SENTINEL);
     }
 
     return values;
-  }, [filterToken, mode]);
+  }, [filterToken, noValueToken]);
 
-  // Get operator info from the filter token
+  // Get operator info from the picker or no value token
   const {initialOperator, operatorDropdownItems} = useMemo(() => {
-    if (!filterToken) {
+    if (!pickerToken) {
       return {
         initialOperator: TermOperator.DEFAULT,
         operatorDropdownItems: [],
       };
     }
 
-    const operatorInfo = getOperatorInfo({filterToken, fieldDefinition});
+    const operatorInfo = getOperatorInfo({filterToken: pickerToken, fieldDefinition});
+
+    // The "(no value)" token has no value, so you can't derive an operator from getOperatorInfo.
+    const noValueOperator =
+      !filterToken && noValueToken
+        ? noValueToken.negated
+          ? TermOperator.DEFAULT
+          : TermOperator.NOT_EQUAL
+        : null;
 
     return {
       initialOperator: noValueOperator ?? operatorInfo?.operator ?? TermOperator.DEFAULT,
@@ -169,7 +144,7 @@ export function FilterSelector({
         },
       })),
     };
-  }, [filterToken, fieldDefinition, noValueOperator]);
+  }, [pickerToken, filterToken, noValueToken, fieldDefinition]);
 
   const [stagedOperator, setStagedOperator] = useState(initialOperator);
   const [activeFilterValues, setActiveFilterValues] = useState(initialValues);
@@ -185,23 +160,22 @@ export function FilterSelector({
   const datasetFilterKeys = searchBarData.getFilterKeys();
   const fullTag = datasetFilterKeys[globalFilter.tag.key];
 
-  const canSelectMultipleValues = filterToken
-    ? tokenSupportsMultipleValues(filterToken, datasetFilterKeys, fieldDefinition)
+  const canSelectMultipleValues = pickerToken
+    ? tokenSupportsMultipleValues(pickerToken, datasetFilterKeys, fieldDefinition)
     : true;
 
   // Retrieve predefined values if the tag has any
   const predefinedValues = useMemo(() => {
-    if (!filterToken) {
+    if (!pickerToken) {
       return null;
     }
-    const filterValue = filterToken.value.text;
     return getPredefinedValues({
       key: fullTag,
-      filterValue,
-      token: filterToken,
+      filterValue: pickerToken.value.text,
+      token: pickerToken,
       fieldDefinition,
     });
-  }, [fullTag, filterToken, fieldDefinition]);
+  }, [fullTag, pickerToken, fieldDefinition]);
 
   // Only fetch values if the tag has no predefined values
   const shouldFetchValues = fullTag
@@ -375,7 +349,7 @@ export function FilterSelector({
     if (isEqual(opts, activeFilterValues) && stagedOperator === initialOperator) {
       return;
     }
-    if (!filterToken) {
+    if (!pickerToken) {
       return;
     }
 
@@ -395,15 +369,15 @@ export function FilterSelector({
     let valueQuery = '';
     if (valueOpts.length > 0) {
       const cleanedValue = prepareInputValueForSaving(
-        getFilterValueType(filterToken, fieldDefinition),
+        getFilterValueType(pickerToken, fieldDefinition),
         valueOpts
           .map(opt => escapeTagValueForSearch(opt, {allowArrayValue: false}))
           .join(',')
       );
-      const isolatedToken = parseFilterValue(filterToken.text, globalFilter)[0];
-      const valueToRewrite = isolatedToken ?? filterToken;
+      const isolatedToken = parseFilterValue(pickerToken.text, globalFilter)[0];
+      const valueToRewrite = isolatedToken ?? pickerToken;
       // Always rebuild the token with the operator the UI is showing.
-      // The synthetic filterToken used for "(no value)" defaults to the string
+      // The synthetic placeholder token used for "(no value)" defaults to the string
       // CONTAINS wildcard, so patching only the value would leak that operator.
       valueQuery = modifyFilterValue(
         valueToRewrite.text,

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -49,6 +49,7 @@ import {
   getFilterToken,
   NO_VALUE_SENTINEL,
   NO_VALUE_SUPPORTED_OPERATORS,
+  operatorFromNoValueToken,
   parseFilterValue,
   stripUnsupportedNoValue,
 } from 'sentry/views/dashboards/globalFilter/utils';
@@ -119,11 +120,7 @@ export function FilterSelector({
 
     // The "(no value)" token has no value, so you can't derive an operator from getOperatorInfo.
     const noValueOperator =
-      !filterToken && noValueToken
-        ? noValueToken.negated
-          ? TermOperator.DEFAULT
-          : TermOperator.NOT_EQUAL
-        : null;
+      !filterToken && noValueToken ? operatorFromNoValueToken(noValueToken) : undefined;
 
     return {
       initialOperator: noValueOperator ?? operatorInfo?.operator ?? TermOperator.DEFAULT,
@@ -245,6 +242,16 @@ export function FilterSelector({
       return noValueOption;
     };
 
+    const prependNoValueOption = (
+      opts: Array<SelectOption<string>>
+    ): Array<SelectOption<string>> => {
+      const noValueOption = buildNoValueOption();
+      if (noValueOption) {
+        opts.unshift(noValueOption);
+      }
+      return opts;
+    };
+
     if (predefinedValues && !canSelectMultipleValues) {
       const predefinedOptions: Array<SelectOption<string>> = predefinedValues.flatMap(
         section =>
@@ -253,11 +260,7 @@ export function FilterSelector({
             value: suggestion.value,
           }))
       );
-      const noValueOption = buildNoValueOption();
-      if (noValueOption) {
-        predefinedOptions.unshift(noValueOption);
-      }
-      return predefinedOptions;
+      return prependNoValueOption(predefinedOptions);
     }
 
     const optionMap = new Map<string, SelectOption<string>>();
@@ -319,17 +322,7 @@ export function FilterSelector({
         addOption(value, fixedOptionMap);
       }
     });
-    const allOptions = [
-      ...Array.from(fixedOptionMap.values()),
-      ...Array.from(optionMap.values()),
-    ];
-
-    const noValueOption = buildNoValueOption();
-    if (noValueOption) {
-      allOptions.unshift(noValueOption);
-    }
-
-    return allOptions;
+    return prependNoValueOption([...fixedOptionMap.values(), ...optionMap.values()]);
   }, [
     fetchedFilterValues,
     predefinedValues,
@@ -388,11 +381,7 @@ export function FilterSelector({
     }
 
     const newValue = includeNoValue
-      ? buildNoValueFilterQuery(
-          globalFilter.tag.key,
-          stagedOperator,
-          valueQuery || undefined
-        )
+      ? buildNoValueFilterQuery(globalFilter.tag.key, stagedOperator, valueQuery)
       : valueQuery;
 
     onUpdateFilter({

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -45,6 +45,7 @@ import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
 import {FilterSelectorTrigger} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
 import {
   buildNoValueFilterQuery,
+  canonicalNoValueOperator,
   deriveFilterState,
   getFilterToken,
   NO_VALUE_SENTINEL,
@@ -359,6 +360,11 @@ export function FilterSelector({
     const includeNoValue = opts.includes(NO_VALUE_SENTINEL);
     const valueOpts = opts.filter(opt => opt !== NO_VALUE_SENTINEL);
 
+    const isNoValueOnly = includeNoValue && valueOpts.length === 0;
+    const effectiveOperator = isNoValueOnly
+      ? canonicalNoValueOperator(stagedOperator)
+      : stagedOperator;
+
     let valueQuery = '';
     if (valueOpts.length > 0) {
       const cleanedValue = prepareInputValueForSaving(
@@ -376,13 +382,17 @@ export function FilterSelector({
         valueToRewrite.text,
         valueToRewrite,
         cleanedValue,
-        stagedOperator
+        effectiveOperator
       );
     }
 
     const newValue = includeNoValue
-      ? buildNoValueFilterQuery(globalFilter.tag.key, stagedOperator, valueQuery)
+      ? buildNoValueFilterQuery(globalFilter.tag.key, effectiveOperator, valueQuery)
       : valueQuery;
+
+    if (effectiveOperator !== stagedOperator) {
+      setStagedOperator(effectiveOperator);
+    }
 
     onUpdateFilter({
       ...globalFilter,

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -14,6 +14,7 @@ import {
 } from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Text} from '@sentry/scraps/text';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -46,8 +47,14 @@ import {type SearchBarData} from 'sentry/views/dashboards/datasetConfig/base';
 import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
 import {FilterSelectorTrigger} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
 import {
+  buildNoValueFilterQuery,
   getFieldDefinitionForDataset,
   getFilterToken,
+  getNoValueOperator,
+  getValueFilterToken,
+  hasNoValueFilter,
+  NO_VALUE_SENTINEL,
+  NO_VALUE_SUPPORTED_OPERATORS,
   parseFilterValue,
 } from 'sentry/views/dashboards/globalFilter/utils';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
@@ -77,12 +84,27 @@ export function FilterSelector({
   // Ref to break the circular dependency: options need toggleOption, but toggleOption
   // comes from useStagedCompactSelect which depends on options.
   const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
+  const stagedValueRef = useRef<string[]>([]);
 
   const {fieldDefinition, filterToken} = useMemo(() => {
     const fieldDef = getFieldDefinitionForDataset(globalFilter.tag, globalFilter.dataset);
+
+    // For "(no value)" filters, drive the UI from the value token when present,
+    // otherwise a default token (the bare has:/!has: has no value to edit).
+    const allTokens = globalFilter.value
+      ? parseFilterValue(globalFilter.value, globalFilter)
+      : [];
+    const containsNoValue = hasNoValueFilter(allTokens);
+    const valueToken = containsNoValue ? getValueFilterToken(allTokens) : null;
+
     return {
       fieldDefinition: fieldDef,
-      filterToken: getFilterToken(globalFilter, fieldDef),
+      filterToken:
+        valueToken ??
+        getFilterToken(
+          containsNoValue ? {...globalFilter, value: ''} : globalFilter,
+          fieldDef
+        ),
     };
   }, [globalFilter]);
 
@@ -91,12 +113,30 @@ export function FilterSelector({
     if (!filterToken) {
       return [];
     }
-    const initialValue = globalFilter.value
-      ? getInitialInputValue(filterToken, true)
-      : '';
+
+    const allTokens = globalFilter.value
+      ? parseFilterValue(globalFilter.value, globalFilter)
+      : [];
+    const includesNoValue = hasNoValueFilter(allTokens);
+    const valueToken = includesNoValue ? getValueFilterToken(allTokens) : null;
+    const tokenForParsing = valueToken ?? filterToken;
+
+    const initialValue =
+      globalFilter.value && !includesNoValue
+        ? getInitialInputValue(tokenForParsing, true)
+        : valueToken
+          ? getInitialInputValue(valueToken, true)
+          : '';
+
     const selectedValues = getSelectedValuesFromText(initialValue);
-    return selectedValues.map(item => item.value);
-  }, [filterToken, globalFilter.value]);
+    const values = selectedValues.map(item => item.value);
+
+    if (includesNoValue) {
+      values.push(NO_VALUE_SENTINEL);
+    }
+
+    return values;
+  }, [filterToken, globalFilter]);
 
   // Get operator info from the filter token
   const {initialOperator, operatorDropdownItems} = useMemo(() => {
@@ -109,8 +149,18 @@ export function FilterSelector({
 
     const operatorInfo = getOperatorInfo({filterToken, fieldDefinition});
 
+    // A bare has:/!has: has no value token, so derive its operator from the
+    // HAS polarity instead of the synthetic (always DEFAULT) filterToken.
+    const allTokens = globalFilter.value
+      ? parseFilterValue(globalFilter.value, globalFilter)
+      : [];
+    const noValueOperator =
+      hasNoValueFilter(allTokens) && !getValueFilterToken(allTokens)
+        ? getNoValueOperator(allTokens)
+        : null;
+
     return {
-      initialOperator: operatorInfo?.operator ?? TermOperator.DEFAULT,
+      initialOperator: noValueOperator ?? operatorInfo?.operator ?? TermOperator.DEFAULT,
       operatorDropdownItems: (operatorInfo?.options ?? []).map(option => ({
         ...option,
         key: option.value,
@@ -118,10 +168,17 @@ export function FilterSelector({
         textValue: option.textValue,
         onClick: () => {
           setStagedOperator(option.value);
+          // Deselect "(no value)" when switching to an unsupported operator.
+          if (
+            !NO_VALUE_SUPPORTED_OPERATORS.has(option.value) &&
+            stagedValueRef.current.includes(NO_VALUE_SENTINEL)
+          ) {
+            toggleOptionRef.current?.(NO_VALUE_SENTINEL);
+          }
         },
       })),
     };
-  }, [filterToken, fieldDefinition]);
+  }, [filterToken, fieldDefinition, globalFilter]);
 
   const [stagedOperator, setStagedOperator] = useState(initialOperator);
   const [activeFilterValues, setActiveFilterValues] = useState(initialValues);
@@ -200,13 +257,42 @@ export function FilterSelector({
   const {data: fetchedFilterValues, isFetching} = queryResult;
 
   const options = useMemo((): Array<SelectOption<string>> => {
+    // "(no value)" option, prepended for supported operators.
+    const buildNoValueOption = (): SelectOption<string> | null => {
+      if (!NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)) {
+        return null;
+      }
+      const noValueOption: SelectOption<string> = {
+        label: <Text variant="muted">{t('(no value)')}</Text>,
+        textValue: t('(no value)'),
+        value: NO_VALUE_SENTINEL,
+      };
+      if (canSelectMultipleValues) {
+        noValueOption.leadingItems = ({isSelected}: {isSelected: boolean}) => (
+          <Checkbox
+            checked={isSelected}
+            onChange={() => toggleOptionRef.current?.(NO_VALUE_SENTINEL)}
+            aria-label={t('Select %s', t('(no value)'))}
+            tabIndex={-1}
+          />
+        );
+      }
+      return noValueOption;
+    };
+
     if (predefinedValues && !canSelectMultipleValues) {
-      return predefinedValues.flatMap(section =>
-        section.suggestions.map(suggestion => ({
-          label: suggestion.value,
-          value: suggestion.value,
-        }))
+      const predefinedOptions: Array<SelectOption<string>> = predefinedValues.flatMap(
+        section =>
+          section.suggestions.map(suggestion => ({
+            label: suggestion.value,
+            value: suggestion.value,
+          }))
       );
+      const noValueOption = buildNoValueOption();
+      if (noValueOption) {
+        predefinedOptions.unshift(noValueOption);
+      }
+      return predefinedOptions;
     }
 
     const optionMap = new Map<string, SelectOption<string>>();
@@ -243,8 +329,10 @@ export function FilterSelector({
       return map.set(value, option);
     };
 
-    // Filter values in the global filter
-    activeFilterValues.forEach(value => addOption(value, optionMap));
+    // Filter values in the global filter (sentinel is added separately)
+    activeFilterValues
+      .filter(value => value !== NO_VALUE_SENTINEL)
+      .forEach(value => addOption(value, optionMap));
 
     // Predefined values
     predefinedValues?.forEach(suggestionSection => {
@@ -263,11 +351,21 @@ export function FilterSelector({
     }
     // Staged filter values inside the filter selector
     stagedFilterValues.forEach(value => {
-      if (!optionMap.has(value)) {
+      if (value !== NO_VALUE_SENTINEL && !optionMap.has(value)) {
         addOption(value, fixedOptionMap);
       }
     });
-    return [...Array.from(fixedOptionMap.values()), ...Array.from(optionMap.values())];
+    const allOptions = [
+      ...Array.from(fixedOptionMap.values()),
+      ...Array.from(optionMap.values()),
+    ];
+
+    const noValueOption = buildNoValueOption();
+    if (noValueOption) {
+      allOptions.unshift(noValueOption);
+    }
+
+    return allOptions;
   }, [
     fetchedFilterValues,
     predefinedValues,
@@ -276,11 +374,17 @@ export function FilterSelector({
     searchQuery,
     canSelectMultipleValues,
     globalFilter.tag.key,
+    stagedOperator,
   ]);
 
   const translatedOptions = translateKnownFilterOptions(options, globalFilter);
 
-  const handleChange = (opts: string[]) => {
+  const handleChange = (rawOpts: string[]) => {
+    // Strip the sentinel if the current operator doesn't support it
+    const opts = NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)
+      ? rawOpts
+      : rawOpts.filter(opt => opt !== NO_VALUE_SENTINEL);
+
     if (isEqual(opts, activeFilterValues) && stagedOperator === initialOperator) {
       return;
     }
@@ -298,19 +402,32 @@ export function FilterSelector({
       return;
     }
 
-    let newValue = '';
-    if (opts.length !== 0) {
+    const includeNoValue = opts.includes(NO_VALUE_SENTINEL);
+    const valueOpts = opts.filter(opt => opt !== NO_VALUE_SENTINEL);
+
+    let valueQuery = '';
+    if (valueOpts.length > 0) {
       const cleanedValue = prepareInputValueForSaving(
         getFilterValueType(filterToken, fieldDefinition),
-        opts.map(opt => escapeTagValueForSearch(opt, {allowArrayValue: false})).join(',')
+        valueOpts
+          .map(opt => escapeTagValueForSearch(opt, {allowArrayValue: false}))
+          .join(',')
       );
-      newValue = modifyFilterValue(filterToken.text, filterToken, cleanedValue);
+      valueQuery = modifyFilterValue(filterToken.text, filterToken, cleanedValue);
+
+      if (stagedOperator !== initialOperator) {
+        const newToken = parseFilterValue(valueQuery, globalFilter)[0] ?? filterToken;
+        valueQuery = modifyFilterOperatorQuery(newToken.text, newToken, stagedOperator);
+      }
     }
 
-    if (stagedOperator !== initialOperator) {
-      const newToken = parseFilterValue(newValue, globalFilter)[0] ?? filterToken;
-      newValue = modifyFilterOperatorQuery(newToken.text, newToken, stagedOperator);
-    }
+    const newValue = includeNoValue
+      ? buildNoValueFilterQuery(
+          globalFilter.tag.key,
+          stagedOperator,
+          valueQuery || undefined
+        )
+      : valueQuery;
 
     onUpdateFilter({
       ...globalFilter,
@@ -330,23 +447,31 @@ export function FilterSelector({
     hasExternalChanges: hasOperatorChanges,
   });
 
-  // Wire up toggleOptionRef after stagedSelect is created to break the circular
+  // Wire up refs after stagedSelect is created to break the circular
   // dependency between options (which need toggleOption) and useStagedCompactSelect
   // (which needs options).
   toggleOptionRef.current = stagedSelect.toggleOption;
+  stagedValueRef.current = stagedSelect.value;
 
   const {dispatch} = stagedSelect;
   const hasStagedChanges =
     xor(stagedSelect.value, activeFilterValues).length > 0 || hasOperatorChanges;
 
-  const renderFilterSelectorTrigger = (filterValues: string[]) => (
-    <FilterSelectorTrigger
-      globalFilter={globalFilter}
-      activeFilterValues={filterValues}
-      operator={stagedOperator}
-      options={translatedOptions}
-    />
-  );
+  const renderFilterSelectorTrigger = (filterValues: string[]) => {
+    // Strip the sentinel from display when the operator doesn't support it
+    const displayValues = NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)
+      ? filterValues
+      : filterValues.filter(v => v !== NO_VALUE_SENTINEL);
+
+    return (
+      <FilterSelectorTrigger
+        globalFilter={globalFilter}
+        activeFilterValues={displayValues}
+        operator={stagedOperator}
+        options={translatedOptions}
+      />
+    );
+  };
 
   const loadingFooter = isFetching ? (
     <Flex justify="center" padding="xs">

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -394,12 +394,14 @@ export function FilterSelector({
           .map(opt => escapeTagValueForSearch(opt, {allowArrayValue: false}))
           .join(',')
       );
+      const isolatedToken = parseFilterValue(filterToken.text, globalFilter)[0];
+      const valueToRewrite = isolatedToken ?? filterToken;
       // Always rebuild the token with the operator the UI is showing.
       // The synthetic filterToken used for "(no value)" defaults to the string
       // CONTAINS wildcard, so patching only the value would leak that operator.
       valueQuery = modifyFilterValue(
-        filterToken.text,
-        filterToken,
+        valueToRewrite.text,
+        valueToRewrite,
         cleanedValue,
         stagedOperator
       );

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -45,9 +45,9 @@ import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
 import {FilterSelectorTrigger} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
 import {
   buildNoValueFilterQuery,
+  classifyFilterValue,
   getFieldDefinitionForDataset,
   getFilterToken,
-  getNoValueInfo,
   NO_VALUE_SENTINEL,
   NO_VALUE_SUPPORTED_OPERATORS,
   parseFilterValue,
@@ -82,34 +82,40 @@ export function FilterSelector({
   const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
   const stagedValueRef = useRef<string[]>([]);
 
-  const {fieldDefinition, filterToken, valueToken, hasNoValue, noValueOperator} =
-    useMemo(() => {
-      const fieldDef = getFieldDefinitionForDataset(
-        globalFilter.tag,
-        globalFilter.dataset
-      );
+  const {fieldDefinition, filterToken, mode, noValueOperator} = useMemo(() => {
+    const fieldDef = getFieldDefinitionForDataset(globalFilter.tag, globalFilter.dataset);
 
-      const allTokens = globalFilter.value
-        ? parseFilterValue(globalFilter.value, globalFilter)
-        : [];
-      const noValueInfo = getNoValueInfo(allTokens);
-      const containsNoValue = noValueInfo.operator !== null;
-      const pairedValueToken = containsNoValue ? noValueInfo.valueToken : null;
+    const allTokens = globalFilter.value
+      ? parseFilterValue(globalFilter.value, globalFilter)
+      : [];
+    const parsed = classifyFilterValue(allTokens);
 
-      return {
-        fieldDefinition: fieldDef,
-        filterToken:
-          pairedValueToken ??
-          getFilterToken(
-            containsNoValue ? {...globalFilter, value: ''} : globalFilter,
-            fieldDef
-          ),
-        valueToken: pairedValueToken,
-        hasNoValue: containsNoValue,
-        noValueOperator:
-          containsNoValue && !pairedValueToken ? noValueInfo.operator : null,
-      };
-    }, [globalFilter]);
+    switch (parsed.mode) {
+      case 'valueAndNoValue':
+        return {
+          fieldDefinition: fieldDef,
+          filterToken: parsed.valueFilterToken,
+          mode: parsed.mode,
+          noValueOperator: null,
+        };
+      case 'noValue':
+        return {
+          fieldDefinition: fieldDef,
+          filterToken: getFilterToken({...globalFilter, value: ''}, fieldDef),
+          mode: parsed.mode,
+          noValueOperator: parsed.noValueOperator,
+        };
+      case 'value':
+      case 'empty':
+      default:
+        return {
+          fieldDefinition: fieldDef,
+          filterToken: getFilterToken(globalFilter, fieldDef),
+          mode: parsed.mode,
+          noValueOperator: null,
+        };
+    }
+  }, [globalFilter]);
 
   // Get initial selected values from the filter token
   const initialValues = useMemo(() => {
@@ -118,7 +124,7 @@ export function FilterSelector({
     }
 
     const tokenForParsing =
-      valueToken ?? (globalFilter.value && !hasNoValue ? filterToken : null);
+      mode === 'value' || mode === 'valueAndNoValue' ? filterToken : null;
     const initialValue = tokenForParsing
       ? getInitialInputValue(tokenForParsing, true)
       : '';
@@ -126,12 +132,12 @@ export function FilterSelector({
     const selectedValues = getSelectedValuesFromText(initialValue);
     const values = selectedValues.map(item => item.value);
 
-    if (hasNoValue) {
+    if (mode === 'noValue' || mode === 'valueAndNoValue') {
       values.push(NO_VALUE_SENTINEL);
     }
 
     return values;
-  }, [filterToken, valueToken, hasNoValue, globalFilter.value]);
+  }, [filterToken, mode]);
 
   // Get operator info from the filter token
   const {initialOperator, operatorDropdownItems} = useMemo(() => {

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -20,10 +20,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useStagedCompactSelect} from 'sentry/components/pageFilters/useStagedCompactSelect';
-import {
-  modifyFilterOperatorQuery,
-  modifyFilterValue,
-} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
+import {modifyFilterValue} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderState';
 import {getOperatorInfo} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
 import {
   escapeTagValueForSearch,
@@ -50,12 +47,11 @@ import {
   buildNoValueFilterQuery,
   getFieldDefinitionForDataset,
   getFilterToken,
-  getNoValueOperator,
-  getValueFilterToken,
-  hasNoValueFilter,
+  getNoValueInfo,
   NO_VALUE_SENTINEL,
   NO_VALUE_SUPPORTED_OPERATORS,
   parseFilterValue,
+  stripUnsupportedNoValue,
 } from 'sentry/views/dashboards/globalFilter/utils';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
 import {
@@ -86,27 +82,36 @@ export function FilterSelector({
   const toggleOptionRef = useRef<((val: string) => void) | undefined>(undefined);
   const stagedValueRef = useRef<string[]>([]);
 
-  const {fieldDefinition, filterToken} = useMemo(() => {
-    const fieldDef = getFieldDefinitionForDataset(globalFilter.tag, globalFilter.dataset);
+  const {fieldDefinition, filterToken, valueToken, hasNoValue, noValueOperator} =
+    useMemo(() => {
+      const fieldDef = getFieldDefinitionForDataset(
+        globalFilter.tag,
+        globalFilter.dataset
+      );
 
-    // For "(no value)" filters, drive the UI from the value token when present,
-    // otherwise a default token (the bare has:/!has: has no value to edit).
-    const allTokens = globalFilter.value
-      ? parseFilterValue(globalFilter.value, globalFilter)
-      : [];
-    const containsNoValue = hasNoValueFilter(allTokens);
-    const valueToken = containsNoValue ? getValueFilterToken(allTokens) : null;
+      const allTokens = globalFilter.value
+        ? parseFilterValue(globalFilter.value, globalFilter)
+        : [];
+      const noValueInfo = getNoValueInfo(allTokens);
+      const containsNoValue = noValueInfo.operator !== null;
+      // The editable value paired with a "(no value)" clause, e.g. the
+      // `browser:firefox` in `(browser:firefox OR !has:browser)`.
+      const pairedValueToken = containsNoValue ? noValueInfo.valueToken : null;
 
-    return {
-      fieldDefinition: fieldDef,
-      filterToken:
-        valueToken ??
-        getFilterToken(
-          containsNoValue ? {...globalFilter, value: ''} : globalFilter,
-          fieldDef
-        ),
-    };
-  }, [globalFilter]);
+      return {
+        fieldDefinition: fieldDef,
+        filterToken:
+          pairedValueToken ??
+          getFilterToken(
+            containsNoValue ? {...globalFilter, value: ''} : globalFilter,
+            fieldDef
+          ),
+        valueToken: pairedValueToken,
+        hasNoValue: containsNoValue,
+        noValueOperator:
+          containsNoValue && !pairedValueToken ? noValueInfo.operator : null,
+      };
+    }, [globalFilter]);
 
   // Get initial selected values from the filter token
   const initialValues = useMemo(() => {
@@ -114,29 +119,21 @@ export function FilterSelector({
       return [];
     }
 
-    const allTokens = globalFilter.value
-      ? parseFilterValue(globalFilter.value, globalFilter)
-      : [];
-    const includesNoValue = hasNoValueFilter(allTokens);
-    const valueToken = includesNoValue ? getValueFilterToken(allTokens) : null;
-    const tokenForParsing = valueToken ?? filterToken;
-
-    const initialValue =
-      globalFilter.value && !includesNoValue
-        ? getInitialInputValue(tokenForParsing, true)
-        : valueToken
-          ? getInitialInputValue(valueToken, true)
-          : '';
+    const tokenForParsing =
+      valueToken ?? (globalFilter.value && !hasNoValue ? filterToken : null);
+    const initialValue = tokenForParsing
+      ? getInitialInputValue(tokenForParsing, true)
+      : '';
 
     const selectedValues = getSelectedValuesFromText(initialValue);
     const values = selectedValues.map(item => item.value);
 
-    if (includesNoValue) {
+    if (hasNoValue) {
       values.push(NO_VALUE_SENTINEL);
     }
 
     return values;
-  }, [filterToken, globalFilter]);
+  }, [filterToken, valueToken, hasNoValue, globalFilter.value]);
 
   // Get operator info from the filter token
   const {initialOperator, operatorDropdownItems} = useMemo(() => {
@@ -148,16 +145,6 @@ export function FilterSelector({
     }
 
     const operatorInfo = getOperatorInfo({filterToken, fieldDefinition});
-
-    // A bare has:/!has: has no value token, so derive its operator from the
-    // HAS polarity instead of the synthetic (always DEFAULT) filterToken.
-    const allTokens = globalFilter.value
-      ? parseFilterValue(globalFilter.value, globalFilter)
-      : [];
-    const noValueOperator =
-      hasNoValueFilter(allTokens) && !getValueFilterToken(allTokens)
-        ? getNoValueOperator(allTokens)
-        : null;
 
     return {
       initialOperator: noValueOperator ?? operatorInfo?.operator ?? TermOperator.DEFAULT,
@@ -178,7 +165,7 @@ export function FilterSelector({
         },
       })),
     };
-  }, [filterToken, fieldDefinition, globalFilter]);
+  }, [filterToken, fieldDefinition, noValueOperator]);
 
   const [stagedOperator, setStagedOperator] = useState(initialOperator);
   const [activeFilterValues, setActiveFilterValues] = useState(initialValues);
@@ -380,10 +367,7 @@ export function FilterSelector({
   const translatedOptions = translateKnownFilterOptions(options, globalFilter);
 
   const handleChange = (rawOpts: string[]) => {
-    // Strip the sentinel if the current operator doesn't support it
-    const opts = NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)
-      ? rawOpts
-      : rawOpts.filter(opt => opt !== NO_VALUE_SENTINEL);
+    const opts = stripUnsupportedNoValue(rawOpts, stagedOperator);
 
     if (isEqual(opts, activeFilterValues) && stagedOperator === initialOperator) {
       return;
@@ -413,12 +397,15 @@ export function FilterSelector({
           .map(opt => escapeTagValueForSearch(opt, {allowArrayValue: false}))
           .join(',')
       );
-      valueQuery = modifyFilterValue(filterToken.text, filterToken, cleanedValue);
-
-      if (stagedOperator !== initialOperator) {
-        const newToken = parseFilterValue(valueQuery, globalFilter)[0] ?? filterToken;
-        valueQuery = modifyFilterOperatorQuery(newToken.text, newToken, stagedOperator);
-      }
+      // Always rebuild the token with the operator the UI is showing.
+      // The synthetic filterToken used for "(no value)" defaults to the string
+      // CONTAINS wildcard, so patching only the value would leak that operator.
+      valueQuery = modifyFilterValue(
+        filterToken.text,
+        filterToken,
+        cleanedValue,
+        stagedOperator
+      );
     }
 
     const newValue = includeNoValue
@@ -459,9 +446,7 @@ export function FilterSelector({
 
   const renderFilterSelectorTrigger = (filterValues: string[]) => {
     // Strip the sentinel from display when the operator doesn't support it
-    const displayValues = NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)
-      ? filterValues
-      : filterValues.filter(v => v !== NO_VALUE_SENTINEL);
+    const displayValues = stripUnsupportedNoValue(filterValues, stagedOperator);
 
     return (
       <FilterSelectorTrigger

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -45,7 +45,6 @@ import {getDatasetLabel} from 'sentry/views/dashboards/globalFilter/addFilter';
 import {FilterSelectorTrigger} from 'sentry/views/dashboards/globalFilter/filterSelectorTrigger';
 import {
   buildNoValueFilterQuery,
-  canonicalNoValueOperator,
   deriveFilterState,
   getFilterToken,
   NO_VALUE_SENTINEL,
@@ -153,6 +152,16 @@ export function FilterSelector({
     setActiveFilterValues(initialValues);
     setStagedFilterValues([]);
   }, [initialValues]);
+
+  /**
+   * Resync stagedOperator to the derived operator whenever the persisted
+   * filter changes, because a stored has:/!has: clause only reconstructs
+   * as is/is not — so the trigger must drop any stale contains/does not
+   * contain it can't actually persist.
+   */
+  useEffect(() => {
+    setStagedOperator(initialOperator);
+  }, [initialOperator]);
 
   // Retrieve full tag definition to check if it has predefined values
   const datasetFilterKeys = searchBarData.getFilterKeys();
@@ -360,11 +369,6 @@ export function FilterSelector({
     const includeNoValue = opts.includes(NO_VALUE_SENTINEL);
     const valueOpts = opts.filter(opt => opt !== NO_VALUE_SENTINEL);
 
-    const isNoValueOnly = includeNoValue && valueOpts.length === 0;
-    const effectiveOperator = isNoValueOnly
-      ? canonicalNoValueOperator(stagedOperator)
-      : stagedOperator;
-
     let valueQuery = '';
     if (valueOpts.length > 0) {
       const cleanedValue = prepareInputValueForSaving(
@@ -382,17 +386,13 @@ export function FilterSelector({
         valueToRewrite.text,
         valueToRewrite,
         cleanedValue,
-        effectiveOperator
+        stagedOperator
       );
     }
 
     const newValue = includeNoValue
-      ? buildNoValueFilterQuery(globalFilter.tag.key, effectiveOperator, valueQuery)
+      ? buildNoValueFilterQuery(globalFilter.tag.key, stagedOperator, valueQuery)
       : valueQuery;
-
-    if (effectiveOperator !== stagedOperator) {
-      setStagedOperator(effectiveOperator);
-    }
 
     onUpdateFilter({
       ...globalFilter,

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -94,8 +94,6 @@ export function FilterSelector({
         : [];
       const noValueInfo = getNoValueInfo(allTokens);
       const containsNoValue = noValueInfo.operator !== null;
-      // The editable value paired with a "(no value)" clause, e.g. the
-      // `browser:firefox` in `(browser:firefox OR !has:browser)`.
       const pairedValueToken = containsNoValue ? noValueInfo.valueToken : null;
 
       return {
@@ -244,14 +242,14 @@ export function FilterSelector({
   const {data: fetchedFilterValues, isFetching} = queryResult;
 
   const options = useMemo((): Array<SelectOption<string>> => {
-    // "(no value)" option, prepended for supported operators.
     const buildNoValueOption = (): SelectOption<string> | null => {
       if (!NO_VALUE_SUPPORTED_OPERATORS.has(stagedOperator)) {
         return null;
       }
+      const noValueLabel = t('(no value)');
       const noValueOption: SelectOption<string> = {
-        label: <Text variant="muted">{t('(no value)')}</Text>,
-        textValue: t('(no value)'),
+        label: <Text variant="muted">{noValueLabel}</Text>,
+        textValue: noValueLabel,
         value: NO_VALUE_SENTINEL,
       };
       if (canSelectMultipleValues) {
@@ -259,7 +257,7 @@ export function FilterSelector({
           <Checkbox
             checked={isSelected}
             onChange={() => toggleOptionRef.current?.(NO_VALUE_SENTINEL)}
-            aria-label={t('Select %s', t('(no value)'))}
+            aria-label={t('Select %s', noValueLabel)}
             tabIndex={-1}
           />
         );
@@ -316,7 +314,6 @@ export function FilterSelector({
       return map.set(value, option);
     };
 
-    // Filter values in the global filter (sentinel is added separately)
     activeFilterValues
       .filter(value => value !== NO_VALUE_SENTINEL)
       .forEach(value => addOption(value, optionMap));
@@ -445,7 +442,6 @@ export function FilterSelector({
     xor(stagedSelect.value, activeFilterValues).length > 0 || hasOperatorChanges;
 
   const renderFilterSelectorTrigger = (filterValues: string[]) => {
-    // Strip the sentinel from display when the operator doesn't support it
     const displayValues = stripUnsupportedNoValue(filterValues, stagedOperator);
 
     return (

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -172,7 +172,7 @@ export const NO_VALUE_SUPPORTED_OPERATORS = new Set<TermOperator>([
 ]);
 
 /** Negated operators flip "(no value)" from "tag absent" to "tag present". */
-export function isNegatedNoValueOperator(operator: TermOperator): boolean {
+function isNegatedNoValueOperator(operator: TermOperator): boolean {
   return (
     operator === TermOperator.NOT_EQUAL || operator === TermOperator.DOES_NOT_CONTAIN
   );

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -213,6 +213,10 @@ export function operatorFromNoValueToken(token: TokenResult<Token.FILTER>): Term
   return token.negated ? TermOperator.DEFAULT : TermOperator.NOT_EQUAL;
 }
 
+export function canonicalNoValueOperator(operator: TermOperator): TermOperator {
+  return isNegatedOperator(operator) ? TermOperator.NOT_EQUAL : TermOperator.DEFAULT;
+}
+
 // Strip 'no value' as an option for operators that don't support this
 export function stripUnsupportedNoValue(
   values: string[],

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -163,7 +163,6 @@ export function newNumericFilterQuery(
 
 /** Sentinel for the "(no value)" option; never sent to the backend. */
 export const NO_VALUE_SENTINEL = '__no_value__';
-
 export const NO_VALUE_SUPPORTED_OPERATORS = new Set<TermOperator>([
   TermOperator.DEFAULT,
   TermOperator.NOT_EQUAL,
@@ -171,37 +170,56 @@ export const NO_VALUE_SUPPORTED_OPERATORS = new Set<TermOperator>([
   TermOperator.DOES_NOT_CONTAIN,
 ]);
 
-/** Negated operators flip "(no value)" from "tag absent" to "tag present". */
-function isNegatedNoValueOperator(operator: TermOperator): boolean {
+function isNegatedOperator(operator: TermOperator): boolean {
   return (
-    operator === TermOperator.NOT_EQUAL || operator === TermOperator.DOES_NOT_CONTAIN
+    operator === TermOperator.NOT_EQUAL ||
+    operator === TermOperator.DOES_NOT_CONTAIN ||
+    operator === TermOperator.DOES_NOT_END_WITH
   );
 }
 
-type NoValueInfo = {
-  operator: TermOperator.DEFAULT | TermOperator.NOT_EQUAL | null;
-  valueToken: TokenResult<Token.FILTER> | null;
-};
-
 /**
- * Inspects parsed tokens for the `has:`/`!has:` clause that backs the
- * "(no value)" option. A `null` operator means no such clause exists.
+ * A parsed global filter value, classified by what it represents:
+ * - `empty`: no value set yet
+ * - `value`: a plain tag value (e.g. `browser:chrome`)
+ * - `noValue`: only "(no value)" (e.g. `!has:browser`)
+ * - `valueAndNoValue`: a value combined with "(no value)"
+ *   (e.g. `(browser:chrome OR !has:browser)`)
+ *
+ * Each variant only carries the fields that are meaningful for it:
+ * `valueFilterToken` exists only when there's a real value clause, and
+ * `noValueOperator` only when the "(no value)" option is selected.
  */
-export function getNoValueInfo(
+export type ParsedFilterValue =
+  | {mode: 'empty'}
+  | {mode: 'value'; valueFilterToken: TokenResult<Token.FILTER>}
+  | {mode: 'noValue'; noValueOperator: TermOperator.DEFAULT | TermOperator.NOT_EQUAL}
+  | {
+      mode: 'valueAndNoValue';
+      noValueOperator: TermOperator.DEFAULT | TermOperator.NOT_EQUAL;
+      valueFilterToken: TokenResult<Token.FILTER>;
+    };
+
+export function classifyFilterValue(
   filterTokens: Array<TokenResult<Token.FILTER>>
-): NoValueInfo {
+): ParsedFilterValue {
   const hasToken = filterTokens.find(token => token.filter === FilterType.HAS);
-  return {
-    operator: hasToken
-      ? hasToken.negated
-        ? TermOperator.DEFAULT
-        : TermOperator.NOT_EQUAL
-      : null,
-    valueToken: filterTokens.find(token => token.filter !== FilterType.HAS) ?? null,
-  };
+  const valueFilterToken =
+    filterTokens.find(token => token.filter !== FilterType.HAS) ?? null;
+
+  if (!hasToken) {
+    return valueFilterToken ? {mode: 'value', valueFilterToken} : {mode: 'empty'};
+  }
+
+  const noValueOperator = hasToken.negated
+    ? TermOperator.DEFAULT
+    : TermOperator.NOT_EQUAL;
+
+  return valueFilterToken
+    ? {mode: 'valueAndNoValue', noValueOperator, valueFilterToken}
+    : {mode: 'noValue', noValueOperator};
 }
 
-/** Removes the "(no value)" sentinel when the operator can't express it. */
 export function stripUnsupportedNoValue(
   values: string[],
   operator: TermOperator
@@ -216,11 +234,11 @@ export function buildNoValueFilterQuery(
   operator: TermOperator,
   valueQuery?: string
 ): string {
-  const noValuePart = isNegatedNoValueOperator(operator)
-    ? `has:${tagKey}`
-    : `!has:${tagKey}`;
+  const negated = isNegatedOperator(operator);
+  const noValuePart = negated ? `has:${tagKey}` : `!has:${tagKey}`;
   if (!valueQuery) {
     return noValuePart;
   }
-  return `(${valueQuery} OR ${noValuePart})`;
+  const joiner = negated ? 'AND' : 'OR';
+  return `(${valueQuery} ${joiner} ${noValuePart})`;
 }

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -7,6 +7,7 @@ import {cleanFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filt
 import {getInitialFilterText} from 'sentry/components/searchQueryBuilder/tokens/utils';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {
+  FilterType,
   TermOperator,
   Token,
   type TokenResult,
@@ -158,4 +159,59 @@ export function newNumericFilterQuery(
     newOperator
   );
   return newFilterQuery;
+}
+
+/** Sentinel for the "(no value)" option; never sent to the backend. */
+export const NO_VALUE_SENTINEL = '__no_value__';
+
+export const NO_VALUE_SUPPORTED_OPERATORS = new Set<TermOperator>([
+  TermOperator.DEFAULT,
+  TermOperator.NOT_EQUAL,
+  TermOperator.CONTAINS,
+  TermOperator.DOES_NOT_CONTAIN,
+]);
+
+/** Negated operators flip "(no value)" from "tag absent" to "tag present". */
+export function isNegatedNoValueOperator(operator: TermOperator): boolean {
+  return (
+    operator === TermOperator.NOT_EQUAL || operator === TermOperator.DOES_NOT_CONTAIN
+  );
+}
+
+export function hasNoValueFilter(
+  filterTokens: Array<TokenResult<Token.FILTER>>
+): boolean {
+  return filterTokens.some(token => token.filter === FilterType.HAS);
+}
+
+/** Maps a HAS token's polarity to an operator: `!has:` → `is`, `has:` → `is not`. */
+export function getNoValueOperator(
+  filterTokens: Array<TokenResult<Token.FILTER>>
+): TermOperator | null {
+  const hasToken = filterTokens.find(token => token.filter === FilterType.HAS);
+  if (!hasToken) {
+    return null;
+  }
+  return hasToken.negated ? TermOperator.DEFAULT : TermOperator.NOT_EQUAL;
+}
+
+/** First non-HAS token, e.g. `browser:firefox` in `(browser:firefox OR !has:browser)`. */
+export function getValueFilterToken(
+  filterTokens: Array<TokenResult<Token.FILTER>>
+): TokenResult<Token.FILTER> | null {
+  return filterTokens.find(token => token.filter !== FilterType.HAS) ?? null;
+}
+
+export function buildNoValueFilterQuery(
+  tagKey: string,
+  operator: TermOperator,
+  valueQuery?: string
+): string {
+  const noValuePart = isNegatedNoValueOperator(operator)
+    ? `has:${tagKey}`
+    : `!has:${tagKey}`;
+  if (!valueQuery) {
+    return noValuePart;
+  }
+  return `(${valueQuery} OR ${noValuePart})`;
 }

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -213,10 +213,6 @@ export function operatorFromNoValueToken(token: TokenResult<Token.FILTER>): Term
   return token.negated ? TermOperator.DEFAULT : TermOperator.NOT_EQUAL;
 }
 
-export function canonicalNoValueOperator(operator: TermOperator): TermOperator {
-  return isNegatedOperator(operator) ? TermOperator.NOT_EQUAL : TermOperator.DEFAULT;
-}
-
 // Strip 'no value' as an option for operators that don't support this
 export function stripUnsupportedNoValue(
   values: string[],

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -161,6 +161,37 @@ export function newNumericFilterQuery(
   return newFilterQuery;
 }
 
+type DerivedFilterState = {
+  fieldDefinition: FieldDefinition | null;
+  /** Token that represents a value clause (e.g. `browser:chrome`), or null */
+  filterToken: TokenResult<Token.FILTER> | null;
+  /** Token that represents the "(no value)" option, or null. */
+  noValueToken: TokenResult<Token.FILTER> | null;
+};
+
+/**
+ * Splits a stored global filter into its (up to two) clauses.
+ *
+ * filterToken is a value clause e.g (`browser:chrome`),
+ * noValueToken is a "(no value)" clause e.g (`!has:browser`)
+ */
+export function deriveFilterState(globalFilter: GlobalFilter): DerivedFilterState {
+  const fieldDefinition = getFieldDefinitionForDataset(
+    globalFilter.tag,
+    globalFilter.dataset
+  );
+
+  const tokens = globalFilter.value
+    ? parseFilterValue(globalFilter.value, globalFilter)
+    : [];
+
+  return {
+    fieldDefinition,
+    filterToken: tokens.find(token => token.filter !== FilterType.HAS) ?? null,
+    noValueToken: tokens.find(token => token.filter === FilterType.HAS) ?? null,
+  };
+}
+
 /** Sentinel for the "(no value)" option; never sent to the backend. */
 export const NO_VALUE_SENTINEL = '__no_value__';
 export const NO_VALUE_SUPPORTED_OPERATORS = new Set<TermOperator>([
@@ -178,48 +209,7 @@ function isNegatedOperator(operator: TermOperator): boolean {
   );
 }
 
-/**
- * A parsed global filter value, classified by what it represents:
- * - `empty`: no value set yet
- * - `value`: a plain tag value (e.g. `browser:chrome`)
- * - `noValue`: only "(no value)" (e.g. `!has:browser`)
- * - `valueAndNoValue`: a value combined with "(no value)"
- *   (e.g. `(browser:chrome OR !has:browser)`)
- *
- * Each variant only carries the fields that are meaningful for it:
- * `valueFilterToken` exists only when there's a real value clause, and
- * `noValueOperator` only when the "(no value)" option is selected.
- */
-export type ParsedFilterValue =
-  | {mode: 'empty'}
-  | {mode: 'value'; valueFilterToken: TokenResult<Token.FILTER>}
-  | {mode: 'noValue'; noValueOperator: TermOperator.DEFAULT | TermOperator.NOT_EQUAL}
-  | {
-      mode: 'valueAndNoValue';
-      noValueOperator: TermOperator.DEFAULT | TermOperator.NOT_EQUAL;
-      valueFilterToken: TokenResult<Token.FILTER>;
-    };
-
-export function classifyFilterValue(
-  filterTokens: Array<TokenResult<Token.FILTER>>
-): ParsedFilterValue {
-  const hasToken = filterTokens.find(token => token.filter === FilterType.HAS);
-  const valueFilterToken =
-    filterTokens.find(token => token.filter !== FilterType.HAS) ?? null;
-
-  if (!hasToken) {
-    return valueFilterToken ? {mode: 'value', valueFilterToken} : {mode: 'empty'};
-  }
-
-  const noValueOperator = hasToken.negated
-    ? TermOperator.DEFAULT
-    : TermOperator.NOT_EQUAL;
-
-  return valueFilterToken
-    ? {mode: 'valueAndNoValue', noValueOperator, valueFilterToken}
-    : {mode: 'noValue', noValueOperator};
-}
-
+// Strip 'no value' as an option for operators that don't support this
 export function stripUnsupportedNoValue(
   values: string[],
   operator: TermOperator

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -178,28 +178,37 @@ export function isNegatedNoValueOperator(operator: TermOperator): boolean {
   );
 }
 
-export function hasNoValueFilter(
-  filterTokens: Array<TokenResult<Token.FILTER>>
-): boolean {
-  return filterTokens.some(token => token.filter === FilterType.HAS);
-}
+type NoValueInfo = {
+  operator: TermOperator.DEFAULT | TermOperator.NOT_EQUAL | null;
+  valueToken: TokenResult<Token.FILTER> | null;
+};
 
-/** Maps a HAS token's polarity to an operator: `!has:` → `is`, `has:` → `is not`. */
-export function getNoValueOperator(
+/**
+ * Inspects parsed tokens for the `has:`/`!has:` clause that backs the
+ * "(no value)" option. A `null` operator means no such clause exists.
+ */
+export function getNoValueInfo(
   filterTokens: Array<TokenResult<Token.FILTER>>
-): TermOperator | null {
+): NoValueInfo {
   const hasToken = filterTokens.find(token => token.filter === FilterType.HAS);
-  if (!hasToken) {
-    return null;
-  }
-  return hasToken.negated ? TermOperator.DEFAULT : TermOperator.NOT_EQUAL;
+  return {
+    operator: hasToken
+      ? hasToken.negated
+        ? TermOperator.DEFAULT
+        : TermOperator.NOT_EQUAL
+      : null,
+    valueToken: filterTokens.find(token => token.filter !== FilterType.HAS) ?? null,
+  };
 }
 
-/** First non-HAS token, e.g. `browser:firefox` in `(browser:firefox OR !has:browser)`. */
-export function getValueFilterToken(
-  filterTokens: Array<TokenResult<Token.FILTER>>
-): TokenResult<Token.FILTER> | null {
-  return filterTokens.find(token => token.filter !== FilterType.HAS) ?? null;
+/** Removes the "(no value)" sentinel when the operator can't express it. */
+export function stripUnsupportedNoValue(
+  values: string[],
+  operator: TermOperator
+): string[] {
+  return NO_VALUE_SUPPORTED_OPERATORS.has(operator)
+    ? values
+    : values.filter(value => value !== NO_VALUE_SENTINEL);
 }
 
 export function buildNoValueFilterQuery(

--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -209,6 +209,10 @@ function isNegatedOperator(operator: TermOperator): boolean {
   );
 }
 
+export function operatorFromNoValueToken(token: TokenResult<Token.FILTER>): TermOperator {
+  return token.negated ? TermOperator.DEFAULT : TermOperator.NOT_EQUAL;
+}
+
 // Strip 'no value' as an option for operators that don't support this
 export function stripUnsupportedNoValue(
   values: string[],


### PR DESCRIPTION
Second stab at https://github.com/getsentry/sentry/pull/111787.

Adds the ability to select a 'no value' option to the global filter selector. Previously, a global filter could only match tag values like `browser:chrome` or `browser:chrome, firefox`. The introduction of a 'no value' token adds an additional clause to a filtered value, enabling us to search for a singular value, (like before `browser:chrome`), the absence of a value, `!has:browser`, or **both** combined `browser: chrome OR !has:browser`. This applies to `is`, `is not`, `contains` and `does not contain`. 

No value
<img width="1111" height="491" alt="Screenshot 2026-07-09 at 6 22 44 PM" src="https://github.com/user-attachments/assets/0ddf2f9e-3dec-4cb7-9a87-2608240fe7dc" />

Absence of value
<img width="1083" height="466" alt="Screenshot 2026-07-09 at 6 23 43 PM" src="https://github.com/user-attachments/assets/79bc84e9-e11a-46c5-a766-ab24be0caa95" />

Value or no value
<img width="1084" height="470" alt="Screenshot 2026-07-09 at 6 24 17 PM" src="https://github.com/user-attachments/assets/fb09e68a-14f3-4d07-9157-8c840d88e99e" />

Closes BROWSE-123