### PR TITLE
chore(conversations): Bump user details and traces to 12px font-size

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -127,13 +127,13 @@ export function ConversationSummaryNew({
                 <IconUser size="md" />
                 {userDisplayName ? (
                   <Tooltip title={userDisplayName} showOnlyOnOverflow skipWrapper>
-                    <Text size="xs" variant="muted" ellipsis>
+                    <Text size="sm" variant="muted" ellipsis>
                       {userDisplayName}
                     </Text>
                   </Tooltip>
                 ) : (
                   <InfoText
-                    size="xs"
+                    size="sm"
                     variant="muted"
                     title={<UserNotInstrumentedTooltip />}
                   >
@@ -152,7 +152,7 @@ export function ConversationSummaryNew({
                 >
                   <Flex align="center" gap="xs">
                     <IconOpen size="xs" />
-                    <Text size="xs" variant="inherit" wrap="nowrap">
+                    <Text size="sm" variant="inherit" wrap="nowrap">
                       {tn('Trace', 'Traces', traces.length)}
                     </Text>
                   </Flex>


### PR DESCRIPTION
Bumps the font-size of the user details (email / not-instrumented placeholder) and the Trace link in the conversation summary header from `xs` (11px) to `sm` (12px), per the design token that evaluates to 12px.

### Changes
- `conversationSummaryNew.tsx`: `Text`/`InfoText` `size="xs"` → `size="sm"` for the user display name, the not-instrumented `—` placeholder, and the Trace link label.

The tool-name chips are rendered by `ToolTag`/`Tag` and are intentionally left unchanged.