### PR TITLE
fix(snapshots): Use sun icon for light/dark preview toggle

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -10,14 +10,7 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {
-  IconFile,
-  IconInfo,
-  IconLightning,
-  IconLink,
-  IconMoon,
-  IconWarning,
-} from 'sentry/icons';
+import {IconFile, IconInfo, IconLink, IconMoon, IconSun, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -368,7 +361,7 @@ export const CardHeader = memo(function CardHeader({
           <IconButton
             aria-label={isDark ? t('Light preview') : t('Dark preview')}
             tooltip={isDark ? t('Light preview') : t('Dark preview')}
-            icon={isDark ? <IconLightning size="sm" /> : <IconMoon size="sm" />}
+            icon={isDark ? <IconSun size="sm" /> : <IconMoon size="sm" />}
             onClick={onToggleDark}
           />
           <IconButton


### PR DESCRIPTION
## Summary

The snapshot preview's light/dark theme toggle used a lightning bolt icon (`IconLightning`) to represent switching to light mode, which didn't convey "light" at all. Swap it for the `IconSun` icon that's now available in the icon set.

The toggle keeps its action-based convention (the icon shows what clicking switches you *to*), so it stays consistent with the existing `Light preview` / `Dark preview` tooltip and aria-label:

- **Dark mode** → sun icon + "Light preview"
- **Light mode** → moon icon + "Dark preview"

## Changes

- `snapshotCards.tsx`: replace `IconLightning` with `IconSun` in the theme toggle `IconButton` and update the import.