### PR TITLE
ref(issues): Collapse recommended sort variants into one dropdown option

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -36,11 +36,9 @@ function getSortTooltip(key: IssueSortOptions) {
     case IssueSortOptions.USER:
       return t('Number of users affected.');
     case IssueSortOptions.RECOMMENDED:
-      return t('Issues ranked by combined recency, severity, and impact signals.');
     case IssueSortOptions.RECOMMENDED_V1:
-      return t('The base recommended scorer, without relevance and lifecycle signals.');
     case IssueSortOptions.RECOMMENDED_EXPERIMENTAL:
-      return t('The recommended scorer with additional relevance and lifecycle signals.');
+      return t('Issues ranked by combined recency, severity, and impact signals.');
     case IssueSortOptions.PROGRESS:
       return t('Issues ranked by how far along they are toward a fix.');
     case IssueSortOptions.DATE:
@@ -58,22 +56,23 @@ export function IssueListSortOptions({
   showIcon = true,
 }: Props) {
   const organization = useOrganization();
+  const hasProgressSort =
+    organization.features.includes('issue-stream-progress-sort') ||
+    sort === IssueSortOptions.PROGRESS;
+  // The explicit v1/v2 sort values are URL-only escape hatches for pinning one of
+  // the two recommended scorers; the dropdown just shows them as Recommended.
+  const isPinnedRecommended =
+    sort === IssueSortOptions.RECOMMENDED_V1 ||
+    sort === IssueSortOptions.RECOMMENDED_EXPERIMENTAL;
+  const sortKey = isPinnedRecommended
+    ? IssueSortOptions.RECOMMENDED
+    : sort || IssueSortOptions.DATE;
   const hasRecommendedSort =
     organization.features.includes('issue-stream-recommended-sort') ||
     // If Recommended is the default sort it must also be selectable, otherwise a
     // user with a stored non-recommended sort can't switch back to it.
     organization.features.includes('issue-stream-recommended-sort-default') ||
-    sort === IssueSortOptions.RECOMMENDED;
-  // The experimental flag serves recommended_v2 behind the regular Recommended sort
-  // server-side. The explicit v1/v2 options only render when the sort query param
-  // already carries them — an escape hatch for comparing the two scorers.
-  const hasV1RecommendedSort = sort === IssueSortOptions.RECOMMENDED_V1;
-  const hasExperimentalRecommendedSort =
-    sort === IssueSortOptions.RECOMMENDED_EXPERIMENTAL;
-  const hasProgressSort =
-    organization.features.includes('issue-stream-progress-sort') ||
-    sort === IssueSortOptions.PROGRESS;
-  const sortKey = sort || IssueSortOptions.DATE;
+    sortKey === IssueSortOptions.RECOMMENDED;
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
@@ -82,10 +81,6 @@ export function IssueListSortOptions({
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
     ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
-    ...(hasV1RecommendedSort ? [IssueSortOptions.RECOMMENDED_V1] : []),
-    ...(hasExperimentalRecommendedSort
-      ? [IssueSortOptions.RECOMMENDED_EXPERIMENTAL]
-      : []),
     ...(hasProgressSort ? [IssueSortOptions.PROGRESS] : []),
   ];
 

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -37,10 +37,10 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('Number of users affected.');
     case IssueSortOptions.RECOMMENDED:
       return t('Issues ranked by combined recency, severity, and impact signals.');
+    case IssueSortOptions.RECOMMENDED_V1:
+      return t('The base recommended scorer, without relevance and lifecycle signals.');
     case IssueSortOptions.RECOMMENDED_EXPERIMENTAL:
-      return t(
-        'Experimental recommended sort with additional relevance and lifecycle signals.'
-      );
+      return t('The recommended scorer with additional relevance and lifecycle signals.');
     case IssueSortOptions.PROGRESS:
       return t('Issues ranked by how far along they are toward a fix.');
     case IssueSortOptions.DATE:
@@ -64,9 +64,10 @@ export function IssueListSortOptions({
     // user with a stored non-recommended sort can't switch back to it.
     organization.features.includes('issue-stream-recommended-sort-default') ||
     sort === IssueSortOptions.RECOMMENDED;
-  // The experimental flag now serves recommended_v2 behind the regular Recommended
-  // sort server-side, so the separate option only renders for stale URLs that still
-  // carry the recommended_v2 sort value.
+  // The experimental flag serves recommended_v2 behind the regular Recommended sort
+  // server-side. The explicit v1/v2 options only render when the sort query param
+  // already carries them — an escape hatch for comparing the two scorers.
+  const hasV1RecommendedSort = sort === IssueSortOptions.RECOMMENDED_V1;
   const hasExperimentalRecommendedSort =
     sort === IssueSortOptions.RECOMMENDED_EXPERIMENTAL;
   const hasProgressSort =
@@ -81,6 +82,7 @@ export function IssueListSortOptions({
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
     ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
+    ...(hasV1RecommendedSort ? [IssueSortOptions.RECOMMENDED_V1] : []),
     ...(hasExperimentalRecommendedSort
       ? [IssueSortOptions.RECOMMENDED_EXPERIMENTAL]
       : []),

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -64,8 +64,10 @@ export function IssueListSortOptions({
     // user with a stored non-recommended sort can't switch back to it.
     organization.features.includes('issue-stream-recommended-sort-default') ||
     sort === IssueSortOptions.RECOMMENDED;
+  // The experimental flag now serves recommended_v2 behind the regular Recommended
+  // sort server-side, so the separate option only renders for stale URLs that still
+  // carry the recommended_v2 sort value.
   const hasExperimentalRecommendedSort =
-    organization.features.includes('issue-stream-recommended-sort-experimental') ||
     sort === IssueSortOptions.RECOMMENDED_EXPERIMENTAL;
   const hasProgressSort =
     organization.features.includes('issue-stream-progress-sort') ||

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -55,11 +55,9 @@ export function getSortLabel(key: string) {
     case IssueSortOptions.INBOX:
       return t('Date Added');
     case IssueSortOptions.RECOMMENDED:
-      return t('Recommended');
     case IssueSortOptions.RECOMMENDED_V1:
-      return t('Recommended (v1)');
     case IssueSortOptions.RECOMMENDED_EXPERIMENTAL:
-      return t('Recommended (v2)');
+      return t('Recommended');
     case IssueSortOptions.PROGRESS:
       return t('Progress');
     case IssueSortOptions.DATE:

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -32,6 +32,10 @@ export enum IssueSortOptions {
   USER = 'user',
   INBOX = 'inbox',
   RECOMMENDED = 'recommended',
+  // Escape hatches for comparing the two recommended scorers regardless of
+  // which one the org's flag serves behind RECOMMENDED. Only reachable via the
+  // sort query param.
+  RECOMMENDED_V1 = 'recommended_v1',
   RECOMMENDED_EXPERIMENTAL = 'recommended_v2',
   PROGRESS = 'progress',
 }
@@ -52,8 +56,10 @@ export function getSortLabel(key: string) {
       return t('Date Added');
     case IssueSortOptions.RECOMMENDED:
       return t('Recommended');
+    case IssueSortOptions.RECOMMENDED_V1:
+      return t('Recommended (v1)');
     case IssueSortOptions.RECOMMENDED_EXPERIMENTAL:
-      return t('Recommended (Experimental)');
+      return t('Recommended (v2)');
     case IssueSortOptions.PROGRESS:
       return t('Progress');
     case IssueSortOptions.DATE:


### PR DESCRIPTION
Follow-up to #119232, which repurposed `issue-stream-recommended-sort-experimental` to serve the `recommended_v2` scorer behind the regular "Recommended" sort server-side (and stopped exposing the flag to the API). The dropdown no longer gates a separate experimental option on the flag — there is a single "Recommended" option.

The explicit sort values (`?sort=recommended_v1` / `?sort=recommended_v2`) remain URL-only escape hatches for pinning a specific scorer; the dropdown simply displays them as "Recommended" rather than differentiating.

Independently mergeable with #119232 in either order.