### PR TITLE
ref(spans): Log full problem objects on span-first detector mismatch

### DIFF
--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -100,6 +100,7 @@ def run_detector(
 
 
 def compare_span_first_problems_to_control_data(
+    project: Project,
     span_first_problems_by_grouptype: dict[str, list[PerformanceProblem]],
     all_control_problems: Sequence[PerformanceProblem],
     get_source_of_truth: Callable[[str], SourceOfTruth],

--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -127,24 +127,13 @@ def compare_span_first_problems_to_control_data(
     for grouptype, span_first_problems in span_first_problems_by_grouptype.items():
         control_problems = control_problems_by_grouptype.get(grouptype) or []
 
-        # TODO: Fingerprint parity proves the detectors agree on which problems exist and how
-        # they're grouped, but doesn't validate the rest of the `PerformanceProblem` payload
-        # (`evidence_data`, `desc`, `offender_span_ids`, `parent_span_ids`, `cause_span_ids`,
-        # `evidence_display`). For most detectors these are derived from the same source data as the
-        # fingerprint, so divergence is unlikely -- but unlikely isn't impossible, and a mismatch
-        # there would mean end users see different issue details despite identical fingerprints.
-        # Once the fingerprint metric shows that the fingerprints are reliably matching, extend the
-        # comparison to cover these fields before cutover.
-        control_fingerprints = {problem.fingerprint for problem in control_problems}
-        span_first_fingerprints = {problem.fingerprint for problem in span_first_problems}
-
         # The vast majority of the time, a given detector isn't going to detect anything, and while
         # it's good to know that the new and legacy detectors agree on not having found anything,
         # those trivial cases can end up overwhelming the more interesting cases. Splitting them off
         # into their own metric lets us continue to track them (at the standard 10% sample rate)
         # while at the same time reducing the hits to the main comparison metric sufficiently that
         # we can afford to ramp its sample rate up to 100%.
-        if not control_fingerprints and not span_first_fingerprints:
+        if not control_problems and not span_first_problems:
             metrics.incr(
                 "span_first_detectors.empty_result_comparison_skipped", tags={"callsite": grouptype}
             )
@@ -152,10 +141,11 @@ def compare_span_first_problems_to_control_data(
 
         SpanFirstDetectorsRolloutController.compare(
             callsite=grouptype,
-            control_data=control_fingerprints,
-            experimental_data=span_first_fingerprints,
-            is_experimental_data_nullish=not bool(span_first_fingerprints),
+            control_data=control_problems,
+            experimental_data=span_first_problems,
+            is_experimental_data_nullish=not bool(span_first_problems),
             source_of_truth=get_source_of_truth(grouptype),
+            data_serializer=lambda problems: [problem.to_dict() for problem in problems],
             metric_sample_rate=1.0,
         )
 

--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
+from types import NoneType
 from typing import Any
 
 from sentry.issue_detection.detectors.span_first.base import SpanFirstDetector
@@ -157,3 +158,116 @@ def compare_span_first_problems_to_control_data(
             source_of_truth=get_source_of_truth(grouptype),
             metric_sample_rate=1.0,
         )
+
+
+def _compare_problem_sets(
+    control_problems: list[PerformanceProblem], span_first_problems: list[PerformanceProblem]
+) -> dict[str, list[str]]:
+    """
+    Compare two lists of (hopefully matching) problems, and return a dictionary containing
+    information about where, if anywhere, they differ.
+    """
+
+    control_problems_by_fingerprint = {problem.fingerprint: problem for problem in control_problems}
+    span_first_problems_by_fingerprint = {
+        problem.fingerprint: problem for problem in span_first_problems
+    }
+
+    overall_diffs = {}
+
+    if control_problems_by_fingerprint.keys() != span_first_problems_by_fingerprint.keys():
+        non_shared_fingerprints = sorted(
+            set(control_problems_by_fingerprint.keys()).symmetric_difference(
+                span_first_problems_by_fingerprint.keys()
+            )
+        )
+        overall_diffs["non_shared_fingerprints"] = non_shared_fingerprints
+
+    for fingerprint, control_problem in control_problems_by_fingerprint.items():
+        span_first_problem = span_first_problems_by_fingerprint.get(fingerprint)
+
+        if not span_first_problem:
+            continue
+
+        problem_diffs = _compare_problems(control_problem, span_first_problem)
+        if problem_diffs:
+            overall_diffs[fingerprint] = problem_diffs
+
+    return overall_diffs
+
+
+def _compare_problems(
+    control_problem: PerformanceProblem, span_first_problem: PerformanceProblem
+) -> list[str]:
+    """
+    Compare the data in the given problems, and return a list of spots in which the problems differ.
+    """
+
+    diffs = []
+
+    if control_problem.op != span_first_problem.op:
+        diffs.append("op")
+
+    if control_problem.desc != span_first_problem.desc:
+        diffs.append("desc")
+
+    if control_problem.type.slug != span_first_problem.type.slug:
+        diffs.append("type")
+
+    if not _are_equivalent_lists(
+        control_problem.parent_span_ids, span_first_problem.parent_span_ids
+    ):
+        diffs.append("parent_span_ids")
+
+    if not _are_equivalent_lists(control_problem.cause_span_ids, span_first_problem.cause_span_ids):
+        diffs.append("cause_span_ids")
+
+    if not _are_equivalent_lists(
+        control_problem.offender_span_ids, span_first_problem.offender_span_ids
+    ):
+        diffs.append("offender_span_ids")
+
+    if not _are_equivalent_lists(
+        [f"{e.name}{e.value}{e.important}" for e in control_problem.evidence_display],
+        [f"{e.name}{e.value}{e.important}" for e in span_first_problem.evidence_display],
+    ):
+        diffs.append("evidence_display")
+
+    if control_problem.evidence_data.keys() != span_first_problem.evidence_data.keys():
+        non_shared_keys = sorted(
+            set(control_problem.evidence_data.keys()).symmetric_difference(
+                span_first_problem.evidence_data.keys()
+            )
+        )
+        diffs.append(f"evidence_data.non_shared_keys: {', '.join(non_shared_keys)}")
+
+    for key, control_value in control_problem.evidence_data.items():
+        if key not in span_first_problem.evidence_data:
+            continue
+        if key in {"op", "parent_span_ids", "cause_span_ids", "offender_span_ids"}:
+            # These values have already been checked at the top level of the problem
+            continue
+
+        span_first_value = span_first_problem.evidence_data[key]
+
+        if key == "span_evidence_key_value":
+            if not _are_equivalent_lists(
+                [f"{d['key']}{d['value']}{d.get('is_multi_value')}" for d in control_value],
+                [f"{d['key']}{d['value']}{d.get('is_multi_value')}" for d in span_first_value],
+            ):
+                diffs.append("evidence_data.span_evidence_key_value")
+        elif isinstance(control_value, (int, float, str, NoneType)):
+            if control_value != span_first_value:
+                diffs.append(f"evidence_data.{key}")
+        elif isinstance(control_value, list):
+            if not _are_equivalent_lists(control_value, span_first_value):
+                diffs.append(f"evidence_data.{key}")
+
+    return diffs
+
+
+def _are_equivalent_lists(list1: Sequence[Any] | None, list2: Sequence[Any] | None) -> bool:
+    """
+    Given two nullable lists, check for equality, ignoring list order.
+    """
+    return set(list1 or []) == set(list2 or [])

--- a/src/sentry/issue_detection/detectors/span_first/run_detectors.py
+++ b/src/sentry/issue_detection/detectors/span_first/run_detectors.py
@@ -140,12 +140,33 @@ def compare_span_first_problems_to_control_data(
             )
             continue  # Skip running the comparison for this grouptype
 
+        # What follows is a little bit of a hack. In the  rollout controller's `compare` method, the
+        # `exact_match_comparator` parameter expects a function returning a boolean, and the
+        # `debug_context` parameter expects a static value, which `compare` doesn't modify. Thus if
+        # we want to include any differences we find as a result of the comparison in the debug
+        # context, we have to do the real comparison here and pass a dummy comparator which just
+        # returns the result we already found.
+        debug_context = {
+            "org_slug": project.organization.slug,
+            "project_id": project.id,
+            "project_slug": project.slug,
+        }
+
+        diffs = _compare_problem_sets(control_problems, span_first_problems)
+        if diffs:
+            debug_context["diffs"] = diffs
+            comparator = lambda _, __: False
+        else:
+            comparator = lambda _, __: True
+
         SpanFirstDetectorsRolloutController.compare(
             callsite=grouptype,
             control_data=control_problems,
             experimental_data=span_first_problems,
             is_experimental_data_nullish=not bool(span_first_problems),
             source_of_truth=get_source_of_truth(grouptype),
+            exact_match_comparator=comparator,
+            debug_context=debug_context,
             data_serializer=lambda problems: [problem.to_dict() for problem in problems],
             metric_sample_rate=1.0,
         )

--- a/src/sentry/issue_detection/detectors/span_first/span_first_utils.py
+++ b/src/sentry/issue_detection/detectors/span_first/span_first_utils.py
@@ -25,6 +25,9 @@ DEFAULT_MAX_EVIDENCE_VALUE_LENGTH = 10_000
 # other isn't.
 class SpanFirstDetectorsRolloutController(SafeRolloutComparator):
     ROLLOUT_NAME = "span_first_detectors"
+    # Log to Sentry only, so we don't have to worry about what we might be logging to an external
+    # service when we log mismatches
+    internal_logs_only = True
 
 
 SPAN_FIRST_DETECTORS_ENABLEMENT_OPTION = (

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -392,6 +392,7 @@ def _maybe_run_span_first_detector_parity_check(
         )
 
         compare_span_first_problems_to_control_data(
+            project,
             span_first_problems_by_grouptype,
             all_control_problems,
             get_source_of_truth=lambda _: (

--- a/tests/sentry/issue_detection/span_first/test_run_detectors.py
+++ b/tests/sentry/issue_detection/span_first/test_run_detectors.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import ANY, patch
 
 import pytest
 
 from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.span_first.base import SpanFirstDetector
 from sentry.issue_detection.detectors.span_first.run_detectors import (
+    _are_equivalent_lists,
+    _compare_problem_sets,
+    _compare_problems,
     compare_span_first_problems_to_control_data,
     run_detector,
     run_span_first_detectors,
@@ -18,32 +22,58 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issue_detection.types import StandaloneSpan
 from sentry.issues.grouptype import (
     GroupType,
-    PerformanceNPlusOneGroupType,
+    PerformanceConsecutiveDBQueriesGroupType,
+    PerformanceNPlusOneAPICallsGroupType,
     PerformanceSlowDBQueryGroupType,
 )
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.testutils.cases import TestCase
 from sentry.testutils.issue_detection.segment_span_generators import (
     create_child_span,
     create_segment,
 )
+from sentry.testutils.pytest.mocking import count_matching_calls
 
+CONSECUTIVE_DB_GROUPTYPE = PerformanceConsecutiveDBQueriesGroupType
+N_PLUS_ONE_API_GROUPTYPE = PerformanceNPlusOneAPICallsGroupType
 SLOW_DB_GROUPTYPE = PerformanceSlowDBQueryGroupType
-N_PLUS_ONE_GROUPTYPE = PerformanceNPlusOneGroupType
+
+CONSECUTIVE_DB_SLUG = CONSECUTIVE_DB_GROUPTYPE.slug
+N_PLUS_ONE_API_SLUG = N_PLUS_ONE_API_GROUPTYPE.slug
 SLOW_DB_SLUG = SLOW_DB_GROUPTYPE.slug
-N_PLUS_ONE_SLUG = N_PLUS_ONE_GROUPTYPE.slug
+
+CONSECUTIVE_DB_FINGERPRINT = "consecutive-http-fingerprint"
+N_PLUS_ONE_API_FINGERPRINT = "n-plus-one-fingerprint"
+SLOW_DB_FINGERPRINT = "slow-db-fingerprint"
+FINGERPRINTS_BY_GROUPTYPE = {
+    CONSECUTIVE_DB_GROUPTYPE: CONSECUTIVE_DB_FINGERPRINT,
+    N_PLUS_ONE_API_GROUPTYPE: N_PLUS_ONE_API_FINGERPRINT,
+    SLOW_DB_GROUPTYPE: SLOW_DB_FINGERPRINT,
+}
 
 
-def make_problem(fingerprint: str, grouptype: type[GroupType]) -> PerformanceProblem:
+def make_problem(
+    grouptype: type[GroupType],
+    *,
+    op: str = "db",
+    desc: str = "test problem",
+    fingerprint: str | None = None,
+    parent_span_ids: list[str] | None = None,
+    cause_span_ids: list[str] | None = None,
+    offender_span_ids: list[str] | None = None,
+    evidence_data: dict[str, Any] | None = None,
+    evidence_display: list[IssueEvidence] | None = None,
+) -> PerformanceProblem:
     return PerformanceProblem(
-        fingerprint=fingerprint,
-        op="db",
-        desc="test problem",
+        op=op,
+        desc=desc,
         type=grouptype,
-        parent_span_ids=[],
-        cause_span_ids=[],
-        offender_span_ids=[],
-        evidence_data={},
-        evidence_display=[],
+        fingerprint=fingerprint or FINGERPRINTS_BY_GROUPTYPE[grouptype],
+        parent_span_ids=parent_span_ids or [],
+        cause_span_ids=cause_span_ids or [],
+        offender_span_ids=offender_span_ids or [],
+        evidence_data=evidence_data or {},
+        evidence_display=evidence_display or [],
     )
 
 
@@ -56,20 +86,20 @@ class MockSlowDBDetector(SpanFirstDetector):
         pass
 
     def on_complete(self) -> None:
-        problem = make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE)
+        problem = make_problem(SLOW_DB_GROUPTYPE)
         self.stored_problems[problem.fingerprint] = problem
 
 
-class MockNPlusOneDetector(SpanFirstDetector):
-    type = DetectorType.N_PLUS_ONE_DB_QUERIES
-    grouptype = N_PLUS_ONE_GROUPTYPE
+class MockNPlusOneAPIDetector(SpanFirstDetector):
+    type = DetectorType.N_PLUS_ONE_API_CALLS
+    grouptype = N_PLUS_ONE_API_GROUPTYPE
 
     def visit_span(self, span: StandaloneSpan) -> None:
         # No-op: this stub emits its problem in `on_complete`.
         pass
 
     def on_complete(self) -> None:
-        problem = make_problem("n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE)
+        problem = make_problem(N_PLUS_ONE_API_GROUPTYPE)
         self.stored_problems[problem.fingerprint] = problem
 
 
@@ -81,7 +111,7 @@ class RunDetectorTest(TestCase):
         result = run_detector(MockSlowDBDetector, {"detection_enabled": True}, segment[0], segment)
 
         assert len(result) == 1
-        assert result[0].fingerprint == "slow-db-fingerprint"
+        assert result[0].fingerprint == SLOW_DB_FINGERPRINT
 
     def test_returns_empty_list_when_creation_is_disallowed(self) -> None:
         segment = create_segment([create_child_span(op="db", duration=1001)])
@@ -102,7 +132,7 @@ class RunSpanFirstDetectorsTest(TestCase):
         # can verify the bucketing without depending on whichever real detectors are wired up.
         mock_registry = {
             SLOW_DB_SLUG: [MockSlowDBDetector],
-            N_PLUS_ONE_SLUG: [MockNPlusOneDetector],
+            N_PLUS_ONE_API_SLUG: [MockNPlusOneAPIDetector],
         }
         with patch.dict(
             "sentry.issue_detection.detectors.span_first.run_detectors.SPAN_FIRST_DETECTORS_BY_GROUPTYPE",
@@ -110,74 +140,201 @@ class RunSpanFirstDetectorsTest(TestCase):
             clear=True,
         ):
             span_first_problems_by_grouptype = run_span_first_detectors(
-                [SLOW_DB_SLUG, N_PLUS_ONE_SLUG],
+                [SLOW_DB_SLUG, N_PLUS_ONE_API_SLUG],
                 dummy_segment[0],
                 dummy_segment,
                 self.project,
             )
 
-        assert set(span_first_problems_by_grouptype.keys()) == {SLOW_DB_SLUG, N_PLUS_ONE_SLUG}
+            assert set(span_first_problems_by_grouptype.keys()) == {
+                SLOW_DB_SLUG,
+                N_PLUS_ONE_API_SLUG,
+            }
 
-        slow_db_problems = span_first_problems_by_grouptype[SLOW_DB_SLUG]
-        n_plus_one_problems = span_first_problems_by_grouptype[N_PLUS_ONE_SLUG]
-        assert [p.fingerprint for p in slow_db_problems] == ["slow-db-fingerprint"]
-        assert [p.fingerprint for p in n_plus_one_problems] == ["n-plus-one-fingerprint"]
+            slow_db_problems = span_first_problems_by_grouptype[SLOW_DB_SLUG]
+            n_plus_one_problems = span_first_problems_by_grouptype[N_PLUS_ONE_API_SLUG]
+            assert [p.fingerprint for p in slow_db_problems] == [SLOW_DB_FINGERPRINT]
+            assert [p.fingerprint for p in n_plus_one_problems] == [N_PLUS_ONE_API_FINGERPRINT]
 
 
 class CompareSpanFirstProblemsToControlDataTest(TestCase):
-    def test_compares_fingerprints_for_each_grouptype(self) -> None:
-        span_first_problems_by_grouptype = {
-            SLOW_DB_SLUG: [
-                make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE),
-                make_problem("span-first-slow-db-fingerprint", SLOW_DB_GROUPTYPE),
-            ],
-            N_PLUS_ONE_SLUG: [
-                make_problem("n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
-                make_problem("span-first-n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
-            ],
+    def _get_base_debug_context(self) -> dict[str, Any]:
+        return {
+            "org_slug": self.project.organization.slug,
+            "project_id": self.project.id,
+            "project_slug": self.project.slug,
         }
-        control_problems = [
-            # One slow DB problem which matches the span-first set, one which doesn't
-            make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE),
-            make_problem("control-slow-db-fingerprint", SLOW_DB_GROUPTYPE),
-            # One N+1 problem which matches the span-first set, one which doesn't
-            make_problem("n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
-            make_problem("control-n-plus-one-fingerprint", N_PLUS_ONE_GROUPTYPE),
-        ]
 
-        with patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare:
+    def _get_base_compare_kwargs(self) -> dict[str, Any]:
+        return {
+            "is_experimental_data_nullish": False,
+            "source_of_truth": "neither",
+            "metric_sample_rate": 1.0,
+            # Lambdas won't compare equal; we'll verify these separately (the comparator by running
+            # it and the serializer by seeing what gets logged)
+            "exact_match_comparator": ANY,
+            "data_serializer": ANY,
+        }
+
+    def test_compares_problems_for_each_grouptype(self) -> None:
+        span_first_slow_db_problems = [
+            make_problem(SLOW_DB_GROUPTYPE, desc="span-first db desc"),
+        ]
+        span_first_n_plus_one_problems = [
+            make_problem(N_PLUS_ONE_API_GROUPTYPE, desc="span-first n+1 desc"),
+        ]
+        span_first_problems_by_grouptype = {
+            SLOW_DB_SLUG: span_first_slow_db_problems,
+            N_PLUS_ONE_API_SLUG: span_first_n_plus_one_problems,
+        }
+
+        control_slow_db_problems = [
+            make_problem(SLOW_DB_GROUPTYPE, desc="control db desc"),
+        ]
+        control_n_plus_one_problems = [
+            make_problem(N_PLUS_ONE_API_GROUPTYPE, desc="control n+1 desc"),
+        ]
+        control_problems = control_slow_db_problems + control_n_plus_one_problems
+
+        with (
+            patch(
+                "sentry.issue_detection.detectors.span_first.run_detectors._compare_problem_sets",
+                wraps=_compare_problem_sets,
+            ) as compare_problem_sets_spy,
+            patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare,
+        ):
             compare_span_first_problems_to_control_data(
+                self.project,
                 span_first_problems_by_grouptype,
                 control_problems,
                 get_source_of_truth=lambda _: "neither",
             )
 
-            mock_compare.assert_any_call(
-                callsite=SLOW_DB_SLUG,
-                control_data={"slow-db-fingerprint", "control-slow-db-fingerprint"},
-                experimental_data={"slow-db-fingerprint", "span-first-slow-db-fingerprint"},
-                is_experimental_data_nullish=False,
-                source_of_truth="neither",
-                metric_sample_rate=1.0,
+            compare_problem_sets_spy.assert_any_call(
+                control_slow_db_problems, span_first_slow_db_problems
             )
-            mock_compare.assert_any_call(
-                callsite=N_PLUS_ONE_SLUG,
-                control_data={"n-plus-one-fingerprint", "control-n-plus-one-fingerprint"},
-                experimental_data={"n-plus-one-fingerprint", "span-first-n-plus-one-fingerprint"},
-                is_experimental_data_nullish=False,
-                source_of_truth="neither",
-                metric_sample_rate=1.0,
+            compare_problem_sets_spy.assert_any_call(
+                control_n_plus_one_problems, span_first_n_plus_one_problems
             )
 
-    def test_skips_comparison_for_null_results(self) -> None:
-        span_first_problems_by_grouptype = {
-            SLOW_DB_SLUG: [make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE)],
-            N_PLUS_ONE_SLUG: [],
-        }
-        control_problems = [make_problem("slow-db-fingerprint", SLOW_DB_GROUPTYPE)]
+            mock_compare.assert_any_call(
+                **self._get_base_compare_kwargs(),
+                callsite=SLOW_DB_SLUG,
+                control_data=control_slow_db_problems,
+                experimental_data=span_first_slow_db_problems,
+                debug_context={
+                    **self._get_base_debug_context(),
+                    "diffs": {SLOW_DB_FINGERPRINT: ["desc"]},
+                },
+            )
+            mock_compare.assert_any_call(
+                **self._get_base_compare_kwargs(),
+                callsite=N_PLUS_ONE_API_SLUG,
+                control_data=control_n_plus_one_problems,
+                experimental_data=span_first_n_plus_one_problems,
+                debug_context={
+                    **self._get_base_debug_context(),
+                    "diffs": {N_PLUS_ONE_API_FINGERPRINT: ["desc"]},
+                },
+            )
+
+    def test_reports_match_when_problems_are_identical(self) -> None:
+        span_first_problems = [make_problem(SLOW_DB_GROUPTYPE)]
+        control_problems = [make_problem(SLOW_DB_GROUPTYPE)]
 
         with patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare:
             compare_span_first_problems_to_control_data(
+                self.project,
+                {SLOW_DB_SLUG: span_first_problems},
+                control_problems,
+                get_source_of_truth=lambda _: "neither",
+            )
+
+            compare_kwargs = mock_compare.call_args.kwargs
+
+            debug_context = compare_kwargs["debug_context"]
+            assert "diffs" not in debug_context
+
+            comparator = compare_kwargs["exact_match_comparator"]
+            assert comparator(control_problems, span_first_problems) is True
+
+    def test_reports_mismatch_when_problems_differ(self) -> None:
+        span_first_problems = [make_problem(SLOW_DB_GROUPTYPE, desc="span-first desc")]
+        control_problems = [make_problem(SLOW_DB_GROUPTYPE, desc="control desc")]
+
+        with patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare:
+            compare_span_first_problems_to_control_data(
+                self.project,
+                {SLOW_DB_SLUG: span_first_problems},
+                control_problems,
+                get_source_of_truth=lambda _: "neither",
+            )
+
+            compare_kwargs = mock_compare.call_args.kwargs
+
+            debug_context = compare_kwargs["debug_context"]
+            assert "diffs" in debug_context
+            assert debug_context["diffs"] == {SLOW_DB_FINGERPRINT: ["desc"]}
+
+            comparator = compare_kwargs["exact_match_comparator"]
+            assert comparator(control_problems, span_first_problems) is False
+
+    def test_logs_mismatch_with_diffs(self) -> None:
+        span_first_problems = [make_problem(SLOW_DB_GROUPTYPE, desc="span-first desc")]
+        control_problems = [make_problem(SLOW_DB_GROUPTYPE, desc="control desc")]
+
+        with (
+            patch.object(
+                SpanFirstDetectorsRolloutController, "_should_log_mismatch", lambda _: True
+            ),
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch("sentry.utils.rollout.sdk_logger.info") as mock_sdk_logger,
+        ):
+            compare_span_first_problems_to_control_data(
+                self.project,
+                {SLOW_DB_SLUG: span_first_problems},
+                control_problems,
+                get_source_of_truth=lambda _: "neither",
+            )
+
+            mock_sdk_logger.assert_any_call(
+                "saferollout.mismatch",
+                attributes={
+                    "callsite": SLOW_DB_SLUG,
+                    "control_data_raw": [problem.to_dict() for problem in control_problems],
+                    "experimental_data_raw": [problem.to_dict() for problem in span_first_problems],
+                    "rollout_name": "span_first_detectors",
+                    "source_of_truth": "neither",
+                    "exact_match": False,
+                    "reasonable_match": None,
+                    "is_null_result": False,
+                    "debug_context": {
+                        **self._get_base_debug_context(),
+                        "diffs": {SLOW_DB_FINGERPRINT: ["desc"]},
+                    },
+                },
+            )
+
+            # Since problem objects can contain customer data, ensure that we're using the SDK
+            # logger (which logs only to Sentry) rather than the Python logger (which logs to both
+            # Sentry and GCP).
+            mock_python_logger.assert_not_called()
+
+    def test_skips_comparison_for_null_results(self) -> None:
+        span_first_slow_db_problems = [make_problem(SLOW_DB_GROUPTYPE)]
+        span_first_n_plus_one_problems: list[PerformanceProblem] = []
+        span_first_problems_by_grouptype = {
+            SLOW_DB_SLUG: span_first_slow_db_problems,
+            N_PLUS_ONE_API_SLUG: span_first_n_plus_one_problems,
+        }
+
+        control_slow_db_problems = [make_problem(SLOW_DB_GROUPTYPE)]
+        control_n_plus_one_problems: list[PerformanceProblem] = []
+        control_problems = control_slow_db_problems + control_n_plus_one_problems
+
+        with patch.object(SpanFirstDetectorsRolloutController, "compare") as mock_compare:
+            compare_span_first_problems_to_control_data(
+                self.project,
                 span_first_problems_by_grouptype,
                 control_problems,
                 get_source_of_truth=lambda _: "neither",
@@ -187,10 +344,198 @@ class CompareSpanFirstProblemsToControlDataTest(TestCase):
             # since they were null
             assert mock_compare.call_count == 1
             mock_compare.assert_any_call(
+                **self._get_base_compare_kwargs(),
                 callsite=SLOW_DB_SLUG,
-                control_data={"slow-db-fingerprint"},
-                experimental_data={"slow-db-fingerprint"},
-                is_experimental_data_nullish=False,
-                source_of_truth="neither",
-                metric_sample_rate=1.0,
+                control_data=control_slow_db_problems,
+                experimental_data=span_first_slow_db_problems,
+                debug_context=self._get_base_debug_context(),
+            )
+
+
+class CompareProblemSetsTest(TestCase):
+    def test_recognizes_matching_problem_sets(self) -> None:
+        control_problems = [make_problem(SLOW_DB_GROUPTYPE)]
+        span_first_problems = [make_problem(SLOW_DB_GROUPTYPE)]
+
+        assert _compare_problem_sets(control_problems, span_first_problems) == {}
+
+    def test_reports_non_shared_fingerprints(self) -> None:
+        control_problems = [
+            make_problem(SLOW_DB_GROUPTYPE, fingerprint="shared-fingerprint"),
+            make_problem(SLOW_DB_GROUPTYPE, fingerprint="control-only-fingerprint"),
+        ]
+        span_first_problems = [
+            make_problem(SLOW_DB_GROUPTYPE, fingerprint="shared-fingerprint"),
+            make_problem(SLOW_DB_GROUPTYPE, fingerprint="span-first-only-fingerprint"),
+        ]
+
+        diffs = _compare_problem_sets(control_problems, span_first_problems)
+
+        # The shared fingerprint's problems match, so the only diff is the set of fingerprints that
+        # aren't shared
+        assert list(diffs.keys()) == ["non_shared_fingerprints"]
+        assert set(diffs["non_shared_fingerprints"]) == {
+            "control-only-fingerprint",
+            "span-first-only-fingerprint",
+        }
+
+    def test_reports_per_problem_diffs_for_shared_fingerprints(self) -> None:
+        control_problems = [make_problem(SLOW_DB_GROUPTYPE, desc="control desc")]
+        span_first_problems = [make_problem(SLOW_DB_GROUPTYPE, desc="span-first desc")]
+
+        assert _compare_problem_sets(control_problems, span_first_problems) == {
+            SLOW_DB_FINGERPRINT: ["desc"]
+        }
+
+
+class CompareProblemsTest(TestCase):
+    def test_recognizes_matching_problems(self) -> None:
+        control_problem = make_problem(SLOW_DB_GROUPTYPE)
+        span_first_problem = make_problem(SLOW_DB_GROUPTYPE)
+
+        assert _compare_problems(control_problem, span_first_problem) == []
+
+    def test_detects_op_desc_and_type_differences(self) -> None:
+        control_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            op="db",
+            desc="control desc",
+        )
+        span_first_problem = make_problem(
+            N_PLUS_ONE_API_GROUPTYPE,
+            op="http.client",
+            desc="span-first desc",
+        )
+
+        assert set(_compare_problems(control_problem, span_first_problem)) == {"op", "desc", "type"}
+
+    def test_detects_span_id_differences(self) -> None:
+        control_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            parent_span_ids=["dogs"],
+            cause_span_ids=["are"],
+            offender_span_ids=["great"],
+        )
+        span_first_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            parent_span_ids=["adopt"],
+            cause_span_ids=["don't"],
+            offender_span_ids=["shop"],
+        )
+
+        assert set(_compare_problems(control_problem, span_first_problem)) == {
+            "parent_span_ids",
+            "cause_span_ids",
+            "offender_span_ids",
+        }
+
+    def test_ignores_span_id_order(self) -> None:
+        control_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            offender_span_ids=["maisey", "charlie"],
+        )
+        span_first_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            offender_span_ids=["charlie", "maisey"],
+        )
+
+        assert _compare_problems(control_problem, span_first_problem) == []
+
+    def test_detects_evidence_display_differences(self) -> None:
+        control_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            evidence_display=[IssueEvidence("Offending Span", "dogs are great", True)],
+        )
+        span_first_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            evidence_display=[IssueEvidence("Offending Span", "adopt don't shop", True)],
+        )
+
+        assert _compare_problems(control_problem, span_first_problem) == ["evidence_display"]
+
+    def test_detects_non_shared_evidence_data_keys(self) -> None:
+        control_problem = make_problem(SLOW_DB_GROUPTYPE, evidence_data={"dogs": "are great"})
+        span_first_problem = make_problem(SLOW_DB_GROUPTYPE, evidence_data={"adopt": "don't shop"})
+
+        diffs = _compare_problems(control_problem, span_first_problem)
+
+        assert len(diffs) == 1
+        assert diffs[0] == "evidence_data.non_shared_keys: adopt, dogs"
+
+    def test_detects_different_evidence_data_values(self) -> None:
+        control_problem = make_problem(
+            SLOW_DB_GROUPTYPE, evidence_data={"repeating_spans_count": 5}
+        )
+        span_first_problem = make_problem(
+            SLOW_DB_GROUPTYPE, evidence_data={"repeating_spans_count": 3}
+        )
+
+        assert _compare_problems(control_problem, span_first_problem) == [
+            "evidence_data.repeating_spans_count"
+        ]
+
+    def test_ignores_order_when_comparing_lists_in_evidence_data(self) -> None:
+        control_problem = make_problem(
+            N_PLUS_ONE_API_GROUPTYPE, evidence_data={"parameters": ["maisey", "charlie"]}
+        )
+        reordered_params_problem = make_problem(
+            N_PLUS_ONE_API_GROUPTYPE, evidence_data={"parameters": ["charlie", "maisey"]}
+        )
+        different_params_problem = make_problem(
+            N_PLUS_ONE_API_GROUPTYPE, evidence_data={"parameters": ["maisey", "piper"]}
+        )
+
+        assert _compare_problems(control_problem, reordered_params_problem) == []
+        assert _compare_problems(control_problem, different_params_problem) == [
+            "evidence_data.parameters"
+        ]
+
+    def test_detects_span_evidence_key_value_diff(self) -> None:
+        control_problem = make_problem(
+            CONSECUTIVE_DB_GROUPTYPE,
+            evidence_data={
+                "span_evidence_key_value": [{"key": "Transaction", "value": "dogs are great"}]
+            },
+        )
+        span_first_problem = make_problem(
+            CONSECUTIVE_DB_GROUPTYPE,
+            evidence_data={
+                "span_evidence_key_value": [{"key": "Transaction", "value": "adopt, don't shop"}]
+            },
+        )
+
+        assert _compare_problems(control_problem, span_first_problem) == [
+            "evidence_data.span_evidence_key_value"
+        ]
+
+    def test_skips_comparing_span_ids_within_evidence_data(self) -> None:
+        control_offender_span_ids = ["dogs_are_great"]
+        span_first_offender_span_ids = ["adopt_dont_shop"]
+
+        control_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            offender_span_ids=control_offender_span_ids,
+            evidence_data={"offender_span_ids": control_offender_span_ids},
+        )
+        span_first_problem = make_problem(
+            SLOW_DB_GROUPTYPE,
+            offender_span_ids=span_first_offender_span_ids,
+            evidence_data={"offender_span_ids": span_first_offender_span_ids},
+        )
+
+        with patch(
+            "sentry.issue_detection.detectors.span_first.run_detectors._are_equivalent_lists",
+            wraps=_are_equivalent_lists,
+        ) as are_equivalent_lists_spy:
+            _compare_problems(control_problem, span_first_problem)
+
+            # Even though the offender span ids appear in two spots in the problem, we only compare
+            # them once (the same applies to parent span ids and cause span ids)
+            assert (
+                count_matching_calls(
+                    are_equivalent_lists_spy,
+                    control_offender_span_ids,
+                    span_first_offender_span_ids,
+                )
+                == 1
             )


### PR DESCRIPTION
As a way to test our new span-first issue detectors, we're currently running both the existing and new detectors on the same data, and using the `SafeRolloutComparator` utility to compare the results to make sure the new detectors are finding the same problems the old detectors do. So far, "the same problems" has meant "problems with the same fingerprints," so we're passing fingerprint sets to the comparator to check if they're equal.

Great, except that on the rare occasions we've found a mismatch, the logs only record the different fingerprints - after all, that's all the comparator has. But bare hash values don't tell us anything about the underlying data, so debugging _why_ the results are different is impossible. Also, fingerprints are only based on a subset of data in the problem, so just because two problems have the same fingerprint, it doesn't guarantee all of the underlying data matches. (Hence [this TODO](https://github.com/getsentry/sentry/blob/8792ae3a91b9262bc4ab37575c7ab1cc8b709c9f/src/sentry/issue_detection/detectors/span_first/run_detectors.py#L129-L136).)

This PR fixes both of those problems by making a few changes to our comparison and logging logic.

- Add a `_compare_problem_sets` helper, which will first compare fingerprints, but will also then go problem by problem and compare the rest of the data. Since this is a bunch more comparisons, it keeps track of the places where it finds disagreement, and returns a dictionary, keyed by problem fingerprint, listing its results.

- Use the rollout comparator's `debug_context` option to include more data when we log a mismatch, including org and project slug, and whatever differences the helper found.

- Pass the full problem sets (rather than just their fingerprints) to the comparator, so they can be included in the mismatch logs.

- Since all of this extra data we're logging might contain customer information, switch the comparator from using the Python logger (which logs to both Sentry and GCP) to using the Python SDK's logging interface (which logs only to Sentry). That way all data is kept in-house.

- Add a whole bunch more tests, to cover the added complexity in our logic.