### PR TITLE
fix(explore): Render square Heat Map cells in unfurled charts

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -125,8 +125,11 @@ def _heatmap_y_buckets(time_range: timedelta, interval: str) -> int | None:
         return None
     x_columns = total / interval_seconds
     column_width_px = EXPLORE_CHART_SIZE["width"] / x_columns
-    # One column can't be split into a square row, so clamp to a single row.
-    return max(1, round(EXPLORE_CHART_SIZE["height"] / column_width_px))
+    square_buckets = round(EXPLORE_CHART_SIZE["height"] / column_width_px)
+    # Clamp to [1 row, one row per vertical pixel]. The lower bound covers the
+    # single-column case; the upper bound keeps very long ranges from requesting
+    # sub-pixel rows (and blowing past the events-heatmap yBuckets cap).
+    return max(1, min(square_buckets, EXPLORE_CHART_SIZE["height"]))
 
 
 def _clamp_interval(url_interval: str, minimum_interval: str) -> str:

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -60,12 +60,16 @@ _DEFAULT_INTERVAL_LADDER: tuple[tuple[timedelta, str], ...] = (
 )
 
 
-# Heat Map unfurls always render to a fixed Chartcuterie canvas, so we target a
-# fixed-density grid sized to those dimensions. 150 x 50 over 1200x400 gives
-# ~8px square cells. 150 is an approximation, since we're limited to a known set
-# of intervals.
+# Heat Map unfurls always render to a fixed Chartcuterie canvas. We pick the
+# X-axis interval to target ~150 columns; the actual column count varies because
+# we're limited to a known set of intervals. The Y-axis bucket count is then
+# derived geometrically from that column width (see `_heatmap_y_buckets`) so
+# cells render square regardless of how the interval quantization landed,
+# falling back to `HEATMAP_FALLBACK_Y_BUCKETS` when the geometry is undefined.
 HEATMAP_TARGET_X_BUCKETS = 150
-HEATMAP_TARGET_Y_BUCKETS = 50
+# Fallback Y-axis bucket count for degenerate time ranges. 50 over the 400px
+# canvas gives ~8px cells.
+HEATMAP_FALLBACK_Y_BUCKETS = 50
 
 
 def _query_time_range(params: QueryDict) -> timedelta:
@@ -105,6 +109,24 @@ def _heatmap_interval(time_range: timedelta) -> str:
         if seconds / granularity <= HEATMAP_TARGET_X_BUCKETS:
             return f"{granularity}s"
     return f"{max(VALID_GRANULARITIES)}s"
+
+
+def _heatmap_y_buckets(time_range: timedelta, interval: str) -> int | None:
+    """Derive the Y-axis bucket count that makes Heat Map cells square on the
+    fixed Chartcuterie canvas: the X column width in px is
+    ``(interval / time_range) * width``, and we pick the Y bucket count whose
+    cell height matches it. Returns ``None`` when the geometry is undefined
+    (empty time range / interval) so the caller can fall back to a default.
+    Mirrors the frontend's ``calculateHeatMapBucketDimensions``."""
+    total = time_range.total_seconds()
+    interval_td = parse_stats_period(interval)
+    interval_seconds = interval_td.total_seconds() if interval_td else 0
+    if total <= 0 or interval_seconds <= 0:
+        return None
+    x_columns = total / interval_seconds
+    column_width_px = EXPLORE_CHART_SIZE["width"] / x_columns
+    # One column can't be split into a square row, so clamp to a single row.
+    return max(1, round(EXPLORE_CHART_SIZE["height"] / column_width_px))
 
 
 def _clamp_interval(url_interval: str, minimum_interval: str) -> str:
@@ -172,9 +194,9 @@ def _parse_aggregate_field_entries(
 def _build_heatmap_query(raw_query: QueryDict) -> QueryDict:
     """Assemble the QueryDict sent to the events-heatmap API. Like
     ``_build_timeseries_query`` but adds the heatmap params (xAxis/yAxis/zAxis/
-    yBuckets). The URL interval is ignored; instead we target a fixed-density
-    grid (`HEATMAP_TARGET_X_BUCKETS` x `HEATMAP_TARGET_Y_BUCKETS`) sized to the
-    Chartcuterie canvas."""
+    yBuckets). The URL interval is ignored; instead we pick the interval that
+    targets `HEATMAP_TARGET_X_BUCKETS` columns and derive `yBuckets`
+    geometrically so cells render square on the Chartcuterie canvas."""
     out = QueryDict(mutable=True)
 
     for param in ("project", "statsPeriod", "start", "end", "environment"):
@@ -199,8 +221,11 @@ def _build_heatmap_query(raw_query: QueryDict) -> QueryDict:
     if not out.get("statsPeriod") and not out.get("start"):
         out["statsPeriod"] = DEFAULT_PERIOD
 
-    out["interval"] = _heatmap_interval(_query_time_range(out))
-    out["yBuckets"] = str(HEATMAP_TARGET_Y_BUCKETS)
+    time_range = _query_time_range(out)
+    interval = _heatmap_interval(time_range)
+    out["interval"] = interval
+    y_buckets = _heatmap_y_buckets(time_range, interval)
+    out["yBuckets"] = str(y_buckets if y_buckets is not None else HEATMAP_FALLBACK_Y_BUCKETS)
 
     # Fixed axes — the endpoint currently only supports these values.
     out["xAxis"] = "time"

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -14,7 +14,7 @@ from sentry.integrations.services.integration.serial import serialize_integratio
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.unfurl.dashboards import build_widget_timeseries_params
-from sentry.integrations.slack.unfurl.explore import _build_heatmap_query
+from sentry.integrations.slack.unfurl.explore import _build_heatmap_query, _heatmap_y_buckets
 from sentry.integrations.slack.unfurl.handlers import link_handlers, match_link
 from sentry.integrations.slack.unfurl.types import LinkType, UnfurlableUrl
 from sentry.models.dashboard_widget import DashboardWidgetDisplayTypes, DashboardWidgetTypes
@@ -1225,7 +1225,8 @@ class UnfurlTest(TestCase):
             " metric.unit:millisecond )"
         )
         assert api_params["interval"] == "21600s"
-        assert api_params["yBuckets"] == "50"
+        # 30d / 21600s = 120 columns; round(400 / (1200 / 120)) = 40 -> square cells.
+        assert api_params["yBuckets"] == "40"
 
         chart_data = mock_generate_chart.call_args[0][1]
         y_axis_meta = chart_data["heatmap"]["meta"]["yAxis"]
@@ -1273,17 +1274,27 @@ class UnfurlTest(TestCase):
 
     def test_build_heatmap_query_interval_and_buckets(self) -> None:
         base = "yAxis=sum(value,my.metric,counter,none)"
+        # yBuckets = round(400 / (1200 / columns)), i.e. round(columns / 3), to
+        # keep cells square on the 1200x400 Chartcuterie canvas.
         cases = [
-            ("1h", "30s"),  # 120 columns (15s -> 240 would exceed 150)
-            ("24h", "600s"),  # 144 columns (300s -> 288 would exceed 150)
-            ("7d", "7200s"),  # 84 columns (3600s -> 168 would exceed 150)
-            ("30d", "21600s"),  # 120 columns (14400s -> 180 would exceed 150)
+            ("1h", "30s", "40"),  # 120 columns (15s -> 240 would exceed 150)
+            ("24h", "600s", "48"),  # 144 columns (300s -> 288 would exceed 150)
+            ("7d", "7200s", "28"),  # 84 columns (3600s -> 168 would exceed 150)
+            ("30d", "21600s", "40"),  # 120 columns (14400s -> 180 would exceed 150)
         ]
-        for stats_period, expected_interval in cases:
+        for stats_period, expected_interval, expected_y_buckets in cases:
             out = _build_heatmap_query(QueryDict(f"{base}&statsPeriod={stats_period}&interval=1m"))
-            assert (out["interval"], out["yBuckets"]) == (expected_interval, "50"), (
-                f"statsPeriod={stats_period}"
-            )
+            assert (out["interval"], out["yBuckets"]) == (
+                expected_interval,
+                expected_y_buckets,
+            ), f"statsPeriod={stats_period}"
+
+    def test_heatmap_y_buckets_degenerate_ranges(self) -> None:
+        # Zero/negative ranges (or intervals) have no defined geometry -> None,
+        # so the caller falls back to a default bucket count.
+        assert _heatmap_y_buckets(timedelta(0), "60s") is None
+        assert _heatmap_y_buckets(timedelta(seconds=-1), "60s") is None
+        assert _heatmap_y_buckets(timedelta(hours=1), "0s") is None
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1296,6 +1296,12 @@ class UnfurlTest(TestCase):
         assert _heatmap_y_buckets(timedelta(seconds=-1), "60s") is None
         assert _heatmap_y_buckets(timedelta(hours=1), "0s") is None
 
+    def test_heatmap_y_buckets_clamped_for_long_ranges(self) -> None:
+        # A multi-year range at the coarsest interval would want ~1/3 of the
+        # column count in rows (well over the events-heatmap cap); clamp to one
+        # row per vertical pixel of the canvas.
+        assert _heatmap_y_buckets(timedelta(days=4000), "86400s") == 400
+
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
     )


### PR DESCRIPTION
Slack Heat Map unfurls onto a fixed 1200×400 canvas, but the number of Y-axis cells is hardcoded to 50. Since the number of X-axis (time) columns varies with the selected time range cells are sometimes rendered as stretched rectangles.

My original thinking was that a set number of Y-axis buckets would make the charts easier to compare but honestly, who cares?

Closes DAIN-1757
