### PR TITLE
fix(conversations): Align transcript turn metadata

### DIFF
--- a/static/app/views/explore/conversations/components/turnMeta.tsx
+++ b/static/app/views/explore/conversations/components/turnMeta.tsx
@@ -1,6 +1,6 @@
 import type {ReactNode} from 'react';
 
-import {Grid} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 
 /**
  * Fixed-width, right-aligned metric + duration columns, mirroring the spans
@@ -8,10 +8,18 @@ import {Grid} from '@sentry/scraps/layout';
  * across message bubbles and tool-call rows.
  */
 export function TurnMeta({metric, duration}: {duration: ReactNode; metric: ReactNode}) {
+  if (!metric && !duration) {
+    return null;
+  }
+
   return (
-    <Grid flexShrink={0} columns="100px 56px" gap="md" justifyItems="end">
-      {metric}
-      {duration}
-    </Grid>
+    <Flex flexShrink={0} gap="md">
+      <Flex width="12ch" justify="end">
+        {metric}
+      </Flex>
+      <Flex width="8ch" justify="end">
+        {duration}
+      </Flex>
+    </Flex>
   );
 }


### PR DESCRIPTION
Transcript metadata now keeps separate right-aligned slots for metrics and duration, so rows with only a duration do not render that value in the metric column.

The sizing uses character-relative widths instead of fixed pixel columns while preserving the existing metric/duration spacing.

Before:
<img width="1462" height="572" alt="CleanShot 2026-07-08 at 12 16 38@2x" src="https://github.com/user-attachments/assets/89da9a3b-b1d4-45d5-bb9f-b9e8e8fa7a25" />


After:
<img width="1462" height="572" alt="CleanShot 2026-07-08 at 12 18 27@2x" src="https://github.com/user-attachments/assets/b9676bed-6743-4536-83aa-3edda8d5f42c" />
