### PR TITLE
chore: Use `uv` for lint pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,13 +22,13 @@ repos:
       # Configuration for ruff exists in pyproject.toml.
       - id: ruff-check
         name: ruff check
-        entry: .venv/bin/ruff check --force-exclude --fix --quiet
+        entry: uv run ruff check --force-exclude --fix --quiet
         language: system
         types: [python]
         require_serial: true
       - id: ruff-format
         name: ruff format
-        entry: .venv/bin/ruff format --force-exclude --quiet
+        entry: uv run ruff format --force-exclude --quiet
         language: system
         types_or: [python, pyi]
         require_serial: true
@@ -37,14 +37,14 @@ repos:
       # Configuration for flake8 S* rules exists in setup.cfg.
       - id: flake8-sentry
         name: flake8 (sentry rules)
-        entry: .venv/bin/flake8 --select=S
+        entry: uv run flake8 --select=S
         language: system
         types: [python]
         log_file: '.artifacts/flake8.pycodestyle.log'
         require_serial: true
       - id: mypy
         name: mypy
-        entry: bash -c 'if [ -n "${SENTRY_MYPY_PRE_PUSH:-}" ]; then exec .venv/bin/mypy --no-warn-unused-configs "$@"; fi' --
+        entry: bash -c 'if [ -n "${SENTRY_MYPY_PRE_PUSH:-}" ]; then exec uv run mypy --no-warn-unused-configs "$@"; fi' --
         language: system
         stages: [pre-push]
         types: [python]


### PR DESCRIPTION
Use `uv` to avoid managing virtual environments and make it easier for agents.