### PR TITLE
fix(search): Support configured prototype filter keys

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5205,6 +5205,31 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
     });
 
+    it('should support configured filters named like Object prototype keys', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowUnsupportedFilters
+          filterKeys={{
+            ...defaultProps.filterKeys,
+            constructor: {
+              key: 'constructor',
+              name: 'Constructor',
+              kind: FieldKind.TAG,
+            },
+          }}
+          initialQuery="constructor:value"
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('row', {name: 'constructor:value'})).not.toHaveAttribute(
+          'aria-invalid',
+          'true'
+        );
+      });
+    });
+
     describe('secondary aliases provided', () => {
       it('should not mark secondary aliases as invalid', async () => {
         render(

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -92,7 +92,7 @@ function getSearchConfigFromKeys({
     sizeKeys: new Set<string>(),
   } satisfies Partial<SearchConfig>;
 
-  for (const key in keys) {
+  for (const key of Object.keys(keys)) {
     addKeyToSearchConfig(config, key, getFieldDefinition);
   }
 

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -921,7 +921,7 @@ export class TokenConverter {
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&
-      !this.config.supportedTags[getKeyName(key)]
+      !Object.hasOwn(this.config.supportedTags, getKeyName(key))
     ) {
       return {
         type: InvalidReason.INVALID_KEY,


### PR DESCRIPTION
Allows search query builder filters named like Object prototype keys, such as `constructor`, to work when they are actually configured.

Still avoids treating inherited object properties as supported filters.