### PR TITLE
ref: Graduate `organizations:on-demand-metrics-ui` to a plan feature

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -112,6 +112,9 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:continuous-profiling-billing": False,
         # Signals that the organization supports the on demand metrics prefill.
         "organizations:on-demand-metrics-prefill": False,
+        # Display on demand metrics related UI elements (alerts). Provided by subscription
+        # plans via getsentry's SubscriptionPlanFeatureHandler.
+        "organizations:on-demand-metrics-ui": False,
         # Metrics: Enable ingestion and storage of custom metrics. See custom-metrics for UI.
         "organizations:custom-metrics": False,
         # Prefix host with organization ID when giving users DSNs (can be

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -154,8 +154,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     # Extract on demand metrics (widget extraction)
     manager.add("organizations:on-demand-metrics-extraction-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Display on demand metrics related UI elements
-    manager.add("organizations:on-demand-metrics-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display on demand metrics related UI elements, for dashboards and widgets. The other flag is for alerts.
     manager.add("organizations:on-demand-metrics-ui-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Only enabled in sentry.io to enable onboarding flows.


### PR DESCRIPTION
Graduate `organizations:on-demand-metrics-ui`: move its registration from `temporary.py` (FLAGPOLE) to `permanent.py` (INTERNAL, `api_expose=True`, self-hosted default `False`), so it is provided by subscription plans via getsentry's `SubscriptionPlanFeatureHandler` instead of a flagpole rollout flag.

No frontend change: the UI keeps checking `organization.features.includes('on-demand-metrics-ui')`; the value now comes from the plan. Current audience (am2 business/enterprise) is preserved.

Companion PRs — **deploy in this order**: getsentry/getsentry#20970 (adds the plan handler; must deploy first) → this PR (flips to INTERNAL) → getsentry/sentry-options-automator#8556 (removes the flagpole config).