### PR TITLE
feat(GALE): Schedule processing task on invalidation

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -211,7 +211,8 @@ def invalidate_group_derived_data(
     group_id: int,
     cursor: tuple[datetime, int] | None = None,
 ) -> None:
-    """Delete derived state so it is rebuilt from scratch on the next pass.
+    """Delete derived state so it is rebuilt from scratch on the next pass,
+    then kicks off an async task to regenerate the derived data.
 
     If *cursor* is ``(date_added, id)`` of the earliest affected entry, the
     row is only deleted when its cursor is at or past that point; otherwise

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -220,6 +220,7 @@ def invalidate_group_derived_data(
     """
     if cursor is None:
         GroupDerivedData.objects.filter(group_id=group_id).delete()
+        process_group_log_task.delay(group_id)
         return
 
     # Only invalidate if the row has already processed past the affected point.
@@ -237,3 +238,4 @@ def invalidate_group_derived_data(
                 "cursor_id": cursor_id,
             },
         )
+        process_group_log_task.delay(group_id)

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -2,7 +2,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry import buffer, eventstream
-from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupmeta import GroupMeta
@@ -230,13 +230,21 @@ class MergeGroupTest(TestCase, SnubaTestCase):
         old_group = self.create_group(project)
         new_group = self.create_group(project)
 
-        GroupDerivedData.objects.create(group=new_group)
+        derived = GroupDerivedData.objects.create(
+            group=new_group, cursor_date=before_now(minutes=5), cursor_id=100
+        )
 
         with self.tasks():
             merge_groups([old_group.id], new_group.id)
 
         assert Group.objects.filter(id=old_group.id).exists() is False
-        assert GroupDerivedData.objects.filter(group_id=new_group.id).exists() is False
+
+        # The derived data is invalidated: the stale row is deleted and rebuilt
+        # from scratch by the scheduled processing task.
+        rebuilt = GroupDerivedData.objects.get(group_id=new_group.id)
+        assert rebuilt.id != derived.id
+        assert rebuilt.cursor_date == EPOCH
+        assert rebuilt.cursor_id == 0
 
     @mock_redis_buffer()
     def test_merge_original_group_id(self) -> None:


### PR DESCRIPTION
Add a call to `process_group_log_task` within `invalidate_group_derived_data` to ensure the derived data will be regenerated immediately.