### PR TITLE
feat(action_log): Add backfill_group_activities

### DIFF
--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -1,0 +1,155 @@
+"""
+Backfill helpers for the group action log.
+
+These are separated from the main publish path because backfill code has
+different semantics: entries arrive with explicit timestamps and idempotency
+keys, bypass the outbox, and must invalidate derived data after insertion.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from django.db import router, transaction
+
+from sentry.issues.action_log.types import (
+    SYSTEM_ACTOR,
+    GroupAction,
+    GroupActionActor,
+)
+from sentry.issues.derived.processing import invalidate_group_derived_data
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.models.activity import Activity
+from sentry.utils import metrics
+from sentry.utils.action_log.activity_translator import activity_to_action
+
+logger = logging.getLogger(__name__)
+
+BACKFILL_ACTIVITY_SOURCE = "backfill:activity"
+
+
+@dataclass(frozen=True)
+class BackfillEntry:
+    """A single action to backfill into a group's log."""
+
+    action: GroupAction
+    actor: GroupActionActor
+    source: str
+    date_added: datetime
+    idempotency_key: str
+
+
+def backfill_actions(
+    *,
+    entries: Sequence[BackfillEntry],
+    group_id: int,
+    project_id: int,
+) -> int:
+    """Insert historical action log entries for a group and invalidate derived data.
+
+    *entries* must be sorted by ``date_added`` ascending. Each entry's
+    ``idempotency_key`` is used for deduplication: rows whose idempotency key
+    already exists for this group are skipped.
+
+    After the batch is committed, ``invalidate_group_derived_data`` is called
+    with the earliest new entry's timestamp so that derived state is recomputed
+    from that point forward.
+
+    Returns the number of entries submitted (an upper bound; duplicates
+    are silently skipped at the DB level).
+    """
+    if not entries:
+        return 0
+
+    for i in range(1, len(entries)):
+        if entries[i].date_added < entries[i - 1].date_added:
+            raise ValueError("entries must be sorted by date_added ascending")
+
+    objects = [
+        GroupActionLogEntry(
+            group_id=group_id,
+            project_id=project_id,
+            type=entry.action.get_type().value,
+            actor_type=entry.actor.actor_type.value,
+            actor_id=entry.actor.actor_id,
+            source=entry.source,
+            data=entry.action.dict(),
+            date_added=entry.date_added,
+            idempotency_key=entry.idempotency_key,
+        )
+        for entry in entries
+    ]
+
+    using = router.db_for_write(GroupActionLogEntry)
+    with transaction.atomic(using=using):
+        GroupActionLogEntry.objects.bulk_create(
+            objects,
+            ignore_conflicts=True,
+            unique_fields=["group_id", "idempotency_key"],
+        )
+
+    metrics.incr(
+        "issues.action_log.backfill",
+        amount=len(entries),
+        tags={"actor_type": entries[0].actor.actor_type.name.lower()},
+    )
+
+    # entries are sorted ascending, so [0] is the earliest.
+    invalidate_group_derived_data(group_id, cursor=(entries[0].date_added, 0))
+
+    return len(entries)
+
+
+def backfill_group_activities(
+    *,
+    group_id: int,
+    project_id: int,
+    batch_size: int = 500,
+) -> int:
+    """Backfill translatable Activity records into the action log for a group.
+
+    Processes activities from newest to oldest in chunks of *batch_size*.
+    Idempotent: safe to call multiple times for the same group.
+
+    Returns the total number of new entries created.
+    """
+    total_created = 0
+    cursor: int | None = None
+
+    while True:
+        qs = Activity.objects.filter(group_id=group_id)
+        if cursor is not None:
+            qs = qs.filter(id__lt=cursor)
+        batch = list(qs.order_by("-id")[:batch_size])
+
+        if not batch:
+            break
+
+        entries: list[BackfillEntry] = []
+        for act in batch:
+            action = activity_to_action(act)
+            if action is None:
+                continue
+            actor = GroupActionActor.user(act.user_id) if act.user_id else SYSTEM_ACTOR
+            entries.append(
+                BackfillEntry(
+                    action=action,
+                    actor=actor,
+                    source=BACKFILL_ACTIVITY_SOURCE,
+                    date_added=act.datetime,
+                    idempotency_key=f"activity:{act.id}",
+                )
+            )
+
+        if entries:
+            entries.sort(key=lambda e: e.date_added)
+            total_created += backfill_actions(
+                entries=entries, group_id=group_id, project_id=project_id
+            )
+
+        cursor = batch[-1].id
+
+    return total_created

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -134,8 +134,8 @@ def backfill_group_activities(
     while True:
         qs = Activity.objects.filter(group_id=group_id)
         if cursor is not None:
-            qs = qs.filter(id__lt=cursor)
-        batch = list(qs.order_by("-id")[:batch_size])
+            qs = qs.filter(id__gt=cursor)
+        batch = list(qs.order_by("id")[:batch_size])
 
         if not batch:
             break

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -100,9 +100,9 @@ def backfill_actions(
     values_clause = ", ".join(values_template for _ in entries)
     using = router.db_for_write(GroupActionLogEntry)
     with transaction.atomic(using=using):
-        cursor = connections[using].cursor()
-        cursor.execute(sql % values_clause, params)
-        inserted = len(cursor.fetchall())
+        with connections[using].cursor() as cursor:
+            cursor.execute(sql % values_clause, params)
+            inserted = len(cursor.fetchall())
 
     metrics.incr("issues.action_log.backfill", amount=inserted, sample_rate=1.0)
 
@@ -127,6 +127,8 @@ def backfill_group_activities(
     Returns the total number of new entries created.
     """
     total_created = 0
+    total_skipped = 0
+    batch_num = 0
     cursor: int | None = None
 
     while True:
@@ -138,10 +140,21 @@ def backfill_group_activities(
         if not batch:
             break
 
+        batch_num += 1
         entries: list[BackfillEntry] = []
+        skipped = 0
         for act in batch:
-            action = activity_to_action(act)
+            try:
+                action = activity_to_action(act)
+            except Exception:
+                logger.exception(
+                    "backfill_group_activities.translation_error",
+                    extra={"activity_id": act.id, "activity_type": act.type, "group_id": group_id},
+                )
+                skipped += 1
+                continue
             if action is None:
+                skipped += 1
                 continue
             actor = GroupActionActor.user(act.user_id) if act.user_id else SYSTEM_ACTOR
             entries.append(
@@ -160,6 +173,19 @@ def backfill_group_activities(
                 entries=entries, group_id=group_id, project_id=project_id
             )
 
+        total_skipped += skipped
         cursor = batch[-1].id
+
+        logger.info(
+            "backfill_group_activities.batch_complete",
+            extra={
+                "group_id": group_id,
+                "batch_num": batch_num,
+                "batch_activities": len(batch),
+                "batch_converted": len(entries),
+                "batch_skipped": skipped,
+                "total_created": total_created,
+            },
+        )
 
     return total_created

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -102,13 +102,9 @@ def backfill_actions(
     with transaction.atomic(using=using):
         cursor = connections[using].cursor()
         cursor.execute(sql % values_clause, params)
-        inserted = cursor.rowcount
+        inserted = len(cursor.fetchall())
 
-    metrics.incr(
-        "issues.action_log.backfill",
-        amount=inserted,
-        tags={"actor_type": entries[0].actor.actor_type.name.lower()},
-    )
+    metrics.incr("issues.action_log.backfill", amount=inserted, sample_rate=1.0)
 
     if inserted:
         # entries are sorted ascending, so [0] is the earliest.

--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -13,7 +13,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
-from django.db import router, transaction
+from django.db import connections, router, transaction
 
 from sentry.issues.action_log.types import (
     SYSTEM_ACTOR,
@@ -23,7 +23,7 @@ from sentry.issues.action_log.types import (
 from sentry.issues.derived.processing import invalidate_group_derived_data
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
-from sentry.utils import metrics
+from sentry.utils import json, metrics
 from sentry.utils.action_log.activity_translator import activity_to_action
 
 logger = logging.getLogger(__name__)
@@ -58,8 +58,7 @@ def backfill_actions(
     with the earliest new entry's timestamp so that derived state is recomputed
     from that point forward.
 
-    Returns the number of entries submitted (an upper bound; duplicates
-    are silently skipped at the DB level).
+    Returns the number of rows actually inserted.
     """
     if not entries:
         return 0
@@ -68,39 +67,54 @@ def backfill_actions(
         if entries[i].date_added < entries[i - 1].date_added:
             raise ValueError("entries must be sorted by date_added ascending")
 
-    objects = [
-        GroupActionLogEntry(
-            group_id=group_id,
-            project_id=project_id,
-            type=entry.action.get_type().value,
-            actor_type=entry.actor.actor_type.value,
-            actor_id=entry.actor.actor_id,
-            source=entry.source,
-            data=entry.action.dict(),
-            date_added=entry.date_added,
-            idempotency_key=entry.idempotency_key,
+    # Use raw SQL so Postgres RETURNING gives us exact inserted count.
+    # Django's bulk_create with ignore_conflicts swallows RETURNING.
+    sql = """
+        INSERT INTO sentry_groupactionlogentry
+            (group_id, project_id, type, actor_type, actor_id, source, data,
+             date_added, date_updated, idempotency_key)
+        VALUES %s
+        ON CONFLICT (group_id, idempotency_key)
+            WHERE idempotency_key IS NOT NULL
+        DO NOTHING
+        RETURNING id
+    """
+    values_template = "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
+    params: list[int | str | datetime] = []
+    for entry in entries:
+        params.extend(
+            [
+                group_id,
+                project_id,
+                entry.action.get_type().value,
+                entry.actor.actor_type.value,
+                entry.actor.actor_id,
+                entry.source,
+                json.dumps(entry.action.dict()),
+                entry.date_added,
+                entry.date_added,  # date_updated
+                entry.idempotency_key,
+            ]
         )
-        for entry in entries
-    ]
 
+    values_clause = ", ".join(values_template for _ in entries)
     using = router.db_for_write(GroupActionLogEntry)
     with transaction.atomic(using=using):
-        GroupActionLogEntry.objects.bulk_create(
-            objects,
-            ignore_conflicts=True,
-            unique_fields=["group_id", "idempotency_key"],
-        )
+        cursor = connections[using].cursor()
+        cursor.execute(sql % values_clause, params)
+        inserted = cursor.rowcount
 
     metrics.incr(
         "issues.action_log.backfill",
-        amount=len(entries),
+        amount=inserted,
         tags={"actor_type": entries[0].actor.actor_type.name.lower()},
     )
 
-    # entries are sorted ascending, so [0] is the earliest.
-    invalidate_group_derived_data(group_id, cursor=(entries[0].date_added, 0))
+    if inserted:
+        # entries are sorted ascending, so [0] is the earliest.
+        invalidate_group_derived_data(group_id, cursor=(entries[0].date_added, 0))
 
-    return len(entries)
+    return inserted
 
 
 def backfill_group_activities(

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -79,8 +79,14 @@ class BackfillActionsTest(TestCase):
 
     def test_skips_duplicates(self) -> None:
         entries = [self._entry(key="dup")]
-        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
-        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        assert (
+            backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+            == 1
+        )
+        assert (
+            backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+            == 0
+        )
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
 
     def test_skips_only_conflicting_entries(self) -> None:
@@ -93,7 +99,10 @@ class BackfillActionsTest(TestCase):
             self._entry(minutes_ago=2, key="existing"),
             self._entry(minutes_ago=1, key="new"),
         ]
-        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        count = backfill_actions(
+            entries=entries, group_id=self.group.id, project_id=self.project.id
+        )
+        assert count == 1
         assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
 
     def test_same_key_different_group_no_conflict(self) -> None:
@@ -128,12 +137,15 @@ class BackfillActionsTest(TestCase):
         mock_invalidate.assert_called_once_with(self.group.id, cursor=(entries[0].date_added, 0))
 
     @patch("sentry.issues.action_log.backfill.invalidate_group_derived_data")
-    def test_always_invalidates_conservatively(self, mock_invalidate: MagicMock) -> None:
+    def test_no_invalidation_when_all_duplicates(self, mock_invalidate: MagicMock) -> None:
         entries = [self._entry(key="x")]
         backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
         mock_invalidate.reset_mock()
-        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
-        mock_invalidate.assert_called_once()
+        count = backfill_actions(
+            entries=entries, group_id=self.group.id, project_id=self.project.id
+        )
+        assert count == 0
+        mock_invalidate.assert_not_called()
 
 
 class BackfillGroupActivitiesTest(TestCase):

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -1,0 +1,284 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.utils import timezone
+
+from sentry.issues.action_log.backfill import (
+    BACKFILL_ACTIVITY_SOURCE,
+    BackfillEntry,
+    backfill_actions,
+    backfill_group_activities,
+)
+from sentry.issues.action_log.types import (
+    SYSTEM_ACTOR,
+    GroupAction,
+    GroupActionActor,
+    GroupActionType,
+    GroupActorType,
+    ResolveAction,
+    ViewAction,
+)
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+
+class BackfillActionsTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.now = timezone.now()
+
+    def _entry(
+        self,
+        *,
+        minutes_ago: int = 0,
+        key: str = "k",
+        action: GroupAction | None = None,
+        actor: GroupActionActor = SYSTEM_ACTOR,
+        source: str = "test",
+    ) -> BackfillEntry:
+        return BackfillEntry(
+            action=action or ViewAction(),
+            actor=actor,
+            source=source,
+            date_added=self.now - timedelta(minutes=minutes_ago),
+            idempotency_key=key,
+        )
+
+    def test_empty_entries(self) -> None:
+        result = backfill_actions(entries=[], group_id=self.group.id, project_id=self.project.id)
+        assert result == 0
+
+    def test_creates_entries(self) -> None:
+        entries = [
+            self._entry(minutes_ago=2, key="a"),
+            self._entry(minutes_ago=1, key="b"),
+        ]
+        count = backfill_actions(
+            entries=entries, group_id=self.group.id, project_id=self.project.id
+        )
+        assert count == 2
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
+
+    def test_sets_fields_correctly(self) -> None:
+        entry = self._entry(
+            key="x", actor=GroupActionActor.user(42), source="web", action=ResolveAction()
+        )
+        backfill_actions(entries=[entry], group_id=self.group.id, project_id=self.project.id)
+        row = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert row.group_id == self.group.id
+        assert row.project_id == self.project.id
+        assert row.type == GroupActionType.RESOLVE.value
+        assert row.actor_type == GroupActorType.USER.value
+        assert row.actor_id == 42
+        assert row.source == "web"
+        assert row.idempotency_key == "x"
+        assert row.date_added == entry.date_added
+
+    def test_skips_duplicates(self) -> None:
+        entries = [self._entry(key="dup")]
+        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_skips_only_conflicting_entries(self) -> None:
+        backfill_actions(
+            entries=[self._entry(key="existing")],
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+        entries = [
+            self._entry(minutes_ago=2, key="existing"),
+            self._entry(minutes_ago=1, key="new"),
+        ]
+        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
+
+    def test_same_key_different_group_no_conflict(self) -> None:
+        other_group = self.create_group()
+        backfill_actions(
+            entries=[self._entry(key="shared")],
+            group_id=self.group.id,
+            project_id=self.project.id,
+        )
+        count = backfill_actions(
+            entries=[self._entry(key="shared")],
+            group_id=other_group.id,
+            project_id=self.project.id,
+        )
+        assert count == 1
+
+    def test_rejects_unsorted_entries(self) -> None:
+        entries = [
+            self._entry(minutes_ago=0, key="a"),
+            self._entry(minutes_ago=5, key="b"),
+        ]
+        with pytest.raises(ValueError, match="sorted"):
+            backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+
+    @patch("sentry.issues.action_log.backfill.invalidate_group_derived_data")
+    def test_invalidates_with_earliest_cursor(self, mock_invalidate: MagicMock) -> None:
+        entries = [
+            self._entry(minutes_ago=5, key="a"),
+            self._entry(minutes_ago=1, key="b"),
+        ]
+        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        mock_invalidate.assert_called_once_with(self.group.id, cursor=(entries[0].date_added, 0))
+
+    @patch("sentry.issues.action_log.backfill.invalidate_group_derived_data")
+    def test_always_invalidates_conservatively(self, mock_invalidate: MagicMock) -> None:
+        entries = [self._entry(key="x")]
+        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        mock_invalidate.reset_mock()
+        backfill_actions(entries=entries, group_id=self.group.id, project_id=self.project.id)
+        mock_invalidate.assert_called_once()
+
+
+class BackfillGroupActivitiesTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.now = timezone.now()
+
+    def test_empty_group(self) -> None:
+        count = backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        assert count == 0
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
+
+    def test_translates_activities(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            datetime=self.now - timedelta(minutes=2),
+        )
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={"assignee": "123", "assigneeType": "user"},
+            datetime=self.now - timedelta(minutes=1),
+        )
+        count = backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        assert count == 2
+        entries = list(
+            GroupActionLogEntry.objects.filter(group_id=self.group.id).order_by("date_added")
+        )
+        assert entries[0].type == GroupActionType.RESOLVE.value
+        assert entries[1].type == GroupActionType.ASSIGN.value
+
+    def test_sets_actor_from_user_id(self) -> None:
+        user = self.create_user()
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            user_id=user.id,
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.actor_type == GroupActorType.USER.value
+        assert entry.actor_id == user.id
+
+    def test_sets_system_actor_when_no_user(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.AUTO_SET_ONGOING.value,
+            data={},
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.actor_type == GroupActorType.SYSTEM.value
+        assert entry.actor_id == 0
+
+    def test_uses_backfill_source(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.source == BACKFILL_ACTIVITY_SOURCE
+
+    def test_idempotency_key_uses_activity_id(self) -> None:
+        act = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.idempotency_key == f"activity:{act.id}"
+
+    def test_skips_untranslatable_activities(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.FIRST_SEEN.value,
+            data={"priority": 1},
+        )
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        count = backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        assert count == 1
+
+    def test_idempotent_on_rerun(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={"assignee": "1"},
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
+
+    def test_processes_in_batches(self) -> None:
+        for i in range(5):
+            self.create_group_activity(
+                group=self.group,
+                type=ActivityType.SET_RESOLVED.value,
+                data={},
+                datetime=self.now - timedelta(minutes=5 - i),
+            )
+        count = backfill_group_activities(
+            group_id=self.group.id, project_id=self.project.id, batch_size=2
+        )
+        assert count == 5
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 5
+
+    def test_does_not_affect_other_groups(self) -> None:
+        other_group = self.create_group()
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        self.create_group_activity(
+            group=other_group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+        assert GroupActionLogEntry.objects.filter(group_id=other_group.id).count() == 0
+
+    def test_preserves_activity_datetime(self) -> None:
+        ts = self.now - timedelta(days=30)
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            datetime=ts,
+        )
+        backfill_group_activities(group_id=self.group.id, project_id=self.project.id)
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.date_added == ts


### PR DESCRIPTION
Add a method to allow Group Activity data to be backfilled.

Initial planned use of this is in manually-triggered jobs. These will be responsible for the triggering of generation, so it isn't included as part of the backfill.