### PR TITLE
Handle Ask Seer wildcard query formatting

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.spec.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.spec.ts
@@ -1,4 +1,10 @@
-import {generateQueryTokensString, getExpandedProjectIds} from './utils';
+import {WildcardOperators} from 'sentry/components/searchSyntax/parser';
+
+import {
+  formatQueryToNaturalLanguage,
+  generateQueryTokensString,
+  getExpandedProjectIds,
+} from './utils';
 
 describe('getExpandedProjectIds', () => {
   it.each([null, undefined, []])('returns undefined when projects is %s', input => {
@@ -41,5 +47,44 @@ describe('generateQueryTokensString', () => {
     expect(generateQueryTokensString({expandedProjectIds: [1]})).toBe(
       'search expanded to 1 project'
     );
+  });
+
+  it('formats wildcard operators without private unicode markers', () => {
+    expect(
+      generateQueryTokensString({
+        query: `browser.name:${WildcardOperators.CONTAINS}FireFox`,
+      })
+    ).toBe("Filter is 'browser.name contains FireFox '");
+  });
+});
+
+describe('formatQueryToNaturalLanguage', () => {
+  it.each([
+    {
+      query: `browser.name:${WildcardOperators.CONTAINS}FireFox`,
+      expected: 'browser.name contains FireFox ',
+    },
+    {
+      query: `url:${WildcardOperators.STARTS_WITH}/api`,
+      expected: 'url starts with /api ',
+    },
+    {
+      query: `path:${WildcardOperators.ENDS_WITH}.js`,
+      expected: 'path ends with .js ',
+    },
+    {
+      query: `!browser.name:${WildcardOperators.CONTAINS}FireFox`,
+      expected: 'browser.name does not contain FireFox ',
+    },
+    {
+      query: `!url:${WildcardOperators.STARTS_WITH}/api`,
+      expected: 'url does not start with /api ',
+    },
+    {
+      query: `!path:${WildcardOperators.ENDS_WITH}.js`,
+      expected: 'path does not end with .js ',
+    },
+  ])('formats $query as $expected', ({query, expected}) => {
+    expect(formatQueryToNaturalLanguage(query)).toBe(expected);
   });
 });

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -6,6 +6,12 @@ import type {
   NoneOfTheseItem,
   QueryTokensProps,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/types';
+import {OP_LABELS} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {
+  TermOperator,
+  type WildcardOperator,
+  wildcardOperators,
+} from 'sentry/components/searchSyntax/parser';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 
@@ -91,9 +97,49 @@ export function getExpandedProjectIds(
   return hasExtraProjects ? returnedProjectIds : undefined;
 }
 
+const NEGATED_WILDCARD_OPERATOR_LABELS: Partial<Record<WildcardOperator, string>> = {
+  [TermOperator.CONTAINS]: OP_LABELS[TermOperator.DOES_NOT_CONTAIN],
+  [TermOperator.STARTS_WITH]: OP_LABELS[TermOperator.DOES_NOT_START_WITH],
+  [TermOperator.ENDS_WITH]: OP_LABELS[TermOperator.DOES_NOT_END_WITH],
+};
+
+function getWildcardOperatorLabel(
+  operator: WildcardOperator,
+  isNegated: boolean
+): string {
+  if (isNegated) {
+    return NEGATED_WILDCARD_OPERATOR_LABELS[operator] ?? `not ${OP_LABELS[operator]}`;
+  }
+
+  return OP_LABELS[operator];
+}
+
+function formatWildcardToken(token: string, isNegated: boolean): string | null {
+  for (const operator of wildcardOperators) {
+    const operatorIndex = token.indexOf(operator);
+
+    if (operatorIndex === -1) {
+      continue;
+    }
+
+    const key = token.slice(0, operatorIndex).replace(/:$/, '').trim();
+    const value = token.slice(operatorIndex + operator.length).trim();
+    const description = getWildcardOperatorLabel(operator, isNegated);
+
+    return `${key} ${description} ${value}`.replace(/\s+/g, ' ').trim();
+  }
+
+  return null;
+}
+
 function formatToken(token: string): string {
   const isNegated = token.startsWith('!') && token.includes(':');
   const actualToken = isNegated ? token.slice(1) : token;
+  const wildcardToken = formatWildcardToken(actualToken, isNegated);
+
+  if (wildcardToken) {
+    return wildcardToken;
+  }
 
   const operators = [
     [':>=', 'greater than or equal to'],


### PR DESCRIPTION
The goal of this PR is to properly convert wildcard operators with Ask Seer.

Closes EXP-1083

<img width="1213" height="83" alt="Screenshot 2026-07-07 at 11 51 02" src="https://github.com/user-attachments/assets/959b89d0-1a34-4515-8e49-68dfe5b98b66" />

converts to

<img width="1210" height="89" alt="Screenshot 2026-07-07 at 11 51 11" src="https://github.com/user-attachments/assets/d757a40a-56a3-4501-aac0-7eaa0f7b128f" />