### PR TITLE
fix(conversations): Keep span detail on the right at narrower widths

### DIFF
--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -112,7 +112,7 @@ export function ConversationViewContentNew({
             background="secondary"
           >
             <Flex
-              direction={{xs: 'column', md: 'row'}}
+              direction={{xs: 'column', sm: 'row'}}
               height="100%"
               width="100%"
               gap="md"
@@ -122,15 +122,15 @@ export function ConversationViewContentNew({
               overflowX="hidden"
             >
               <Container
-                flex={{xs: '0 0 auto', md: '1'}}
+                flex={{xs: '0 0 auto', sm: '1'}}
                 minWidth="0"
-                minHeight={{xs: 'auto', md: '0'}}
+                minHeight={{xs: 'auto', sm: '0'}}
                 padding={isTranscript ? '0' : 'md'}
                 background="primary"
                 border="primary"
                 radius="md"
                 overflowX="hidden"
-                overflowY={{xs: 'hidden', md: 'auto'}}
+                overflowY={{xs: 'hidden', sm: 'auto'}}
               >
                 {isTranscript ? (
                   isLoading ? (
@@ -155,9 +155,9 @@ export function ConversationViewContentNew({
               </Container>
               {detailState.detailOpen && selectedNode ? (
                 <Flex
-                  width={{xs: '100%', md: '430px'}}
+                  width={{xs: '100%', sm: '430px'}}
                   flex="0 0 auto"
-                  minHeight={{xs: 'auto', md: '0'}}
+                  minHeight={{xs: 'auto', sm: '0'}}
                 >
                   <ConversationSpanDetail
                     node={selectedNode}


### PR DESCRIPTION
The span detail panel switches from the right side to the bottom via a container query, but the `md` (992px) threshold was higher than the ~934px of container width left at a 1230px viewport once the sidebars and page padding (~296px) are subtracted, so it wrongly stacked. Lowering the threshold to `sm` (800px) keeps the panel on the right at ~1230px while still stacking on genuinely narrow layouts, and stays a container query so it adapts to the resizable secondary sidebar.