### PR TITLE
fix(taskworker): Add the ability to send canary tasks from taskbroker_send_tasks

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -404,8 +404,12 @@ def taskbroker_send_tasks(
     namespace: str,
     extra_arg_bytes: int | None,
 ) -> None:
+    from taskbroker_client.canary import CANARY_TASK_NAME
+    from taskbroker_client.constants import INTERNAL_NAMESPACE
+
     from sentry.conf.server import KAFKA_CLUSTERS
     from sentry.taskworker.adapters import set_route_overrides
+    from sentry.taskworker.runtime import app
     from sentry.utils.imports import import_string
 
     if bootstrap_servers:
@@ -414,11 +418,14 @@ def taskbroker_send_tasks(
     if kafka_topic and namespace:
         set_route_overrides({namespace: kafka_topic})
 
-    try:
-        func = import_string(task_function_path)
-    except Exception as e:
-        click.echo(f"Error: {e}")
-        raise click.Abort()
+    if task_function_path == CANARY_TASK_NAME and namespace == INTERNAL_NAMESPACE:
+        func = app.get_task(namespace, task_function_path)
+    else:
+        try:
+            func = import_string(task_function_path)
+        except Exception as e:
+            click.echo(f"Error: {e}")
+            raise click.Abort()
 
     task_args = [] if not args else eval(args)
     task_kwargs = {} if not kwargs else eval(kwargs)


### PR DESCRIPTION
For verifying non-sentry pools, there is a default canary task that is registered for every pool.
Adding that task to the sender to make it easier to test new pools. Verified that the task is sent
locally.