### PR TITLE
ci: Skip SIGTERM handling in the `timeout_info` plugin if we're not in the main thread

### DIFF
--- a/src/sentry/testutils/pytest/timeout_info.py
+++ b/src/sentry/testutils/pytest/timeout_info.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import signal
 import sys
+import threading
 import time
 from types import FrameType
 
@@ -34,6 +35,8 @@ def _on_sigterm(signum: int, frame: FrameType | None) -> None:
 
 
 def pytest_configure(config: Config) -> None:
+    if threading.current_thread() is not threading.main_thread():
+        return
     global _original_stdout_fd
     _original_stdout_fd = os.dup(sys.stdout.fileno())
     signal.signal(signal.SIGTERM, _on_sigterm)


### PR DESCRIPTION
Skip SIGTERM handling in the `timeout_info` pytest plugin when `pytest_configure` runs off the main thread.

[Snuba pipelines](https://github.com/getsentry/snuba/actions/runs/28952393754/job/85910197522) are failing frequently(but intermittently) due to #119208 .  This PR is a partial revert of that change so that the signal handler doesn't get registered when we're not in the main thread (and therefore doesn't crash).

## Problem

The `timeout_info` plugin (added in #119208) registers a SIGTERM handler in `pytest_configure` via `signal.signal()`. `pytest_configure` runs in every process — the xdist controller *and* each worker. Under pytest-xdist, execnet can run a worker's session (including `pytest_configure`) on a **non-main thread**, and `signal.signal()` only works from the main thread of the main interpreter. When that happens the worker raises:

```
ValueError: signal only works in main thread of the main interpreter
```

which takes down the whole test run.

This is a startup race in `execnet`, so it's timing/platform-dependent — it reproduces intermittently on CI (Linux) and generally not on local macOS runs, so it's flaky.

## Fix

Apply a partial revert by guard-ing `pytest_configure` so it only registers the handler when running on the main thread. This skips xdist workers (where the hook may run off-main-thread) and keeps the handler on the process CI's `timeout` actually signals. The controller still reports in-flight tests, since xdist forwards `pytest_runtest_logstart`/`logreport` to it.

## Testing

The race is hard to hit on demand, so I forced the failing path locally by making execnet always run worker execs on a non-main thread. In `.venv/lib/python3.13/site-packages/execnet/gateway_base.py`, short-circuit `WorkerPool._try_send_to_primary_thread` to always return `False`:

```python
def _try_send_to_primary_thread(self, reply):
    # REF1 in 'thread' model we give priority to running in main thread
    # note that we should be called with _running_lock hold
    return False  # <-- added: force every exec onto a freshly spawned (non-main) thread
    primary_thread_task_ready = self._primary_thread_task_ready
    ...
```

With that patch, every xdist worker runs `pytest_configure` off the main thread, so the bug reproduces deterministically:

```bash
.venv/bin/pytest -n2 --dist=loadfile tests/sentry/utils/test_strings.py
```

- **Before this change:** `INTERNALERROR> ValueError: signal only works in main thread of the main interpreter`.
- **After this change:** collects and passes normally.

Revert the execnet hack afterward (it's a vendored dep, so `devenv sync` / any reinstall also wipes it):

```bash
.venv/bin/pip install --force-reinstall execnet==1.9.0
```


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
