### PR TITLE
feat(conversations): Indent nested collapsible XML tags

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
@@ -60,4 +60,20 @@ describe('AIContentRenderer', () => {
     render(<AIContentRenderer text="simple text" />);
     expect(screen.getByText('simple text')).toBeInTheDocument();
   });
+
+  it('renders collapsible XML tags with tag name label', () => {
+    const text = '<thinking>\nsome thought\n</thinking>';
+    render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+
+    expect(screen.getByText('thinking')).toBeInTheDocument();
+  });
+
+  it('renders nested collapsible XML with hierarchy', () => {
+    const text = '<outer>\n<inner>nested content</inner>\n</outer>';
+    render(<AIContentRenderer text={text} inline collapsibleXmlTags />);
+
+    expect(screen.getByText('outer')).toBeInTheDocument();
+    expect(screen.getByText('inner')).toBeInTheDocument();
+    expect(screen.getByText('nested content')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -45,7 +45,9 @@ function XmlTagBlock({
     return (
       <Container margin="sm 0">
         <CollapsibleContent title={label}>
-          <Container paddingTop="md">{body}</Container>
+          <Container paddingTop="md" paddingLeft="md">
+            {body}
+          </Container>
         </CollapsibleContent>
       </Container>
     );


### PR DESCRIPTION
Add left padding to collapsible XML tag content so nested tags are visually indented when expanded. Previously all nesting levels rendered flat.

<img width="699" height="305" alt="CleanShot 2026-07-07 at 16 48 10" src="https://github.com/user-attachments/assets/430e63ae-4d47-421f-a732-9b48020f887e" />

Closes TET-2618