### PR TITLE
fix(seer): Route issue_comment webhooks to handler for GHE

### DIFF
--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -21,12 +21,17 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.github.client import GitHubBaseClient
 from sentry.integrations.github.webhook import (
+    CheckRunEventWebhook,
+    CheckSuiteWebhook,
     GitHubWebhook,
     InstallationEventWebhook,
     InstallationRepositoriesEventWebhook,
     IssueCommentEventWebhook,
     IssuesEventWebhook,
     PullRequestEventWebhook,
+    PullRequestReviewCommentEventWebhook,
+    PullRequestReviewEventWebhook,
+    PullRequestReviewThreadEventWebhook,
     PushEventWebhook,
     get_github_external_id,
 )
@@ -151,6 +156,32 @@ class GitHubEnterpriseIssueCommentEventWebhook(GitHubEnterpriseWebhook, IssueCom
     pass
 
 
+class GitHubEnterpriseCheckRunEventWebhook(GitHubEnterpriseWebhook, CheckRunEventWebhook):
+    pass
+
+
+class GitHubEnterpriseCheckSuiteWebhook(GitHubEnterpriseWebhook, CheckSuiteWebhook):
+    pass
+
+
+class GitHubEnterprisePullRequestReviewEventWebhook(
+    GitHubEnterpriseWebhook, PullRequestReviewEventWebhook
+):
+    pass
+
+
+class GitHubEnterprisePullRequestReviewCommentEventWebhook(
+    GitHubEnterpriseWebhook, PullRequestReviewCommentEventWebhook
+):
+    pass
+
+
+class GitHubEnterprisePullRequestReviewThreadEventWebhook(
+    GitHubEnterpriseWebhook, PullRequestReviewThreadEventWebhook
+):
+    pass
+
+
 class GitHubEnterpriseWebhookBase(Endpoint):
     authentication_classes = ()
     permission_classes = ()
@@ -162,6 +193,11 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         "installation_repositories": GitHubEnterpriseInstallationRepositoriesEventWebhook,
         "issues": GitHubEnterpriseIssuesEventWebhook,
         "issue_comment": GitHubEnterpriseIssueCommentEventWebhook,
+        "check_run": GitHubEnterpriseCheckRunEventWebhook,
+        "check_suite": GitHubEnterpriseCheckSuiteWebhook,
+        "pull_request_review": GitHubEnterprisePullRequestReviewEventWebhook,
+        "pull_request_review_comment": GitHubEnterprisePullRequestReviewCommentEventWebhook,
+        "pull_request_review_thread": GitHubEnterprisePullRequestReviewThreadEventWebhook,
     }
 
     def _get_host(self, request: HttpRequest) -> str | None:

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -24,6 +24,7 @@ from sentry.integrations.github.webhook import (
     GitHubWebhook,
     InstallationEventWebhook,
     InstallationRepositoriesEventWebhook,
+    IssueCommentEventWebhook,
     IssuesEventWebhook,
     PullRequestEventWebhook,
     PushEventWebhook,
@@ -146,6 +147,10 @@ class GitHubEnterpriseIssuesEventWebhook(GitHubEnterpriseWebhook, IssuesEventWeb
     pass
 
 
+class GitHubEnterpriseIssueCommentEventWebhook(GitHubEnterpriseWebhook, IssueCommentEventWebhook):
+    pass
+
+
 class GitHubEnterpriseWebhookBase(Endpoint):
     authentication_classes = ()
     permission_classes = ()
@@ -156,6 +161,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
         "installation": GitHubEnterpriseInstallationEventWebhook,
         "installation_repositories": GitHubEnterpriseInstallationRepositoriesEventWebhook,
         "issues": GitHubEnterpriseIssuesEventWebhook,
+        "issue_comment": GitHubEnterpriseIssueCommentEventWebhook,
     }
 
     def _get_host(self, request: HttpRequest) -> str | None:

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -20,9 +20,14 @@ from fixtures.github_enterprise import (
     PUSH_EVENT_EXAMPLE_INSTALLATION,
 )
 from sentry.integrations.github_enterprise.webhook import (
+    GitHubEnterpriseCheckRunEventWebhook,
+    GitHubEnterpriseCheckSuiteWebhook,
     GitHubEnterpriseGitHubComWebhookEndpoint,
     GitHubEnterpriseInstallationRepositoriesEventWebhook,
     GitHubEnterpriseIssueCommentEventWebhook,
+    GitHubEnterprisePullRequestReviewCommentEventWebhook,
+    GitHubEnterprisePullRequestReviewEventWebhook,
+    GitHubEnterprisePullRequestReviewThreadEventWebhook,
     GitHubEnterpriseWebhookEndpoint,
     get_host,
 )
@@ -1185,11 +1190,27 @@ class IssueCommentEventWebhookTest(APITestCase):
     def _signature(self, body: bytes) -> str:
         return "sha1=" + hmac.new(self.secret.encode("utf-8"), body, hashlib.sha1).hexdigest()
 
-    def test_handler_is_registered(self, mock_get_installation_metadata: MagicMock) -> None:
-        # Regression: GitHub Enterprise omitted "issue_comment" from its handler
-        # map, so "@sentry review" PR comments were dropped before any handler ran.
-        handler = GitHubEnterpriseWebhookEndpoint().get_handler("issue_comment")
-        assert handler is GitHubEnterpriseIssueCommentEventWebhook
+    def test_handlers_are_registered(self, mock_get_installation_metadata: MagicMock) -> None:
+        # Regression: GitHub Enterprise kept its own handler map that omitted these
+        # events, so they were dropped before any handler ran. "issue_comment" is the
+        # "@sentry review" trigger; the rest round out code-review / pr-metrics parity
+        # with the GitHub.com endpoint.
+        endpoint = GitHubEnterpriseWebhookEndpoint()
+        assert endpoint.get_handler("issue_comment") is GitHubEnterpriseIssueCommentEventWebhook
+        assert endpoint.get_handler("check_run") is GitHubEnterpriseCheckRunEventWebhook
+        assert endpoint.get_handler("check_suite") is GitHubEnterpriseCheckSuiteWebhook
+        assert (
+            endpoint.get_handler("pull_request_review")
+            is GitHubEnterprisePullRequestReviewEventWebhook
+        )
+        assert (
+            endpoint.get_handler("pull_request_review_comment")
+            is GitHubEnterprisePullRequestReviewCommentEventWebhook
+        )
+        assert (
+            endpoint.get_handler("pull_request_review_thread")
+            is GitHubEnterprisePullRequestReviewThreadEventWebhook
+        )
 
     @patch("sentry.integrations.github.webhook.IssueCommentEventWebhook.__call__")
     def test_issue_comment_is_routed_to_handler(
@@ -1207,6 +1228,30 @@ class IssueCommentEventWebhookTest(APITestCase):
             data=body,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="issue_comment",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE=self._signature(body),
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+        assert mock_call.call_count == 1
+
+    @patch("sentry.integrations.github.webhook.CheckRunEventWebhook.__call__")
+    def test_check_run_is_routed_to_handler(
+        self, mock_call: MagicMock, mock_get_installation_metadata: MagicMock
+    ) -> None:
+        # check_run runs the richest processor set (code review + preprod + pr
+        # metrics); confirm the event now reaches the handler instead of a bare 204.
+        mock_get_installation_metadata.return_value = self.metadata
+        mock_call.return_value = None
+
+        body = orjson.dumps({"action": "created"})
+
+        response = self.client.post(
+            path=self.url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="check_run",
             HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
             HTTP_X_HUB_SIGNATURE=self._signature(body),
             HTTP_X_GITHUB_DELIVERY=str(uuid4()),

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -1,7 +1,10 @@
+import hashlib
+import hmac
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import orjson
 import responses
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory
@@ -19,6 +22,7 @@ from fixtures.github_enterprise import (
 from sentry.integrations.github_enterprise.webhook import (
     GitHubEnterpriseGitHubComWebhookEndpoint,
     GitHubEnterpriseInstallationRepositoriesEventWebhook,
+    GitHubEnterpriseIssueCommentEventWebhook,
     GitHubEnterpriseWebhookEndpoint,
     get_host,
 )
@@ -1162,3 +1166,51 @@ class GitHubEnterpriseParserGitHubComTest(TestCase):
         parser.view_class = GitHubEnterpriseWebhookEndpoint
         external_id = parser._get_external_id(event={"installation": {"id": 42}})
         assert external_id == "github.example.org:42"
+
+
+@patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
+class IssueCommentEventWebhookTest(APITestCase):
+    def setUp(self) -> None:
+        self.url = "/extensions/github-enterprise/webhook/"
+        self.secret = "b3002c3e321d4b7880360d397db2ccfd"
+        self.metadata = {
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": self.secret,
+            "private_key": "private_key",
+            "verify_ssl": True,
+        }
+
+    def _signature(self, body: bytes) -> str:
+        return "sha1=" + hmac.new(self.secret.encode("utf-8"), body, hashlib.sha1).hexdigest()
+
+    def test_handler_is_registered(self, mock_get_installation_metadata: MagicMock) -> None:
+        # Regression: GitHub Enterprise omitted "issue_comment" from its handler
+        # map, so "@sentry review" PR comments were dropped before any handler ran.
+        handler = GitHubEnterpriseWebhookEndpoint().get_handler("issue_comment")
+        assert handler is GitHubEnterpriseIssueCommentEventWebhook
+
+    @patch("sentry.integrations.github.webhook.IssueCommentEventWebhook.__call__")
+    def test_issue_comment_is_routed_to_handler(
+        self, mock_call: MagicMock, mock_get_installation_metadata: MagicMock
+    ) -> None:
+        # Previously this returned 204 *without* invoking any handler (no eyes
+        # reaction, no code review). It must now dispatch to the comment handler.
+        mock_get_installation_metadata.return_value = self.metadata
+        mock_call.return_value = None
+
+        body = orjson.dumps({"action": "created"})
+
+        response = self.client.post(
+            path=self.url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="issue_comment",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE=self._signature(body),
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+
+        assert response.status_code == 204
+        assert mock_call.call_count == 1


### PR DESCRIPTION
## Summary

`@sentry review` PR comments never triggered a Seer code review on **GitHub Enterprise** — not even the 👀 reaction — although PR-open auto-reviews worked.

Root cause: the GHE webhook endpoint keeps its **own** handler dispatch map (`GitHubEnterpriseWebhookBase._handlers`) that omitted several event types. GitHub delivers PR comments as `issue_comment` events, so on GHE the lookup returned `None` and the request short-circuited with a `204` at `if not handler: return HttpResponse(status=204)` — before signature verification, before the handler, and before the event was published to the SCM Kafka stream that the code-review consumer reads. GitHub.com registers these events and so was unaffected.

## Change

Register the webhook events GHE was missing relative to GitHub.com, each as a thin subclass of the shared handler plus the `GitHubEnterpriseWebhook` identity mixin (same pattern as the existing five handlers):

- `issue_comment` → `GitHubEnterpriseIssueCommentEventWebhook` — **the `@sentry review` trigger** (fixes the reported bug)
- `check_run` → `GitHubEnterpriseCheckRunEventWebhook`
- `check_suite` → `GitHubEnterpriseCheckSuiteWebhook`
- `pull_request_review` → `GitHubEnterprisePullRequestReviewEventWebhook`
- `pull_request_review_comment` → `GitHubEnterprisePullRequestReviewCommentEventWebhook`
- `pull_request_review_thread` → `GitHubEnterprisePullRequestReviewThreadEventWebhook`

The review/metrics logic itself is 100% shared with GitHub.com via inheritance — this PR only fixes routing. The base `GitHubWebhook.__call__` is provider-agnostic (keys off `self.provider`, which the mixin overrides to `github_enterprise` via MRO), which is the same path the existing push/PR/issues handlers already use.

## Compatibility verification

Before registering, every processor reachable from the new handlers was audited to confirm none makes hardcoded github.com API calls for an enterprise repo:

| Processor | Finding |
|---|---|
| `handle_webhook_event` (Seer code review) | Builds client via `integration.get_installation().get_client()` → `GitHubEnterpriseApiClient` (base URL from `metadata["domain_name"]`). Eyes reaction runs against the GHE host. Preflight has no provider gate. **COMPATIBLE** |
| all `pr_metrics_*` | Make no API calls, never touch `integration`, write provider-agnostic DB rows. **COMPATIBLE** |
| `handle_preprod_check_run_event` | Makes no API calls itself; identifier-gated org-scoped DB work; downstream task derives client from integration and whitelists `GITHUB_ENTERPRISE`. **COMPATIBLE** |
| `handle_issue_comment_for_autofix_iteration` | Client is integration-derived; a Seer provider-key mismatch degrades to a clean early no-op before any write. **COMPATIBLE** |

`GitHubWebhook._handle` also wraps each processor in its own try/except, so a processor failure can't 500 the webhook or block siblings.

## Tests

`IssueCommentEventWebhookTest`:
- `test_handlers_are_registered` — guards every new dispatch-map entry (the exact regression).
- `test_issue_comment_is_routed_to_handler` / `test_check_run_is_routed_to_handler` — post a signed webhook and assert the handler's `__call__` is invoked (previously these 204'd without calling any handler).

Full GHE webhook suite: 44 passed. mypy + ruff clean.

## Related

Pairs with #119260, which removes the now-fully-rolled-out `organizations:seer-code-review-github-enterprise` gate. Both are needed for `@sentry review` to work end-to-end on GHE: this PR routes the event; #119260 drops the org gate.