### PR TITLE
fix(conversations): Anchor summary heading tooltip to the title text

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -99,11 +99,7 @@ export function ConversationSummaryNew({
     >
       <Stack gap="md" minWidth={0} flex={1}>
         <Container minWidth={0}>
-          <Tooltip
-            title={conversationId}
-            showOnlyOnOverflow={!isUUID(conversationId)}
-            skipWrapper
-          >
+          <Tooltip title={conversationId} showOnlyOnOverflow={!isUUID(conversationId)}>
             <Heading as="h2" ellipsis>
               {displayId}
             </Heading>


### PR DESCRIPTION
The conversation-id heading tooltip used `skipWrapper`, which anchored it to the full-width `<h2>` block. Its default centered position then landed over the empty space beside a truncated id instead of above the visible text.

Dropping `skipWrapper` lets the Tooltip wrap the heading in its own `inline-block` container, which hugs the text width, so the tooltip sits over the id in both the short and truncated cases.