### PR TITLE
feat(ai): Unify XML tag collapsing across chat and span details

### DIFF
--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -103,7 +103,6 @@ export function MessagesPanelNew({
                     text={message.content}
                     inline
                     autoCollapseLimit={10}
-                    collapsibleXmlTags
                   />
                 </MessageText>
               </UserMessageBlock>
@@ -195,12 +194,7 @@ function AssistantTurn({
           onClick={onClick}
         >
           <MessageText align="left">
-            <AIContentRenderer
-              text={message.content}
-              inline
-              autoCollapseLimit={10}
-              collapsibleXmlTags
-            />
+            <AIContentRenderer text={message.content} inline autoCollapseLimit={10} />
           </MessageText>
         </AssistantMessageBlock>
       )}
@@ -254,12 +248,7 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
     >
       <Container padding="xs md">
         <MessageText size="sm" align="left" variant="muted" monospace>
-          <AIContentRenderer
-            text={reasoning}
-            inline
-            autoCollapseLimit={10}
-            collapsibleXmlTags
-          />
+          <AIContentRenderer text={reasoning} inline autoCollapseLimit={10} />
         </MessageText>
       </Container>
     </CollapsibleContent>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -106,7 +106,7 @@ export function AIContentRenderer({
   inline = false,
   maxJsonDepth = 2,
   autoCollapseLimit,
-  collapsibleXmlTags,
+  collapsibleXmlTags = true,
 }: AIContentRendererProps) {
   const detection = useMemo(() => detectAIContentType(text), [text]);
 


### PR DESCRIPTION
Align the XML tag collapsing behavior between the AI chat bubble transcript and the input/output span details.

Both surfaces render AI message content through the shared `AIContentRenderer`, but only the transcript call sites passed `collapsibleXmlTags`. As a result, chat bubbles collapsed XML tags into clickable blocks while the input/output span details (`aiInput`, `aiOutput`, and the redesigned `conversationSpanDetail`) rendered the same tags always-expanded with different styling.

This flips the `collapsibleXmlTags` default to `true` in `AIContentRenderer`, so every surface that uses the renderer collapses XML tags consistently, and removes the now-redundant explicit prop from the transcript call sites in `messagesPanelNew`.

We chose to change the default in one place rather than add the prop to each span-details call site, so the behavior stays unified and future call sites can't silently diverge again. Note this also applies collapsing to the legacy `messagesPanel` (flag-off) path, which is consistent and being retired.

Fixes TET-2627