### PR TITLE
ref(weekly-report): Merge error and perf sections into unified Top Issues

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -726,8 +726,8 @@ def render_template_context(
             ),
         }
 
-    def key_errors():
-        def all_key_errors():
+    def top_issues():
+        def all_issues():
             for project_ctx in user_projects:
                 for group, count in project_ctx.key_errors_by_group:
                     display = get_group_display(group)
@@ -748,12 +748,6 @@ def render_template_context(
                         "group_substatus_color": substatus_color,
                         "group_substatus_text_color": substatus_text_color,
                     }
-
-        return heapq.nlargest(5, all_key_errors(), lambda d: d["count"])
-
-    def key_performance_issues():
-        def all_key_performance_issues():
-            for project_ctx in user_projects:
                 for group, group_history, count in project_ctx.key_performance_issues:
                     display = get_group_display(group)
                     (
@@ -779,7 +773,7 @@ def render_template_context(
                         "group_substatus_text_color": substatus_text_color,
                     }
 
-        return heapq.nlargest(5, all_key_performance_issues(), lambda d: d["count"])
+        return heapq.nlargest(5, all_issues(), lambda d: d["count"])
 
     def past_issues():
         def all_past_issues():
@@ -825,8 +819,7 @@ def render_template_context(
         "start": date_format(local_start),
         "end": date_format(local_end),
         "trends": trends(),
-        "key_errors": key_errors(),
-        "key_performance_issues": key_performance_issues(),
+        "top_issues": top_issues(),
         "past_issues": past_issues() if show_past_issues else [],
         "show_past_issues": show_past_issues,
         "issue_summary": issue_summary(),

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -406,33 +406,10 @@
   </div>
   {% endif %}
 
-  {% if key_errors|length > 0 and not enhanced_privacy %}
-  <div id="key-errors">
-    <h4>Issues with the most errors</h4>
-    {% for a in key_errors %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
-      <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
-      <div style="width: 65%; min-width: 0; overflow: hidden;">
-        {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
-        {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 21px; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
-           href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
-        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 17px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
-        <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
-      </div>
-      {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.group_substatus}}</span>
-      {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
-      {% endif %}
-      </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-  {% if key_performance_issues|length > 0 and not enhanced_privacy %}
-  <div id="key-performance-issues">
-    <h4>Most frequent performance issues</h4>
-    {% for a in key_performance_issues %}
+  {% if top_issues|length > 0 and not enhanced_privacy %}
+  <div id="top-issues">
+    <h4>Top Issues</h4>
+    {% for a in top_issues %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0; overflow: hidden;">

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -461,8 +461,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "regression_substatus_count": 0,
                 "total_substatus_count": 2,
             }
-            assert len(context["key_errors"]) == 0
-            assert len(context["key_performance_issues"]) == 2
+            assert len(context["top_issues"]) == 2
             assert context["trends"]["total_error_count"] == 2
             assert context["trends"]["total_transaction_count"] == 10
             assert "Weekly Report for" in message_params["subject"]
@@ -544,8 +543,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "regression_substatus_count": 0,
                 "total_substatus_count": 4,
             }
-            assert len(context["key_errors"]) == 2
-            assert len(context["key_performance_issues"]) == 2
+            assert len(context["top_issues"]) == 4
             assert context["trends"]["total_error_count"] == 2
             assert context["trends"]["total_transaction_count"] == 10
             assert "Weekly Report for" in message_params["subject"]
@@ -618,7 +616,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "regression_substatus_count": 0,
                 "total_substatus_count": 2,
             }
-            assert len(context["key_errors"]) == 2
+            assert len(context["top_issues"]) == 2
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -712,7 +710,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
                 "regression_substatus_count": 0,
                 "total_substatus_count": 0,
             }
-            assert len(context["key_errors"]) == 0
+            assert len(context["top_issues"]) == 0
             assert context["trends"]["total_error_count"] == 2
             assert context["trends"]["total_transaction_count"] == 10
             assert "Weekly Report for" in message_params["subject"]
@@ -920,7 +918,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         unique_enum_count = len(enum_values)
         assert len(group_status_to_color) == unique_enum_count
 
-    def test_key_errors_and_performance_issues_share_substatus_badges(self) -> None:
+    def test_top_issues_share_substatus_badges(self) -> None:
         user = self.create_user()
         self.create_member(teams=[self.team], user=user, organization=self.organization)
         error_group = self.create_group(
@@ -954,15 +952,15 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         rendered_context = render_template_context(ctx, user.id)
 
         assert rendered_context is not None
-        key_error = rendered_context["key_errors"][0]
-        performance_issue = rendered_context["key_performance_issues"][0]
+        issues = rendered_context["top_issues"]
+        assert len(issues) == 2
         substatus_fields = (
             "group_substatus",
             "group_substatus_color",
             "group_substatus_text_color",
         )
-        assert {field: key_error[field] for field in substatus_fields} == {
-            field: performance_issue[field] for field in substatus_fields
+        assert {field: issues[0][field] for field in substatus_fields} == {
+            field: issues[1][field] for field in substatus_fields
         }
 
     @mock.patch("sentry.analytics.record")
@@ -1385,8 +1383,7 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
         ctx = message_params["context"]
 
         assert ctx["enhanced_privacy"]
-        assert len(ctx["key_errors"]) == 0
-        assert len(ctx["key_performance_issues"]) == 0
+        assert len(ctx["top_issues"]) == 0
         assert ctx["trends"]["total_error_count"] == 2
         assert ctx["issue_summary"] is not None
 
@@ -1834,4 +1831,4 @@ class WeeklyReportsTest(OutcomesSnubaTest, SnubaTestCase, PerformanceIssueTestCa
             context = call_args.kwargs["context"]
             assert context["show_past_issues"] is False
             assert len(context["past_issues"]) == 0
-            assert len(context["key_errors"]) == 1
+            assert len(context["top_issues"]) == 1


### PR DESCRIPTION
## Summary
- Merge separate "Issues with the most errors" and "Most frequent performance issues" email sections into a single "Top Issues" section
- Combine `key_errors()` and `key_performance_issues()` template context functions into `top_issues()`, showing top 5 across both categories by event count
- Update email template (`body.html`) to render the unified section

Stacks on #amyc/worktree-surface-top-issues

## Test plan
- [x] All 46 weekly report tests pass
- [x] Updated assertions from `key_errors`/`key_performance_issues` to `top_issues`