### PR TITLE
feat(issues): Log and count restricted large merges/unmerges

### DIFF
--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 from functools import partial
 from typing import TypedDict
@@ -37,6 +38,8 @@ from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils import metrics
 from sentry.utils.snuba import raw_query
+
+logger = logging.getLogger(__name__)
 
 
 class GroupHashesResult(TypedDict):
@@ -136,6 +139,17 @@ class GroupHashesEndpoint(GroupEndpoint):
 
         max_times_seen = options.get("issues.merge-unmerge.max-group-times-seen")
         if max_times_seen and group.times_seen > max_times_seen:
+            metrics.incr("issues.merge_unmerge.restricted", tags={"op": "unmerge"})
+            logger.info(
+                "merge_unmerge.restricted",
+                extra={
+                    "op": "unmerge",
+                    "project_id": group.project_id,
+                    "source_id": group.id,
+                    "grouphash_ids": grouphash_ids,
+                    "max_times_seen": max_times_seen,
+                },
+            )
             return Response(
                 {"detail": "Large merges and unmerges are temporarily restricted at this time."},
                 status=400,

--- a/src/sentry/issues/merge.py
+++ b/src/sentry/issues/merge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from typing import TypedDict
 from uuid import uuid4
@@ -15,6 +16,9 @@ from sentry.tasks.merge import merge_groups
 from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
 
 
 class MergedGroup(TypedDict):
@@ -37,6 +41,16 @@ def handle_merge(
 
     max_times_seen = options.get("issues.merge-unmerge.max-group-times-seen")
     if max_times_seen and any(group.times_seen > max_times_seen for group in group_list):
+        metrics.incr("issues.merge_unmerge.restricted", tags={"op": "merge"})
+        logger.info(
+            "merge_unmerge.restricted",
+            extra={
+                "op": "merge",
+                "project_id": group_list[0].project_id,
+                "group_ids": [group.id for group in group_list],
+                "max_times_seen": max_times_seen,
+            },
+        )
         raise rest_framework.exceptions.ValidationError(
             detail="Large merges and unmerges are temporarily restricted at this time."
         )


### PR DESCRIPTION
The large-merge/unmerge restriction (`issues.merge-unmerge.max-group-times-seen`) returned a 400 with no log or metric, so there was no way to tell how often it fires or which groups were involved.

Both rejection sites — the merge handler (`issues/merge.py`) and the unmerge endpoint (`group_hashes.py`) — now emit:

- a metric `issues.merge_unmerge.restricted` tagged `op:merge|unmerge` (how often it's hit, alertable), and
- a structured log `merge_unmerge.restricted` with the project id and the attempted `group_ids` (merge) or `source_id` + `grouphash_ids` (unmerge), which the generic API access log can't capture since the ids travel as query params.