### PR TITLE
ref(billing): remove dead org-level downsampled retention

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -885,7 +885,7 @@ describe('CustomerOverview', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      orgRetention: {standard: 1234567, downsampled: null},
+      orgRetention: {standard: 1234567},
     });
 
     render(
@@ -904,7 +904,7 @@ describe('CustomerOverview', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
       categories: {
         errors: MetricHistoryFixture({
           retention: {standard: 987, downsampled: null},
@@ -928,7 +928,7 @@ describe('CustomerOverview', () => {
     const subscription = SubscriptionFixture({
       organization,
       plan: 'am3_f',
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
     });
 
     render(

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.spec.tsx
@@ -48,7 +48,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: 1234567, downsampled: null},
+      orgRetention: {standard: 1234567},
     });
 
     openUpdateRetentionSettingsModal({
@@ -124,7 +124,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
     });
 
     openUpdateRetentionSettingsModal({
@@ -160,7 +160,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: 123, downsampled: null},
+      orgRetention: {standard: 123},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -202,7 +202,6 @@ describe('UpdateRetentionSettingsModal', () => {
           data: {
             orgRetention: {
               standard: 456,
-              downsampled: null,
             },
             retentions: {
               spans: {
@@ -240,7 +239,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am2_f'),
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -281,7 +280,6 @@ describe('UpdateRetentionSettingsModal', () => {
           data: {
             orgRetention: {
               standard: null,
-              downsampled: null,
             },
             retentions: {
               transactions: {
@@ -319,7 +317,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: 123, downsampled: null},
+      orgRetention: {standard: 123},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -357,7 +355,6 @@ describe('UpdateRetentionSettingsModal', () => {
           data: {
             orgRetention: {
               standard: null,
-              downsampled: null,
             },
             retentions: {
               spans: {
@@ -395,7 +392,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -436,7 +433,6 @@ describe('UpdateRetentionSettingsModal', () => {
           data: {
             orgRetention: {
               standard: null,
-              downsampled: null,
             },
             retentions: {
               spans: {
@@ -474,7 +470,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -509,7 +505,6 @@ describe('UpdateRetentionSettingsModal', () => {
           data: {
             orgRetention: {
               standard: null,
-              downsampled: null,
             },
             retentions: {
               spans: {
@@ -545,7 +540,7 @@ describe('UpdateRetentionSettingsModal', () => {
         }),
       },
       planDetails: PlanDetailsLookupFixture('am3_f'),
-      orgRetention: {standard: null, downsampled: null},
+      orgRetention: {standard: null},
     });
 
     const updateMock = MockApiClient.addMockResponse({
@@ -580,7 +575,6 @@ describe('UpdateRetentionSettingsModal', () => {
           data: {
             orgRetention: {
               standard: null,
-              downsampled: null,
             },
             retentions: {
               spans: {

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -86,7 +86,6 @@ function UpdateRetentionSettingsModal({
 
     const orgRetention = {
       standard: getNumberOrNull(orgStandard),
-      downsampled: null,
     };
 
     const data = {retentions, orgRetention};

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -140,11 +140,6 @@ type AddOns = Partial<Record<AddOnCategory, AddOn>>;
 // how addons are represented in the checkout form data
 export type CheckoutAddOns = Partial<Record<AddOnCategory, Pick<AddOn, 'enabled'>>>;
 
-type RetentionSettings = {
-  downsampled: number | null;
-  standard: number | null;
-};
-
 export type Plan = {
   addOnCategories: Partial<Record<AddOnCategory, AddOnCategoryInfo>>;
   allowOnDemand: boolean;
@@ -342,7 +337,7 @@ export type Subscription = {
   onDemandPeriodStart: string;
   onDemandSpendUsed: number;
   onTrialPlan: boolean;
-  orgRetention: RetentionSettings | null;
+  orgRetention: {standard: number | null} | null;
   partner: Partner | null;
   paymentSource: {
     brand: string;

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -144,7 +144,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
     dateJoined: '2018-09-10T23:58:10.167Z',
     onDemandPeriodEnd: '2018-10-24',
     msaUpdatedForDataConsent: false,
-    orgRetention: {standard: null, downsampled: null},
+    orgRetention: {standard: null},
     addOns,
     reservedBudgets,
     categories: {


### PR DESCRIPTION
Frontend counter part to: https://github.com/getsentry/getsentry/pull/20972.

`orgRetention.downsampled` in the customer API serializer was incomplete and non-functional; so I'm cleaning this up to prepare for the billing platform counterpart of this.

