### PR TITLE
feat(sentry-apps): Add flag-gated instant-save avatar rows to the details form

### DIFF
--- a/static/app/components/avatarChooser/useUploader.tsx
+++ b/static/app/components/avatarChooser/useUploader.tsx
@@ -22,9 +22,9 @@ export function useUploader({onSelect, minImageSize}: UseUploaderOptions) {
 
   useEffect(() => () => cleanupObjectUrl(), [cleanupObjectUrl]);
 
-  const openUpload = useCallback((ev: React.MouseEvent<HTMLElement>) => {
-    ev.currentTarget.blur();
-    ev.preventDefault();
+  const openUpload = useCallback((ev?: React.MouseEvent<HTMLElement>) => {
+    ev?.currentTarget.blur();
+    ev?.preventDefault();
     fileInputRef.current?.click();
   }, []);
 

--- a/static/app/views/settings/organizationDeveloperSettings/avatarCropModal.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/avatarCropModal.tsx
@@ -1,0 +1,59 @@
+import {Fragment, useState} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {AvatarCropper} from 'sentry/components/avatarChooser/avatarCropper';
+import {t} from 'sentry/locale';
+
+interface AvatarCropModalProps extends ModalRenderProps {
+  dataUrl: string;
+  maxDimension: number;
+  minDimension: number;
+  onCrop: (dataUrl: string) => void;
+}
+
+export function AvatarCropModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  dataUrl,
+  minDimension,
+  maxDimension,
+  onCrop,
+}: AvatarCropModalProps) {
+  const [croppedDataUrl, setCroppedDataUrl] = useState<string | null>(null);
+
+  return (
+    <Fragment>
+      <Header closeButton>{t('Crop your image')}</Header>
+      <Body>
+        <AvatarCropper
+          minDimension={minDimension}
+          maxDimension={maxDimension}
+          dataUrl={dataUrl}
+          updateDataUrlState={setCroppedDataUrl}
+        />
+      </Body>
+      <Footer>
+        <Flex gap="md">
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button
+            variant="primary"
+            disabled={!croppedDataUrl}
+            onClick={() => {
+              if (croppedDataUrl) {
+                onCrop(croppedDataUrl);
+              }
+              closeModal();
+            }}
+          >
+            {t('Save image')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryAppAvatarField.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryAppAvatarField.tsx
@@ -1,0 +1,221 @@
+import styled from '@emotion/styled';
+import {useMutation} from '@tanstack/react-query';
+
+import {SentryAppAvatar} from '@sentry/scraps/avatar';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {useModal} from '@sentry/scraps/modal';
+import {Text} from '@sentry/scraps/text';
+
+import {
+  addErrorMessage,
+  addMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {useUploader} from 'sentry/components/avatarChooser/useUploader';
+import type {MenuItemProps} from 'sentry/components/dropdownMenu';
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconCheckmark} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {Avatar} from 'sentry/types/core';
+import type {SentryApp, SentryAppAvatarPhotoType} from 'sentry/types/integrations';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+import {AvatarCropModal} from './avatarCropModal';
+
+export const SENTRY_APP_AVATAR_STYLES = {
+  logo: {
+    title: t('Logo'),
+    label: t('Default logo'),
+    description: t('The default icon for integrations'),
+    help: t('Image must be between 256px by 256px and 1024px by 1024px.'),
+  },
+  icon: {
+    title: t('Small Icon'),
+    label: t('Default small icon'),
+    description: tct('This is a silhouette icon used only for [uiDocs:UI Components]', {
+      uiDocs: (
+        <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/ui-components/" />
+      ),
+    }),
+    help: t(
+      'Image must be between 256px by 256px and 1024px by 1024px, and may only use black and transparent pixels.'
+    ),
+  },
+} satisfies Record<SentryAppAvatarPhotoType, unknown>;
+
+// These values must be synced with the avatar endpoint in backend.
+const MIN_DIMENSION = 256;
+const MAX_DIMENSION = 1024;
+
+interface SentryAppAvatarFieldProps {
+  app: SentryApp;
+  isInternal: boolean;
+  onSave: (app: SentryApp) => void;
+  photoType: SentryAppAvatarPhotoType;
+}
+
+/**
+ * A settings field row that previews one of a sentry app's two avatars (logo
+ * or small icon) and saves a new choice immediately on selection.
+ */
+export function SentryAppAvatarField({
+  app,
+  isInternal,
+  onSave,
+  photoType,
+}: SentryAppAvatarFieldProps) {
+  const {openModal} = useModal();
+  const style = SENTRY_APP_AVATAR_STYLES[photoType];
+  const isColor = photoType === 'logo';
+
+  const avatarType =
+    app.avatars?.find(appAvatar => appAvatar.color === isColor)?.avatarType ?? 'default';
+
+  const saveMutation = useMutation({
+    mutationFn: (data: {
+      avatar_type: Avatar['avatarType'];
+      color: boolean;
+      photoType: SentryAppAvatarPhotoType;
+      avatar_photo?: string;
+    }) =>
+      fetchMutation<SentryApp>({
+        url: `/sentry-apps/${app.slug}/avatar/`,
+        method: 'PUT',
+        data,
+      }),
+  });
+
+  const saveAvatar = async (newType: Avatar['avatarType'], photoData?: string) => {
+    const previousType = avatarType;
+
+    try {
+      const updated = await saveMutation.mutateAsync({
+        avatar_type: newType,
+        color: isColor,
+        photoType,
+        ...(newType === 'upload' && photoData !== undefined
+          ? {avatar_photo: photoData}
+          : {}),
+      });
+      onSave(updated);
+
+      const savedMessage = tct('[label] updated', {label: style.title});
+
+      // A change away from the previous source can be undone by re-saving it
+      // (uploaded files are retained server-side). Overwriting an upload with
+      // a new upload cannot.
+      if (previousType === newType) {
+        addSuccessMessage(savedMessage);
+      } else {
+        addMessage(savedMessage, 'undo', {undo: () => saveAvatar(previousType)});
+      }
+    } catch (error) {
+      const photoField =
+        error instanceof RequestError ? error.responseJSON?.avatar_photo : undefined;
+      const photoErrors = Array.isArray(photoField)
+        ? photoField.filter(message => typeof message === 'string')
+        : [];
+
+      if (photoErrors.length) {
+        photoErrors.forEach(message => addErrorMessage(message));
+      } else {
+        addErrorMessage(t('There was an error saving your preferences.'));
+      }
+    }
+  };
+
+  const {fileInput, openUpload} = useUploader({
+    minImageSize: MIN_DIMENSION,
+    onSelect: url =>
+      openModal(deps => (
+        <AvatarCropModal
+          {...deps}
+          dataUrl={url}
+          minDimension={MIN_DIMENSION}
+          maxDimension={MAX_DIMENSION}
+          onCrop={croppedUrl => saveAvatar('upload', croppedUrl.split(',')[1])}
+        />
+      )),
+  });
+
+  const currentMark = (key: Avatar['avatarType']) =>
+    avatarType === key ? <IconCheckmark size="xs" /> : undefined;
+
+  const menuItems: MenuItemProps[] = [
+    {
+      key: 'default',
+      label: style.label,
+      details: style.description,
+      trailingItems: currentMark('default'),
+      onAction: () => saveAvatar('default'),
+    },
+    {
+      key: 'upload',
+      label: t('Upload an image…'),
+      trailingItems: currentMark('upload'),
+      onAction: () => openUpload(),
+    },
+  ];
+
+  const help = isInternal ? style.help : `${style.help} ${t('Required for publishing.')}`;
+
+  return (
+    <Flex direction="row" gap="xl" align="center" justify="between" flexGrow={1}>
+      <Stack width="50%" gap="xs">
+        <Text>{style.title}</Text>
+        <Text size="sm" variant="muted">
+          {help}
+        </Text>
+      </Stack>
+      <Flex align="center" justify="end" gap="lg" flexGrow={1}>
+        {fileInput}
+        <AvatarPreview>
+          <SentryAppAvatar size={48} sentryApp={app} isColor={isColor} />
+        </AvatarPreview>
+        <DropdownMenu
+          items={menuItems}
+          triggerLabel={t('Change')}
+          triggerProps={{size: 'sm'}}
+        />
+      </Flex>
+    </Flex>
+  );
+}
+
+const AvatarPreview = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${p => p.theme.space.xs};
+  border-radius: ${p => p.theme.radius.md};
+  background-size: 12px 12px;
+  background-position:
+    0 0,
+    0 6px,
+    6px -6px,
+    -6px 0px;
+  background-color: ${p => p.theme.tokens.background.primary};
+  background-image:
+    linear-gradient(
+      45deg,
+      ${p => p.theme.tokens.background.secondary} 25%,
+      rgba(0, 0, 0, 0) 25%
+    ),
+    linear-gradient(
+      -45deg,
+      ${p => p.theme.tokens.background.secondary} 25%,
+      rgba(0, 0, 0, 0) 25%
+    ),
+    linear-gradient(
+      45deg,
+      rgba(0, 0, 0, 0) 75%,
+      ${p => p.theme.tokens.background.secondary} 75%
+    ),
+    linear-gradient(
+      -45deg,
+      rgba(0, 0, 0, 0) 75%,
+      ${p => p.theme.tokens.background.secondary} 75%
+    );
+`;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -818,4 +818,74 @@ describe('Sentry Application Details', () => {
       expect(rotateSecretApiCall).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('Editing with the new branding UI', () => {
+    const organization = OrganizationFixture({features: ['sentry-app-branding-v2']});
+    const initialRouterConfig: RouterConfig = {
+      location: {
+        pathname: '/sentry-apps/sample-app/',
+      },
+      route: '/sentry-apps/:appSlug/',
+    };
+    function renderComponent() {
+      return render(<SentryApplicationDetails />, {initialRouterConfig, organization});
+    }
+
+    beforeEach(() => {
+      sentryApp = SentryAppFixture();
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
+        body: [],
+      });
+    });
+
+    it('renders avatar rows in the details form instead of the panels', async () => {
+      renderComponent();
+      await screen.findByRole('button', {name: 'Save Changes'});
+
+      expect(screen.getByText('Logo')).toBeInTheDocument();
+      expect(screen.getByText('Small Icon')).toBeInTheDocument();
+      expect(screen.getAllByRole('button', {name: 'Change'})).toHaveLength(2);
+
+      // The old radio chooser is gone, and name still lives in the form.
+      expect(screen.queryByRole('radio', {name: 'Default logo'})).not.toBeInTheDocument();
+      expect(screen.getByRole('textbox', {name: 'Name'})).toBeInTheDocument();
+    });
+
+    it('saves an avatar choice immediately from the change menu', async () => {
+      const avatarRequest = MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/avatar/`,
+        method: 'PUT',
+        body: sentryApp,
+      });
+
+      renderComponent();
+      await screen.findByText('Logo');
+
+      await userEvent.click(screen.getAllByRole('button', {name: 'Change'})[0]!);
+      await userEvent.click(
+        await screen.findByRole('menuitemradio', {name: /Default logo/})
+      );
+
+      await waitFor(() =>
+        expect(avatarRequest).toHaveBeenCalledWith(
+          `/sentry-apps/${sentryApp.slug}/avatar/`,
+          expect.objectContaining({
+            method: 'PUT',
+            data: expect.objectContaining({
+              avatar_type: 'default',
+              color: true,
+              photoType: 'logo',
+            }),
+          })
+        )
+      );
+    });
+  });
 });

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -66,25 +66,10 @@ import {
   WEBHOOK_GRANULAR_EVENT_CHOICES,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
-
-const AVATAR_STYLES = {
-  color: {
-    label: t('Default logo'),
-    description: t('The default icon for integrations'),
-    help: t('Image must be between 256px by 256px and 1024px by 1024px.'),
-  },
-  simple: {
-    label: t('Default small icon'),
-    description: tct('This is a silhouette icon used only for [uiDocs:UI Components]', {
-      uiDocs: (
-        <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/ui-components/" />
-      ),
-    }),
-    help: t(
-      'Image must be between 256px by 256px and 1024px by 1024px, and may only use black and transparent pixels.'
-    ),
-  },
-};
+import {
+  SENTRY_APP_AVATAR_STYLES,
+  SentryAppAvatarField,
+} from 'sentry/views/settings/organizationDeveloperSettings/sentryAppAvatarField';
 
 const sentryAppFormSchema = z
   .object({
@@ -304,6 +289,9 @@ function SentryApplicationForm({
 
   const sentryAppQueryOptions = sentryAppApiOptions({appSlug: appSlug ?? null});
 
+  const hasNewBranding =
+    !!app && organization.features.includes('sentry-app-branding-v2');
+
   const [newTokens, setNewTokens] = useState<NewInternalAppApiToken[]>([]);
   const [scopeErrors, setScopeErrors] = useState<ScopeErrors>({permissions: {}});
 
@@ -497,13 +485,21 @@ function SentryApplicationForm({
     }
   };
 
+  const applyAvatars = (updated: SentryApp) => {
+    if (app) {
+      queryClient.setQueryData(sentryAppQueryOptions.queryKey, {
+        json: {...app, avatars: updated.avatars},
+        headers: {},
+      });
+    }
+  };
+
   const getAvatarChooser = (isColor: boolean) => {
     if (!app) {
       return null;
     }
 
-    const avatarStyle = isColor ? 'color' : 'simple';
-    const styleProps = AVATAR_STYLES[avatarStyle];
+    const styleProps = SENTRY_APP_AVATAR_STYLES[isColor ? 'logo' : 'icon'];
 
     return (
       <AvatarChooser
@@ -512,7 +508,7 @@ function SentryApplicationForm({
         type={isColor ? 'sentryAppColor' : 'sentryAppSimple'}
         model={app}
         onSave={addAvatar}
-        title={isColor ? t('Logo') : t('Small Icon')}
+        title={styleProps.title}
         help={styleProps.help.concat(isInternal ? '' : t(' Required for publishing.'))}
         defaultChoice={{
           label: styleProps.label,
@@ -676,6 +672,23 @@ function SentryApplicationForm({
               </field.Layout.Row>
             )}
           </form.AppField>
+        )}
+
+        {hasNewBranding && app && (
+          <Fragment>
+            <SentryAppAvatarField
+              app={app}
+              photoType="logo"
+              isInternal={isInternal}
+              onSave={applyAvatars}
+            />
+            <SentryAppAvatarField
+              app={app}
+              photoType="icon"
+              isInternal={isInternal}
+              onSave={applyAvatars}
+            />
+          </Fragment>
         )}
 
         <form.AppField
@@ -847,8 +860,12 @@ function SentryApplicationForm({
         </form.AppField>
       </form.FieldGroup>
 
-      {getAvatarChooser(true)}
-      {getAvatarChooser(false)}
+      {!hasNewBranding && (
+        <Fragment>
+          {getAvatarChooser(true)}
+          {getAvatarChooser(false)}
+        </Fragment>
+      )}
 
       <form.Subscribe selector={state => isInternal && !state.values.webhookUrl}>
         {webhookDisabled => (


### PR DESCRIPTION
Behind the `sentry-app-branding-v2` org flag, the sentry app details page replaces its two avatar chooser panels with logo and small icon rows inside the Integration Details form, next to name and author: each row previews the current avatar and saves immediately from a Change menu — uploads crop in a modal, and switching between avatar sources offers an undo toast. With the flag off, the page renders exactly as it does today.

This is a working prototype of a unified avatar pattern (an avatar is an identity-style field row that saves on selection, rather than a dedicated panel with a radio group and its own save button), shown on one surface before the pattern is promoted to the shared chooser and rolled out to the other places avatars are chosen (user, organization, team, doc integrations).

The new components (`sentryAppAvatarField`, `avatarCropModal`) are local to the developer-settings area, so no other surface changes behavior; the only shared edit widens the `openUpload` signature in `useUploader` to allow calls without a mouse event.

The flag registration ships in a separate backend PR; until that deploys and the FlagPole config exists, the flag reads as off everywhere.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
