### PR TITLE
fix(conversations): Show skeleton for span details to avoid layout shift

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -163,63 +163,65 @@ export function ConversationSpanDetail({
             <Tag variant={comparison.variant}>{comparison.deltaText}</Tag>
           ) : null}
         </Flex>
-        <SpanMetadata node={node} attributes={attributes} />
+        {isAttributesLoading ? (
+          <SpanMetadataSkeleton />
+        ) : isError ? null : (
+          <SpanMetadata node={node} attributes={attributes} />
+        )}
       </Stack>
 
-      <TabStateProvider<DetailTab>
-        value={activeTab}
-        onChange={onTabChange}
-        disableOverflow
-      >
-        <Flex flexShrink={0}>
-          <TabList>
-            <TabList.Item key="input">{t('Input')}</TabList.Item>
-            <TabList.Item key="output">{t('Output')}</TabList.Item>
-            <TabList.Item key="attributes">{t('Attributes')}</TabList.Item>
-          </TabList>
-        </Flex>
-
-        <Container
-          flex="0 0 auto"
-          minHeight="0"
-          width="100%"
-          overflowX="visible"
-          overflowY="visible"
-          // Gutter so the scroll container doesn't clip a focused input's focus ring.
-          padding="xs"
+      {/*
+       * The per-span fetch backs both the metadata and the tab content, and it
+       * isn't returned by the conversation list endpoint. Rather than let each
+       * piece pop in on its own — which shifts the layout as the user clicks
+       * between spans — show a skeleton until the fetch resolves, then reveal
+       * the whole detail at once.
+       */}
+      {isAttributesLoading ? (
+        <SpanTabsSkeleton />
+      ) : isError ? (
+        <EmptyTab message={t('Failed to load span details')} />
+      ) : (
+        <TabStateProvider<DetailTab>
+          value={activeTab}
+          onChange={onTabChange}
+          disableOverflow
         >
-          <TabPanels
-            css={css`
-              padding-top: 0;
-            `}
+          <Flex flexShrink={0}>
+            <TabList>
+              <TabList.Item key="input">{t('Input')}</TabList.Item>
+              <TabList.Item key="output">{t('Output')}</TabList.Item>
+              <TabList.Item key="attributes">{t('Attributes')}</TabList.Item>
+            </TabList>
+          </Flex>
+
+          <Container
+            flex="0 0 auto"
+            minHeight="0"
+            width="100%"
+            overflowX="visible"
+            overflowY="visible"
+            // Gutter so the scroll container doesn't clip a focused input's focus ring.
+            padding="xs"
           >
-            <TabPanels.Item key="input">
-              <InputTab
-                node={node}
-                attributes={attributes}
-                isLoading={isAttributesLoading}
-                isError={isError}
-              />
-            </TabPanels.Item>
-            <TabPanels.Item key="output">
-              <OutputTab
-                node={node}
-                attributes={attributes}
-                isLoading={isAttributesLoading}
-                isError={isError}
-              />
-            </TabPanels.Item>
-            <TabPanels.Item key="attributes">
-              <AttributesTab
-                node={node}
-                attributes={attributes}
-                isLoading={isAttributesLoading}
-                isError={isError}
-              />
-            </TabPanels.Item>
-          </TabPanels>
-        </Container>
-      </TabStateProvider>
+            <TabPanels
+              css={css`
+                padding-top: 0;
+              `}
+            >
+              <TabPanels.Item key="input">
+                <InputTab node={node} attributes={attributes} />
+              </TabPanels.Item>
+              <TabPanels.Item key="output">
+                <OutputTab node={node} attributes={attributes} />
+              </TabPanels.Item>
+              <TabPanels.Item key="attributes">
+                <AttributesTab node={node} attributes={attributes} />
+              </TabPanels.Item>
+            </TabPanels>
+          </Container>
+        </TabStateProvider>
+      )}
     </SpanDetailCard>
   );
 }
@@ -268,12 +270,8 @@ function SpanMetadata({
 function InputTab({
   node,
   attributes,
-  isLoading,
-  isError,
 }: {
   attributes: SpanAttributes;
-  isError: boolean;
-  isLoading: boolean;
   node: AITraceSpanNode;
 }) {
   const {messages} = getAIInputMessages(node, attributes);
@@ -287,13 +285,7 @@ function InputTab({
 
   const hasContent = (messages && messages.length > 0) || toolArgs || embeddingsInput;
   if (!hasContent) {
-    return (
-      <TabFallback
-        isLoading={isLoading}
-        isError={isError}
-        emptyMessage={t('No input for this span')}
-      />
-    );
+    return <EmptyTab message={t('No input for this span')} />;
   }
 
   return (
@@ -321,25 +313,15 @@ function InputTab({
 function OutputTab({
   node,
   attributes,
-  isLoading,
-  isError,
 }: {
   attributes: SpanAttributes;
-  isError: boolean;
-  isLoading: boolean;
   node: AITraceSpanNode;
 }) {
   const {responseText, responseObject, toolCalls} = getAIOutputData(node, attributes);
   const toolOutput = getAIToolOutput(node, attributes);
 
   if (!responseText && !responseObject && !toolCalls && !toolOutput) {
-    return (
-      <TabFallback
-        isLoading={isLoading}
-        isError={isError}
-        emptyMessage={t('No output for this span')}
-      />
-    );
+    return <EmptyTab message={t('No output for this span')} />;
   }
 
   return (
@@ -386,12 +368,8 @@ function MessageContent({content}: {content: unknown}) {
 function AttributesTab({
   node,
   attributes,
-  isLoading,
-  isError,
 }: {
   attributes: SpanAttributes;
-  isError: boolean;
-  isLoading: boolean;
   node: AITraceSpanNode;
 }) {
   const theme = useTheme();
@@ -401,18 +379,8 @@ function AttributesTab({
   const {projects} = useProjects({slugs: projectSlug ? [projectSlug] : []});
   const project = projectSlug ? projects.find(p => p.slug === projectSlug) : undefined;
 
-  if (!isEAPSpanNode(node)) {
+  if (!isEAPSpanNode(node) || !attributes) {
     return <EmptyTab message={t('No attributes for this span')} />;
-  }
-
-  if (!attributes) {
-    return (
-      <TabFallback
-        isLoading={isLoading}
-        isError={isError}
-        emptyMessage={t('No attributes for this span')}
-      />
-    );
   }
 
   return (
@@ -425,31 +393,6 @@ function AttributesTab({
       project={project}
     />
   );
-}
-
-/**
- * Fallback for a tab with no renderable content. Tool inputs/results and
- * embeddings aren't returned by the conversation list endpoint, so they only
- * appear once the per-span fetch resolves — show a placeholder while it's in
- * flight and an error state on failure so a pending or failed load isn't
- * mistaken for genuinely empty I/O.
- */
-function TabFallback({
-  isLoading,
-  isError,
-  emptyMessage,
-}: {
-  emptyMessage: string;
-  isError: boolean;
-  isLoading: boolean;
-}) {
-  if (isLoading) {
-    return <Placeholder />;
-  }
-  if (isError) {
-    return <EmptyTab message={t('Failed to load span details')} />;
-  }
-  return <EmptyTab message={emptyMessage} />;
 }
 
 function EmptyTab({message}: {message: string}) {
@@ -469,19 +412,33 @@ function SpanDetailSkeleton({embedded}: {embedded?: boolean}) {
       </Flex>
       <Stack gap="md" flexShrink={0}>
         <Placeholder height="16px" width="60px" />
-        <Grid columns="max-content minmax(0, 1fr)" gap="md lg" align="center">
-          <Placeholder height="14px" width="80px" />
-          <Placeholder height="14px" width="200px" />
-          <Placeholder height="14px" width="60px" />
-          <Placeholder height="14px" width="160px" />
-        </Grid>
+        <SpanMetadataSkeleton />
       </Stack>
+      <SpanTabsSkeleton />
+    </SpanDetailCard>
+  );
+}
+
+function SpanMetadataSkeleton() {
+  return (
+    <Grid columns="max-content minmax(0, 1fr)" gap="md lg" align="center">
+      <Placeholder height="14px" width="80px" />
+      <Placeholder height="14px" width="200px" />
+      <Placeholder height="14px" width="60px" />
+      <Placeholder height="14px" width="160px" />
+    </Grid>
+  );
+}
+
+function SpanTabsSkeleton() {
+  return (
+    <Fragment>
       <Flex gap="lg" flexShrink={0}>
         <Placeholder height="16px" width="44px" />
         <Placeholder height="16px" width="56px" />
         <Placeholder height="16px" width="96px" />
       </Flex>
       <Placeholder height="240px" width="100%" />
-    </SpanDetailCard>
+    </Fragment>
   );
 }

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -165,7 +165,7 @@ export function ConversationSpanDetail({
         </Flex>
         {isAttributesLoading ? (
           <SpanMetadataSkeleton />
-        ) : isError ? null : (
+        ) : (
           <SpanMetadata node={node} attributes={attributes} />
         )}
       </Stack>


### PR DESCRIPTION
The metadata card and the input/output/attributes tabs are backed by a per-span fetch that the conversation list endpoint doesn't return. Each piece previously rendered its own placeholder and popped in on its own as the fetch resolved, shifting the layout every time the user clicked between spans.

Now the metadata and tabs sit behind a single skeleton until the fetch resolves, then appear together so the panel lands in its final shape once. The header (icon, title) and duration come from the list data and stay visible throughout, since they don't change when the fetch lands. The skeleton reuses the same placeholder shapes as the full-panel loading state, so the two loading states look identical.

Fixes [TET-2617](https://linear.app/getsentry/issue/TET-2617/delay-in-span-details-resulting-in-layout-shift)