### PR TITLE
feat(pr-metrics): Defer scm.pr.closed emission behind a cooldown

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -65,6 +65,13 @@ class PullRequestVerdict(models.TextChoices):
     # event won't forward twice; Seer's callback overwrites it with a real verdict.
     # Never a judge *result* — the callback rejects it coming back from Seer.
     JUDGE_IN_PROGRESS = "judge_in_progress"
+    # Transient, internal: a terminal event has been claimed at the close/merge
+    # webhook and an emission task scheduled, but the cooldown window (during which
+    # late attribution and activity settle) hasn't elapsed yet. Reuses the verdict
+    # column as the redelivery guard so a redelivered terminal event won't schedule
+    # a second task; the cooldown task overwrites it with a real verdict (or the
+    # JUDGE_IN_PROGRESS sentinel). Never a judge *result*.
+    WAITING_EVENT_COOLDOWN = "waiting_event_cooldown"
 
 
 # SCM providers that can legitimately back a Repository. A reporting source (Seer, a

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -612,6 +612,13 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Cooldown (seconds) between a PR's terminal close/merge webhook and emitting its
+# scm.pr.closed metrics row, so late attribution and activity can settle first.
+register(
+    "pr_metrics.emit_cooldown_seconds",
+    default=3600,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -61,9 +61,12 @@ seer_pr_metrics_connection_pool = connection_from_url(
     timeout=settings.SEER_DEFAULT_TIMEOUT,
 )
 
-# The verdicts Seer may return: every real outcome, never the internal forward
-# sentinel. The callback rejects JUDGE_IN_PROGRESS coming back from Seer.
-RESULT_VERDICTS = frozenset(PullRequestVerdict.values) - {PullRequestVerdict.JUDGE_IN_PROGRESS}
+# The verdicts Seer may return: every real outcome, never an internal sentinel.
+# The callback rejects JUDGE_IN_PROGRESS / WAITING_EVENT_COOLDOWN coming back from Seer.
+RESULT_VERDICTS = frozenset(PullRequestVerdict.values) - {
+    PullRequestVerdict.JUDGE_IN_PROGRESS,
+    PullRequestVerdict.WAITING_EVENT_COOLDOWN,
+}
 
 
 # check_run fires per check per push, so a busy PR can accumulate far more check

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -7,6 +7,7 @@ import logging
 from taskbroker_client.retry import Retry
 from urllib3.exceptions import HTTPError
 
+from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest, PullRequestActivity
 from sentry.models.repository import Repository
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge
@@ -68,6 +69,55 @@ def forward_pr_to_seer_task(
         return
 
     forward_pr_to_seer_judge(pull_request, repository)
+
+
+@instrumented_task(
+    name="sentry.pr_metrics.tasks.emit_pr_metrics_cooldown",
+    namespace=seer_code_review_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def emit_pr_metrics_cooldown_task(
+    *,
+    pull_request_id: int,
+    organization_id: int,
+    repository_id: int,
+) -> None:
+    """Settle and emit a PR's ``scm.pr.closed`` row after the post-close cooldown.
+
+    Scheduled by ``handle_emission`` when a close/merge webhook claims the
+    ``WAITING_EVENT_COOLDOWN`` sentinel. Deferring emission by the cooldown lets
+    late attribution and activity settle before the verdict is chosen and the row
+    read (see ``run_deferred_emission``). A PR or org that vanished between enqueue
+    and run is permanent and dropped.
+    """
+    log_extra = {
+        "pull_request_id": pull_request_id,
+        "organization_id": organization_id,
+        "repository_id": repository_id,
+    }
+    # Scope to the claimed org+repo, matching the rest of the pipeline.
+    try:
+        pull_request = PullRequest.objects.get(
+            id=pull_request_id,
+            organization_id=organization_id,
+            repository_id=repository_id,
+        )
+    except PullRequest.DoesNotExist:
+        logger.warning("pr_metrics.cooldown.pull_request_not_found", extra=log_extra)
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "pr_gone"})
+        return
+
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.warning("pr_metrics.cooldown.organization_not_found", extra=log_extra)
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "org_gone"})
+        return
+
+    # Imported here to avoid a circular import: webhooks imports this module.
+    from sentry.pr_metrics.webhooks import run_deferred_emission
+
+    run_deferred_emission(pull_request, organization)
 
 
 @instrumented_task(

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -27,7 +27,7 @@ from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
-from sentry import features
+from sentry import features, options
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.issues.constants import cache_key_for_issue_view
@@ -75,7 +75,7 @@ from sentry.pr_metrics.emit import (
     is_pr_tracked,
     select_verdict,
 )
-from sentry.pr_metrics.tasks import forward_pr_to_seer_task
+from sentry.pr_metrics.tasks import emit_pr_metrics_cooldown_task, forward_pr_to_seer_task
 from sentry.pr_metrics.utils import (
     DELEGATED_AGENT_AUTHOR_LOGINS,
     DELEGATED_AGENT_BRANCH_PREFIXES,
@@ -297,6 +297,23 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
     metrics.incr("pr_metrics.judge.enqueued")
 
 
+def _claim_cooldown(pr: PullRequest) -> bool:
+    """Claim a terminal event's emission cooldown, guarding against redelivery.
+
+    Ensures the metrics row exists (``select_verdict`` runs later in the task and
+    tolerates a missing row, but the compare-and-set needs a row to update), then
+    atomically transitions ``verdict`` NULL -> ``WAITING_EVENT_COOLDOWN``. Only the
+    first close/merge delivery wins, so exactly one cooldown task is scheduled;
+    redeliveries — and a reopen-then-reclose while the window is still open — find
+    the row already claimed and no-op. Returns True if this call won the claim.
+    """
+    PullRequestMetrics.objects.get_or_create(pull_request=pr)
+    claimed = PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=True).update(
+        verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
+    )
+    return bool(claimed)
+
+
 def handle_emission(
     *,
     github_event: GithubWebhookType,
@@ -306,19 +323,19 @@ def handle_emission(
     integration: RpcIntegration | None = None,
     **kwargs: Any,
 ) -> None:
-    """Emit a metrics row on a terminal (close/merge) PR webhook for a tracked PR.
+    """Schedule deferred emission on a terminal (close/merge) PR webhook.
 
-    GitHub's single ``closed`` action covers both merges and plain closes; emit
-    derives which from the stored row, so this handler only filters for ``closed``
-    and delegates. All non-terminal actions are ignored.
+    GitHub's single ``closed`` action covers both merges and plain closes. Rather
+    than emitting inline, this claims a cooldown on the metrics row and schedules
+    ``emit_pr_metrics_cooldown_task`` ``pr_metrics.emit_cooldown_seconds`` out, so
+    late attribution and activity can settle before the verdict is chosen and the
+    row emitted (see ``run_deferred_emission``). All non-terminal actions are
+    ignored.
 
-    Untracked PRs (no valid attribution) are dropped first, before any verdict is
+    Untracked PRs (no valid attribution) are dropped first, before the cooldown is
     claimed: claiming would burn the redelivery guard, so a PR that gained
-    attribution only later (e.g. a Seer backfill) could never emit. ``select_verdict``
-    then decides the outcome: a deterministic verdict is claimed (the redelivery
-    guard) and emitted; a PR that needs a judge is forwarded to Seer instead (gated
-    on ``pr-metrics-judge``, guarded by the same claim against redelivery), and Seer
-    calls back to settle and emit it.
+    attribution only later could never emit. The cooldown claim is the redelivery
+    guard — only the first delivery schedules a task; redeliveries no-op.
     """
     if event.get("action") != "closed":
         return
@@ -340,12 +357,78 @@ def handle_emission(
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "untracked"})
         return
 
-    verdict = select_verdict(pr, organization)
-    if verdict is None:
-        _forward_to_judge(pr, organization)
+    if not _claim_cooldown(pr):
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "already_claimed"})
         return
 
-    if not _claim_terminal_event(pr, verdict):
+    log_extra = {
+        "organization_id": organization.id,
+        "repository_id": pr.repository_id,
+        "pull_request_id": pr.id,
+    }
+    try:
+        emit_pr_metrics_cooldown_task.apply_async(
+            kwargs={
+                "pull_request_id": pr.id,
+                "organization_id": organization.id,
+                "repository_id": pr.repository_id,
+            },
+            countdown=options.get("pr_metrics.emit_cooldown_seconds"),
+        )
+    except Exception:
+        # The claim committed but the enqueue didn't, so no task will settle this PR.
+        # Release the cooldown sentinel (only if it's still ours) so a redelivery can
+        # reschedule rather than the PR sticking in WAITING_EVENT_COOLDOWN.
+        PullRequestMetrics.objects.filter(
+            pull_request=pr, verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
+        ).update(verdict=None)
+        metrics.incr("pr_metrics.cooldown.enqueue_failed")
+        logger.exception("pr_metrics.cooldown.enqueue_failed", extra=log_extra)
+        return
+
+    metrics.incr("pr_metrics.cooldown.scheduled")
+
+
+def run_deferred_emission(pull_request: PullRequest, organization: Organization) -> None:
+    """Settle and emit a PR's terminal metrics row after the cooldown window.
+
+    Runs from ``emit_pr_metrics_cooldown_task`` ``pr_metrics.emit_cooldown_seconds``
+    after the close/merge webhook claimed ``WAITING_EVENT_COOLDOWN``. By now late
+    attribution and activity have settled, so verdict selection and emission read
+    final state.
+
+    Reopen handling: if the PR is no longer terminal (reopened during the window),
+    release the sentinel and stop — a later re-close reschedules. Otherwise release
+    the cooldown claim back to NULL and run the standard verdict -> emit/forward
+    path, whose own NULL-based guards settle the row exactly once (a late redelivery
+    that races the brief NULL window still emits once: whichever of the two claims
+    the verdict wins, the other no-ops).
+    """
+    log_extra = {
+        "organization_id": organization.id,
+        "repository_id": pull_request.repository_id,
+        "pull_request_id": pull_request.id,
+    }
+
+    # Release our cooldown claim so the deterministic/judge guards below — which
+    # compare-and-set against a NULL verdict — can settle the row.
+    PullRequestMetrics.objects.filter(
+        pull_request=pull_request, verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
+    ).update(verdict=None)
+
+    if pull_request.closed_at is None or pull_request.head_commit_sha is None:
+        # Reopened (or no longer terminal) while waiting. Release the sentinel so a
+        # later re-close can re-claim and reschedule.
+        metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "reopened"})
+        logger.info("pr_metrics.cooldown.reopened", extra=log_extra)
+        return
+
+    verdict = select_verdict(pull_request, organization)
+    if verdict is None:
+        _forward_to_judge(pull_request, organization)
+        return
+
+    if not _claim_terminal_event(pull_request, verdict):
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"})
         return
 
@@ -353,7 +436,8 @@ def handle_emission(
     # analytics.record is best-effort, async-batched telemetry; if it raises the
     # claim still stands and the row is forgone — an acceptable loss for telemetry,
     # not worth a rollback that would reopen the redelivery race.
-    emit_pr_metrics_row(pull_request=pr)
+    emit_pr_metrics_row(pull_request=pull_request)
+    metrics.incr("pr_metrics.cooldown.emitted")
 
 
 def handle_metrics(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -19,7 +19,9 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
     PullRequestMetrics,
+    PullRequestVerdict,
 )
+from sentry.pr_metrics.tasks import emit_pr_metrics_cooldown_task
 from sentry.pr_metrics.webhooks import (
     handle_activity,
     handle_attribution,
@@ -289,6 +291,23 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         # used to resolve the PR by number.
         return {"number": 42}
 
+    def _run_scheduled_cooldown(self) -> None:
+        # Emission is deferred: handle_emission only claims WAITING_EVENT_COOLDOWN and
+        # schedules the cooldown task. Run that task now, as it would fire after the
+        # window, so these end-to-end tests observe the eventual emit/forward. Only
+        # run it when the claim was actually won (mirrors production, where the task
+        # exists only if it was scheduled).
+        claimed = PullRequestMetrics.objects.filter(
+            pull_request=self.pull_request,
+            verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN,
+        ).exists()
+        if claimed:
+            emit_pr_metrics_cooldown_task(
+                pull_request_id=self.pull_request.id,
+                organization_id=self.organization.id,
+                repository_id=self.repo.id,
+            )
+
     def _call(self, *, action: str = "closed", merged: bool = True) -> None:
         if action == "closed":
             # PullRequestEventWebhook._handle persists every lifecycle fact on the
@@ -301,12 +320,15 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
                 merge_commit_sha=MERGE_SHA if merged else None,
                 draft=False,
             )
-        handle_emission(
-            github_event=GithubWebhookType.PULL_REQUEST,
-            event={"action": action, "pull_request": self._payload()},
-            organization=self.organization,
-            repo=self.repo,
-        )
+        # Suppress the real enqueue; _run_scheduled_cooldown drives the task instead.
+        with patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async"):
+            handle_emission(
+                github_event=GithubWebhookType.PULL_REQUEST,
+                event={"action": action, "pull_request": self._payload()},
+                organization=self.organization,
+                repo=self.repo,
+            )
+        self._run_scheduled_cooldown()
 
     @patch("sentry.analytics.record")
     def test_emits_on_merge(self, mock_record: MagicMock) -> None:
@@ -350,12 +372,19 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
 
     @patch("sentry.analytics.record")
-    def test_skips_emit_when_metrics_row_missing(self, mock_record: MagicMock) -> None:
-        # A missing metrics row (handle_metrics failed) is deferred to a judge, not
-        # silently dropped as a redelivery — for a merge as much as a close.
+    def test_recreates_missing_metrics_row_when_claiming_cooldown(
+        self, mock_record: MagicMock
+    ) -> None:
+        # The cooldown claim get_or_creates the metrics row, so a missing row (e.g.
+        # handle_metrics failed) is recreated at claim time rather than deferred as a
+        # judge case. The deferred task then settles on the present (empty) row — a
+        # clean merge still resolves to merged_unchanged.
         PullRequestMetrics.objects.filter(pull_request=self.pull_request).delete()
         self._call(merged=True)
-        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
 
     @patch("sentry.analytics.record")
     def test_ignores_non_terminal_actions(self, mock_record: MagicMock) -> None:
@@ -459,6 +488,130 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
                 "github_delivery_id": None,
                 "reason": "missing_opened_at",
             },
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+
+
+@with_feature("organizations:pr-metrics-emit")
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@cell_silo_test
+class HandleWebhookForPrMetricsCooldownTest(TestCase):
+    """The webhook-side scheduling of deferred emission and its cooldown claim."""
+
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="99")
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+        PullRequestAttribution.objects.create(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=True,
+        )
+        PullRequestMetrics.objects.create(pull_request=self.pull_request, additions=1)
+        self.pull_request.update(
+            head_commit_sha=HEAD_SHA,
+            opened_at=OPENED_AT,
+            closed_at=CLOSED_AT,
+            merged_at=CLOSED_AT,
+            merge_commit_sha=MERGE_SHA,
+            draft=False,
+        )
+
+    def _handle(self) -> None:
+        handle_emission(
+            github_event=GithubWebhookType.PULL_REQUEST,
+            event={"action": "closed", "pull_request": {"number": 42}},
+            organization=self.organization,
+            repo=self.repo,
+        )
+
+    def _verdict(self) -> str | None:
+        return PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict
+
+    @patch("sentry.analytics.record")
+    @patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async")
+    def test_claims_cooldown_and_schedules_task(
+        self, mock_apply_async: MagicMock, mock_record: MagicMock
+    ) -> None:
+        self._handle()
+
+        assert self._verdict() == "waiting_event_cooldown"
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "pull_request_id": self.pull_request.id,
+                "organization_id": self.organization.id,
+                "repository_id": self.repo.id,
+            },
+            countdown=3600,
+        )
+        # Nothing is emitted synchronously — the deferred task does that.
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+
+    @patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async")
+    def test_redelivery_during_cooldown_schedules_once(self, mock_apply_async: MagicMock) -> None:
+        self._handle()
+        self._handle()
+        # The second delivery finds the row already claimed and no-ops.
+        assert mock_apply_async.call_count == 1
+
+    @patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async")
+    def test_untracked_pr_does_not_schedule(self, mock_apply_async: MagicMock) -> None:
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
+        self._handle()
+        assert mock_apply_async.call_count == 0
+        assert self._verdict() is None
+
+    @patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async")
+    def test_enqueue_failure_releases_cooldown(self, mock_apply_async: MagicMock) -> None:
+        # If the claim commits but the enqueue fails, the sentinel is released so a
+        # redelivery can reschedule rather than the PR sticking in cooldown.
+        mock_apply_async.side_effect = RuntimeError("broker down")
+        self._handle()
+        assert self._verdict() is None
+
+    @patch("sentry.analytics.record")
+    @patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async")
+    def test_reopened_during_cooldown_releases_and_does_not_emit(
+        self, mock_apply_async: MagicMock, mock_record: MagicMock
+    ) -> None:
+        self._handle()
+        assert self._verdict() == "waiting_event_cooldown"
+
+        # Reopened before the window elapsed: the PR is no longer terminal.
+        self.pull_request.update(closed_at=None, merged_at=None)
+        emit_pr_metrics_cooldown_task(
+            pull_request_id=self.pull_request.id,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+        )
+
+        assert self._verdict() is None
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+
+    @patch("sentry.analytics.record")
+    @patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async")
+    def test_deferred_task_emits_after_window(
+        self, mock_apply_async: MagicMock, mock_record: MagicMock
+    ) -> None:
+        self._handle()
+        emit_pr_metrics_cooldown_task(
+            pull_request_id=self.pull_request.id,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+        )
+
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert self._verdict() == "merged_unchanged"
+
+    @patch("sentry.analytics.record")
+    def test_task_drops_when_pull_request_gone(self, mock_record: MagicMock) -> None:
+        emit_pr_metrics_cooldown_task(
+            pull_request_id=self.pull_request.id + 999,
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
 
@@ -1683,6 +1836,21 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
             payload={},
         )
 
+    def _run_scheduled_cooldown(self) -> None:
+        # Emission is deferred: handle_emission only claims WAITING_EVENT_COOLDOWN and
+        # schedules the cooldown task, which is where the judge fork now runs. Drive
+        # that task as it would fire after the window, but only when the claim was won.
+        claimed = PullRequestMetrics.objects.filter(
+            pull_request=self.pull_request,
+            verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN,
+        ).exists()
+        if claimed:
+            emit_pr_metrics_cooldown_task(
+                pull_request_id=self.pull_request.id,
+                organization_id=self.organization.id,
+                repository_id=self.repo.id,
+            )
+
     def _call(self) -> None:
         self.pull_request.update(
             head_commit_sha=HEAD_SHA,
@@ -1692,12 +1860,15 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
             merge_commit_sha=MERGE_SHA,
             draft=False,
         )
-        handle_emission(
-            github_event=GithubWebhookType.PULL_REQUEST,
-            event={"action": "closed", "pull_request": {"number": 42}},
-            organization=self.organization,
-            repo=self.repo,
-        )
+        # Suppress the real enqueue; _run_scheduled_cooldown drives the task instead.
+        with patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async"):
+            handle_emission(
+                github_event=GithubWebhookType.PULL_REQUEST,
+                event={"action": "closed", "pull_request": {"number": 42}},
+                organization=self.organization,
+                repo=self.repo,
+            )
+        self._run_scheduled_cooldown()
 
     @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
@@ -1731,8 +1902,9 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
     def test_forwards_when_metrics_row_missing(
         self, mock_record: MagicMock, mock_delay: MagicMock
     ) -> None:
-        # A missing metrics row defers to a judge; the forward path creates the row
-        # so it can claim the sentinel and still forward.
+        # A missing metrics row is recreated when the cooldown is claimed; the
+        # deferred task then still forwards (the later commit makes the merge
+        # non-deterministic regardless of the freshly-created row).
         PullRequestMetrics.objects.filter(pull_request=self.pull_request).delete()
         self._call()
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (


### PR DESCRIPTION
As the AI mentions below I've seen some cases where the PR is open-closed within 1min and that can mess up some of the attributions for delegated agents in particular (that go through an async path).

I've decided to create a new task and keep the judge-path task as is. The cooldown is added as an option so we can change it on-the-fly if needed.

Refs CORE-274

---

## Summary

Terminal (`closed`/`merge`) PR webhooks emitted the `scm.pr.closed` metrics row inline. Attribution and activity that land shortly *after* the close — async delegated-agent attribution signals, late comments/reviews, follow-up pushes — were therefore missed by verdict selection and by the emitted row.

This defers emission behind a cooldown so that verdict selection and emission run on settled state.

## How it works

- `handle_emission` no longer emits inline. It claims a new `WAITING_EVENT_COOLDOWN` sentinel on the `PullRequestMetrics` row and schedules `emit_pr_metrics_cooldown_task` `pr_metrics.emit_cooldown_seconds` out (option, default 1h).
- The cooldown claim is the redelivery guard: only the first delivery schedules a task; redeliveries — and a reopen-then-reclose while the window is still open — find the row already claimed and no-op.
- The deferred task re-reads all state, releases the claim, then reuses the existing deterministic-emit and judge-forward paths (Seer's callback still settles the judge path).

## Reopen handling

If the PR is no longer terminal when the task runs (reopened during the window), the sentinel is released and a later re-close reschedules — rather than emitting a close for a now-open PR. Instrumented via `pr_metrics.cooldown.skipped{reason=reopened}`.

## Notes

- The cooldown claim `get_or_create`s the metrics row, so a genuinely missing row (a failed `handle_metrics`) is recreated at claim time and settled on present data rather than deferred as a judge case.
- New metrics for observability: `pr_metrics.cooldown.{scheduled,emitted,enqueue_failed}` and `.skipped{reason=already_claimed|reopened|pr_gone|org_gone}`.
- `pr_metrics.emit_cooldown_seconds` is automator-modifiable, so the window is tunable without a deploy.
