### PR TITLE
fix(issues): Hide trace section when trace_id is synthetic

### DIFF
--- a/static/app/components/events/contexts/index.spec.ts
+++ b/static/app/components/events/contexts/index.spec.ts
@@ -57,6 +57,37 @@ describe('getOrderedContextItems', () => {
     expect(osIndex).not.toBe(-1);
   });
 
+  it('filters out the trace context when the trace is synthetic', () => {
+    const mockEvent = EventFixture({
+      contexts: {
+        runtime: {name: 'node', type: 'runtime'},
+        trace: {trace_id: 'abc123', span_id: 'def456', status: 'ok'},
+      },
+      _meta: {
+        contexts: {
+          trace: {trace_id: {'': {err: ['trace_id.missing']}}},
+        },
+      },
+    });
+
+    const items = getOrderedContextItems(mockEvent);
+
+    expect(items.find(item => item.alias === 'trace')).toBeUndefined();
+    expect(items.find(item => item.alias === 'runtime')).toBeDefined();
+  });
+
+  it('keeps the trace context when the trace is not synthetic', () => {
+    const mockEvent = EventFixture({
+      contexts: {
+        trace: {trace_id: 'abc123', span_id: 'def456', status: 'ok'},
+      },
+    });
+
+    const items = getOrderedContextItems(mockEvent);
+
+    expect(items.find(item => item.alias === 'trace')).toBeDefined();
+  });
+
   it('filters out empty contexts and contexts only with type', () => {
     const mockEvent = EventFixture({
       contexts: {

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -2,6 +2,7 @@ import {useCallback, useEffect} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {ContextDataSection} from 'sentry/components/events/contexts/contextDataSection';
+import {eventHasSyntheticTrace} from 'sentry/components/events/interfaces/performance/utils';
 import type {Event, EventContexts as EventContextValues} from 'sentry/types/event';
 import {useProjects} from 'sentry/utils/useProjects';
 
@@ -62,7 +63,10 @@ export function getOrderedContextItems(event: Event): ContextItem[] {
   ]);
 
   const items = orderedContext
-    .filter(([_k, ctxValue]) => {
+    .filter(([alias, ctxValue]) => {
+      if (alias === 'trace' && eventHasSyntheticTrace(event)) {
+        return false;
+      }
       const contextKeys = Object.keys(ctxValue ?? {});
       const isInvalid =
         // Empty context

--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -150,4 +150,36 @@ describe('EventTraceView', () => {
 
     expect(await screen.findByText('Trace Preview')).toBeInTheDocument();
   });
+
+  it('does not render the trace section when the trace_id is synthetic', () => {
+    const missingTraceIdEvent = EventFixture({
+      contexts: {
+        trace: {
+          trace_id: traceId,
+        },
+      },
+      eventID: 'issue-5',
+      _meta: {
+        contexts: {
+          trace: {
+            trace_id: {
+              '': {
+                err: ['trace_id.missing'],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    render(
+      <EventTraceView
+        group={group}
+        event={missingTraceIdEvent}
+        organization={organization}
+      />
+    );
+
+    expect(screen.queryByText('Trace Preview')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -5,6 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
 
 import {
+  eventHasSyntheticTrace,
   isWebVitalsEvent,
   TRACE_WATERFALL_PREFERENCES_KEY,
 } from 'sentry/components/events/interfaces/performance/utils';
@@ -163,7 +164,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
   );
 
   // Performance issues have a Span Evidence section that contains the trace view
-  if (!traceId || issueTypeConfig.spanEvidence.enabled) {
+  if (!traceId || eventHasSyntheticTrace(event) || issueTypeConfig.spanEvidence.enabled) {
     return null;
   }
 

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react';
 import keyBy from 'lodash/keyBy';
 
+import {getContextMeta} from 'sentry/components/events/contexts/utils';
 import type {
   RawSpanType,
   TraceContextSpanProxy,
@@ -11,6 +12,17 @@ import {getIssueTypeFromOccurrenceType, IssueType} from 'sentry/types/group';
 
 export const TRACE_WATERFALL_PREFERENCES_KEY =
   'issue-details-trace-waterfall-preferences';
+
+/**
+ * Trace IDs are required for EAP occurrences, but some events will not have a trace (e.g. metric issues).
+ * Relay will synthesize a `trace_id` in this case and flags the field with a `trace_id.missing` remark in `_meta`.
+ */
+export function eventHasSyntheticTrace(event: Event): boolean {
+  const traceMeta = getContextMeta(event, 'trace');
+  return (traceMeta.trace_id?.['']?.err ?? []).some(
+    (err: unknown) => (Array.isArray(err) ? err[0] : err) === 'trace_id.missing'
+  );
+}
 
 export function getSpanInfoFromTransactionEvent(
   event: Pick<


### PR DESCRIPTION
This follows from https://github.com/getsentry/sentry/pull/118678

Metric/cron/uptime issues were displaying a broken trace view after trace IDs were added to all events in the migration to EAP. This PR hides the trace section and context item when the missing trace meta remark is seen on the event.

<img width="600"  alt="CleanShot 2026-07-08 at 10 50 47@2x" src="https://github.com/user-attachments/assets/e07b3ff0-cdf4-4d3b-9fcf-93e0c81f1f56" />
