### PR TITLE
fix(explore): Report aggregate sort in Seer on-page context

### DIFF
--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -23,6 +23,7 @@ import {
 } from 'sentry/views/explore/queryParams/context';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 
 function Wrapper({children}: {children: ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
@@ -169,6 +170,26 @@ describe('SpansTabContent', () => {
       expect.objectContaining({result_mode: 'aggregates'})
     );
   });
+
+  it('publishes the aggregate sort to the LLM context in aggregate mode', async () => {
+    let getLLMContext: ReturnType<typeof useLLMContext>['getLLMContext'] | undefined;
+    function Component() {
+      ({getLLMContext} = useLLMContext());
+      return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
+    }
+
+    render(<Component />, {organization, additionalWrapper: Wrapper});
+
+    await userEvent.click(await screen.findByRole('tab', {name: 'Aggregates'}));
+    await screen.findByText(/No spans found/);
+
+    await waitFor(() => {
+      const node = getLLMContext!().nodes.find(n => n.nodeType === 'traces-explorer');
+      const data = node?.data as Record<string, unknown>;
+      expect(data.activeTab).toBe('aggregate');
+      expect(data.sortBys).toEqual(['-count(span.duration)']);
+    });
+  }, 20_000);
 
   it('inserts group bys from aggregate mode as fields in samples mode', async () => {
     let fields: readonly string[] = [];

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -189,7 +189,7 @@ describe('SpansTabContent', () => {
       expect(data.activeTab).toBe('aggregate');
       expect(data.sortBys).toEqual(['-count(span.duration)']);
     });
-  }, 20_000);
+  });
 
   it('inserts group bys from aggregate mode as fields in samples mode', async () => {
     let fields: readonly string[] = [];

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -49,6 +49,7 @@ import {
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
 import {
+  useQueryParamsAggregateSortBys,
   useQueryParamsExtrapolate,
   useQueryParamsGroupBys,
   useQueryParamsId,
@@ -195,7 +196,12 @@ function SpanTabContentSectionInner({
   const crossEventDatasetAvailability = useCrossEventDatasetAvailability(organization);
   const crossEventQueries = useCrossEventQueries(crossEventDatasetAvailability);
   const sortBys = useQueryParamsSortBys();
+  const aggregateSortBys = useQueryParamsAggregateSortBys();
   const groupBys = useQueryParamsGroupBys();
+
+  // In aggregate mode the table is driven by aggregateSortBys, not the
+  // samples sort (which falls back to `-timestamp`), so pick accordingly.
+  const activeSortBys = tab === Mode.AGGREGATE ? aggregateSortBys : sortBys;
 
   // Push page state into the LLM context tree for Seer Explorer.
   useLLMContext({
@@ -207,7 +213,7 @@ function SpanTabContentSectionInner({
     activeTab: tab,
     visualizes: visualizes.map(v => v.yAxis),
     groupBys: groupBys.filter(g => g !== ''),
-    sortBys: sortBys.map(s => (s.kind === 'desc' ? `-${s.field}` : s.field)),
+    sortBys: activeSortBys.map(s => (s.kind === 'desc' ? `-${s.field}` : s.field)),
     currentSelectedDateRange: selection.datetime,
   });
 


### PR DESCRIPTION
The traces explorer publishes its query state into the Seer Explorer LLM (on-page) context, but it always read the samples sort. In aggregate mode the visible table is sorted by the *aggregate* sort, so the context reported the inert samples default instead of the sort actually driving the results — feeding Seer a stale, misleading value.

**Sort now tracks the active mode**

`useLLMContext` reads `aggregateSortBys` in aggregate mode and `sortBys` otherwise, matching what the rendered table uses. On the aggregates tab the reported sort changes from the samples fallback to the real aggregate sort:

```diff
- sortBys: ["-timestamp"]
+ sortBys: ["-count(span.duration)"]
```

Samples, trace, and attribute-breakdown tabs are unchanged.

Adds a `spansTab` test that renders the real explorer, switches to the aggregates tab, and asserts the published `traces-explorer` context carries the aggregate sort (fails on the pre-fix code with `-timestamp`).