### PR TITLE
fix(gsadmin): render the doc integration logo preview correctly

### DIFF
--- a/static/app/components/avatarChooser/index.tsx
+++ b/static/app/components/avatarChooser/index.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {
+  DocIntegrationAvatar,
   OrganizationAvatar,
   SentryAppAvatar,
   TeamAvatar,
@@ -23,6 +24,7 @@ import {IconUpload} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Avatar} from 'sentry/types/core';
 import type {
+  DocIntegration,
   SentryApp,
   SentryAppAvatarPhotoType,
   SentryAppAvatar as SentryAppAvatarType,
@@ -41,7 +43,13 @@ interface SimpleAvatar {
 
 type AvatarType = Avatar['avatarType'];
 
-type AvatarModel = AvatarUser | Team | Organization | SentryApp | SimpleAvatar;
+type AvatarModel =
+  | AvatarUser
+  | Team
+  | Organization
+  | SentryApp
+  | DocIntegration
+  | SimpleAvatar;
 
 type DefaultChoice = {
   description?: React.ReactNode;
@@ -80,7 +88,7 @@ type AvatarChooserProps = AvatarChooserBaseProps &
         onSave?: (model: SimpleAvatar) => void;
       }
     | {
-        model: SimpleAvatar;
+        model: DocIntegration;
         type: 'docIntegration';
         onSave?: (model: SimpleAvatar) => void;
       }
@@ -262,6 +270,11 @@ export function AvatarChooser({
       <TeamAvatar {...sharedAvatarProps} team={model as Team} />
     ) : type === 'organization' ? (
       <OrganizationAvatar {...sharedAvatarProps} organization={model as Organization} />
+    ) : type === 'docIntegration' ? (
+      <DocIntegrationAvatar
+        {...sharedAvatarProps}
+        docIntegration={model as DocIntegration}
+      />
     ) : isSentryApp ? (
       <SentryAppAvatar
         {...sharedAvatarProps}

--- a/static/gsAdmin/components/docIntegrationModal.tsx
+++ b/static/gsAdmin/components/docIntegrationModal.tsx
@@ -284,7 +284,7 @@ export function DocIntegrationModal(props: Props) {
               type="docIntegration"
               supportedTypes={['upload']}
               endpoint={`/doc-integrations/${docIntegration.slug}/avatar/`}
-              model={docIntegration.avatar ? docIntegration : {}}
+              model={docIntegration}
               onSave={() => {}}
               title="Logo"
               help="The company's logo"


### PR DESCRIPTION
Drive by avatar fixing:
<img width="581" height="222" alt="Screenshot 2026-07-07 at 4 30 41 PM" src="https://github.com/user-attachments/assets/8fb79aa0-27cf-403c-ad7c-39113f20edfc" />

Was looking at some other avatar stuff, and noticed this bit in _admin didn't seem to work at all. 