### PR TITLE
feat(agents): Preview multiple tool-call arguments

### DIFF
--- a/static/app/views/explore/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCalls.tsx
@@ -9,7 +9,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {ToolCall} from 'sentry/views/explore/conversations/utils/conversationMessages';
-import {getFirstToolInputValue} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {getToolInputPreview} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 
 interface MessageToolCallsProps {
@@ -85,13 +85,13 @@ export function MessageToolCalls({
 }
 
 function ToolInputPreview({node}: {node: AITraceSpanNode}) {
-  const firstInputValue = getFirstToolInputValue(node);
-  if (!firstInputValue) {
+  const inputPreview = getToolInputPreview(node);
+  if (!inputPreview) {
     return null;
   }
   return (
     <Text size="xs" monospace variant="muted" ellipsis>
-      {firstInputValue}
+      {inputPreview}
     </Text>
   );
 }

--- a/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
@@ -13,7 +13,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {ToolTag} from 'sentry/views/explore/conversations/components/toolTag';
 import {TurnMeta} from 'sentry/views/explore/conversations/components/turnMeta';
 import type {ToolCall} from 'sentry/views/explore/conversations/utils/conversationMessages';
-import {getFirstToolInputValue} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {getToolInputPreview} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {useToolOutputBytes} from 'sentry/views/insights/pages/agents/utils/useToolOutputBytes';
 
@@ -151,13 +151,13 @@ function ToolOutputSize({
 }
 
 function ToolInputPreview({node}: {node: AITraceSpanNode}) {
-  const firstInputValue = getFirstToolInputValue(node);
-  if (!firstInputValue) {
+  const inputPreview = getToolInputPreview(node);
+  if (!inputPreview) {
     return null;
   }
   return (
     <Text size="xs" monospace variant="muted" ellipsis>
-      {firstInputValue}
+      {inputPreview}
     </Text>
   );
 }

--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -13,7 +13,7 @@ import {t} from 'sentry/locale';
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {
-  getFirstToolInputValue,
+  getToolInputPreview,
   getGenAiOpType,
   getIsAiAgentNode,
   getNumberAttr,
@@ -500,12 +500,12 @@ function getSpanPresentation(
     }
     case GenAiOperationType.TOOL: {
       const toolName = getStringAttr(node, SpanFields.GEN_AI_TOOL_NAME);
-      const firstInputValue = getFirstToolInputValue(node);
+      const inputPreview = getToolInputPreview(node);
       return {
         icon: <IconFix size="md" />,
         color,
         title: toolName || op,
-        subtitle: firstInputValue || (toolName ? op : ''),
+        subtitle: inputPreview || (toolName ? op : ''),
       };
     }
     case GenAiOperationType.HANDOFF:

--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -22,7 +22,7 @@ import {
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {
   type ColorByOpType,
-  getFirstToolInputValue,
+  getToolInputPreview,
   getGenAiOpType,
   getIsAiAgentNode,
   getNumberAttr,
@@ -334,13 +334,13 @@ function getSpanPresentation(
     }
     case GenAiOperationType.TOOL: {
       const toolName = getStringAttr(node, SpanFields.GEN_AI_TOOL_NAME);
-      const firstInputValue = getFirstToolInputValue(node);
+      const inputPreview = getToolInputPreview(node);
       return {
         icon: <IconFix size="md" />,
         color,
         isTool: true,
         title: toolName || op,
-        secondary: firstInputValue || '',
+        secondary: inputPreview || '',
       };
     }
     case GenAiOperationType.HANDOFF:

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
@@ -1,7 +1,16 @@
 import {SpanFields} from 'sentry/views/insights/types';
 
-import {hasError} from './aiTraceNodes';
+import {getToolInputPreview, hasError} from './aiTraceNodes';
 import type {AITraceSpanNode} from './types';
+
+function makeToolNode(toolInput?: unknown): AITraceSpanNode {
+  const attributes: Record<string, unknown> = {};
+  if (toolInput !== undefined) {
+    attributes['gen_ai.tool.call.arguments'] =
+      typeof toolInput === 'string' ? toolInput : JSON.stringify(toolInput);
+  }
+  return {errors: new Set(), attributes} as unknown as AITraceSpanNode;
+}
 
 function makeNode({
   errorCount = 0,
@@ -26,6 +35,46 @@ function makeNode({
     attributes,
   } as unknown as AITraceSpanNode;
 }
+
+describe('getToolInputPreview', () => {
+  it('returns undefined when there is no tool input', () => {
+    expect(getToolInputPreview(makeToolNode())).toBeUndefined();
+  });
+
+  it('renders multiple object keys as `key: value` pairs', () => {
+    const node = makeToolNode({path: 'src/foo.ts', limit: 10, recursive: true});
+    expect(getToolInputPreview(node)).toBe(
+      'path: "src/foo.ts", limit: 10, recursive: true'
+    );
+  });
+
+  it('caps the preview at four keys', () => {
+    const node = makeToolNode({a: 1, b: 2, c: 3, d: 4, e: 5});
+    expect(getToolInputPreview(node)).toBe('a: 1, b: 2, c: 3, d: 4');
+  });
+
+  it('truncates long string values', () => {
+    const node = makeToolNode({query: 'x'.repeat(60)});
+    const preview = getToolInputPreview(node)!;
+    expect(preview.startsWith('query: "')).toBe(true);
+    expect(preview).toContain('...');
+    expect(preview.length).toBeLessThan(60);
+  });
+
+  it('previews non-object JSON (array) as a truncated string', () => {
+    const node = makeToolNode(['a', 'b', 'c']);
+    expect(getToolInputPreview(node)).toBe('["a","b","c"]');
+  });
+
+  it('falls back to the raw string for invalid JSON', () => {
+    const node = makeToolNode('not json');
+    expect(getToolInputPreview(node)).toBe('not json');
+  });
+
+  it('returns undefined for an empty object', () => {
+    expect(getToolInputPreview(makeToolNode({}))).toBeUndefined();
+  });
+});
 
 describe('hasError', () => {
   it('returns true when node has explicit errors', () => {

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -144,13 +144,75 @@ export function getNumberAttr(node: AITraceSpanNode, field: string): number | un
   return undefined;
 }
 
-const MAX_TOOL_INPUT_PREVIEW_LENGTH = 80;
+const MAX_TOOL_INPUT_PREVIEW_LENGTH = 96;
+const MAX_TOOL_INPUT_VALUE_LENGTH = 48;
+const MAX_TOOL_INPUT_PREVIEW_KEYS = 4;
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength
+    ? `${value.slice(0, Math.max(0, maxLength - 3))}...`
+    : value;
+}
+
+function previewToolArgumentValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(truncateText(value, MAX_TOOL_INPUT_VALUE_LENGTH));
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return truncateText(
+    JSON.stringify(value).replace(/\s+/g, ' ').trim(),
+    MAX_TOOL_INPUT_VALUE_LENGTH
+  );
+}
+
+function formatToolInputPreview(input: unknown): string | undefined {
+  if (input === null || input === undefined || input === '') {
+    return undefined;
+  }
+
+  if (typeof input === 'string') {
+    const formatted = input.replace(/\s+/g, ' ').trim();
+    return formatted ? truncateText(formatted, MAX_TOOL_INPUT_PREVIEW_LENGTH) : undefined;
+  }
+
+  if (Array.isArray(input)) {
+    return truncateText(
+      JSON.stringify(input).replace(/\s+/g, ' ').trim(),
+      MAX_TOOL_INPUT_PREVIEW_LENGTH
+    );
+  }
+
+  if (typeof input === 'object') {
+    const entries = Object.entries(input as Record<string, unknown>).slice(
+      0,
+      MAX_TOOL_INPUT_PREVIEW_KEYS
+    );
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return entries
+      .map(([key, value]) => `${key}: ${previewToolArgumentValue(value)}`)
+      .join(', ');
+  }
+
+  if (typeof input === 'number' || typeof input === 'boolean') {
+    return String(input);
+  }
+
+  return undefined;
+}
 
 /**
- * Parses tool input JSON and returns the value of the first key.
- * Used to show a preview of the tool input next to the tool name.
+ * Builds a compact preview of a tool call's input arguments to show next to the
+ * tool name. Objects are rendered as `key1: "value1", key2: "value2"` (up to
+ * four keys); strings, arrays, and primitives are stringified and truncated.
  */
-export function getFirstToolInputValue(node: AITraceSpanNode): string | undefined {
+export function getToolInputPreview(node: AITraceSpanNode): string | undefined {
   const toolInput =
     getStringAttr(node, 'gen_ai.tool.call.arguments') ||
     getStringAttr(node, 'gen_ai.tool.input');
@@ -158,24 +220,15 @@ export function getFirstToolInputValue(node: AITraceSpanNode): string | undefine
     return undefined;
   }
 
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(toolInput);
-    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-      const firstKey = Object.keys(parsed)[0];
-      if (firstKey !== undefined) {
-        const value = parsed[firstKey];
-        const str = typeof value === 'string' ? value : JSON.stringify(value);
-        if (str.length > MAX_TOOL_INPUT_PREVIEW_LENGTH) {
-          return str.slice(0, MAX_TOOL_INPUT_PREVIEW_LENGTH) + '\u2026';
-        }
-        return str;
-      }
-    }
+    parsed = JSON.parse(toolInput);
   } catch {
-    // Invalid JSON, return undefined
+    // Not valid JSON; fall back to previewing the raw string.
+    parsed = toolInput;
   }
 
-  return undefined;
+  return formatToolInputPreview(parsed);
 }
 
 export function hasError(node: AITraceSpanNode): boolean {

--- a/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRow/traceEAPSpanRow.tsx
@@ -3,7 +3,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {
-  getFirstToolInputValue,
+  getToolInputPreview,
   getStringAttr,
 } from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
@@ -24,7 +24,7 @@ import {
 
 /**
  * Returns an enriched description for AI spans when attributes are available.
- * - Tool spans: "toolName: firstInputValue"
+ * - Tool spans: "toolName: inputPreview"
  * - AI client spans: responseModel (e.g., "gpt-4o")
  * Falls back to undefined so the caller can use the default description.
  */
@@ -44,9 +44,9 @@ function getAIEnhancedDescription(node: EapSpanNode): string | undefined {
 
   if (opType === GenAiOperationType.TOOL) {
     const toolName = getStringAttr(node as any, SpanFields.GEN_AI_TOOL_NAME);
-    const firstValue = getFirstToolInputValue(node as any);
-    if (toolName && firstValue) {
-      return `${toolName}: ${firstValue}`;
+    const inputPreview = getToolInputPreview(node as any);
+    if (toolName && inputPreview) {
+      return `${toolName}: ${inputPreview}`;
     }
     return toolName ?? undefined;
   }


### PR DESCRIPTION
Tool-call previews in the conversation transcript, AI span timeline, and trace-detail rows now show several arguments instead of just the first key's value, so a call like a file read renders `path: "src/foo.ts", limit: 10` rather than a bare `src/foo.ts`.

**Preview format**

`getFirstToolInputValue` is renamed to `getToolInputPreview`. Object inputs render up to four `key: "value"` pairs with each value truncated (~48 chars); strings and arrays are whitespace-collapsed and truncated (~96 chars). String values are quoted via `JSON.stringify`, and numbers/booleans render bare.

**Invalid JSON**

Non-JSON tool input previously returned nothing; it now falls back to a truncated raw-string preview. The helper still returns a plain string, so all existing consumers render it unchanged.

<img width="1558" height="544" alt="CleanShot 2026-07-07 at 15 39 50" src="https://github.com/user-attachments/assets/480c09be-0503-4904-85d5-5453a8332fe3" />

Closes https://linear.app/getsentry/issue/TET-2625/smarter-preview-of-tool-call-attributes