### PR TITLE
ref(track_outcome): use FutureTrackingProducer for everything

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3796,14 +3796,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Rolls out the new TaskProducer to track_outcome in tasks
-register(
-    "tasks.producer.track_outcome.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Rolls out the new TaskProducer to preprod tasks
 register(
     "tasks.producer.preprod.rollout",

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -6,20 +6,15 @@ import time
 from collections import namedtuple
 from datetime import datetime, timedelta
 from enum import IntEnum
-from functools import partial
 from threading import Lock
 
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import FutureTrackingProducer, KafkaPayload, KafkaProducer
 from arroyo.types import Topic as ArroyoTopic
-from taskbroker_client.state import current_task
-from taskbroker_client.worker.producer import TaskProducer
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.constants import DataCategory
-from sentry.options.rollout import in_random_rollout
-from sentry.taskworker.producer import get_task_producer
 from sentry.utils import json, kafka_config, metrics
-from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.arroyo_producer import get_arroyo_producer
 from sentry.utils.dates import to_datetime
 
 # Aggregation key for grouping outcomes
@@ -164,29 +159,27 @@ class Outcome(IntEnum):
         return self in (Outcome.ACCEPTED, Outcome.RATE_LIMITED)
 
 
-def _get_outcomes_producer(name: str = "sentry.utils.outcomes") -> KafkaProducer:
+def _get_outcomes_producer() -> KafkaProducer:
     return get_arroyo_producer(
-        name,
+        "sentry.utils.outcomes",
         Topic.OUTCOMES,
     )
 
 
-def _get_billing_producer(name: str = "sentry.utils.outcomes.billing") -> KafkaProducer:
+def _get_billing_producer() -> KafkaProducer:
     return get_arroyo_producer(
-        name,
+        "sentry.utils.outcomes.billing",
         Topic.OUTCOMES_BILLING,
     )
 
 
-outcomes_producer = SingletonProducer(_get_outcomes_producer)
-outcomes_tp_name = "sentry.utils.outcomes.taskproducer"
-outcomes_task_producer = get_task_producer(
-    outcomes_tp_name, partial(_get_outcomes_producer, outcomes_tp_name)
+outcomes_producer = FutureTrackingProducer(
+    "sentry.utils.outcomes",
+    _get_outcomes_producer,
 )
-billing_producer = SingletonProducer(_get_billing_producer)
-billing_tp_name = "sentry.utils.outcomes.billing.taskproducer"
-billing_task_producer = get_task_producer(
-    billing_tp_name, partial(_get_billing_producer, billing_tp_name)
+billing_producer = FutureTrackingProducer(
+    "sentry.utils.outcomes.billing",
+    _get_billing_producer,
 )
 
 LATE_OUTCOME_THRESHOLD = timedelta(days=1)
@@ -232,15 +225,9 @@ def track_outcome(
     # Create a second producer instance only if the cluster differs. Otherwise,
     # reuse the same producer and just send to the other topic.
     if use_billing and billing_config["cluster"] != outcomes_config["cluster"]:
-        if current_task() is not None and in_random_rollout("tasks.producer.track_outcome.rollout"):
-            producer: SingletonProducer | TaskProducer = billing_task_producer
-        else:
-            producer = billing_producer
+        producer = billing_producer
     else:
-        if current_task() is not None and in_random_rollout("tasks.producer.track_outcome.rollout"):
-            producer = outcomes_task_producer
-        else:
-            producer = outcomes_producer
+        producer = outcomes_producer
 
     now = to_datetime(time.time())
     timestamp = timestamp or now


### PR DESCRIPTION
https://github.com/getsentry/arroyo/pull/547 introduced a producer abstraction in Arroyo which is essentially the same as `TaskProducer` but can be used anywhere, not just in tasks.

This PR replaces `TaskProducer` with `FutureTrackingProducer` in track_outcome, and cleans up all of the rollout logic now that this is fully rolled out everywhere.