### PR TITLE
ref: remove seer-code-review-github-enterprise gate

### DIFF
--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -8,10 +8,8 @@ import sentry_sdk
 from redis.client import StrictRedis
 from sentry_redis_tools.clients import RedisCluster
 
-from sentry import features
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.services.integration import RpcIntegration
-from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.utils import json
@@ -65,10 +63,6 @@ def handle_webhook_event(
     """
     if integration is None:
         return
-
-    if integration.provider == IntegrationProviderSlug.GITHUB_ENTERPRISE:
-        if not features.has("organizations:seer-code-review-github-enterprise", organization):
-            return
 
     # Set Sentry scope tags so all logs, errors, and spans in this scope carry them automatically.
     tags = {}

--- a/tests/sentry/seer/code_review/webhooks/test_handlers.py
+++ b/tests/sentry/seer/code_review/webhooks/test_handlers.py
@@ -16,29 +16,8 @@ class TestHandleWebhookEvent(TestCase):
     """Unit tests for handle_webhook_event."""
 
     @patch("sentry.seer.code_review.webhooks.handlers.CodeReviewPreflightService")
-    def test_skips_github_enterprise_when_flag_is_off(self, mock_preflight: MagicMock) -> None:
-        """GHE webhooks are blocked when the feature flag is disabled."""
-        integration = MagicMock()
-        integration.provider = IntegrationProviderSlug.GITHUB_ENTERPRISE
-
-        handle_webhook_event(
-            github_event=GithubWebhookType.PULL_REQUEST,
-            event={"action": "opened", "pull_request": {}},
-            organization=self.organization,
-            repo=MagicMock(),
-            integration=integration,
-        )
-
-        mock_preflight.assert_not_called()
-
-    @patch("sentry.seer.code_review.webhooks.handlers.features")
-    @patch("sentry.seer.code_review.webhooks.handlers.CodeReviewPreflightService")
-    def test_allows_github_enterprise_when_flag_is_on(
-        self, mock_preflight: MagicMock, mock_features: MagicMock
-    ) -> None:
-        """GHE webhooks proceed to preflight when the feature flag is enabled."""
-        mock_features.has.return_value = True
-
+    def test_processes_github_enterprise(self, mock_preflight: MagicMock) -> None:
+        """GHE webhooks proceed to preflight normally."""
         integration = MagicMock()
         integration.provider = IntegrationProviderSlug.GITHUB_ENTERPRISE
         integration.id = 456
@@ -56,9 +35,6 @@ class TestHandleWebhookEvent(TestCase):
             integration=integration,
         )
 
-        mock_features.has.assert_called_once_with(
-            "organizations:seer-code-review-github-enterprise", self.organization
-        )
         mock_preflight.assert_called_once()
 
     @patch("sentry.seer.code_review.webhooks.handlers.CodeReviewPreflightService")


### PR DESCRIPTION
## Summary

The `organizations:seer-code-review-github-enterprise` feature flag is fully rolled out (enabled for all orgs), so the gate around Seer AI code review for GitHub Enterprise integrations is now dead weight. This removes the code gate. GitHub Enterprise webhooks now flow through the code review handler exactly like GitHub.com.

## Changes

- **`src/sentry/seer/code_review/webhooks/handlers.py`** — remove the GHE feature gate in `handle_webhook_event`, plus the now-unused `features` and `IntegrationProviderSlug` imports.
- **`tests/sentry/seer/code_review/webhooks/test_handlers.py`** — drop the two flag-specific tests (`test_skips_github_enterprise_when_flag_is_off`, `test_allows_github_enterprise_when_flag_is_on`) and replace them with a single `test_processes_github_enterprise` that asserts GHE webhooks proceed to preflight normally.

## Removal order (split across PRs)

The flag registration and Flagpole config are removed separately, in order, to avoid the options automator applying an unregistered option:

1. **This PR** — remove the code gate + tests (mergeable now).
2. **getsentry/sentry-options-automator#8569** — remove the Flagpole config.
3. **#119311** — remove the `features/temporary.py` registration (merge only after #8569 has deployed).

## Testing

- `ruff check` on changed files: passed
- `mypy` (pre-push) on changed files: passed
- `pytest tests/sentry/seer/code_review/webhooks/test_handlers.py`: 7 passed