### PR TITLE
fix(issue-progress): keep progress column visible at smaller viewport widths

### DIFF
--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -179,7 +179,7 @@ export const COLUMN_BREAKPOINTS = {
   EVENTS: '700px',
   USERS: '900px',
   PRIORITY: '1100px',
-  PROGRESS: '1100px',
+  PROGRESS: '400px',
   ASSIGNEE: '500px',
 };
 


### PR DESCRIPTION
We want the progress column to stay visible when you make the screen smaller. It's the primary thing users want to see on the awaiting input page so we want to avoid hiding it unless there is really no room.