### PR TITLE
chore(seer-activity): Remove the feature flag

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/webhook_handler.py
@@ -1,9 +1,7 @@
 import logging
 from typing import override
 
-from sentry import features
 from sentry.models.activity import Activity
-from sentry.models.organization import Organization
 from sentry.notifications.notification_action.utils import execute_via_activity_type_registry
 from sentry.sentry_apps.services.legacy_webhook.service import (
     get_triggering_rule_name,
@@ -61,11 +59,7 @@ class WebhookActionHandler(ActionHandler):
 
         if isinstance(invocation.event_data.event, Activity):
             try:
-                organization = Organization.objects.get_from_cache(id=organization.id)
-                if features.has(
-                    "organizations:workflow-engine-evaluate-seer-activities", organization
-                ):
-                    execute_via_activity_type_registry(invocation=invocation)
+                execute_via_activity_type_registry(invocation=invocation)
             except Exception:
                 logger.exception(
                     "Error executing via activity type registry",

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -7,7 +7,6 @@ from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.grouptype import MetricIssue
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models.activity import Activity
-from sentry.models.organization import Organization
 from sentry.notifications.notification_action.registry import (
     activity_handler_registry,
     group_type_notification_registry,
@@ -53,18 +52,15 @@ def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
         ):
             return execute_via_metric_alert_handler(invocation)
 
-        organization_id = invocation.detector.project.organization_id
         try:
-            organization = Organization.objects.get_from_cache(id=organization_id)
-            if features.has("organizations:workflow-engine-evaluate-seer-activities", organization):
-                return execute_via_activity_type_registry(invocation=invocation)
-        except (Exception, Organization.DoesNotExist):
+            return execute_via_activity_type_registry(invocation=invocation)
+        except Exception:
             logger.exception(
                 "Error executing via activity type registry",
                 extra={
                     "action_id": invocation.action.id,
                     "detector_id": invocation.detector.id,
-                    "organization_id": organization_id,
+                    "organization_id": invocation.detector.project.organization_id,
                 },
             )
         return invocation.event_data.event.send_notification()

--- a/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_data_condition_index.py
@@ -3,7 +3,6 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -23,7 +22,7 @@ from sentry.workflow_engine.endpoints.serializers.data_condition_handler_seriali
     DataConditionHandlerResponse,
     DataConditionHandlerSerializer,
 )
-from sentry.workflow_engine.models.data_condition import LEGACY_CONDITIONS, Condition
+from sentry.workflow_engine.models.data_condition import LEGACY_CONDITIONS
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler
 
@@ -67,11 +66,6 @@ class OrganizationDataConditionIndexEndpoint(OrganizationEndpoint):
         data_conditions = []
 
         for condition_type, handler in condition_handler_registry.registrations.items():
-            if condition_type == Condition.SEER_ACTIVITY_TRIGGER and not features.has(
-                "organizations:workflow-engine-evaluate-seer-activities", organization
-            ):
-                continue
-
             if condition_type not in LEGACY_CONDITIONS and handler.group == group:
                 serialized = serialize(
                     handler,

--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -17,7 +17,7 @@ WORKFLOW_CONFIG_HELP_TEXT = """
         ```
         """
 
-WORKFLOW_TRIGGERS_HELP_TEXT = """The conditions on which the alert will trigger. See available options below. Note: `seer_activity_trigger` may not be available to all organizations.
+WORKFLOW_TRIGGERS_HELP_TEXT = """The conditions on which the alert will trigger. See available options below.
         ```json
             "triggers": {
                 "organizationId": "1",

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -1,6 +1,5 @@
 import logging
 
-from sentry import features
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.types.activity import ActivityType
@@ -57,11 +56,6 @@ def seer_activity_handler(
     logging_ctx["activity_name"] = activity_type.name
 
     if activity_type not in SEER_WORKFLOW_ACTIVITIES:
-        return
-
-    if not features.has(
-        "organizations:workflow-engine-evaluate-seer-activities", group.organization
-    ):
         return
 
     event_data = WorkflowEventData(event=activity, group=group)

--- a/tests/sentry/notifications/notification_action/test_activity_handler.py
+++ b/tests/sentry/notifications/notification_action/test_activity_handler.py
@@ -111,21 +111,10 @@ class TestExecuteViaActivityTypeRegistry(ActivityHandlerTest):
 
 class TestExecuteViaGroupTypeRegistryActivityPath(ActivityHandlerTest):
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_activity_type_registry")
-    def test_option_enabled_uses_registry(self, mock_execute: mock.MagicMock) -> None:
+    def test_activity_uses_registry(self, mock_execute: mock.MagicMock) -> None:
         invocation = self._make_invocation(self._make_activity())
-        with self.feature({"organizations:workflow-engine-evaluate-seer-activities": True}):
-            execute_via_group_type_registry(invocation)
+        execute_via_group_type_registry(invocation)
         mock_execute.assert_called_once_with(invocation=invocation)
-
-    def test_option_disabled_falls_through_to_send_notification(self) -> None:
-        activity = self._make_activity()
-        invocation = self._make_invocation(activity)
-        with (
-            self.feature({"organizations:workflow-engine-evaluate-seer-activities": False}),
-            mock.patch.object(activity, "send_notification") as mock_send,
-        ):
-            execute_via_group_type_registry(invocation)
-            mock_send.assert_called_once_with()
 
     @mock.patch("sentry.notifications.notification_action.utils.execute_via_activity_type_registry")
     def test_registry_error_falls_through_to_send_notification(
@@ -134,9 +123,6 @@ class TestExecuteViaGroupTypeRegistryActivityPath(ActivityHandlerTest):
         mock_execute.side_effect = RuntimeError("handler failed")
         activity = self._make_activity()
         invocation = self._make_invocation(activity)
-        with (
-            self.feature({"organizations:workflow-engine-evaluate-seer-activities": True}),
-            mock.patch.object(activity, "send_notification") as mock_send,
-        ):
+        with mock.patch.object(activity, "send_notification") as mock_send:
             execute_via_group_type_registry(invocation)
             mock_send.assert_called_once_with()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_data_condition_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_data_condition_index.py
@@ -3,7 +3,6 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import cell_silo_test
 from sentry.utils.registry import Registry
 from sentry.workflow_engine.models.data_condition import Condition
@@ -130,23 +129,7 @@ class OrganizationDataConditionIndexBaseTest(OrganizationDataConditionAPITestCas
     def test_no_group(self) -> None:
         self.get_error_response(self.organization.slug, status_code=400)
 
-    def test_seer_activity_trigger_hidden_without_feature(self) -> None:
-        @self.registry.register(Condition.SEER_ACTIVITY_TRIGGER)
-        @dataclass(frozen=True)
-        class TestSeerActivityTrigger(DataConditionHandler[dict[str, str]]):
-            group = DataConditionHandler.Group.WORKFLOW_TRIGGER
-            comparison_json_schema = {"type": "array", "items": {"type": "string"}}
-
-        response = self.get_success_response(
-            self.organization.slug,
-            group=DataConditionHandler.Group.WORKFLOW_TRIGGER,
-            status_code=200,
-        )
-        condition_types = [item["type"] for item in response.data]
-        assert Condition.SEER_ACTIVITY_TRIGGER.value not in condition_types
-
-    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
-    def test_seer_activity_trigger_shown_with_feature(self) -> None:
+    def test_seer_activity_trigger_shown(self) -> None:
         @self.registry.register(Condition.SEER_ACTIVITY_TRIGGER)
         @dataclass(frozen=True)
         class TestSeerActivityTrigger(DataConditionHandler[dict[str, str]]):

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import (
     SEER_WORKFLOW_ACTIVITIES,
@@ -35,14 +34,6 @@ class SeerActivityHandlerTest(TestCase):
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
-    def test_feature_flag_disabled(self, mock_process_workflow_activity: MagicMock) -> None:
-        seer_activity_handler(self.group, self.activity, None)
-        mock_process_workflow_activity.delay.assert_not_called()
-
-    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
-    @mock.patch(
-        "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
-    )
     def test_all_supported_activity_types_dispatch(
         self, mock_process_workflow_activity: MagicMock
     ) -> None:
@@ -59,7 +50,6 @@ class SeerActivityHandlerTest(TestCase):
                 detector_id=self.detector.id,
             )
 
-    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
@@ -71,7 +61,6 @@ class SeerActivityHandlerTest(TestCase):
 
         mock_process_workflow_activity.delay.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
@@ -86,7 +75,6 @@ class SeerActivityHandlerTest(TestCase):
 
         mock_process_workflow_activity.delay.assert_not_called()
 
-    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )
@@ -104,7 +92,6 @@ class SeerActivityHandlerTest(TestCase):
             detector_id=detector.id,
         )
 
-    @with_feature("organizations:workflow-engine-evaluate-seer-activities")
     @mock.patch(
         "sentry.workflow_engine.handlers.workflow.workflow_activity_handlers.process_workflow_activity"
     )


### PR DESCRIPTION
This will also enable the flag for self-hosted and ST. Afterward, the flagpole config can be removed, then the flag unregistered from temporary.py