### PR TITLE
fix(conversations): Give the stacked span detail panel more min height

### DIFF
--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -35,6 +35,11 @@ export const CONVERSATION_VIEW_TABS: readonly ConversationViewTab[] = [
   'timeline',
 ];
 
+// On narrow screens the panels stack vertically; these floors keep each usable.
+// The detail panel gets more room since its header + tabs leave little for content.
+const LIST_PANEL_STACKED_MIN_HEIGHT = '320px';
+const DETAIL_PANEL_STACKED_MIN_HEIGHT = '400px';
+
 interface ConversationViewContentNewProps {
   activeTab: ConversationViewTab;
   conversation: UseConversationsOptions;
@@ -124,7 +129,7 @@ export function ConversationViewContentNew({
               <Container
                 flex="1"
                 minWidth="0"
-                minHeight={{xs: '320px', md: '0'}}
+                minHeight={{xs: LIST_PANEL_STACKED_MIN_HEIGHT, md: '0'}}
                 padding={isTranscript ? '0' : 'md'}
                 background="primary"
                 border="primary"
@@ -157,7 +162,7 @@ export function ConversationViewContentNew({
                 <Flex
                   width={{xs: '100%', md: '430px'}}
                   flex={{xs: '1', md: '0 0 auto'}}
-                  minHeight={{xs: '320px', md: '0'}}
+                  minHeight={{xs: DETAIL_PANEL_STACKED_MIN_HEIGHT, md: '0'}}
                 >
                   <ConversationSpanDetail
                     node={selectedNode}


### PR DESCRIPTION
## Summary

On narrow (`xs`) screens the conversation view stacks its two panels vertically: the timeline/transcript list on top and the span detail panel below. Both shared a `320px` min-height floor.

For the detail panel, `320px` is too tight — the header, duration, metadata grid, and tab bar eat most of it, leaving only a sliver for the actual input/output/attributes content. This bumps the detail panel's floor to `400px` while keeping the list at `320px`, and extracts both values into named constants so the two panels no longer share an anonymous magic number.

No change on `md`+ screens, where the panels sit side by side and both use `minHeight: 0`.

## Notes

- Frontend-only; no API or behavior changes.

Co-Authored-By: Claude <noreply@anthropic.com>