### PR TITLE
fix(conversations): Don't auto-select a span on the transcript view

### DIFF
--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -51,6 +51,9 @@ export function ConversationViewContentNew({
     onSelectSpan,
     focusedTool,
     isLoading,
+    // The transcript opens the span detail only on user action; the timeline
+    // still auto-selects a default span on load.
+    autoSelectDefaultNode: isTimeline,
   });
 
   const [detailState, setDetailState] = useQueryStates(


### PR DESCRIPTION
Landing on the conversation transcript auto-selected the first assistant span and opened its detail pane, instead of leaving nothing selected until the user clicks a message.

[#119094](https://github.com/getsentry/sentry/pull/119094) dropped the `autoSelectDefaultNode: isTimeline` argument to `useConversationSelection` while wiring up selectable messages, which reverted the hook to its `true` default and reintroduced auto-selection on the transcript.

Fixes TET-2643