### PR TITLE
fix(github): Ungate inbound issue status sync from removed feature flag

### DIFF
--- a/src/sentry/integrations/github/issue_sync.py
+++ b/src/sentry/integrations/github/issue_sync.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry import features
 from sentry.integrations.mixins.issues import IssueSyncIntegration, ResolveSyncAction
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -26,13 +25,6 @@ class GitHubIssueSyncSpec(IssueSyncIntegration):
     outbound_assignee_key = "sync_forward_assignment"
     inbound_assignee_key = "sync_reverse_assignment"
     resolution_strategy_key = "resolution_strategy"
-
-    def check_feature_flag(self) -> bool:
-        """
-        A temporary method so we can gate Github & Github Enterprise project management features.
-        """
-        ff_key = f"organizations:integrations-{self.model.provider}-project-management"
-        return features.has(ff_key, self.organization)
 
     def split_external_issue_key(
         self, external_issue_key: str
@@ -203,9 +195,6 @@ class GitHubIssueSyncSpec(IssueSyncIntegration):
         Given webhook data, check whether the GitHub issue status changed.
         GitHub issues only have open/closed state.
         """
-        if not self.check_feature_flag():
-            return ResolveSyncAction.NOOP
-
         if data.get("action") == IssueEvenntWebhookActionType.CLOSED.value:
             return ResolveSyncAction.RESOLVE
         elif data.get("action") == IssueEvenntWebhookActionType.REOPENED.value:


### PR DESCRIPTION
## Summary

Closing or reopening a GitHub issue stopped resolving/unresolving its linked Sentry issue (GitHub → Sentry inbound status sync). Outbound sync (Sentry → GitHub) was unaffected, matching the customer reports.

`GitHubIssueSyncSpec.get_resolve_sync_action` gated on `check_feature_flag()`, which checked `organizations:integrations-github-project-management`. That flag was removed from the registry in #116551 — deemed "zero usage" because the only reference builds the flag name dynamically from `self.model.provider`, so a literal grep missed it. `features.has()` on an unregistered flag raises `FeatureNotRegistered` internally and returns `False`, so `get_resolve_sync_action` always returned `NOOP` and the inbound sync silently no-oped.

The flag had previously been registered in #114789 and the check was moved into the shared spec in #103422.

## Fix

Both `github` and `github_enterprise` project-management flags are fully rolled out (GA at 100% in `sentry-options-automator`), so this drops the gate entirely rather than re-registering a flag no one maintains. This restores inbound status sync for both GitHub and GitHub Enterprise (GHE inherits `GitHubIssueSyncSpec`).

Fixes GH-110299