### PR TITLE
feat(GAL): Add single-group backfill task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -958,6 +958,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.auth.check_auth",
     "sentry.tasks.auth.cleanup_pending_users",
     "sentry.tasks.auto_ongoing_issues",
+    "sentry.tasks.backfill_group_action_log",
     "sentry.tasks.auto_remove_inbox",
     "sentry.tasks.auto_resolve_issues",
     "sentry.tasks.auto_source_code_config",

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -1,0 +1,55 @@
+import logging
+
+from sentry.models.group import Group
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import issues_tasks
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.backfill_group_action_log.backfill_group_action_log_for_group",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def backfill_group_action_log_for_group(
+    group_id: int,
+    **kwargs: object,
+) -> None:
+    from sentry.issues.action_log.backfill import backfill_group_activities
+
+    try:
+        group = Group.objects.get(id=group_id)
+    except Group.DoesNotExist:
+        logger.warning(
+            "backfill_group_action_log.group_not_found",
+            extra={"group_id": group_id},
+        )
+        return
+
+    try:
+        total = backfill_group_activities(
+            group_id=group_id,
+            project_id=group.project_id,
+        )
+    except Exception:
+        logger.exception(
+            "backfill_group_action_log.group_failed",
+            extra={"group_id": group_id, "project_id": group.project_id},
+        )
+        raise
+
+    logger.info(
+        "backfill_group_action_log.group_completed",
+        extra={
+            "group_id": group_id,
+            "project_id": group.project_id,
+            "total_created": total,
+        },
+    )
+    metrics.incr(
+        "issues.backfill_group_action_log.group_completed",
+        sample_rate=1.0,
+    )

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -4,7 +4,6 @@ from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
-from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +47,4 @@ def backfill_group_action_log_for_group(
             "project_id": group.project_id,
             "total_created": total,
         },
-    )
-    metrics.incr(
-        "issues.backfill_group_action_log.group_completed",
-        sample_rate=1.0,
     )

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.tasks.backfill_group_action_log import backfill_group_action_log_for_group
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+
+class BackfillGroupActionLogForGroupTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.now = timezone.now()
+
+    def test_backfills_activities_for_group(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            user_id=self.user.id,
+            datetime=self.now - timedelta(minutes=2),
+        )
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={"assignee": str(self.user.id), "assigneeType": "user"},
+            user_id=self.user.id,
+            datetime=self.now - timedelta(minutes=1),
+        )
+
+        backfill_group_action_log_for_group(self.group.id)
+
+        entries = GroupActionLogEntry.objects.filter(group_id=self.group.id).order_by("date_added")
+        assert entries.count() == 2
+        assert entries[0].type == GroupActionType.RESOLVE.value
+        assert entries[1].type == GroupActionType.ASSIGN.value
+
+    def test_sets_actor_from_user_id(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            user_id=self.user.id,
+        )
+
+        backfill_group_action_log_for_group(self.group.id)
+
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.actor_type == GroupActorType.USER.value
+        assert entry.actor_id == self.user.id
+
+    def test_sets_system_actor_when_no_user(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.AUTO_SET_ONGOING.value,
+            data={},
+        )
+
+        backfill_group_action_log_for_group(self.group.id)
+
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.actor_type == GroupActorType.SYSTEM.value
+        assert entry.actor_id == 0
+
+    def test_noop_for_nonexistent_group(self) -> None:
+        backfill_group_action_log_for_group(999999999)
+
+        assert GroupActionLogEntry.objects.count() == 0
+
+    def test_idempotent_rerun(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            user_id=self.user.id,
+        )
+
+        backfill_group_action_log_for_group(self.group.id)
+        backfill_group_action_log_for_group(self.group.id)
+
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+    def test_does_not_affect_other_groups(self) -> None:
+        other_group = self.create_group()
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        self.create_group_activity(
+            group=other_group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+
+        backfill_group_action_log_for_group(self.group.id)
+
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+        assert GroupActionLogEntry.objects.filter(group_id=other_group.id).count() == 0
+
+    def test_preserves_activity_datetime(self) -> None:
+        ts = self.now - timedelta(days=30)
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            datetime=ts,
+        )
+
+        backfill_group_action_log_for_group(self.group.id)
+
+        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
+        assert entry.date_added == ts
+
+    @patch("sentry.issues.action_log.backfill.backfill_group_activities")
+    def test_logs_and_reraises_on_failure(self, mock_backfill: Any) -> None:
+        mock_backfill.side_effect = RuntimeError("boom")
+
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+
+        with pytest.raises(RuntimeError):
+            backfill_group_action_log_for_group(self.group.id)


### PR DESCRIPTION
## Summary
- Add a Celery task `backfill_group_action_log_for_group(group_id)` that wraps `backfill_group_activities()` from #119162 for targeted production use
- Looks up the group, delegates to the backfill function, logs completion and errors
- Intended to be triggered via a getsentry job manifest or direct task invocation for specific groups

### Relationship to other PRs
- **#119162** (merged): provides `backfill_group_activities()` — the per-group backfill logic this task wraps
- **#119164**: org-wide backfill task that iterates all projects/activities for a full organization. Handles the bulk case with its own inline logic (no derived data processing)
- **This PR**: single-group backfill for targeted use. Uses Kyle's function which handles derived data invalidation

## Test plan
- [x] 8 unit tests covering: happy path, actor mapping (user/system), nonexistent group, idempotent re-run, cross-group isolation, timestamp preservation, error re-raise
- [ ] getsentry job manifest to be added in a follow-up PR