### PR TITLE
fix(ui): Ignore 1Password in overlay search inputs

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -616,6 +616,7 @@ export function CommandPalette({
                 <StyledInputGroupInput
                   seerEnabled={seerExplorerEnabled}
                   autoFocus
+                  data-1p-ignore
                   ref={state.input}
                   value={state.query}
                   aria-label={t('Search commands')}

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -579,6 +579,7 @@ export function Control({
                     </InputGroup.LeadingItems>
                     <SearchInput
                       ref={searchRef}
+                      data-1p-ignore
                       placeholder={normalizedSearch?.placeholder ?? 'Search…'}
                       value={searchInputValue}
                       onFocus={onSearchFocus}


### PR DESCRIPTION
These overlay search inputs get mounted and focused immediately, which can make 1Password treat them like possible credential fields.

Adds the 1Password ignore hint to Cmd+K and CompactSelect search inputs. Relevant guidance: https://www.1password.dev/web/compatible-website-design

Saves ~20ms of the total 140ms it took to open cmd+k in this example below

<img width="515" height="296" alt="image" src="https://github.com/user-attachments/assets/2082b947-1047-4f61-aeb0-f77058f7721d" />
