### PR TITLE
feat(conversations): Drop span-detail Show More clips for scroll + role folding

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -303,7 +303,8 @@ function InputTab({
           <TraceDrawerComponents.MultilineTextLabel>
             {capitalize(message.role)}
           </TraceDrawerComponents.MultilineTextLabel>
-          <MessageContent content={message.content} />
+          {/* System prompts are usually long, repetitive, and sit on top, so keep them clipped */}
+          <MessageContent content={message.content} clip={message.role === 'system'} />
         </Fragment>
       ))}
       {toolArgs ? (
@@ -375,9 +376,9 @@ function OutputTab({
   );
 }
 
-function MessageContent({content}: {content: unknown}) {
+function MessageContent({content, clip = false}: {content: unknown; clip?: boolean}) {
   return typeof content === 'string' ? (
-    <AIContentRenderer text={content} clip={false} />
+    <AIContentRenderer text={content} clip={clip} />
   ) : (
     <TraceDrawerComponents.MultilineJSON value={content} maxDefaultDepth={2} />
   );

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -380,7 +380,11 @@ function MessageContent({content, clip = false}: {content: unknown; clip?: boole
   return typeof content === 'string' ? (
     <AIContentRenderer text={content} clip={clip} />
   ) : (
-    <TraceDrawerComponents.MultilineJSON value={content} maxDefaultDepth={2} />
+    <TraceDrawerComponents.MultilineJSON
+      value={content}
+      maxDefaultDepth={2}
+      clip={clip}
+    />
   );
 }
 

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -310,7 +310,7 @@ function InputTab({
         <TraceDrawerComponents.MultilineJSON value={toolArgs} maxDefaultDepth={1} />
       ) : null}
       {embeddingsInput ? (
-        <TraceDrawerComponents.MultilineText>
+        <TraceDrawerComponents.MultilineText clip={false}>
           {embeddingsInput.toString()}
         </TraceDrawerComponents.MultilineText>
       ) : null}
@@ -349,7 +349,7 @@ function OutputTab({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <AIContentRenderer text={responseText} />
+          <AIContentRenderer text={responseText} clip={false} />
         </Fragment>
       ) : null}
       {responseObject ? (
@@ -357,7 +357,7 @@ function OutputTab({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <AIContentRenderer text={responseObject} />
+          <AIContentRenderer text={responseObject} clip={false} />
         </Fragment>
       ) : null}
       {toolCalls ? (
@@ -377,7 +377,7 @@ function OutputTab({
 
 function MessageContent({content}: {content: unknown}) {
   return typeof content === 'string' ? (
-    <AIContentRenderer text={content} />
+    <AIContentRenderer text={content} clip={false} />
   ) : (
     <TraceDrawerComponents.MultilineJSON value={content} maxDefaultDepth={2} />
   );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -17,6 +17,11 @@ import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/tr
 interface AIContentRendererProps {
   text: string;
   autoCollapseLimit?: number;
+  /**
+   * Clips tall text content behind a "Show More" button. Disable when the
+   * container scrolls on its own. Only applies to non-inline text.
+   */
+  clip?: boolean;
   collapsibleXmlTags?: boolean;
   inline?: boolean;
   maxJsonDepth?: number;
@@ -105,6 +110,7 @@ export function AIContentRenderer({
   maxJsonDepth = 2,
   autoCollapseLimit,
   collapsibleXmlTags,
+  clip = true,
 }: AIContentRendererProps) {
   const detection = useMemo(() => detectAIContentType(text), [text]);
 
@@ -141,6 +147,7 @@ export function AIContentRenderer({
       }
       return (
         <TraceDrawerComponents.MultilineText
+          clip={clip}
           renderFormatted={rawText => (
             <MarkdownWithXmlRenderer
               text={rawText}
@@ -157,7 +164,9 @@ export function AIContentRenderer({
         return <MarkedText as={TraceDrawerComponents.MarkdownContainer} text={text} />;
       }
       return (
-        <TraceDrawerComponents.MultilineText>{text}</TraceDrawerComponents.MultilineText>
+        <TraceDrawerComponents.MultilineText clip={clip}>
+          {text}
+        </TraceDrawerComponents.MultilineText>
       );
 
     case 'plain-text':
@@ -166,7 +175,9 @@ export function AIContentRenderer({
         return <Fragment>{text}</Fragment>;
       }
       return (
-        <TraceDrawerComponents.MultilineText>{text}</TraceDrawerComponents.MultilineText>
+        <TraceDrawerComponents.MultilineText clip={clip}>
+          {text}
+        </TraceDrawerComponents.MultilineText>
       );
   }
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -18,8 +18,9 @@ interface AIContentRendererProps {
   text: string;
   autoCollapseLimit?: number;
   /**
-   * Clips tall text content behind a "Show More" button. Disable when the
-   * container scrolls on its own. Only applies to non-inline text.
+   * Clips tall content behind a "Show More" button. Disable when the container
+   * scrolls on its own. Only applies to non-inline content. When unset, text
+   * defaults to clipped and JSON defaults to flowing (matching prior behavior).
    */
   clip?: boolean;
   collapsibleXmlTags?: boolean;
@@ -112,9 +113,14 @@ export function AIContentRenderer({
   maxJsonDepth = 2,
   autoCollapseLimit,
   collapsibleXmlTags,
-  clip = true,
+  clip,
 }: AIContentRendererProps) {
   const detection = useMemo(() => detectAIContentType(text), [text]);
+
+  // Preserve each branch's historical default when the caller doesn't specify:
+  // text was clipped, JSON flowed. Explicit `clip` always wins.
+  const clipText = clip ?? true;
+  const clipJson = clip ?? false;
 
   switch (detection.type) {
     case 'json':
@@ -124,7 +130,7 @@ export function AIContentRenderer({
           value={detection.parsedData}
           maxDefaultDepth={maxJsonDepth}
           autoCollapseLimit={autoCollapseLimit}
-          clip={clip}
+          clip={clipJson}
         />
       );
 
@@ -135,7 +141,7 @@ export function AIContentRenderer({
             value={detection.parsedData}
             maxDefaultDepth={maxJsonDepth}
             autoCollapseLimit={autoCollapseLimit}
-            clip={clip}
+            clip={clipJson}
           />
           <Text size="xs" variant="muted">
             {t('Truncated')}
@@ -151,7 +157,7 @@ export function AIContentRenderer({
       }
       return (
         <TraceDrawerComponents.MultilineText
-          clip={clip}
+          clip={clipText}
           renderFormatted={rawText => (
             <MarkdownWithXmlRenderer
               text={rawText}
@@ -168,7 +174,7 @@ export function AIContentRenderer({
         return <MarkedText as={TraceDrawerComponents.MarkdownContainer} text={text} />;
       }
       return (
-        <TraceDrawerComponents.MultilineText clip={clip}>
+        <TraceDrawerComponents.MultilineText clip={clipText}>
           {text}
         </TraceDrawerComponents.MultilineText>
       );
@@ -179,7 +185,7 @@ export function AIContentRenderer({
         return <Fragment>{text}</Fragment>;
       }
       return (
-        <TraceDrawerComponents.MultilineText clip={clip}>
+        <TraceDrawerComponents.MultilineText clip={clipText}>
           {text}
         </TraceDrawerComponents.MultilineText>
       );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -124,6 +124,7 @@ export function AIContentRenderer({
           value={detection.parsedData}
           maxDefaultDepth={maxJsonDepth}
           autoCollapseLimit={autoCollapseLimit}
+          clip={clip}
         />
       );
 
@@ -134,6 +135,7 @@ export function AIContentRenderer({
             value={detection.parsedData}
             maxDefaultDepth={maxJsonDepth}
             autoCollapseLimit={autoCollapseLimit}
+            clip={clip}
           />
           <Text size="xs" variant="muted">
             {t('Truncated')}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1138,40 +1138,50 @@ const CardValueText = styled('span')`
 function MultilineText({
   children,
   renderFormatted,
+  clip = true,
 }: {
   children: string;
+  /**
+   * Clips tall content behind a "Show More" button. Disable when the container
+   * scrolls on its own, so content flows instead of being clipped and hidden.
+   */
+  clip?: boolean;
   renderFormatted?: (text: string) => React.ReactNode;
 }) {
   const [showRaw, setShowRaw] = useState(false);
   const {hoverProps, isHovered} = useHover({});
   const theme = useTheme();
 
+  const content = (
+    <MultilineTextWrapper {...hoverProps}>
+      <Container position="absolute" top={theme.space.xs} right={theme.space.xs}>
+        {isHovered && (
+          <SegmentedControl
+            size="xs"
+            value={showRaw ? 'raw' : 'formatted'}
+            onChange={value => setShowRaw(value === 'raw')}
+          >
+            <SegmentedControl.Item key="formatted">{t('Pretty')}</SegmentedControl.Item>
+            <SegmentedControl.Item key="raw">{t('Raw')}</SegmentedControl.Item>
+          </SegmentedControl>
+        )}
+      </Container>
+      {showRaw
+        ? children.trim()
+        : (renderFormatted?.(children) ?? (
+            <MarkedText as={MarkdownContainer} text={children} />
+          ))}
+    </MultilineTextWrapper>
+  );
+
+  if (!clip) {
+    return content;
+  }
+
   return (
-    <Fragment>
-      <StyledClippedBox clipHeight={150} buttonProps={{variant: 'secondary', size: 'xs'}}>
-        <MultilineTextWrapper {...hoverProps}>
-          <Container position="absolute" top={theme.space.xs} right={theme.space.xs}>
-            {isHovered && (
-              <SegmentedControl
-                size="xs"
-                value={showRaw ? 'raw' : 'formatted'}
-                onChange={value => setShowRaw(value === 'raw')}
-              >
-                <SegmentedControl.Item key="formatted">
-                  {t('Pretty')}
-                </SegmentedControl.Item>
-                <SegmentedControl.Item key="raw">{t('Raw')}</SegmentedControl.Item>
-              </SegmentedControl>
-            )}
-          </Container>
-          {showRaw
-            ? children.trim()
-            : (renderFormatted?.(children) ?? (
-                <MarkedText as={MarkdownContainer} text={children} />
-              ))}
-        </MultilineTextWrapper>
-      </StyledClippedBox>
-    </Fragment>
+    <StyledClippedBox clipHeight={150} buttonProps={{variant: 'secondary', size: 'xs'}}>
+      {content}
+    </StyledClippedBox>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1262,9 +1262,15 @@ function MultilineJSON({
   value,
   maxDefaultDepth = 2,
   autoCollapseLimit,
+  clip = false,
 }: {
   value: any;
   autoCollapseLimit?: number;
+  /**
+   * Clips tall content behind a "Show More" button. Disable when the container
+   * scrolls on its own, so content flows instead of being clipped and hidden.
+   */
+  clip?: boolean;
   maxDefaultDepth?: number;
 }) {
   const [showRaw, setShowRaw] = useState(false);
@@ -1279,7 +1285,7 @@ function MultilineJSON({
     return Array.from(new Set(['$', ...childPaths]));
   }, [maxDefaultDepth, json, autoCollapseLimit]);
 
-  return (
+  const content = (
     <MultilineTextWrapperMonospace {...hoverProps}>
       {isHovered && (
         <Container
@@ -1320,6 +1326,16 @@ function MultilineJSON({
         />
       )}
     </MultilineTextWrapperMonospace>
+  );
+
+  if (!clip) {
+    return content;
+  }
+
+  return (
+    <StyledClippedBox clipHeight={150} buttonProps={{variant: 'secondary', size: 'xs'}}>
+      {content}
+    </StyledClippedBox>
   );
 }
 


### PR DESCRIPTION
Removes the "Show More" clip from the conversation span-detail card. Since the card scrolls on its own, clipping only hid a line or two while adding nested-scroll + click-to-expand friction — so Input/Output content now just flows and the card scrolls.

Implemented via an opt-out `clip` prop on the shared `MultilineText` (threaded through `AIContentRenderer`, default `true`), so the conversation view disables clipping while every other trace-drawer consumer keeps its existing 150px clip untouched.

_Note: along the way we experimented with an adaptive alternative — clipping a message only when it was tall enough to dominate the panel (threshold derived from the scroll container's height) — but it didn't buy enough to justify the added complexity, so we dropped it in favor of simply letting content flow._


TET-2619