### PR TITLE
ref(workflow_engine): Dual-write NotifyEventAction to be handled by webhook handler

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -137,7 +137,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
 
             try:
                 notification_actions_data = translate_rule_data_actions_to_notification_actions(
-                    [action_blob], skip_failures=False
+                    [action_blob], skip_failures=False, project=rule.project
                 )
                 actions = [Action(**action_data) for action_data in notification_actions_data]
                 action = actions[0]

--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -139,6 +139,10 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 notification_actions_data = translate_rule_data_actions_to_notification_actions(
                     [action_blob], skip_failures=False, project=rule.project
                 )
+                # An action can translate to nothing (e.g. a NotifyEventAction on a project without
+                # legacy webhooks enabled), leaving no action to test-fire, so skip it.
+                if not notification_actions_data:
+                    continue
                 actions = [Action(**action_data) for action_data in notification_actions_data]
                 action = actions[0]
                 action.id = TEST_NOTIFICATION_ID

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -786,7 +786,7 @@ def format_request_data(
 
     translated_actions: list[ActionInput] = []
     for action_data in translate_rule_data_actions_to_notification_actions(
-        data.get("actions", []), False
+        data.get("actions", []), False, project=project
     ):
         action: ActionInput = {
             "type": action_data["type"],

--- a/src/sentry/sentry_apps/services/legacy_webhook/service.py
+++ b/src/sentry/sentry_apps/services/legacy_webhook/service.py
@@ -6,6 +6,7 @@ from typing import Any, TypedDict
 from sentry.eventstore.models import GroupEvent
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.tasks.sentry_apps import send_alert_webhook_v2
@@ -33,6 +34,13 @@ def split_urls(value: str) -> list[str]:
     if not value:
         return []
     return list(filter(bool, (url.strip() for url in value.splitlines())))
+
+
+def is_legacy_webhook_enabled(project: Project) -> bool:
+    """Return whether the project has the legacy webhook enabled."""
+    # TODO: After the script migrates/removes all plugin actions, delete this helper and the
+    # `project` threading through the dual-write path.
+    return bool(ProjectOption.objects.get_value(project, "webhooks:enabled", default=False))
 
 
 def get_triggering_rule_name(invocation: ActionInvocation) -> str:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_dual_write.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
 from sentry.rules.processing.processor import split_conditions_and_filters
@@ -76,8 +77,12 @@ def create_if_dcg(
     return if_dcg
 
 
-def create_workflow_actions(if_dcg: DataConditionGroup, actions: list[dict[str, Any]]) -> None:
-    notification_actions = build_notification_actions_from_rule_data_actions(actions)
+def create_workflow_actions(
+    if_dcg: DataConditionGroup, actions: list[dict[str, Any]], project: Project
+) -> None:
+    notification_actions = build_notification_actions_from_rule_data_actions(
+        actions, project=project
+    )
     dcg_actions = [
         DataConditionGroupAction(action=action, condition_group=if_dcg)
         for action in notification_actions
@@ -143,7 +148,9 @@ def update_migrated_issue_alert(rule: Rule) -> Workflow | None:
     )
 
     delete_workflow_actions(if_dcg=if_dcg)
-    create_workflow_actions(if_dcg=if_dcg, actions=data["actions"])  # action(s) must exist
+    create_workflow_actions(
+        if_dcg=if_dcg, actions=data["actions"], project=rule.project
+    )  # action(s) must exist
 
     workflow.environment_id = rule.environment_id
     if frequency := data["frequency"]:

--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_migration.py
@@ -335,7 +335,7 @@ class IssueAlertMigrator:
         self, if_dcg: DataConditionGroup, actions: list[dict[str, Any]]
     ) -> None:
         notification_actions = build_notification_actions_from_rule_data_actions(
-            actions, is_dry_run=self.is_dry_run or False
+            actions, is_dry_run=self.is_dry_run or False, project=self.project
         )
         dcg_actions = [
             DataConditionGroupAction(action=action, condition_group=if_dcg)

--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -65,10 +65,8 @@ def translate_rule_data_actions_to_notification_actions(
                 f"Action translator not found for action with registry ID: {registry_id}, uuid: {action.get('uuid')}"
             ) from e
 
-        # The legacy NotifyEventAction dual-writes to a WEBHOOK("webhooks") action delivered by the
-        # legacy webhook path. Only emit it when the project has the legacy webhook enabled;
-        # otherwise it would deliver nothing, so skip it (leaving a valid "No actions" automation)
-        # rather than persist a dead action.
+        # NotifyEventAction delivers legacy webhooks; skip it unless the project has them enabled so
+        # we don't persist a dead action.
         if isinstance(translator, NotifyEventActionTranslator) and not (
             project is not None and is_legacy_webhook_enabled(project)
         ):

--- a/src/sentry/workflow_engine/migration_helpers/rule_action.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_action.py
@@ -1,8 +1,13 @@
 import logging
 from typing import Any, TypedDict
 
+from sentry.models.project import Project
+from sentry.sentry_apps.services.legacy_webhook.service import is_legacy_webhook_enabled
 from sentry.workflow_engine.models.action import Action
-from sentry.workflow_engine.typings.notification_action import issue_alert_action_translator_mapping
+from sentry.workflow_engine.typings.notification_action import (
+    NotifyEventActionTranslator,
+    issue_alert_action_translator_mapping,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +20,7 @@ class NotificationActionData(TypedDict):
 
 
 def translate_rule_data_actions_to_notification_actions(
-    actions: list[dict[str, Any]], skip_failures: bool
+    actions: list[dict[str, Any]], skip_failures: bool, project: Project | None = None
 ) -> list[NotificationActionData]:
     """
     Builds notification actions from action field in Rule's data blob.
@@ -23,6 +28,8 @@ def translate_rule_data_actions_to_notification_actions(
 
     :param actions: list of action data (Rule.data.actions)
     :param skip_failures: if True, invalid actions will be skipped instead of raising exceptions
+    :param project: the project the rule belongs to; used to gate the legacy NotifyEventAction
+        dual-write on whether the project has the legacy webhook enabled
     :return: list of notification actions (Action)
     """
 
@@ -57,6 +64,15 @@ def translate_rule_data_actions_to_notification_actions(
             raise ValueError(
                 f"Action translator not found for action with registry ID: {registry_id}, uuid: {action.get('uuid')}"
             ) from e
+
+        # The legacy NotifyEventAction dual-writes to a WEBHOOK("webhooks") action delivered by the
+        # legacy webhook path. Only emit it when the project has the legacy webhook enabled;
+        # otherwise it would deliver nothing, so skip it (leaving a valid "No actions" automation)
+        # rather than persist a dead action.
+        if isinstance(translator, NotifyEventActionTranslator) and not (
+            project is not None and is_legacy_webhook_enabled(project)
+        ):
+            continue
 
         # Check if the action is well-formed
         if not translator.is_valid():
@@ -95,7 +111,7 @@ def translate_rule_data_actions_to_notification_actions(
 
 
 def build_notification_actions_from_rule_data_actions(
-    actions: list[dict[str, Any]], is_dry_run: bool = False
+    actions: list[dict[str, Any]], is_dry_run: bool = False, project: Project | None = None
 ) -> list[Action]:
     """
     Builds notification actions from action field in Rule's data blob.
@@ -107,11 +123,13 @@ def build_notification_actions_from_rule_data_actions(
 
     :param actions: list of action data (Rule.data.actions)
     :param is_dry_run: run in dry-run mode
+    :param project: the project the rule belongs to; used to gate the legacy NotifyEventAction
+        dual-write on whether the project has the legacy webhook enabled
     :return: list of notification actions (Action)
     """
 
     notification_actions_data = translate_rule_data_actions_to_notification_actions(
-        actions, skip_failures=not is_dry_run
+        actions, skip_failures=not is_dry_run, project=project
     )
     notification_actions = [Action(**action_data) for action_data in notification_actions_data]
 

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -617,24 +617,6 @@ class EmailActionTranslator(BaseActionTranslator, EmailActionHelper):
         return {}
 
 
-class PluginActionTranslator(BaseActionTranslator):
-    @property
-    def action_type(self) -> ActionType:
-        return ActionType.PLUGIN
-
-    @property
-    def required_fields(self) -> list[str]:
-        # NotifyEventAction doesn't appear to have any required fields
-        # beyond the standard id and uuid
-        return []
-
-    @property
-    def target_type(self) -> None:
-        # This appears to be a generic plugin notification
-        # so we'll use SPECIFIC as the target type
-        return None
-
-
 class WebhookActionTranslator(BaseActionTranslator):
     @property
     def action_type(self) -> ActionType:
@@ -651,6 +633,26 @@ class WebhookActionTranslator(BaseActionTranslator):
                 ActionFieldMappingKeys.TARGET_IDENTIFIER_KEY.value
             ]
         ]
+
+
+class NotifyEventActionTranslator(WebhookActionTranslator):
+    """
+    Translates the legacy ``NotifyEventAction`` ("Send a notification for all legacy integrations")
+    into a ``WEBHOOK`` action targeting the legacy webhooks service.
+    """
+
+    @property
+    def required_fields(self) -> list[str]:
+        # Unlike NotifyEventServiceAction, a NotifyEventAction blob has no `service` field, so there
+        # are no required fields beyond the standard id/uuid.
+        return []
+
+    @property
+    def target_identifier(self) -> str:
+        # At delivery time, WebhookActionHandler.execute routes the action to the legacy webhook
+        # path (_handle_legacy_webhooks) when target_identifier == "webhooks". The blob has no
+        # target field, so return the literal to opt into that path.
+        return "webhooks"
 
 
 class SentryAppActionTranslator(BaseActionTranslator):
@@ -790,7 +792,7 @@ issue_alert_action_translator_mapping: dict[str, type[BaseActionTranslator]] = {
     ACTION_FIELD_MAPPINGS[ActionType.JIRA]["id"]: JiraActionTranslatorBase,
     ACTION_FIELD_MAPPINGS[ActionType.JIRA_SERVER]["id"]: JiraServerActionTranslatorBase,
     ACTION_FIELD_MAPPINGS[ActionType.EMAIL]["id"]: EmailActionTranslator,
-    ACTION_FIELD_MAPPINGS[ActionType.PLUGIN]["id"]: PluginActionTranslator,
+    ACTION_FIELD_MAPPINGS[ActionType.PLUGIN]["id"]: NotifyEventActionTranslator,
     ACTION_FIELD_MAPPINGS[ActionType.WEBHOOK]["id"]: WebhookActionTranslator,
     ACTION_FIELD_MAPPINGS[ActionType.SENTRY_APP]["id"]: SentryAppActionTranslator,
 }

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -58,9 +58,12 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
             )
 
     @mock.patch(
-        "sentry.notifications.notification_action.action_handler_registry.plugin_handler.send_legacy_webhooks_for_invocation"
+        "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_legacy_webhooks_for_invocation"
     )
     def test_actions(self, mock_send) -> None:
+        # NotifyEventAction only dual-writes a WEBHOOK action (routed to the legacy webhook path)
+        # when the project has the legacy webhook enabled.
+        self.project.update_option("webhooks:enabled", True)
         action_data = [
             {
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -72,6 +72,21 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
         self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
         assert mock_send.called
 
+    @mock.patch(
+        "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_legacy_webhooks_for_invocation"
+    )
+    def test_actions_notify_event_webhooks_disabled(self, mock_send) -> None:
+        # With webhooks disabled, NotifyEventAction translates to no action, so the test-fire should
+        # skip it gracefully (success, nothing fired) rather than raising an IndexError -> 400.
+        action_data = [
+            {
+                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+            }
+        ]
+
+        self.get_success_response(self.organization.slug, self.project.slug, actions=action_data)
+        assert not mock_send.called
+
     def test_unknown_action_returns_400(self) -> None:
         action_data = [
             {

--- a/tests/sentry/api/endpoints/test_project_rule_actions.py
+++ b/tests/sentry/api/endpoints/test_project_rule_actions.py
@@ -61,8 +61,7 @@ class ProjectRuleActionsEndpointWorkflowEngineTest(APITestCase, BaseWorkflowTest
         "sentry.notifications.notification_action.action_handler_registry.webhook_handler.send_legacy_webhooks_for_invocation"
     )
     def test_actions(self, mock_send) -> None:
-        # NotifyEventAction only dual-writes a WEBHOOK action (routed to the legacy webhook path)
-        # when the project has the legacy webhook enabled.
+        # NotifyEventAction only dual-writes a WEBHOOK action when webhooks are enabled.
         self.project.update_option("webhooks:enabled", True)
         action_data = [
             {

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -125,11 +125,9 @@ def assert_serializer_results_match(
             del rule_action_data["legacy_rule_id"]
         if rule_action_data.get("workflow_id"):
             del rule_action_data["workflow_id"]
-        # The legacy NotifyEventAction dual-writes to a WEBHOOK("webhooks") action, which the
-        # workflow-engine serializer renders as the equivalent NotifyEventServiceAction(service=
-        # "webhooks"). This divergence is intentional -- NotifyEventAction ("Send a notification for
-        # all legacy integrations") is being deprecated in favor of the explicit webhooks service
-        # action -- so treat the two forms as equal here.
+        # NotifyEventAction dual-writes to WEBHOOK("webhooks"), which serializes back as
+        # NotifyEventServiceAction(service="webhooks"). This divergence is intentional, so treat the
+        # two forms as equal.
         if (
             rule_action_data.get("id") == "sentry.rules.actions.notify_event.NotifyEventAction"
             and workflow_action_data.get("id")
@@ -314,9 +312,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # Several tests here use the legacy NotifyEventAction, which only dual-writes a WEBHOOK
-        # action when the project has the legacy webhook enabled. Enable it so the workflow-engine
-        # serializer produces a comparable action for the dual-read parity checks.
+        # NotifyEventAction (used by several tests) only dual-writes a WEBHOOK action when webhooks
+        # are enabled; enable it so the parity checks have a comparable action to compare.
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
     def mock_conversations_list(self, channels):

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -15,6 +15,7 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.integrations.slack.utils.channel import strip_channel_name
 from sentry.models.environment import Environment
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.sentry_apps.services.app.model import RpcAlertRuleActionResult
 from sentry.sentry_apps.utils.errors import SentryAppErrorType
@@ -124,6 +125,18 @@ def assert_serializer_results_match(
             del rule_action_data["legacy_rule_id"]
         if rule_action_data.get("workflow_id"):
             del rule_action_data["workflow_id"]
+        # The legacy NotifyEventAction dual-writes to a WEBHOOK("webhooks") action, which the
+        # workflow-engine serializer renders as the equivalent NotifyEventServiceAction(service=
+        # "webhooks"). This divergence is intentional -- NotifyEventAction ("Send a notification for
+        # all legacy integrations") is being deprecated in favor of the explicit webhooks service
+        # action -- so treat the two forms as equal here.
+        if (
+            rule_action_data.get("id") == "sentry.rules.actions.notify_event.NotifyEventAction"
+            and workflow_action_data.get("id")
+            == "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
+            and workflow_action_data.get("service") == "webhooks"
+        ):
+            continue
         assert rule_action_data == workflow_action_data
 
     # XXX: actionMatch is always coerced to 'any-short' for a Workflow as it is the only acceptable value
@@ -298,6 +311,13 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
 
 class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
     method = "PUT"
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Several tests here use the legacy NotifyEventAction, which only dual-writes a WEBHOOK
+        # action when the project has the legacy webhook enabled. Enable it so the workflow-engine
+        # serializer produces a comparable action for the dual-read parity checks.
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
     def mock_conversations_list(self, channels):
         return patch(

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -342,9 +342,8 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # Several tests here use the legacy NotifyEventAction, which only dual-writes a WEBHOOK
-        # action when the project has the legacy webhook enabled. Enable it so the workflow-engine
-        # serializer produces a comparable action for the dual-read parity checks.
+        # NotifyEventAction (used by several tests) only dual-writes a WEBHOOK action when webhooks
+        # are enabled; enable it so the parity checks have a comparable action to compare.
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
     def mock_conversations_info(self, channel):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -19,6 +19,7 @@ from sentry.incidents.endpoints.serializers.utils import (
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
 from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
 from sentry.silo.base import SiloMode
@@ -338,6 +339,13 @@ class GetProjectRulesTest(ProjectRuleBaseTestCase):
 
 class CreateProjectRuleTest(ProjectRuleBaseTestCase):
     method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Several tests here use the legacy NotifyEventAction, which only dual-writes a WEBHOOK
+        # action when the project has the legacy webhook enabled. Enable it so the workflow-engine
+        # serializer produces a comparable action for the dual-read parity checks.
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
     def mock_conversations_info(self, channel):
         return patch(

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -1,4 +1,5 @@
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import RuleSource
 from sentry.projects.project_rules.creator import ProjectRuleCreator
 from sentry.testutils.cases import TestCase
@@ -54,6 +55,10 @@ class TestProjectRuleCreator(TestCase):
         )
 
     def test_create_rule_and_workflow(self) -> None:
+        # NotifyEventAction dual-writes to a WEBHOOK action only when the project has the legacy
+        # webhook enabled.
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
+
         rule = self.creator.run()
 
         rule_id = rule.id
@@ -91,3 +96,12 @@ class TestProjectRuleCreator(TestCase):
         action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
         assert action.type == Action.Type.WEBHOOK
         assert action.config.get("target_identifier") == "webhooks"
+
+    def test_create_rule_and_workflow__notify_event_webhooks_disabled(self) -> None:
+        # Without the legacy webhook enabled, the NotifyEventAction is skipped and no action is
+        # written; the workflow is left as a valid "No actions" automation.
+        rule = self.creator.run()
+
+        workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow
+        action_filter = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        assert not DataConditionGroupAction.objects.filter(condition_group=action_filter).exists()

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -55,8 +55,7 @@ class TestProjectRuleCreator(TestCase):
         )
 
     def test_create_rule_and_workflow(self) -> None:
-        # NotifyEventAction dual-writes to a WEBHOOK action only when the project has the legacy
-        # webhook enabled.
+        # NotifyEventAction dual-writes a WEBHOOK action only when webhooks are enabled.
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
         rule = self.creator.run()
@@ -98,8 +97,7 @@ class TestProjectRuleCreator(TestCase):
         assert action.config.get("target_identifier") == "webhooks"
 
     def test_create_rule_and_workflow__notify_event_webhooks_disabled(self) -> None:
-        # Without the legacy webhook enabled, the NotifyEventAction is skipped and no action is
-        # written; the workflow is left as a valid "No actions" automation.
+        # Webhooks disabled: no action written; the workflow is a valid "No actions" automation.
         rule = self.creator.run()
 
         workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow

--- a/tests/sentry/projects/project_rules/test_creator.py
+++ b/tests/sentry/projects/project_rules/test_creator.py
@@ -89,4 +89,5 @@ class TestProjectRuleCreator(TestCase):
         assert data_condition.comparison == {"key": "foo", "match": "is"}
 
         action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
-        assert action.type == Action.Type.PLUGIN
+        assert action.type == Action.Type.WEBHOOK
+        assert action.config.get("target_identifier") == "webhooks"

--- a/tests/sentry/projects/project_rules/test_updater.py
+++ b/tests/sentry/projects/project_rules/test_updater.py
@@ -184,7 +184,8 @@ class TestUpdater(TestCase):
         assert data_condition.comparison == {"key": "foo", "match": "is"}
 
         action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
-        assert action.type == Action.Type.PLUGIN
+        assert action.type == Action.Type.WEBHOOK
+        assert action.config.get("target_identifier") == "webhooks"
 
     def test_dual_create_workflow_engine__errors_on_invalid_conditions(self) -> None:
         IssueAlertMigrator(self.rule, user_id=self.user.id).run()

--- a/tests/sentry/projects/project_rules/test_updater.py
+++ b/tests/sentry/projects/project_rules/test_updater.py
@@ -1,6 +1,7 @@
 import pytest
 
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import Rule
 from sentry.projects.project_rules.updater import ProjectRuleUpdater
 from sentry.rules.conditions.event_frequency import EventFrequencyCondition
@@ -121,6 +122,10 @@ class TestUpdater(TestCase):
         assert self.rule.data["frequency"] == 5
 
     def test_dual_update_workflow_engine(self) -> None:
+        # NotifyEventAction dual-writes to a WEBHOOK action only when the project has the legacy
+        # webhook enabled.
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
+
         conditions = [
             {
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
@@ -186,6 +191,40 @@ class TestUpdater(TestCase):
         action = DataConditionGroupAction.objects.get(condition_group=action_filter).action
         assert action.type == Action.Type.WEBHOOK
         assert action.config.get("target_identifier") == "webhooks"
+
+    def test_dual_update_workflow_engine__notify_event_webhooks_disabled(self) -> None:
+        # Without the legacy webhook enabled, the NotifyEventAction is skipped and no action is
+        # written; the workflow is left as a valid "No actions" automation.
+        new_user_id = self.create_user().id
+
+        ProjectRuleUpdater(
+            rule=self.rule,
+            name="Updated Rule",
+            owner=Actor.from_id(new_user_id),
+            project=self.project,
+            action_match="all",
+            filter_match="any",
+            conditions=[
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "key": "foo",
+                    "match": "eq",
+                    "value": "bar",
+                },
+            ],
+            environment=None,
+            actions=[
+                {
+                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                    "name": "Send a notification (for all legacy integrations)",
+                }
+            ],
+            frequency=5,
+        ).run()
+
+        workflow = AlertRuleWorkflow.objects.get(rule_id=self.rule.id).workflow
+        action_filter = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        assert not DataConditionGroupAction.objects.filter(condition_group=action_filter).exists()
 
     def test_dual_create_workflow_engine__errors_on_invalid_conditions(self) -> None:
         IssueAlertMigrator(self.rule, user_id=self.user.id).run()

--- a/tests/sentry/projects/project_rules/test_updater.py
+++ b/tests/sentry/projects/project_rules/test_updater.py
@@ -122,8 +122,7 @@ class TestUpdater(TestCase):
         assert self.rule.data["frequency"] == 5
 
     def test_dual_update_workflow_engine(self) -> None:
-        # NotifyEventAction dual-writes to a WEBHOOK action only when the project has the legacy
-        # webhook enabled.
+        # NotifyEventAction dual-writes a WEBHOOK action only when webhooks are enabled.
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
         conditions = [
@@ -193,8 +192,7 @@ class TestUpdater(TestCase):
         assert action.config.get("target_identifier") == "webhooks"
 
     def test_dual_update_workflow_engine__notify_event_webhooks_disabled(self) -> None:
-        # Without the legacy webhook enabled, the NotifyEventAction is skipped and no action is
-        # written; the workflow is left as a valid "No actions" automation.
+        # Webhooks disabled: no action written; the workflow is a valid "No actions" automation.
         new_user_id = self.create_user().id
 
         ProjectRuleUpdater(

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -134,8 +134,7 @@ class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
         assert workflow.enabled is True
 
     def test_update_issue_alert(self) -> None:
-        # NotifyEventAction dual-writes to a WEBHOOK action only when the project has the legacy
-        # webhook enabled.
+        # NotifyEventAction dual-writes a WEBHOOK action only when webhooks are enabled.
         assert self.issue_alert.project
         ProjectOption.objects.set_value(self.issue_alert.project, "webhooks:enabled", True)
 
@@ -208,8 +207,7 @@ class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
         assert action.config.get("target_identifier") == "webhooks"
 
     def test_update_issue_alert__notify_event_webhooks_disabled(self) -> None:
-        # Without the legacy webhook enabled, the NotifyEventAction is skipped and no action is
-        # written -- the workflow is left as a valid "No actions" automation.
+        # Webhooks disabled: no action written; the workflow is a valid "No actions" automation.
         rule_data = self.issue_alert.data
         rule_data.update(
             {

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -4,6 +4,7 @@ from jsonschema.exceptions import ValidationError
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.rule import Rule
 from sentry.models.rulesnooze import RuleSnooze
 from sentry.rules.age import AgeComparisonType
@@ -133,6 +134,11 @@ class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
         assert workflow.enabled is True
 
     def test_update_issue_alert(self) -> None:
+        # NotifyEventAction dual-writes to a WEBHOOK action only when the project has the legacy
+        # webhook enabled.
+        assert self.issue_alert.project
+        ProjectOption.objects.set_value(self.issue_alert.project, "webhooks:enabled", True)
+
         conditions_payload = [
             {
                 "id": FirstSeenEventCondition.id,
@@ -200,6 +206,33 @@ class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
         # tested fully in test_migrate_rule_action.py
         assert action.type == Action.Type.WEBHOOK
         assert action.config.get("target_identifier") == "webhooks"
+
+    def test_update_issue_alert__notify_event_webhooks_disabled(self) -> None:
+        # Without the legacy webhook enabled, the NotifyEventAction is skipped and no action is
+        # written -- the workflow is left as a valid "No actions" automation.
+        rule_data = self.issue_alert.data
+        rule_data.update(
+            {
+                "action_match": "none",
+                "filter_match": "all",
+                "conditions": [{"id": FirstSeenEventCondition.id}],
+                "frequency": 60,
+                "actions": [
+                    {
+                        "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+                        "uuid": "test-uuid",
+                    }
+                ],
+            }
+        )
+
+        self.issue_alert.update(data=rule_data)
+        update_migrated_issue_alert(self.issue_alert)
+
+        issue_alert_workflow = AlertRuleWorkflow.objects.get(rule_id=self.issue_alert.id)
+        workflow = Workflow.objects.get(id=issue_alert_workflow.workflow.id)
+        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+        assert not DataConditionGroupAction.objects.filter(condition_group=if_dcg).exists()
 
     def test_update_issue_alert__none_match(self) -> None:
         conditions_payload = [

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_dual_write.py
@@ -197,7 +197,9 @@ class IssueAlertDualWriteUpdateTest(RuleMigrationHelpersTestBase):
 
         dcg_actions = DataConditionGroupAction.objects.get(condition_group=if_dcg)
         action = dcg_actions.action
-        assert action.type == Action.Type.PLUGIN  # tested fully in test_migrate_rule_action.py
+        # tested fully in test_migrate_rule_action.py
+        assert action.type == Action.Type.WEBHOOK
+        assert action.config.get("target_identifier") == "webhooks"
 
     def test_update_issue_alert__none_match(self) -> None:
         conditions_payload = [

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sentry.models.options.project_option import ProjectOption
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.cases import TestCase
@@ -643,22 +644,26 @@ class TestNotificationActionMigrationUtils(TestCase):
         with pytest.raises(ValueError):
             build_notification_actions_from_rule_data_actions(action_data, is_dry_run=True)
 
-    def test_notify_event_action_migration(self) -> None:
-        # NotifyEventAction dual-writes to a WEBHOOK action targeting the legacy webhooks service.
-        # Runtime delivery stays gated by send_legacy_webhooks_for_invocation (webhooks:enabled/urls).
-        action_data = [
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "c792d184-81db-419f-8ab2-83baef1216f4",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "0202a169-326b-4575-8887-afe69cc58040",
-            },
-        ]
+    NOTIFY_EVENT_ACTION_DATA = [
+        {
+            "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+            "uuid": "c792d184-81db-419f-8ab2-83baef1216f4",
+        },
+        {
+            "id": "sentry.rules.actions.notify_event.NotifyEventAction",
+            "uuid": "0202a169-326b-4575-8887-afe69cc58040",
+        },
+    ]
 
-        actions = build_notification_actions_from_rule_data_actions(action_data)
-        assert len(actions) == len(action_data)
+    def test_notify_event_action_migration_webhooks_enabled(self) -> None:
+        # NotifyEventAction dual-writes to a WEBHOOK action targeting the legacy webhooks service,
+        # but only when the project has the legacy webhook enabled.
+        ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
+
+        actions = build_notification_actions_from_rule_data_actions(
+            self.NOTIFY_EVENT_ACTION_DATA, project=self.project
+        )
+        assert len(actions) == len(self.NOTIFY_EVENT_ACTION_DATA)
         for action in actions:
             action.refresh_from_db()
             assert action.type == Action.Type.WEBHOOK
@@ -667,6 +672,19 @@ class TestNotificationActionMigrationUtils(TestCase):
             assert action.config.get("target_type") is None
             assert action.integration_id is None
             assert action.data == {}
+
+    def test_notify_event_action_migration_webhooks_disabled(self) -> None:
+        # Without the legacy webhook enabled, NotifyEventAction delivers nothing, so it is skipped
+        # (no action written) rather than persisted as a dead webhook action.
+        actions = build_notification_actions_from_rule_data_actions(
+            self.NOTIFY_EVENT_ACTION_DATA, project=self.project
+        )
+        assert actions == []
+
+    def test_notify_event_action_migration_no_project(self) -> None:
+        # Without a project to gate on, the NotifyEventAction dual-write is skipped.
+        actions = build_notification_actions_from_rule_data_actions(self.NOTIFY_EVENT_ACTION_DATA)
+        assert actions == []
 
     def test_webhook_action_migration(self) -> None:
         action_data = WEBHOOK_ACTION_DATA_BLOBS
@@ -856,14 +874,6 @@ class TestNotificationActionMigrationUtils(TestCase):
                     "targetType": "IssueOwners",
                 },
                 Action.Type.EMAIL,
-            ),
-            # NotifyEventAction (legacy webhooks) -> WEBHOOK
-            (
-                {
-                    "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                    "uuid": "test-uuid",
-                },
-                Action.Type.WEBHOOK,
             ),
             # Webhook
             (

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -656,8 +656,7 @@ class TestNotificationActionMigrationUtils(TestCase):
     ]
 
     def test_notify_event_action_migration_webhooks_enabled(self) -> None:
-        # NotifyEventAction dual-writes to a WEBHOOK action targeting the legacy webhooks service,
-        # but only when the project has the legacy webhook enabled.
+        # NotifyEventAction dual-writes a WEBHOOK("webhooks") action when webhooks are enabled.
         ProjectOption.objects.set_value(self.project, "webhooks:enabled", True)
 
         actions = build_notification_actions_from_rule_data_actions(
@@ -674,15 +673,14 @@ class TestNotificationActionMigrationUtils(TestCase):
             assert action.data == {}
 
     def test_notify_event_action_migration_webhooks_disabled(self) -> None:
-        # Without the legacy webhook enabled, NotifyEventAction delivers nothing, so it is skipped
-        # (no action written) rather than persisted as a dead webhook action.
+        # Webhooks disabled: skip the action instead of writing a dead one.
         actions = build_notification_actions_from_rule_data_actions(
             self.NOTIFY_EVENT_ACTION_DATA, project=self.project
         )
         assert actions == []
 
     def test_notify_event_action_migration_no_project(self) -> None:
-        # Without a project to gate on, the NotifyEventAction dual-write is skipped.
+        # No project to gate on: skip.
         actions = build_notification_actions_from_rule_data_actions(self.NOTIFY_EVENT_ACTION_DATA)
         assert actions == []
 

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -643,7 +643,9 @@ class TestNotificationActionMigrationUtils(TestCase):
         with pytest.raises(ValueError):
             build_notification_actions_from_rule_data_actions(action_data, is_dry_run=True)
 
-    def test_plugin_action_migration(self) -> None:
+    def test_notify_event_action_migration(self) -> None:
+        # NotifyEventAction dual-writes to a WEBHOOK action targeting the legacy webhooks service.
+        # Runtime delivery stays gated by send_legacy_webhooks_for_invocation (webhooks:enabled/urls).
         action_data = [
             {
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
@@ -653,30 +655,18 @@ class TestNotificationActionMigrationUtils(TestCase):
                 "id": "sentry.rules.actions.notify_event.NotifyEventAction",
                 "uuid": "0202a169-326b-4575-8887-afe69cc58040",
             },
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "ad671f12-6bb7-4b9d-a4fe-f32e985fe08e",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "efe1841d-d33a-460a-8d65-7697893ec7f1",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "8c0c2fc9-5d89-4974-9d3c-31b1d602a065",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "e63c387c-94f4-4284-bef8-c08b218654a3",
-            },
-            {
-                "id": "sentry.rules.actions.notify_event.NotifyEventAction",
-                "uuid": "0269d028-9466-4826-8ab9-18cd47fb08d2",
-            },
         ]
 
         actions = build_notification_actions_from_rule_data_actions(action_data)
-        self.assert_actions_migrated_correctly(actions, action_data, None, None, None)
+        assert len(actions) == len(action_data)
+        for action in actions:
+            action.refresh_from_db()
+            assert action.type == Action.Type.WEBHOOK
+            assert action.config.get("target_identifier") == "webhooks"
+            assert action.config.get("target_display") is None
+            assert action.config.get("target_type") is None
+            assert action.integration_id is None
+            assert action.data == {}
 
     def test_webhook_action_migration(self) -> None:
         action_data = WEBHOOK_ACTION_DATA_BLOBS
@@ -757,7 +747,7 @@ class TestNotificationActionMigrationUtils(TestCase):
             ),
             (
                 "sentry.rules.actions.notify_event.NotifyEventAction",
-                ActionType.PLUGIN,
+                ActionType.WEBHOOK,
             ),
             (
                 "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
@@ -867,13 +857,13 @@ class TestNotificationActionMigrationUtils(TestCase):
                 },
                 Action.Type.EMAIL,
             ),
-            # Plugin
+            # NotifyEventAction (legacy webhooks) -> WEBHOOK
             (
                 {
                     "id": "sentry.rules.actions.notify_event.NotifyEventAction",
                     "uuid": "test-uuid",
                 },
-                Action.Type.PLUGIN,
+                Action.Type.WEBHOOK,
             ),
             # Webhook
             (


### PR DESCRIPTION
## Summary
This PR mainly changes the dual write flow such that when we see a write operation to the NotifyEventAction (ActionType.PLUGIN) we instead create a webhook action. Otherwise the write operation still saves the Rule but no workflow Action is saved.

We added a new translator for NotifyEventAction -> webhooks action. AND we're passing through the project through the dual write layers so we can check if an enabled ProjectOption exists (i.e they have the legacy Webhooks enabled) then make a webhook action. This checking is a little jank because we need to pass the project down a bunch of layers (but otherwise idk how we can get project). But it's temporary for this migration, because for the migration script I want to delete all actions that are plugins and don't have an enabled webhooks config for a clean state.


**PR 1** of the effort to remove `Action.Type.PLUGIN` from the workflow engine