### PR TITLE
fix(search): Ignore prototype filter key matches

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2399,6 +2399,25 @@ describe('SearchQueryBuilder', () => {
       ).toBeInTheDocument();
     });
 
+    it('does not crash when opening values for Object prototype filter keys', async () => {
+      const mockGetTagValues = jest.fn().mockResolvedValue(['tag_value_one']);
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          getTagValues={mockGetTagValues}
+          initialQuery="constructor:something"
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit value for filter: constructor'})
+      );
+
+      expect(
+        await screen.findByRole('option', {name: 'tag_value_one'})
+      ).toBeInTheDocument();
+    });
+
     it('shows value counts in the dropdown when the response includes them', async () => {
       const mockGetTagValues = jest
         .fn()

--- a/static/app/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual.tsx
@@ -20,7 +20,9 @@ export function useAggregateParamVisual({token}: UseAggregateParamVisualOptions)
 
         let argumentText = arg.value?.text ?? '';
         if (argumentKind === 'column') {
-          const argumentKey = filterKeys[argumentText];
+          const argumentKey = Object.hasOwn(filterKeys, argumentText)
+            ? filterKeys[argumentText]
+            : undefined;
           if (argumentKey) {
             const argumentDefinition = getFieldDefinition(arg.value?.text ?? '');
             argumentText = getKeyLabel(argumentKey, argumentDefinition);

--- a/static/app/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useAggregateParamVisual.tsx
@@ -24,7 +24,7 @@ export function useAggregateParamVisual({token}: UseAggregateParamVisualOptions)
             ? filterKeys[argumentText]
             : undefined;
           if (argumentKey) {
-            const argumentDefinition = getFieldDefinition(arg.value?.text ?? '');
+            const argumentDefinition = getFieldDefinition(argumentText);
             argumentText = getKeyLabel(argumentKey, argumentDefinition);
           }
         }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -217,7 +217,7 @@ export function getPredefinedValues({
     return null;
   }
 
-  const definedValues = key?.values ?? fieldDefinition?.values;
+  const definedValues = Array.isArray(key?.values) ? key.values : fieldDefinition?.values;
   const valueType = getFilterValueType(token, fieldDefinition);
 
   if (!definedValues?.length) {
@@ -281,7 +281,8 @@ export function tokenSupportsMultipleValues(
     case FilterType.TEXT: {
       // The search parser defaults to the text type, so we need to do further
       // checks to ensure that the filter actually supports multiple values
-      const key = keys[getKeyName(token.key)];
+      const keyName = getKeyName(token.key);
+      const key = Object.hasOwn(keys, keyName) ? keys[keyName] : undefined;
       if (!key) {
         return true;
       }
@@ -377,7 +378,7 @@ function useFilterSuggestions({
     getTagKeys,
     getTagValues,
   } = useSearchQueryBuilderConfig();
-  const key = filterKeys[keyName];
+  const key = Object.hasOwn(filterKeys, keyName) ? filterKeys[keyName] : undefined;
   const fieldDefinition = getFieldDefinition(keyName);
   const valueType = getFilterValueType(token, fieldDefinition);
   const predefinedValues = useMemo(

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -217,7 +217,8 @@ export function getPredefinedValues({
     return null;
   }
 
-  const definedValues = Array.isArray(key?.values) ? key.values : fieldDefinition?.values;
+  const keyValues = Array.isArray(key?.values) ? key.values : undefined;
+  const definedValues = keyValues ?? fieldDefinition?.values;
   const valueType = getFilterValueType(token, fieldDefinition);
 
   if (!definedValues?.length) {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -216,7 +216,10 @@ function FilterKeyMenuContent<T extends SelectOptionOrSectionWithKey<string>>({
         | string
         | undefined)
     : undefined;
-  const focusedKey = focusedItem ? filterKeys[focusedItem] : null;
+  const focusedKey =
+    focusedItem && Object.hasOwn(filterKeys, focusedItem)
+      ? filterKeys[focusedItem]
+      : null;
   const showRecentFilters = recentFilters.length > 0;
   const showDetailsPane = fullWidth && selectedSection !== RECENT_SEARCH_CATEGORY_VALUE;
 

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -92,7 +92,7 @@ export function createSection(
     label: section.label,
     options: section.children
       .map(key => {
-        if (!keys[key]) {
+        if (!Object.hasOwn(keys, key)) {
           return null;
         }
         return createItem(keys[key], getFieldDefinition(key), section);

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -92,10 +92,11 @@ export function createSection(
     label: section.label,
     options: section.children
       .map(key => {
-        if (!Object.hasOwn(keys, key)) {
+        const tag = Object.hasOwn(keys, key) ? keys[key] : undefined;
+        if (!tag) {
           return null;
         }
-        return createItem(keys[key], getFieldDefinition(key), section);
+        return createItem(tag, getFieldDefinition(key), section);
       })
       .filter(defined),
     type: 'section',

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -516,7 +516,9 @@ function SearchQueryBuilderInputInternal({
             shouldCommitQuery: false,
           });
           resetInputValue();
-          const selectedKey = filterKeys[value];
+          const selectedKey = Object.hasOwn(filterKeys, value)
+            ? filterKeys[value]
+            : undefined;
           trackAnalytics('search.key_autocompleted', {
             organization,
             search_type: recentSearchTypeToLabel(recentSearches),
@@ -650,7 +652,9 @@ function SearchQueryBuilderInputInternal({
               getSuggestedFilterKey,
               loadedItems: sortedFilteredItems,
             });
-            const key = filterKeys[filterKey];
+            const key = Object.hasOwn(filterKeys, filterKey)
+              ? filterKeys[filterKey]
+              : undefined;
             dispatch({
               type: 'UPDATE_FREE_TEXT_ON_COLON',
               tokens: [token],

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -144,7 +144,7 @@ export function resolveFilterKey({
     return trimmedKey;
   }
 
-  if (filterKeys[trimmedKey]) {
+  if (Object.hasOwn(filterKeys, trimmedKey)) {
     return trimmedKey;
   }
 


### PR DESCRIPTION
Fixes a search query builder crash when a query uses a key like `constructor:something`.

The key maps are plain objects, so prototype names could resolve to inherited properties instead of real configured filter keys. This checks own properties before reading filter metadata so those queries stay editable instead of crashing the value combobox.

Refs #119134
fixes JAVASCRIPT-3A0H