### PR TITLE
feat(preprod): Store raw build number for display purposes

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -49,6 +49,7 @@ def validate_preprod_artifact_update_schema(
             "artifact_type": {"type": "integer", "minimum": 0, "maximum": 2},
             "build_version": {"type": "string", "maxLength": 255},
             "build_number": {"type": "integer"},
+            "build_number_raw": {"type": "string", "maxLength": 255},
             "error_code": {"type": "integer", "minimum": 0, "maximum": 3},
             "error_message": {"type": "string"},
             "app_id": {"type": "string", "maxLength": 255},
@@ -91,6 +92,7 @@ def validate_preprod_artifact_update_schema(
         "error_message": "The error_message field must be a string.",
         "build_version": "The build_version field must be a string with a maximum length of 255 characters.",
         "build_number": "The build_number field must be an integer.",
+        "build_number_raw": "The build_number_raw field must be a string with a maximum length of 255 characters.",
         "app_id": "The app_id field must be a string with a maximum length of 255 characters.",
         "app_name": "The app_name field must be a string with a maximum length of 255 characters.",
         "apple_app_info": "The apple_app_info field must be an object.",
@@ -288,6 +290,22 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
             mobile_app_info_updates["app_icon_id"] = data["app_icon_id"]
         if "app_name" in data:
             mobile_app_info_updates["app_name"] = data["app_name"]
+
+        if "build_number_raw" in data:
+            # extras is a JSONField, so update_or_create's `defaults` would
+            # overwrite it wholesale on an update. Query it directly rather than
+            # via head_artifact.get_mobile_app_info(), which would cache a
+            # pre-update instance on head_artifact and go stale for the
+            # get_mobile_app_info() call later in this method.
+            existing_extras = (
+                PreprodArtifactMobileAppInfo.objects.filter(preprod_artifact=head_artifact)
+                .values_list("extras", flat=True)
+                .first()
+            ) or {}
+            mobile_app_info_updates["extras"] = {
+                **existing_extras,
+                "build_number_raw": data["build_number_raw"],
+            }
 
         if mobile_app_info_updates:
             PreprodArtifactMobileAppInfo.objects.update_or_create(

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -24,6 +24,7 @@ from sentry.preprod.authentication import (
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactMobileAppInfo,
+    PreprodArtifactMobileAppInfoExtras,
     PreprodArtifactSizeMetrics,
 )
 from sentry.preprod.quotas import PreprodFeature, should_run_distribution, should_run_size
@@ -297,10 +298,10 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 .values_list("extras", flat=True)
                 .first()
             ) or {}
-            mobile_app_info_updates["extras"] = {
-                **existing_extras,
-                "build_number_raw": data["build_number_raw"],
+            extras_update: PreprodArtifactMobileAppInfoExtras = {
+                "build_number_raw": data["build_number_raw"]
             }
+            mobile_app_info_updates["extras"] = {**existing_extras, **extras_update}
 
         if mobile_app_info_updates:
             PreprodArtifactMobileAppInfo.objects.update_or_create(

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -292,11 +292,6 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
             mobile_app_info_updates["app_name"] = data["app_name"]
 
         if "build_number_raw" in data:
-            # extras is a JSONField, so update_or_create's `defaults` would
-            # overwrite it wholesale on an update. Query it directly rather than
-            # via head_artifact.get_mobile_app_info(), which would cache a
-            # pre-update instance on head_artifact and go stale for the
-            # get_mobile_app_info() call later in this method.
             existing_extras = (
                 PreprodArtifactMobileAppInfo.objects.filter(preprod_artifact=head_artifact)
                 .values_list("extras", flat=True)

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -43,6 +43,7 @@ class BuildDetailsAppInfo(BaseModel):
     name: str | None
     version: str | None
     build_number: int | None = None
+    build_number_raw: str | None = None
     date_added: str | None = None
     date_built: str | None = None
     artifact_type: PreprodArtifact.ArtifactType | None = None
@@ -209,6 +210,11 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
         name=mobile_app_info.app_name if mobile_app_info else None,
         version=(mobile_app_info.build_version if mobile_app_info else None),
         build_number=(mobile_app_info.build_number if mobile_app_info else None),
+        build_number_raw=(
+            mobile_app_info.extras.get("build_number_raw")
+            if mobile_app_info and mobile_app_info.extras
+            else None
+        ),
         date_added=(artifact.date_added.isoformat() if artifact.date_added else None),
         date_built=(artifact.date_built.isoformat() if artifact.date_built else None),
         artifact_type=artifact.artifact_type,

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, cast
 
 from django.utils import timezone
 from pydantic import BaseModel, Field
@@ -19,6 +19,7 @@ from sentry.preprod.build_distribution_utils import (
 from sentry.preprod.models import (
     Platform,
     PreprodArtifact,
+    PreprodArtifactMobileAppInfoExtras,
     PreprodArtifactSizeMetrics,
     PreprodComparisonApproval,
 )
@@ -211,7 +212,7 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
         version=(mobile_app_info.build_version if mobile_app_info else None),
         build_number=(mobile_app_info.build_number if mobile_app_info else None),
         build_number_raw=(
-            mobile_app_info.extras.get("build_number_raw")
+            cast(PreprodArtifactMobileAppInfoExtras, mobile_app_info.extras).get("build_number_raw")
             if mobile_app_info and mobile_app_info.extras
             else None
         ),

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from enum import IntEnum, StrEnum
-from typing import ClassVar, Self, assert_never
+from typing import ClassVar, Self, TypedDict, assert_never, cast
 
 import sentry_sdk
 from django.db import models
@@ -794,6 +794,14 @@ class PreprodArtifactSizeComparison(DefaultFieldsModel):
         unique_together = ("organization_id", "head_size_analysis", "base_size_analysis")
 
 
+class PreprodArtifactMobileAppInfoExtras(TypedDict, total=False):
+    """Known keys stored in PreprodArtifactMobileAppInfo.extras."""
+
+    # Unparsed build identifier (e.g. raw CFBundleVersion) for display, since
+    # build_number may be a synthesized sortable int rather than the literal value.
+    build_number_raw: str
+
+
 @cell_silo_model
 class PreprodArtifactMobileAppInfo(DefaultFieldsModel):
     """
@@ -814,17 +822,15 @@ class PreprodArtifactMobileAppInfo(DefaultFieldsModel):
     app_icon_id = models.CharField(max_length=255, null=True)
     # The name of the app, e.g. "My App"
     app_name = models.CharField(max_length=255, null=True)
-    # Miscellaneous fields that we don't need columns for.
-    # Known keys:
-    #   build_number_raw (str): unparsed build identifier (e.g. raw CFBundleVersion)
-    #   for display, since build_number may be a synthesized sortable int.
+    # Miscellaneous fields that we don't need columns for; see PreprodArtifactMobileAppInfoExtras.
     extras = models.JSONField(null=True)
 
     def format_version_string(self, default: str = "--") -> str:
         parts: list[str] = []
         if self.build_version:
             parts.append(self.build_version)
-        build_number_raw = self.extras.get("build_number_raw") if self.extras else None
+        extras = cast(PreprodArtifactMobileAppInfoExtras, self.extras) if self.extras else None
+        build_number_raw = extras.get("build_number_raw") if extras else None
         if build_number_raw:
             parts.append(f"({build_number_raw})")
         elif self.build_number:

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -814,14 +814,20 @@ class PreprodArtifactMobileAppInfo(DefaultFieldsModel):
     app_icon_id = models.CharField(max_length=255, null=True)
     # The name of the app, e.g. "My App"
     app_name = models.CharField(max_length=255, null=True)
-    # Miscellaneous fields that we don't need columns for
+    # Miscellaneous fields that we don't need columns for.
+    # Known keys:
+    #   build_number_raw (str): unparsed build identifier (e.g. raw CFBundleVersion)
+    #   for display, since build_number may be a synthesized sortable int.
     extras = models.JSONField(null=True)
 
     def format_version_string(self, default: str = "--") -> str:
         parts: list[str] = []
         if self.build_version:
             parts.append(self.build_version)
-        if self.build_number:
+        build_number_raw = self.extras.get("build_number_raw") if self.extras else None
+        if build_number_raw:
+            parts.append(f"({build_number_raw})")
+        elif self.build_number:
             parts.append(f"({self.build_number})")
         return " ".join(parts) if parts else default
 

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -73,6 +73,7 @@ class BuildsEndpointTest(APITestCase):
                     "name": None,
                     "version": None,
                     "build_number": None,
+                    "build_number_raw": None,
                     "date_added": ANY,
                     "date_built": None,
                     "artifact_type": 2,

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -527,6 +527,41 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         assert mobile_app_info.app_icon_id is None
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_update_preprod_artifact_stores_build_number_raw(self) -> None:
+        data = {
+            "build_version": "1.2.3",
+            "build_number": 1_000_002_000_003,
+            "build_number_raw": "1.2.3",
+        }
+        response = self._make_request(data)
+
+        assert response.status_code == 200
+        mobile_app_info = PreprodArtifactMobileAppInfo.objects.get(
+            preprod_artifact=self.preprod_artifact
+        )
+        assert mobile_app_info.build_number == 1_000_002_000_003
+        assert mobile_app_info.extras == {"build_number_raw": "1.2.3"}
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_update_preprod_artifact_build_number_raw_merges_into_existing_extras(self) -> None:
+        self.create_preprod_artifact_mobile_app_info(
+            self.preprod_artifact,
+            extras={"some_other_key": "keep-me"},
+        )
+
+        data = {"build_number_raw": "1.2.3"}
+        response = self._make_request(data)
+
+        assert response.status_code == 200
+        mobile_app_info = PreprodArtifactMobileAppInfo.objects.get(
+            preprod_artifact=self.preprod_artifact
+        )
+        assert mobile_app_info.extras == {
+            "some_other_key": "keep-me",
+            "build_number_raw": "1.2.3",
+        }
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_preprod_artifact_returns_requested_features(self) -> None:
         """Test that the response includes requestedFeatures with both features by default."""
         data = {"artifact_type": 1}

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -69,7 +69,21 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         assert resp_data["app_info"]["name"] == self.mobile_app_info.app_name
         assert resp_data["app_info"]["version"] == self.mobile_app_info.build_version
         assert resp_data["app_info"]["build_number"] == self.mobile_app_info.build_number
+        assert resp_data["app_info"]["build_number_raw"] is None
         assert resp_data["app_info"]["artifact_type"] == self.preprod_artifact.artifact_type
+
+    def test_get_build_details_build_number_raw(self) -> None:
+        self.mobile_app_info.extras = {"build_number_raw": "1.2.3"}
+        self.mobile_app_info.save()
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["app_info"]["build_number_raw"] == "1.2.3"
 
     def test_get_build_details_distribution_info(self) -> None:
         self.preprod_artifact.extras = {"release_notes": "Build notes"}

--- a/tests/sentry/preprod/test_models.py
+++ b/tests/sentry/preprod/test_models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactMobileAppInfo
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -1599,3 +1599,43 @@ class PreprodArtifactBatchBaseArtifactTest(PreprodArtifactModelTestBase):
 
         assert len(result) == 1
         assert result[head_artifact.id] == base_artifact_with_config
+
+
+@cell_silo_test
+class PreprodArtifactMobileAppInfoFormatVersionStringTest(PreprodArtifactModelTestBase):
+    """Tests for PreprodArtifactMobileAppInfo.format_version_string."""
+
+    def _create_mobile_app_info(self, **kwargs) -> PreprodArtifactMobileAppInfo:
+        preprod_artifact = self.create_preprod_artifact(project=self.project)
+        return self.create_preprod_artifact_mobile_app_info(preprod_artifact, **kwargs)
+
+    def test_format_version_string_prefers_raw_build_number(self) -> None:
+        mobile_app_info = self._create_mobile_app_info(
+            build_version="1.2.3",
+            build_number=1_000_002_000_003,
+            extras={"build_number_raw": "1.2.3"},
+        )
+
+        assert mobile_app_info.format_version_string() == "1.2.3 (1.2.3)"
+
+    def test_format_version_string_falls_back_to_build_number(self) -> None:
+        mobile_app_info = self._create_mobile_app_info(
+            build_version="1.2.3",
+            build_number=9999,
+        )
+
+        assert mobile_app_info.format_version_string() == "1.2.3 (9999)"
+
+    def test_format_version_string_ignores_unrelated_extras(self) -> None:
+        mobile_app_info = self._create_mobile_app_info(
+            build_version="1.2.3",
+            build_number=9999,
+            extras={"some_other_key": "value"},
+        )
+
+        assert mobile_app_info.format_version_string() == "1.2.3 (9999)"
+
+    def test_format_version_string_default_when_empty(self) -> None:
+        mobile_app_info = self._create_mobile_app_info()
+
+        assert mobile_app_info.format_version_string() == "--"


### PR DESCRIPTION
## Summary
- Launchpad will start packing multi-component Apple `CFBundleVersion` values (e.g. `1.2.3`) into a large synthesized int for `build_number` (getsentry/launchpad#645), which would otherwise show up as an odd, unreadable number anywhere a build number is displayed.
- Adds `build_number_raw` — the original unparsed build string — so those surfaces can show the real value instead. Stored in `PreprodArtifactMobileAppInfo.extras` (no migration needed) and exposed via `BuildDetailsAppInfo`.
- Safe to deploy ahead of the launchpad change: it's a no-op until launchpad starts sending the field.
- Frontend changes to consume this are a separate follow-up PR.

## Test plan
- [x] New unit tests covering storage, the API response, and display formatting
- [x] `prek` passing