### PR TITLE
feat(conversations): Polish transcript layout width and spacing

### DIFF
--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -47,6 +47,8 @@ interface UserMessageBlockProps {
 export function UserMessageBlock({children, className, expand}: UserMessageBlockProps) {
   return (
     <MessageBlock justify="end" className={className}>
+      {/* Placeholder for spacing as we want to keep the right aligned look even on smaller screens */}
+      <Container paddingLeft="3xl" flexShrink={0} />
       <UserBubble
         maxWidth={AI_MESSAGE_MAX_WIDTH}
         width={expand ? '100%' : 'fit-content'}

--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -51,6 +51,9 @@ export function ConversationViewContentNew({
     onSelectSpan,
     focusedTool,
     isLoading,
+    // The transcript opens the span detail only on user action; the timeline
+    // still auto-selects a default span on load.
+    autoSelectDefaultNode: isTimeline,
   });
 
   const [detailState, setDetailState] = useQueryStates(

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -91,6 +91,7 @@ export function ConversationViewContainer({children}: {children: React.ReactNode
       overflow="hidden"
       border={hasConversationsRedesign ? undefined : 'primary'}
       radius={hasConversationsRedesign ? undefined : 'md'}
+      maxWidth={hasConversationsRedesign ? '1340px' : undefined}
       background="primary"
       display="flex"
     >


### PR DESCRIPTION
Constrain the conversation redesign container to a max width of 1340px, and add a spacing placeholder to the user message block.

The transcript view could stretch arbitrarily wide on large viewports, hurting readability; capping the container keeps line lengths comfortable. Separately, the user message bubble is right-aligned, but on smaller screens it could lose that alignment — a fixed-width placeholder on the left preserves the right-aligned look across breakpoints.

Both changes are gated behind the existing `hasConversationsRedesign` flag (the max-width only applies when the redesign is on), so there's no impact on the current layout.

Part of TET-2613