### PR TITLE
ref(flags): Remove organizations:uptime-response-capture

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -365,8 +365,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable AI-powered assertion suggestions for uptime monitors
     manager.add("organizations:uptime-ai-assertion-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable storing HTTP response captures for uptime monitor failures
-    manager.add("organizations:uptime-response-capture", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 

--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -699,9 +699,7 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
                 )
             return
 
-        if result["status"] == CHECKSTATUS_FAILURE and features.has(
-            "organizations:uptime-response-capture", organization
-        ):
+        if result["status"] == CHECKSTATUS_FAILURE:
             create_uptime_response_capture(subscription, result)
 
         if last_update_ms > 0:


### PR DESCRIPTION
Remove `organizations:uptime-response-capture`. This flag was registered with `default=True` and is not present in the options automator, so it was effectively fully enabled everywhere. The registration and the sole `features.has()` check are removed, making response captures on uptime check failures unconditional (the per-subscription `response_capture_enabled` toggle still governs behavior).

This revives the cleanup from #116644, which proposed the same change but was auto-closed as stale on 2026-07-01 without merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzEwZbGA6r1zTyLUKt23DH)_