### PR TITLE
fix(seer): Narrow night shift scheduling spread to 1 hour

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -59,7 +59,7 @@ from sentry.utils.query import RangeQuerySetWrapper
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
-NIGHT_SHIFT_SPREAD_DURATION = timedelta(hours=4)
+NIGHT_SHIFT_SPREAD_DURATION = timedelta(hours=1)
 
 BATCH_FEATURE_NAMES = [
     "organizations:seer-night-shift",


### PR DESCRIPTION
## Summary
- `schedule_night_shift` spreads per-org triage dispatch over `NIGHT_SHIFT_SPREAD_DURATION` using a deterministic per-org countdown.
- Taskbroker silently caps `countdown`/ETA at 1 hour, so the previous 4-hour window meant most tasks with a countdown beyond that cap were effectively clamped, bunching dispatch near the 1-hour mark instead of spreading evenly.
- Narrow `NIGHT_SHIFT_SPREAD_DURATION` from 4 hours to 1 hour so the spread window matches what taskbroker actually honors.