### PR TITLE
feat(traces): Use new transcript in AI trace tabs

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -324,15 +324,13 @@ function TraceConversationTranscript({
         }
         right={
           selectedNode ? (
-            <Flex flex="1" minHeight="0" background="primary">
-              <ConversationSpanDetail
-                node={selectedNode}
-                traceId={nodeTraceMap.get(selectedNode.id) ?? ''}
-                activeTab={detailTab}
-                onTabChange={setDetailTab}
-                embedded
-              />
-            </Flex>
+            <ConversationSpanDetail
+              node={selectedNode}
+              traceId={nodeTraceMap.get(selectedNode.id) ?? ''}
+              activeTab={detailTab}
+              onTabChange={setDetailTab}
+              embedded
+            />
           ) : (
             <EmptyMessage>{t('Select a span to see its details')}</EmptyMessage>
           )

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -45,9 +45,7 @@ export function TraceAiConversations({
 }: TraceAiConversationsProps) {
   const organization = useOrganization();
   const hasRedesign = hasGenAiConversationsRedesignFeature(organization);
-  const [activeSubTab, setActiveSubTab] = useState(() =>
-    hasRedesign && conversationIds.length > 0 ? `chat-${conversationIds[0]}` : 'spans'
-  );
+  const [activeSubTab, setActiveSubTab] = useState('spans');
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
 
   const handleTabChange = useCallback((key: Key) => {
@@ -102,9 +100,7 @@ export function TraceAiConversations({
       conversationId: id,
     }));
 
-    return hasRedesign
-      ? [...conversationTabs, spansTab]
-      : [spansTab, ...conversationTabs];
+    return [spansTab, ...conversationTabs];
   }, [conversationIds, hasRedesign]);
 
   const linkConversationId = activeConversationId ?? conversationIds[0] ?? null;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -308,14 +308,7 @@ function TraceConversationTranscript({
         sizeStorageKey="trace-conversation-split-size"
         left={
           <ConversationLeftPanel>
-            <Flex
-              flex="1"
-              minHeight="0"
-              width="100%"
-              background="secondary"
-              overflowX="hidden"
-              overflowY="auto"
-            >
+       <Flex flex="1" minHeight="0" overflowY="auto">
               <MessagesPanelNew
                 nodes={nodes}
                 selectedNodeId={selectedNode?.id ?? null}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -21,10 +21,7 @@ import {
 } from 'sentry/views/explore/conversations/components/conversationSpanDetail';
 import {ConversationAggregatesBar} from 'sentry/views/explore/conversations/components/conversationSummary';
 import {MessagesPanel} from 'sentry/views/explore/conversations/components/messagesPanel';
-import {
-  MessagesPanelNew,
-  MessagesPanelSkeleton,
-} from 'sentry/views/explore/conversations/components/messagesPanelNew';
+import {MessagesPanelNew} from 'sentry/views/explore/conversations/components/messagesPanelNew';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
 import {useConversationSelection} from 'sentry/views/explore/conversations/hooks/useConversationSelection';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
@@ -48,8 +45,6 @@ export function TraceAiConversations({
 }: TraceAiConversationsProps) {
   const organization = useOrganization();
   const hasRedesign = hasGenAiConversationsRedesignFeature(organization);
-  // The redesign leads with the transcript, so default to the first
-  // conversation tab instead of the Timeline/Spans tab.
   const [activeSubTab, setActiveSubTab] = useState(() =>
     hasRedesign && conversationIds.length > 0 ? `chat-${conversationIds[0]}` : 'spans'
   );
@@ -107,7 +102,6 @@ export function TraceAiConversations({
       conversationId: id,
     }));
 
-    // The redesign leads with the transcript(s), then the timeline.
     return hasRedesign
       ? [...conversationTabs, spansTab]
       : [spansTab, ...conversationTabs];
@@ -268,12 +262,6 @@ function TraceConversationChat({
   );
 }
 
-/**
- * Redesigned transcript for the trace AI tab, gated behind
- * `gen-ai-conversations-redesign`. Mirrors `ConversationViewContentNew`: the
- * Seer Explorer-styled transcript on the left and the redesigned span detail
- * panel on the right, opened only when the user selects a span.
- */
 function TraceConversationTranscript({
   nodes,
   nodeTraceMap,
@@ -294,28 +282,20 @@ function TraceConversationTranscript({
     selectedSpanId,
     onSelectSpan,
     isLoading,
-    // The redesign opens the span detail only when the user selects a span.
     autoSelectDefaultNode: false,
   });
 
-  const [detailState, setDetailState] = useState<{open: boolean; tab: DetailTab}>({
-    open: true,
-    tab: 'input',
-  });
+  const [detailTab, setDetailTab] = useState<DetailTab>('input');
 
-  const handleSelectAndOpenDetail = useCallback(
-    (node: AITraceSpanNode) => {
-      setDetailState(prev => ({...prev, open: true}));
-      handleSelectNode(node);
-    },
-    [handleSelectNode]
-  );
+  if (isLoading) {
+    return <ConversationViewSkeleton />;
+  }
 
   if (error) {
     return <EmptyMessage>{t('Failed to load conversation')}</EmptyMessage>;
   }
 
-  if (!isLoading && nodes.length === 0) {
+  if (nodes.length === 0) {
     return (
       <EmptyMessage>
         {t('No chat messages in this portion of the conversation')}
@@ -325,65 +305,43 @@ function TraceConversationTranscript({
 
   return (
     <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
-      <Flex flex="1" minWidth="0" minHeight="0" overflow="hidden">
-        <ConversationLeftPanel>
-          <Container
-            containerType="inline-size"
-            flex="1"
-            minHeight="0"
-            width="100%"
-            background="secondary"
-          >
+      <ConversationSplitLayout
+        sizeStorageKey="trace-conversation-split-size"
+        left={
+          <ConversationLeftPanel>
             <Flex
-              direction={{xs: 'column', md: 'row'}}
-              height="100%"
-              width="100%"
-              gap="md"
-              padding="md"
+              flex="1"
               minHeight="0"
-              overflowY="auto"
+              width="100%"
+              background="secondary"
               overflowX="hidden"
+              overflowY="auto"
             >
-              <Container
-                flex="1"
-                minWidth="0"
-                minHeight={{xs: '320px', md: '0'}}
-                background="primary"
-                border="primary"
-                radius="md"
-                overflowX="hidden"
-                overflowY="auto"
-              >
-                {isLoading ? (
-                  <MessagesPanelSkeleton />
-                ) : (
-                  <MessagesPanelNew
-                    nodes={nodes}
-                    selectedNodeId={selectedNode?.id ?? null}
-                    onSelectNode={handleSelectAndOpenDetail}
-                    nodeTraceMap={nodeTraceMap}
-                  />
-                )}
-              </Container>
-              {detailState.open && selectedNode ? (
-                <Flex
-                  width={{xs: '100%', md: '430px'}}
-                  flex={{xs: '1', md: '0 0 auto'}}
-                  minHeight={{xs: '320px', md: '0'}}
-                >
-                  <ConversationSpanDetail
-                    node={selectedNode}
-                    traceId={nodeTraceMap.get(selectedNode.id) ?? ''}
-                    activeTab={detailState.tab}
-                    onTabChange={tab => setDetailState(prev => ({...prev, tab}))}
-                    onClose={() => setDetailState(prev => ({...prev, open: false}))}
-                  />
-                </Flex>
-              ) : null}
+              <MessagesPanelNew
+                nodes={nodes}
+                selectedNodeId={selectedNode?.id ?? null}
+                onSelectNode={handleSelectNode}
+                nodeTraceMap={nodeTraceMap}
+              />
             </Flex>
-          </Container>
-        </ConversationLeftPanel>
-      </Flex>
+          </ConversationLeftPanel>
+        }
+        right={
+          selectedNode ? (
+            <Flex flex="1" minHeight="0" background="primary">
+              <ConversationSpanDetail
+                node={selectedNode}
+                traceId={nodeTraceMap.get(selectedNode.id) ?? ''}
+                activeTab={detailTab}
+                onTabChange={setDetailTab}
+                embedded
+              />
+            </Flex>
+          ) : (
+            <EmptyMessage>{t('Select a span to see its details')}</EmptyMessage>
+          )
+        }
+      />
     </TraceStateProvider>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -21,7 +21,10 @@ import {
 } from 'sentry/views/explore/conversations/components/conversationSpanDetail';
 import {ConversationAggregatesBar} from 'sentry/views/explore/conversations/components/conversationSummary';
 import {MessagesPanel} from 'sentry/views/explore/conversations/components/messagesPanel';
-import {MessagesPanelNew} from 'sentry/views/explore/conversations/components/messagesPanelNew';
+import {
+  MessagesPanelNew,
+  MessagesPanelSkeleton,
+} from 'sentry/views/explore/conversations/components/messagesPanelNew';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
 import {useConversationSelection} from 'sentry/views/explore/conversations/hooks/useConversationSelection';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
@@ -284,7 +287,7 @@ function TraceConversationTranscript({
   const [detailTab, setDetailTab] = useState<DetailTab>('input');
 
   if (isLoading) {
-    return <ConversationViewSkeleton />;
+    return <MessagesPanelSkeleton />;
   }
 
   if (error) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -15,8 +15,16 @@ import {
   ConversationSplitLayout,
   ConversationViewSkeleton,
 } from 'sentry/views/explore/conversations/components/conversationLayout';
+import {
+  ConversationSpanDetail,
+  type DetailTab,
+} from 'sentry/views/explore/conversations/components/conversationSpanDetail';
 import {ConversationAggregatesBar} from 'sentry/views/explore/conversations/components/conversationSummary';
 import {MessagesPanel} from 'sentry/views/explore/conversations/components/messagesPanel';
+import {
+  MessagesPanelNew,
+  MessagesPanelSkeleton,
+} from 'sentry/views/explore/conversations/components/messagesPanelNew';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
 import {useConversationSelection} from 'sentry/views/explore/conversations/hooks/useConversationSelection';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
@@ -39,7 +47,12 @@ export function TraceAiConversations({
   traceSlug,
 }: TraceAiConversationsProps) {
   const organization = useOrganization();
-  const [activeSubTab, setActiveSubTab] = useState('spans');
+  const hasRedesign = hasGenAiConversationsRedesignFeature(organization);
+  // The redesign leads with the transcript, so default to the first
+  // conversation tab instead of the Timeline/Spans tab.
+  const [activeSubTab, setActiveSubTab] = useState(() =>
+    hasRedesign && conversationIds.length > 0 ? `chat-${conversationIds[0]}` : 'spans'
+  );
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
 
   const handleTabChange = useCallback((key: Key) => {
@@ -72,29 +85,33 @@ export function TraceAiConversations({
     [conversationNodes, nodeTraceMap, traceSlug]
   );
 
-  const hasRedesign = hasGenAiConversationsRedesignFeature(organization);
+  const tabItems = useMemo((): Array<{
+    conversationId: string | null;
+    key: string;
+    label: string;
+  }> => {
+    const spansTab = {
+      key: 'spans',
+      label: hasRedesign ? t('Timeline') : t('Spans'),
+      conversationId: null,
+    };
+    const conversationTabs = conversationIds.map(id => ({
+      key: `chat-${id}`,
+      label: hasRedesign
+        ? conversationIds.length === 1
+          ? t('Transcript')
+          : t('Transcript %s', id.slice(0, 8))
+        : conversationIds.length === 1
+          ? t('Chat')
+          : t('Chat %s', id.slice(0, 8)),
+      conversationId: id,
+    }));
 
-  const tabItems = useMemo(
-    (): Array<{conversationId: string | null; key: string; label: string}> => [
-      {
-        key: 'spans',
-        label: hasRedesign ? t('Timeline') : t('Spans'),
-        conversationId: null,
-      },
-      ...conversationIds.map(id => ({
-        key: `chat-${id}`,
-        label: hasRedesign
-          ? conversationIds.length === 1
-            ? t('Transcript')
-            : t('Transcript %s', id.slice(0, 8))
-          : conversationIds.length === 1
-            ? t('Chat')
-            : t('Chat %s', id.slice(0, 8)),
-        conversationId: id,
-      })),
-    ],
-    [conversationIds, hasRedesign]
-  );
+    // The redesign leads with the transcript(s), then the timeline.
+    return hasRedesign
+      ? [...conversationTabs, spansTab]
+      : [spansTab, ...conversationTabs];
+  }, [conversationIds, hasRedesign]);
 
   const linkConversationId = activeConversationId ?? conversationIds[0] ?? null;
   const conversationUrl = linkConversationId
@@ -134,14 +151,25 @@ export function TraceAiConversations({
             {tabItems.map(item =>
               item.conversationId ? (
                 <TabPanels.Item key={item.key}>
-                  <TraceConversationChat
-                    nodes={traceNodes}
-                    nodeTraceMap={nodeTraceMap}
-                    isLoading={isLoading}
-                    error={error}
-                    selectedSpanId={selectedSpanId}
-                    onSelectSpan={handleSelectSpan}
-                  />
+                  {hasRedesign ? (
+                    <TraceConversationTranscript
+                      nodes={traceNodes}
+                      nodeTraceMap={nodeTraceMap}
+                      isLoading={isLoading}
+                      error={error}
+                      selectedSpanId={selectedSpanId}
+                      onSelectSpan={handleSelectSpan}
+                    />
+                  ) : (
+                    <TraceConversationChat
+                      nodes={traceNodes}
+                      nodeTraceMap={nodeTraceMap}
+                      isLoading={isLoading}
+                      error={error}
+                      selectedSpanId={selectedSpanId}
+                      onSelectSpan={handleSelectSpan}
+                    />
+                  )}
                 </TabPanels.Item>
               ) : (
                 <TabPanels.Item key={item.key}>
@@ -236,6 +264,126 @@ function TraceConversationChat({
           />
         }
       />
+    </TraceStateProvider>
+  );
+}
+
+/**
+ * Redesigned transcript for the trace AI tab, gated behind
+ * `gen-ai-conversations-redesign`. Mirrors `ConversationViewContentNew`: the
+ * Seer Explorer-styled transcript on the left and the redesigned span detail
+ * panel on the right, opened only when the user selects a span.
+ */
+function TraceConversationTranscript({
+  nodes,
+  nodeTraceMap,
+  isLoading,
+  error,
+  selectedSpanId,
+  onSelectSpan,
+}: {
+  error: boolean;
+  isLoading: boolean;
+  nodeTraceMap: Map<string, string>;
+  nodes: AITraceSpanNode[];
+  onSelectSpan: (spanId: string) => void;
+  selectedSpanId: string | null;
+}) {
+  const {selectedNode, handleSelectNode} = useConversationSelection({
+    nodes,
+    selectedSpanId,
+    onSelectSpan,
+    isLoading,
+    // The redesign opens the span detail only when the user selects a span.
+    autoSelectDefaultNode: false,
+  });
+
+  const [detailState, setDetailState] = useState<{open: boolean; tab: DetailTab}>({
+    open: true,
+    tab: 'input',
+  });
+
+  const handleSelectAndOpenDetail = useCallback(
+    (node: AITraceSpanNode) => {
+      setDetailState(prev => ({...prev, open: true}));
+      handleSelectNode(node);
+    },
+    [handleSelectNode]
+  );
+
+  if (error) {
+    return <EmptyMessage>{t('Failed to load conversation')}</EmptyMessage>;
+  }
+
+  if (!isLoading && nodes.length === 0) {
+    return (
+      <EmptyMessage>
+        {t('No chat messages in this portion of the conversation')}
+      </EmptyMessage>
+    );
+  }
+
+  return (
+    <TraceStateProvider initialPreferences={DEFAULT_TRACE_VIEW_PREFERENCES}>
+      <Flex flex="1" minWidth="0" minHeight="0" overflow="hidden">
+        <ConversationLeftPanel>
+          <Container
+            containerType="inline-size"
+            flex="1"
+            minHeight="0"
+            width="100%"
+            background="secondary"
+          >
+            <Flex
+              direction={{xs: 'column', md: 'row'}}
+              height="100%"
+              width="100%"
+              gap="md"
+              padding="md"
+              minHeight="0"
+              overflowY="auto"
+              overflowX="hidden"
+            >
+              <Container
+                flex="1"
+                minWidth="0"
+                minHeight={{xs: '320px', md: '0'}}
+                background="primary"
+                border="primary"
+                radius="md"
+                overflowX="hidden"
+                overflowY="auto"
+              >
+                {isLoading ? (
+                  <MessagesPanelSkeleton />
+                ) : (
+                  <MessagesPanelNew
+                    nodes={nodes}
+                    selectedNodeId={selectedNode?.id ?? null}
+                    onSelectNode={handleSelectAndOpenDetail}
+                    nodeTraceMap={nodeTraceMap}
+                  />
+                )}
+              </Container>
+              {detailState.open && selectedNode ? (
+                <Flex
+                  width={{xs: '100%', md: '430px'}}
+                  flex={{xs: '1', md: '0 0 auto'}}
+                  minHeight={{xs: '320px', md: '0'}}
+                >
+                  <ConversationSpanDetail
+                    node={selectedNode}
+                    traceId={nodeTraceMap.get(selectedNode.id) ?? ''}
+                    activeTab={detailState.tab}
+                    onTabChange={tab => setDetailState(prev => ({...prev, tab}))}
+                    onClose={() => setDetailState(prev => ({...prev, open: false}))}
+                  />
+                </Flex>
+              ) : null}
+            </Flex>
+          </Container>
+        </ConversationLeftPanel>
+      </Flex>
     </TraceStateProvider>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -1,5 +1,6 @@
 import {type Key, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import * as qs from 'query-string';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -109,7 +110,12 @@ export function TraceAiConversations({
   const linkConversationId = activeConversationId ?? conversationIds[0] ?? null;
   const conversationUrl = linkConversationId
     ? normalizeUrl(
-        `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${linkConversationId}/${selectedSpanId && activeConversationId ? `?spanId=${encodeURIComponent(selectedSpanId)}` : ''}`
+        `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${linkConversationId}/?${qs.stringify(
+          {
+            referrer: 'trace-view',
+            ...(selectedSpanId && activeConversationId ? {spanId: selectedSpanId} : {}),
+          }
+        )}`
       )
     : null;
 
@@ -308,7 +314,7 @@ function TraceConversationTranscript({
         sizeStorageKey="trace-conversation-split-size"
         left={
           <ConversationLeftPanel>
-       <Flex flex="1" minHeight="0" overflowY="auto">
+            <Flex flex="1" minHeight="0" overflowY="auto">
               <MessagesPanelNew
                 nodes={nodes}
                 selectedNodeId={selectedNode?.id ?? null}


### PR DESCRIPTION
Behind the `gen-ai-conversations-redesign` flag, the trace AI tab uses the redesigned transcript and span detail components. The conversation panel renders `MessagesPanelNew` on the left and the redesigned `ConversationSpanDetail` on the right, reusing the existing `ConversationSplitLayout` resizable panel — no hardcoded pixel sizes.

Tab order is `[Timeline, Transcript(s)]` with Timeline selected by default. The flag-off path is unchanged: Spans first, legacy `MessagesPanel`.

Closes TET-2604