### PR TITLE
ref: Graduate `organizations:on-demand-metrics-ui` (frontend)

### DIFF
--- a/static/app/utils/onDemandMetrics/features.tsx
+++ b/static/app/utils/onDemandMetrics/features.tsx
@@ -6,10 +6,7 @@ export function hasOnDemandMetricAlertFeature(organization: Organization) {
 
 export function shouldShowOnDemandMetricAlertUI(organization: Organization) {
   // we want to show the UI only for orgs that can create new on-demand metric alerts
-  return (
-    hasOnDemandMetricAlertFeature(organization) &&
-    organization.features.includes('on-demand-metrics-ui')
-  );
+  return hasOnDemandMetricAlertFeature(organization);
 }
 
 export function hasOnDemandMetricWidgetFeature(organization: Organization) {

--- a/static/app/views/detectors/datasetConfig/transactions.spec.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.spec.tsx
@@ -35,7 +35,7 @@ describe('DetectorTransactionsConfig', () => {
 
     it('on-demand success (apdex) returns METRICS_ENHANCED and prefixed query', () => {
       const orgWithFeature = OrganizationFixture({
-        features: ['on-demand-metrics-extraction', 'on-demand-metrics-ui'],
+        features: ['on-demand-metrics-extraction'],
       });
 
       const key = DetectorTransactionsConfig.getSeriesQueryOptions({


### PR DESCRIPTION
Closing: superseded. Graduating `on-demand-metrics-ui` to a subscription plan feature (getsentry `SubscriptionPlanFeatureHandler` + sentry `permanent.py` INTERNAL registration) preserves the current am2-business/enterprise audience with **no frontend change** — the UI keeps its `organization.features.includes('on-demand-metrics-ui')` check. Removing that check here would have leaked the alert UI to am3 business/enterprise orgs. See getsentry/sentry#119152.