### PR TITLE
ref(sentry-apps): copy `EVENT_EXPANSION` webhook definitions in frontend

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,10 +1,51 @@
+import type {WebhookEvent} from 'sentry/types/integrations';
+
 export const EVENT_CHOICES = [
   'issue',
   'error',
   'comment',
   'seer',
   'preprod_artifact',
-] as const;
+] as const satisfies readonly WebhookEvent[];
+
+// Mirrors EVENT_EXPANSION on the backend (sentry_apps/utils/webhooks.py)
+export const RESOURCE_EVENTS = {
+  issue: [
+    'issue.created',
+    'issue.resolved',
+    'issue.assigned',
+    'issue.ignored',
+    'issue.unresolved',
+  ],
+  error: ['error.created'],
+  comment: ['comment.created', 'comment.updated', 'comment.deleted'],
+  seer: [
+    'seer.root_cause_started',
+    'seer.root_cause_completed',
+    'seer.solution_started',
+    'seer.solution_completed',
+    'seer.coding_started',
+    'seer.coding_completed',
+    'seer.pr_created',
+    'seer.iteration_started',
+    'seer.iteration_completed',
+  ],
+  preprod_artifact: [
+    'preprod_artifact.size_analysis_completed',
+    'preprod_artifact.build_distribution_completed',
+  ],
+} as const satisfies Record<WebhookEvent, readonly string[]>;
+
+export type WebhookGranularEvent = (typeof RESOURCE_EVENTS)[WebhookEvent][number];
+
+const EVENT_LABEL_OVERRIDES: Partial<Record<WebhookGranularEvent, string>> = {
+  'issue.ignored': 'archived', // the product renamed ignore → archive
+  'comment.updated': 'edited', // the product renamed update → edit
+};
+
+export function webhookEventLabel(event: WebhookGranularEvent): string {
+  return EVENT_LABEL_OVERRIDES[event] ?? event.slice(event.indexOf('.') + 1);
+}
 
 export const PERMISSIONS_MAP = {
   issue: 'Event',

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -8,7 +8,11 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {EVENT_CHOICES} from 'sentry/views/settings/organizationDeveloperSettings/constants';
-import {PERMISSIONS_MAP} from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import {
+  PERMISSIONS_MAP,
+  RESOURCE_EVENTS,
+  webhookEventLabel,
+} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 
 type Resource = (typeof EVENT_CHOICES)[number];
 
@@ -55,13 +59,7 @@ export function SubscriptionBox({
     message = t('Cannot enable webhook subscription without specifying a webhook url');
   }
 
-  const DESCRIPTIONS: Record<(typeof EVENT_CHOICES)[number], string> = {
-    issue: 'created, resolved, assigned, archived, unresolved',
-    error: 'created',
-    comment: 'created, edited, deleted',
-    seer: 'root_cause_started, root_cause_completed, solution_started, solution_completed, coding_started, coding_completed, pr_created',
-    preprod_artifact: 'size_analysis_completed, build_distribution_completed',
-  };
+  const description = RESOURCE_EVENTS[resource].map(webhookEventLabel).join(', ');
 
   return (
     <Tooltip disabled={!disabled} title={message} key={resource}>
@@ -71,7 +69,7 @@ export function SubscriptionBox({
             {resource}
             {isNew && <FeatureBadge type="new" />}
           </SubscriptionTitle>
-          <SubscriptionDescription>{DESCRIPTIONS[resource]}</SubscriptionDescription>
+          <SubscriptionDescription>{description}</SubscriptionDescription>
         </Stack>
         <Checkbox
           key={`${resource}${checked}`}


### PR DESCRIPTION
Move the webhook subscription descriptions around to match the backend structure. Also adds in some seer events that were missing.