### PR TITLE
fix(conversations): Fix size hierarchy in AI span detail card

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -135,10 +135,10 @@ export function ConversationSpanDetail({
       <Flex align="center" gap="lg" flexShrink={0}>
         <Flex flex="1" minWidth="0" align="center" gap="md">
           <Flex flexShrink={0} style={{color: squareColor}}>
-            {getGenAiOpTypeIcon(getGenAiOpType(node))}
+            {getGenAiOpTypeIcon(getGenAiOpType(node), 'md')}
           </Flex>
           <Tooltip title={title} showOnlyOnOverflow skipWrapper>
-            <Text size="md" bold ellipsis>
+            <Text size="lg" bold ellipsis>
               {title}
             </Text>
           </Tooltip>
@@ -154,9 +154,9 @@ export function ConversationSpanDetail({
         ) : null}
       </Flex>
 
-      <Stack gap="md" flexShrink={0}>
+      <Stack gap="lg" flexShrink={0}>
         <Flex align="center" gap="sm" wrap="wrap">
-          <Text size="md">{getDuration(duration, 2, true, true)}</Text>
+          <Text size="lg">{getDuration(duration, 2, true, true)}</Text>
           {duration > 0 &&
           comparison &&
           comparison.deltaPct >= MIN_PCT_DURATION_DIFFERENCE ? (
@@ -242,7 +242,7 @@ function SpanMetadata({
   }
 
   return (
-    <Grid columns="max-content minmax(0, 1fr)" gap="md lg" align="center">
+    <Grid columns="max-content minmax(0, 1fr)" gap="lg" align="center">
       {rows.map(row => (
         <Fragment key={row.name}>
           <Text size="md" variant="muted">


### PR DESCRIPTION
### Problem

In the AI span detail card, the title, duration, and promoted-attribute rows all rendered at ~14px. The duration no longer stood out and the header read as flat.

### Fix

Restore a clear size hierarchy while keeping the metadata at a readable 14px:

| Element | Before | After |
|---|---|---|
| Title icon | 14px (sm) | **16px (md)** |
| Title | 14px (md), bold | **16px (lg)**, bold |
| Duration | 14px (md) | **16px (lg)** |
| Metadata rows | 14px (md) | 14px (md) — unchanged |

The title and duration share a size but are distinguished by weight (bold title + the colored 16px op-type icon), so the title still heads the card while the duration clearly outranks the 14px metadata. Font weights match Figma (title = medium, duration/metadata = regular).

Row spacing bumped from 8px → 12px, proportional to the larger text (the ticket flagged the vertical spacing as feeling off).

Refs [TET-2634](https://linear.app/getsentry/issue/TET-2634/size-of-the-duration-does-not-have-the-right-proportions)



**Before**

<img width="449" height="678" alt="image" src="https://github.com/user-attachments/assets/5bb9cebb-3e97-4835-b432-7f1efda29f1a" />



**After**

<img width="443" height="386" alt="image" src="https://github.com/user-attachments/assets/4f8583e5-ab58-4d5b-96c8-24309c14f5a0" />
