### PR TITLE
ref(issue-progress): Remove pr-group-activity feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -190,8 +190,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-web-vitals-seer-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Emit group activity when a linked pull request is closed
-    manager.add("organizations:pr-group-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Write PullRequestActivity rows from GitHub PR lifecycle webhooks
     manager.add("organizations:pr-metrics-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Record PullRequestAttribution from webhook and seer.pr_created events

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import F
 from django.db.models.signals import post_save, pre_save
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.integrations.analytics import IntegrationResolveCommitEvent, IntegrationResolvePREvent
 from sentry.issues.action_log import (
@@ -26,7 +26,6 @@ from sentry.models.grouphistory import (
 )
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupsubscription import GroupSubscription
-from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
@@ -279,13 +278,6 @@ def pull_request_closing(instance: PullRequest, **kwargs: object) -> None:
     """
     try:
         if instance.state != PullRequestLifecycleState.CLOSED:
-            return
-
-        try:
-            organization = Organization.objects.get_from_cache(id=instance.organization_id)
-        except Organization.DoesNotExist:
-            return
-        if not features.has("organizations:pr-group-activity", organization):
             return
 
         if instance.pk is not None:

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -425,9 +425,8 @@ class PullRequestClosedSignalTest(TestCase):
         self.pull_request.state = state
         self.pull_request.save()
 
-    def test_closed_emits_activity_when_flag_enabled(self) -> None:
-        with self.feature("organizations:pr-group-activity"):
-            self._save_with_state(PullRequestLifecycleState.CLOSED)
+    def test_closed_emits_activity(self) -> None:
+        self._save_with_state(PullRequestLifecycleState.CLOSED)
 
         activity = Activity.objects.get(
             group=self.group, type=ActivityType.PULL_REQUEST_CLOSED.value
@@ -436,25 +435,17 @@ class PullRequestClosedSignalTest(TestCase):
         assert activity.data == {"pull_request": self.pull_request.id}
 
     def test_merged_does_not_emit_activity(self) -> None:
-        with self.feature("organizations:pr-group-activity"):
-            self._save_with_state(PullRequestLifecycleState.MERGED)
+        self._save_with_state(PullRequestLifecycleState.MERGED)
 
         assert not Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).exists()
 
     def test_open_does_not_emit_activity(self) -> None:
-        with self.feature("organizations:pr-group-activity"):
-            self._save_with_state(PullRequestLifecycleState.OPEN)
-
-        assert not Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).exists()
-
-    def test_closed_skips_activity_when_flag_disabled(self) -> None:
-        self._save_with_state(PullRequestLifecycleState.CLOSED)
+        self._save_with_state(PullRequestLifecycleState.OPEN)
 
         assert not Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).exists()
 
     def test_resaving_closed_pr_does_not_duplicate(self) -> None:
-        with self.feature("organizations:pr-group-activity"):
-            self._save_with_state(PullRequestLifecycleState.CLOSED)
-            self._save_with_state(PullRequestLifecycleState.CLOSED)
+        self._save_with_state(PullRequestLifecycleState.CLOSED)
+        self._save_with_state(PullRequestLifecycleState.CLOSED)
 
         assert Activity.objects.filter(type=ActivityType.PULL_REQUEST_CLOSED.value).count() == 1


### PR DESCRIPTION
The `organizations:pr-group-activity` flag has been fully rolled out to all orgs: https://github.com/getsentry/sentry-options-automator/pull/8443