### PR TITLE
feat(issues): Serve recommended_v2 behind the recommended sort key

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -319,8 +319,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-stream-recommended-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Make the "recommended" sort the default sort in the issue stream
     manager.add("organizations:issue-stream-recommended-sort-default", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Show the experimental "recommended" sort (recommended_v2) as an option in the issue stream sort dropdown
-    manager.add("organizations:issue-stream-recommended-sort-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Serve the recommended_v2 scorer behind the issue stream's "recommended" sort
+    manager.add("organizations:issue-stream-recommended-sort-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the "progress" sort option (by issue fix-cycle progress) in the issue stream
     manager.add("organizations:issue-stream-progress-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -183,6 +183,15 @@ def search_issues(
         query_kwargs["environments"] = environments if environments else None
 
         query_kwargs["actor"] = request.user
+        # Serve the v2 scorer behind the single "Recommended" sort; clients never
+        # see the recommended_v2 sort key, so the flag can flip scoring per-org
+        # without any client state changing.
+        if query_kwargs["sort_by"] == "recommended" and features.has(
+            "organizations:issue-stream-recommended-sort-experimental",
+            organization,
+            actor=request.user,
+        ):
+            query_kwargs["sort_by"] = "recommended_v2"
         if query_kwargs["sort_by"] == "progress" and not features.has(
             "organizations:issue-stream-progress-sort", organization, actor=request.user
         ):

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -185,13 +185,17 @@ def search_issues(
         query_kwargs["actor"] = request.user
         # Serve the v2 scorer behind the single "Recommended" sort; clients never
         # see the recommended_v2 sort key, so the flag can flip scoring per-org
-        # without any client state changing.
+        # without any client state changing. sort=recommended_v1 and
+        # sort=recommended_v2 remain explicit escape hatches for comparing the
+        # two scorers regardless of the flag.
         if query_kwargs["sort_by"] == "recommended" and features.has(
             "organizations:issue-stream-recommended-sort-experimental",
             organization,
             actor=request.user,
         ):
             query_kwargs["sort_by"] = "recommended_v2"
+        elif query_kwargs["sort_by"] == "recommended_v1":
+            query_kwargs["sort_by"] = "recommended"
         if query_kwargs["sort_by"] == "progress" and not features.has(
             "organizations:issue-stream-progress-sort", organization, actor=request.user
         ):

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -212,6 +212,28 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             response = self.get_success_response(sort="progress", query="is:unresolved")
         assert [item["id"] for item in response.data] == [str(group_2.id), str(group_1.id)]
 
+    def test_recommended_sort_serves_v2_with_experimental_flag(self) -> None:
+        # group_1 has the newer event, so it wins the base recommended score (recency);
+        # group_2 is regressed, which only the v2 scorer boosts.
+        group_1 = self.store_event(
+            data={"timestamp": before_now(seconds=1).isoformat(), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        ).group
+        group_2 = self.store_event(
+            data={"timestamp": before_now(hours=1).isoformat(), "fingerprint": ["group-2"]},
+            project_id=self.project.id,
+        ).group
+        group_2.update(substatus=GroupSubStatus.REGRESSED)
+        self.login_as(user=self.user)
+
+        response = self.get_success_response(sort="recommended", query="is:unresolved")
+        assert [item["id"] for item in response.data] == [str(group_1.id), str(group_2.id)]
+
+        # The same sort key serves the v2 scorer when the flag is on.
+        with self.feature("organizations:issue-stream-recommended-sort-experimental"):
+            response = self.get_success_response(sort="recommended", query="is:unresolved")
+        assert [item["id"] for item in response.data] == [str(group_2.id), str(group_1.id)]
+
     def test_sort_by_inbox(self) -> None:
         group_1 = self.store_event(
             data={

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -234,6 +234,14 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             response = self.get_success_response(sort="recommended", query="is:unresolved")
         assert [item["id"] for item in response.data] == [str(group_2.id), str(group_1.id)]
 
+        # Explicit escape hatches force a scorer regardless of the flag.
+        response = self.get_success_response(sort="recommended_v2", query="is:unresolved")
+        assert [item["id"] for item in response.data] == [str(group_2.id), str(group_1.id)]
+
+        with self.feature("organizations:issue-stream-recommended-sort-experimental"):
+            response = self.get_success_response(sort="recommended_v1", query="is:unresolved")
+        assert [item["id"] for item in response.data] == [str(group_1.id), str(group_2.id)]
+
     def test_sort_by_inbox(self) -> None:
         group_1 = self.store_event(
             data={


### PR DESCRIPTION
When an org has `issue-stream-recommended-sort-experimental`, the issue stream endpoint now rewrites `sort=recommended` to the `recommended_v2` scorer (same pattern as the existing `progress` sort gate). Clients only ever see one "Recommended" sort — URLs, saved searches, and the persisted sort selection all keep the `recommended` value — so the flag flips scoring per-org with no client state involved, and rollback is a flag flip.