### PR TITLE
fix(dashboards): Carry Heat Map visualize when saving from Explore

### DIFF
--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -705,16 +705,11 @@ export function handleAddQueryToDashboard({
         queries: [
           {
             ...defaultWidgetQuery,
-            aggregates: [
-              ...(typeof yAxis === 'string' ? [yAxis] : (yAxis ?? ['count()'])),
-            ],
-            ...{
-              // The widget query params filters out aggregate fields
-              // so we can use the fields as columns. This is so yAxes
-              // can be grouped by the fields.
-              fields: widgetAsQueryParams?.field ?? [],
-              columns: widgetAsQueryParams?.field ?? [],
-            },
+            ...widgetQueryFieldsForDisplayType(
+              displayType,
+              typeof yAxis === 'string' ? [yAxis] : (yAxis ?? ['count()']),
+              widgetAsQueryParams?.field ?? []
+            ),
           },
         ],
         interval: eventView.interval!,
@@ -774,9 +769,11 @@ export function handleAddMultipleQueriesToDashboard({
       queries: [
         {
           ...defaultWidgetQuery,
-          aggregates: toArray(yAxis ?? 'count()'),
-          fields: widgetAsQueryParams?.field ?? [],
-          columns: widgetAsQueryParams?.field ?? [],
+          ...widgetQueryFieldsForDisplayType(
+            displayType,
+            toArray(yAxis ?? 'count()'),
+            widgetAsQueryParams?.field ?? []
+          ),
         },
       ],
       interval: eventView.interval!,
@@ -793,6 +790,27 @@ export function handleAddMultipleQueriesToDashboard({
     source,
     actions: ['add-and-stay-on-current-page', 'add-and-open-dashboard'],
   });
+}
+
+/**
+ * Builds the `aggregates`/`fields`/`columns` for a widget query when adding to a
+ * dashboard, given the resolved aggregates and group-by columns.
+ *
+ * Time-series widgets store aggregates in `yAxis` and use `fields`/`columns` for
+ * the group-by columns (aggregates are filtered out of `field`). Heat maps,
+ * however, have no group by and the widget builder reads their aggregate from
+ * `fields` rather than `yAxis` — so the aggregate must live in `fields`,
+ * otherwise the "Visualize" selection is lost and the saved widget is broken.
+ */
+function widgetQueryFieldsForDisplayType(
+  displayType: DisplayType,
+  aggregates: string[],
+  groupByFields: string[]
+): Pick<WidgetQuery, 'aggregates' | 'fields' | 'columns'> {
+  if (displayType === DisplayType.HEATMAP) {
+    return {aggregates, fields: aggregates, columns: []};
+  }
+  return {aggregates, fields: groupByFields, columns: groupByFields};
 }
 
 export function getTargetForTransactionSummaryLink(

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
@@ -138,6 +138,60 @@ describe('useAddMetricToDashboard', () => {
     );
   });
 
+  it('carries the aggregate into fields for heat maps so the visualize is preserved', () => {
+    // Heat maps store their aggregate in `fields` (not `yAxis`), since the widget
+    // builder reads non-time-series aggregates from `fields`. If it only landed in
+    // `aggregates`, the visualize would be dropped and the widget would be broken.
+    const yAxis = 'count(value,metric.a,counter,none)';
+    const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.HEATMAP});
+    const metricQuery: BaseMetricQuery = {
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        cursor: '',
+        fields: [],
+        sortBys: [],
+        aggregateCursor: '',
+        aggregateFields: [visualize],
+        aggregateSortBys: [{field: yAxis, kind: 'desc'}],
+      }),
+    };
+
+    const {result} = renderHookWithProviders(useAddMetricToDashboard, {
+      ...context,
+    });
+
+    act(() => {
+      result.current.addToDashboard(metricQuery);
+    });
+
+    expect(openAddToDashboardModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widgets: [
+          {
+            title: 'Custom Widget',
+            displayType: DisplayType.HEATMAP,
+            interval: undefined,
+            limit: undefined,
+            widgetType: WidgetType.TRACEMETRICS,
+            queries: [
+              {
+                aggregates: [yAxis],
+                columns: [],
+                fields: [yAxis],
+                conditions: 'release:1.2.3',
+                orderby: '',
+                name: '',
+              },
+            ],
+          },
+        ],
+      })
+    );
+  });
+
   it('does not pass an orderby if there are no group bys', () => {
     const yAxis = 'avg(value,metric.a,counter,none)';
     const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.BAR});


### PR DESCRIPTION
Saving a Heat Map from Explore to a dashboard produced a broken widget: the metric aggregate (the "Visualize" selection) was dropped, leaving a widget with no metric to plot. Since the Widget Builder saves the state slightly differently than expected, we need to massage this and make sure the aggregate goes into `fields` and not `yAxis`.

I extracted a little helper that returns the current `aggregates`, `fields`, and `columns` at the same time, just to keep it all together.

Closes DAIN-1770