### PR TITLE
feat(issues): Add dedicated issues.merge task namespace

### DIFF
--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -147,6 +147,11 @@ issues_tasks = app.taskregistry.create_namespace(
     app_feature="issueplatform",
 )
 
+issues_merge_tasks = app.taskregistry.create_namespace(
+    "issues.merge",
+    app_feature="issueplatform",
+)
+
 integrations_tasks = app.taskregistry.create_namespace(
     "integrations",
     app_feature="integrations",


### PR DESCRIPTION
## Summary
- Registers a new `issues.merge` taskworker namespace for merge and unmerge tasks
- This namespace will allow routing merge/unmerge to a dedicated worker pool, isolating them from the ~40 other tasks sharing the `issues` namespace
- **No tasks are moved yet** — `merge_groups` and `unmerge` still use `issues_tasks`. They'll be switched over once ops-side routing is configured.

## Rollout plan
1. This PR: register the namespace (no-op, nothing uses it yet)
2. Ops PR: add `issues.merge` to a worker pool in `k8s/services/taskbroker/_values.yaml`
3. Follow-up sentry PR: switch `merge.py` and `unmerge.py` to `namespace=issues_merge_tasks`