### PR TITLE
fix(spans): Parse callstack string in 'file I/O on main thread' detector

### DIFF
--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections import defaultdict
 from typing import Any
 
@@ -15,6 +16,7 @@ from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.lang.java.proguard import open_proguard_mapper
 from sentry.models.debugfile import ProjectDebugFile
 from sentry.models.project import Project
+from sentry.utils import json
 from sentry.utils.tracing import start_span
 
 from ..base import DetectorType, PerformanceDetector
@@ -25,6 +27,8 @@ from ..detectors.utils import (
 )
 from ..performance_problem import PerformanceProblem
 from ..types import Span
+
+logger = logging.getLogger(__name__)
 
 
 class BaseIOMainThreadDetector(PerformanceDetector):
@@ -178,7 +182,20 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
             data = span.get("data")
             if data is None:
                 continue
-            for item in data.get("call_stack", []):
+
+            callstack = data.get("call_stack", [])
+            # Spans from the new span buffer (which can land here via the shim in `process_segment`)
+            # contain stringified callstacks, so if we need to reinflate the callstack value, do
+            # that now
+            if isinstance(callstack, str):
+                try:
+                    callstack = json.loads(callstack)
+                except Exception:
+                    logger.exception(
+                        "issue_detectors.io_main_thread_detector.callstack_json_parse_error"
+                    )
+                    callstack = []
+            for item in callstack:
                 module = self._deobfuscate_module(item.get("module", ""))
                 function = self._deobfuscate_function(item)
                 call_stack_strings.append(f"{module}.{function}")

--- a/src/sentry/issue_detection/detectors/io_main_thread_detector.py
+++ b/src/sentry/issue_detection/detectors/io_main_thread_detector.py
@@ -195,14 +195,17 @@ class FileIOMainThreadDetector(BaseIOMainThreadDetector):
                         "issue_detectors.io_main_thread_detector.callstack_json_parse_error"
                     )
                     callstack = []
-            for item in callstack:
-                module = self._deobfuscate_module(item.get("module", ""))
-                function = self._deobfuscate_function(item)
-                call_stack_strings.append(f"{module}.{function}")
-            # Use set to remove dupes, and list index to preserve order
-            overall_stack.append(
-                ".".join(sorted(set(call_stack_strings), key=lambda c: call_stack_strings.index(c)))
-            )
+            if isinstance(callstack, list):  # Insurance - by this point should always be true
+                for item in callstack:
+                    module = self._deobfuscate_module(item.get("module", ""))
+                    function = self._deobfuscate_function(item)
+                    call_stack_strings.append(f"{module}.{function}")
+                # Use set to remove dupes, and list index to preserve order
+                overall_stack.append(
+                    ".".join(
+                        sorted(set(call_stack_strings), key=lambda c: call_stack_strings.index(c))
+                    )
+                )
         call_stack = "-".join(sorted(set(overall_stack), key=lambda s: overall_stack.index(s)))
         hashed_stack = hashlib.sha1(call_stack.encode("utf8")).hexdigest()
         return f"1-{PerformanceFileIOMainThreadGroupType.type_id}-{hashed_stack}"

--- a/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
+++ b/tests/sentry/issue_detection/test_file_io_on_main_thread_detector.py
@@ -19,6 +19,7 @@ from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TestCase
 from sentry.testutils.issue_detection.event_generators import get_event
 from sentry.testutils.objectstore import debug_files_test_both_backends
+from sentry.utils import json
 
 PROGUARD_SOURCE = b"""\
 # compiler: R8
@@ -178,4 +179,52 @@ class FileIOMainThreadDetectorTest(TestCase):
             "054ba3a3a4d54ab2",
             "054ba3a3a4d54ab3",
             "054ba3a3a4d54ab4",
+        ]
+
+    def test_handles_stringified_callstack(self) -> None:
+        event = get_event("file-io-on-main-thread/file-io-on-main-thread")
+        event["spans"][0]["data"]["call_stack"] = json.dumps(
+            event["spans"][0]["data"]["call_stack"]
+        )
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint=f"1-{PerformanceFileIOMainThreadGroupType.type_id}-153198dd61706844cf3d9a922f6f82543df8125f",
+                op="file.write",
+                desc="1669031858711_file.txt (4.0 kB)",
+                type=PerformanceFileIOMainThreadGroupType,
+                parent_span_ids=["b93d2be92cd64fd5"],
+                cause_span_ids=[],
+                offender_span_ids=["054ba3a374d543eb"],
+                evidence_data={
+                    "op": "file.write",
+                    "parent_span_ids": ["b93d2be92cd64fd5"],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["054ba3a374d543eb"],
+                },
+                evidence_display=[],
+            )
+        ]
+
+    def test_no_crash_on_non_json_string_callstack(self) -> None:
+        event = get_event("file-io-on-main-thread/file-io-on-main-thread")
+        event["spans"][0]["data"]["call_stack"] = "dogs are great"
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint=f"1-{PerformanceFileIOMainThreadGroupType.type_id}-da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                op="file.write",
+                desc="1669031858711_file.txt (4.0 kB)",
+                type=PerformanceFileIOMainThreadGroupType,
+                parent_span_ids=["b93d2be92cd64fd5"],
+                cause_span_ids=[],
+                offender_span_ids=["054ba3a374d543eb"],
+                evidence_data={
+                    "op": "file.write",
+                    "parent_span_ids": ["b93d2be92cd64fd5"],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["054ba3a374d543eb"],
+                },
+                evidence_display=[],
+            )
         ]


### PR DESCRIPTION
In spans that come from transaction events, `data.call_stack` is a list of frame dicts, but in spans that come from the span buffer, it's a stringified version of that list. Now that we're experimentally running the existing issue detectors on data from the span buffer, this is causing a problem, because our "file I/O on the main thread" detector expects to be able to call `.get()` on each item it gets back when iterating over the callstack. Strings are also iterable, so that part works fine, but that iteration gives back a character at a time, and you can't call `.get()` on a single-character string, leading the detector to crash.

This fixes the problem by calling `json.loads` on string callstacks before trying to iterate over them. It also adds a check before iteration (but after JSON parsing) to ensure we do in fact have a list to iterate over.

Fixes https://sentry.sentry.io/issues/7574792044.