### PR TITLE
feat(conversations): Deselect span when closing detail

### DIFF
--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -31,6 +31,7 @@ interface ConversationViewContentNewProps {
   activeTab: ConversationViewTab;
   conversation: UseConversationsOptions;
   focusedTool?: string | null;
+  onDeselectSpan?: () => void;
   onSelectSpan?: (spanId: string) => void;
   selectedSpanId?: string | null;
 }
@@ -40,21 +41,12 @@ export function ConversationViewContentNew({
   activeTab,
   selectedSpanId,
   onSelectSpan,
+  onDeselectSpan,
   focusedTool,
 }: ConversationViewContentNewProps) {
   const isTimeline = activeTab === 'timeline';
 
   const {nodes, nodeTraceMap, isLoading, error} = useConversation(conversation);
-  const {selectedNode, handleSelectNode} = useConversationSelection({
-    nodes,
-    selectedSpanId,
-    onSelectSpan,
-    focusedTool,
-    isLoading,
-    // The transcript opens the span detail only on user action; the timeline
-    // still auto-selects a default span on load.
-    autoSelectDefaultNode: isTimeline,
-  });
 
   const [detailState, setDetailState] = useQueryStates(
     {
@@ -63,6 +55,18 @@ export function ConversationViewContentNew({
     },
     {history: 'replace'}
   );
+
+  const {selectedNode, handleSelectNode} = useConversationSelection({
+    nodes,
+    selectedSpanId,
+    onSelectSpan,
+    focusedTool,
+    isLoading,
+    // The transcript opens the span detail only on user action; the timeline
+    // auto-selects a default span on load, but not once the user explicitly
+    // closes the detail (which deselects the span).
+    autoSelectDefaultNode: isTimeline && detailState.detailOpen,
+  });
   const handleSelectAndOpenDetail = useCallback(
     (node: AITraceSpanNode) => {
       setDetailState({detailOpen: true});
@@ -133,7 +137,10 @@ export function ConversationViewContentNew({
               traceId={selectedNode ? (nodeTraceMap?.get(selectedNode.id) ?? '') : ''}
               activeTab={detailState.detailTab}
               onTabChange={detailTab => setDetailState({detailTab})}
-              onClose={() => setDetailState({detailOpen: false, detailTab: null})}
+              onClose={() => {
+                setDetailState({detailOpen: false, detailTab: null});
+                onDeselectSpan?.();
+              }}
             />
           ) : null
         }

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -62,6 +62,10 @@ export function ConversationDetailPageNew() {
     [setQueryState]
   );
 
+  const handleDeselectSpan = useCallback(() => {
+    setQueryState({spanId: null, focusedTool: null});
+  }, [setQueryState]);
+
   return (
     <ViewportConstrainedPage background="secondary">
       <TopBar.Slot name="title">
@@ -90,6 +94,7 @@ export function ConversationDetailPageNew() {
             activeTab={queryState.tab}
             selectedSpanId={queryState.spanId}
             onSelectSpan={handleSelectSpan}
+            onDeselectSpan={handleDeselectSpan}
             focusedTool={queryState.focusedTool}
           />
         </ConversationViewContainer>

--- a/static/app/views/explore/conversations/hooks/useConversationSelection.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationSelection.spec.tsx
@@ -1,0 +1,79 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+import {SpanFields} from 'sentry/views/insights/types';
+
+import {useConversationSelection} from './useConversationSelection';
+
+function createToolNode(id: string, startTimestamp = 1000): AITraceSpanNode {
+  const end = startTimestamp + 100;
+  return {
+    id,
+    type: 'span' as const,
+    op: 'gen_ai.execute_tool',
+    startTimestamp,
+    endTimestamp: end,
+    value: {start_timestamp: startTimestamp, end_timestamp: end},
+    attributes: {
+      [SpanFields.GEN_AI_OPERATION_TYPE]: 'tool',
+      [SpanFields.GEN_AI_TOOL_NAME]: `tool-${id}`,
+    },
+    errors: new Set(),
+  } as unknown as AITraceSpanNode;
+}
+
+describe('useConversationSelection', () => {
+  const nodes = [createToolNode('span-a', 1000), createToolNode('span-b', 2000)];
+
+  it('auto-selects the default node when enabled and nothing is selected', () => {
+    const onSelectSpan = jest.fn();
+
+    const {result} = renderHookWithProviders(() =>
+      useConversationSelection({
+        nodes,
+        selectedSpanId: null,
+        onSelectSpan,
+        isLoading: false,
+        autoSelectDefaultNode: true,
+      })
+    );
+
+    expect(onSelectSpan).toHaveBeenCalledWith('span-a');
+    expect(result.current.selectedNode?.id).toBe('span-a');
+  });
+
+  it('does not auto-select when disabled, so an explicit deselect sticks', () => {
+    const onSelectSpan = jest.fn();
+
+    const {result} = renderHookWithProviders(() =>
+      useConversationSelection({
+        nodes,
+        selectedSpanId: null,
+        onSelectSpan,
+        isLoading: false,
+        // Mirrors the timeline after the user closes the span detail.
+        autoSelectDefaultNode: false,
+      })
+    );
+
+    expect(onSelectSpan).not.toHaveBeenCalled();
+    expect(result.current.selectedNode).toBeUndefined();
+  });
+
+  it('resolves an explicitly selected span even with auto-select disabled', () => {
+    const onSelectSpan = jest.fn();
+
+    const {result} = renderHookWithProviders(() =>
+      useConversationSelection({
+        nodes,
+        selectedSpanId: 'span-b',
+        onSelectSpan,
+        isLoading: false,
+        autoSelectDefaultNode: false,
+      })
+    );
+
+    expect(onSelectSpan).not.toHaveBeenCalled();
+    expect(result.current.selectedNode?.id).toBe('span-b');
+  });
+});


### PR DESCRIPTION
Closing the span detail in the redesigned conversation view now deselects the span everywhere instead of only hiding the detail pane. The transcript and timeline highlights clear and the `spanId` is removed from the URL, so the selection state no longer disagrees with an empty detail pane.

**Timeline auto-select**

The timeline's default-span auto-select is now gated on the detail being open, so an explicit close sticks instead of immediately re-selecting a span. Re-entering the timeline reopens the detail and restores the default selection as before.

Scoped to the redesign (behind `hasGenAiConversationsRedesignFeature`); the legacy view is untouched since its detail panel has no close button.

Closes https://linear.app/getsentry/issue/TET-2645/closing-span-details-should-deselect-the-span-in-timelinetranscripturl