### PR TITLE
feat(seer): Render docs-link embeds in Seer Explorer markdown

### DIFF
--- a/static/app/components/core/markdown/markdown.mdx
+++ b/static/app/components/core/markdown/markdown.mdx
@@ -184,6 +184,9 @@ function StreamingExample() {
 
 Tags are a minimal Markdown syntax extension for custom embedded components. Inspired by [Markdoc](https://markdoc.dev/) tag syntax, they let consumers wire up their own integration surface — for example, Seer uses tags to embed entity refs and generated artifacts inline in streamed markdown.
 
+> [!NOTE]
+> Seer output should use `<SeerMarkdown>`. For the list of components available by default in `SeerMarkdown`, see the [SeerMarkdown](/stories/product/views/seerexplorer/components/chat/seermarkdown/) story.
+
 Two syntax forms are supported:
 
 **Self-closing** — inline within text, no body:

--- a/static/app/views/seerExplorer/components/chat/__stories__/seerEmbeds.tsx
+++ b/static/app/views/seerExplorer/components/chat/__stories__/seerEmbeds.tsx
@@ -1,0 +1,30 @@
+import {InlineCode} from '@sentry/scraps/code';
+import {Text} from '@sentry/scraps/text';
+
+import * as Storybook from 'sentry/stories';
+import {SeerComponentRegistry} from 'sentry/views/seerExplorer/components/chat/seerComponents';
+
+export function SeerEmbedTable() {
+  const embeds = SeerComponentRegistry.list();
+
+  return (
+    <Storybook.Table>
+      <thead>
+        <tr>
+          <th>Tag</th>
+          <th>Rendered</th>
+        </tr>
+      </thead>
+      <tbody>
+        {embeds.map(({name, component: Embed, example}) => (
+          <tr key={name}>
+            <td>
+              <InlineCode>{name}</InlineCode>
+            </td>
+            <td>{example ? <Embed {...example} /> : <Text variant="muted">—</Text>}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Storybook.Table>
+  );
+}

--- a/static/app/views/seerExplorer/components/chat/docsLink.mdx
+++ b/static/app/views/seerExplorer/components/chat/docsLink.mdx
@@ -1,0 +1,58 @@
+---
+title: Docs Link
+description: Renders an inline link to the Sentry documentation, embedded in Seer Explorer markdown via a docs-link tag.
+source: 'sentry/views/seerExplorer/components/chat/docsLink'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/views/seerExplorer/components/chat/docsLink.tsx
+---
+
+import * as Storybook from 'sentry/stories';
+import {DocsLink} from 'sentry/views/seerExplorer/components/chat/docsLink';
+import {SeerMarkdown} from 'sentry/views/seerExplorer/components/chat/shared';
+
+`<DocsLink>` renders a link to a page in the Sentry documentation. Seer Explorer emits it as an embed inside its markdown so that references to Sentry features become rich, clickable links instead of bare URLs.
+
+The component takes a `url` and a `title` and renders an external link.
+
+<Storybook.Demo>
+  <DocsLink url="https://docs.sentry.io/product/issues/" title="Issues" />
+</Storybook.Demo>
+
+```jsx
+<DocsLink url="https://docs.sentry.io/product/issues/" title="Issues" />
+```
+
+## Markdown tag
+
+`<DocsLink>` is wired into Seer's markdown as the `docs-link` [tag](/stories/core/markdown/#tags). Seer references the docs by emitting the tag inline; `<SeerMarkdown>` renders it.
+
+Two syntax forms are supported.
+
+**Block** — with a JSON body carrying `url` and `title`:
+
+<Storybook.Demo>
+  <SeerMarkdown
+    raw={`Group similar events with {% docs-link %}{"url": "https://docs.sentry.io/product/issues/grouping-and-fingerprints/", "title": "fingerprints"}{% /docs-link %}, then tune alerts from the {% docs-link %}{"url": "https://docs.sentry.io/product/alerts/", "title": "Alerts"}{% /docs-link %} docs.`}
+  />
+</Storybook.Demo>
+
+```
+Group similar events with {% docs-link %}{"url": "https://docs.sentry.io/product/issues/grouping-and-fingerprints/", "title": "fingerprints"}{% /docs-link %}.
+```
+
+**Self-closing** — with the `url` and `title` as opening-tag attributes:
+
+<Storybook.Demo>
+  <SeerMarkdown
+    raw={`Read the {% docs-link url="https://docs.sentry.io/platforms/" title="Platforms" /%} overview.`}
+  />
+</Storybook.Demo>
+
+```
+Read the {% docs-link url="https://docs.sentry.io/platforms/" title="Platforms" /%} overview.
+```
+
+> [!NOTE]
+> Only absolute `https://docs.sentry.io` URLs render. An embed pointing at any other host — or one missing a `url` — renders nothing, so Seer can't surface off-brand or unsafe links.
+
+`<DocsLink>` is registered as the `docs-link` embed via an adapter that parses the tag's `attrs`/`data` into its props. See the [Seer Markdown](/stories/product/views/seerexplorer/components/chat/seermarkdown/) story for how embeds are registered and rendered.

--- a/static/app/views/seerExplorer/components/chat/docsLink.tsx
+++ b/static/app/views/seerExplorer/components/chat/docsLink.tsx
@@ -1,0 +1,53 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
+import {
+  SeerComponentRegistry,
+  type SeerEmbedProps,
+} from 'sentry/views/seerExplorer/components/chat/seerComponentRegistry';
+
+const DOCS_HOSTNAME = 'docs.sentry.io';
+
+interface DocsLinkProps {
+  title: string;
+  url: string;
+}
+
+export function DocsLink({url, title}: DocsLinkProps) {
+  return <ExternalLink href={url}>{title}</ExternalLink>;
+}
+
+// Seer emits `{% docs-link %}{"url": ..., "title": ...}{% /docs-link %}`; the url/title
+// live on the JSON body (`data`) but we also accept opening-tag attrs as a fallback.
+function parseDocsLink(
+  attrs: Record<string, string>,
+  data: unknown
+): DocsLinkProps | null {
+  const source =
+    data && typeof data === 'object' ? (data as Record<string, unknown>) : attrs;
+  const url = typeof source.url === 'string' ? source.url : undefined;
+  const title = typeof source.title === 'string' ? source.title : undefined;
+  if (!url) {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' || parsed.hostname !== DOCS_HOSTNAME) {
+    return null;
+  }
+  return {url, title: title || url};
+}
+
+function DocsLinkEmbed({attrs, data}: SeerEmbedProps) {
+  const props = parseDocsLink(attrs, data);
+  return props ? <DocsLink {...props} /> : null;
+}
+
+SeerComponentRegistry.register('docs-link', DocsLinkEmbed, {
+  attrs: {},
+  data: {url: 'https://docs.sentry.io/product/issues/', title: 'Issues'},
+  level: 'inline',
+});

--- a/static/app/views/seerExplorer/components/chat/seerComponentRegistry.tsx
+++ b/static/app/views/seerExplorer/components/chat/seerComponentRegistry.tsx
@@ -1,0 +1,49 @@
+import type {ReactNode} from 'react';
+
+/**
+ * The generic props every Seer embed receives, mirroring the markdown `Tag`
+ * renderer. Each embed adapts these into its component's real props.
+ */
+export interface SeerEmbedProps {
+  attrs: Record<string, string>;
+  data: unknown;
+  level: 'block' | 'inline';
+  name: string;
+}
+
+export type SeerEmbedComponent = (props: SeerEmbedProps) => ReactNode;
+
+export interface RegisteredSeerEmbed {
+  component: SeerEmbedComponent;
+  name: string;
+  /** Sample props used to preview the embed in docs/stories. */
+  example?: SeerEmbedProps;
+}
+
+const registry = new Map<string, RegisteredSeerEmbed>();
+
+/**
+ * Registry mapping a markdown tag name (e.g. `docs-link`) to the embed that
+ * renders it. Components register themselves at module load; the markdown `Tag`
+ * renderer looks them up by name. See `seerComponents.tsx` for the import that
+ * pulls every embed in so its registration runs.
+ */
+export const SeerComponentRegistry = {
+  register(
+    name: string,
+    component: SeerEmbedComponent,
+    example?: Omit<SeerEmbedProps, 'name'>
+  ): void {
+    registry.set(name, {
+      name,
+      component,
+      example: example && {name, ...example},
+    });
+  },
+  get(name: string): SeerEmbedComponent | undefined {
+    return registry.get(name)?.component;
+  },
+  list(): RegisteredSeerEmbed[] {
+    return [...registry.values()];
+  },
+};

--- a/static/app/views/seerExplorer/components/chat/seerComponents.tsx
+++ b/static/app/views/seerExplorer/components/chat/seerComponents.tsx
@@ -1,0 +1,6 @@
+// Importing each embed module runs its `SeerComponentRegistry.register(...)`
+// call, wiring the markdown tag name to its renderer. Register new Seer embed
+// components by adding their import here.
+import 'sentry/views/seerExplorer/components/chat/docsLink';
+
+export {SeerComponentRegistry} from 'sentry/views/seerExplorer/components/chat/seerComponentRegistry';

--- a/static/app/views/seerExplorer/components/chat/seerMarkdown.mdx
+++ b/static/app/views/seerExplorer/components/chat/seerMarkdown.mdx
@@ -1,0 +1,116 @@
+---
+title: Seer Markdown
+description: Renders Seer Explorer assistant output as markdown, adding issue linkification, relative links, and embeds on top of the core Markdown component.
+source: 'sentry/views/seerExplorer/components/chat/shared'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/views/seerExplorer/components/chat/shared.tsx
+---
+
+import * as Storybook from 'sentry/stories';
+import {SeerMarkdown} from 'sentry/views/seerExplorer/components/chat/shared';
+
+import {SeerEmbedTable} from './__stories__/seerEmbeds';
+
+`<SeerMarkdown>` wraps the core [`<Markdown>`](/stories/core/markdown/) component with the overrides Seer Explorer uses when rendering streamed assistant responses. It takes the same `raw` (and `variant`) props but fixes the component set, so callers can't override rendering.
+
+<Storybook.Demo>
+  <SeerMarkdown
+    raw={`## Root cause
+
+The token expiration check uses **UTC timestamps** but the session store uses
+_local time_, causing a mismatch during DST transitions.`}
+/>
+
+</Storybook.Demo>
+
+```jsx
+<SeerMarkdown
+  raw={`## Root cause
+
+The token expiration check uses **UTC timestamps** but the session store uses
+_local time_, causing a mismatch during DST transitions.`}
+/>
+```
+
+## Issue linkification
+
+Issue short IDs are turned into links to the issue, both in plain text and inside inline code — so Seer can mention an issue without emitting an explicit markdown link.
+
+<Storybook.Demo>
+  <SeerMarkdown
+    raw={`The regression was traced to SENTRY-1234, related to the earlier fix in \`SENTRY-5678\`.`}
+  />
+</Storybook.Demo>
+
+```
+The regression was traced to SENTRY-1234, related to the earlier fix in `SENTRY-5678`.
+```
+
+## Relative links
+
+Links back to Sentry itself are rewritten to relative paths, so they navigate client-side instead of triggering a full page load. Links to other hosts are left untouched.
+
+## Embeds
+
+Seer can emit embed tags that render as rich inline components. Embeds are looked up by tag name in the `SeerComponentRegistry`; an unrecognized tag renders nothing. See the core [Markdown](/stories/core/markdown/#tags) story for the underlying tag syntax and parser.
+
+### Available embeds
+
+Every embed registered in the `SeerComponentRegistry`, rendered from its example. The `docs-link` embed links into the Sentry documentation — see the [Docs Link](/stories/product/views/seerexplorer/components/chat/docslink/) story for details.
+
+<SeerEmbedTable />
+
+### Adding an embed
+
+1. Add (or reuse) a normal component with real props.
+2. Add an `*Embed` adapter that maps the generic tag props into the component's props.
+3. Register the adapter with the `SeerComponentRegistry`, and make sure its module is imported in `seerComponents.tsx` so the registration runs.
+4. Register the matching embed widget on the backend (see the note below).
+
+Every embed receives the same generic props from the markdown `Tag` renderer:
+
+```tsx
+// seerComponentRegistry.tsx
+interface SeerEmbedProps {
+  attrs: Record<string, string>; // key="value" pairs from the opening tag
+  data: unknown; // parsed JSON body, or undefined for self-closing tags
+  level: 'block' | 'inline';
+  name: string;
+}
+```
+
+The component itself stays a plain component with real props and an adapter maps the generic props onto them:
+
+```tsx
+// docsLink.tsx
+interface DocsLinkProps {
+  title: string;
+  url: string;
+}
+
+// A normal component with real props. Kept separate from the tag format so it
+// can be rendered anywhere, not just inside SeerMarkdown.
+export function DocsLink({url, title}: DocsLinkProps) {
+  /* ...renders the link... */
+}
+
+// Adapter: parses the generic tag props into DocsLink's real props.
+function DocsLinkEmbed({attrs, data}: SeerEmbedProps) {
+  const props = parseDocsLink(attrs, data); // validate + adapt, or null
+  return props ? <DocsLink {...props} /> : null;
+}
+
+// Registering here (rather than in SeerMarkdown's Tag renderer) means adding an
+// embed only touches this one file — no central switch to edit.
+SeerComponentRegistry.register('docs-link', DocsLinkEmbed);
+```
+
+Registration runs when the module is imported, so add the embed's import to `seerComponents.tsx`:
+
+```tsx
+// seerComponents.tsx
+import 'sentry/views/seerExplorer/components/chat/docsLink';
+```
+
+> [!NOTE]
+> Registering the frontend component is only half of an embed. Seer won't emit the tag unless a matching embed widget is registered on the backend in [`src/sentry/seer/agent/embed_widgets.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/seer/agent/embed_widgets.py). Add the tag in both places.

--- a/static/app/views/seerExplorer/components/chat/shared.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/shared.spec.tsx
@@ -1,0 +1,38 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/views/seerExplorer/components/chat/shared';
+
+describe('SeerMarkdown docs-link tag', () => {
+  it('renders a link from the JSON body', () => {
+    render(
+      <SeerMarkdown raw='{% docs-link %}{"url": "https://docs.sentry.io/product/issues/", "title": "Issues"}{% /docs-link %}' />
+    );
+    const link = screen.getByRole('link', {name: 'Issues'});
+    expect(link).toHaveAttribute('href', 'https://docs.sentry.io/product/issues/');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('accepts opening-tag attrs as a fallback', () => {
+    render(
+      <SeerMarkdown raw='{% docs-link url="https://docs.sentry.io/platforms/" title="Platforms" /%}' />
+    );
+    expect(screen.getByRole('link', {name: 'Platforms'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/'
+    );
+  });
+
+  it('ignores links to non-docs hosts', () => {
+    render(
+      <SeerMarkdown raw='{% docs-link %}{"url": "https://evil.example.com/", "title": "Nope"}{% /docs-link %}' />
+    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('ignores an entry with no url', () => {
+    render(
+      <SeerMarkdown raw='{% docs-link %}{"title": "Missing url"}{% /docs-link %}' />
+    );
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerExplorer/components/chat/shared.tsx
+++ b/static/app/views/seerExplorer/components/chat/shared.tsx
@@ -8,6 +8,7 @@ import {Link} from '@sentry/scraps/link';
 import {Markdown, type MarkdownProps} from '@sentry/scraps/markdown';
 import {Heading} from '@sentry/scraps/text';
 
+import {SeerComponentRegistry} from 'sentry/views/seerExplorer/components/chat/seerComponents';
 import type {Block, SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 
 interface BlockVariantProps {
@@ -118,6 +119,13 @@ function toRelativeHref(href: string): string {
 }
 
 const SEER_MARKDOWN_COMPONENTS: MarkdownProps['components'] = {
+  Tag: ({name, attrs, data, level, Default}) => {
+    const Embed = SeerComponentRegistry.get(name);
+    if (Embed) {
+      return <Embed name={name} attrs={attrs} data={data} level={level} />;
+    }
+    return <Default name={name} attrs={attrs} data={data} level={level} />;
+  },
   Link: ({children, Default, href, title}) => (
     <IsInsideLinkContext.Provider value>
       <Default href={toRelativeHref(href)} title={title}>


### PR DESCRIPTION
Adds a `SeerComponentRegistry` and wires `SeerMarkdown`'s `Tag` renderer to look embeds up by name instead of hardcoding them. The first embed, `docs-link`, renders a validated link into the Sentry docs (only `https://docs.sentry.io` URLs render).

Each embed is a normal component with real props, paired with a thin adapter that maps the generic tag props (`attrs`/`data`) onto them. Adapters self-register, so adding an embed touches a single file — no central switch.