### PR TITLE
ref(workflow-engine): Block new PLUGIN action creation on endpoints

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -29,6 +29,7 @@ from sentry.workflow_engine.endpoints.serializers.action_handler_serializer impo
     ActionHandlerSerializer,
     ActionHandlerSerializerResponse,
 )
+from sentry.workflow_engine.endpoints.validators.base.action import DEPRECATED_ACTION_TYPES
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.action import (
     get_available_action_integrations_for_org,
@@ -112,6 +113,10 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
             if not can_create_tickets and handler.group == ActionHandler.Group.TICKET_CREATION:
                 continue
 
+            # skip deprecated action types
+            if action_type in DEPRECATED_ACTION_TYPES:
+                continue
+
             # add integration actions
             if hasattr(handler, "provider_slug"):
                 integrations = provider_integrations.get(handler.provider_slug, [])
@@ -160,7 +165,7 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
                         )
                     )
 
-            # add all other action types (EMAIL, PLUGIN, etc.)
+            # add all other action types (EMAIL, etc.)
             else:
                 actions.append(
                     serialize(
@@ -171,11 +176,7 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
         actions.sort(
             key=lambda x: (
                 x["handlerGroup"],
-                (
-                    0
-                    if x["type"] in [Action.Type.EMAIL, Action.Type.PLUGIN, Action.Type.WEBHOOK]
-                    else 1
-                ),
+                (0 if x["type"] in [Action.Type.EMAIL, Action.Type.WEBHOOK] else 1),
                 x["type"],
                 (x["sentryApp"].get("name", "") if x.get("sentryApp") else ""),
             )

--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -12,6 +12,8 @@ from sentry.workflow_engine.processors.action import is_action_permitted
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler
 
+DEPRECATED_ACTION_TYPES: frozenset[Action.Type] = frozenset({Action.Type.PLUGIN})
+
 ActionData = dict[str, Any]
 ActionConfig = dict[str, Any]
 
@@ -63,6 +65,10 @@ class BaseActionValidator(CamelSnakeSerializer[Any]):
             action_type = Action.Type(value)
         except ValueError:
             raise serializers.ValidationError(f"Invalid action type: {value}")
+        if action_type in DEPRECATED_ACTION_TYPES:
+            raise serializers.ValidationError(
+                f"Action type {value} is deprecated and cannot be created."
+            )
         self._check_action_type(action_type)
         return value
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -443,19 +443,11 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
         self.setup_webhooks()
         self.setup_email()
 
-        @self.registry.register(Action.Type.PLUGIN)
-        @dataclass(frozen=True)
-        class PluginActionHandler(ActionHandler):
-            group = ActionHandler.Group.OTHER
-
-            config_schema = {}
-            data_schema = {}
-
         response = self.get_success_response(
             self.organization.slug,
             status_code=200,
         )
-        assert len(response.data) == 8
+        assert len(response.data) == 7
         assert response.data == [
             # notification actions, sorted alphabetically with email first
             {
@@ -474,12 +466,6 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                 ],
             },
             # other actions, non sentry app actions first then sentry apps sorted alphabetically by name
-            {
-                "type": Action.Type.PLUGIN,
-                "handlerGroup": ActionHandler.Group.OTHER.value,
-                "configSchema": {},
-                "dataSchema": {},
-            },
             # webhook action should include sentry apps without components
             {
                 "type": Action.Type.WEBHOOK,
@@ -563,3 +549,17 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
                 ],
             },
         ]
+
+    def test_plugin_not_in_available_actions(self) -> None:
+        @self.registry.register(Action.Type.PLUGIN)
+        @dataclass(frozen=True)
+        class PluginActionHandler(ActionHandler):
+            group = ActionHandler.Group.OTHER
+            config_schema = {}
+            data_schema = {}
+
+        response = self.get_success_response(
+            self.organization.slug,
+            status_code=200,
+        )
+        assert len(response.data) == 0

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -101,14 +101,8 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             f"[{self.issue_stream_detector.name}]:"
         )
 
-    @mock.patch(
-        "sentry.notifications.notification_action.action_handler_registry.plugin_handler.send_legacy_webhooks_for_invocation"
-    )
-    def test_plugin_notify_event_action(
-        self,
-        mock_send: mock.MagicMock,
-    ) -> None:
-        """Test a Plugin action (NotifyEventAction)"""
+    def test_plugin_action_rejected_as_deprecated(self) -> None:
+        """Test that Plugin actions are rejected as deprecated"""
         action_data = [
             {
                 "type": Action.Type.PLUGIN.value,
@@ -117,9 +111,8 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             }
         ]
 
-        response = self.get_success_response(self.organization.slug, actions=action_data)
-        assert response.status_code == 200
-        assert mock_send.called
+        response = self.get_error_response(self.organization.slug, actions=action_data)
+        assert response.status_code == 400
 
     @mock.patch.object(JiraIntegration, "create_issue")
     @mock.patch.object(sentry_sdk, "capture_exception")
@@ -201,9 +194,9 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
 
         action_data = [
             {
-                "type": Action.Type.PLUGIN.value,
+                "type": Action.Type.EMAIL.value,
                 "data": {},
-                "config": {},
+                "config": {"target_type": 4},
             }
         ]
 
@@ -228,9 +221,9 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
 
         action_data = [
             {
-                "type": Action.Type.PLUGIN.value,
+                "type": Action.Type.EMAIL.value,
                 "data": {},
-                "config": {},
+                "config": {"target_type": 4},
             }
         ]
 
@@ -250,9 +243,9 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         """Test that an invalid project_slug returns with a 400 error"""
         action_data = [
             {
-                "type": Action.Type.PLUGIN.value,
+                "type": Action.Type.EMAIL.value,
                 "data": {},
-                "config": {},
+                "config": {"target_type": 4},
             }
         ]
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -196,7 +196,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             {
                 "type": Action.Type.EMAIL.value,
                 "data": {},
-                "config": {"target_type": 4},
+                "config": {"target_type": "issue_owners"},
             }
         ]
 
@@ -223,7 +223,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             {
                 "type": Action.Type.EMAIL.value,
                 "data": {},
-                "config": {"target_type": 4},
+                "config": {"target_type": "issue_owners"},
             }
         ]
 
@@ -245,7 +245,7 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             {
                 "type": Action.Type.EMAIL.value,
                 "data": {},
-                "config": {"target_type": 4},
+                "config": {"target_type": "issue_owners"},
             }
         ]
 

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_action.py
@@ -110,6 +110,22 @@ class TestBaseActionValidator(TestCase):
         result = validator.is_valid()
         assert result is False
 
+    def test_validate_type__deprecated(
+        self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
+    ) -> None:
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "type": Action.Type.PLUGIN,
+            },
+            context={"organization": self.organization},
+        )
+
+        result = validator.is_valid()
+        assert result is False
+        assert "type" in validator.errors
+        assert "deprecated" in str(validator.errors["type"][0]).lower()
+
     def test_validate_type__action_gated(
         self, mock_action_handler_get: mock.MagicMock, mock_action_validator_get: mock.MagicMock
     ) -> None:
@@ -160,7 +176,7 @@ class TestBaseActionValidator(TestCase):
         # non integration actions should not have an integration id
         validator = BaseActionValidator(
             data={
-                "type": Action.Type.PLUGIN,
+                "type": Action.Type.EMAIL,
                 "config": {"foo": "bar"},
                 "data": {"baz": "bar"},
                 "integrationId": 1,
@@ -172,7 +188,7 @@ class TestBaseActionValidator(TestCase):
         assert validator.errors == {
             "nonFieldErrors": [
                 ErrorDetail(
-                    string="Integration ID is not allowed for action type plugin", code="invalid"
+                    string="Integration ID is not allowed for action type email", code="invalid"
                 )
             ]
         }


### PR DESCRIPTION
## Summary
- Reject `type=plugin` in `BaseActionValidator.validate_type` with a clear deprecation error
- Remove `PLUGIN` from the available-actions listing endpoint (frontend will show red error but that's ok since this action is deprecated)

Part of the `Action.Type.PLUGIN` removal effort. This PR fixes the leaky bucket so no new plugin actions are created via the API. 
