### PR TITLE
docs(api): Add download query parameter to attachment details OpenAPI schema

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -79,7 +79,7 @@ class EventAttachmentDetailsPermission(ProjectPermission):
 @extend_schema(tags=["Events"])
 @cell_silo_endpoint
 class EventAttachmentDetailsEndpoint(ProjectEndpoint):
-    owner = ApiOwner.OWNERS_INGEST
+    owner = ApiOwner.FOUNDATIONAL_STORAGE
     publish_status = {
         "DELETE": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PUBLIC,

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -39,10 +39,11 @@ DOWNLOAD_PARAM = OpenApiParameter(
     name="download",
     location="query",
     required=False,
-    type=bool,
+    type=str,
     description=(
-        "If set, the response will be a binary file download instead of JSON metadata. "
-        "The response will include `Content-Disposition` and `Content-Type` headers."
+        "If this parameter is present, the response will be a binary file download "
+        "instead of JSON metadata. The value does not matter — any value (including "
+        "empty) triggers the download."
     ),
 )
 

--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -35,6 +35,17 @@ ATTACHMENT_ID_PARAM = OpenApiParameter(
     description="The numeric ID of the attachment, as returned from the attachments list endpoint.",
 )
 
+DOWNLOAD_PARAM = OpenApiParameter(
+    name="download",
+    location="query",
+    required=False,
+    type=bool,
+    description=(
+        "If set, the response will be a binary file download instead of JSON metadata. "
+        "The response will include `Content-Disposition` and `Content-Type` headers."
+    ),
+)
+
 
 class EventAttachmentDetailsPermission(ProjectPermission):
     def has_object_permission(self, request: Request, view, project):
@@ -100,6 +111,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
             GlobalParams.PROJECT_ID_OR_SLUG,
             EventParams.EVENT_ID,
             ATTACHMENT_ID_PARAM,
+            DOWNLOAD_PARAM,
         ],
         responses={
             200: inline_sentry_response_serializer(
@@ -120,7 +132,8 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
         | StreamingHttpResponse
     ):
         """
-        Retrieve metadata for a single attachment on an event.
+        Retrieve metadata for a single attachment on an event, or download its
+        contents by passing the `download` query parameter.
 
         Requires the `event-attachments` organization feature.
         """

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -33,7 +33,7 @@ EVENT_ATTACHMENTS_QUERY_PARAM = OpenApiParameter(
 @extend_schema(tags=["Events"])
 @cell_silo_endpoint
 class EventAttachmentsEndpoint(ProjectEndpoint):
-    owner = ApiOwner.OWNERS_INGEST
+    owner = ApiOwner.FOUNDATIONAL_STORAGE
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }


### PR DESCRIPTION
The event attachment details endpoint supports a `download` query parameter
that switches the response from JSON metadata to a binary file stream, but
this parameter was not declared in the `@extend_schema` decorator and was
therefore missing from the generated API docs.

Closes FS-387