### PR TITLE
fix(replays): handle sentry.cocoa.unreal in configure replay card

### DIFF
--- a/static/app/components/replays/header/configureReplayCard.spec.tsx
+++ b/static/app/components/replays/header/configureReplayCard.spec.tsx
@@ -22,47 +22,44 @@ describe('ConfigureReplayCard', () => {
       const replayRecord = ReplayRecordFixture({
         sdk: {name: 'sentry.cocoa', version: '8.0.0'},
       });
-      render(
-        <ConfigureReplayCard isMobile replayRecord={replayRecord} />,
-        {organization: OrganizationFixture()}
-      );
+      render(<ConfigureReplayCard isMobile replayRecord={replayRecord} />, {
+        organization: OrganizationFixture(),
+      });
 
       await userEvent.click(screen.getByRole('button', {name: 'Configure Replay'}));
 
       expect(captureSpy).not.toHaveBeenCalled();
-      expect(screen.queryAllByRole('option')).not.toHaveLength(0);
+      expect(screen.getAllByRole('menuitemradio')).not.toHaveLength(0);
     });
 
     it('enables menu items for sentry.cocoa.unreal (iOS Unreal via embedded Cocoa SDK)', async () => {
       const replayRecord = ReplayRecordFixture({
         sdk: {name: 'sentry.cocoa.unreal', version: '1.0.0'},
       });
-      render(
-        <ConfigureReplayCard isMobile replayRecord={replayRecord} />,
-        {organization: OrganizationFixture()}
-      );
+      render(<ConfigureReplayCard isMobile replayRecord={replayRecord} />, {
+        organization: OrganizationFixture(),
+      });
 
       await userEvent.click(screen.getByRole('button', {name: 'Configure Replay'}));
 
-      // Should NOT fall through to the default case; no captureMessage call
+      // Should NOT fall through to the default case — no captureMessage call
       expect(captureSpy).not.toHaveBeenCalled();
 
-      // All three items should be enabled (not aria-disabled)
-      const items = screen.getAllByRole('option');
+      // All menu items should be enabled (not aria-disabled)
+      const items = screen.getAllByRole('menuitemradio');
       expect(items.length).toBeGreaterThan(0);
       items.forEach(item => {
         expect(item).not.toHaveAttribute('aria-disabled', 'true');
       });
     });
 
-    it('logs and disables menu items for unknown mobile platforms', async () => {
+    it('logs and disables menu items for unknown mobile platforms', () => {
       const replayRecord = ReplayRecordFixture({
         sdk: {name: 'sentry.unknown.platform', version: '0.0.0'},
       });
-      render(
-        <ConfigureReplayCard isMobile replayRecord={replayRecord} />,
-        {organization: OrganizationFixture()}
-      );
+      render(<ConfigureReplayCard isMobile replayRecord={replayRecord} />, {
+        organization: OrganizationFixture(),
+      });
 
       expect(captureSpy).toHaveBeenCalledWith(
         'Unknown mobile platform in configure card: sentry.unknown.platform'

--- a/static/app/components/replays/header/configureReplayCard.spec.tsx
+++ b/static/app/components/replays/header/configureReplayCard.spec.tsx
@@ -1,0 +1,72 @@
+import * as Sentry from '@sentry/react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ConfigureReplayCard} from 'sentry/components/replays/header/configureReplayCard';
+
+describe('ConfigureReplayCard', () => {
+  let captureSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    captureSpy = jest.spyOn(Sentry, 'captureMessage').mockImplementation(() => '');
+  });
+
+  afterEach(() => {
+    captureSpy.mockRestore();
+  });
+
+  describe('getPath — mobile SDK routing', () => {
+    it('enables menu items for sentry.cocoa (iOS)', async () => {
+      const replayRecord = ReplayRecordFixture({
+        sdk: {name: 'sentry.cocoa', version: '8.0.0'},
+      });
+      render(
+        <ConfigureReplayCard isMobile replayRecord={replayRecord} />,
+        {organization: OrganizationFixture()}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Configure Replay'}));
+
+      expect(captureSpy).not.toHaveBeenCalled();
+      expect(screen.queryAllByRole('option')).not.toHaveLength(0);
+    });
+
+    it('enables menu items for sentry.cocoa.unreal (iOS Unreal via embedded Cocoa SDK)', async () => {
+      const replayRecord = ReplayRecordFixture({
+        sdk: {name: 'sentry.cocoa.unreal', version: '1.0.0'},
+      });
+      render(
+        <ConfigureReplayCard isMobile replayRecord={replayRecord} />,
+        {organization: OrganizationFixture()}
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Configure Replay'}));
+
+      // Should NOT fall through to the default case; no captureMessage call
+      expect(captureSpy).not.toHaveBeenCalled();
+
+      // All three items should be enabled (not aria-disabled)
+      const items = screen.getAllByRole('option');
+      expect(items.length).toBeGreaterThan(0);
+      items.forEach(item => {
+        expect(item).not.toHaveAttribute('aria-disabled', 'true');
+      });
+    });
+
+    it('logs and disables menu items for unknown mobile platforms', async () => {
+      const replayRecord = ReplayRecordFixture({
+        sdk: {name: 'sentry.unknown.platform', version: '0.0.0'},
+      });
+      render(
+        <ConfigureReplayCard isMobile replayRecord={replayRecord} />,
+        {organization: OrganizationFixture()}
+      );
+
+      expect(captureSpy).toHaveBeenCalledWith(
+        'Unknown mobile platform in configure card: sentry.unknown.platform'
+      );
+    });
+  });
+});

--- a/static/app/components/replays/header/configureReplayCard.tsx
+++ b/static/app/components/replays/header/configureReplayCard.tsx
@@ -44,6 +44,7 @@ export function ConfigureReplayCard({
 function getPath(sdkName: string | null | undefined) {
   switch (sdkName) {
     case 'sentry.cocoa':
+    case 'sentry.cocoa.unreal': // Session Replay on iOS builds of Unreal Engine games via the embedded Cocoa SDK
       return 'apple/guides/ios'; // https://docs.sentry.io/platforms/apple/guides/ios/session-replay/
     case 'sentry.java.android':
       return 'android'; // https://docs.sentry.io/platforms/android/session-replay/


### PR DESCRIPTION
## What

Adds `sentry.cocoa.unreal` to the `getPath()` switch in `configureReplayCard.tsx`, routing it to the same `apple/guides/ios` docs path as `sentry.cocoa`.

## Why

`sentry-unreal` (see [sentry-unreal#1468](https://github.com/getsentry/sentry-unreal/pull/1468)) embeds the Cocoa SDK to provide Session Replay on iOS builds of Unreal Engine games. That embedded SDK reports its name as `sentry.cocoa.unreal`. Because this name wasn't in the `getPath()` switch:

- Every affected page load hit the `default` branch, firing `Sentry.captureMessage('Unknown mobile platform in configure card: sentry.cocoa.unreal')`
- All three Configure Replay dropdown items (General / Masking / Identify Users) were disabled for those sessions

The underlying replay implementation is the standard Cocoa SDK, so `apple/guides/ios` is the correct docs target.

## Changes

- `configureReplayCard.tsx`: add `case 'sentry.cocoa.unreal':` as a fall-through to `case 'sentry.cocoa':` with an explanatory comment
- `configureReplayCard.spec.tsx`: new test file covering `sentry.cocoa.unreal` → enabled menu items and no `captureMessage`, plus regression coverage for unknown SDK names

## Verification

TypeScript compiler not available in sandbox; relied on manual review of the one-line fall-through change. CI will cover type checks and the new spec.

Fixes JAVASCRIPT-3ARC


<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC013P75SQUB%3A1783512585.309359/?project=4510944073809921)

<!-- junior-session-footer:end -->