### PR TITLE
feat(preprod): Add Releases breadcrumb to install page

### DIFF
--- a/static/app/views/preprod/install/buildInstallHeader.tsx
+++ b/static/app/views/preprod/install/buildInstallHeader.tsx
@@ -7,14 +7,18 @@ import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {Placeholder} from 'sentry/components/placeholder';
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {Version} from 'sentry/components/version';
 import {IconClock, IconFile, IconJson, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getFormat, getFormattedDate, getUtcToSystem} from 'sentry/utils/dates';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {TopBar} from 'sentry/views/navigation/topBar';
 import {AppIcon} from 'sentry/views/preprod/components/appIcon';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {
@@ -23,6 +27,7 @@ import {
   getReadableArtifactTypeTooltip,
   getReadablePlatformLabel,
 } from 'sentry/views/preprod/utils/labelUtils';
+import {makeReleasesUrl} from 'sentry/views/preprod/utils/releasesUrl';
 
 interface BuildInstallHeaderProps {
   buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
@@ -30,6 +35,7 @@ interface BuildInstallHeaderProps {
 }
 
 export function BuildInstallHeader(props: BuildInstallHeaderProps) {
+  const organization = useOrganization();
   const {buildDetailsQuery, projectId} = props;
   const {
     data: buildDetailsData,
@@ -42,29 +48,48 @@ export function BuildInstallHeader(props: BuildInstallHeaderProps) {
     timeZone: true,
   });
 
+  const releasesCrumb: Crumb = {
+    to: makeReleasesUrl(organization.slug, projectId, {
+      display: PreprodBuildsDisplay.DISTRIBUTION,
+      query: 'installable:true',
+      tab: 'mobile-builds',
+    }),
+    label: t('Releases'),
+  };
+
   if (isBuildDetailsPending) {
+    const crumbs: Crumb[] = [
+      releasesCrumb,
+      {
+        label: (
+          <Flex align="center" gap="sm" minHeight="1lh">
+            <Placeholder width="24px" height="24px" />
+            <Placeholder width="140px" height="1em" />
+            <Placeholder width="120px" height="1em" />
+          </Flex>
+        ),
+      },
+    ];
     return (
       <Layout.HeaderContent>
-        <Flex direction="column" gap="sm">
-          <Layout.Title>
-            <Flex align="center" gap="sm" minHeight="1lh">
-              <Placeholder width="24px" height="24px" />
-              <Placeholder width="140px" height="1em" />
-              <Placeholder width="120px" height="1em" />
-            </Flex>
-          </Layout.Title>
-          <Flex gap="lg" wrap="wrap" align="center">
-            <Placeholder width="120px" height="16px" />
-            <Placeholder width="160px" height="16px" />
-            <Placeholder width="180px" height="16px" />
-          </Flex>
+        <TopBar.Slot name="title">
+          <StyledBreadcrumbs crumbs={crumbs} />
+        </TopBar.Slot>
+        <Flex gap="lg" wrap="wrap" align="center">
+          <Placeholder width="120px" height="16px" />
+          <Placeholder width="160px" height="16px" />
+          <Placeholder width="180px" height="16px" />
         </Flex>
       </Layout.HeaderContent>
     );
   }
 
   if (isBuildDetailsError || !buildDetailsData) {
-    return null;
+    return (
+      <TopBar.Slot name="title">
+        <StyledBreadcrumbs crumbs={[releasesCrumb]} />
+      </TopBar.Slot>
+    );
   }
 
   const appInfo = buildDetailsData.app_info;
@@ -75,99 +100,106 @@ export function BuildInstallHeader(props: BuildInstallHeaderProps) {
     ? `v${version}${buildNumber ? ` (${buildNumber})` : ''}`
     : undefined;
 
+  const crumbs: Crumb[] = [
+    releasesCrumb,
+    {
+      label: (
+        <Flex align="center" gap="xs" minHeight="1lh">
+          {appInfo.app_icon_id && appInfo.name ? (
+            <AppIcon
+              appName={appInfo.name}
+              appIconId={appInfo.app_icon_id}
+              projectId={projectId}
+            />
+          ) : null}
+          {appInfo.name ? <span>{appInfo.name}</span> : null}
+          {versionTitle ? (
+            <Fragment>
+              <Text as="span" size="md" variant="muted">
+                -
+              </Text>
+              <Version version={versionTitle} anchor={false} truncate />
+            </Fragment>
+          ) : (
+            <Placeholder width="30ch" height="1em" />
+          )}
+        </Flex>
+      ),
+    },
+  ];
+
   return (
     <Layout.HeaderContent>
-      <Flex direction="column" gap="sm">
-        <Layout.Title>
-          <Flex align="center" gap="xs" minHeight="1lh">
-            {appInfo.app_icon_id && appInfo.name ? (
-              <AppIcon
-                appName={appInfo.name}
-                appIconId={appInfo.app_icon_id}
-                projectId={projectId}
-              />
-            ) : null}
-            {appInfo.name ? <span>{appInfo.name}</span> : null}
-            {versionTitle ? (
-              <Fragment>
-                <Text as="span" size="md" variant="muted">
-                  -
-                </Text>
-                <Version version={versionTitle} anchor={false} truncate />
-              </Fragment>
-            ) : (
-              <Placeholder width="30ch" height="1em" />
-            )}
-          </Flex>
-        </Layout.Title>
-        <Flex gap="lg" wrap="wrap" align="center">
-          {appInfo.platform ? (
-            <Tooltip title={t('Platform')}>
-              <Flex gap="2xs" align="center">
-                <Flex align="center" justify="center" width="24px" height="24px">
-                  <PlatformIcon platform={appInfo.platform} />
-                </Flex>
-                <Text size="sm" variant="muted">
-                  {getReadablePlatformLabel(appInfo.platform)}
-                </Text>
+      <TopBar.Slot name="title">
+        <StyledBreadcrumbs crumbs={crumbs} />
+      </TopBar.Slot>
+      <Flex gap="lg" wrap="wrap" align="center">
+        {appInfo.platform ? (
+          <Tooltip title={t('Platform')}>
+            <Flex gap="2xs" align="center">
+              <Flex align="center" justify="center" width="24px" height="24px">
+                <PlatformIcon platform={appInfo.platform} />
               </Flex>
-            </Tooltip>
-          ) : null}
-          {appInfo.app_id ? (
-            <Tooltip title={labels.appId}>
-              <Flex gap="2xs" align="center">
-                <Flex align="center" justify="center" width="24px" height="24px">
-                  <IconJson />
-                </Flex>
-                <Text size="sm" variant="muted">
-                  {appInfo.app_id}
-                </Text>
+              <Text size="sm" variant="muted">
+                {getReadablePlatformLabel(appInfo.platform)}
+              </Text>
+            </Flex>
+          </Tooltip>
+        ) : null}
+        {appInfo.app_id ? (
+          <Tooltip title={labels.appId}>
+            <Flex gap="2xs" align="center">
+              <Flex align="center" justify="center" width="24px" height="24px">
+                <IconJson />
               </Flex>
-            </Tooltip>
-          ) : null}
-          {(appInfo.date_built || appInfo.date_added) && (
-            <Tooltip
-              title={appInfo.date_built ? t('App build time') : t('App upload time')}
-            >
-              <Flex gap="2xs" align="center">
-                <Flex align="center" justify="center" width="24px" height="24px">
-                  <IconClock />
-                </Flex>
-                <Text size="sm" variant="muted">
-                  {getFormattedDate(
-                    getUtcToSystem(appInfo.date_built || appInfo.date_added),
-                    datetimeFormat,
-                    {local: true}
-                  )}
-                </Text>
+              <Text size="sm" variant="muted">
+                {appInfo.app_id}
+              </Text>
+            </Flex>
+          </Tooltip>
+        ) : null}
+        {(appInfo.date_built || appInfo.date_added) && (
+          <Tooltip
+            title={appInfo.date_built ? t('App build time') : t('App upload time')}
+          >
+            <Flex gap="2xs" align="center">
+              <Flex align="center" justify="center" width="24px" height="24px">
+                <IconClock />
               </Flex>
-            </Tooltip>
-          )}
-          {appInfo.build_configuration ? (
-            <Tooltip title={labels.buildConfiguration}>
-              <Flex gap="2xs" align="center">
-                <Flex align="center" justify="center" width="24px" height="24px">
-                  <IconMobile />
-                </Flex>
-                <InlineCodeSnippet data-render-inline hideCopyButton>
-                  {appInfo.build_configuration}
-                </InlineCodeSnippet>
+              <Text size="sm" variant="muted">
+                {getFormattedDate(
+                  getUtcToSystem(appInfo.date_built || appInfo.date_added),
+                  datetimeFormat,
+                  {local: true}
+                )}
+              </Text>
+            </Flex>
+          </Tooltip>
+        )}
+        {appInfo.build_configuration ? (
+          <Tooltip title={labels.buildConfiguration}>
+            <Flex gap="2xs" align="center">
+              <Flex align="center" justify="center" width="24px" height="24px">
+                <IconMobile />
               </Flex>
-            </Tooltip>
-          ) : null}
-          {appInfo.artifact_type !== null && appInfo.artifact_type !== undefined ? (
-            <Tooltip title={getReadableArtifactTypeTooltip(appInfo.artifact_type)}>
-              <Flex gap="2xs" align="center">
-                <Flex align="center" justify="center" width="24px" height="24px">
-                  <IconFile />
-                </Flex>
-                <Text size="sm" variant="muted">
-                  {getReadableArtifactTypeLabel(appInfo.artifact_type)}
-                </Text>
+              <InlineCodeSnippet data-render-inline hideCopyButton>
+                {appInfo.build_configuration}
+              </InlineCodeSnippet>
+            </Flex>
+          </Tooltip>
+        ) : null}
+        {appInfo.artifact_type !== null && appInfo.artifact_type !== undefined ? (
+          <Tooltip title={getReadableArtifactTypeTooltip(appInfo.artifact_type)}>
+            <Flex gap="2xs" align="center">
+              <Flex align="center" justify="center" width="24px" height="24px">
+                <IconFile />
               </Flex>
-            </Tooltip>
-          ) : null}
-        </Flex>
+              <Text size="sm" variant="muted">
+                {getReadableArtifactTypeLabel(appInfo.artifact_type)}
+              </Text>
+            </Flex>
+          </Tooltip>
+        ) : null}
       </Flex>
     </Layout.HeaderContent>
   );
@@ -175,4 +207,8 @@ export function BuildInstallHeader(props: BuildInstallHeaderProps) {
 
 const InlineCodeSnippet = styled(CodeBlock)`
   padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
+`;
+
+const StyledBreadcrumbs = styled(Breadcrumbs)`
+  padding: 0;
 `;

--- a/static/app/views/preprod/install/buildInstallHeader.tsx
+++ b/static/app/views/preprod/install/buildInstallHeader.tsx
@@ -85,10 +85,13 @@ export function BuildInstallHeader(props: BuildInstallHeaderProps) {
   }
 
   if (isBuildDetailsError || !buildDetailsData) {
+    const crumbs: Crumb[] = [releasesCrumb, {label: t('Install')}];
     return (
-      <TopBar.Slot name="title">
-        <StyledBreadcrumbs crumbs={[releasesCrumb]} />
-      </TopBar.Slot>
+      <Layout.HeaderContent>
+        <TopBar.Slot name="title">
+          <StyledBreadcrumbs crumbs={crumbs} />
+        </TopBar.Slot>
+      </Layout.HeaderContent>
     );
   }
 

--- a/static/app/views/preprod/install/installPage.spec.tsx
+++ b/static/app/views/preprod/install/installPage.spec.tsx
@@ -1,0 +1,83 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreprodBuildDetailsWithSizeInfoFixture} from 'sentry-fixture/preprod';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {TopBar} from 'sentry/views/navigation/topBar';
+import {BuildDetailsSizeAnalysisState} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+import InstallPage from './installPage';
+
+describe('InstallPage', () => {
+  const organization = OrganizationFixture();
+
+  const initialRouterConfig = {
+    location: {
+      pathname: `/organizations/${organization.slug}/preprod/install/artifact-1/`,
+      query: {project: 'project-1'},
+    },
+    route: '/organizations/:orgId/preprod/install/:artifactId/',
+  };
+
+  const BUILD_DETAILS_URL =
+    '/organizations/org-slug/preprodartifacts/artifact-1/build-details/';
+  const INSTALL_DETAILS_URL =
+    '/organizations/org-slug/preprodartifacts/artifact-1/private-install-details/';
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: BUILD_DETAILS_URL,
+      method: 'GET',
+      body: PreprodBuildDetailsWithSizeInfoFixture({
+        state: BuildDetailsSizeAnalysisState.COMPLETED,
+        size_metrics: [],
+        base_size_metrics: [],
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      method: 'GET',
+      body: {platform: 'ios'},
+    });
+  });
+
+  function renderInstallPage() {
+    return render(
+      <TopBar.Slot.Provider>
+        <TopBar.Slot.Outlet name="title">
+          {props => <div {...props} data-test-id="topbar-title-slot" />}
+        </TopBar.Slot.Outlet>
+        <InstallPage />
+      </TopBar.Slot.Provider>,
+      {organization, initialRouterConfig}
+    );
+  }
+
+  it('renders the Releases breadcrumb linking to the mobile-builds distribution view', async () => {
+    renderInstallPage();
+
+    expect(await screen.findByText('Test App')).toBeInTheDocument();
+
+    const topbarSlot = screen.getByTestId('topbar-title-slot');
+    const releasesLink = within(topbarSlot).getByRole('link', {name: 'Releases'});
+
+    expect(releasesLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/releases/?project=test-project&tab=mobile-builds&display=distribution&query=installable%3Atrue`
+    );
+  });
+
+  it('renders the app info as the current crumb after Releases', async () => {
+    renderInstallPage();
+
+    expect(await screen.findByText('Test App')).toBeInTheDocument();
+
+    const topbarSlot = screen.getByTestId('topbar-title-slot');
+
+    expect(within(topbarSlot).getByRole('link', {name: 'Releases'})).toBeInTheDocument();
+    expect(within(topbarSlot).getByText('Test App')).toBeInTheDocument();
+    expect(within(topbarSlot).getByText('v1.0.0 (123)')).toBeInTheDocument();
+    expect(within(topbarSlot).queryByText('Install')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/preprod/install/installPage.spec.tsx
+++ b/static/app/views/preprod/install/installPage.spec.tsx
@@ -80,4 +80,22 @@ describe('InstallPage', () => {
     expect(within(topbarSlot).getByText('v1.0.0 (123)')).toBeInTheDocument();
     expect(within(topbarSlot).queryByText('Install')).not.toBeInTheDocument();
   });
+
+  it('keeps the Releases breadcrumb clickable when build details fail to load', async () => {
+    MockApiClient.addMockResponse({
+      url: BUILD_DETAILS_URL,
+      method: 'GET',
+      statusCode: 500,
+      body: {detail: 'Internal Error'},
+    });
+
+    renderInstallPage();
+
+    expect(await screen.findByText('Install')).toBeInTheDocument();
+
+    const topbarSlot = screen.getByTestId('topbar-title-slot');
+
+    expect(within(topbarSlot).getByRole('link', {name: 'Releases'})).toBeInTheDocument();
+    expect(within(topbarSlot).getByText('Install')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/preprod/install/installPage.spec.tsx
+++ b/static/app/views/preprod/install/installPage.spec.tsx
@@ -95,7 +95,11 @@ describe('InstallPage', () => {
 
     const topbarSlot = screen.getByTestId('topbar-title-slot');
 
-    expect(within(topbarSlot).getByRole('link', {name: 'Releases'})).toBeInTheDocument();
+    const releasesLink = within(topbarSlot).getByRole('link', {name: 'Releases'});
+    expect(releasesLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/releases/?tab=mobile-builds&display=distribution&query=installable%3Atrue`
+    );
     expect(within(topbarSlot).getByText('Install')).toBeInTheDocument();
   });
 });

--- a/static/app/views/preprod/utils/releasesUrl.ts
+++ b/static/app/views/preprod/utils/releasesUrl.ts
@@ -1,4 +1,5 @@
 type ReleasesUrlParams = {
+  display?: string;
   query?: string;
   tab?: string;
 };
@@ -6,7 +7,7 @@ type ReleasesUrlParams = {
 export function makeReleasesUrl(
   organizationSlug: string,
   projectId: string | undefined,
-  {query, tab = 'mobile-builds'}: ReleasesUrlParams = {}
+  {display, query, tab = 'mobile-builds'}: ReleasesUrlParams = {}
 ): string {
   // Not knowing the projectId should be transient.
   if (projectId === undefined) {
@@ -16,6 +17,10 @@ export function makeReleasesUrl(
   const params = new URLSearchParams();
   params.set('project', projectId);
   params.set('tab', tab);
+
+  if (display) {
+    params.set('display', display);
+  }
 
   const queries: string[] = [];
   if (query) {

--- a/static/app/views/preprod/utils/releasesUrl.ts
+++ b/static/app/views/preprod/utils/releasesUrl.ts
@@ -9,13 +9,10 @@ export function makeReleasesUrl(
   projectId: string | undefined,
   {display, query, tab = 'mobile-builds'}: ReleasesUrlParams = {}
 ): string {
-  // Not knowing the projectId should be transient.
-  if (projectId === undefined) {
-    return '#';
-  }
-
   const params = new URLSearchParams();
-  params.set('project', projectId);
+  if (projectId !== undefined) {
+    params.set('project', projectId);
+  }
   params.set('tab', tab);
 
   if (display) {


### PR DESCRIPTION
The install page (`/preprod/install/:artifactId/`) now shows a breadcrumb in the secondary top nav, matching the issue-details style. It renders `Releases / {app icon, name, version}`, where **Releases** links to the mobile builds distribution view (`display=distribution`, `installable:true`, `tab=mobile-builds`) so users can get back to the list of installable builds.

The app identity (icon, name, version + build number) is the breadcrumb's current crumb rather than a separate title. `Layout.Title` already portals into the shared `TopBar.Slot name="title"`, so folding the app info into the crumb keeps everything in one breadcrumb list and keeps **Releases** clickable — `Breadcrumbs` strips the link from the last crumb, so a lone `Releases` crumb would render as plain text. The build metadata row (platform, app id, build time, configuration, artifact type) stays in the page body.

`makeReleasesUrl` gains an optional `display` param; the existing callers are unaffected.

Refs EME-1235