### PR TITLE
feat(trace): Add operation-type icons to AI span details title

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -20,6 +20,8 @@ import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetail
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getNodeTimeBounds} from 'sentry/views/insights/pages/agents/components/aiSpanList';
 import {
+  getGenAiOpType,
+  getGenAiOpTypeIcon,
   getSpanColor,
   getTimelineColorByOpType,
   getTraceNodeAttribute,
@@ -139,13 +141,9 @@ export function ConversationSpanDetail({
     >
       <Flex align="center" gap="lg" flexShrink={0}>
         <Flex flex="1" minWidth="0" align="center" gap="md">
-          <Container
-            width="16px"
-            height="16px"
-            flexShrink={0}
-            radius="2xs"
-            style={{backgroundColor: squareColor}}
-          />
+          <Flex flexShrink={0} style={{color: squareColor}}>
+            {getGenAiOpTypeIcon(getGenAiOpType(node))}
+          </Flex>
           <Tooltip title={title} showOnlyOnOverflow skipWrapper>
             <Text size="md" bold ellipsis>
               {title}

--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -8,8 +8,7 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
-import {IconChat, IconChevron, IconCode, IconFire, IconFix} from 'sentry/icons';
-import {IconBot} from 'sentry/icons/iconBot';
+import {IconFire} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {getDuration} from 'sentry/utils/duration/getDuration';
@@ -24,6 +23,7 @@ import {
   type ColorByOpType,
   getFirstToolInputValue,
   getGenAiOpType,
+  getGenAiOpTypeIcon,
   getIsAiAgentNode,
   getNumberAttr,
   getSpanColor,
@@ -314,7 +314,7 @@ function getSpanPresentation(
         getStringAttr(node, SpanFields.GEN_AI_RESPONSE_MODEL) ||
         '';
       return {
-        icon: <IconBot size="md" />,
+        icon: getGenAiOpTypeIcon(genAiOpType, 'md'),
         color,
         isTool: false,
         title: name || op,
@@ -325,7 +325,7 @@ function getSpanPresentation(
       const responseModel = getStringAttr(node, SpanFields.GEN_AI_RESPONSE_MODEL);
       const title = responseModel || description || op;
       return {
-        icon: <IconChat size="md" />,
+        icon: getGenAiOpTypeIcon(genAiOpType, 'md'),
         color,
         isTool: false,
         title,
@@ -336,7 +336,7 @@ function getSpanPresentation(
       const toolName = getStringAttr(node, SpanFields.GEN_AI_TOOL_NAME);
       const firstInputValue = getFirstToolInputValue(node);
       return {
-        icon: <IconFix size="md" />,
+        icon: getGenAiOpTypeIcon(genAiOpType, 'md'),
         color,
         isTool: true,
         title: toolName || op,
@@ -345,7 +345,7 @@ function getSpanPresentation(
     }
     case GenAiOperationType.HANDOFF:
       return {
-        icon: <IconChevron size="md" isDouble direction="right" />,
+        icon: getGenAiOpTypeIcon(genAiOpType, 'md'),
         color,
         isTool: false,
         title: op,
@@ -353,7 +353,7 @@ function getSpanPresentation(
       };
     default:
       return {
-        icon: <IconCode size="md" />,
+        icon: getGenAiOpTypeIcon(genAiOpType, 'md'),
         color,
         isTool: false,
         title: op,

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -1,5 +1,7 @@
 import type {Theme} from '@emotion/react';
 
+import {IconChat, IconChevron, IconCode, IconFix} from 'sentry/icons';
+import {IconBot} from 'sentry/icons/iconBot';
 import type {EventTransaction} from 'sentry/types/event';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -222,4 +224,25 @@ export function getTimelineColorByOpType(theme: Theme): ColorByOpType {
     default: theme.tokens.content.secondary,
     error: theme.tokens.content.danger,
   };
+}
+
+/**
+ * Returns the icon element for a given gen_ai operation type.
+ */
+export function getGenAiOpTypeIcon(
+  opType: string | undefined,
+  size: 'xs' | 'sm' | 'md' | 'lg' = 'sm'
+) {
+  switch (opType) {
+    case GenAiOperationType.AGENT:
+      return <IconBot size={size} />;
+    case GenAiOperationType.AI_CLIENT:
+      return <IconChat size={size} />;
+    case GenAiOperationType.TOOL:
+      return <IconFix size={size} />;
+    case GenAiOperationType.HANDOFF:
+      return <IconChevron size={size} isDouble direction="right" />;
+    default:
+      return <IconCode size={size} />;
+  }
 }


### PR DESCRIPTION
Replace the plain colored square in the conversation span detail header with operation-type-specific icons that match the AI span timeline: IconBot for agents, IconChat for AI clients, IconFix for tools, IconChevron for handoffs, and IconCode as the default. The icons sit inside the same colored badge and use the existing op-type color palette.

<img width="416" height="273" alt="CleanShot 2026-07-07 at 10 58 36" src="https://github.com/user-attachments/assets/5afdd3cb-ffcc-4cfd-8c94-0906e163f21d" />


Closes TET-2620