### PR TITLE
ref(forms): Migrate sudo modal off deprecatedforms to scraps form

### DIFF
--- a/static/app/components/core/form/field/radioField.spec.tsx
+++ b/static/app/components/core/form/field/radioField.spec.tsx
@@ -122,12 +122,6 @@ describe('RadioField', () => {
     expect(screen.getByText('Urgent issues')).toBeInTheDocument();
   });
 
-  it('reserves space for field status without reflowing options', () => {
-    render(<TestForm label="Priority" />);
-
-    expect(screen.getByRole('radiogroup').lastElementChild).toBeEmptyDOMElement();
-  });
-
   it('renders as radiogroup with associated label as text', () => {
     render(<TestForm label="Priority" />);
 

--- a/static/app/components/core/form/field/radioField.spec.tsx
+++ b/static/app/components/core/form/field/radioField.spec.tsx
@@ -122,6 +122,12 @@ describe('RadioField', () => {
     expect(screen.getByText('Urgent issues')).toBeInTheDocument();
   });
 
+  it('reserves space for field status without reflowing options', () => {
+    render(<TestForm label="Priority" />);
+
+    expect(screen.getByRole('radiogroup').lastElementChild).toBeEmptyDOMElement();
+  });
+
   it('renders as radiogroup with associated label as text', () => {
     render(<TestForm label="Priority" />);
 

--- a/static/app/components/core/form/field/radioField.tsx
+++ b/static/app/components/core/form/field/radioField.tsx
@@ -68,7 +68,9 @@ function RadioGroup({children, value, onChange, disabled}: RadioGroupProps) {
         <Flex role="radiogroup" aria-labelledby={labelId} gap="sm" align="center">
           {children}
           {indicator ?? (autoSaveContext ? <Flex width="14px" flexShrink={0} /> : null)}
-          <FieldMeta.Status disabled={disabled} />
+          <Flex width="14px" flexShrink={0}>
+            <FieldMeta.Status disabled={disabled} />
+          </Flex>
         </Flex>
       </RadioContext>
     </GroupProvider>
@@ -96,9 +98,9 @@ function RadioItem({children, value, description}: RadioItemProps) {
         onChange={() => onChange(value)}
       />
       <Stack gap="xs" paddingTop="xs">
-        <Text>{children}</Text>
+        <Text bold={false}>{children}</Text>
         {description && (
-          <Text size="sm" variant="muted" id={descriptionId}>
+          <Text bold={false} size="sm" variant="muted" id={descriptionId}>
             {description}
           </Text>
         )}

--- a/static/app/components/core/form/field/radioField.tsx
+++ b/static/app/components/core/form/field/radioField.tsx
@@ -68,9 +68,7 @@ function RadioGroup({children, value, onChange, disabled}: RadioGroupProps) {
         <Flex role="radiogroup" aria-labelledby={labelId} gap="sm" align="center">
           {children}
           {indicator ?? (autoSaveContext ? <Flex width="14px" flexShrink={0} /> : null)}
-          <Flex width="14px" flexShrink={0}>
-            <FieldMeta.Status disabled={disabled} />
-          </Flex>
+          <FieldMeta.Status disabled={disabled} />
         </Flex>
       </RadioContext>
     </GroupProvider>

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -258,7 +258,6 @@ describe('Sudo Modal', () => {
       expect(
         await screen.findByText('Please add a U2F authenticator to your Sentry account')
       ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
     });
 
     it('shows an error when authentication fails', async () => {

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -248,6 +248,19 @@ describe('Sudo Modal', () => {
       });
     });
 
+    it('reports a missing authenticator instead of a silently inert submit', async () => {
+      ConfigStore.set('isSelfHosted', true);
+      MockApiClient.addMockResponse({url: '/authenticators/', body: []});
+      setHasPasswordAuth(false);
+
+      renderSuperuserModal();
+
+      expect(
+        await screen.findByText('Please add a U2F authenticator to your Sentry account')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+    });
+
     it('shows an error when authentication fails', async () => {
       ConfigStore.set('disableU2FForSUForm', true);
       MockApiClient.addMockResponse({

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -2,9 +2,47 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {makeClosableHeader, ModalBody} from '@sentry/scraps/modal';
+
+import SudoModal from 'sentry/components/modals/sudoModal';
+import {registerOverride} from 'sentry/overrideRegistry';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
+import type {SuperuserAccessCategoryProps} from 'sentry/types/overrides';
 import {App} from 'sentry/views/app';
+
+function TestAccessCategory({
+  accessCategory,
+  accessCategoryError,
+  onAccessCategoryChange,
+  onReasonChange,
+  reason,
+  reasonError,
+}: SuperuserAccessCategoryProps) {
+  return (
+    <div>
+      <label>
+        <input
+          checked={accessCategory === 'development'}
+          name="superuserAccessCategory"
+          type="radio"
+          onChange={() => onAccessCategoryChange?.('development')}
+        />
+        Development
+      </label>
+      {accessCategoryError ? <div role="alert">{accessCategoryError}</div> : null}
+      <label>
+        Reason for Access
+        <input
+          name="superuserReason"
+          value={reason ?? ''}
+          onChange={event => onReasonChange?.(event.target.value)}
+        />
+      </label>
+      {reasonError ? <div role="alert">{reasonError}</div> : null}
+    </div>
+  );
+}
 
 describe('Sudo Modal', () => {
   const setHasPasswordAuth = (hasPasswordAuth: boolean) =>
@@ -103,10 +141,7 @@ describe('Sudo Modal', () => {
     expect(sudoMock).not.toHaveBeenCalled();
 
     // "Sudo" auth
-    await userEvent.type(
-      await screen.findByRole('textbox', {name: 'Password'}),
-      'password'
-    );
+    await userEvent.type(await screen.findByLabelText('Password'), 'password');
     await userEvent.click(screen.getByRole('button', {name: 'Confirm Password'}));
 
     expect(sudoMock).toHaveBeenCalledWith(
@@ -145,5 +180,118 @@ describe('Sudo Modal', () => {
       '/auth/login/?next=http%3A%2F%2Flocalhost%2F'
     );
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+  });
+
+  describe('superuser', () => {
+    beforeEach(() => {
+      registerOverride('component:superuser-access-category', TestAccessCategory);
+      ConfigStore.set('isSelfHosted', false);
+      ConfigStore.set('validateSUForm', true);
+      ConfigStore.set('disableU2FForSUForm', false);
+      setHasPasswordAuth(true);
+    });
+
+    function renderSuperuserModal() {
+      return render(
+        <SudoModal
+          Header={makeClosableHeader(jest.fn())}
+          Body={ModalBody}
+          closeModal={jest.fn()}
+          isSuperuser
+        />
+      );
+    }
+
+    it('captures access details before starting WebAuthn', async () => {
+      MockApiClient.addMockResponse({
+        url: '/authenticators/',
+        body: [{id: 'u2f', challenge: {}}],
+      });
+      const authRequest = MockApiClient.addMockResponse({
+        url: '/auth/',
+        method: 'PUT',
+      });
+
+      renderSuperuserModal();
+
+      await userEvent.click(await screen.findByRole('radio', {name: 'Development'}));
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Reason for Access'}),
+        'Investigating an issue'
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      // Access form is replaced by the "Change reason" step; no auth call yet.
+      expect(
+        await screen.findByRole('button', {name: 'Change reason'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('textbox', {name: 'Reason for Access'})
+      ).not.toBeInTheDocument();
+      expect(authRequest).not.toHaveBeenCalled();
+    });
+
+    it('validates the access category and reason before continuing', async () => {
+      MockApiClient.addMockResponse({
+        url: '/authenticators/',
+        body: [{id: 'u2f', challenge: {}}],
+      });
+
+      renderSuperuserModal();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Continue'}));
+
+      expect(await screen.findByText('Select an access category')).toBeInTheDocument();
+      expect(
+        screen.getByText('Enter a reason of at least 4 characters')
+      ).toBeInTheDocument();
+    });
+
+    it('submits COPS/CSM access details when U2F is disabled', async () => {
+      ConfigStore.set('disableU2FForSUForm', true);
+      const authRequest = MockApiClient.addMockResponse({
+        url: '/auth/',
+        method: 'PUT',
+      });
+
+      renderSuperuserModal();
+
+      await userEvent.click(await screen.findByRole('button', {name: 'COPS/CSM'}));
+
+      await waitFor(() => {
+        expect(authRequest).toHaveBeenCalledWith(
+          '/auth/',
+          expect.objectContaining({
+            method: 'PUT',
+            data: {
+              isSuperuserModal: true,
+              superuserAccessCategory: 'cops_csm',
+              superuserReason: 'COPS and CSM use',
+            },
+          })
+        );
+      });
+    });
+
+    it('shows an error when authentication fails', async () => {
+      ConfigStore.set('disableU2FForSUForm', true);
+      MockApiClient.addMockResponse({
+        url: '/auth/',
+        method: 'PUT',
+        statusCode: 403,
+        body: {detail: {code: 'invalid_password'}},
+      });
+
+      renderSuperuserModal();
+
+      await userEvent.click(await screen.findByRole('radio', {name: 'Development'}));
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Reason for Access'}),
+        'Investigating an issue'
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      expect(await screen.findByText('Incorrect password')).toBeInTheDocument();
+    });
   });
 });

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {makeClosableHeader, ModalBody} from '@sentry/scraps/modal';
+import {makeClosableHeader, ModalBody, ModalFooter} from '@sentry/scraps/modal';
 
 import SudoModal from 'sentry/components/modals/sudoModal';
 import {registerOverride} from 'sentry/overrideRegistry';
@@ -11,37 +11,8 @@ import {OrganizationStore} from 'sentry/stores/organizationStore';
 import type {SuperuserAccessCategoryProps} from 'sentry/types/overrides';
 import {App} from 'sentry/views/app';
 
-function TestAccessCategory({
-  accessCategory,
-  accessCategoryError,
-  onAccessCategoryChange,
-  onReasonChange,
-  reason,
-  reasonError,
-}: SuperuserAccessCategoryProps) {
-  return (
-    <div>
-      <label>
-        <input
-          checked={accessCategory === 'development'}
-          name="superuserAccessCategory"
-          type="radio"
-          onChange={() => onAccessCategoryChange?.('development')}
-        />
-        Development
-      </label>
-      {accessCategoryError ? <div role="alert">{accessCategoryError}</div> : null}
-      <label>
-        Reason for Access
-        <input
-          name="superuserReason"
-          value={reason ?? ''}
-          onChange={event => onReasonChange?.(event.target.value)}
-        />
-      </label>
-      {reasonError ? <div role="alert">{reasonError}</div> : null}
-    </div>
-  );
+function TestAccessCategory({RadioItem}: SuperuserAccessCategoryProps) {
+  return <RadioItem value="development">Development</RadioItem>;
 }
 
 describe('Sudo Modal', () => {
@@ -169,7 +140,9 @@ describe('Sudo Modal', () => {
     setHasPasswordAuth(false);
 
     // Should return w/ `sudoRequired` and trigger the modal to open
-    new MockApiClient().request('/organizations/org-slug/', {method: 'DELETE'});
+    new MockApiClient().request('/organizations/org-slug/', {
+      method: 'DELETE',
+    });
 
     render(<App />);
 
@@ -196,6 +169,7 @@ describe('Sudo Modal', () => {
         <SudoModal
           Header={makeClosableHeader(jest.fn())}
           Body={ModalBody}
+          Footer={ModalFooter}
           closeModal={jest.fn()}
           isSuperuser
         />

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -260,6 +260,29 @@ describe('Sudo Modal', () => {
       ).toBeInTheDocument();
     });
 
+    it('stays on the access step when there is no authenticator', async () => {
+      MockApiClient.addMockResponse({url: '/authenticators/', body: []});
+
+      renderSuperuserModal();
+
+      await userEvent.click(await screen.findByRole('radio', {name: 'Development'}));
+      await userEvent.type(
+        screen.getByRole('textbox', {name: 'Reason for Access'}),
+        'Investigating an issue'
+      );
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      expect(
+        await screen.findByText('Please add a U2F authenticator to your Sentry account')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('textbox', {name: 'Reason for Access'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Re-authenticate'})
+      ).not.toBeInTheDocument();
+    });
+
     it('shows an error when authentication fails', async () => {
       ConfigStore.set('disableU2FForSUForm', true);
       MockApiClient.addMockResponse({

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -199,6 +199,7 @@ describe('Sudo Modal', () => {
       expect(
         await screen.findByRole('button', {name: 'Change reason'})
       ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Re-authenticate'})).toBeInTheDocument();
       expect(
         screen.queryByRole('textbox', {name: 'Reason for Access'})
       ).not.toBeInTheDocument();

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -155,11 +155,6 @@ function SudoModal({
     refetchOnWindowFocus: true,
   });
 
-  const {mutateAsync: authenticate} = useMutation({
-    mutationFn: (data: AuthPayload) =>
-      fetchMutation({method: 'PUT', url: '/auth/', data}),
-  });
-
   const handleSuccess = useCallback(() => {
     if (isSuperuser) {
       navigate(
@@ -190,6 +185,13 @@ function SudoModal({
     );
   }, []);
 
+  const {mutateAsync: authenticate} = useMutation({
+    mutationFn: (data: AuthPayload) =>
+      fetchMutation({method: 'PUT', url: '/auth/', data}),
+    onSuccess: handleSuccess,
+    onError: handleError,
+  });
+
   const passwordForm = useScrapsForm({
     ...defaultFormOptions,
     defaultValues: {password: ''},
@@ -200,10 +202,8 @@ function SudoModal({
           isSuperuserModal: isSuperuser,
           ...(user.hasPasswordAuth ? {password: value.password} : {}),
         });
-        handleSuccess();
-      } catch (err) {
+      } catch {
         passwordForm.reset();
-        handleError(err);
       }
     },
   });
@@ -231,10 +231,8 @@ function SudoModal({
 
       try {
         await authenticate({isSuperuserModal: true, ...access});
-        handleSuccess();
-      } catch (err) {
+      } catch {
         superuserForm.reset();
-        handleError(err);
       }
     },
   });
@@ -251,9 +249,8 @@ function SudoModal({
       }
       // It's ok to throw from here, u2fInterface will handle it.
       await authenticate(payload);
-      handleSuccess();
     },
-    [authenticate, handleSuccess, isSuperuser, webAuthnAccess]
+    [authenticate, isSuperuser, webAuthnAccess]
   );
 
   const getAuthLoginPath = (): string => {

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -1,11 +1,13 @@
-import {Fragment, useCallback, useState} from 'react';
-import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
+import {Fragment, useCallback, useEffect, useState} from 'react';
+import {useMutation, useQuery} from '@tanstack/react-query';
 import trimEnd from 'lodash/trimEnd';
+import {z} from 'zod';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {logout} from 'sentry/actionCreators/account';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -14,8 +16,6 @@ import {
   getBootstrapOrganizationQueryOptions,
   getBootstrapProjectsQueryOptions,
 } from 'sentry/bootstrap/bootstrapRequests';
-import {SecretField} from 'sentry/components/forms/fields/secretField';
-import {Form} from 'sentry/components/forms/form';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Override} from 'sentry/components/override';
 import {WebAuthn} from 'sentry/components/webAuthn';
@@ -23,33 +23,34 @@ import {ErrorCodes} from 'sentry/constants/superuserAccessErrors';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Authenticator} from 'sentry/types/auth';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
-interface WebAuthnParams {
-  challenge: string;
-  response: string;
+type AuthPayload = {
+  challenge?: string;
   isSuperuserModal?: boolean;
+  password?: string;
+  response?: string;
   superuserAccessCategory?: string;
   superuserReason?: string;
-}
+};
+
+type AccessDetails = {
+  superuserAccessCategory: string;
+  superuserReason: string;
+};
+
+type SuperuserStep = {step: 'access'} | {access: AccessDetails; step: 'webauthn'};
 
 type DefaultProps = {
   closeButton?: boolean;
-};
-
-type State = {
-  error: boolean;
-  errorType: string;
-  showAccessForms: boolean;
-  superuserAccessCategory: string;
-  superuserReason: string;
 };
 
 type Props = DefaultProps &
@@ -66,6 +67,37 @@ type Props = DefaultProps &
     retryRequest?: () => Promise<any>;
   };
 
+const passwordSchema = z.object({
+  password: z.string(),
+});
+
+const accessSchema = z.object({
+  superuserAccessCategory: z.string().min(1, t('Select an access category')),
+  superuserReason: z
+    .string()
+    .trim()
+    .min(4, t('Enter a reason of at least 4 characters'))
+    .max(128, t('Reason must be 128 characters or fewer')),
+});
+
+function getErrorType(err: RequestError): ErrorCodes {
+  const detail = err.responseJSON?.detail;
+  const code = detail !== null && typeof detail === 'object' ? detail.code : undefined;
+
+  switch (err.status) {
+    case 403:
+      return code === 'no_u2f'
+        ? ErrorCodes.NO_AUTHENTICATOR
+        : ErrorCodes.INVALID_PASSWORD;
+    case 401:
+      return ErrorCodes.INVALID_SSO_SESSION;
+    case 400:
+      return ErrorCodes.INVALID_ACCESS_CATEGORY;
+    default:
+      return ErrorCodes.UNKNOWN_ERROR;
+  }
+}
+
 function SudoModal({
   closeModal,
   isSuperuser,
@@ -80,16 +112,11 @@ function SudoModal({
   const params = useParams<{orgId?: string}>();
   const location = useLocation();
   const api = useApi();
-  const [state, setState] = useState<State>({
-    error: false,
-    errorType: '',
-    showAccessForms: true,
-    superuserAccessCategory: '',
-    superuserReason: '',
-  });
 
-  const {error, errorType, showAccessForms, superuserAccessCategory, superuserReason} =
-    state;
+  const [errorType, setErrorType] = useState<ErrorCodes | undefined>(undefined);
+  const [superuserStep, setSuperuserStep] = useState<SuperuserStep>({step: 'access'});
+
+  const disableU2FForSUForm = ConfigStore.get('disableU2FForSUForm');
 
   const orgSlug = params.orgId ?? null;
   // We have to wait for these requests to finish before we can sudo, otherwise
@@ -113,10 +140,10 @@ function SudoModal({
     data: authenticators = [],
     isFetching: authenticatorsFetching,
     isFetchedAfterMount: authenticatorsLoaded,
-  } = useApiQuery<Authenticator[]>([getApiUrl('/authenticators/')], {
+  } = useQuery({
+    ...apiOptions.as<Authenticator[]>()('/authenticators/', {staleTime: 0}),
     // Fetch authenticators after preload requests to avoid overwriting session cookie
     enabled: !bootstrapIsPending,
-    staleTime: 0,
     retry: false,
     // Immeditealy refetch authenticators on window / tab focus. If a user had
     // multiple tabs open and required authentication in any other tabs we may
@@ -125,61 +152,10 @@ function SudoModal({
     refetchOnWindowFocus: true,
   });
 
-  const handleSubmitCOPS = () => {
-    setState(prevState => ({
-      ...prevState,
-      superuserAccessCategory: 'cops_csm',
-      superuserReason: 'COPS and CSM use',
-    }));
-  };
-
-  const handleChangeReason = (e: React.MouseEvent) => {
-    // XXX(epurkhiser): We have to prevent default here to avoid react from
-    // propagating this event up to the form and causing the form to be
-    // submitted. This is happening because when the form is rendered the same
-    // button is replaced with a button that has type="submit", this happens
-    // before the event is propegated to the form, and by the time that handler
-    // is run react thinks the button is type submit and will submit the form.
-    //
-    // See https://github.com/facebook/react/issues/8554#issuecomment-278580583
-    e.preventDefault();
-
-    setState(prevState => ({
-      ...prevState,
-      showAccessForms: true,
-      superuserAccessCategory: '',
-      superuserReason: '',
-    }));
-  };
-
-  const handleSubmit = async (data: any) => {
-    const disableU2FForSUForm = ConfigStore.get('disableU2FForSUForm');
-
-    const suAccessCategory = superuserAccessCategory || data.superuserAccessCategory;
-
-    const suReason = superuserReason || data.superuserReason;
-
-    if (!authenticators.length && !disableU2FForSUForm) {
-      handleError(ErrorCodes.NO_AUTHENTICATOR);
-      return;
-    }
-
-    if (showAccessForms && isSuperuser && !disableU2FForSUForm) {
-      setState(prevState => ({
-        ...prevState,
-        showAccessForms: false,
-        superuserAccessCategory: suAccessCategory,
-        superuserReason: suReason,
-      }));
-    } else {
-      try {
-        await api.requestPromise('/auth/', {method: 'PUT', data});
-        handleSuccess();
-      } catch (err) {
-        handleError(err);
-      }
-    }
-  };
+  const {mutateAsync: authenticate} = useMutation({
+    mutationFn: (data: AuthPayload) =>
+      fetchMutation({method: 'PUT', url: '/auth/', data}),
+  });
 
   const handleSuccess = useCallback(() => {
     if (isSuperuser) {
@@ -188,7 +164,7 @@ function SudoModal({
         {replace: true}
       );
       if (needsReload) {
-        window.location.reload();
+        testableWindowLocation.reload();
       }
       return;
     }
@@ -198,55 +174,78 @@ function SudoModal({
       return;
     }
 
-    retryRequest().then(() => {
-      setState(prevState => ({...prevState, showAccessForms: true}));
-      closeModal();
-    });
+    retryRequest().then(closeModal);
   }, [closeModal, isSuperuser, location.pathname, navigate, needsReload, retryRequest]);
 
-  const handleError = useCallback((err: any) => {
-    let newErrorType = ''; // Create a new variable to store the error type
-
-    if (err.status === 403) {
-      if (err.responseJSON.detail.code === 'no_u2f') {
-        newErrorType = ErrorCodes.NO_AUTHENTICATOR;
-      } else {
-        newErrorType = ErrorCodes.INVALID_PASSWORD;
-      }
-    } else if (err.status === 401) {
-      newErrorType = ErrorCodes.INVALID_SSO_SESSION;
-    } else if (err.status === 400) {
-      newErrorType = ErrorCodes.INVALID_ACCESS_CATEGORY;
-    } else if (err === ErrorCodes.NO_AUTHENTICATOR) {
-      newErrorType = ErrorCodes.NO_AUTHENTICATOR;
-    } else {
-      newErrorType = ErrorCodes.UNKNOWN_ERROR;
-    }
-
-    setState(prevState => ({
-      ...prevState,
-      error: true,
-      errorType: newErrorType,
-      showAccessForms: true,
-    }));
+  const handleError = useCallback((err: unknown) => {
+    setErrorType(
+      err instanceof RequestError ? getErrorType(err) : ErrorCodes.UNKNOWN_ERROR
+    );
+    // Return a superuser flow to the access step so the error is visible.
+    setSuperuserStep({step: 'access'});
   }, []);
 
+  const passwordForm = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {password: ''},
+    validators: {onDynamic: passwordSchema},
+    onSubmit: async ({value}) => {
+      try {
+        await authenticate({
+          isSuperuserModal: isSuperuser,
+          ...(user.hasPasswordAuth ? {password: value.password} : {}),
+        });
+        handleSuccess();
+      } catch (err) {
+        passwordForm.reset();
+        handleError(err);
+      }
+    },
+  });
+
+  const superuserForm = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      superuserAccessCategory: '',
+      superuserReason: '',
+    },
+    validators: {onDynamic: accessSchema},
+    onSubmit: async ({value}) => {
+      const access = accessSchema.parse(value);
+
+      if (!disableU2FForSUForm) {
+        if (!authenticators.length) {
+          setErrorType(ErrorCodes.NO_AUTHENTICATOR);
+          return;
+        }
+
+        setErrorType(undefined);
+        setSuperuserStep({step: 'webauthn', access});
+        return;
+      }
+
+      try {
+        await authenticate({isSuperuserModal: true, ...access});
+        handleSuccess();
+      } catch (err) {
+        superuserForm.reset();
+        handleError(err);
+      }
+    },
+  });
+
   const handleWebAuthn = useCallback(
-    async (data: WebAuthnParams) => {
-      data.isSuperuserModal = isSuperuser;
-      data.superuserAccessCategory = state.superuserAccessCategory;
-      data.superuserReason = state.superuserReason;
+    async (data: {challenge: string; response: string}) => {
+      const payload: AuthPayload = {...data, isSuperuserModal: isSuperuser};
+      if (superuserStep.step === 'webauthn') {
+        payload.superuserAccessCategory = superuserStep.access.superuserAccessCategory;
+        payload.superuserReason = superuserStep.access.superuserReason;
+      }
       // It's ok to throw from here, u2fInterface will handle it.
-      await api.requestPromise('/auth/', {method: 'PUT', data});
+      await authenticate(payload);
       handleSuccess();
     },
-    [
-      api,
-      handleSuccess,
-      isSuperuser,
-      state.superuserAccessCategory,
-      state.superuserReason,
-    ]
+    [authenticate, handleSuccess, isSuperuser, superuserStep]
   );
 
   const getAuthLoginPath = (): string => {
@@ -258,12 +257,19 @@ function SudoModal({
     return authLoginPath;
   };
 
+  // An expired SSO session is terminal: redirect to re-auth.
+  const ssoExpired = errorType === ErrorCodes.INVALID_SSO_SESSION;
+  useEffect(() => {
+    if (ssoExpired) {
+      logout(api, getAuthLoginPath());
+    }
+  }, [api, ssoExpired]);
+
   const renderBodyContent = () => {
     const isSelfHosted = ConfigStore.get('isSelfHosted');
     const validateSUForm = ConfigStore.get('validateSUForm');
 
-    if (errorType === ErrorCodes.INVALID_SSO_SESSION) {
-      logout(api, getAuthLoginPath());
+    if (ssoExpired) {
       return null;
     }
 
@@ -271,111 +277,138 @@ function SudoModal({
       return <LoadingIndicator />;
     }
 
+    const errorAlert = errorType ? <Alert variant="danger">{errorType}</Alert> : null;
+
     if (
       (!user.hasPasswordAuth && authenticators.length === 0) ||
       (isSuperuser && !isSelfHosted && validateSUForm)
     ) {
-      return (
-        <Fragment>
-          <StyledTextBlock>
-            {isSuperuser
-              ? t(
-                  'You are attempting to access a resource that requires superuser access, please re-authenticate as a superuser.'
-                )
-              : t('You will need to reauthenticate to continue')}
-          </StyledTextBlock>
-          {error && <Alert variant="danger">{errorType}</Alert>}
-          {isSuperuser ? (
-            <Form
-              apiMethod="PUT"
-              apiEndpoint="/auth/"
-              submitLabel={showAccessForms ? t('Continue') : t('Re-authenticate')}
-              onSubmit={handleSubmit}
-              onSubmitSuccess={handleSuccess}
-              onSubmitError={handleError}
-              initialData={{isSuperuserModal: isSuperuser}}
-              extraButton={
-                <Flex align="center" margin="0 3xl">
-                  {showAccessForms ? (
-                    <Button type="submit" onClick={handleSubmitCOPS}>
-                      {t('COPS/CSM')}
-                    </Button>
-                  ) : (
-                    <Button variant="transparent" size="sm" onClick={handleChangeReason}>
-                      {t('Change reason')}
-                    </Button>
-                  )}
-                </Flex>
-              }
-              resetOnError
-            >
-              {!isSelfHosted && showAccessForms && (
-                <Override name="component:superuser-access-category" />
-              )}
-              {!isSelfHosted && !showAccessForms && (
-                <WebAuthn
-                  mode="sudo"
-                  authenticators={authenticators}
-                  onWebAuthn={handleWebAuthn}
-                />
-              )}
-            </Form>
-          ) : (
+      const introText = isSuperuser
+        ? t(
+            'You are attempting to access a resource that requires superuser access, please re-authenticate as a superuser.'
+          )
+        : t('You will need to reauthenticate to continue');
+
+      if (!isSuperuser) {
+        return (
+          <Stack gap="xl">
+            <Text as="p">{introText}</Text>
+            {errorAlert}
             <LinkButton variant="primary" href={getAuthLoginPath()}>
               {t('Continue')}
             </LinkButton>
-          )}
-        </Fragment>
+          </Stack>
+        );
+      }
+
+      const isAccessStep = superuserStep.step === 'access';
+
+      return (
+        <superuserForm.AppForm form={superuserForm}>
+          <Stack gap="xl">
+            <Text as="p">{introText}</Text>
+            {errorAlert}
+            {!isSelfHosted && isAccessStep && (
+              <superuserForm.AppField name="superuserAccessCategory">
+                {accessCategoryField => (
+                  <superuserForm.AppField name="superuserReason">
+                    {reasonField => (
+                      <Override
+                        name="component:superuser-access-category"
+                        accessCategory={accessCategoryField.state.value}
+                        accessCategoryError={
+                          accessCategoryField.state.meta.errors[0]?.message
+                        }
+                        reason={reasonField.state.value}
+                        reasonError={reasonField.state.meta.errors[0]?.message}
+                        onAccessCategoryChange={accessCategoryField.handleChange}
+                        onReasonChange={reasonField.handleChange}
+                      />
+                    )}
+                  </superuserForm.AppField>
+                )}
+              </superuserForm.AppField>
+            )}
+            {!isSelfHosted && !isAccessStep && (
+              <WebAuthn
+                mode="sudo"
+                authenticators={authenticators}
+                onWebAuthn={handleWebAuthn}
+              />
+            )}
+          </Stack>
+          <Flex justify="between" align="center" gap="md" margin="xl 0 0">
+            {isAccessStep ? (
+              <Fragment>
+                <Button
+                  onClick={() => {
+                    superuserForm.setFieldValue('superuserAccessCategory', 'cops_csm');
+                    superuserForm.setFieldValue('superuserReason', 'COPS and CSM use');
+                    superuserForm.handleSubmit();
+                  }}
+                >
+                  {t('COPS/CSM')}
+                </Button>
+                <superuserForm.SubmitButton>{t('Continue')}</superuserForm.SubmitButton>
+              </Fragment>
+            ) : (
+              <Button
+                variant="transparent"
+                onClick={() => {
+                  superuserForm.reset();
+                  setErrorType(undefined);
+                  setSuperuserStep({step: 'access'});
+                }}
+              >
+                {t('Change reason')}
+              </Button>
+            )}
+          </Flex>
+        </superuserForm.AppForm>
       );
     }
 
     return (
-      <Fragment>
-        <StyledTextBlock>
-          {isSuperuser
-            ? t(
-                'You are attempting to access a resource that requires superuser access, please re-authenticate as a superuser.'
-              )
-            : t('Help us keep your account safe by confirming your identity.')}
-        </StyledTextBlock>
-
-        {error && <Alert variant="danger">{errorType}</Alert>}
-
-        <Form
-          apiMethod="PUT"
-          apiEndpoint="/auth/"
-          submitLabel={t('Confirm Password')}
-          onSubmitSuccess={handleSuccess}
-          onSubmitError={handleError}
-          hideFooter={!user.hasPasswordAuth && authenticators.length === 0}
-          initialData={{isSuperuserModal: isSuperuser}}
-          resetOnError
-        >
+      <passwordForm.AppForm form={passwordForm}>
+        <Stack gap="xl">
+          <Text as="p">
+            {isSuperuser
+              ? t(
+                  'You are attempting to access a resource that requires superuser access, please re-authenticate as a superuser.'
+                )
+              : t('Help us keep your account safe by confirming your identity.')}
+          </Text>
+          {errorAlert}
           {user.hasPasswordAuth && (
-            <SecretField
-              inline={false}
-              stacked
-              label={t('Password')}
-              name="password"
-              autoFocus
-              flexibleControlStateSize
-            />
+            <passwordForm.AppField name="password">
+              {field => (
+                <field.Layout.Stack label={t('Password')}>
+                  <field.Password
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    autoFocus
+                  />
+                </field.Layout.Stack>
+              )}
+            </passwordForm.AppField>
           )}
-
           <WebAuthn
             mode="sudo"
             authenticators={authenticators}
             onWebAuthn={handleWebAuthn}
           />
-        </Form>
-      </Fragment>
+        </Stack>
+        <Flex justify="end" margin="xl 0 0">
+          <passwordForm.SubmitButton>{t('Confirm Password')}</passwordForm.SubmitButton>
+        </Flex>
+      </passwordForm.AppForm>
     );
   };
 
   return (
     <Fragment>
       <Header closeButton={closeButton}>
-        <h4>{t('Confirm Password to Continue')}</h4>
+        <Heading as="h4">{t('Confirm Password to Continue')}</Heading>
       </Header>
       <Body>{renderBodyContent()}</Body>
     </Fragment>
@@ -383,7 +416,3 @@ function SudoModal({
 }
 
 export default SudoModal;
-
-const StyledTextBlock = styled(TextBlock)`
-  margin-bottom: ${p => p.theme.space.md};
-`;

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -401,16 +401,21 @@ function SudoModal({
                 <superuserForm.SubmitButton>{t('Continue')}</superuserForm.SubmitButton>
               </Flex>
             ) : (
-              <Button
-                variant="transparent"
-                onClick={() => {
-                  superuserForm.reset();
-                  setErrorType(undefined);
-                  setSuperuserStep({step: 'access'});
-                }}
-              >
-                {t('Change reason')}
-              </Button>
+              <Flex width="100%" justify="between" align="center" gap="md">
+                <Button
+                  variant="transparent"
+                  onClick={() => {
+                    superuserForm.reset();
+                    setErrorType(undefined);
+                    setSuperuserStep({step: 'access'});
+                  }}
+                >
+                  {t('Change reason')}
+                </Button>
+                <superuserForm.SubmitButton>
+                  {t('Re-authenticate')}
+                </superuserForm.SubmitButton>
+              </Flex>
             )}
           </Footer>
         </superuserForm.AppForm>

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -54,7 +54,7 @@ type DefaultProps = {
 };
 
 type Props = DefaultProps &
-  Pick<ModalRenderProps, 'Body' | 'Header'> & {
+  Pick<ModalRenderProps, 'Body' | 'Footer' | 'Header'> & {
     closeModal: () => void;
     /**
      * User is a superuser without an active su session
@@ -105,6 +105,7 @@ function SudoModal({
   retryRequest,
   Header,
   Body,
+  Footer,
   closeButton,
 }: Props) {
   const user = useUser();
@@ -114,7 +115,9 @@ function SudoModal({
   const api = useApi();
 
   const [errorType, setErrorType] = useState<ErrorCodes | undefined>(undefined);
-  const [superuserStep, setSuperuserStep] = useState<SuperuserStep>({step: 'access'});
+  const [superuserStep, setSuperuserStep] = useState<SuperuserStep>({
+    step: 'access',
+  });
 
   const disableU2FForSUForm = ConfigStore.get('disableU2FForSUForm');
 
@@ -182,7 +185,9 @@ function SudoModal({
       err instanceof RequestError ? getErrorType(err) : ErrorCodes.UNKNOWN_ERROR
     );
     // Return a superuser flow to the access step so the error is visible.
-    setSuperuserStep({step: 'access'});
+    setSuperuserStep(currentStep =>
+      currentStep.step === 'access' ? currentStep : {step: 'access'}
+    );
   }, []);
 
   const passwordForm = useScrapsForm({
@@ -234,18 +239,21 @@ function SudoModal({
     },
   });
 
+  const webAuthnAccess =
+    superuserStep.step === 'webauthn' ? superuserStep.access : undefined;
+
   const handleWebAuthn = useCallback(
     async (data: {challenge: string; response: string}) => {
       const payload: AuthPayload = {...data, isSuperuserModal: isSuperuser};
-      if (superuserStep.step === 'webauthn') {
-        payload.superuserAccessCategory = superuserStep.access.superuserAccessCategory;
-        payload.superuserReason = superuserStep.access.superuserReason;
+      if (webAuthnAccess) {
+        payload.superuserAccessCategory = webAuthnAccess.superuserAccessCategory;
+        payload.superuserReason = webAuthnAccess.superuserReason;
       }
       // It's ok to throw from here, u2fInterface will handle it.
       await authenticate(payload);
       handleSuccess();
     },
-    [authenticate, handleSuccess, isSuperuser, superuserStep]
+    [authenticate, handleSuccess, isSuperuser, webAuthnAccess]
   );
 
   const getAuthLoginPath = (): string => {
@@ -265,16 +273,33 @@ function SudoModal({
     }
   }, [api, ssoExpired]);
 
-  const renderBodyContent = () => {
+  const renderModalContent = () => {
     const isSelfHosted = ConfigStore.get('isSelfHosted');
     const validateSUForm = ConfigStore.get('validateSUForm');
+    const header = (
+      <Header closeButton={closeButton}>
+        <Heading as="h4">{t('Confirm Password to Continue')}</Heading>
+      </Header>
+    );
 
     if (ssoExpired) {
-      return null;
+      return (
+        <Fragment>
+          {header}
+          <Body />
+        </Fragment>
+      );
     }
 
     if (authenticatorsFetching || !authenticatorsLoaded || bootstrapIsPending) {
-      return <LoadingIndicator />;
+      return (
+        <Fragment>
+          {header}
+          <Body>
+            <LoadingIndicator />
+          </Body>
+        </Fragment>
+      );
     }
 
     const errorAlert = errorType ? <Alert variant="danger">{errorType}</Alert> : null;
@@ -291,13 +316,20 @@ function SudoModal({
 
       if (!isSuperuser) {
         return (
-          <Stack gap="xl">
-            <Text as="p">{introText}</Text>
-            {errorAlert}
-            <LinkButton variant="primary" href={getAuthLoginPath()}>
-              {t('Continue')}
-            </LinkButton>
-          </Stack>
+          <Fragment>
+            {header}
+            <Body>
+              <Stack gap="xl">
+                <Text as="p">{introText}</Text>
+                {errorAlert}
+              </Stack>
+            </Body>
+            <Footer>
+              <LinkButton variant="primary" href={getAuthLoginPath()}>
+                {t('Continue')}
+              </LinkButton>
+            </Footer>
+          </Fragment>
         );
       }
 
@@ -305,52 +337,69 @@ function SudoModal({
 
       return (
         <superuserForm.AppForm form={superuserForm}>
-          <Stack gap="xl">
-            <Text as="p">{introText}</Text>
-            {errorAlert}
-            {!isSelfHosted && isAccessStep && (
-              <superuserForm.AppField name="superuserAccessCategory">
-                {accessCategoryField => (
-                  <superuserForm.AppField name="superuserReason">
-                    {reasonField => (
-                      <Override
-                        name="component:superuser-access-category"
-                        accessCategory={accessCategoryField.state.value}
-                        accessCategoryError={
-                          accessCategoryField.state.meta.errors[0]?.message
-                        }
-                        reason={reasonField.state.value}
-                        reasonError={reasonField.state.meta.errors[0]?.message}
-                        onAccessCategoryChange={accessCategoryField.handleChange}
-                        onReasonChange={reasonField.handleChange}
-                      />
+          {header}
+          <Body>
+            <Stack gap="xl">
+              <Text as="p">{introText}</Text>
+              {errorAlert}
+              {!isSelfHosted && isAccessStep && (
+                <Fragment>
+                  <superuserForm.AppField name="superuserAccessCategory">
+                    {field => (
+                      <field.Radio.Group
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      >
+                        <field.Layout.Stack
+                          label={t('Categories of Superuser Access')}
+                          required
+                        >
+                          <Override
+                            name="component:superuser-access-category"
+                            RadioItem={field.Radio.Item}
+                          />
+                        </field.Layout.Stack>
+                      </field.Radio.Group>
                     )}
                   </superuserForm.AppField>
-                )}
-              </superuserForm.AppField>
-            )}
-            {!isSelfHosted && !isAccessStep && (
-              <WebAuthn
-                mode="sudo"
-                authenticators={authenticators}
-                onWebAuthn={handleWebAuthn}
-              />
-            )}
-          </Stack>
-          <Flex justify="between" align="center" gap="md" margin="xl 0 0">
+                  <superuserForm.AppField name="superuserReason">
+                    {field => (
+                      <field.Layout.Stack label={t('Reason for Access')} required>
+                        <field.Input
+                          maxLength={128}
+                          minLength={4}
+                          placeholder={t('e.g. disabling SSO enforcement')}
+                          value={field.state.value}
+                          onChange={field.handleChange}
+                        />
+                      </field.Layout.Stack>
+                    )}
+                  </superuserForm.AppField>
+                </Fragment>
+              )}
+              {!isSelfHosted && !isAccessStep && (
+                <WebAuthn
+                  mode="sudo"
+                  authenticators={authenticators}
+                  onWebAuthn={handleWebAuthn}
+                />
+              )}
+            </Stack>
+          </Body>
+          <Footer>
             {isAccessStep ? (
-              <Fragment>
-                <Button
+              <Flex width="100%" justify="between" align="center" gap="md">
+                <superuserForm.SubmitButton
+                  variant="secondary"
                   onClick={() => {
                     superuserForm.setFieldValue('superuserAccessCategory', 'cops_csm');
                     superuserForm.setFieldValue('superuserReason', 'COPS and CSM use');
-                    superuserForm.handleSubmit();
                   }}
                 >
                   {t('COPS/CSM')}
-                </Button>
+                </superuserForm.SubmitButton>
                 <superuserForm.SubmitButton>{t('Continue')}</superuserForm.SubmitButton>
-              </Fragment>
+              </Flex>
             ) : (
               <Button
                 variant="transparent"
@@ -363,56 +412,52 @@ function SudoModal({
                 {t('Change reason')}
               </Button>
             )}
-          </Flex>
+          </Footer>
         </superuserForm.AppForm>
       );
     }
 
     return (
       <passwordForm.AppForm form={passwordForm}>
-        <Stack gap="xl">
-          <Text as="p">
-            {isSuperuser
-              ? t(
-                  'You are attempting to access a resource that requires superuser access, please re-authenticate as a superuser.'
-                )
-              : t('Help us keep your account safe by confirming your identity.')}
-          </Text>
-          {errorAlert}
-          {user.hasPasswordAuth && (
-            <passwordForm.AppField name="password">
-              {field => (
-                <field.Layout.Stack label={t('Password')}>
-                  <field.Password
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                    autoFocus
-                  />
-                </field.Layout.Stack>
-              )}
-            </passwordForm.AppField>
-          )}
-          <WebAuthn
-            mode="sudo"
-            authenticators={authenticators}
-            onWebAuthn={handleWebAuthn}
-          />
-        </Stack>
-        <Flex justify="end" margin="xl 0 0">
+        {header}
+        <Body>
+          <Stack gap="xl">
+            <Text as="p">
+              {isSuperuser
+                ? t(
+                    'You are attempting to access a resource that requires superuser access, please re-authenticate as a superuser.'
+                  )
+                : t('Help us keep your account safe by confirming your identity.')}
+            </Text>
+            {errorAlert}
+            {user.hasPasswordAuth && (
+              <passwordForm.AppField name="password">
+                {field => (
+                  <field.Layout.Stack label={t('Password')}>
+                    <field.Password
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      autoFocus
+                    />
+                  </field.Layout.Stack>
+                )}
+              </passwordForm.AppField>
+            )}
+            <WebAuthn
+              mode="sudo"
+              authenticators={authenticators}
+              onWebAuthn={handleWebAuthn}
+            />
+          </Stack>
+        </Body>
+        <Footer>
           <passwordForm.SubmitButton>{t('Confirm Password')}</passwordForm.SubmitButton>
-        </Flex>
+        </Footer>
       </passwordForm.AppForm>
     );
   };
 
-  return (
-    <Fragment>
-      <Header closeButton={closeButton}>
-        <Heading as="h4">{t('Confirm Password to Continue')}</Heading>
-      </Header>
-      <Body>{renderBodyContent()}</Body>
-    </Fragment>
-  );
+  return renderModalContent();
 }
 
 export default SudoModal;

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -219,6 +219,12 @@ function SudoModal({
       const access = accessSchema.parse(value);
 
       if (!disableU2FForSUForm) {
+        // Without an authenticator the webauthn step has nothing to render.
+        if (!authenticators.length) {
+          setErrorType(ErrorCodes.NO_AUTHENTICATOR);
+          return;
+        }
+
         setErrorType(undefined);
         setSuperuserStep({step: 'webauthn', access});
         return;

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -114,7 +114,7 @@ function SudoModal({
   const location = useLocation();
   const api = useApi();
 
-  const [errorType, setErrorType] = useState<ErrorCodes | undefined>(undefined);
+  const [errorType, setErrorType] = useState<ErrorCodes>();
   const [superuserStep, setSuperuserStep] = useState<SuperuserStep>({
     step: 'access',
   });

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -257,8 +257,7 @@ function SudoModal({
     return authLoginPath;
   };
 
-  // A superuser flow needs an authenticator unless U2F is disabled. Surfaced at
-  // render time so it reports even when validation blocks submission.
+  // Resolved at render time so it reports even when validation blocks submission.
   const noAuthenticator =
     isSuperuser && !disableU2FForSUForm && authenticatorsLoaded && !authenticators.length;
   const resolvedErrorType =
@@ -392,7 +391,6 @@ function SudoModal({
               <Flex width="100%" justify="between" align="center" gap="md">
                 <superuserForm.SubmitButton
                   variant="secondary"
-                  disabled={noAuthenticator}
                   onClick={() => {
                     superuserForm.setFieldValue('superuserAccessCategory', 'cops_csm');
                     superuserForm.setFieldValue('superuserReason', 'COPS and CSM use');
@@ -400,9 +398,7 @@ function SudoModal({
                 >
                   {t('COPS/CSM')}
                 </superuserForm.SubmitButton>
-                <superuserForm.SubmitButton disabled={noAuthenticator}>
-                  {t('Continue')}
-                </superuserForm.SubmitButton>
+                <superuserForm.SubmitButton>{t('Continue')}</superuserForm.SubmitButton>
               </Flex>
             ) : (
               <Flex width="100%" justify="between" align="center" gap="md">

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -219,11 +219,6 @@ function SudoModal({
       const access = accessSchema.parse(value);
 
       if (!disableU2FForSUForm) {
-        if (!authenticators.length) {
-          setErrorType(ErrorCodes.NO_AUTHENTICATOR);
-          return;
-        }
-
         setErrorType(undefined);
         setSuperuserStep({step: 'webauthn', access});
         return;
@@ -262,8 +257,15 @@ function SudoModal({
     return authLoginPath;
   };
 
+  // A superuser flow needs an authenticator unless U2F is disabled. Surfaced at
+  // render time so it reports even when validation blocks submission.
+  const noAuthenticator =
+    isSuperuser && !disableU2FForSUForm && authenticatorsLoaded && !authenticators.length;
+  const resolvedErrorType =
+    errorType ?? (noAuthenticator ? ErrorCodes.NO_AUTHENTICATOR : undefined);
+
   // An expired SSO session is terminal: redirect to re-auth.
-  const ssoExpired = errorType === ErrorCodes.INVALID_SSO_SESSION;
+  const ssoExpired = resolvedErrorType === ErrorCodes.INVALID_SSO_SESSION;
   useEffect(() => {
     if (ssoExpired) {
       logout(api, getAuthLoginPath());
@@ -299,7 +301,9 @@ function SudoModal({
       );
     }
 
-    const errorAlert = errorType ? <Alert variant="danger">{errorType}</Alert> : null;
+    const errorAlert = resolvedErrorType ? (
+      <Alert variant="danger">{resolvedErrorType}</Alert>
+    ) : null;
 
     if (
       (!user.hasPasswordAuth && authenticators.length === 0) ||
@@ -388,6 +392,7 @@ function SudoModal({
               <Flex width="100%" justify="between" align="center" gap="md">
                 <superuserForm.SubmitButton
                   variant="secondary"
+                  disabled={noAuthenticator}
                   onClick={() => {
                     superuserForm.setFieldValue('superuserAccessCategory', 'cops_csm');
                     superuserForm.setFieldValue('superuserReason', 'COPS and CSM use');
@@ -395,7 +400,9 @@ function SudoModal({
                 >
                   {t('COPS/CSM')}
                 </superuserForm.SubmitButton>
-                <superuserForm.SubmitButton>{t('Continue')}</superuserForm.SubmitButton>
+                <superuserForm.SubmitButton disabled={noAuthenticator}>
+                  {t('Continue')}
+                </superuserForm.SubmitButton>
               </Flex>
             ) : (
               <Flex width="100%" justify="between" align="center" gap="md">

--- a/static/app/components/superuserStaffAccessForm.spec.tsx
+++ b/static/app/components/superuserStaffAccessForm.spec.tsx
@@ -6,37 +6,8 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import type {SuperuserAccessCategoryProps} from 'sentry/types/overrides';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
-function TestAccessCategory({
-  accessCategory,
-  accessCategoryError,
-  onAccessCategoryChange,
-  onReasonChange,
-  reason,
-  reasonError,
-}: SuperuserAccessCategoryProps) {
-  return (
-    <div>
-      <label>
-        <input
-          checked={accessCategory === 'development'}
-          name="superuserAccessCategory"
-          type="radio"
-          onChange={() => onAccessCategoryChange?.('development')}
-        />
-        Development
-      </label>
-      {accessCategoryError ? <div role="alert">{accessCategoryError}</div> : null}
-      <label>
-        Reason for Access
-        <input
-          name="superuserReason"
-          value={reason ?? ''}
-          onChange={event => onReasonChange?.(event.target.value)}
-        />
-      </label>
-      {reasonError ? <div role="alert">{reasonError}</div> : null}
-    </div>
-  );
+function TestAccessCategory({RadioItem}: SuperuserAccessCategoryProps) {
+  return <RadioItem value="development">Development</RadioItem>;
 }
 
 function addAuthenticatorResponse(body: unknown[] = [{id: 'u2f', challenge: {}}]) {

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import {useMutation, useQuery} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -231,28 +231,39 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
       <Stack gap="xl">
         {errorAlert}
         {state.step === 'access' ? (
-          <form.AppField name="superuserAccessCategory">
-            {accessCategoryField => (
-              <form.AppField name="superuserReason">
-                {reasonField => (
-                  // TODO(scraps-forms): This override is shared with sudoModal, which
-                  // still uses the legacy FormModel. Keep Scraps as the source of truth
-                  // and bridge values and errors until both consumers migrate together.
-                  <Override
-                    name="component:superuser-access-category"
-                    accessCategory={accessCategoryField.state.value}
-                    accessCategoryError={
-                      accessCategoryField.state.meta.errors[0]?.message
-                    }
-                    reason={reasonField.state.value}
-                    reasonError={reasonField.state.meta.errors[0]?.message}
-                    onAccessCategoryChange={accessCategoryField.handleChange}
-                    onReasonChange={reasonField.handleChange}
+          <Fragment>
+            <form.AppField name="superuserAccessCategory">
+              {field => (
+                <field.Radio.Group
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                >
+                  <field.Layout.Stack
+                    label={t('Categories of Superuser Access')}
+                    required
+                  >
+                    <Override
+                      name="component:superuser-access-category"
+                      RadioItem={field.Radio.Item}
+                    />
+                  </field.Layout.Stack>
+                </field.Radio.Group>
+              )}
+            </form.AppField>
+            <form.AppField name="superuserReason">
+              {field => (
+                <field.Layout.Stack label={t('Reason for Access')} required>
+                  <field.Input
+                    maxLength={128}
+                    minLength={4}
+                    placeholder={t('e.g. disabling SSO enforcement')}
+                    value={field.state.value}
+                    onChange={field.handleChange}
                   />
-                )}
-              </form.AppField>
-            )}
-          </form.AppField>
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+          </Fragment>
         ) : (
           <WebAuthn
             mode="sudo"
@@ -263,16 +274,16 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
       </Stack>
       {state.step === 'access' ? (
         <Flex justify="between" align="center" gap="md" margin="xl 0 0">
-          <Button
+          <form.SubmitButton
+            variant="secondary"
             disabled={!authenticatorsReady}
             onClick={() => {
               form.setFieldValue('superuserAccessCategory', 'cops_csm');
               form.setFieldValue('superuserReason', 'COPS and CSM use');
-              form.handleSubmit();
             }}
           >
             {t('COPS/CSM')}
-          </Button>
+          </form.SubmitButton>
           <form.SubmitButton disabled={!authenticatorsReady}>
             {t('Continue')}
           </form.SubmitButton>

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -94,12 +94,6 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
 
   const autoSubmittedRef = useRef(false);
 
-  const {mutateAsync: authenticate} = useMutation({
-    // authUrl is a runtime branch (/auth/ or /staff-auth/), not a known URL
-    // literal, so it's passed to fetchMutation as a plain string.
-    mutationFn: (data: AuthPayload) => fetchMutation({method: 'PUT', url: authUrl, data}),
-  });
-
   const handleError = useCallback((err: unknown) => {
     setState({
       step: 'access',
@@ -107,6 +101,14 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
         err instanceof RequestError ? getErrorType(err) : ErrorCodes.UNKNOWN_ERROR,
     });
   }, []);
+
+  const {mutateAsync: authenticate} = useMutation({
+    // authUrl is a runtime branch (/auth/ or /staff-auth/), not a known URL
+    // literal, so it's passed to fetchMutation as a plain string.
+    mutationFn: (data: AuthPayload) => fetchMutation({method: 'PUT', url: authUrl, data}),
+    onSuccess: reloadPage,
+    onError: handleError,
+  });
 
   const form = useScrapsForm({
     ...defaultFormOptions,
@@ -130,10 +132,8 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
 
       try {
         await authenticate({isSuperuserModal: true, ...access});
-        reloadPage();
-      } catch (err) {
+      } catch {
         form.reset();
-        handleError(err);
       }
     },
   });
@@ -153,15 +153,13 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
       }
       try {
         await authenticate(payload);
-        reloadPage();
       } catch (err) {
         form.reset();
-        handleError(err);
         // u2fInterface relies on this
         throw err;
       }
     },
-    [authenticate, form, handleError, hasStaff, webAuthnAccess]
+    [authenticate, form, hasStaff, webAuthnAccess]
   );
 
   // Staff local dev with U2F disabled: submit immediately on mount (once).
@@ -170,10 +168,8 @@ function SuperuserStaffAccessForm({hasStaff}: Props) {
       return;
     }
     autoSubmittedRef.current = true;
-    authenticate({superuserAccessCategory: '', superuserReason: ''})
-      .then(reloadPage)
-      .catch(handleError);
-  }, [authenticate, handleError, shouldAutoSubmit]);
+    authenticate({superuserAccessCategory: '', superuserReason: ''}).catch(() => {});
+  }, [authenticate, shouldAutoSubmit]);
 
   const requiresAuthenticator = !disableU2FForSUForm;
   const noAuthenticator =

--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -102,17 +102,8 @@ type ReplayOnboardingCTAProps = {
 };
 type ProductUnavailableCTAProps = {organization: Organization};
 
-/**
- * Compatibility props for rendering the legacy access-category override inside a
- * Scraps form. They remain optional for consumers backed by the legacy FormModel.
- */
 export type SuperuserAccessCategoryProps = {
-  accessCategory?: string;
-  accessCategoryError?: string;
-  onAccessCategoryChange?: (value: string) => void;
-  onReasonChange?: (value: string) => void;
-  reason?: string;
-  reasonError?: string;
+  RadioItem: React.ComponentType<{children: React.ReactNode; value: string}>;
 };
 
 type ContinuousProfilingBillingRequirementBannerProps = {

--- a/static/gsApp/overrides/superuserAccessCategory.spec.tsx
+++ b/static/gsApp/overrides/superuserAccessCategory.spec.tsx
@@ -1,0 +1,41 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+
+import {SuperuserAccessCategory} from 'getsentry/overrides/superuserAccessCategory';
+
+function TestForm() {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {superuserAccessCategory: 'development'},
+  });
+
+  return (
+    <form.AppForm form={form}>
+      <form.AppField name="superuserAccessCategory">
+        {field => (
+          <field.Radio.Group value={field.state.value} onChange={field.handleChange}>
+            <field.Layout.Stack label="Categories of Superuser Access" required>
+              <SuperuserAccessCategory RadioItem={field.Radio.Item} />
+            </field.Layout.Stack>
+          </field.Radio.Group>
+        )}
+      </form.AppField>
+    </form.AppForm>
+  );
+}
+
+describe('SuperuserAccessCategory', () => {
+  it('renders category options inside a bound Scraps field', async () => {
+    render(<TestForm />);
+
+    expect(
+      screen.getByRole('radiogroup', {name: 'Categories of Superuser Access'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Development'})).toBeChecked();
+    expect(screen.getByText('(required)')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('radio', {name: 'Debugging'}));
+    expect(screen.getByRole('radio', {name: 'Debugging'})).toBeChecked();
+  });
+});

--- a/static/gsApp/overrides/superuserAccessCategory.tsx
+++ b/static/gsApp/overrides/superuserAccessCategory.tsx
@@ -1,130 +1,63 @@
-import {Fragment} from 'react';
-import styled from '@emotion/styled';
-
 import {Alert} from '@sentry/scraps/alert';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {FieldRequiredBadge} from 'sentry/components/forms/fieldGroup/fieldRequiredBadge';
-import {RadioField} from 'sentry/components/forms/fields/radioField';
-import {TextField} from 'sentry/components/forms/fields/textField';
 import type {SuperuserAccessCategoryProps} from 'sentry/types/overrides';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
-type SuperuserAccessCategories = [string, React.ReactNode];
+type SuperuserAccessCategory = [value: string, label: React.ReactNode];
 
-const EngineeringCategories: SuperuserAccessCategories[] = [
+const ENGINEERING_CATEGORIES: SuperuserAccessCategory[] = [
   ['development', 'Development'],
   ['debugging', 'Debugging'],
   ['validate_feature', 'Validate a feature'],
 ];
 
-const ReactiveSupportCategories: SuperuserAccessCategories[] = [
+const REACTIVE_SUPPORT_CATEGORIES: SuperuserAccessCategory[] = [
   ['_admin_actions', '_admin actions'],
   ['organization_setting_change', 'Change organization settings'],
   ['intercom', 'Intercom'],
 ];
 
-const ProactiveSupportCategories: SuperuserAccessCategories[] = [
+const PROACTIVE_SUPPORT_CATEGORIES: SuperuserAccessCategory[] = [
   ['account_review', 'Account review/research'],
   ['customer_demo', 'Customer demo'],
   ['customer_provisioning', 'Customer provisioning'],
   ['onboarding_setup', 'Onboarding setup'],
 ];
 
-const OtherCategory: SuperuserAccessCategories[] = [['other', 'Other']];
+const OTHER_CATEGORIES: SuperuserAccessCategory[] = [['other', 'Other']];
+
+const ACCESS_CATEGORY_GROUPS = [
+  {label: 'Engineering', options: ENGINEERING_CATEGORIES},
+  {label: 'Reactive Support', options: REACTIVE_SUPPORT_CATEGORIES},
+  {label: 'Proactive Support', options: PROACTIVE_SUPPORT_CATEGORIES},
+  {label: 'Others', options: OTHER_CATEGORIES},
+];
 
 const DOCUMENTATION_URL = 'https://www.notion.so/sentry/aae9a918b5814fe0918d8e7aecacf97a';
 
-export function SuperuserAccessCategory({
-  accessCategory,
-  accessCategoryError,
-  onAccessCategoryChange,
-  onReasonChange,
-  reason,
-  reasonError,
-}: SuperuserAccessCategoryProps) {
+export function SuperuserAccessCategory({RadioItem}: SuperuserAccessCategoryProps) {
   return (
-    <Fragment>
+    <Stack gap="xl" flexGrow={1}>
       <Alert variant="muted" showIcon={false}>
         For more information on these categories, please{' '}
         <ExternalLink href={DOCUMENTATION_URL}>see this Notion document</ExternalLink>.
       </Alert>
-      <CategoriesLabel>
-        Categories of Superuser Access
-        <FieldRequiredBadge />
-      </CategoriesLabel>
-      <CategoryGrid>
-        <RadioField
-          name="superuserAccessCategory"
-          inline={false}
-          label="Engineering"
-          choices={EngineeringCategories}
-          onChange={onAccessCategoryChange}
-          value={accessCategory}
-          stacked
-        />
-        <RadioField
-          name="superuserAccessCategory"
-          inline={false}
-          label="Reactive Support"
-          choices={ReactiveSupportCategories}
-          onChange={onAccessCategoryChange}
-          value={accessCategory}
-          stacked
-        />
-        <RadioField
-          name="superuserAccessCategory"
-          inline={false}
-          label="Proactive Support"
-          choices={ProactiveSupportCategories}
-          onChange={onAccessCategoryChange}
-          value={accessCategory}
-          stacked
-        />
-        <RadioField
-          name="superuserAccessCategory"
-          inline={false}
-          label="Others"
-          choices={OtherCategory}
-          onChange={onAccessCategoryChange}
-          value={accessCategory}
-          stacked
-        />
-      </CategoryGrid>
-      {accessCategoryError ? (
-        <Text role="alert" size="sm" variant="danger">
-          {accessCategoryError}
-        </Text>
-      ) : null}
-      <TextField
-        name="superuserReason"
-        label="Reason for Access"
-        inline={false}
-        stacked
-        flexibleControlStateSize
-        required
-        maxLength={128}
-        minLength={4}
-        onChange={onReasonChange}
-        placeholder="e.g. disabling SSO enforcement"
-        value={reason}
-      />
-      {reasonError ? (
-        <Text role="alert" size="sm" variant="danger">
-          {reasonError}
-        </Text>
-      ) : null}
-    </Fragment>
+      <Grid columns="repeat(2, minmax(0, 1fr))" gap="xl 2xl">
+        {ACCESS_CATEGORY_GROUPS.map(group => (
+          <Stack gap="md" key={group.label}>
+            <Text bold>{group.label}</Text>
+            <Stack gap="md">
+              {group.options.map(([value, label]) => (
+                <RadioItem value={value} key={value}>
+                  {label}
+                </RadioItem>
+              ))}
+            </Stack>
+          </Stack>
+        ))}
+      </Grid>
+    </Stack>
   );
 }
-
-const CategoriesLabel = styled(TextBlock)`
-  margin-top: ${p => p.theme.space.md};
-  margin-bottom: ${p => p.theme.space.md};
-`;
-
-const CategoryGrid = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-`;


### PR DESCRIPTION
Migrates the sudo / re-authentication modal off the legacy `Form`/`FormModel` system to the scraps form system (`@sentry/scraps/form`), preserving the password, WebAuthn, and superuser access-category flows.
