### PR TITLE
fix(traces): Reserve min-width for interactive object Pretty/Raw control

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1318,6 +1318,9 @@ const MultilineTextWrapperMonospace = styled(MultilineTextWrapper)`
   font-size: ${p => p.theme.font.size.sm};
   /* Reserve vertical space for the hoverable Pretty/Raw segmented control (form height + top/bottom spacing) */
   min-height: calc(${p => p.theme.form.xs.height} + (${p => p.theme.space.xs} * 2));
+  /* Reserve horizontal space so the absolutely-positioned Pretty/Raw control doesn't
+   * overlap the content when the object is narrow (e.g. inside a fit-content bubble). */
+  min-width: 210px;
   pre {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Interactive object blocks (the `MultilineJSON` renderer used for JSON/tool-result content) show a Pretty/Raw `SegmentedControl` that is absolutely positioned in the top-right corner and appears on hover. The wrapper already reserved vertical room for it via `min-height`, but nothing reserved horizontal room — so when the object renders narrow (e.g. a small JSON payload inside a `fit-content` conversation-transcript bubble), the control lands on top of the content and hides it.

This adds a matching `min-width` to the JSON wrapper, the horizontal counterpart to the existing `min-height` reservation. Because `MultilineJSON` is the shared interactive-object renderer, the fix applies everywhere it's used — the conversation transcript and the trace drawer — without threading content-type detection through the message panel.

<img width="245" height="75" alt="Screenshot 2026-07-07 at 10 31 01" src="https://github.com/user-attachments/assets/effccec6-e666-4ff2-8225-b1d4103b6cfb" />

Closes TET-2612