### PR TITLE
fix(seer): Skip GitLab seat seeding when webhook actor is not the MR author

### DIFF
--- a/fixtures/gitlab.py
+++ b/fixtures/gitlab.py
@@ -73,6 +73,7 @@ class GitLabTestCase(APITestCase):
 MERGE_REQUEST_OPENED_EVENT = b"""{
   "object_kind": "merge_request",
   "user": {
+    "id": 51,
     "name": "Administrator",
     "username": "root",
     "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"

--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -27,6 +27,12 @@ that are already opted in to GitLab code review. The downstream
 ``should_increment_contributor_seat`` check additionally requires
 ``organizations:seat-based-seer-enabled``.
 
+Both processors skip seeding when the webhook actor (``event.user``) is not the
+MR author (``object_attributes.author_id``): the row is keyed by the author but
+its ``alias`` defaults to the actor's username, so on a mismatch (e.g. an MR
+opened via the API on behalf of another author) we'd store the wrong alias. We
+log ``actor_author_mismatch`` and skip instead.
+
 ``MergeEventWebhook.WEBHOOK_EVENT_PROCESSORS`` registers these
 **before** ``handle_merge_request_event`` so the contributor row exists when
 the code-review handler's preflight billing check runs. Without that
@@ -117,7 +123,9 @@ def track_gitlab_contributor_seat_processor(
 
     try:
         user_id = object_attributes["author_id"]
-        user_username = event["user"]["username"]
+        event_user = event["user"]
+        event_actor_id = event_user["id"]
+        user_username = event_user["username"]
         iid = object_attributes["iid"]
     except KeyError as e:
         debug_log(
@@ -130,6 +138,20 @@ def track_gitlab_contributor_seat_processor(
         return
 
     base_extra["author_id"] = user_id
+
+    # Skip when the webhook actor isn't the MR author: alias comes from the actor
+    # but the row is keyed by the author, so seeding would store the wrong alias.
+    # Runs before the dedup mark so a skipped mismatch doesn't block a later,
+    # matching delivery from seeding the author.
+    if user_id != event_actor_id:
+        debug_log(
+            logger,
+            organization,
+            "actor_author_mismatch",
+            {**base_extra, "event_actor_id": event_actor_id},
+            level=logging.WARNING,
+        )
+        return
 
     # Resolve the Organization before marking the delivery as seen so a missing
     # org does not poison the dedup window and block GitLab redeliveries from
@@ -183,9 +205,29 @@ def track_gitlab_contributor_action_processor(
     object_attributes = event.get("object_attributes") or {}
     try:
         user_id = object_attributes["author_id"]
-        user_username = event["user"]["username"]
+        event_user = event["user"]
+        event_actor_id = event_user["id"]
+        user_username = event_user["username"]
         iid = object_attributes["iid"]
     except KeyError:
+        return
+
+    # Skip when the webhook actor isn't the MR author, to avoid seeding the wrong
+    # alias against the author's row (see track_gitlab_contributor_seat_processor).
+    if user_id != event_actor_id:
+        debug_log(
+            logger,
+            organization,
+            "actor_author_mismatch",
+            {
+                "organization_id": organization.id,
+                "repo_id": repo.id,
+                "mr_iid": iid,
+                "author_id": user_id,
+                "event_actor_id": event_actor_id,
+            },
+            level=logging.WARNING,
+        )
         return
 
     try:

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -115,6 +115,39 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
 
     @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_when_actor_is_not_author(self, mock_track: Any) -> None:
+        # The MR author (object_attributes.author_id) and the webhook actor
+        # (event.user) diverge — e.g. an MR opened via the API on behalf of
+        # another author. Seeding would store the actor's username as the alias
+        # for the author's external_identifier, so we skip instead.
+        event = _make_event()
+        event["user"]["id"] = event["object_attributes"]["author_id"] + 1
+        self._call(event=event)
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_no_call_when_actor_id_missing(self, mock_track: Any) -> None:
+        event = _make_event()
+        del event["user"]["id"]
+        self._call(event=event)
+        mock_track.assert_not_called()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
+    def test_actor_mismatch_does_not_poison_dedup(self, mock_track: Any) -> None:
+        # A skipped mismatch delivery must not consume the dedup window: a later
+        # delivery for the same MR whose actor IS the author still seeds.
+        mismatch = _make_event()
+        mismatch["user"]["id"] = mismatch["object_attributes"]["author_id"] + 1
+        self._call(event=mismatch)
+        mock_track.assert_not_called()
+
+        self._call(event=_make_event())
+        mock_track.assert_called_once()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
     def test_duplicate_delivery_within_window_skipped(self, mock_track: Any) -> None:
         # GitLab redelivers webhooks on response timeout, and the endpoint
         # dispatches each payload once per installed organization. Both can
@@ -243,6 +276,34 @@ class TrackGitlabContributorActionProcessorTest(GitLabTestCase):
     def test_missing_iid(self, mock_record: Any) -> None:
         event = _make_event()
         del event["object_attributes"]["iid"]
+        track_gitlab_contributor_action_processor(
+            event=event,
+            organization=self.rpc_organization,
+            repo=self.repo,
+            integration=self.integration,
+        )
+        mock_record.assert_not_called()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.record_contributor_action")
+    def test_no_call_when_actor_is_not_author(self, mock_record: Any) -> None:
+        # The row is keyed by the author id but seeded with the actor's username
+        # as the alias, so skip seeding when the actor is not the author.
+        event = _make_event()
+        event["user"]["id"] = event["object_attributes"]["author_id"] + 1
+        track_gitlab_contributor_action_processor(
+            event=event,
+            organization=self.rpc_organization,
+            repo=self.repo,
+            integration=self.integration,
+        )
+        mock_record.assert_not_called()
+
+    @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.record_contributor_action")
+    def test_missing_actor_id(self, mock_record: Any) -> None:
+        event = _make_event()
+        del event["user"]["id"]
         track_gitlab_contributor_action_processor(
             event=event,
             organization=self.rpc_organization,


### PR DESCRIPTION
With GitLab's webhooks, we only have the MR's author id, which can differ from the full user object of the user who triggered the webhook event. We should skip the seat seeding in this case.

## Summary

GitLab's `merge_request` seat-tracking processors (`track_gitlab_contributor_seat_processor` and `track_gitlab_contributor_action_processor` in `seat_tracking.py`) key the `OrganizationContributors` row by `external_identifier=str(author_id)` — the MR author — but default the cosmetic `alias` to `event["user"]["username"]`, which is *whoever triggered the webhook*, not necessarily the author.

On a normal MR **open** these name the same person, so this is usually harmless. But they diverge when:

- an MR is opened via the API on behalf of another author,
- a service account triggers the hook, or
- an admin action triggers it.

In those cases we'd persist a mismatched `alias` against the author's `external_identifier`.

## Change

Compare `object_attributes["author_id"]` against `event["user"]["id"]` (GitLab includes the actor id in the payload) and **skip seeding** on a mismatch rather than persist the wrong alias. We log `actor_author_mismatch` at `WARNING` so the case is observable.

In the seat processor, the check runs **before** the Redis dedup mark so a skipped mismatch does not poison the dedup window and block a later, matching delivery for the same MR from seeding the author. The same mismatch/log guard is applied to the action processor, which shares the identical author-id/actor-username split.

### Notes
- The `MERGE_REQUEST_OPENED_EVENT` fixture gained a `user.id` (set equal to `author_id`, matching a normal open) — real GitLab payloads always include it; the trimmed fixture didn't.
- Trade-off: for a genuine on-behalf-of open where the only delivery has `actor != author`, the contributor won't be seeded from that event. This is the intended behavior — we prefer not seeding over seeding a mismatched identity.

## Test plan
- New tests in `test_seat_tracking.py` covering both processors: actor≠author skips, missing `user.id` skips, and a mismatch not poisoning the seat dedup window.
- `pytest tests/sentry/seer/code_review/webhooks/test_seat_tracking.py` — 22 passed.
- Verified `test_merge_request.py` and gitlab `test_webhook.py` still pass with the fixture change.

Fixes SCM-121

🤖 Generated with [Claude Code](https://claude.com/claude-code)