### PR TITLE
feat(conversations): Make messages selectable in the transcript view

### DIFF
--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -1,4 +1,5 @@
 import type {ReactNode} from 'react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -71,40 +72,63 @@ interface AssistantMessageBlockProps {
   className?: string;
   /** Fill the bubble to its max-width instead of shrinking to fit the content. */
   expand?: boolean;
+  /** Whether this message is currently selected. */
+  isSelected?: boolean;
   /** Content rendered to the right of the bubble (e.g. cost/time metadata). */
   meta?: ReactNode;
+  /** Called when the user clicks the message bubble. */
+  onClick?: () => void;
 }
 
 /**
  * Assistant text output as a left-aligned accent bubble mirroring
- * `UserMessageBlock`'s width. Not interactive — tool calls are selected
- * separately by the caller.
+ * `UserMessageBlock`'s width.
  */
 export function AssistantMessageBlock({
   children,
   className,
   expand,
   meta,
+  isSelected,
+  onClick,
 }: AssistantMessageBlockProps) {
+  const theme = useTheme();
+
+  const bubbleCss = css`
+    overflow-wrap: anywhere;
+    background: ${theme.tokens.background.transparent.accent.muted};
+    ${onClick &&
+    css`
+      cursor: pointer;
+      &:hover {
+        opacity: 0.85;
+      }
+    `}
+    ${isSelected &&
+    css`
+      outline: 2px solid ${theme.tokens.focus.default};
+      outline-offset: -2px;
+    `}
+  `;
+
   return (
     <MessageBlock className={className}>
       <Flex justify="between" align="start" gap="md" width="100%">
-        <AssistantBubble
+        <Container
           maxWidth={AI_MESSAGE_MAX_WIDTH}
           width={expand ? '100%' : 'fit-content'}
           minWidth={0}
           padding="md"
           radius="xs"
+          css={bubbleCss}
+          onClick={onClick}
+          role={onClick ? 'button' : undefined}
+          tabIndex={onClick ? 0 : undefined}
         >
           {children}
-        </AssistantBubble>
+        </Container>
         {meta}
       </Flex>
     </MessageBlock>
   );
 }
-
-const AssistantBubble = styled(Container)`
-  overflow-wrap: anywhere;
-  background: ${p => p.theme.tokens.background.transparent.accent.muted};
-`;

--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -59,9 +59,6 @@ export function ConversationViewContentNew({
     onSelectSpan,
     focusedTool,
     isLoading,
-    // In the transcript view the span detail only opens on user action; in the
-    // timeline view we auto-select a default span so its detail is visible.
-    autoSelectDefaultNode: isTimeline,
   });
 
   const [detailState, setDetailState] = useQueryStates(

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {EMPTY_TEXT_CONTENT} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -180,6 +180,39 @@ describe('MessagesPanelNew', () => {
     );
 
     expect(screen.getByText('weather')).toBeInTheDocument();
+  });
+
+  it('selects assistant messages on click but not user messages', async () => {
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: JSON.stringify([
+          {role: 'user', content: 'Hello there'},
+        ]),
+        [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Assistant response',
+      },
+    });
+
+    render(
+      <MessagesPanelNew
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+        nodeTraceMap={new Map()}
+      />
+    );
+
+    // User messages are not interactive
+    await userEvent.click(screen.getByText('Hello there'));
+    expect(mockOnSelectNode).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: /Hello there/})).not.toBeInTheDocument();
+
+    // Assistant messages select the corresponding node
+    await userEvent.click(screen.getByText('Assistant response'));
+    expect(mockOnSelectNode).toHaveBeenCalledWith(node);
+    expect(
+      screen.getByText('Assistant response').closest('[role="button"]')
+    ).toBeInTheDocument();
   });
 
   it('keeps reasoning text in the DOM inside a collapsed details element', () => {

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -49,6 +49,7 @@ export function MessagesPanelNew({
   onSelectNode,
   nodeTraceMap,
 }: MessagesPanelNewProps) {
+  const organization = useOrganization();
   const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
 
   // Detect XML once per list so selection re-renders don't re-parse every message.
@@ -71,6 +72,14 @@ export function MessagesPanelNew({
     return map;
   }, [nodes]);
 
+  const handleMessageClick = (message: ConversationMessage) => {
+    trackAnalytics('conversations.message.click', {organization});
+    const node = nodeMap.get(message.nodeId);
+    if (node) {
+      onSelectNode(node);
+    }
+  };
+
   if (messages.length === 0) {
     return (
       <PanelContainer>
@@ -84,6 +93,7 @@ export function MessagesPanelNew({
       <Stack gap="0" width="100%">
         {messages.map(message => {
           const hasXmlTags = hasXmlByMessageId.get(message.id) ?? false;
+          const isSelected = message.nodeId === selectedNodeId;
 
           if (message.role === 'user') {
             return (
@@ -105,10 +115,12 @@ export function MessagesPanelNew({
               key={message.id}
               message={message}
               hasXmlTags={hasXmlTags}
+              isSelected={message.role === 'assistant' && isSelected}
               selectedNodeId={selectedNodeId}
               nodeMap={nodeMap}
               nodeTraceMap={nodeTraceMap}
               onSelectNode={onSelectNode}
+              onClick={() => handleMessageClick(message)}
             />
           );
         })}
@@ -119,9 +131,11 @@ export function MessagesPanelNew({
 
 interface AssistantTurnProps {
   hasXmlTags: boolean;
+  isSelected: boolean;
   message: ConversationMessage;
   nodeMap: Map<string, AITraceSpanNode>;
   nodeTraceMap: Map<string, string>;
+  onClick: () => void;
   onSelectNode: (node: AITraceSpanNode) => void;
   selectedNodeId: string | null;
 }
@@ -129,10 +143,12 @@ interface AssistantTurnProps {
 function AssistantTurn({
   message,
   hasXmlTags,
+  isSelected,
   selectedNodeId,
   nodeMap,
   nodeTraceMap,
   onSelectNode,
+  onClick,
 }: AssistantTurnProps) {
   const generationNode = nodeMap.get(message.nodeId);
   // Spans often report `gen_ai.cost.total_tokens` as 0 when the API omits cost;
@@ -166,13 +182,18 @@ function AssistantTurn({
         // Tool/reasoning-only turn: still surface the turn's cost and duration.
         hasMeta && <MessageBlock justify="end">{meta}</MessageBlock>
       ) : message.content === EMPTY_TEXT_CONTENT ? (
-        <AssistantMessageBlock meta={meta}>
+        <AssistantMessageBlock meta={meta} isSelected={isSelected} onClick={onClick}>
           <MessageText align="left" variant="muted">
             {message.content}
           </MessageText>
         </AssistantMessageBlock>
       ) : (
-        <AssistantMessageBlock expand={hasXmlTags} meta={meta}>
+        <AssistantMessageBlock
+          expand={hasXmlTags}
+          meta={meta}
+          isSelected={isSelected}
+          onClick={onClick}
+        >
           <MessageText align="left">
             <AIContentRenderer
               text={message.content}


### PR DESCRIPTION
Clicking an assistant message bubble in the redesigned transcript panel now selects the corresponding span node and opens the span detail sidebar — matching the click-to-select interaction that tool call badges already support. User messages remain non-interactive.

Selected messages use the same `outline` styling as selected tool calls for visual consistency. The selection tracks the explicitly clicked message and falls back to the assistant message for the currently selected node when selection changes externally (e.g. via the timeline tab). The existing `conversations.message.click` analytics event fires on each click.

<img width="705" height="141" alt="CleanShot 2026-07-07 at 10 48 44" src="https://github.com/user-attachments/assets/d879f9e6-4bfc-4413-90e1-720229fda6ea" />


Closes TET-2616