### PR TITLE
chore(flags): remove heat-map-unfurl feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -115,8 +115,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable LLM-generated title and description for external issue details
     manager.add("organizations:external-issues-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable unfurling heat maps in Slack
-    manager.add("organizations:heat-map-unfurl", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:inbound-filters-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)


### PR DESCRIPTION
Removes the `organizations:heat-map-unfurl` feature flag declaration from `temporary.py`.

The flag was only ever declared — it was never wired into any `has_feature`/`features.has` check, frontend code, test, or flagpole rollout config in `sentry-options-automator`. This is dead-declaration cleanup rather than graduating a shipped feature, so there is no code path to make permanent and no accompanying frontend or options-automator PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)