### PR TITLE
ref(apis): Add `suggested_api` to cell-related deprecated APIs

### DIFF
--- a/src/sentry/issues/endpoints/group_activities.py
+++ b/src/sentry/issues/endpoints/group_activities.py
@@ -17,7 +17,11 @@ class GroupActivitiesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-activities"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-activities",
+        url_names=["sentry-api-0-group-activities"],
+    )
     def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve all the Activities for a Group

--- a/src/sentry/issues/endpoints/group_attachments.py
+++ b/src/sentry/issues/endpoints/group_attachments.py
@@ -72,7 +72,11 @@ class GroupAttachmentsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-attachments"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-attachments",
+        url_names=["sentry-api-0-group-attachments"],
+    )
     def get(self, request: Request, group) -> Response:
         """
         List Event Attachments

--- a/src/sentry/issues/endpoints/group_current_release.py
+++ b/src/sentry/issues/endpoints/group_current_release.py
@@ -51,7 +51,11 @@ class GroupCurrentReleaseEndpoint(GroupEndpoint):
         except IndexError:
             return None
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-current-release"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-current-release",
+        url_names=["sentry-api-0-group-current-release"],
+    )
     def get(self, request: Request, group) -> Response:
         """Get the current release in the group's project.
 

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -180,7 +180,11 @@ class GroupDetailsEndpoint(GroupEndpoint):
         },
         examples=IssueExamples.GROUP_DETAILS,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-details",
+        url_names=["sentry-api-0-group-details"],
+    )
     def get(self, request: Request, group: Group) -> Response[GroupDetailsResponse]:
         """
         Return details on an individual issue, including its basic stats, comment
@@ -376,7 +380,11 @@ class GroupDetailsEndpoint(GroupEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-details",
+        url_names=["sentry-api-0-group-details"],
+    )
     def put(
         self, request: Request, group: Group
     ) -> Response[BaseGroupSerializerResponse] | Response[DetailResponse]:
@@ -447,7 +455,11 @@ class GroupDetailsEndpoint(GroupEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-details",
+        url_names=["sentry-api-0-group-details"],
+    )
     def delete(self, request: Request, group: Group) -> Response[None]:
         """
         Asynchronously queue an individual issue for deletion.

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -163,7 +163,11 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
         },
         examples=EventExamples.GROUP_EVENT_DETAILS,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-event-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-event-details",
+        url_names=["sentry-api-0-group-event-details"],
+    )
     def get(
         self, request: Request, group: Group, event_id: str
     ) -> (

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -94,7 +94,11 @@ class GroupEventsEndpoint(GroupEndpoint):
         },
         examples=EventExamples.GROUP_EVENTS_SIMPLE,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-events"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-events",
+        url_names=["sentry-api-0-group-events"],
+    )
     def get(
         self, request: Request, group: Group
     ) -> Response[list[SimpleEventSerializerResponse]] | Response[DetailResponse]:

--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -82,7 +82,11 @@ class GroupHashesEndpoint(GroupEndpoint):
         },
         examples=EventExamples.GROUP_HASHES,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-hashes"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-hashes",
+        url_names=["sentry-api-0-group-hashes"],
+    )
     def get(self, request: Request, group: Group) -> Response[list[GroupHashesResult]]:
         """
         List the hashes that make up an issue. Each hash represents a grouping
@@ -113,7 +117,11 @@ class GroupHashesEndpoint(GroupEndpoint):
             paginator=GenericOffsetPaginator(data_fn=data_fn),
         )
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-hashes"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-hashes",
+        url_names=["sentry-api-0-group-hashes"],
+    )
     def put(self, request: Request, group: Group) -> Response:
         """
         Perform an unmerge by reassigning events with hash values corresponding to the given

--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -148,7 +148,11 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         },
         examples=IntegrationExamples.GROUP_INTEGRATION_ISSUE_CONFIG,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-integration-details",
+        url_names=["sentry-api-0-group-integration-details"],
+    )
     def get(
         self, request: Request, group: Group, integration_id: str
     ) -> Response[IntegrationIssueConfigResponse] | Response[DetailResponse]:
@@ -238,7 +242,11 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         },
         examples=IntegrationExamples.EXTERNAL_ISSUE_LINK,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-integration-details",
+        url_names=["sentry-api-0-group-integration-details"],
+    )
     def post(
         self, request: Request, group: Group, integration_id: str
     ) -> (
@@ -388,7 +396,11 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         },
         examples=IntegrationExamples.EXTERNAL_ISSUE_LINK,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-integration-details",
+        url_names=["sentry-api-0-group-integration-details"],
+    )
     def put(
         self, request: Request, group: Group, integration_id: str
     ) -> (
@@ -534,7 +546,11 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integration-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-integration-details",
+        url_names=["sentry-api-0-group-integration-details"],
+    )
     def delete(
         self, request: Request, group: Group, integration_id: str
     ) -> Response[None] | Response[DetailResponse]:

--- a/src/sentry/issues/endpoints/group_integrations.py
+++ b/src/sentry/issues/endpoints/group_integrations.py
@@ -96,7 +96,11 @@ class GroupIntegrationsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-integrations"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-integrations",
+        url_names=["sentry-api-0-group-integrations"],
+    )
     def get(self, request: Request, group) -> Response:
         has_issue_basic = features.has(
             "organizations:integrations-issue-basic", group.organization, actor=request.user

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -45,7 +45,11 @@ class GroupNotesEndpoint(GroupEndpoint):
             )
         },
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-notes",
+        url_names=["sentry-api-0-group-notes"],
+    )
     def get(self, request: Request, group: Group) -> Response:
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)
 
@@ -63,7 +67,11 @@ class GroupNotesEndpoint(GroupEndpoint):
             201: inline_sentry_response_serializer("CreateGroupNote", ActivitySerializerResponse)
         },
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-notes"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-notes",
+        url_names=["sentry-api-0-group-notes"],
+    )
     def post(self, request: Request, group: Group) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to create Note")

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -42,7 +42,11 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
     # an individual. Not sure if we'd want to allow an ApiKey
     # to delete/update other users' comments
     @extend_schema(responses={204: RESPONSE_NO_CONTENT})
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-note-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-note-details",
+        url_names=["sentry-api-0-group-note-details"],
+    )
     def delete(self, request: Request, group: Group, note_id: str) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to delete Note")
@@ -101,7 +105,11 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             200: inline_sentry_response_serializer("UpdateGroupNote", ActivitySerializerResponse)
         },
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-note-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-note-details",
+        url_names=["sentry-api-0-group-note-details"],
+    )
     def put(self, request: Request, group: Group, note_id: str) -> Response:
         if not request.user.is_authenticated:
             raise PermissionDenied(detail="Key doesn't have permission to edit Note")

--- a/src/sentry/issues/endpoints/group_reprocessing.py
+++ b/src/sentry/issues/endpoints/group_reprocessing.py
@@ -15,7 +15,11 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-reprocessing"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-reprocessing",
+        url_names=["sentry-api-0-group-reprocessing"],
+    )
     def post(self, request: Request, group) -> Response:
         """
         Reprocess a group

--- a/src/sentry/issues/endpoints/group_similar_issues.py
+++ b/src/sentry/issues/endpoints/group_similar_issues.py
@@ -32,7 +32,11 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-similar"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-similar",
+        url_names=["sentry-api-0-group-similar"],
+    )
     def get(self, request: Request, group: Group) -> Response:
         # Any project using embeddings-based grouping will not work with this endpoint
         if group.project.get_option("sentry:similarity_backfill_completed"):

--- a/src/sentry/issues/endpoints/group_stats.py
+++ b/src/sentry/issues/endpoints/group_stats.py
@@ -19,7 +19,11 @@ class GroupStatsEndpoint(GroupEndpoint, StatsMixin):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-stats"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-stats",
+        url_names=["sentry-api-0-group-stats"],
+    )
     def get(self, request: Request, group) -> Response:
         try:
             environment_id = get_environment_id(request, group.project.organization_id)

--- a/src/sentry/issues/endpoints/group_tagkey_details.py
+++ b/src/sentry/issues/endpoints/group_tagkey_details.py
@@ -66,7 +66,11 @@ class GroupTagKeyDetailsEndpoint(GroupEndpoint):
         },
         examples=[TagsExamples.GROUP_TAGKEY_DETAILS],
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tag-key-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-tag-key-details",
+        url_names=["sentry-api-0-group-tag-key-details"],
+    )
     def get(self, request: Request, group, key) -> Response[TagKeySerializerResponse]:
         """
         Returns the values and aggregate details of a given tag key related to an issue.

--- a/src/sentry/issues/endpoints/group_tagkey_values.py
+++ b/src/sentry/issues/endpoints/group_tagkey_values.py
@@ -70,7 +70,11 @@ class GroupTagKeyValuesEndpoint(GroupEndpoint):
         },
         examples=[TagsExamples.GROUP_TAGKEY_VALUES],
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tag-key-values"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-tag-key-values",
+        url_names=["sentry-api-0-group-tag-key-values"],
+    )
     def get(self, request: Request, group, key) -> Response[list[TagValueSerializerResponse]]:
         """
         List a Tag's Values

--- a/src/sentry/issues/endpoints/group_tags.py
+++ b/src/sentry/issues/endpoints/group_tags.py
@@ -40,7 +40,11 @@ class GroupTagsEndpoint(GroupEndpoint):
         }
     )
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-tags"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-tags",
+        url_names=["sentry-api-0-group-tags"],
+    )
     def get(self, request: Request, group: Group) -> Response:
         if request.GET.get("useFlagsBackend") == "1":
             backend = tagstore.flag_backend

--- a/src/sentry/issues/endpoints/group_user_reports.py
+++ b/src/sentry/issues/endpoints/group_user_reports.py
@@ -19,7 +19,11 @@ class GroupUserReportsEndpoint(GroupEndpoint):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-user-reports"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-user-reports",
+        url_names=["sentry-api-0-group-user-reports"],
+    )
     def get(self, request: Request, group) -> Response:
         """
         List User Reports

--- a/src/sentry/issues/endpoints/related_issues.py
+++ b/src/sentry/issues/endpoints/related_issues.py
@@ -37,7 +37,11 @@ class RelatedIssuesEndpoint(GroupEndpoint):
     )
 
     # We get a Group object since the endpoint is /issues/{issue_id}/related-issues
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-related-issues"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-related-issues",
+        url_names=["sentry-api-0-related-issues"],
+    )
     def get(self, request: Request, group: Group) -> Response:
         """
         Retrieve related issues for a Group

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -212,7 +212,11 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         },
         examples=AutofixExamples.AUTOFIX_POST_RESPONSE,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-autofix",
+        url_names=["sentry-api-0-group-autofix"],
+    )
     def post(
         self, request: Request, group: Group
     ) -> (
@@ -436,7 +440,11 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         },
         examples=AutofixExamples.AUTOFIX_GET_RESPONSE,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-autofix",
+        url_names=["sentry-api-0-group-autofix"],
+    )
     def get(self, request: Request, group: Group) -> Response[AutofixStateResponse]:
         """
         Retrieve the current detailed state of an issue fix process for a specific issue including:

--- a/src/sentry/seer/endpoints/group_ai_summary.py
+++ b/src/sentry/seer/endpoints/group_ai_summary.py
@@ -38,7 +38,11 @@ class GroupAiSummaryEndpoint(GroupAiEndpoint):
         }
     )
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-ai-summary"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-ai-summary",
+        url_names=["sentry-api-0-group-ai-summary"],
+    )
     def post(self, request: Request, group: Group) -> Response:
         data = orjson.loads(request.body) if request.body else {}
         force_event_id = data.get("event_id", None)

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -72,7 +72,11 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         }
     )
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-autofix-setup"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-autofix-setup",
+        url_names=["sentry-api-0-group-autofix-setup"],
+    )
     def get(self, request: Request, group: Group) -> Response:
         """
         Checks if we are able to run Autofix on the given group.

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issue_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issue_details.py
@@ -25,7 +25,11 @@ class GroupExternalIssueDetailsEndpoint(GroupEndpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
 
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-external-issues-details"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-external-issues-details",
+        url_names=["sentry-api-0-group-external-issues-details"],
+    )
     def delete(self, request: Request, external_issue_id, group) -> Response:
         try:
             external_issue = PlatformExternalIssue.objects.get(

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -41,7 +41,11 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
         },
         examples=SentryAppExamples.GET_PLATFORM_EXTERNAL_ISSUE,
     )
-    @deprecated(CELL_API_DEPRECATION_DATE, url_names=["sentry-api-0-group-external-issues"])
+    @deprecated(
+        CELL_API_DEPRECATION_DATE,
+        suggested_api="sentry-api-0-organization-group-group-external-issues",
+        url_names=["sentry-api-0-group-external-issues"],
+    )
     def get(
         self, request: Request, group
     ) -> Response[list[PlatformExternalIssueSerializerResponse]]:


### PR DESCRIPTION
We have a bunch of APIs marked `@deprecated` due to incompatibility with cells (missing orgs in their path). This is meant to be a very small QoL improvement to readers and callers to point out the proper org-scoped endpoint to use instead.

For readers: Personally I did this because I got confused by seeing the `@deprecated` annotation on an endpoint I knew was still in use, before realizing that the same endpoint code is mounted at two named URLs, and only one was deprecated. This hopefully helps future readers see that the endpoint as a whole isn't deprecated, just one of the URLs pointing to it.

For callers: this will put the new path in `X-Sentry-Replacement-Endpoint`. IDK if anyone's checking them, but I don't think it can hurt.

If there's any risk here we can scrap the PR, it's a marginal improvement at best.

---

🤖 Used Claude to find candidate endpoints, find the replacement names, and confirm that every `suggested_api` actually exists in urls.py.