### PR TITLE
feat(discover): hide transactions saved queries

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -89,6 +89,14 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         # enforces this via `check_object_permissions`; without this filter the list endpoint
         # would leak the body of queries belonging to projects the caller has no access to.
         queryset = filter_to_accessible_discover_queries(request, queryset)
+
+        # Hide transactions saved queries if organizations has the discover transactions
+        # deprecation flag enabled
+        if features.has(
+            "organizations:discover-saved-queries-deprecation", organization, actor=request.user
+        ):
+            queryset = queryset.exclude(dataset=DiscoverSavedQueryTypes.TRANSACTION_LIKE)
+
         query = request.query_params.get("query")
         if query:
             tokens = tokenize_query(query)

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -282,6 +282,46 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert len(response.data) == 1
         assert not any([query["name"] == "Homepage Test Query" for query in response.data])
 
+    def test_get_hides_transaction_queries_with_deprecation_flag(self) -> None:
+        transaction_query = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Transaction query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+            version=1,
+            dataset=DiscoverSavedQueryTypes.TRANSACTION_LIKE,
+        )
+        transaction_query.set_projects(self.project_ids)
+
+        with (
+            self.feature(self.feature_name),
+            self.feature("organizations:discover-saved-queries-deprecation"),
+        ):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200, response.content
+        ids = [row["id"] for row in response.data]
+        assert str(transaction_query.id) not in ids
+        assert all(row["queryDataset"] != "transaction-like" for row in response.data)
+
+    def test_get_shows_transaction_queries_without_deprecation_flag(self) -> None:
+        transaction_query = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Transaction query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+            version=1,
+            dataset=DiscoverSavedQueryTypes.TRANSACTION_LIKE,
+        )
+        transaction_query.set_projects(self.project_ids)
+
+        with self.feature(self.feature_name):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200, response.content
+        ids = [row["id"] for row in response.data]
+        assert str(transaction_query.id) in ids
+
     def test_get_hides_queries_when_no_project_access(self) -> None:
         # Disable Open Membership so project-level access actually applies.
         self.org.flags.allow_joinleave = False


### PR DESCRIPTION
Since we're deprecating discover -> transactions we want to hide those queries in the request. I've put in an exclusion filter behind the deprecation flag.

Closes EXP-1100