### PR TITLE
feat(features): Register organizations:ui-migration-breadcrumbs flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -359,6 +359,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Enables view hierarchy attachment scrubbing
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable the redesigned page breadcrumbs (BreadcrumbList) on migrated pages
+    manager.add("organizations:ui-migration-breadcrumbs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-powered assertion suggestions for uptime monitors
     manager.add("organizations:uptime-ai-assertion-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam classification at User Feedback ingest time


### PR DESCRIPTION
Registers the `organizations:ui-migration-breadcrumbs` feature flag (OrganizationFeature, FlagPole, `api_expose=True`) that gates the redesigned page breadcrumbs (`BreadcrumbList`) on migrated pages.

Off by default. Backend-only, split from the frontend gating per the repo's frontend/backend deploy-split rule — this should land first so the flag exists to be toggled. Rollout (which orgs / %) lives in `sentry-options-automator` (FlagPole YAML).

Frontend usage lands in #119060.

Refs DE-1348 — https://linear.app/getsentry/issue/DE-1348/develop-new-components-ready-for-migration