### PR TITLE
fix(conversations): Sort agent selector options alphabetically

### DIFF
--- a/static/app/views/insights/common/components/agentSelector.tsx
+++ b/static/app/views/insights/common/components/agentSelector.tsx
@@ -76,10 +76,12 @@ export function AgentSelector({referrer}: AgentSelectorProps) {
     });
 
     // Show the agents that were selected when the menu opened at the top of the
-    // list. sortBy is stable, so the count-desc order is preserved within the
-    // selected and unselected groups.
+    // list, then sort each group alphabetically.
     const anchor = new Set(orderAnchor);
-    return sortBy(list, option => !anchor.has(option.value));
+    return sortBy(list, [
+      option => !anchor.has(option.value),
+      option => option.label.toLowerCase(),
+    ]);
   }, [agentData, selectedAgents, orderAnchor]);
 
   return (


### PR DESCRIPTION
The agent selector dropdown in the conversations/agent-monitoring UI recently stopped ordering options alphabetically.

`#119182` added `sortBy(list, option => !anchor.has(option.value))` to float agents that were selected when the menu opened to the top. Because `sortBy` is stable and the options are fetched sorted by span count (`count()` desc), the visible order within each group became count-descending rather than alphabetical.

This adds an alphabetical (case-insensitive) tiebreaker as a secondary sort key, so agents are sorted A–Z within both the selected and unselected groups while the "selected first" behavior is preserved.

## Before
- Selected agents first, then the rest — each group ordered by span count (desc)

## After
- Selected agents first, then the rest — each group ordered alphabetically
