### PR TITLE
fix(conversations): Preserve agent filter on saved query navigation

### DIFF
--- a/static/app/views/insights/common/components/agentSelector.tsx
+++ b/static/app/views/insights/common/components/agentSelector.tsx
@@ -62,14 +62,19 @@ export function AgentSelector({storageKeyPrefix, referrer}: AgentSelectorProps) 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Reset when project changes
+  // Reset when project changes, but preserve agent if it was set via URL
+  // (e.g. navigating to a saved query that includes both project and agent)
   const prevProjectKey = useRef(projectKey);
   useEffect(() => {
     if (prevProjectKey.current !== projectKey) {
       prevProjectKey.current = projectKey;
-      setQueryStates({[AGENT_URL_PARAM]: null, [TableUrlParams.CURSOR]: null});
+      if (urlAgents?.length) {
+        setQueryStates({[TableUrlParams.CURSOR]: null});
+      } else {
+        setQueryStates({[AGENT_URL_PARAM]: null, [TableUrlParams.CURSOR]: null});
+      }
     }
-  }, [projectKey, setQueryStates]);
+  }, [projectKey, urlAgents, setQueryStates]);
 
   const selectedAgents = useMemo(() => {
     // Prevent cache pollution during project transitions


### PR DESCRIPTION
When navigating to a saved conversation query from the sidebar, the `AgentSelector`'s project-change reset effect fires and unconditionally nulls out the `agent` URL param — even though the URL already has the correct agent value from the saved query.

**Root cause:** The saved query URL sets both `project` and `agent`. `PageFiltersContainer` picks up the new project, which changes `projectKey` in the `AgentSelector`, triggering the reset effect that clears agent. This doesn't happen from the All Queries page because that navigation does a full page load.

**Fix:** Skip the agent reset when the URL already contains agent params, only reset the cursor.

Contributes to TET-2552