### PR TITLE
chore(copy to markdown): Add stuff to copy to markdown

### DIFF
--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -137,6 +137,33 @@ describe('useCopyIssueDetails', () => {
       }
     });
 
+    it('falls back to dateReceived when dateCreated is absent', () => {
+      const user = UserFixture();
+      user.options.timezone = 'America/New_York';
+      user.options.clock24Hours = false;
+      ConfigStore.set('user', user);
+
+      // Transaction/performance events (e.g. N+1 DB) carry dateReceived but not
+      // dateCreated.
+      const performanceEvent = EventFixture({
+        id: '123456',
+        dateCreated: undefined,
+        dateReceived: '2023-01-01T00:00:00Z',
+      });
+
+      try {
+        const result = issueAndEventToMarkdown({
+          group: performanceGroup,
+          event: performanceEvent,
+          organization,
+        });
+
+        expect(result).toContain('**Date:** Dec 31, 2022 7:00:00 PM EST');
+      } finally {
+        ConfigStore.set('user', UserFixture());
+      }
+    });
+
     it('includes autofix data when provided', () => {
       const result = issueAndEventToMarkdown({
         group,

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -1,12 +1,14 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {renderHook, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
 import * as explorerAutofixHooks from 'sentry/components/events/autofix/useExplorerAutofix';
+import {ConfigStore} from 'sentry/stores/configStore';
 import {EntryType} from 'sentry/types/event';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import * as copyToClipboardModule from 'sentry/utils/useCopyToClipboard';
@@ -99,7 +101,40 @@ describe('useCopyIssueDetails', () => {
 
       expect(result).toContain(`# ${group.title}`);
       expect(result).toContain(`**Issue ID:** ${group.id}`);
+      expect(result).toContain(`**Short ID:** ${group.shortId}`);
       expect(result).toContain(`**Project:** ${group.project?.slug}`);
+    });
+
+    it("renders the date in the user's timezone and clock preference", () => {
+      const user = UserFixture();
+      user.options.timezone = 'America/New_York';
+      user.options.clock24Hours = false;
+      ConfigStore.set('user', user);
+
+      try {
+        const result = issueAndEventToMarkdown({group, event, organization});
+
+        // dateCreated is 2023-01-01T00:00:00Z, which is EST (UTC-5) in New York,
+        // and the timezone abbreviation is appended so it's unambiguous.
+        expect(result).toContain('**Date:** Dec 31, 2022 7:00:00 PM EST');
+      } finally {
+        ConfigStore.set('user', UserFixture());
+      }
+    });
+
+    it("renders the date with the user's 24-hour clock preference", () => {
+      const user = UserFixture();
+      user.options.timezone = 'America/New_York';
+      user.options.clock24Hours = true;
+      ConfigStore.set('user', user);
+
+      try {
+        const result = issueAndEventToMarkdown({group, event, organization});
+
+        expect(result).toContain('**Date:** Dec 31, 2022 19:00:00 EST');
+      } finally {
+        ConfigStore.set('user', UserFixture());
+      }
     });
 
     it('includes autofix data when provided', () => {

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -280,13 +280,17 @@ export const issueAndEventToMarkdown = ({
     markdownText += `**Project:** ${group.project?.slug}\n`;
   }
 
-  if (event && typeof event.dateCreated === 'string') {
+  // In the detailed event payload, `dateCreated` is populated for error/default
+  // events but not transactions (perf issues like N+1 DB). `dateReceived` is
+  // present on every event, so fall back to it.
+  const eventDate = event?.dateCreated ?? event?.dateReceived;
+  if (typeof eventDate === 'string') {
     // Render in the viewer's preferred timezone and 12h/24h clock, and include
     // the timezone abbreviation so the timestamp is unambiguous once copied.
     const timezone =
       getUserTimezone() ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
     const formattedDate = moment
-      .tz(event.dateCreated, timezone)
+      .tz(eventDate, timezone)
       .format(getFormat({year: true, seconds: true, timeZone: true}));
     markdownText += `**Date:** ${formattedDate}\n`;
   }

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo, useSyncExternalStore} from 'react';
+import moment from 'moment-timezone';
 
 import {useHotkeys} from '@sentry/scraps/hotkey';
 
@@ -19,6 +20,7 @@ import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getFormat, getUserTimezone} from 'sentry/utils/dates';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {formatSpanEvidenceToMarkdown} from 'sentry/views/issueDetails/hooks/spanEvidenceMarkdown';
@@ -270,12 +272,23 @@ export const issueAndEventToMarkdown = ({
   let markdownText = `# ${group.title}\n\n`;
   markdownText += `**Issue ID:** ${group.id}\n`;
 
+  if (group.shortId) {
+    markdownText += `**Short ID:** ${group.shortId}\n`;
+  }
+
   if (group.project?.slug) {
     markdownText += `**Project:** ${group.project?.slug}\n`;
   }
 
   if (event && typeof event.dateCreated === 'string') {
-    markdownText += `**Date:** ${new Date(event.dateCreated).toLocaleString()}\n`;
+    // Render in the viewer's preferred timezone and 12h/24h clock, and include
+    // the timezone abbreviation so the timestamp is unambiguous once copied.
+    const timezone =
+      getUserTimezone() ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const formattedDate = moment
+      .tz(event.dateCreated, timezone)
+      .format(getFormat({year: true, seconds: true, timeZone: true}));
+    markdownText += `**Date:** ${formattedDate}\n`;
   }
 
   // Mirror Seer: include the event message only when it adds something beyond


### PR DESCRIPTION
Adds issue short ID and updates date formatting for copy to markdown. 

Before:
```
# DeserializationError

**Issue ID:** 7248983129
**Project:** sentry
**Date:** 7/7/2026, 2:08:06 PM
```
After
```
# DeserializationError

**Issue ID:** 7248983129
**Short ID:** SENTRY-5J6Z
**Project:** sentry
**Date:** Jul 7, 2026 2:08:13 PM PDT
```
