### PR TITLE
feat(seer): Add GitLab orgs to context engine indexing

### DIFF
--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -316,10 +316,9 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
     Get the list of allowed organizations for context engine indexing.
 
     Divides all active orgs with a supported SCM integration (Seer prerequisite:
-    GitHub, GitHub Enterprise, or GitLab) into 24 buckets via md5 hash. GitLab
-    orgs are gated on the seer-gitlab-support feature flag. Only the bucket
-    matching the current hour is checked for the seer-explorer-index feature
-    flag, keeping feature check volume at ~1/24th of total orgs.
+    GitHub, GitHub Enterprise, or GitLab) into 24 buckets via md5 hash. Only the
+    bucket matching the current hour is checked for the seer-explorer-index
+    feature flag, keeping feature check volume at ~1/24th of total orgs.
     """
     with start_span(
         op="explorer.context_engine.get_allowed_org_ids_context_engine_indexing",
@@ -328,24 +327,14 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
         now = datetime.now(UTC)
         TOTAL_HOURLY_SLOTS = 24
 
-        github_org_ids = set(
-            integration_service.get_organization_ids_with_providers(
-                providers=[
-                    IntegrationProviderSlug.GITHUB.value,
-                    IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
-                ],
-                status=ObjectStatus.ACTIVE,
-            )
+        scm_org_ids = integration_service.get_organization_ids_with_providers(
+            providers=[
+                IntegrationProviderSlug.GITHUB.value,
+                IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+                IntegrationProviderSlug.GITLAB.value,
+            ],
+            status=ObjectStatus.ACTIVE,
         )
-        # GitLab orgs are candidates too, but gated per-org on seer-gitlab-support
-        # below (we can't evaluate a per-org flag during this bulk fetch).
-        gitlab_org_ids = set(
-            integration_service.get_organization_ids_with_providers(
-                providers=[IntegrationProviderSlug.GITLAB.value],
-                status=ObjectStatus.ACTIVE,
-            )
-        )
-        scm_org_ids = list(github_org_ids | gitlab_org_ids)
         logger.info(
             "SCM integration enabled org ids fetched",
             extra={"count": len(scm_org_ids)},
@@ -367,13 +356,6 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
             Organization.objects.filter(id__in=hourly_scm_org_ids, status=ObjectStatus.ACTIVE),
             result_value_getter=lambda o: o.id,
         ):
-            # GitLab-only orgs require the seer-gitlab-support flag; orgs also
-            # reachable via GitHub are unaffected.
-            if org.id not in github_org_ids and not features.has(
-                "organizations:seer-gitlab-support", org
-            ):
-                continue
-
             if features.has("organizations:seer-explorer-index", org):
                 eligible_org_ids.append(org.id)
                 continue

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -315,9 +315,11 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
     """
     Get the list of allowed organizations for context engine indexing.
 
-    Divides all active orgs with github integration (Seer prerequisite) into 24 buckets via md5 hash.
-    Only the bucket matching the current hour is checked for the seer-explorer-index
-    feature flag, keeping feature check volume at ~1/24th of total orgs.
+    Divides all active orgs with a supported SCM integration (Seer prerequisite:
+    GitHub, GitHub Enterprise, or GitLab) into 24 buckets via md5 hash. GitLab
+    orgs are gated on the seer-gitlab-support feature flag. Only the bucket
+    matching the current hour is checked for the seer-explorer-index feature
+    flag, keeping feature check volume at ~1/24th of total orgs.
     """
     with start_span(
         op="explorer.context_engine.get_allowed_org_ids_context_engine_indexing",
@@ -326,13 +328,24 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
         now = datetime.now(UTC)
         TOTAL_HOURLY_SLOTS = 24
 
-        scm_org_ids = integration_service.get_organization_ids_with_providers(
-            providers=[
-                IntegrationProviderSlug.GITHUB.value,
-                IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
-            ],
-            status=ObjectStatus.ACTIVE,
+        github_org_ids = set(
+            integration_service.get_organization_ids_with_providers(
+                providers=[
+                    IntegrationProviderSlug.GITHUB.value,
+                    IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+                ],
+                status=ObjectStatus.ACTIVE,
+            )
         )
+        # GitLab orgs are candidates too, but gated per-org on seer-gitlab-support
+        # below (we can't evaluate a per-org flag during this bulk fetch).
+        gitlab_org_ids = set(
+            integration_service.get_organization_ids_with_providers(
+                providers=[IntegrationProviderSlug.GITLAB.value],
+                status=ObjectStatus.ACTIVE,
+            )
+        )
+        scm_org_ids = list(github_org_ids | gitlab_org_ids)
         logger.info(
             "SCM integration enabled org ids fetched",
             extra={"count": len(scm_org_ids)},
@@ -354,6 +367,13 @@ def get_allowed_org_ids_context_engine_indexing() -> list[int]:
             Organization.objects.filter(id__in=hourly_scm_org_ids, status=ObjectStatus.ACTIVE),
             result_value_getter=lambda o: o.id,
         ):
+            # GitLab-only orgs require the seer-gitlab-support flag; orgs also
+            # reachable via GitHub are unaffected.
+            if org.id not in github_org_ids and not features.has(
+                "organizations:seer-gitlab-support", org
+            ):
+                continue
+
             if features.has("organizations:seer-explorer-index", org):
                 eligible_org_ids.append(org.id)
                 continue

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -128,6 +128,15 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
         )
         return org
 
+    def _create_org_with_gitlab(self):
+        org = self.create_organization()
+        self.create_integration(
+            organization=org,
+            provider="gitlab",
+            external_id=f"gitlab:{org.id}",
+        )
+        return org
+
     def test_returns_only_orgs_assigned_to_current_slot(self) -> None:
         from sentry.utils.hashlib import md5_text
 
@@ -262,6 +271,67 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
                 eligible = get_allowed_org_ids_context_engine_indexing()
 
         assert org_without_github.id not in eligible
+
+    def test_includes_gitlab_org_with_gitlab_support_flag(self) -> None:
+        org = self._create_org_with_gitlab()
+
+        TOTAL_SLOTS = 24
+        target_slot = int(md5_text(str(org.id)).hexdigest(), 16) % TOTAL_SLOTS
+        frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
+
+        with freeze_time(frozen_time):
+            with self.feature(
+                {
+                    "organizations:seer-gitlab-support": [org.slug],
+                    "organizations:seer-explorer-index": [org.slug],
+                }
+            ):
+                eligible = get_allowed_org_ids_context_engine_indexing()
+
+        assert org.id in eligible
+
+    def test_excludes_gitlab_org_without_gitlab_support_flag(self) -> None:
+        org = self._create_org_with_gitlab()
+
+        TOTAL_SLOTS = 24
+        target_slot = int(md5_text(str(org.id)).hexdigest(), 16) % TOTAL_SLOTS
+        frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
+
+        # Seer-eligible, but without seer-gitlab-support the GitLab org is gated out.
+        with freeze_time(frozen_time):
+            with self.feature(
+                {
+                    "organizations:seer-explorer-index": [org.slug],
+                    "organizations:seat-based-seer-enabled": [org.slug],
+                    "organizations:seer-added": [org.slug],
+                }
+            ):
+                eligible = get_allowed_org_ids_context_engine_indexing()
+
+        assert org.id not in eligible
+
+    def test_includes_github_and_gitlab_org_without_gitlab_support_flag(self) -> None:
+        # An org reachable via GitHub is included even without seer-gitlab-support.
+        org = self._create_org_with_github()
+        self.create_integration(
+            organization=org,
+            provider="gitlab",
+            external_id=f"gitlab:{org.id}",
+        )
+
+        TOTAL_SLOTS = 24
+        target_slot = int(md5_text(str(org.id)).hexdigest(), 16) % TOTAL_SLOTS
+        frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
+
+        with freeze_time(frozen_time):
+            with self.feature(
+                {
+                    "organizations:seer-explorer-index": [org.slug],
+                }
+            ):
+                eligible = get_allowed_org_ids_context_engine_indexing()
+
+        assert org.id in eligible
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -272,7 +272,9 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
 
         assert org_without_github.id not in eligible
 
-    def test_includes_gitlab_org_with_gitlab_support_flag(self) -> None:
+    def test_includes_gitlab_org(self) -> None:
+        # GitLab orgs are candidates on the same footing as GitHub orgs; they
+        # only need the usual Seer eligibility flag.
         org = self._create_org_with_gitlab()
 
         TOTAL_SLOTS = 24
@@ -282,7 +284,6 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
         with freeze_time(frozen_time):
             with self.feature(
                 {
-                    "organizations:seer-gitlab-support": [org.slug],
                     "organizations:seer-explorer-index": [org.slug],
                 }
             ):
@@ -290,48 +291,25 @@ class TestGetAllowedOrgIdsContextEngineIndexing(TestCase):
 
         assert org.id in eligible
 
-    def test_excludes_gitlab_org_without_gitlab_support_flag(self) -> None:
+    def test_excludes_gitlab_org_without_seer_flags(self) -> None:
+        # A GitLab org with no Seer eligibility flag is excluded, just like GitHub.
         org = self._create_org_with_gitlab()
 
         TOTAL_SLOTS = 24
         target_slot = int(md5_text(str(org.id)).hexdigest(), 16) % TOTAL_SLOTS
         frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
 
-        # Seer-eligible, but without seer-gitlab-support the GitLab org is gated out.
         with freeze_time(frozen_time):
             with self.feature(
                 {
-                    "organizations:seer-explorer-index": [org.slug],
-                    "organizations:seat-based-seer-enabled": [org.slug],
-                    "organizations:seer-added": [org.slug],
+                    "organizations:seer-explorer-index": False,
+                    "organizations:seat-based-seer-enabled": False,
+                    "organizations:seer-added": False,
                 }
             ):
                 eligible = get_allowed_org_ids_context_engine_indexing()
 
         assert org.id not in eligible
-
-    def test_includes_github_and_gitlab_org_without_gitlab_support_flag(self) -> None:
-        # An org reachable via GitHub is included even without seer-gitlab-support.
-        org = self._create_org_with_github()
-        self.create_integration(
-            organization=org,
-            provider="gitlab",
-            external_id=f"gitlab:{org.id}",
-        )
-
-        TOTAL_SLOTS = 24
-        target_slot = int(md5_text(str(org.id)).hexdigest(), 16) % TOTAL_SLOTS
-        frozen_time = f"2024-01-14 {target_slot:02d}:00:00"
-
-        with freeze_time(frozen_time):
-            with self.feature(
-                {
-                    "organizations:seer-explorer-index": [org.slug],
-                }
-            ):
-                eligible = get_allowed_org_ids_context_engine_indexing()
-
-        assert org.id in eligible
 
 
 @django_db_all


### PR DESCRIPTION
## Summary

`get_allowed_org_ids_context_engine_indexing` (in `src/sentry/tasks/seer/context_engine_index.py`) hardcoded the SCM provider fetch to `[GITHUB, GITHUB_ENTERPRISE]`, so **GitLab orgs were never candidates** for context-engine indexing.

This adds GitLab to the supported SCM providers so GitLab orgs are indexed on the same footing as GitHub orgs. GitLab support is now generally available, so no per-org feature gate is applied — a GitLab org becomes eligible through the usual Seer eligibility flags (`seer-explorer-index`, `seat-based-seer-enabled`, `seer-added`), exactly like GitHub.

## Changes

- Add `IntegrationProviderSlug.GITLAB` to the provider list in the bulk org-id fetch.
- Update the docstring (GitHub → GitHub/GitHub Enterprise/GitLab).
- Add tests: GitLab org with a Seer eligibility flag → included; GitLab org with no Seer flags → excluded.

## Test Plan

- `pytest tests/sentry/tasks/seer/test_context_engine_index.py -k TestGetAllowedOrgIdsContextEngineIndexing`
- `mypy src/sentry/tasks/seer/context_engine_index.py` → **Success: no issues found**.

Refs CW-1505

Companion fix for `group_autofix_setup_check.py`: #117678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
