### PR TITLE
fix(trials): Fix missing and negative day-count in product trial alerts and tags

### DIFF
--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -112,7 +112,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
         {t('Learn More')}
       </LinkButton>
     );
-  } else if (daysLeft > 0 && daysLeft <= 7 && trial.isStarted) {
+  } else if (daysLeft >= 0 && daysLeft <= 7 && trial.isStarted) {
     alertHeader = t('%s Trial', titleCase(getProductName(trial.category)));
     if (isPaid && categoryUsesOnDemand) {
       alertText = t(

--- a/static/gsApp/components/productTrial/productTrialTag.tsx
+++ b/static/gsApp/components/productTrial/productTrialTag.tsx
@@ -1,5 +1,3 @@
-import moment from 'moment-timezone';
-
 import {Tag, type TagProps} from '@sentry/scraps/badge';
 
 import {IconBusiness} from 'sentry/icons';
@@ -21,9 +19,9 @@ export function ProductTrialTag({
   variant,
   showTrialEnded = false,
 }: ProductTrialTagProps) {
-  const now = moment();
+  const daysLeft = -1 * getDaysSinceDate(trial.endDate ?? '');
 
-  if (moment(trial.endDate).add(1, 'days').isBefore(now)) {
+  if (daysLeft < 0) {
     if (!showTrialEnded) {
       return null;
     }
@@ -42,8 +40,6 @@ export function ProductTrialTag({
       </Tag>
     );
   }
-
-  const daysLeft = -1 * getDaysSinceDate(trial.endDate ?? '');
 
   return (
     <Tag icon={<IconClock />} variant={variant ?? (daysLeft <= 7 ? 'warning' : 'info')}>


### PR DESCRIPTION
Two related bugs in the logging trial UI when a trial's `endDate` is today or yesterday.

**Bug 1 — `ProductTrialTag` shows "-1 days left" instead of "Trial ended"**

When `endDate` has a late-day time component (e.g. `2026-07-05T23:00:00`), the old "Trial ended" guard used an exact timestamp check: `moment(endDate).add(1, 'days').isBefore(now)`. If `endDate + 1 day` hasn't passed in clock time, the guard doesn't fire. But `getDaysSinceDate` normalizes to start-of-day before diffing, so it returns `1` for a trial that ended yesterday regardless of time — producing `daysLeft = -1` and rendering "-1 days left".

Fix: compute `daysLeft` first via `getDaysSinceDate` (the single source of truth), then branch on `daysLeft < 0` for the "Trial ended" state.

**Bug 2 — `ProductTrialAlert` renders nothing when `daysLeft === 0`**

When the trial ends today (`daysLeft === 0` and `trial.isStarted === true`), none of the four conditional branches in `ProductTrialAlert` matched:

- `daysLeft >= 0 && !isStarted` — false (trial is started)
- `daysLeft > 7` — false
- `daysLeft > 0 && daysLeft <= 7` — false (`0 > 0` is false)
- `daysLeft < 0` — false

So `alertHeader`, `alertText`, `alertButton` all stayed null and the alert rendered invisible — no notice shown at all.

Fix: change `daysLeft > 0 && daysLeft <= 7` to `daysLeft >= 0 && daysLeft <= 7` to include the last-day case in the 0–7 days remaining branch.