### PR TITLE
fix(dashboards): Show correct type badge for categorical bar X-axis attributes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/xAxisSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/xAxisSelector.tsx
@@ -63,7 +63,7 @@ export function WidgetBuilderXAxisSelector() {
       return Object.values(allTags).map(tag => ({
         label: prettifyTagKey(tag.name),
         value: tag.key,
-        trailingItems: () => <TypeBadge valueKind={FieldValueKind.TAG} />,
+        trailingItems: () => <TypeBadge kind={tag.kind} />,
       }));
     }
 


### PR DESCRIPTION
The categorical bar chart's X-axis picker rendered a `tag` badge on every span attribute, weird!

The picker was hardcoding `<TypeBadge valueKind={FieldValueKind.TAG} />` for every EAP attribute. Each attribute already carries its correct `kind`, so this drives the badge from `tag.kind` instead.

**Before:**
<img width="668" height="247" alt="Screenshot 2026-07-06 at 1 59 08 PM" src="https://github.com/user-attachments/assets/a32399a5-3446-48d1-8bac-fd133617169d" />

**After:**
<img width="659" height="399" alt="Screenshot 2026-07-06 at 1 59 00 PM" src="https://github.com/user-attachments/assets/2f72933c-c7f2-49eb-a772-e61c863bfc26" />

Fixes DAIN-1765