### PR TITLE
fix(autofix): Fix Overlapping Feedback Attribution with Feedback

### DIFF
--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -466,7 +466,7 @@ function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
     case 'in_progress':
       return (
         <Tooltip title={t('This feedback is being processed')}>
-          <LoadingIndicator size={14} />
+          <LoadingIndicator size={14} style={{margin: 0}} />
         </Tooltip>
       );
     case 'queued':
@@ -491,7 +491,7 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
     <Flex gap="md" align="start" justify="between">
       <Flex gap="md" align="start" flex="1" minWidth={0}>
         <Flex align="center" gap="md" height="1lh">
-          <Flex align="center" justify="center" flex="0 0 28px">
+          <Flex width="28px" justify="center">
             <FeedbackStatusIcon status={item.status} />
           </Flex>
           <FeedbackAttribution item={item} />

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -491,7 +491,7 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
     <Flex gap="md" align="start" justify="between">
       <Flex gap="md" align="start" flex="1" minWidth={0}>
         <Flex align="center" gap="md" height="1lh">
-          <Flex width="28px" justify="center">
+          <Flex align="center" justify="center" flex="0 0 28px">
             <FeedbackStatusIcon status={item.status} />
           </Flex>
           <FeedbackAttribution item={item} />

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -491,7 +491,7 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
     <Flex gap="md" align="start" justify="between">
       <Flex gap="md" align="start" flex="1" minWidth={0}>
         <Flex align="center" gap="md" height="1lh">
-          <Flex align="center" justify="center" flex="0 0 28px">
+          <Flex align="center" justify="center" width="28px">
             <FeedbackStatusIcon status={item.status} />
           </Flex>
           <FeedbackAttribution item={item} />


### PR DESCRIPTION
The in-progress feedback icon in `codeChangesCard` rendered wrong: a huge spinner margin, and the icon column overflowing into the feedback attribution.

- `LoadingIndicator`'s `size` prop only shrinks the inner spinner; the outer `.loading` wrapper keeps a hardcoded `margin: 6em auto`. Pass `style={{margin: 0}}` to collapse it.
- The icon column used `flex="0 0 28px"` (`flex-shrink: 0`), so an icon wider than 28px couldn't shrink and overflowed centered into the adjacent attribution. Switch to `width="28px"`, which keeps the default `flex-shrink: 1` and sizes to content.

Previously:

<img width="750" height="63" alt="image" src="https://github.com/user-attachments/assets/86dfa68e-b67c-4584-a883-a9697d512e47" />

After:

<img width="775" height="116" alt="image" src="https://github.com/user-attachments/assets/d26594fe-bf89-4c74-9a19-b60e46ca793e" />

completes CORE-273