### PR TITLE
feat(relay): Warn on Client Keys pages when a Relay DSN endpoint override is set

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/index.tsx
+++ b/static/app/views/settings/project/projectKeys/details/index.tsx
@@ -14,6 +14,7 @@ import {RouteError} from 'sentry/views/routeError';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {KeySettings} from 'sentry/views/settings/project/projectKeys/details/keySettings';
 import {KeyStats} from 'sentry/views/settings/project/projectKeys/details/keyStats';
+import {RelayDsnOverrideAlert} from 'sentry/views/settings/project/projectKeys/relayDsnOverrideAlert';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -77,6 +78,7 @@ export default function ProjectKeyDetails() {
       <div data-test-id="key-details">
         <SettingsPageHeader title={t('Key Details')} />
         <ProjectPermissionAlert project={project} />
+        <RelayDsnOverrideAlert />
         <KeyStats />
         <KeySettings
           data={projKeyData}

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -28,6 +28,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+import {RelayDsnOverrideAlert} from 'sentry/views/settings/project/projectKeys/relayDsnOverrideAlert';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -214,6 +215,7 @@ export default function ProjectKeys() {
       />
 
       <ProjectPermissionAlert project={project} />
+      <RelayDsnOverrideAlert />
 
       {isEmpty ? renderEmpty() : renderResults()}
     </div>

--- a/static/app/views/settings/project/projectKeys/relayDsnOverrideAlert.tsx
+++ b/static/app/views/settings/project/projectKeys/relayDsnOverrideAlert.tsx
@@ -1,0 +1,28 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Link} from '@sentry/scraps/link';
+
+import {tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function RelayDsnOverrideAlert() {
+  const organization = useOrganization();
+  const override = organization.relayDsnEndpoint;
+
+  if (!override) {
+    return null;
+  }
+
+  return (
+    <Alert.Container>
+      <Alert variant="info">
+        {tct(
+          'DSNs on this page point to the [link:custom Relay endpoint] at [override].',
+          {
+            link: <Link to={`/settings/${organization.slug}/relay/`} />,
+            override: <code>{override}</code>,
+          }
+        )}
+      </Alert>
+    </Alert.Container>
+  );
+}


### PR DESCRIPTION
Adds a small info alert to the project Client Keys list and detail pages when the org has `sentry:relay_dsn_endpoint` configured. The alert names the override URL and links back to org Relay settings so the reader can trace where the DSN they're looking at is pointing.

Renders nothing when the option is unset.

<img width="934" height="75" alt="Screenshot 2026-07-07 at 11 09 59" src="https://github.com/user-attachments/assets/e4c89f9c-4f28-4b57-ad0a-3a4544780ff9" />

Closes TET-2601