### PR TITLE
fix(conversations): Show 0 B for tool size when output bytes are unavailable

### DIFF
--- a/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
@@ -140,9 +140,6 @@ function ToolOutputSize({
   traceId: string | undefined;
 }) {
   const bytes = useToolOutputBytes(node, traceId);
-  if (!bytes) {
-    return null;
-  }
   return (
     <Text size="xs" variant="muted" tabular align="right">
       {formatBytesBase10(bytes)}

--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -212,12 +212,23 @@ const TimelineRow = memo(function TimelineRow({
                   >
                     {metric}
                   </Text>
-                ) : isTool && traceId ? (
-                  <ToolOutputSizeMetric
-                    node={node}
-                    traceId={traceId}
-                    isSelected={isSelected}
-                  />
+                ) : isTool ? (
+                  traceId ? (
+                    <ToolOutputSizeMetric
+                      node={node}
+                      traceId={traceId}
+                      isSelected={isSelected}
+                    />
+                  ) : (
+                    <Text
+                      size="sm"
+                      variant={isSelected ? 'primary' : 'muted'}
+                      align="right"
+                      tabular
+                    >
+                      {formatBytesBase10(0)}
+                    </Text>
+                  )
                 ) : null}
               </Flex>
               <Flex flexShrink={0} width="56px" justify="end">
@@ -277,10 +288,6 @@ function ToolOutputSizeMetric({
   traceId: string;
 }) {
   const bytes = useToolOutputBytes(node, traceId);
-
-  if (!bytes) {
-    return null;
-  }
 
   return (
     <Text size="sm" variant={isSelected ? 'primary' : 'muted'} align="right" tabular>


### PR DESCRIPTION
Tool spans now always display a size value ("0 B" when unavailable) instead of rendering nothing and leaving a visual gap that shifts columns out of alignment. Fixed in both the AI trace timeline and the conversation transcript view.

Closes TET-2624