### PR TITLE
ref(performance): Remove outdated comment re: transactions use

### DIFF
--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -114,10 +114,6 @@ export function PageLayout(props: Props) {
       case Tab.EVENTS:
       case Tab.TAGS:
       case Tab.TRANSACTION_SUMMARY:
-        // The transactions summary page technically also uses transactions
-        // in additional to spans. But if we specify transactions here, it'll
-        // use the 90d retention for transactions instead of the 30d retention
-        // for spans in some cases which is not what we want.
         return [DataCategory.SPANS];
       default:
         throw new Error(`Unsupported tab: ${tab}`);


### PR DESCRIPTION
The transactions summary page no longer uses the transactions dataset at all, so remove the outdated comment saying it does.