### PR TITLE
feat(taskbroker): Add taskworker-process-segments to Topic enum

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2779,6 +2779,7 @@ KAFKA_TOPIC_TO_CLUSTER: Mapping[str, str] = {
     "taskworker-launchpad-push": "default",
     "taskworker-long": "default",
     "taskworker-long-dlq": "default",
+    "taskworker-process-segments": "default",
     "taskworker-products": "default",
     "taskworker-products-dlq": "default",
     "taskworker-sentryapp": "default",

--- a/src/sentry/conf/types/kafka_definition.py
+++ b/src/sentry/conf/types/kafka_definition.py
@@ -104,6 +104,7 @@ class Topic(Enum):
     TASKWORKER_LIMITED_DLQ = "taskworker-limited-dlq"
     TASKWORKER_LONG = "taskworker-long"
     TASKWORKER_LONG_DLQ = "taskworker-long-dlq"
+    TASKWORKER_PROCESS_SEGMENTS = "taskworker-process-segments"
     TASKWORKER_PRODUCTS = "taskworker-products"
     TASKWORKER_PRODUCTS_DLQ = "taskworker-products-dlq"
     TASKWORKER_SENTRYAPP = "taskworker-sentryapp"


### PR DESCRIPTION
Registers the `taskworker-process-segments` topic in the Topic enum and maps it to the default cluster.

Sentry kafka schemas is already bumped to 2.1.40 which contains the schema for `taskworker-process-segments`.