### PR TITLE
fix(conversations): Show errors summary link in red to match table

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -256,7 +256,7 @@ function Stat({
         <Placeholder width="32px" height="24px" />
       ) : isInteractive ? (
         <Link to={to} onClick={onClick}>
-          <Text size="xl" tabular variant="inherit" wrap="nowrap">
+          <Text size="xl" tabular variant="danger" wrap="nowrap">
             {value}
           </Text>
         </Link>


### PR DESCRIPTION
## Summary

In the new conversations detail summary bar (`LLM Calls`, `Errors`, `Tokens`, `Cost`), the **Errors** value becomes a link to the filtered errors view when there are errors. It was rendered in the default accent link color, which didn't match the red error count shown in the conversations table.

This changes the errors summary link to use the `danger` text variant so its color matches the table's error count (`<Text variant="danger">`).

## Details

- File: `static/app/views/explore/conversations/components/conversationSummaryNew.tsx`
- The interactive `Stat` branch is only ever used by the Errors metric (the only stat with a `to`, and it only links when `errorCount > 0`), so switching `variant="inherit"` → `variant="danger"` cleanly matches the "red when there are errors" behavior of the table.

## Test plan

- Open a conversation with errors and confirm the **Errors** count in the summary bar renders in red and still links through to the filtered errors view.