### PR TITLE
feat(taskworker): Make the router default topic configurable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -860,6 +860,12 @@ TASKWORKER_ROUTER: str = "sentry.taskworker.adapters.SentryRouter"
 # Expected to be a JSON encoded dictionary of namespace:topic
 TASKWORKER_ROUTES = os.getenv("TASKWORKER_ROUTES")
 
+# The topic a namespace produces to when it is not explicitly routed via
+# TASKWORKER_ROUTES. When unset, region silos fall back to the `taskworker`
+# topic (control silos always use `taskworker-control`). Set per-region to make
+# a different pool the catch-all, e.g. `taskworker-push` in s4s2.
+TASKWORKER_DEFAULT_TOPIC = os.getenv("TASKWORKER_DEFAULT_TOPIC")
+
 # The list of modules that workers will import after starting up
 # Taskworkers need to import task modules to make tasks
 # accessible to the worker.

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -76,11 +76,14 @@ class SentryRouter(LibraryRouter):
             except Exception as err:
                 capture_exception(err)
         self._route_map = routes
-        self._default_topic = (
-            Topic.TASKWORKER_CONTROL
-            if SiloMode.get_current_mode() == SiloMode.CONTROL
-            else Topic.TASKWORKER
-        )
+        if SiloMode.get_current_mode() == SiloMode.CONTROL:
+            # Control silos always use the control topic; the region default
+            # topic override never applies to them.
+            self._default_topic = Topic.TASKWORKER_CONTROL
+        elif settings.TASKWORKER_DEFAULT_TOPIC:
+            self._default_topic = Topic(settings.TASKWORKER_DEFAULT_TOPIC)
+        else:
+            self._default_topic = Topic.TASKWORKER
 
     def route_namespace(self, name: str) -> str:
         # Check local overrides

--- a/tests/sentry/taskworker/test_adapters.py
+++ b/tests/sentry/taskworker/test_adapters.py
@@ -62,6 +62,29 @@ def test_default_router_topic_control_silo() -> None:
         assert topic == Topic.TASKWORKER_CONTROL.value
 
 
+@pytest.mark.django_db
+def test_default_router_topic_override() -> None:
+    with override_settings(
+        SILO_MODE=SiloMode.CELL,
+        TASKWORKER_DEFAULT_TOPIC=Topic.TASKWORKER_PUSH.value,
+    ):
+        router = SentryRouter()
+        topic = router.route_namespace("test.tasks.test_router.unrouted")
+        assert topic == Topic.TASKWORKER_PUSH.value
+
+
+@pytest.mark.django_db(databases=["default", "control"])
+def test_default_router_topic_override_ignored_in_control_silo() -> None:
+    # The region default-topic override must never redirect control-silo tasks.
+    with override_settings(
+        SILO_MODE=SiloMode.CONTROL,
+        TASKWORKER_DEFAULT_TOPIC=Topic.TASKWORKER_PUSH.value,
+    ):
+        router = SentryRouter()
+        topic = router.route_namespace("test.tasks.test_router.control")
+        assert topic == Topic.TASKWORKER_CONTROL.value
+
+
 class TestViewerContextHook:
     def test_on_dispatch_with_context(self) -> None:
         hook = ViewerContextHook()


### PR DESCRIPTION
Makes `SentryRouter`'s fallback topic configurable via a new `TASKWORKER_DEFAULT_TOPIC` setting (env var), instead of the hardcoded `Topic.TASKWORKER` for region silos. This will give us the ability to migrate the default (catch-all) topic to the new push taskworker topic