### PR TITLE
ci: Show in-flight tests on test suite timeout

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n ${XDIST_WORKERS} --dist=loadfile"
-          timeout 1200 make run-acceptance || rc=$?
+          timeout -k 30 1200 make run-acceptance || rc=$?
           [ "${rc:-0}" -ne 124 ] || echo "::error::Test run timed out after 20 minutes (possible xdist hang)"
           exit "${rc:-0}"
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n ${XDIST_WORKERS} --dist=loadfile"
-          timeout -k 30 1200 make run-acceptance || rc=$?
+          timeout --signal=INT -k 30 1200 make run-acceptance || rc=$?
           [ "${rc:-0}" -ne 124 ] || echo "::error::Test run timed out after 20 minutes (possible xdist hang)"
           exit "${rc:-0}"
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
           export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n ${XDIST_WORKERS} --dist=loadfile"
-          timeout --signal=INT -k 30 1200 make run-acceptance || rc=$?
+          timeout -k 30 1200 make run-acceptance || rc=$?
           [ "${rc:-0}" -ne 124 ] || echo "::error::Test run timed out after 20 minutes (possible xdist hang)"
           exit "${rc:-0}"
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -294,7 +294,7 @@ jobs:
         run: |
           if [ -n "${XDIST_WORKERS}" ]; then
             export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n ${XDIST_WORKERS} --dist=loadfile"
-            timeout 1200 make test-python-ci || {
+            timeout -k 30 1200 make test-python-ci || {
               rc=$?
               if [ "$rc" -eq 124 ]; then
                 echo "::error::Test run timed out after 20 minutes (possible xdist hang)"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -294,7 +294,7 @@ jobs:
         run: |
           if [ -n "${XDIST_WORKERS}" ]; then
             export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n ${XDIST_WORKERS} --dist=loadfile"
-            timeout -k 30 1200 make test-python-ci || {
+            timeout --signal=INT -k 30 1200 make test-python-ci || {
               rc=$?
               if [ "$rc" -eq 124 ]; then
                 echo "::error::Test run timed out after 20 minutes (possible xdist hang)"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -294,7 +294,7 @@ jobs:
         run: |
           if [ -n "${XDIST_WORKERS}" ]; then
             export PYTEST_ADDOPTS="$PYTEST_ADDOPTS -n ${XDIST_WORKERS} --dist=loadfile"
-            timeout --signal=INT -k 30 1200 make test-python-ci || {
+            timeout -k 30 1200 make test-python-ci || {
               rc=$?
               if [ "$rc" -eq 124 ]; then
                 echo "::error::Test run timed out after 20 minutes (possible xdist hang)"

--- a/src/sentry/testutils/pytest/__init__.py
+++ b/src/sentry/testutils/pytest/__init__.py
@@ -12,6 +12,7 @@ pytest_plugins = [
     "sentry.testutils.pytest.json_report_reruns",
     "sentry.testutils.pytest.show_flaky_failures",
     "sentry.testutils.thread_leaks.pytest",
+    "sentry.testutils.pytest.timeout_info",
 ]
 
 if os.environ.get("SENTRY_SKIP_SELENIUM_PLUGIN") != "1":

--- a/src/sentry/testutils/pytest/timeout_info.py
+++ b/src/sentry/testutils/pytest/timeout_info.py
@@ -1,0 +1,45 @@
+import os
+import signal
+import sys
+import time
+
+import pytest
+
+_in_flight: dict[str, float] = {}
+_original_stdout_fd: int | None = None
+
+
+def _on_sigterm(signum, frame):
+    msg_parts = []
+    if _in_flight:
+        msg_parts.append(f"\n\n{'=' * 60}")
+        msg_parts.append("SIGTERM received — tests still in progress:")
+        now = time.monotonic()
+        for nodeid, start in sorted(_in_flight.items(), key=lambda x: x[1]):
+            elapsed = now - start
+            msg_parts.append(f"  [{elapsed:.1f}s] {nodeid}")
+        msg_parts.append(f"{'=' * 60}\n")
+    msg = "\n".join(msg_parts)
+    fd = _original_stdout_fd if _original_stdout_fd is not None else 1
+    try:
+        os.write(fd, msg.encode())
+    except Exception:
+        pass
+    os._exit(1)
+
+
+def pytest_configure(config):
+    global _original_stdout_fd
+    _original_stdout_fd = os.dup(sys.stdout.fileno())
+    signal.signal(signal.SIGTERM, _on_sigterm)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_logstart(nodeid, location):
+    _in_flight[nodeid] = time.monotonic()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_logreport(report):
+    if report.when == "teardown":
+        _in_flight.pop(report.nodeid, None)

--- a/src/sentry/testutils/pytest/timeout_info.py
+++ b/src/sentry/testutils/pytest/timeout_info.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import os
 import signal
 import sys
 import time
+from types import FrameType
 
 import pytest
+from _pytest.config import Config
+from _pytest.reports import TestReport
 
 _in_flight: dict[str, float] = {}
 _original_stdout_fd: int | None = None
 
 
-def _on_sigterm(signum, frame):
+def _on_sigterm(signum: int, frame: FrameType | None) -> None:
     msg_parts = []
     if _in_flight:
         msg_parts.append(f"\n\n{'=' * 60}")
@@ -28,18 +33,18 @@ def _on_sigterm(signum, frame):
     os._exit(1)
 
 
-def pytest_configure(config):
+def pytest_configure(config: Config) -> None:
     global _original_stdout_fd
     _original_stdout_fd = os.dup(sys.stdout.fileno())
     signal.signal(signal.SIGTERM, _on_sigterm)
 
 
 @pytest.hookimpl(trylast=True)
-def pytest_runtest_logstart(nodeid, location):
+def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]) -> None:
     _in_flight[nodeid] = time.monotonic()
 
 
 @pytest.hookimpl(trylast=True)
-def pytest_runtest_logreport(report):
+def pytest_runtest_logreport(report: TestReport) -> None:
     if report.when == "teardown":
         _in_flight.pop(report.nodeid, None)


### PR DESCRIPTION
When a pytest run hits the 20-minute `timeout` in CI, the process is killed with no output about which tests were still in progress. 
The only signal is dots and a generic "Test run timed out after 20 minutes" annotation.

This adds a small pytest plugin (`timeout_info`) that registers a SIGTERM handler. 
When the timeout fires, it prints the currently in-flight tests with their durations before exiting:

```
============================================================
SIGTERM received — tests still in progress:
  [3.8s] test_hang.py::test_hangs_forever
============================================================
```

This might be useful to tell if the timeout is just random flakiness, or caused by a specific test that hangs or runs for too long.

The plugin saves the original stdout fd at configure time to bypass pytest's per-test capture, and uses `os._exit` to avoid noisy traceback output from xdist teardown.

The `timeout` invocations in `backend.yml` and `acceptance.yml` gain `-k 30` so that after SIGTERM there's a 30-second window for the plugin to print before escalating to SIGKILL.