### PR TITLE
ref(issues): Rename Sentry Configuration menu item to Configuration

### DIFF
--- a/static/app/views/issueList/taxonomies.tsx
+++ b/static/app/views/issueList/taxonomies.tsx
@@ -59,7 +59,7 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
   },
   [IssueTaxonomy.SENTRY_CONFIGURATION]: {
     categories: [IssueCategory.CONFIGURATION],
-    label: t('Sentry Configuration'),
+    label: t('Configuration'),
     key: 'sentry-configuration',
     badge: 'beta',
     description: t(


### PR DESCRIPTION
The issue taxonomy sub-menu item now reads "Configuration" instead of "Sentry Configuration". Only the user-visible label changes — the taxonomy key (`sentry-configuration`) and `IssueTaxonomy.SENTRY_CONFIGURATION` enum are untouched, so routing and stored preferences are unaffected.

Closes TET-2595