### PR TITLE
fix(conversations): Make the agent selector wrap on narrow viewports

### DIFF
--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -101,7 +101,7 @@ function ConversationsOverviewPage() {
         <Layout.Main width="full">
           <Stack gap="md">
             <Flex gap="md" align="center" wrap="wrap">
-              <Flex gap="md" align="center">
+              <Flex gap="md" align="center" wrap="wrap">
                 <PageFilterBar condensed>
                   <ProjectPageFilter resetParamsOnChange={[TableUrlParams.CURSOR]} />
                   <EnvironmentPageFilter resetParamsOnChange={[TableUrlParams.CURSOR]} />


### PR DESCRIPTION
**Before**

<img width="735" height="1030" alt="image" src="https://github.com/user-attachments/assets/b49b5256-613e-4aeb-b285-228e6b8003ad" />


**After**

<img width="720" height="1039" alt="image" src="https://github.com/user-attachments/assets/d573c3f5-e814-46b0-8f47-04d1b762022a" />
