### PR TITLE
fix(conversations): Increase span detail metadata font-size to 14px

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -255,16 +255,16 @@ function SpanMetadata({
     <Grid columns="max-content minmax(0, 1fr)" gap="md lg" align="center">
       {rows.map(row => (
         <Fragment key={row.name}>
-          <Text size="xs" variant="muted">
+          <Text size="md" variant="muted">
             {row.name}
           </Text>
           <Container minWidth="0">
             {typeof row.value === 'string' ? (
-              <Text size="xs" as="div" ellipsis>
+              <Text size="md" as="div" ellipsis>
                 {row.value}
               </Text>
             ) : (
-              <Text size="xs" as="div">
+              <Text size="md" as="div">
                 {row.value}
               </Text>
             )}


### PR DESCRIPTION
Increases the font-size of the AI span detail panel's metadata rows (the key/value attribute grid below the title) from 11px (`size="xs"`) to 14px (`size="md"`), restoring it to the larger, more readable size.

Only the highlighted-attribute label and value `Text` elements in `SpanMetadata` are affected — the title header was already 14px.