### PR TITLE
fix(conversations): Order thinking between tool calls

### DIFF
--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -159,24 +159,49 @@ function AssistantTurn({
   const hasMeta =
     cost !== undefined || (message.duration !== undefined && message.duration > 0);
   const meta = <AssistantMeta cost={cost} duration={message.duration} />;
+  const assistantBlocks = message.assistantBlocks ?? [];
 
   return (
     <Fragment>
-      {message.toolCalls && message.toolCalls.length > 0 && (
-        <MessageBlock>
-          <MessageToolCallsNew
-            toolCalls={message.toolCalls}
-            selectedNodeId={selectedNodeId}
-            nodeMap={nodeMap}
-            nodeTraceMap={nodeTraceMap}
-            onSelectNode={onSelectNode}
-          />
-        </MessageBlock>
-      )}
-      {message.reasoning && (
-        <MessageBlock>
-          <ReasoningSection reasoning={message.reasoning} />
-        </MessageBlock>
+      {assistantBlocks.length > 0 ? (
+        assistantBlocks.map((block, index) =>
+          block.type === 'toolCalls' ? (
+            <MessageBlock
+              key={`tool-${index}-${block.toolCalls.map(toolCall => toolCall.nodeId).join('-')}`}
+            >
+              <MessageToolCallsNew
+                toolCalls={block.toolCalls}
+                selectedNodeId={selectedNodeId}
+                nodeMap={nodeMap}
+                nodeTraceMap={nodeTraceMap}
+                onSelectNode={onSelectNode}
+              />
+            </MessageBlock>
+          ) : (
+            <MessageBlock key={`reasoning-${index}`}>
+              <ReasoningSection reasoning={block.reasoning} />
+            </MessageBlock>
+          )
+        )
+      ) : (
+        <Fragment>
+          {message.toolCalls && message.toolCalls.length > 0 && (
+            <MessageBlock>
+              <MessageToolCallsNew
+                toolCalls={message.toolCalls}
+                selectedNodeId={selectedNodeId}
+                nodeMap={nodeMap}
+                nodeTraceMap={nodeTraceMap}
+                onSelectNode={onSelectNode}
+              />
+            </MessageBlock>
+          )}
+          {message.reasoning && (
+            <MessageBlock>
+              <ReasoningSection reasoning={message.reasoning} />
+            </MessageBlock>
+          )}
+        </Fragment>
       )}
       {message.content === '' ? (
         // Tool/reasoning-only turn: still surface the turn's cost and duration.

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -971,6 +971,49 @@ describe('conversationMessages utilities', () => {
       const assistant = turnsToMessages(turns).find(m => m.role === 'assistant');
       expect(assistant?.reasoning).toBe('Let me think step by step...');
     });
+
+    it('orders thinking between matched tool outputs from input history', () => {
+      const inputMessages = JSON.stringify([
+        {role: 'user', content: 'Question'},
+        {role: 'assistant', parts: [{type: 'tool_call', toolName: 'search'}]},
+        {role: 'tool', content: 'Search result'},
+        {
+          role: 'assistant',
+          parts: [
+            {type: 'reasoning', content: 'Thinking between tools'},
+            {type: 'tool_call', toolName: 'calculator'},
+          ],
+        },
+        {role: 'tool', content: 'Calculator result'},
+      ]);
+      const turns = [
+        makeTurn({
+          generation: {
+            id: 'gen-1',
+            value: {start_timestamp: 1000, end_timestamp: 1100},
+            attributes: {[SpanFields.GEN_AI_INPUT_MESSAGES]: inputMessages},
+          } as any,
+          assistantContent: 'Final answer',
+          toolCalls: [
+            {name: 'search', nodeId: 'tool-1', hasError: false},
+            {name: 'calculator', nodeId: 'tool-2', hasError: false},
+          ],
+        }),
+      ];
+
+      const assistant = turnsToMessages(turns).find(m => m.role === 'assistant');
+      expect(assistant?.assistantBlocks).toEqual([
+        {
+          type: 'toolCalls',
+          toolCalls: [{name: 'search', nodeId: 'tool-1', hasError: false}],
+        },
+        {type: 'reasoning', reasoning: 'Thinking between tools'},
+        {
+          type: 'toolCalls',
+          toolCalls: [{name: 'calculator', nodeId: 'tool-2', hasError: false}],
+        },
+      ]);
+    });
   });
 
   describe('extractMessagesFromNodes (integration)', () => {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -25,6 +25,12 @@ export interface ToolCall {
   duration?: number;
 }
 
+// Temporary render-order metadata for the new transcript. Long term, split the
+// transcript into ordered items instead of embedding UI blocks in ConversationMessage.
+export type ConversationAssistantBlock =
+  | {toolCalls: ToolCall[]; type: 'toolCalls'}
+  | {reasoning: string; type: 'reasoning'};
+
 export interface ConversationMessage {
   content: string;
   id: string;
@@ -32,6 +38,7 @@ export interface ConversationMessage {
   role: 'user' | 'assistant';
   timestamp: number;
   agentName?: string;
+  assistantBlocks?: ConversationAssistantBlock[];
   duration?: number;
   modelName?: string;
   reasoning?: string;
@@ -247,6 +254,8 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
       }
       const modelName = getStringAttr(turn.generation, SpanFields.GEN_AI_RESPONSE_MODEL);
 
+      const assistantBlocks = getOrderedAssistantBlocks(turn.generation, turn.toolCalls);
+
       messages.push({
         id: `assistant-${turn.generation.id}`,
         role: 'assistant',
@@ -254,6 +263,7 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
         timestamp: endTs,
         nodeId: turn.generation.id,
         toolCalls: hasToolCalls ? turn.toolCalls : undefined,
+        assistantBlocks,
         duration,
         agentName: agentName || undefined,
         modelName: modelName || undefined,
@@ -275,6 +285,135 @@ function findToolSpansBetween(
     const ts = getNodeTimestamp(span);
     return ts > startTime && ts < endTime;
   });
+}
+
+function getOrderedAssistantBlocks(
+  node: AITraceSpanNode,
+  toolCalls: ToolCall[]
+): ConversationAssistantBlock[] | undefined {
+  if (toolCalls.length < 2) {
+    return undefined;
+  }
+
+  const raw =
+    getStringAttr(node, SpanFields.GEN_AI_INPUT_MESSAGES) ||
+    getStringAttr(node, SpanFields.GEN_AI_REQUEST_MESSAGES);
+
+  if (!raw || raw === FILTERED) {
+    return undefined;
+  }
+
+  const messages = parseRawMessages(raw);
+  if (messages.length === 0) {
+    return undefined;
+  }
+
+  const blocks: ConversationAssistantBlock[] = [];
+  let toolResultCount = 0;
+  let matchedToolCount = 0;
+  let matchedReasoning = false;
+
+  for (const message of messages) {
+    const reasoning = getReasoningFromMessage(message);
+    if (reasoning) {
+      blocks.push({type: 'reasoning', reasoning});
+      matchedReasoning = true;
+    }
+
+    if (isToolResultMessage(message)) {
+      toolResultCount++;
+      if (matchedToolCount < toolCalls.length) {
+        const toolCall = toolCalls[matchedToolCount];
+        if (!toolCall) {
+          continue;
+        }
+        blocks.push({type: 'toolCalls', toolCalls: [toolCall]});
+        matchedToolCount++;
+      }
+    }
+  }
+
+  if (
+    toolResultCount !== toolCalls.length ||
+    matchedToolCount !== toolCalls.length ||
+    !matchedReasoning
+  ) {
+    return undefined;
+  }
+
+  return blocks;
+}
+
+function parseRawMessages(raw: string): unknown[] {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+    if (isRecord(parsed) && Array.isArray(parsed.messages)) {
+      return parsed.messages;
+    }
+  } catch {
+    // Existing parsing paths handle invalid JSON; ordered blocks are best-effort.
+  }
+  return [];
+}
+
+function getReasoningFromMessage(message: unknown): string | null {
+  if (!isRecord(message) || message.role !== 'assistant') {
+    return null;
+  }
+
+  const parts = getMessageParts(message);
+  const reasoning = parts
+    .map(part => {
+      if (!isRecord(part)) {
+        return null;
+      }
+      const type = getStringValue(part.type);
+      if (type !== 'reasoning' && type !== 'thinking') {
+        return null;
+      }
+      return getStringValue(part.content) ?? getStringValue(part.text);
+    })
+    .filter(Boolean);
+
+  return reasoning.length > 0 ? reasoning.join('\n') : null;
+}
+
+function isToolResultMessage(message: unknown): boolean {
+  if (!isRecord(message)) {
+    return false;
+  }
+  if (message.role === 'tool') {
+    return true;
+  }
+
+  return getMessageParts(message).some(part => {
+    if (!isRecord(part)) {
+      return false;
+    }
+    const type = getStringValue(part.type);
+    return type === 'tool_result' || type === 'tool_call_response';
+  });
+}
+
+function getMessageParts(message: Record<string, unknown>): unknown[] {
+  if (Array.isArray(message.parts)) {
+    return message.parts;
+  }
+  if (Array.isArray(message.content)) {
+    return message.content;
+  }
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getStringValue(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
 }
 
 /**


### PR DESCRIPTION
The new conversation transcript now places thinking blocks between tool calls when the AI client input history shows that order. When the tool output count does not match the tool spans, the transcript keeps the existing fallback rendering of all tool calls followed by thinking.

This keeps the fix scoped while both old and new transcript renderers coexist

Before:

After:


Closes TET-2637

