### PR TITLE
fix(conversations): Remove native tooltips on tool-calls in table

### DIFF
--- a/static/app/views/explore/conversations/components/conversationToolCallsBreakdown.tsx
+++ b/static/app/views/explore/conversations/components/conversationToolCallsBreakdown.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import {Tag} from '@sentry/scraps/badge';
 import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -49,9 +50,11 @@ export function ConversationToolCallsBreakdown({
             // Cap long tool names; the inner Text truncates with an ellipsis.
             style={{justifySelf: 'start', maxWidth: 200, minWidth: 0}}
           >
-            <Text ellipsis variant="inherit">
-              {tool.toolName}
-            </Text>
+            <Tooltip title={tool.toolName} showOnlyOnOverflow skipWrapper>
+              <Text ellipsis variant="inherit">
+                {tool.toolName}
+              </Text>
+            </Tooltip>
           </Tag>
           <Text size="sm" tabular>
             <Count value={tool.calls} /> {tn('call', 'calls', tool.calls)}

--- a/static/app/views/explore/conversations/components/conversationToolCallsBreakdown.tsx
+++ b/static/app/views/explore/conversations/components/conversationToolCallsBreakdown.tsx
@@ -46,7 +46,6 @@ export function ConversationToolCallsBreakdown({
         <Fragment key={tool.toolName}>
           <Tag
             variant={tool.hasError ? 'danger' : 'muted'}
-            title={tool.toolName}
             // Cap long tool names; the inner Text truncates with an ellipsis.
             style={{justifySelf: 'start', maxWidth: 200, minWidth: 0}}
           >

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -23,6 +23,7 @@ import {IconEdit, IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {isUUID} from 'sentry/utils/string/isUUID';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -354,11 +355,7 @@ function ToolCallsCell({
   });
 
   if (dataRow.toolCalls === 0) {
-    return (
-      <Text as="div">
-        <Count value={dataRow.toolCalls} />
-      </Text>
-    );
+    return <Text as="div">{formatAbbreviatedNumber(dataRow.toolCalls)}</Text>;
   }
 
   return (
@@ -367,7 +364,7 @@ function ToolCallsCell({
         maxWidth={400}
         title={<ConversationToolCallsBreakdown conversationId={dataRow.conversationId} />}
       >
-        <Count value={dataRow.toolCalls} />
+        {formatAbbreviatedNumber(dataRow.toolCalls)}
       </InfoText>
     </Text>
   );


### PR DESCRIPTION
Removes the redundant native browser tooltips on the Conversations table's tool-calls cell (rendered by `Count`'s `title` attribute) and on the tool-name tags in the breakdown. Truncated tool names now reveal their full name via the custom `Tooltip` on overflow instead of a native one.