### PR TITLE
feat(conversations): Add dot separator to metric/duration meta

### DIFF
--- a/static/app/components/ai/chat/collapsibleContent.tsx
+++ b/static/app/components/ai/chat/collapsibleContent.tsx
@@ -76,6 +76,7 @@ export function CollapsibleContent({
 
 const Details = styled('details')`
   width: 100%;
+  min-width: 0;
 
   summary {
     list-style: none;

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -18,7 +18,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {MessageToolCallsNew} from 'sentry/views/explore/conversations/components/messageToolCallsNew';
-import {TurnMeta} from 'sentry/views/explore/conversations/components/turnMeta';
+import {
+  TURN_META_WIDTH,
+  TurnMeta,
+} from 'sentry/views/explore/conversations/components/turnMeta';
 import {
   type ConversationMessage,
   extractMessagesFromNodes,
@@ -181,6 +184,7 @@ function AssistantTurn({
       {message.reasoning && (
         <MessageBlock>
           <ReasoningSection reasoning={message.reasoning} />
+          <Container width={TURN_META_WIDTH} flexShrink={0} />
         </MessageBlock>
       )}
       {message.content === '' ? (

--- a/static/app/views/explore/conversations/components/turnMeta.tsx
+++ b/static/app/views/explore/conversations/components/turnMeta.tsx
@@ -1,11 +1,14 @@
 import type {ReactNode} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+export const TURN_META_WIDTH = '140px';
 
 /**
- * Fixed-width, right-aligned metric + duration columns, mirroring the spans
- * timeline. Space is reserved even when a value is absent so the columns line up
- * across message bubbles and tool-call rows.
+ * Fixed-width, right-aligned metric + duration, mirroring the spans timeline.
+ * A dot separates the two when both are present. The block keeps a fixed width
+ * so values line up across message bubbles and tool-call rows.
  */
 export function TurnMeta({metric, duration}: {duration: ReactNode; metric: ReactNode}) {
   if (!metric && !duration) {
@@ -13,13 +16,14 @@ export function TurnMeta({metric, duration}: {duration: ReactNode; metric: React
   }
 
   return (
-    <Flex flexShrink={0} gap="md">
-      <Flex width="12ch" justify="end">
-        {metric}
-      </Flex>
-      <Flex width="8ch" justify="end">
-        {duration}
-      </Flex>
+    <Flex flexShrink={0} width={TURN_META_WIDTH} align="center" justify="end" gap="xs">
+      {metric}
+      {metric && duration ? (
+        <Text size="xs" variant="muted">
+          •
+        </Text>
+      ) : null}
+      {duration}
     </Flex>
   );
 }

--- a/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanTimeline.tsx
@@ -254,7 +254,7 @@ const TimelineRow = memo(function TimelineRow({
                   </Tooltip>
                 )}
               </Flex>
-              <Flex flexShrink={0} width="100px" justify="end">
+              <Flex align="center" justify="end" flexShrink={0} gap="xs">
                 {metric ? (
                   <Text
                     size="sm"
@@ -282,8 +282,11 @@ const TimelineRow = memo(function TimelineRow({
                     </Text>
                   )
                 ) : null}
-              </Flex>
-              <Flex flexShrink={0} width="56px" justify="end">
+                {metric || isTool ? (
+                  <Text size="sm" variant={isSelected ? 'primary' : 'muted'}>
+                    •
+                  </Text>
+                ) : null}
                 <Text
                   size="sm"
                   variant={isSelected ? 'primary' : 'muted'}


### PR DESCRIPTION
Separate the metric and duration values with a `•` in the conversation meta — both in the transcript turn meta (`TurnMeta`) and in the spans timeline rows (`aiSpanTimeline`). Each row's metric, separator, and duration are now grouped into a single tight cluster instead of sitting in separate fixed-width columns, so they no longer read as a sparse grid.

The timeline previously placed the metric and duration in two fixed-width columns that were direct children of a `gap="md"` flex row, which spread them far apart. Grouping them into one flex and spacing with `gap="xs"` fixes that while keeping them right-aligned. The transcript `TurnMeta` gets the matching treatment and re-exports `TURN_META_WIDTH` so the reasoning block can reserve the same width and stay aligned with the message rows above it. `collapsibleContent` gains `min-width: 0` so collapsible content can shrink within the new flex layout.

Fixes TET-2642