### PR TITLE
feat(pr-metrics): Record sentry-app PR attribution on close

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -161,7 +161,10 @@ def handle_attribution(
     if pr is None:
         return
 
-    if action == "opened":
+    # SENTRY_APP author attribution is recorded on open and re-checked on close.
+    # This is for the unlikely event that we missed the open webhook or for cases
+    # where the PR open and closes super fast and the webhooks might be out of order
+    if action in ("opened", "closed"):
         pr_url = (pull_request or {}).get("html_url") or None
         _write_author_attribution(pr, github_user, pr_url=pr_url, group_ids=resolved_group_ids(pr))
     if features.has("organizations:mcp-issue-view-attribution", organization):

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -102,7 +102,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
 
         assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
 
-    def test_app_attribution_only_written_on_opened(self) -> None:
+    def test_app_attribution_not_written_on_non_terminal_actions(self) -> None:
         self._call(action="synchronize", user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
         self._call(action="labeled", user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID)
 
@@ -111,12 +111,34 @@ class HandleWebhookForPrMetricsTest(TestCase):
             signal_type=PullRequestAttributionSignalType.SENTRY_APP,
         ).exists()
 
+    def test_app_attribution_written_on_closed(self) -> None:
+        # A Sentry-authored PR that never got a row at open (e.g. opened before the
+        # flag, or resolving no issues) is still attributed at the terminal close
+        # event so it can be tracked for emission.
+        self._call(action="closed", user_id=settings.SENTRY_GITHUB_APP_USER_ID)
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_type == PullRequestAttributionSignalType.SENTRY_APP
+        assert attr.source == PullRequestAttributionSource.WEBHOOK_DATA
+        assert attr.is_valid is True
+
+    def test_app_attribution_idempotent_across_open_then_close(self) -> None:
+        self._call(action="opened", user_id=settings.SENTRY_GITHUB_APP_USER_ID)
+        self._call(action="closed", user_id=settings.SENTRY_GITHUB_APP_USER_ID)
+
+        assert (
+            PullRequestAttribution.objects.filter(
+                pull_request=self.pr,
+                signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            ).count()
+            == 1
+        )
+
     # --- Action gate ---
 
     def test_irrelevant_actions_skipped(self) -> None:
         for action in (
             "synchronize",
-            "closed",
             "labeled",
             "assigned",
         ):


### PR DESCRIPTION
There are some attribution signals that we should be capturing but are not.
The difference comes basically from events that `ai.autofix.pr.closed|merged` record but we don't record attribution to.

I think it could be the webhooks come out of order for PRs that open and close super fast? I've seen an example that the open-close was like 3mins. Maybe things get swapped and we don't process the attribution in time.

Because this one is cheap enough we can just double-check on close. This should be pretty safe to do.

---
# AI fluff
## Summary

`handle_attribution` (the `pull_request` webhook processor for PR Merge Live Metrics) only recorded the `SENTRY_APP` author signal on the `opened` action. A Sentry-authored PR that missed its open webhook — or was opened before the `organizations:pr-metrics-attribution` flag was enabled — therefore had no attribution row, so it was never tracked for emission when it closed.

This re-checks the author signal on `closed` as well, so those PRs still get a `SENTRY_APP` attribution and can emit at their terminal event.

## Details

- `_write_author_attribution` writes only when the PR author is the Seer/Sentry GitHub app, so this is scoped to `SENTRY_APP`. MCP and delegated-agent attribution stay `opened`-only for now.
- `record_attribution_signal` is keyed on `(pull_request, signal_type, source)` — the model's unique constraint — so re-running at close doesn't duplicate the row. When it already exists it refreshes `signal_details` in place (`resolved_group_ids` may resolve more at close than at open), which is acceptable here.
- `handle_attribution` runs before `handle_emission` in the same webhook delivery, so a PR first attributed at close is tracked in time to emit.
- `run_id` is left unset and `group_ids` is whatever `resolved_group_ids` returns (empty for group-less Sentry PRs) — no run-state lookup is added on this path.
