### PR TITLE
fix(conversations): Show tool calls and redacted notice on empty transcript

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -29,6 +29,7 @@ import {getTimeBoundsFromNodes} from 'sentry/views/explore/conversations/utils/t
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {
+  getIsEmbeddingNode,
   getNumberAttr,
   getStringAttr,
   hasError,
@@ -81,6 +82,10 @@ export function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggre
   const erroredToolNameSet = new Set<string>();
 
   for (const node of nodes) {
+    if (getIsEmbeddingNode(node)) {
+      continue;
+    }
+
     const opType = getGenAiOpType(node);
     const nodeHasError = hasError(node);
 

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -57,7 +57,7 @@ describe('MessagesPanelNew', () => {
     jest.clearAllMocks();
   });
 
-  it('renders empty message when no nodes provided', () => {
+  it('shows "not captured" notice when there are no nodes at all', () => {
     render(
       <MessagesPanelNew
         nodes={[]}
@@ -67,7 +67,47 @@ describe('MessagesPanelNew', () => {
       />
     );
 
-    expect(screen.getByText('No messages found')).toBeInTheDocument();
+    expect(
+      screen.getByText('Message inputs and outputs were not captured')
+    ).toBeInTheDocument();
+  });
+
+  it('shows placeholder bubbles when generation spans have no message content', () => {
+    const genNode = createMockNode({id: 'gen-1', startTimestamp: 1000});
+
+    render(
+      <MessagesPanelNew
+        nodes={[genNode] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+        nodeTraceMap={new Map()}
+      />
+    );
+
+    // Two "(not captured)" placeholders: one user bubble, one assistant bubble
+    expect(screen.getAllByText('(not captured)')).toHaveLength(2);
+  });
+
+  it('shows tool calls and notice when there are only tool spans and no generation spans', () => {
+    const toolNode = createMockToolNode({
+      id: 'tool-1',
+      toolName: 'search',
+      startTimestamp: 1000,
+    });
+
+    render(
+      <MessagesPanelNew
+        nodes={[toolNode] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+        nodeTraceMap={new Map()}
+      />
+    );
+
+    expect(screen.getByText('search')).toBeInTheDocument();
+    expect(
+      screen.getByText('Message inputs and outputs were not captured')
+    ).toBeInTheDocument();
   });
 
   it('renders user and assistant messages', () => {

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -72,7 +72,7 @@ describe('MessagesPanelNew', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows one placeholder bubble for each generation span without input/output', () => {
+  it('folds consecutive generation spans without input/output into one placeholder bubble', () => {
     const genNode1 = createMockNode({id: 'gen-1', startTimestamp: 1000});
     const genNode2 = createMockNode({id: 'gen-2', startTimestamp: 2000});
 
@@ -85,7 +85,7 @@ describe('MessagesPanelNew', () => {
       />
     );
 
-    expect(screen.getAllByText(EMPTY_TEXT_CONTENT)).toHaveLength(2);
+    expect(screen.getAllByText(EMPTY_TEXT_CONTENT)).toHaveLength(1);
     expect(
       screen.queryByText('Message inputs and outputs were not captured')
     ).not.toBeInTheDocument();

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -72,20 +72,23 @@ describe('MessagesPanelNew', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows placeholder bubbles when generation spans have no message content', () => {
-    const genNode = createMockNode({id: 'gen-1', startTimestamp: 1000});
+  it('shows one placeholder bubble for each generation span without input/output', () => {
+    const genNode1 = createMockNode({id: 'gen-1', startTimestamp: 1000});
+    const genNode2 = createMockNode({id: 'gen-2', startTimestamp: 2000});
 
     render(
       <MessagesPanelNew
-        nodes={[genNode] as any}
+        nodes={[genNode1, genNode2] as any}
         selectedNodeId={null}
         onSelectNode={mockOnSelectNode}
         nodeTraceMap={new Map()}
       />
     );
 
-    // Two "(not captured)" placeholders: one user bubble, one assistant bubble
-    expect(screen.getAllByText('(not captured)')).toHaveLength(2);
+    expect(screen.getAllByText(EMPTY_TEXT_CONTENT)).toHaveLength(2);
+    expect(
+      screen.queryByText('Message inputs and outputs were not captured')
+    ).not.toBeInTheDocument();
   });
 
   it('shows tool calls and notice when there are only tool spans and no generation spans', () => {

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -11,7 +11,6 @@ import {
   MessageBlock,
   UserMessageBlock,
 } from 'sentry/components/ai/chat/messageBlock';
-import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -20,8 +19,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {MessageToolCallsNew} from 'sentry/views/explore/conversations/components/messageToolCallsNew';
 import {TurnMeta} from 'sentry/views/explore/conversations/components/turnMeta';
 import {
+  buildToolCallsFromSpans,
   type ConversationMessage,
   extractMessagesFromNodes,
+  partitionSpansByType,
 } from 'sentry/views/explore/conversations/utils/conversationMessages';
 import {EMPTY_TEXT_CONTENT} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {getNumberAttr} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
@@ -87,9 +88,49 @@ export function MessagesPanelNew({
   }
 
   if (messages.length === 0) {
+    // Even without message content, tool spans and generation spans may be
+    // present. Surface them so the user sees AI activity rather than a blank
+    // panel. Generation spans with no input/output get placeholder bubbles
+    // ("not captured") to preserve the conversational shape.
+    const {generationSpans, toolSpans} = partitionSpansByType(nodes);
+    const orphanToolCalls = buildToolCallsFromSpans(toolSpans);
+    const hasGenerations = generationSpans.length > 0;
+
     return (
       <PanelContainer>
-        <EmptyMessage>{t('No messages found')}</EmptyMessage>
+        <Stack gap="0" width="100%">
+          {hasGenerations && (
+            <UserMessageBlock>
+              <MessageText align="left" variant="muted">
+                {t('(not captured)')}
+              </MessageText>
+            </UserMessageBlock>
+          )}
+          {orphanToolCalls.length > 0 && (
+            <MessageBlock>
+              <MessageToolCallsNew
+                toolCalls={orphanToolCalls}
+                selectedNodeId={selectedNodeId}
+                nodeMap={nodeMap}
+                nodeTraceMap={nodeTraceMap}
+                onSelectNode={onSelectNode}
+              />
+            </MessageBlock>
+          )}
+          {hasGenerations ? (
+            <AssistantMessageBlock>
+              <MessageText align="left" variant="muted">
+                {t('(not captured)')}
+              </MessageText>
+            </AssistantMessageBlock>
+          ) : (
+            <Flex padding="md xl" width="100%" justify="center">
+              <Text size="sm" variant="muted" align="center">
+                {t('Message inputs and outputs were not captured')}
+              </Text>
+            </Flex>
+          )}
+        </Stack>
       </PanelContainer>
     );
   }

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -88,24 +88,12 @@ export function MessagesPanelNew({
   }
 
   if (messages.length === 0) {
-    // Even without message content, tool spans and generation spans may be
-    // present. Surface them so the user sees AI activity rather than a blank
-    // panel. Generation spans with no input/output get placeholder bubbles
-    // ("not captured") to preserve the conversational shape.
-    const {generationSpans, toolSpans} = partitionSpansByType(nodes);
+    const {toolSpans} = partitionSpansByType(nodes);
     const orphanToolCalls = buildToolCallsFromSpans(toolSpans);
-    const hasGenerations = generationSpans.length > 0;
 
     return (
       <PanelContainer>
         <Stack gap="0" width="100%">
-          {hasGenerations && (
-            <UserMessageBlock>
-              <MessageText align="left" variant="muted">
-                {t('(not captured)')}
-              </MessageText>
-            </UserMessageBlock>
-          )}
           {orphanToolCalls.length > 0 && (
             <MessageBlock>
               <MessageToolCallsNew
@@ -117,19 +105,11 @@ export function MessagesPanelNew({
               />
             </MessageBlock>
           )}
-          {hasGenerations ? (
-            <AssistantMessageBlock>
-              <MessageText align="left" variant="muted">
-                {t('(not captured)')}
-              </MessageText>
-            </AssistantMessageBlock>
-          ) : (
-            <Flex padding="md xl" width="100%" justify="center">
-              <Text size="sm" variant="muted" align="center">
-                {t('Message inputs and outputs were not captured')}
-              </Text>
-            </Flex>
-          )}
+          <Flex padding="md xl" width="100%" justify="center">
+            <Text size="sm" variant="muted" align="center">
+              {t('Message inputs and outputs were not captured')}
+            </Text>
+          </Flex>
         </Stack>
       </PanelContainer>
     );

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -2,6 +2,7 @@ import {SpanFields} from 'sentry/views/insights/types';
 
 import {
   buildConversationTurns,
+  buildToolCallsFromSpans,
   extractMessagesFromNodes,
   getInputMessageStats,
   getNodeTimestamp,
@@ -600,6 +601,25 @@ describe('conversationMessages utilities', () => {
       ]);
     });
 
+    it('creates a synthetic turn for orphaned tool calls when result is empty', () => {
+      const turns = [
+        makeTurn({
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+        }),
+      ];
+
+      const merged = mergeEmptyTurns(turns);
+
+      expect(merged).toHaveLength(1);
+      expect(merged[0]?.toolCalls).toHaveLength(1);
+      expect(merged[0]?.toolCalls[0]?.name).toBe('search');
+      expect(merged[0]?.generation.id).toBe('gen-1');
+    });
+
     it('flushes pending tool calls onto last turn when no subsequent turn has content', () => {
       const turns = [
         makeTurn({
@@ -1188,6 +1208,67 @@ describe('conversationMessages utilities', () => {
     it('returns empty array when no generation spans', () => {
       const tool = createMockToolNode({id: 'tool-1', toolName: 'search'});
       expect(extractMessagesFromNodes([tool as any])).toEqual([]);
+    });
+
+    it('surfaces tool calls from generation spans with no message content', () => {
+      // Generation spans exist but have no input/output. Tool spans between
+      // them should still appear as a tool-call-only assistant message.
+      const gen1 = createMockNode({id: 'gen-1', startTimestamp: 1000});
+      const tool = createMockToolNode({
+        id: 'tool-1',
+        toolName: 'search',
+        startTimestamp: 1500,
+      });
+      const gen2 = createMockNode({id: 'gen-2', startTimestamp: 2000});
+
+      const messages = extractMessagesFromNodes([gen1, tool, gen2] as any);
+
+      const assistantMessages = messages.filter(m => m.role === 'assistant');
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0]?.content).toBe('');
+      expect(assistantMessages[0]?.toolCalls).toHaveLength(1);
+      expect(assistantMessages[0]?.toolCalls?.[0]?.name).toBe('search');
+    });
+  });
+
+  describe('buildToolCallsFromSpans', () => {
+    it('converts tool spans to ToolCall objects', () => {
+      const tool1 = createMockToolNode({
+        id: 'tool-1',
+        toolName: 'search',
+        startTimestamp: 1000,
+        endTimestamp: 1200,
+      });
+      const tool2 = createMockToolNode({
+        id: 'tool-2',
+        toolName: 'calculator',
+        startTimestamp: 2000,
+        endTimestamp: 2050,
+      });
+
+      const toolCalls = buildToolCallsFromSpans([tool1, tool2] as any);
+
+      expect(toolCalls).toHaveLength(2);
+      expect(toolCalls[0]).toMatchObject({
+        name: 'search',
+        nodeId: 'tool-1',
+        hasError: false,
+      });
+      expect(toolCalls[1]).toMatchObject({
+        name: 'calculator',
+        nodeId: 'tool-2',
+        hasError: false,
+      });
+    });
+
+    it('skips spans without a tool name', () => {
+      const noName = createMockNode({id: 'gen-1'});
+      const toolCalls = buildToolCallsFromSpans([noName] as any);
+      expect(toolCalls).toHaveLength(0);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(buildToolCallsFromSpans([])).toEqual([]);
     });
   });
 

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -1,3 +1,4 @@
+import {EMPTY_TEXT_CONTENT} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {SpanFields} from 'sentry/views/insights/types';
 
 import {
@@ -507,6 +508,20 @@ describe('conversationMessages utilities', () => {
       expect(result.generationSpans).toHaveLength(1);
       expect(result.toolSpans).toHaveLength(0);
     });
+
+    it('filters embedding spans out of conversation messages', () => {
+      const embeddingNode = createMockNode({
+        id: 'embedding-1',
+        attributes: {
+          [SpanFields.GEN_AI_OPERATION_NAME]: 'embeddings',
+        },
+      });
+      const genNode = createMockNode({id: 'gen-1'});
+
+      const result = partitionSpansByType([embeddingNode, genNode] as any);
+
+      expect(result.generationSpans.map(span => span.id)).toEqual(['gen-1']);
+    });
   });
 
   describe('buildConversationTurns', () => {
@@ -568,7 +583,7 @@ describe('conversationMessages utilities', () => {
       expect(merged[1]?.toolCalls.map(t => t.name)).toEqual(['search', 'calc']);
     });
 
-    it('chains multiple empty turns', () => {
+    it('surfaces empty LLM calls while carrying pending tool calls to them', () => {
       const turns = [
         makeTurn({
           generation: {id: 'gen-1'} as any,
@@ -589,19 +604,14 @@ describe('conversationMessages utilities', () => {
 
       const merged = mergeEmptyTurns(turns);
 
-      // Turn 1 keeps user content but no tool calls (they moved to turn 3)
-      // Turn 2 is skipped (no user content, no assistant content)
-      // Turn 3 has all tool calls merged
-      expect(merged).toHaveLength(2);
-      expect(merged[1]?.toolCalls).toHaveLength(3);
-      expect(merged[1]?.toolCalls.map(t => t.name)).toEqual([
-        'tool-a',
-        'tool-b',
-        'tool-c',
-      ]);
+      expect(merged).toHaveLength(3);
+      expect(merged[0]?.toolCalls).toHaveLength(0);
+      expect(merged[1]?.assistantContent).toBe(EMPTY_TEXT_CONTENT);
+      expect(merged[1]?.toolCalls.map(t => t.name)).toEqual(['tool-a', 'tool-b']);
+      expect(merged[2]?.toolCalls.map(t => t.name)).toEqual(['tool-c']);
     });
 
-    it('creates a synthetic turn for orphaned tool calls when result is empty', () => {
+    it('creates a placeholder turn for an LLM call with no input/output', () => {
       const turns = [
         makeTurn({
           generation: {
@@ -615,12 +625,13 @@ describe('conversationMessages utilities', () => {
       const merged = mergeEmptyTurns(turns);
 
       expect(merged).toHaveLength(1);
+      expect(merged[0]?.assistantContent).toBe(EMPTY_TEXT_CONTENT);
       expect(merged[0]?.toolCalls).toHaveLength(1);
       expect(merged[0]?.toolCalls[0]?.name).toBe('search');
       expect(merged[0]?.generation.id).toBe('gen-1');
     });
 
-    it('flushes pending tool calls onto last turn when no subsequent turn has content', () => {
+    it('keeps trailing empty LLM calls visible', () => {
       const turns = [
         makeTurn({
           generation: {id: 'gen-1'} as any,
@@ -635,10 +646,10 @@ describe('conversationMessages utilities', () => {
 
       const merged = mergeEmptyTurns(turns);
 
-      // The pending tool call should be flushed onto the last result turn
-      expect(merged).toHaveLength(1);
-      expect(merged[0]?.toolCalls).toHaveLength(1);
-      expect(merged[0]?.toolCalls[0]?.name).toBe('search');
+      expect(merged).toHaveLength(2);
+      expect(merged[0]?.toolCalls).toHaveLength(0);
+      expect(merged[1]?.assistantContent).toBe(EMPTY_TEXT_CONTENT);
+      expect(merged[1]?.toolCalls[0]?.name).toBe('search');
     });
 
     it('preserves user content turns even without assistant response', () => {
@@ -1210,9 +1221,7 @@ describe('conversationMessages utilities', () => {
       expect(extractMessagesFromNodes([tool as any])).toEqual([]);
     });
 
-    it('surfaces tool calls from generation spans with no message content', () => {
-      // Generation spans exist but have no input/output. Tool spans between
-      // them should still appear as a tool-call-only assistant message.
+    it('surfaces every generation span with no input/output as a placeholder', () => {
       const gen1 = createMockNode({id: 'gen-1', startTimestamp: 1000});
       const tool = createMockToolNode({
         id: 'tool-1',
@@ -1224,10 +1233,13 @@ describe('conversationMessages utilities', () => {
       const messages = extractMessagesFromNodes([gen1, tool, gen2] as any);
 
       const assistantMessages = messages.filter(m => m.role === 'assistant');
-      expect(assistantMessages).toHaveLength(1);
-      expect(assistantMessages[0]?.content).toBe('');
-      expect(assistantMessages[0]?.toolCalls).toHaveLength(1);
-      expect(assistantMessages[0]?.toolCalls?.[0]?.name).toBe('search');
+      expect(assistantMessages).toHaveLength(2);
+      expect(assistantMessages.map(m => m.content)).toEqual([
+        EMPTY_TEXT_CONTENT,
+        EMPTY_TEXT_CONTENT,
+      ]);
+      expect(assistantMessages[1]?.toolCalls).toHaveLength(1);
+      expect(assistantMessages[1]?.toolCalls?.[0]?.name).toBe('search');
     });
   });
 

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -631,6 +631,26 @@ describe('conversationMessages utilities', () => {
       expect(merged[0]?.generation.id).toBe('gen-1');
     });
 
+    it('folds consecutive empty LLM calls into one placeholder turn', () => {
+      const turns = [
+        makeTurn({
+          generation: {id: 'gen-1'} as any,
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+        }),
+        makeTurn({
+          generation: {id: 'gen-2'} as any,
+          toolCalls: [{name: 'calc', nodeId: 'tool-2', hasError: false}],
+        }),
+      ];
+
+      const merged = mergeEmptyTurns(turns);
+
+      expect(merged).toHaveLength(1);
+      expect(merged[0]?.assistantContent).toBe(EMPTY_TEXT_CONTENT);
+      expect(merged[0]?.generation.id).toBe('gen-2');
+      expect(merged[0]?.toolCalls.map(t => t.name)).toEqual(['search', 'calc']);
+    });
+
     it('keeps trailing empty LLM calls visible', () => {
       const turns = [
         makeTurn({
@@ -797,6 +817,36 @@ describe('conversationMessages utilities', () => {
 
       const assistantMessages = messages.filter(m => m.role === 'assistant');
       expect(assistantMessages).toHaveLength(1);
+    });
+
+    it('folds adjacent assistant placeholders into one message', () => {
+      const messages = turnsToMessages([
+        makeTurn({
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+          } as any,
+          userContent: 'Question',
+          assistantContent: EMPTY_TEXT_CONTENT,
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+        }),
+        makeTurn({
+          generation: {
+            id: 'gen-2',
+            value: {start_timestamp: 1200, end_timestamp: 1300},
+          } as any,
+          assistantContent: EMPTY_TEXT_CONTENT,
+          toolCalls: [{name: 'calc', nodeId: 'tool-2', hasError: false}],
+        }),
+      ]);
+
+      const assistantMessages = messages.filter(m => m.role === 'assistant');
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0]?.content).toBe(EMPTY_TEXT_CONTENT);
+      expect(assistantMessages[0]?.toolCalls?.map(t => t.name)).toEqual([
+        'search',
+        'calc',
+      ]);
     });
 
     it('does not deduplicate [Filtered] messages across turns', () => {
@@ -1221,7 +1271,7 @@ describe('conversationMessages utilities', () => {
       expect(extractMessagesFromNodes([tool as any])).toEqual([]);
     });
 
-    it('surfaces every generation span with no input/output as a placeholder', () => {
+    it('folds consecutive generation spans with no input/output into one placeholder', () => {
       const gen1 = createMockNode({id: 'gen-1', startTimestamp: 1000});
       const tool = createMockToolNode({
         id: 'tool-1',
@@ -1233,13 +1283,10 @@ describe('conversationMessages utilities', () => {
       const messages = extractMessagesFromNodes([gen1, tool, gen2] as any);
 
       const assistantMessages = messages.filter(m => m.role === 'assistant');
-      expect(assistantMessages).toHaveLength(2);
-      expect(assistantMessages.map(m => m.content)).toEqual([
-        EMPTY_TEXT_CONTENT,
-        EMPTY_TEXT_CONTENT,
-      ]);
-      expect(assistantMessages[1]?.toolCalls).toHaveLength(1);
-      expect(assistantMessages[1]?.toolCalls?.[0]?.name).toBe('search');
+      expect(assistantMessages).toHaveLength(1);
+      expect(assistantMessages[0]?.content).toBe(EMPTY_TEXT_CONTENT);
+      expect(assistantMessages[0]?.toolCalls).toHaveLength(1);
+      expect(assistantMessages[0]?.toolCalls?.[0]?.name).toBe('search');
     });
   });
 

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -165,12 +165,25 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
       pendingToolCalls = [];
       pendingToolSpanNodes = [];
     } else if (!turn.userContent) {
-      result.push({
-        ...turn,
-        assistantContent: EMPTY_TEXT_CONTENT,
-        toolCalls: allToolCalls,
-        toolSpanNodes: allToolSpanNodes,
-      });
+      const previousTurn = result.at(-1);
+      if (
+        previousTurn?.assistantContent === EMPTY_TEXT_CONTENT &&
+        !previousTurn.userContent
+      ) {
+        result.splice(-1, 1, {
+          ...turn,
+          assistantContent: EMPTY_TEXT_CONTENT,
+          toolCalls: [...previousTurn.toolCalls, ...allToolCalls],
+          toolSpanNodes: [...(previousTurn.toolSpanNodes ?? []), ...allToolSpanNodes],
+        });
+      } else {
+        result.push({
+          ...turn,
+          assistantContent: EMPTY_TEXT_CONTENT,
+          toolCalls: allToolCalls,
+          toolSpanNodes: allToolSpanNodes,
+        });
+      }
       pendingToolCalls = [];
       pendingToolSpanNodes = [];
     } else if (allToolCalls.length > 0 || allToolSpanNodes.length > 0) {
@@ -287,7 +300,32 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
   }
 
   messages.sort((a, b) => a.timestamp - b.timestamp);
-  return messages;
+  return foldConsecutiveEmptyAssistantMessages(messages);
+}
+
+function foldConsecutiveEmptyAssistantMessages(
+  messages: ConversationMessage[]
+): ConversationMessage[] {
+  const foldedMessages: ConversationMessage[] = [];
+
+  for (const message of messages) {
+    const previousMessage = foldedMessages.at(-1);
+    if (
+      previousMessage?.role === 'assistant' &&
+      message.role === 'assistant' &&
+      previousMessage.content === EMPTY_TEXT_CONTENT &&
+      message.content === EMPTY_TEXT_CONTENT
+    ) {
+      foldedMessages.splice(-1, 1, {
+        ...message,
+        toolCalls: [...(previousMessage.toolCalls ?? []), ...(message.toolCalls ?? [])],
+      });
+    } else {
+      foldedMessages.push(message);
+    }
+  }
+
+  return foldedMessages;
 }
 
 function findToolSpansBetween(

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -148,8 +148,10 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
   const result: ConversationTurn[] = [];
   let pendingToolCalls: ToolCall[] = [];
   let pendingToolSpanNodes: AITraceSpanNode[] = [];
+  let lastSeenTurn: ConversationTurn | null = null;
 
   for (const turn of turns) {
+    lastSeenTurn = turn;
     const allToolCalls = [...pendingToolCalls, ...turn.toolCalls];
     const allToolSpanNodes = [...pendingToolSpanNodes, ...(turn.toolSpanNodes ?? [])];
 
@@ -170,14 +172,26 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
     }
   }
 
-  // Flush any remaining pending tool calls as a tool-call-only turn
+  // Flush any remaining pending tool calls as a tool-call-only turn.
   const lastTurn = result.at(-1);
-  if (pendingToolCalls.length > 0 && lastTurn) {
-    result[result.length - 1] = {
-      ...lastTurn,
-      toolCalls: [...lastTurn.toolCalls, ...pendingToolCalls],
-      toolSpanNodes: [...(lastTurn.toolSpanNodes ?? []), ...pendingToolSpanNodes],
-    };
+  if (pendingToolCalls.length > 0) {
+    if (lastTurn) {
+      result[result.length - 1] = {
+        ...lastTurn,
+        toolCalls: [...lastTurn.toolCalls, ...pendingToolCalls],
+        toolSpanNodes: [...(lastTurn.toolSpanNodes ?? []), ...pendingToolSpanNodes],
+      };
+    } else if (lastSeenTurn) {
+      // All generation spans had no content; surface the orphaned tool calls
+      // as a tool-call-only assistant turn anchored on the last generation span.
+      result.push({
+        ...lastSeenTurn,
+        userContent: null,
+        assistantContent: null,
+        toolCalls: pendingToolCalls,
+        toolSpanNodes: pendingToolSpanNodes,
+      });
+    }
   }
 
   return result;
@@ -415,6 +429,30 @@ function getNodeEndTimestamp(node: AITraceSpanNode): number {
     return node.value.timestamp;
   }
   return 0;
+}
+
+/**
+ * Converts raw tool span nodes into ToolCall objects for direct rendering.
+ * Use this when there are no generation spans to anchor tool calls (e.g. when
+ * all generation spans lack message content, or when only tool spans are present).
+ */
+export function buildToolCallsFromSpans(spans: AITraceSpanNode[]): ToolCall[] {
+  return spans.flatMap(span => {
+    const name = getStringAttr(span, SpanFields.GEN_AI_TOOL_NAME);
+    if (!name) {
+      return [];
+    }
+    const start = getNodeStartTimestamp(span);
+    const end = getNodeEndTimestamp(span);
+    const duration = end > start ? end - start : undefined;
+    const toolCall: ToolCall = {
+      name,
+      nodeId: span.id,
+      hasError: hasError(span),
+      duration,
+    };
+    return [toolCall];
+  });
 }
 
 function getGenAiOpType(node: AITraceSpanNode): string | undefined {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -6,6 +6,7 @@ import {
 } from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {
   AGENT_NAME_FIELDS,
+  getIsEmbeddingNode,
   getStringAttr,
   hasError,
 } from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
@@ -77,6 +78,10 @@ export function partitionSpansByType(nodes: AITraceSpanNode[]): {
   const toolSpans: AITraceSpanNode[] = [];
 
   for (const node of nodes) {
+    if (getIsEmbeddingNode(node)) {
+      continue;
+    }
+
     const opType = getGenAiOpType(node);
     if (getIsAiGenerationSpan(opType)) {
       generationSpans.push(node);
@@ -159,13 +164,20 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
       result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
       pendingToolCalls = [];
       pendingToolSpanNodes = [];
+    } else if (!turn.userContent) {
+      result.push({
+        ...turn,
+        assistantContent: EMPTY_TEXT_CONTENT,
+        toolCalls: allToolCalls,
+        toolSpanNodes: allToolSpanNodes,
+      });
+      pendingToolCalls = [];
+      pendingToolSpanNodes = [];
     } else if (allToolCalls.length > 0 || allToolSpanNodes.length > 0) {
-      if (turn.userContent) {
-        result.push({...turn, toolCalls: [], toolSpanNodes: []});
-      }
+      result.push({...turn, toolCalls: [], toolSpanNodes: []});
       pendingToolCalls = allToolCalls;
       pendingToolSpanNodes = allToolSpanNodes;
-    } else if (turn.userContent) {
+    } else {
       result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
       pendingToolCalls = [];
       pendingToolSpanNodes = [];
@@ -176,18 +188,16 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
   const lastTurn = result.at(-1);
   if (pendingToolCalls.length > 0) {
     if (lastTurn) {
-      result[result.length - 1] = {
+      result.splice(-1, 1, {
         ...lastTurn,
         toolCalls: [...lastTurn.toolCalls, ...pendingToolCalls],
         toolSpanNodes: [...(lastTurn.toolSpanNodes ?? []), ...pendingToolSpanNodes],
-      };
+      });
     } else if (lastSeenTurn) {
-      // All generation spans had no content; surface the orphaned tool calls
-      // as a tool-call-only assistant turn anchored on the last generation span.
       result.push({
         ...lastSeenTurn,
         userContent: null,
-        assistantContent: null,
+        assistantContent: EMPTY_TEXT_CONTENT,
         toolCalls: pendingToolCalls,
         toolSpanNodes: pendingToolSpanNodes,
       });

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
@@ -1,6 +1,6 @@
 import {SpanFields} from 'sentry/views/insights/types';
 
-import {getToolInputPreview, hasError} from './aiTraceNodes';
+import {getIsEmbeddingNode, getToolInputPreview, hasError} from './aiTraceNodes';
 import type {AITraceSpanNode} from './types';
 
 function makeToolNode(toolInput?: unknown): AITraceSpanNode {
@@ -73,6 +73,40 @@ describe('getToolInputPreview', () => {
 
   it('returns undefined for an empty object', () => {
     expect(getToolInputPreview(makeToolNode({}))).toBeUndefined();
+  });
+});
+
+describe('getIsEmbeddingNode', () => {
+  it('detects embedding spans from operation name, span name, or embeddings input', () => {
+    expect(
+      getIsEmbeddingNode({
+        attributes: {[SpanFields.GEN_AI_OPERATION_NAME]: 'embeddings'},
+        errors: new Set(),
+      } as unknown as AITraceSpanNode)
+    ).toBe(true);
+    expect(
+      getIsEmbeddingNode({
+        attributes: {},
+        value: {name: 'gen_ai.embeddings'},
+        errors: new Set(),
+      } as unknown as AITraceSpanNode)
+    ).toBe(true);
+    expect(
+      getIsEmbeddingNode({
+        attributes: {'gen_ai.embeddings.input': 'text to embed'},
+        errors: new Set(),
+      } as unknown as AITraceSpanNode)
+    ).toBe(true);
+  });
+
+  it('does not treat chat generations as embedding spans', () => {
+    expect(
+      getIsEmbeddingNode({
+        attributes: {[SpanFields.GEN_AI_OPERATION_NAME]: 'chat'},
+        value: {name: 'gen_ai.chat'},
+        errors: new Set(),
+      } as unknown as AITraceSpanNode)
+    ).toBe(false);
   });
 });
 

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -103,6 +103,21 @@ export function getStringAttr(node: AITraceSpanNode, field: string): string | un
   return typeof val === 'string' ? val : undefined;
 }
 
+export function getIsEmbeddingNode(node: AITraceSpanNode): boolean {
+  const operationName = getStringAttr(node, SpanFields.GEN_AI_OPERATION_NAME);
+  const spanName =
+    node.value && 'name' in node.value && typeof node.value.name === 'string'
+      ? node.value.name
+      : undefined;
+
+  return (
+    operationName === 'embeddings' ||
+    operationName === 'gen_ai.embeddings' ||
+    spanName === 'gen_ai.embeddings' ||
+    getTraceNodeAttribute('gen_ai.embeddings.input', node) !== undefined
+  );
+}
+
 /**
  * Agent name fallback resolution.
  *


### PR DESCRIPTION
When a conversation's generation spans carry no message content, the redesigned transcript (`gen-ai-conversations-redesign`) previously showed a blank "No messages found" panel — even when tool calls had run during the conversation.

Two improvements are included:

**Show tool calls even when there are no messages.** Tool spans are now extracted directly from the node list and rendered via `MessageToolCallsNew` in the empty-messages path. This covers both the case where tool spans have no accompanying generation span, and the case where generation spans exist but their inputs/outputs were not captured.

**Treat missing inputs/outputs as redacted.** When the panel renders with no message content, it now shows a muted "Message inputs and outputs were not captured" notice instead of nothing, making the reason for the blank panel explicit.

**Bug fix: `mergeEmptyTurns` dropped orphaned tool calls.** When every generation span in a conversation had no `assistantContent`, pending tool calls accumulated but were silently discarded because there was no committed turn to flush onto. The fix creates a synthetic tool-call-only turn from the last generation span in that case, so those calls reach `turnsToMessages` and appear as an assistant message with empty text but visible tool badges.

A new `buildToolCallsFromSpans` helper is exported for converting raw tool span nodes to `ToolCall[]` without needing a generation span as an anchor.

Refs TET-2607
