### PR TITLE
fix(replays): Fix web vital tooltip rendering in the replay timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -102,8 +102,8 @@ export function BreadcrumbWebVital({
   }
 
   return (
-    <Flex gap="lg" justify="between" align="start">
-      <NoMarginWrapper flex="1">
+    <Flex direction="column" gap="sm" align="start">
+      <NoMarginWrapper>
         <StructuredEventData
           initialExpandedPaths={expandPaths ?? []}
           onToggleExpand={(expandedPaths, path) => {
@@ -156,6 +156,7 @@ const SelectorButton = styled(Button)`
 `;
 
 const NoMarginWrapper = styled(Flex)`
+  width: 100%;
   pre {
     margin: 0;
     flex: 1;

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -13,6 +13,7 @@ import {getFrameDetails} from 'sentry/utils/replays/getFrameDetails';
 import {useActiveReplayTab} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import {useCrumbHandlers} from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
+import {isWebVitalFrame} from 'sentry/utils/replays/types';
 import type {GraphicsVariant} from 'sentry/utils/theme';
 
 const NODE_SIZES = [8, 12, 16];
@@ -106,14 +107,20 @@ function Event({
     </Container>
   );
 
+  // Web vital frames render an expandable JSON block that needs more room than
+  // the default tooltip width, otherwise its content wraps to a very tall sliver.
+  const hasWebVitalFrame = frames.some(isWebVitalFrame);
+  const tooltipWidth = hasWebVitalFrame ? 400 : 291;
+  const mobileMaxWidth = hasWebVitalFrame ? 300 : 220;
+
   const overlayStyle = css`
     /* We make sure to override existing styles */
     padding: ${theme.space.xs} !important;
-    max-width: 291px !important;
-    width: 291px;
+    max-width: ${tooltipWidth}px !important;
+    width: ${tooltipWidth}px;
 
     @media screen and (max-width: ${theme.breakpoints.sm}) {
-      max-width: 220px !important;
+      max-width: ${mobileMaxWidth}px !important;
     }
   `;
 


### PR DESCRIPTION
Fixes overflow on replays tooltip
### Before 
(notice `all web vitals` is cut off when json collapsed, and  json looks really narrow when expanded)

<img width="261" height="292" alt="image" src="https://github.com/user-attachments/assets/7431a315-657c-4c08-a103-5eca5a1de5ea" />
<img width="236" height="392" alt="image" src="https://github.com/user-attachments/assets/aec9f5a5-377c-4128-bd7d-604c8e1f52f5" />

### After
<img width="263" height="478" alt="image" src="https://github.com/user-attachments/assets/314d167b-38ff-4b94-8ec3-325a4b0f63a4" />
<img width="244" height="517" alt="image" src="https://github.com/user-attachments/assets/6c2488ea-0081-4c6b-abc5-b878e99fb254" />




## Ai Summary

Fixes [REPLAY-862](https://linear.app/getsentry/issue/REPLAY-862/weird-rendering-issue-in-the-timeline) — the tooltip for web vital markers on the replay timeline rendered "weird".

Web vital markers show an expandable `StructuredEventData` JSON block alongside an "All Web Vitals" link. In the default 291px tooltip the JSON column was squeezed so narrow that even a short key like `value` wrapped to two characters per line (making the tooltip very tall), and the `nowrap` link could overflow the tooltip edge.

- Widen the tooltip to **400px only for web vital frames** (`frames.some(isWebVitalFrame)`); all other breadcrumb tooltips keep their existing 291px width.
- Stack the "All Web Vitals" link **below** the now full-width JSON block instead of beside it, so the link can never be pushed outside the tooltip (e.g. with long CSS selectors).

## Test plan

- [ ] Open a replay containing LCP/CLS web vital breadcrumbs and hover the web vital marker on the timeline bar under the player.
- [ ] Confirm the JSON renders at normal height (keys like `value` on one line) and the "All Web Vitals" link sits inside the tooltip, below the JSON.
- [ ] Confirm non-web-vital breadcrumb tooltips (clicks, navigations) are unchanged at their original width.