### PR TITLE
fix(conversations): Widen tool calls tooltip trigger area

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -1,7 +1,7 @@
 import {Fragment, memo, useCallback, useMemo, useState} from 'react';
+import {css, type Theme} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
-import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
@@ -25,6 +25,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {isUUID} from 'sentry/utils/string/isUUID';
+import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -345,6 +346,8 @@ function ToolCallsCell({
   dataRow: Conversation;
   isRowHovered: boolean;
 }) {
+  const [isCellHovered, setIsCellHovered] = useState(false);
+
   // Prefetch the breakdown on row hover so the card is already populated by the
   // time it opens. Shares the card's query key, so this only warms the cache —
   // it never fires a second request. The card fetches on its own when opened
@@ -358,14 +361,55 @@ function ToolCallsCell({
     return <Text as="div">{formatAbbreviatedNumber(dataRow.toolCalls)}</Text>;
   }
 
+  // Hovering anywhere in the cell force-opens the tooltip, but it stays anchored
+  // to the number itself (`position="top"` over the number-sized count) rather
+  // than the center of the wide cell. Once the pointer leaves the cell we hand
+  // control back to the tooltip's own hover handling (forceVisible falls through
+  // to undefined) so the hoverable breakdown card and its close delay still work.
+  //
+  // Each cell gets its own hover-overlay group so a neighbouring cell opening
+  // can't snap this one closed — that snap-close state can't be cleared through
+  // the force-visible path, which would otherwise leave a hovered cell blank.
   return (
-    <Text as="div">
-      <InfoText
-        maxWidth={400}
-        title={<ConversationToolCallsBreakdown conversationId={dataRow.conversationId} />}
-      >
-        {formatAbbreviatedNumber(dataRow.toolCalls)}
-      </InfoText>
-    </Text>
+    <Flex flex="1" align="center">
+      {props => (
+        <div
+          {...props}
+          onMouseEnter={() => setIsCellHovered(true)}
+          onMouseLeave={() => setIsCellHovered(false)}
+        >
+          <HoverOverlayGroupProvider>
+            <Tooltip
+              // `undefined` (not `false`) hands control back to native hover so
+              // the card stays reachable; `false` would force it shut on leave.
+              forceVisible={isCellHovered || undefined}
+              isHoverable
+              skipWrapper
+              position="top"
+              maxWidth={400}
+              title={
+                <ConversationToolCallsBreakdown conversationId={dataRow.conversationId} />
+              }
+            >
+              <Text
+                tabIndex={0}
+                css={(theme: Theme) => css`
+                  text-decoration: underline dotted ${theme.tokens.content.secondary};
+                  text-decoration-thickness: 0.75px;
+                  text-underline-offset: 1.25px;
+                  outline: none;
+
+                  &:focus-visible {
+                    ${theme.focusRing()}
+                  }
+                `}
+              >
+                {formatAbbreviatedNumber(dataRow.toolCalls)}
+              </Text>
+            </Tooltip>
+          </HoverOverlayGroupProvider>
+        </div>
+      )}
+    </Flex>
   );
 }


### PR DESCRIPTION
**Before**


https://github.com/user-attachments/assets/05b07528-9090-4142-a08d-3830fea51dd8


**After**


https://github.com/user-attachments/assets/bad6478b-0a45-4bfc-b536-95e37b5c4825




Fixes [TET-2640](https://linear.app/getsentry/issue/TET-2640/tool-calls-tooltip-should-have-larger-trigger-area)