### PR TITLE
chore(seer): Disable seer branch override button

### DIFF
--- a/static/app/components/seer/projectDetails/autofixRepositoriesItem.tsx
+++ b/static/app/components/seer/projectDetails/autofixRepositoriesItem.tsx
@@ -284,9 +284,12 @@ export function AutofixRepositoriesItem({
                     ))}
                     <Flex align="center">
                       <Button
-                        disabled={!canWrite}
+                        disabled
                         size="xs"
                         icon={<IconAdd size="sm" />}
+                        tooltipProps={{
+                          title: t('Branch overrides are no longer supported'),
+                        }}
                         onClick={() =>
                           fieldApi.pushValue({
                             id: '',


### PR DESCRIPTION
This doesnt work with the seer agent based autofix. Disable the setting for now