### PR TITLE
fix(conversations): Stop table rows growing in Safari on back-nav

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -213,7 +213,10 @@ export function CellContent({text, ref, ...props}: CellContentProps) {
   const cleanedText = cleanMarkdownForCell(text);
   return (
     <SingleLineMarkdown ref={ref} {...props}>
-      <MarkedText text={ellipsize(cleanedText, CELL_MAX_CHARS)} />
+      {/* inline: no block <p>/<pre> children, so white-space:nowrap clamps to
+          one line without relying on `* {display:inline}` (Safari drops it on
+          MarkedText's async innerHTML swap, growing rows on back-nav). */}
+      <MarkedText inline text={ellipsize(cleanedText, CELL_MAX_CHARS)} />
     </SingleLineMarkdown>
   );
 }


### PR DESCRIPTION
On Safari, navigating back to the conversations table (browser back or sidebar) made rows randomly grow taller, on both the old and new designs. The shared Input/Output cell rendered block markdown kept on one line only by CSS (`* { display: inline }`), which Safari drops when `MarkedText` swaps its `innerHTML` asynchronously—so the block content lays out multi-line and the cell grows. This renders the cell as inline-only markdown so `white-space: nowrap` clamps it to one line without relying on that fragile override.