### PR TITLE
perf(issues): Fold low-value span re-parenting into a single pass

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/utils.ts
@@ -189,29 +189,20 @@ export function getPythonSpanFilterSnippet(
 
 
 def before_send_transaction(event, hint):
-    dropped_parents = {}
+    reparent = {}
     kept_spans = []
+    # Filtering span and rewriting parent_id
     for span in event.get("spans", []):
+        parent = span.get("parent_span_id")
+        while parent in reparent:
+            parent = reparent[parent]
         if (
 ${conditions.join('\n')}
         ):
-            span_id = span.get("span_id")
-            if span_id is not None:
-                dropped_parents[span_id] = span.get("parent_span_id")
+            reparent[span.get("span_id")] = parent
         else:
+            span["parent_span_id"] = parent
             kept_spans.append(span)
-
-    if not dropped_parents:
-        return event
-
-    # Re-parent children of dropped spans so the trace stays connected.
-    for span in kept_spans:
-        parent = span.get("parent_span_id")
-        if parent not in dropped_parents:
-            continue
-        while parent in dropped_parents:
-            parent = dropped_parents[parent]
-        span["parent_span_id"] = parent
 
     event["spans"] = kept_spans
     return event


### PR DESCRIPTION
Rewrite the Python snippet in the low-value span troubleshooting section so the drop/keep decision and the re-parent walk happen in one pass over `event["spans"]` instead of two. Same output; ~30% fewer lines and one less data structure.

For each span we resolve the parent up through any dropped ancestors via a `while` walk, then either record the resolved parent under this `span_id` (if the span matches the drop criteria) or write it back onto the span and keep it.

Follow-up to [sentry#118813](https://github.com/getsentry/sentry/pull/118813).