### PR TITLE
fix(issues): Contain activity sidebar names

### DIFF
--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -62,10 +62,10 @@ function Item({
       ) : (
         <IconWrapper className="timeline-icon-wrapper" />
       )}
-      <Flex align="center" gap="xs" wrap="wrap">
+      <TitleRow align="center" gap="xs" wrap="wrap">
         <Title style={{color: config.title}}>{title}</Title>
         {titleTrailingItems}
-      </Flex>
+      </TitleRow>
       {timestamp ?? <div />}
       <Container justifySelf="center" width="0" height="100%" column="span 1" />
       <Content hasMarker={hasMarker}>{children}</Content>
@@ -120,6 +120,8 @@ const IconWrapper = styled('div')`
     margin: ${p => p.theme.space.xs};
   }
 `;
+
+const TitleRow = styled(Flex)``;
 
 const Title = styled('div')`
   font-weight: bold;
@@ -177,6 +179,8 @@ const TimelineContainer = styled('div')`
 export const Timeline = {
   Data,
   Text,
+  Title,
+  TitleRow,
   Item,
   Container: TimelineContainer,
 };

--- a/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
@@ -47,6 +47,7 @@ export function ActivityLine({
         title={compactItem.title}
         details={compactItem.details}
         timestamp={timestamp}
+        variant={inputVariant}
       />
       <ActivityLineBody subtext={compactItem.subtext} />
     </ActivityLineRow>

--- a/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
@@ -14,6 +14,7 @@ interface ActivityLineRowProps {
 interface ActivityLineHeadlineProps {
   timestamp: React.ReactNode;
   title: React.ReactNode;
+  variant: ActivityLineVariant;
   actions?: React.ReactNode;
   details?: React.ReactNode;
 }
@@ -31,6 +32,7 @@ export function ActivityLineHeadline({
   details,
   timestamp,
   actions,
+  variant,
 }: ActivityLineHeadlineProps) {
   return (
     <Flex
@@ -42,9 +44,15 @@ export function ActivityLineHeadline({
       wrap="wrap"
       gap="xs"
     >
-      <Text as="span" bold density="comfortable" wordBreak="break-word">
+      <ActivityLineTitleText
+        as="span"
+        bold
+        data-compact={variant === 'compact' ? true : undefined}
+        density="comfortable"
+        wordBreak="break-word"
+      >
         {title}
-      </Text>
+      </ActivityLineTitleText>
       {details && <ActivityLineDetails>{details}</ActivityLineDetails>}
       <ActivityLineMeta>
         <Text as="span" variant="muted" density="comfortable">
@@ -92,6 +100,18 @@ const ActivityLineRowElement = styled('div')`
 const CompactActivityLineRow = styled('div')`
   ${activityLineRowStyles};
   column-gap: ${p => p.theme.space.sm};
+`;
+
+const ActivityLineTitleText = styled(Text)`
+  min-width: 0;
+  overflow-wrap: anywhere;
+
+  &[data-compact='true'] {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
 `;
 
 const ActivityLineDetails = styled('span')`

--- a/static/app/views/issueDetails/activitySection/activityLineItem/note.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/note.tsx
@@ -59,6 +59,7 @@ export function ActivityLineNote({
       <ActivityLineHeadline
         title={getNoteAuthorName(activity)}
         timestamp={timestamp}
+        variant={inputVariant}
         actions={
           !editing && (
             <CommentActionsDropdown

--- a/static/app/views/issueDetails/activitySection/commentActionsDropdown.tsx
+++ b/static/app/views/issueDetails/activitySection/commentActionsDropdown.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu, type DropdownMenuProps} from 'sentry/components/dropdownMenu';
 import {IconEllipsis} from 'sentry/icons';
@@ -25,7 +27,7 @@ export function CommentActionsDropdown({
   }
 
   return (
-    <DropdownMenu
+    <StyledDropdownMenu
       offset={4}
       size="sm"
       triggerProps={{
@@ -43,6 +45,7 @@ export function CommentActionsDropdown({
           tooltip: activeUser.isSuperuser
             ? t('You can edit this comment due to your superuser status')
             : undefined,
+          tooltipOptions: {delay: 1000},
         },
         {
           key: 'delete',
@@ -60,9 +63,14 @@ export function CommentActionsDropdown({
           tooltip: activeUser.isSuperuser
             ? t('You can delete this comment due to your superuser status')
             : undefined,
+          tooltipOptions: {delay: 1000},
         },
       ]}
       {...props}
     />
   );
 }
+
+const StyledDropdownMenu = styled(DropdownMenu)`
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+`;

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -151,18 +151,18 @@ function LegacyTimelineItem({
   return (
     <ActivityTimelineItem
       title={
-        <Flex gap="xs" align="center" justify="start">
-          <TitleTooltip title={title} showOnlyOnOverflow>
-            {title}
-          </TitleTooltip>
-          {item.type === GroupActivityType.NOTE && !editing && (
+        <TitleRow>
+          <Tooltip title={title} showOnlyOnOverflow skipWrapper>
+            <TitleText>{title}</TitleText>
+          </Tooltip>
+          {item.type === GroupActivityType.NOTE && !editing ? (
             <CommentActionsDropdown
               onDelete={() => handleDelete(item)}
               onEdit={() => setEditing(true)}
               user={item.user}
             />
-          )}
-        </Flex>
+          ) : null}
+        </TitleRow>
       }
       timestamp={<Timestamp date={item.dateCreated} unitStyle={timestampUnitStyle} />}
       icon={
@@ -382,15 +382,43 @@ export function ActivitySection({
   );
 }
 
-const TitleTooltip = styled(Tooltip)`
-  justify-self: start;
+const TitleRow = styled('span')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  min-width: 0;
+  max-width: 100%;
+`;
+
+const TitleText = styled('span')`
+  display: inline-block;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  > * {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 `;
 
 const ActivityTimelineItem = styled(Timeline.Item)`
   align-items: start;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
+
+  ${Timeline.TitleRow} {
+    min-width: 0;
+  }
+
+  ${Timeline.Title} {
+    min-width: 0;
+    max-width: 100%;
+  }
 `;
 
 const Timestamp = styled(TimeSince)`


### PR DESCRIPTION
Long user names could blow out the old issue activity sidebar title row. This keeps the name and comment actions in a small local grid and targets the timeline title pieces with component selectors instead of depending on DOM shape.

Also fixes an issue where the items in the dropdown where bold because they're a child of an element with bold text.

before

<img width="339" height="75" alt="image" src="https://github.com/user-attachments/assets/e0abed47-91b7-4e69-9db8-94837b8aa16c" />

after

<img width="321" height="67" alt="image" src="https://github.com/user-attachments/assets/33d62c7a-e78c-405a-bb03-68544ebdc4c8" />

fixes JAVASCRIPT-3AQK