### PR TITLE
fix(trace): Escape syntax-like span attribute filters

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.spec.tsx
@@ -3,10 +3,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
   getAttributeFilterSearch,
+  getSearchInExploreTarget,
   getTraceAttributesTreeActions,
   getTraceKeyValueActions,
   getTraceIssueSeverityClassName,
   parseJsonWithFix,
+  TraceDrawerActionKind,
   TraceDrawerActionValueKind,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
@@ -26,6 +28,78 @@ describe('getAttributeFilterSearch', () => {
     expect(getAttributeFilterSearch('span.description', 'GET /api/users')).toBe(
       'span.description:"GET /api/users"'
     );
+  });
+
+  it('quotes JSON array attribute values as a single literal', () => {
+    expect(
+      getAttributeFilterSearch(
+        'gen_ai.system_instructions',
+        '[{"type": "text", "content": "hello"}]'
+      )
+    ).toBe(
+      'gen_ai.system_instructions:"[{\\"type\\": \\"text\\", \\"content\\": \\"hello\\"}]"'
+    );
+  });
+});
+
+const organization = OrganizationFixture({slug: 'org-slug'});
+const location = LocationFixture({query: {statsPeriod: '14d'}});
+
+describe('getSearchInExploreTarget', () => {
+  it('quotes JSON array values as a single literal in the generated explore query', () => {
+    const target = getSearchInExploreTarget(
+      organization,
+      location,
+      '1',
+      'gen_ai.system_instructions',
+      '[{"type": "text", "content": "hello"}]',
+      TraceDrawerActionKind.INCLUDE
+    );
+
+    expect(target.query.query).toBe(
+      'gen_ai.system_instructions:"[{\\"type\\": \\"text\\", \\"content\\": \\"hello\\"}]"'
+    );
+  });
+
+  it('escapes already escaped quotes in JSON string values for the query layer', () => {
+    const target = getSearchInExploreTarget(
+      organization,
+      location,
+      '1',
+      'gen_ai.system_instructions',
+      '[{"type": "text", "content": "say \\"backend\\""}]',
+      TraceDrawerActionKind.INCLUDE
+    );
+
+    expect(target.query.query).toBe(
+      'gen_ai.system_instructions:"[{\\"type\\": \\"text\\", \\"content\\": \\"say \\\\"backend\\\\"\\"}]"'
+    );
+  });
+
+  it('quotes values that are already wrapped in quotes as a single literal', () => {
+    const target = getSearchInExploreTarget(
+      organization,
+      location,
+      '1',
+      'span.description',
+      '"hello"',
+      TraceDrawerActionKind.INCLUDE
+    );
+
+    expect(target.query.query).toBe('span.description:"\\"hello\\""');
+  });
+
+  it('handles null values', () => {
+    const target = getSearchInExploreTarget(
+      organization,
+      location,
+      '1',
+      'app.device',
+      null,
+      TraceDrawerActionKind.INCLUDE
+    );
+
+    expect(target.query.query).toBe('app.device:""');
   });
 });
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -53,21 +53,42 @@ export enum TraceDrawerActionKind {
   LESS_THAN = 'less_than',
 }
 
+// TODO(constantinius): Hoist literal-value handling into MutableSearch so UI-added
+// filter values cannot be interpreted as search syntax by default.
+function escapeSearchQuotedValue(value: string) {
+  return value.replace(/"/g, '\\"');
+}
+
+function formatSearchFilterValue(value: string | null) {
+  if (value === null) {
+    return '';
+  }
+
+  if (
+    (value.startsWith('[') && value.endsWith(']')) ||
+    (value.startsWith('"') && value.endsWith('"'))
+  ) {
+    return `"${escapeSearchQuotedValue(value)}"`;
+  }
+  return value;
+}
+
 export function getSearchInExploreTarget(
   organization: Organization,
   location: Location,
   projectIds: string | string[] | undefined,
   key: string,
-  value: string,
+  value: string | null,
   kind: TraceDrawerActionKind
 ) {
   const {start, end, statsPeriod} = normalizeDateTimeParams(location.query);
   const search = new MutableSearch('');
+  const filterValue = formatSearchFilterValue(value);
 
   if (kind === TraceDrawerActionKind.INCLUDE) {
-    search.setFilterValues(key, [value]);
+    search.setFilterValues(key, [filterValue]);
   } else if (kind === TraceDrawerActionKind.EXCLUDE) {
-    search.setFilterValues(`!${key}`, [value]);
+    search.setFilterValues(`!${key}`, [filterValue]);
   } else if (kind === TraceDrawerActionKind.GREATER_THAN) {
     search.setFilterValues(key, [`>${value}`]);
   } else {
@@ -115,7 +136,10 @@ export function sortAttributes(attributes: TraceItemResponseAttribute[]) {
 
 export function getAttributeFilterSearch(rowKey: string, rowValue: string | number) {
   const search = new MutableSearch('');
-  search.addFilterValue(rowKey, rowValue.toString());
+  search.addFilterValue(
+    rowKey,
+    typeof rowValue === 'number' ? rowValue.toString() : formatSearchFilterValue(rowValue)
+  );
   return search.formatString();
 }
 


### PR DESCRIPTION
Trace drawer Explore actions now treat bracket-wrapped and quote-wrapped attribute values as literals before handing them to `MutableSearch`. Values like JSON arrays previously looked like existing search syntax, so `MutableSearch` preserved them unquoted and the parser could split on spaces or field-like fragments inside the value.

This is intentionally scoped to the trace drawer paths that build Explore filters and copy attribute filters. The follow-up general solution is to move literal-value handling into `MutableSearch` itself, so UI-added values can be marked as literals instead of being interpreted as query syntax at any call site.

Closes TET-2571