### PR TITLE
fix(spans): Retry transient process segment task failures

### DIFF
--- a/src/sentry/spans/consumers/process_segments/tasks.py
+++ b/src/sentry/spans/consumers/process_segments/tasks.py
@@ -4,7 +4,10 @@ from functools import partial
 
 from arroyo import Topic as ArroyoTopic
 from arroyo.backends.kafka import KafkaProducer
+from redis.exceptions import TimeoutError as RedisTimeoutError
 from taskbroker_client.constants import CompressionType
+from taskbroker_client.retry import Retry
+from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.conf.types.kafka_definition import Topic
 from sentry.silo.base import SiloMode
@@ -37,7 +40,7 @@ _snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_t
     name="sentry.spans.process_segments.process_segment",
     namespace=spans_process_segments_tasks,
     processing_deadline_duration=65,
-    at_most_once=True,
+    retry=Retry(times=3, delay=5, on=(ProcessingDeadlineExceeded, RedisTimeoutError)),
     compression_type=CompressionType.ZSTD,
     silo_mode=SiloMode.CELL,
 )


### PR DESCRIPTION
Refs STREAM-1589

The old Arroyo `process_segments` consumer had two different failure behaviours:

- Processing exceptions inside `_process_message()` were caught and converted to `InvalidMessage`.
- The broader Kafka/Arroyo pipeline was still at-least-once: crashes, rebalances, producer failures, or offset-commit gaps could replay the same message from `buffered-segments`.

That second behaviour is why we previously saw `sentry.spans.process_segments.duplicate_span` spikes during deployment. A segment could be processed once, mark span dedupe keys, produce some downstream items, then be redelivered before the consumed offset was committed.  For the task path, we did not see this spike anymore as we did not retry at all on failure.

We want to be able to retry on these two transient errors to match previous segments consumers behaviour:

- `ProcessingDeadlineExceeded`: this seems like an error of “the worker did not successfully finish the activation,” which is closer to the old Arroyo at-least-once failure modes than to a deterministic bad segment, which could be retried. Since dedupe filtering is already enabled, the retry should not produce duplicate downstream spans. The known tradeoff remains the existing dedupe tradeoff: if the first attempt timed out after marking dedupe keys but before producing all Snuba items, a retry may drop those already-marked spans.
- `redis.exceptions.TimeoutError`: We saw some Redis timeout came from `_record_signals()` / `FeatureAdoption` cache reads before `_check_span_duplicates()` and before Snuba item production. It would be safe to retry here as no span dedupe keys or downstream span items have been produced at that point.

This intentionally does not retry broad `Exception`. The task should only retry failures that look like transient taskworker/runtime infrastructure problems, while preserving fail-fast behavior for unexpected processing errors.