### PR TITLE
fix(ourlogs): stop drag-to-zoom writing multiple history entries

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -7,7 +7,6 @@ import type {
 } from 'echarts';
 import type {Location} from 'history';
 import moment, {type MomentInput} from 'moment-timezone';
-import * as qs from 'query-string';
 
 import {CHART_ZOOM_MERGE_OPTIONS} from 'sentry/components/charts/chartZoomConfig';
 import {DataZoomInside} from 'sentry/components/charts/components/dataZoomInside';
@@ -22,6 +21,7 @@ import type {
   EChartRestoreHandler,
 } from 'sentry/types/echarts';
 import {getUtcDateString, getUtcToLocalDateObject} from 'sentry/utils/dates';
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import {useLocation} from 'sentry/utils/useLocation';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -170,10 +170,7 @@ class ChartZoom extends Component<Props> {
         pageStatsPeriod: period ?? undefined,
       };
 
-      // Only push new location if query params has changed because this will cause a heavy re-render
-      if (qs.stringify(newQuery) !== qs.stringify(location.query)) {
-        navigate({pathname: location.pathname, query: newQuery});
-      }
+      navigateIfQueryChanged(navigate, location, {query: newQuery});
     } else {
       updateDateTime(
         {

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import type {DataZoomComponentOption, ECharts, ToolboxComponentOption} from 'echarts';
-import * as qs from 'query-string';
 
 import {CHART_ZOOM_MERGE_OPTIONS} from 'sentry/components/charts/chartZoomConfig';
 import {DataZoomInside} from 'sentry/components/charts/components/dataZoomInside';
@@ -14,6 +13,7 @@ import type {
   EChartFinishedHandler,
 } from 'sentry/types/echarts';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
@@ -222,13 +222,7 @@ export function useChartZoom({
           statsPeriod: formattedPeriod.period ?? undefined,
         };
 
-        // Only push new location if query params has changed because this will cause a heavy re-render
-        if (qs.stringify(newQuery) !== qs.stringify(location.query)) {
-          navigate({
-            pathname: location.pathname,
-            query: newQuery,
-          });
-        }
+        navigateIfQueryChanged(navigate, location, {query: newQuery});
       } else {
         updateDateTime(formattedPeriod, location, navigate, {save: saveOnZoom});
       }

--- a/static/app/components/pageFilters/actions.spec.tsx
+++ b/static/app/components/pageFilters/actions.spec.tsx
@@ -648,7 +648,7 @@ describe('PageFilters ActionCreators', () => {
 
       expect(nav).toHaveBeenCalledWith(
         {pathname: '/test/', query: {project: ['1']}},
-        {replace: false}
+        {replace: undefined}
       );
     });
     it('does not update history when queries are the same', () => {
@@ -721,7 +721,7 @@ describe('PageFilters ActionCreators', () => {
 
       expect(nav).toHaveBeenCalledWith(
         {pathname: '/test/', query: {environment: ['new-env']}},
-        {replace: false}
+        {replace: undefined}
       );
     });
 
@@ -734,7 +734,7 @@ describe('PageFilters ActionCreators', () => {
 
       expect(nav).toHaveBeenCalledWith(
         {pathname: '/test/', query: {environment: ['new-env', 'another-env']}},
-        {replace: false}
+        {replace: undefined}
       );
     });
 
@@ -744,7 +744,10 @@ describe('PageFilters ActionCreators', () => {
         location: {pathname: '/test/', query: {environment: 'test'}},
       }).location;
       updateEnvironments(null, location, nav);
-      expect(nav).toHaveBeenCalledWith({pathname: '/test/', query: {}}, {replace: false});
+      expect(nav).toHaveBeenCalledWith(
+        {pathname: '/test/', query: {}},
+        {replace: undefined}
+      );
     });
 
     it('does not override an absolute date selection', () => {
@@ -785,7 +788,7 @@ describe('PageFilters ActionCreators', () => {
 
       expect(nav).toHaveBeenCalledWith(
         {pathname: '/test/', query: {statsPeriod: '24h'}},
-        {replace: false}
+        {replace: undefined}
       );
     });
 
@@ -798,7 +801,7 @@ describe('PageFilters ActionCreators', () => {
 
       expect(nav).toHaveBeenCalledWith(
         {pathname: '/test/', query: {statsPeriod: '24h'}},
-        {replace: false}
+        {replace: undefined}
       );
     });
 
@@ -818,7 +821,7 @@ describe('PageFilters ActionCreators', () => {
           pathname: '/test/',
           query: {start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
         },
-        {replace: false}
+        {replace: undefined}
       );
     });
   });

--- a/static/app/components/pageFilters/actions.tsx
+++ b/static/app/components/pageFilters/actions.tsx
@@ -3,7 +3,6 @@ import type {Location} from 'history';
 import isInteger from 'lodash/isInteger';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
-import * as qs from 'query-string';
 
 import {
   ALL_ACCESS_PROJECTS,
@@ -28,6 +27,7 @@ import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 
 type EnvironmentId = Environment['id'];
@@ -491,13 +491,12 @@ function updateParams(
 
   const newQuery = getNewQueryParams(obj, location.query, options);
 
-  // Only push new location if query params has changed because this will cause a heavy re-render
-  if (qs.stringify(newQuery) === qs.stringify(location.query)) {
-    return;
-  }
-
-  const to = {pathname: location.pathname, query: newQuery};
-  navigate(to, {replace: !!options?.replace});
+  navigateIfQueryChanged(
+    navigate,
+    location,
+    {query: newQuery},
+    {replace: options?.replace}
+  );
 }
 
 /**

--- a/static/app/utils/navigateIfQueryChanged.spec.tsx
+++ b/static/app/utils/navigateIfQueryChanged.spec.tsx
@@ -1,0 +1,72 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+
+describe('navigateIfQueryChanged', () => {
+  it('does not navigate when the query is unchanged', () => {
+    const navigate: ReactRouter3Navigate = jest.fn();
+    const location = LocationFixture({query: {foo: 'bar'}});
+
+    navigateIfQueryChanged(navigate, location, {query: {foo: 'bar'}});
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates when the query changed', () => {
+    const navigate: ReactRouter3Navigate = jest.fn();
+    const location = LocationFixture({pathname: '/foo/', query: {foo: 'bar'}});
+
+    navigateIfQueryChanged(navigate, location, {query: {foo: 'baz'}});
+
+    expect(navigate).toHaveBeenCalledWith(
+      {pathname: '/foo/', query: {foo: 'baz'}},
+      undefined
+    );
+  });
+
+  it('does not navigate when just the query key order is changed', () => {
+    const navigate: ReactRouter3Navigate = jest.fn();
+    const location = LocationFixture({query: {a: '1', b: '2'}});
+
+    navigateIfQueryChanged(navigate, location, {query: {b: '2', a: '1'}});
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates with navigate options passed through when they are provided', () => {
+    const navigate: ReactRouter3Navigate = jest.fn();
+    const location = LocationFixture({pathname: '/foo/', query: {foo: 'bar'}});
+
+    navigateIfQueryChanged(navigate, location, {query: {foo: 'baz'}}, {replace: true});
+
+    expect(navigate).toHaveBeenCalledWith(
+      {pathname: '/foo/', query: {foo: 'baz'}},
+      {replace: true}
+    );
+  });
+
+  it('navigates with defaulting the target pathname to the current location pathname when it is not provided', () => {
+    const navigate: ReactRouter3Navigate = jest.fn();
+    const location = LocationFixture({pathname: '/current/', query: {foo: 'bar'}});
+
+    navigateIfQueryChanged(navigate, location, {query: {foo: 'baz'}});
+
+    expect(navigate).toHaveBeenCalledWith(
+      {pathname: '/current/', query: {foo: 'baz'}},
+      undefined
+    );
+  });
+
+  it('does not navigate when only the pathname changed', () => {
+    const navigate: ReactRouter3Navigate = jest.fn();
+    const location = LocationFixture({pathname: '/foo/', query: {foo: 'bar'}});
+
+    navigateIfQueryChanged(navigate, location, {
+      pathname: '/other/',
+      query: {foo: 'bar'},
+    });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/utils/navigateIfQueryChanged.tsx
+++ b/static/app/utils/navigateIfQueryChanged.tsx
@@ -1,0 +1,21 @@
+import type {NavigateOptions} from 'react-router-dom';
+import type {Location} from 'history';
+import * as qs from 'query-string';
+
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+
+interface NavigateTarget {
+  query: Location['query'];
+  pathname?: string;
+}
+
+export function navigateIfQueryChanged(
+  navigate: ReactRouter3Navigate,
+  location: Location,
+  target: NavigateTarget,
+  options?: NavigateOptions
+): void {
+  if (qs.stringify(target.query) !== qs.stringify(location.query)) {
+    navigate({...target, pathname: target.pathname ?? location.pathname}, options);
+  }
+}

--- a/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
+++ b/static/app/views/explore/contexts/logs/logsAutoRefreshContext.tsx
@@ -2,6 +2,7 @@ import {createContext, useCallback, useContext, useRef, useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 import type {Location} from 'history';
 
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import {decodeInteger, decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -166,7 +167,7 @@ export function useSetLogsAutoRefresh() {
         target.query[LOGS_AUTO_REFRESH_KEY] = autoRefresh;
       }
 
-      navigate(target);
+      navigateIfQueryChanged(navigate, location, target);
     },
     [navigate, location, queryClient, queryKey, setPausedAt, currentPausedAt]
   );

--- a/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.spec.tsx
@@ -5,12 +5,21 @@ import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingL
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {LOGS_AUTO_REFRESH_KEY} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
+import {
+  type AutoRefreshState,
+  LOGS_AUTO_REFRESH_KEY,
+  useSetLogsAutoRefresh,
+} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {LogsPageDataProvider} from 'sentry/views/explore/contexts/logs/logsPageData';
 import {LOGS_FIELDS_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {AutorefreshToggle} from 'sentry/views/explore/logs/logsAutoRefresh';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
+
+function SetAutoRefreshButton({state}: {state: AutoRefreshState}) {
+  const setAutoRefresh = useSetLogsAutoRefresh();
+  return <button onClick={() => setAutoRefresh(state)}>set-auto-refresh</button>;
+}
 
 describe('LogsAutoRefresh Integration Tests', () => {
   const {
@@ -39,6 +48,7 @@ describe('LogsAutoRefresh Integration Tests', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
     MockApiClient.clearMockResponses();
 
     // Default API mock
@@ -377,5 +387,35 @@ describe('LogsAutoRefresh Integration Tests', () => {
 
     // Eventually rate limited
     expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBe('rate_limit');
+  });
+
+  it('does not navigate when auto-refresh is set to an unchanged state', async () => {
+    const {router} = renderWithProviders(<SetAutoRefreshButton state="idle" />, {
+      initialRouterConfig: routerConfig,
+      organization,
+    });
+
+    const keyBefore = router.location.key;
+
+    await userEvent.click(screen.getByRole('button', {name: 'set-auto-refresh'}));
+
+    expect(router.location.key).toBe(keyBefore);
+    expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBeUndefined();
+  });
+
+  it('navigates when the auto-refresh state actually changes', async () => {
+    const {router} = renderWithProviders(<SetAutoRefreshButton state="enabled" />, {
+      initialRouterConfig: routerConfig,
+      organization,
+    });
+
+    const keyBefore = router.location.key;
+
+    await userEvent.click(screen.getByRole('button', {name: 'set-auto-refresh'}));
+
+    await waitFor(() => {
+      expect(router.location.query[LOGS_AUTO_REFRESH_KEY]).toBe('enabled');
+    });
+    expect(router.location.key).not.toBe(keyBefore);
   });
 });

--- a/static/app/views/explore/spans/spansQueryParamsProvider.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 import {useCallback, useMemo, useRef} from 'react';
-import type {Location} from 'history';
 
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
@@ -11,13 +11,6 @@ import {
   getTargetWithReadableQueryParams,
   isDefaultFields,
 } from 'sentry/views/explore/spans/spansQueryParams';
-
-function isSameLocation(a: Location, b: Location): boolean {
-  if (a.pathname !== b.pathname) {
-    return false;
-  }
-  return JSON.stringify(a.query) === JSON.stringify(b.query);
-}
 
 interface SpansQueryParamsProviderProps {
   children: ReactNode;
@@ -45,11 +38,7 @@ export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderPro
         writableQueryParams
       );
 
-      // Only navigate if the target URL is different from current location
-      // This prevents duplicate history entries which can cause browser back button issues
-      if (!isSameLocation(locationRef.current, target)) {
-        navigate(target);
-      }
+      navigateIfQueryChanged(navigate, locationRef.current, target);
     },
     [navigate]
   );


### PR DESCRIPTION
`LogsAutoRefreshContext` was missing the _"only `navigate()` if the query changed"_ logic from other places like `chartZoom`. I added it there, then added a shared `navigateIfQueryChanged` helper to deduplicate the half-dozen places it was used.

Closes LOGS-383.