### PR TITLE
ref(occurrences): use FutureTrackingProducer for everything

### DIFF
--- a/src/sentry/issues/producer.py
+++ b/src/sentry/issues/producer.py
@@ -2,26 +2,22 @@ from __future__ import annotations
 
 import logging
 from collections.abc import MutableMapping
-from functools import partial
 from typing import Any, cast
 from uuid import uuid4
 
 from arroyo import Topic as ArroyoTopic
-from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import FutureTrackingProducer, KafkaPayload, KafkaProducer
 from arroyo.types import Message, Value
 from confluent_kafka import KafkaException
 from django.conf import settings
-from taskbroker_client.state import current_task
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.hybridcloud.rpc import ValueEqualityEnum
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.run import process_message
 from sentry.issues.status_change_message import StatusChangeMessage
-from sentry.options.rollout import in_random_rollout
-from sentry.taskworker.producer import get_task_producer
 from sentry.utils import json
-from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.arroyo_producer import get_arroyo_producer
 from sentry.utils.kafka_config import get_topic_definition
 from sentry.utils.safe import get_path, set_path
 
@@ -40,21 +36,17 @@ class PayloadType(ValueEqualityEnum):
     STATUS_CHANGE = "status_change"
 
 
-def _get_occurrence_producer(name: str = "sentry.issues.producer") -> KafkaProducer:
+def _get_occurrence_producer() -> KafkaProducer:
     return get_arroyo_producer(
-        name,
+        "sentry.issues.producer",
         Topic.INGEST_OCCURRENCES,
         exclude_config_keys=["compression.type", "message.max.bytes"],
     )
 
 
-_occurrence_producer = SingletonProducer(
-    _get_occurrence_producer, max_futures=settings.SENTRY_ISSUE_PLATFORM_FUTURES_MAX_LIMIT
-)
-
-_occurrence_task_producer = get_task_producer(
-    producer_name="sentry.issues.tasks.producer",
-    producer_factory=partial(_get_occurrence_producer, name="sentry.issues.tasks.producer"),
+_occurrence_producer = FutureTrackingProducer(
+    name="sentry.issues.producer",
+    producer_factory=_get_occurrence_producer,
 )
 
 
@@ -89,10 +81,7 @@ def produce_occurrence_to_kafka(
 
     try:
         topic = get_topic_definition(Topic.INGEST_OCCURRENCES)["real_topic_name"]
-        if current_task() is not None and in_random_rollout("tasks.producer.occurrences.rollout"):
-            _occurrence_task_producer.produce(ArroyoTopic(topic), payload)
-        else:
-            _occurrence_producer.produce(ArroyoTopic(topic), payload)
+        _occurrence_producer.produce(ArroyoTopic(topic), payload)
     except KafkaException:
         logger.exception(
             "Failed to send occurrence to issue platform",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3756,14 +3756,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Rolls out the new TaskProducer to calls of produce_occurrence_to_kafka() from within taskworkers
-register(
-    "tasks.producer.occurrences.rollout",
-    type=Float,
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Rolls out the new TaskProducer to the clock_pulse task
 register(
     "tasks.producer.clock-pulse.rollout",


### PR DESCRIPTION
https://github.com/getsentry/arroyo/pull/547 introduced a producer abstraction in Arroyo which is essentially the same as TaskProducer but can be used anywhere, not just in tasks.

This PR begins the process of replacing TaskProducer with FutureTrackingProducer, and cleans up all of the rollout logic in the occurrence producer now that this is fully rolled out everywhere.