### PR TITLE
fix(dashboards): explain why Heat Map visualization is unavailable

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -8,6 +8,7 @@ import {IconGraph, IconMarkdown, IconNumber, IconSettings, IconTable} from 'sent
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
+import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -172,14 +173,17 @@ export function WidgetBuilderTypeSelector({
       >
         <CompactSelect
           value={state.displayType}
-          options={displayTypeOrder.map(({type, label, details}) => ({
-            leadingItems: DISPLAY_TYPE_ICONS[type],
-            label,
-            value: type,
-            details,
-            disabled:
-              type !== DisplayType.TEXT && !config.supportedDisplayTypes.includes(type),
-          }))}
+          options={displayTypeOrder.map(({type, label, details}) => {
+            const disabledReason = getDisabledReason(type, config);
+            return {
+              leadingItems: DISPLAY_TYPE_ICONS[type],
+              label,
+              value: type,
+              details,
+              disabled: defined(disabledReason),
+              tooltip: disabledReason,
+            };
+          })}
           menuWidth={300}
           onChange={selection => {
             const newValue = selection.value;
@@ -223,6 +227,18 @@ export function WidgetBuilderTypeSelector({
       </StyledFieldGroup>
     </Fragment>
   );
+}
+
+// Returns why a display type is unavailable, or undefined when it's usable — so
+// the dropdown can both disable and explain the option from a single source.
+function getDisabledReason(
+  type: DisplayType,
+  config: ReturnType<typeof getDatasetConfig>
+): string | undefined {
+  if (type !== DisplayType.TEXT && !config.supportedDisplayTypes.includes(type)) {
+    return t('This visualization is not supported for the selected dataset.');
+  }
+  return undefined;
 }
 
 const StyledFieldGroup = styled(FieldGroup)`

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -174,7 +174,7 @@ export function WidgetBuilderTypeSelector({
         <CompactSelect
           value={state.displayType}
           options={displayTypeOrder.map(({type, label, details}) => {
-            const disabledReason = getDisabledReason(type, config);
+            const disabledReason = getVisualizationTypeDisabledReason(type, config);
             return {
               leadingItems: DISPLAY_TYPE_ICONS[type],
               label,
@@ -231,7 +231,7 @@ export function WidgetBuilderTypeSelector({
 
 // Returns why a display type is unavailable, or undefined when it's usable — so
 // the dropdown can both disable and explain the option from a single source.
-function getDisabledReason(
+function getVisualizationTypeDisabledReason(
   type: DisplayType,
   config: ReturnType<typeof getDatasetConfig>
 ): string | undefined {

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -72,8 +72,6 @@ export function getMetricsChartTypeOptions(
   return EXPLORE_CHART_TYPE_OPTIONS;
 }
 
-// Returns why the option is unavailable, or undefined when it's usable — so the
-// dropdown can both disable and explain the option from a single source.
 function getDisabledReason(
   isEquation: boolean,
   metric?: TraceMetric

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -58,7 +58,7 @@ export function getMetricsChartTypeOptions(
   metric?: TraceMetric
 ) {
   if (canUseMetricsHeatMap(organization)) {
-    const disabledReason = getDisabledReason(isEquation, metric);
+    const disabledReason = getVisualizationTypeDisabledReason(isEquation, metric);
     return [
       ...EXPLORE_CHART_TYPE_OPTIONS,
       {
@@ -72,7 +72,7 @@ export function getMetricsChartTypeOptions(
   return EXPLORE_CHART_TYPE_OPTIONS;
 }
 
-function getDisabledReason(
+function getVisualizationTypeDisabledReason(
   isEquation: boolean,
   metric?: TraceMetric
 ): string | undefined {

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -58,16 +58,36 @@ export function getMetricsChartTypeOptions(
   metric?: TraceMetric
 ) {
   if (canUseMetricsHeatMap(organization)) {
+    const disabledReason = getDisabledReason(isEquation, metric);
     return [
       ...EXPLORE_CHART_TYPE_OPTIONS,
       {
         value: ChartType.HEATMAP,
         label: t('Heat Map'),
-        disabled: isEquation || !metric || !doesMetricSupportHeatMapVisualization(metric),
+        disabled: defined(disabledReason),
+        tooltip: disabledReason,
       },
     ];
   }
   return EXPLORE_CHART_TYPE_OPTIONS;
+}
+
+// Returns why the option is unavailable, or undefined when it's usable — so the
+// dropdown can both disable and explain the option from a single source.
+function getDisabledReason(
+  isEquation: boolean,
+  metric?: TraceMetric
+): string | undefined {
+  if (isEquation) {
+    return t('Heat maps are not available for equations.');
+  }
+  if (!metric) {
+    return t('Select a metric to visualize it as a heat map.');
+  }
+  if (!doesMetricSupportHeatMapVisualization(metric)) {
+    return t('Heat maps can only visualize distribution metrics.');
+  }
+  return undefined;
 }
 
 interface MetricsGraphProps {


### PR DESCRIPTION
The "Heat Map" visualization option (and a bunch of others, actually) was disabled in the visualization dropdowns in Dashboards and Explore without any explanation of why. This adds a tooltip to the disabled option in both surfaces.

**e.g.,**
<img width="260" height="123" alt="Screenshot 2026-07-08 at 4 46 49 PM" src="https://github.com/user-attachments/assets/dd00232a-7795-455f-85ec-0fd02e5420d7" />
<img width="319" height="230" alt="Screenshot 2026-07-08 at 5 17 37 PM" src="https://github.com/user-attachments/assets/52ae18a7-ed1a-49d7-ba82-b0f194c51547" />



Closes [DAIN-1769](https://linear.app/getsentry/issue/DAIN-1769/visualization-dropdown-doesnt-explain-why-heat-map-is-not-available)