### PR TITLE
feat(issues): Move merge/unmerge tasks to dedicated namespace

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -17,7 +17,7 @@ from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.tasks.post_process import fetch_buffered_group_stats
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import issues_merge_tasks
 from sentry.tsdb.base import TSDBModel
 
 logger = logging.getLogger("sentry.merge")
@@ -26,7 +26,7 @@ delete_logger = logging.getLogger("sentry.deletions.async")
 
 @instrumented_task(
     name="sentry.tasks.merge.merge_groups",
-    namespace=issues_tasks,
+    namespace=issues_merge_tasks,
     retry=Retry(delay=60 * 5),
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -17,7 +17,7 @@ from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.tasks.post_process import fetch_buffered_group_stats
-from sentry.taskworker.namespaces import issues_merge_tasks
+from sentry.taskworker.namespaces import issues_merge_tasks, issues_tasks
 from sentry.tsdb.base import TSDBModel
 
 logger = logging.getLogger("sentry.merge")
@@ -27,6 +27,7 @@ delete_logger = logging.getLogger("sentry.deletions.async")
 @instrumented_task(
     name="sentry.tasks.merge.merge_groups",
     namespace=issues_merge_tasks,
+    alias_namespace=issues_tasks,
     retry=Retry(delay=60 * 5),
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -29,7 +29,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_tasks
+from sentry.taskworker.namespaces import issues_merge_tasks
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType
 from sentry.unmerge import InitialUnmergeArgs, SuccessiveUnmergeArgs, UnmergeArgs, UnmergeArgsBase
@@ -498,7 +498,7 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
 
 @instrumented_task(
     name="sentry.tasks.unmerge",
-    namespace=issues_tasks,
+    namespace=issues_merge_tasks,
     processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -29,7 +29,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_merge_tasks
+from sentry.taskworker.namespaces import issues_merge_tasks, issues_tasks
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType
 from sentry.unmerge import InitialUnmergeArgs, SuccessiveUnmergeArgs, UnmergeArgs, UnmergeArgsBase
@@ -499,6 +499,7 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
 @instrumented_task(
     name="sentry.tasks.unmerge",
     namespace=issues_merge_tasks,
+    alias_namespace=issues_tasks,
     processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,
 )


### PR DESCRIPTION
## Summary
- Switches `merge_groups` and `unmerge` tasks from the shared `issues` namespace to the dedicated `issues.merge` namespace
- This isolates merge/unmerge from the ~40 other tasks sharing the `issues` worker pool, preventing merge/unmerge storms from starving other issue processing

## Dependencies
- Namespace registered in #119161 (merged)
- Ops-side routing configured (done)