### PR TITLE
ref(billing): bump sentry-protos to 0.41.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.37.3",
+  "sentry-protos>=0.41.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.30.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.40" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.37.3" },
+    { name = "sentry-protos", specifier = ">=0.41.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.30.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.37.3"
+version = "0.41.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.37.3-py3-none-any.whl", hash = "sha256:7725c9218964d579b8627ef15c4b29bfd16b2af5cb9d815859ee1b611adb4eac" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.41.0-py3-none-any.whl", hash = "sha256:00d76675e1f3c561f69c631a3ec518fd7571069d444a18e478a7466e4349d5e5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bumps `sentry-protos` from `>=0.37.3` to `>=0.41.0`.
- Regenerates `uv.lock` for the new version.

Unblocks the imports needed by [getsentry/getsentry#20887](https://github.com/getsentry/getsentry/pull/20887) (dataclass-prototype promotion). The new types being consumed there were added in [sentry-protos#338](https://github.com/getsentry/sentry-protos/pull/338), which was released as `0.41.0`.

## Test plan

- [ ] CI passes.
- [ ] `.venv/bin/uv sync` clean in a fresh checkout.