### PR TITLE
feat(utils): Add jitter option to CursoredScheduler

### DIFF
--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -52,6 +52,18 @@ Optional validate_item callback:
 
 When provided, validate_item is called for each PK before dispatching.
 Items that fail validation are skipped without dispatching the task.
+
+Optional jitter:
+
+    scheduler = CursoredScheduler(
+        ...
+        jitter=True,
+    )
+
+When enabled, each task is dispatched via apply_async with a random
+countdown between 0 and the tick interval (in seconds). This spreads
+task execution evenly across the time until the next tick, avoiding
+spikes when a single tick dispatches a large batch.
 """
 
 from __future__ import annotations
@@ -138,6 +150,7 @@ class CursoredScheduler[M: Model]:
         lock_duration: int = DEFAULT_LOCK_DURATION_SECONDS,
         validate_item: Callable[[int], bool] | None = None,
         shuffle: bool = False,
+        jitter: bool = False,
     ):
         self.name = name
         self.schedule_key = schedule_key
@@ -154,6 +167,7 @@ class CursoredScheduler[M: Model]:
         self.lock_duration = lock_duration
         self.validate_item = validate_item
         self.shuffle = shuffle
+        self.jitter = jitter
         self._metric_tags = {"scheduler": name}
 
     @property
@@ -211,10 +225,14 @@ class CursoredScheduler[M: Model]:
             return False
 
         dispatched = 0
+        jitter_window = int(self.tick_interval.total_seconds()) if self.jitter else 0
         for pk in items:
             if self.validate_item is not None and not self.validate_item(pk):
                 continue
-            self.task.delay(pk)
+            if jitter_window > 0:
+                self.task.apply_async(args=(pk,), countdown=random.randint(0, jitter_window))
+            else:
+                self.task.delay(pk)
             dispatched += 1
 
         metrics.gauge("cursored_scheduler.batch_size", dispatched, tags=self._metric_tags)

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -489,6 +489,43 @@ class CursoredSchedulerTest(TestCase):
 
         assert all_dispatched == sorted_pks
 
+    def test_jitter_dispatches_via_apply_async(self):
+        """When jitter=True, tasks are dispatched via apply_async with a countdown."""
+        self._create_org_integrations(30)
+
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=OrganizationIntegration.objects.filter(
+                integration__provider="github",
+                status=ObjectStatus.ACTIVE,
+            ),
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            jitter=True,
+        )
+
+        scheduler.tick()
+
+        # Should use apply_async, not delay
+        self.mock_task.delay.assert_not_called()
+        assert self.mock_task.apply_async.call_count == 10
+
+        # Each call should have a countdown between 0 and tick interval (60s)
+        for call in self.mock_task.apply_async.call_args_list:
+            countdown = call.kwargs["countdown"]
+            assert 0 <= countdown <= 60
+
+    def test_jitter_false_dispatches_via_delay(self):
+        """When jitter=False (default), tasks are dispatched via delay."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+
+        assert self.mock_task.delay.call_count == 10
+        self.mock_task.apply_async.assert_not_called()
+
     def test_interval_decrease_halves_batch_size(self):
         """When tick interval is halved, batch size is halved for remaining items."""
         self._create_org_integrations(30)


### PR DESCRIPTION
When `jitter=True`, tasks are dispatched via `apply_async` with a random countdown between 0 and the tick interval (in seconds). This spreads task execution evenly across the time until the next tick, avoiding spikes when a single tick dispatches a large batch.

The countdown is handled by the taskbroker service (via the `delay` field on the `TaskActivation` protobuf), not in worker memory. The jitter window is bounded by the tick interval, not the cycle duration, so even for long cycles (e.g. 1h) the max delay per task is still just the tick interval (e.g. 60s).

Closes TET-2605