### PR TITLE
feat(seer): Give each project its own night shift candidate quota

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -518,10 +518,8 @@ def _get_eligible_projects(
 
 
 def _should_use_per_project_quotas(source: NightShiftRunSource, organization_id: int) -> bool:
-    """allowed_project_slugs is an internal ops override (org_tweaks), not a
-    customer setting. When set, give each allowed project its own quota
-    instead of one shared pool. Manual runs bypass allowed_project_slugs (see
-    _get_eligible_projects), so they never get per-project quotas."""
+    """When allowed_project_slugs (org_tweaks) is set, give each project its
+    own quota. Manual runs bypass allowed_project_slugs, so never per-project."""
     if source != "cron":
         return False
     org_tweaks = get_night_shift_org_tweaks(organization_id)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -518,11 +518,10 @@ def _get_eligible_projects(
 
 
 def _should_use_per_project_quotas(source: NightShiftRunSource, organization_id: int) -> bool:
-    """An org that explicitly enumerates its allowed_project_slugs has told us
-    which projects matter — give each one a guaranteed share of max_candidates
-    instead of letting the busiest project crowd out the rest. Manual runs
-    aren't restricted by allowed_project_slugs (see _get_eligible_projects), so
-    they don't get per-project quotas either."""
+    """allowed_project_slugs is an internal ops override (org_tweaks), not a
+    customer setting. When set, give each allowed project its own quota
+    instead of one shared pool. Manual runs bypass allowed_project_slugs (see
+    _get_eligible_projects), so they never get per-project quotas."""
     if source != "cron":
         return False
     org_tweaks = get_night_shift_org_tweaks(organization_id)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -39,6 +39,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.simple_triage import (
     ScoredCandidate,
     fixability_score_strategy,
+    fixability_score_strategy_per_project,
     priority_label,
 )
 from sentry.tasks.seer.night_shift.tweaks import (
@@ -316,7 +317,10 @@ def run_night_shift_execution(
         logger.info("night_shift.no_eligible_projects", extra=log_extra)
         return None
 
-    _dispatch_to_seer_feature(run, organization, eligible, resolved_options, log_extra, start_time)
+    per_project_quotas = _should_use_per_project_quotas(resolved_options["source"], organization.id)
+    _dispatch_to_seer_feature(
+        run, organization, eligible, resolved_options, log_extra, start_time, per_project_quotas
+    )
 
 
 def _run_option_defaults(data: Mapping[str, Any]) -> SeerNightShiftRunOptions:
@@ -516,6 +520,18 @@ def _get_eligible_projects(
     return pr_producing
 
 
+def _should_use_per_project_quotas(source: NightShiftRunSource, organization_id: int) -> bool:
+    """An org that explicitly enumerates its allowed_project_slugs has told us
+    which projects matter — give each one a guaranteed share of max_candidates
+    instead of letting the busiest project crowd out the rest. Manual runs
+    aren't restricted by allowed_project_slugs (see _get_eligible_projects), so
+    they don't get per-project quotas either."""
+    if source != "cron":
+        return False
+    org_tweaks = get_night_shift_org_tweaks(organization_id)
+    return org_tweaks is not None and org_tweaks.allowed_project_slugs is not None
+
+
 def _build_triage_payload(
     candidates: Sequence[ScoredCandidate],
     resolved_options: SeerNightShiftRunOptions,
@@ -550,6 +566,7 @@ def _dispatch_to_seer_feature(
     resolved_options: SeerNightShiftRunOptions,
     log_extra: dict[str, object],
     start_time: float,
+    per_project_quotas: bool,
 ) -> None:
     """Shard the scored candidates into chunks of seer.night_shift.shard_size and
     dispatch each chunk as its own Seer feature run, recorded as a
@@ -557,7 +574,10 @@ def _dispatch_to_seer_feature(
     deliver_feature_result."""
     eligible_projects = [ep.project for ep in eligible]
     repos_by_project = {ep.project.id: ep.connected_repos for ep in eligible}
-    scored = fixability_score_strategy(eligible_projects, resolved_options["max_candidates"])
+    score_strategy = (
+        fixability_score_strategy_per_project if per_project_quotas else fixability_score_strategy
+    )
+    scored = score_strategy(eligible_projects, resolved_options["max_candidates"])
     run.update(extras={**(run.extras or {}), "num_candidates": len(scored)})
     if not scored:
         logger.info("night_shift.no_candidates", extra=log_extra)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -317,10 +317,7 @@ def run_night_shift_execution(
         logger.info("night_shift.no_eligible_projects", extra=log_extra)
         return None
 
-    per_project_quotas = _should_use_per_project_quotas(resolved_options["source"], organization.id)
-    _dispatch_to_seer_feature(
-        run, organization, eligible, resolved_options, log_extra, start_time, per_project_quotas
-    )
+    _dispatch_to_seer_feature(run, organization, eligible, resolved_options, log_extra, start_time)
 
 
 def _run_option_defaults(data: Mapping[str, Any]) -> SeerNightShiftRunOptions:
@@ -566,7 +563,6 @@ def _dispatch_to_seer_feature(
     resolved_options: SeerNightShiftRunOptions,
     log_extra: dict[str, object],
     start_time: float,
-    per_project_quotas: bool,
 ) -> None:
     """Shard the scored candidates into chunks of seer.night_shift.shard_size and
     dispatch each chunk as its own Seer feature run, recorded as a
@@ -574,6 +570,7 @@ def _dispatch_to_seer_feature(
     deliver_feature_result."""
     eligible_projects = [ep.project for ep in eligible]
     repos_by_project = {ep.project.id: ep.connected_repos for ep in eligible}
+    per_project_quotas = _should_use_per_project_quotas(resolved_options["source"], organization.id)
     score_strategy = (
         fixability_score_strategy_per_project if per_project_quotas else fixability_score_strategy
     )

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -20,9 +20,7 @@ from sentry.types.group import PriorityLevel
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
 NIGHT_SHIFT_ISSUE_FETCH_LIMIT = 100
-# Per-project fetch limit is a multiple of max_candidates rather than the flat
-# NIGHT_SHIFT_ISSUE_FETCH_LIMIT, since each project only needs to fill its own
-# quota rather than compete in a shared pool.
+# Scales the per-project fetch limit instead of using the flat limit above.
 NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER = 3
 FIXABILITY_SCORE_THRESHOLD = FixabilityScoreThresholds.MEDIUM.value
 
@@ -40,13 +38,8 @@ def fixability_score_strategy(
     projects: Sequence[Project],
     max_candidates: int,
 ) -> list[ScoredCandidate]:
-    """
-    Fetch top recommended unresolved issues that haven't been triaged by Seer yet,
-    scored across all projects combined. A project with disproportionately more
-    issues can consume the whole max_candidates budget — see
-    fixability_score_strategy_per_project for an alternative that guarantees each
-    project a share.
-    """
+    """Scores candidates across all projects combined — a busy project can eat
+    the whole max_candidates budget. See fixability_score_strategy_per_project."""
     return _fetch_and_score(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
 
 
@@ -54,11 +47,8 @@ def fixability_score_strategy_per_project(
     projects: Sequence[Project],
     max_candidates: int,
 ) -> list[ScoredCandidate]:
-    """
-    Like fixability_score_strategy, but queries and scores each project on its
-    own and takes up to max_candidates from each, so no single project can crowd
-    out the others' share of the org's candidates.
-    """
+    """Like fixability_score_strategy, but scores each project independently so
+    no project can crowd out the others' share of max_candidates."""
     fetch_limit = min(
         NIGHT_SHIFT_ISSUE_FETCH_LIMIT, max_candidates * NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER
     )

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -20,6 +20,10 @@ from sentry.types.group import PriorityLevel
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
 NIGHT_SHIFT_ISSUE_FETCH_LIMIT = 100
+# Per-project fetch limit is a multiple of max_candidates rather than the flat
+# NIGHT_SHIFT_ISSUE_FETCH_LIMIT, since each project only needs to fill its own
+# quota rather than compete in a shared pool.
+NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER = 3
 FIXABILITY_SCORE_THRESHOLD = FixabilityScoreThresholds.MEDIUM.value
 
 
@@ -37,7 +41,39 @@ def fixability_score_strategy(
     max_candidates: int,
 ) -> list[ScoredCandidate]:
     """
-    Fetch top recommended unresolved issues that haven't been triaged by Seer yet.
+    Fetch top recommended unresolved issues that haven't been triaged by Seer yet,
+    scored across all projects combined. A project with disproportionately more
+    issues can consume the whole max_candidates budget — see
+    fixability_score_strategy_per_project for an alternative that guarantees each
+    project a share.
+    """
+    return _fetch_and_score(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
+
+
+def fixability_score_strategy_per_project(
+    projects: Sequence[Project],
+    max_candidates: int,
+) -> list[ScoredCandidate]:
+    """
+    Like fixability_score_strategy, but queries and scores each project on its
+    own and takes up to max_candidates from each, so no single project can crowd
+    out the others' share of the org's candidates.
+    """
+    fetch_limit = min(
+        NIGHT_SHIFT_ISSUE_FETCH_LIMIT, max_candidates * NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER
+    )
+    selected: list[ScoredCandidate] = []
+    for project in projects:
+        selected.extend(_fetch_and_score([project], max_candidates, fetch_limit))
+    return selected
+
+
+def _fetch_and_score(
+    projects: Sequence[Project],
+    max_candidates: int,
+    fetch_limit: int,
+) -> list[ScoredCandidate]:
+    """
     Issues with a fixability score above the threshold are taken first (sorted by
     fixability), then backfilled with unscored issues in their original recommended
     sort order.
@@ -45,7 +81,7 @@ def fixability_score_strategy(
     result = search.backend.query(
         projects=projects,
         sort_by="recommended",
-        limit=NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
+        limit=fetch_limit,
         search_filters=[
             SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
             SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -64,6 +64,7 @@ def _fetch_and_score(
     fetch_limit: int,
 ) -> list[ScoredCandidate]:
     """
+    Fetch top recommended unresolved issues that haven't been triaged by Seer yet.
     Issues with a fixability score above the threshold are taken first (sorted by
     fixability), then backfilled with unscored issues in their original recommended
     sort order.

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -20,7 +20,11 @@ from sentry.tasks.seer.night_shift.cron import (
     schedule_night_shift,
 )
 from sentry.tasks.seer.night_shift.models import TriageAction
-from sentry.tasks.seer.night_shift.simple_triage import ScoredCandidate, fixability_score_strategy
+from sentry.tasks.seer.night_shift.simple_triage import (
+    ScoredCandidate,
+    fixability_score_strategy,
+    fixability_score_strategy_per_project,
+)
 from sentry.tasks.seer.night_shift.skip_cache import key as skip_cache_key
 from sentry.tasks.seer.night_shift.skip_cache import mark_skipped
 from sentry.testutils.cases import SnubaTestCase, TestCase
@@ -521,6 +525,72 @@ class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
         mock_score.assert_called_once()
         assert [p.id for p in mock_score.call_args.args[0]] == [enabled.id]
 
+    def test_allowed_project_slugs_triggers_per_project_quotas(self) -> None:
+        org = self.create_organization()
+        keep = self.create_project(organization=org, slug="keep")
+        self._make_eligible(keep)
+
+        with (
+            self.options(
+                {"seer.night_shift.org_tweaks": {str(org.id): {"allowed_project_slugs": ["keep"]}}}
+            ),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy_per_project",
+                return_value=[],
+            ) as mock_per_project,
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
+                return_value=[],
+            ) as mock_global,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_per_project.assert_called_once()
+        mock_global.assert_not_called()
+
+    def test_without_allowed_project_slugs_uses_global_strategy(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        with (
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy_per_project",
+                return_value=[],
+            ) as mock_per_project,
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
+                return_value=[],
+            ) as mock_global,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_global.assert_called_once()
+        mock_per_project.assert_not_called()
+
+    def test_manual_run_ignores_allowed_project_slugs_for_quota_strategy(self) -> None:
+        org = self.create_organization()
+        keep = self.create_project(organization=org, slug="keep")
+        self._make_eligible(keep)
+
+        with (
+            self.options(
+                {"seer.night_shift.org_tweaks": {str(org.id): {"allowed_project_slugs": ["keep"]}}}
+            ),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy_per_project",
+                return_value=[],
+            ) as mock_per_project,
+            patch(
+                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
+                return_value=[],
+            ) as mock_global,
+        ):
+            run_night_shift_for_org(org.id, options={"source": "manual"}, project_ids=[keep.id])
+
+        mock_global.assert_called_once()
+        mock_per_project.assert_not_called()
+
 
 @django_db_all
 class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCase):
@@ -924,6 +994,46 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         assert null.id in result_ids
         # Low-scored issue (below threshold) is excluded entirely
         assert len(result) == 3
+
+    def test_per_project_gives_each_project_its_own_quota(self) -> None:
+        noisy = self.create_project(slug="noisy")
+        quiet = self.create_project(slug="quiet")
+        for i in range(3):
+            self._store_event_and_update_group(
+                noisy, f"noisy-{i}", seer_fixability_score=0.9, times_seen=5
+            )
+        quiet_issue = self._store_event_and_update_group(
+            quiet, "quiet-issue", seer_fixability_score=0.5, times_seen=1
+        )
+
+        result = fixability_score_strategy_per_project([noisy, quiet], max_candidates=1)
+
+        # max_candidates=1 caps each project individually, not the combined total.
+        assert len(result) == 2
+        assert {c.group.project_id for c in result} == {noisy.id, quiet.id}
+        assert quiet_issue.id in [c.group.id for c in result]
+
+    def test_per_project_fetch_limit_scales_with_max_candidates(self) -> None:
+        project = self.create_project()
+
+        with patch(
+            "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
+        ) as mock_query:
+            mock_query.return_value = Mock(results=[])
+            fixability_score_strategy_per_project([project], max_candidates=5)
+
+        assert mock_query.call_args.kwargs["limit"] == 15
+
+    def test_per_project_fetch_limit_caps_at_global_fetch_limit(self) -> None:
+        project = self.create_project()
+
+        with patch(
+            "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
+        ) as mock_query:
+            mock_query.return_value = Mock(results=[])
+            fixability_score_strategy_per_project([project], max_candidates=40)
+
+        assert mock_query.call_args.kwargs["limit"] == 100
 
 
 class TestTriageActionFromFixabilityScore:

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -967,24 +967,6 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         # Low-scored issue (below threshold) is excluded entirely
         assert len(result) == 3
 
-    def test_per_project_gives_each_project_its_own_quota(self) -> None:
-        noisy = self.create_project(slug="noisy")
-        quiet = self.create_project(slug="quiet")
-        for i in range(3):
-            self._store_event_and_update_group(
-                noisy, f"noisy-{i}", seer_fixability_score=0.9, times_seen=5
-            )
-        quiet_issue = self._store_event_and_update_group(
-            quiet, "quiet-issue", seer_fixability_score=0.5, times_seen=1
-        )
-
-        result = fixability_score_strategy_per_project([noisy, quiet], max_candidates=1)
-
-        # max_candidates=1 caps each project individually, not the combined total.
-        assert len(result) == 2
-        assert {c.group.project_id for c in result} == {noisy.id, quiet.id}
-        assert quiet_issue.id in [c.group.id for c in result]
-
     def test_per_project_fetch_limit_scales_with_max_candidates(self) -> None:
         project = self.create_project()
 

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -525,72 +525,6 @@ class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):
         mock_score.assert_called_once()
         assert [p.id for p in mock_score.call_args.args[0]] == [enabled.id]
 
-    def test_allowed_project_slugs_triggers_per_project_quotas(self) -> None:
-        org = self.create_organization()
-        keep = self.create_project(organization=org, slug="keep")
-        self._make_eligible(keep)
-
-        with (
-            self.options(
-                {"seer.night_shift.org_tweaks": {str(org.id): {"allowed_project_slugs": ["keep"]}}}
-            ),
-            patch(
-                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy_per_project",
-                return_value=[],
-            ) as mock_per_project,
-            patch(
-                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
-                return_value=[],
-            ) as mock_global,
-        ):
-            run_night_shift_for_org(org.id)
-
-        mock_per_project.assert_called_once()
-        mock_global.assert_not_called()
-
-    def test_without_allowed_project_slugs_uses_global_strategy(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        self._make_eligible(project)
-
-        with (
-            patch(
-                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy_per_project",
-                return_value=[],
-            ) as mock_per_project,
-            patch(
-                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
-                return_value=[],
-            ) as mock_global,
-        ):
-            run_night_shift_for_org(org.id)
-
-        mock_global.assert_called_once()
-        mock_per_project.assert_not_called()
-
-    def test_manual_run_ignores_allowed_project_slugs_for_quota_strategy(self) -> None:
-        org = self.create_organization()
-        keep = self.create_project(organization=org, slug="keep")
-        self._make_eligible(keep)
-
-        with (
-            self.options(
-                {"seer.night_shift.org_tweaks": {str(org.id): {"allowed_project_slugs": ["keep"]}}}
-            ),
-            patch(
-                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy_per_project",
-                return_value=[],
-            ) as mock_per_project,
-            patch(
-                "sentry.tasks.seer.night_shift.cron.fixability_score_strategy",
-                return_value=[],
-            ) as mock_global,
-        ):
-            run_night_shift_for_org(org.id, options={"source": "manual"}, project_ids=[keep.id])
-
-        mock_global.assert_called_once()
-        mock_per_project.assert_not_called()
-
 
 @django_db_all
 class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCase):
@@ -714,6 +648,44 @@ class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCa
         assert run.extras.get("error_message") is None
         # Verdicts and autofix are Seer's responsibility now; no result rows here.
         assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
+
+    def test_allowed_project_slugs_gives_each_project_its_own_quota(self) -> None:
+        org = self.create_organization()
+        noisy = self._make_eligible(self.create_project(organization=org, slug="noisy"))
+        quiet = self._make_eligible(self.create_project(organization=org, slug="quiet"))
+
+        for i in range(3):
+            self._store_event_and_update_group(
+                noisy, f"noisy-{i}", seer_fixability_score=0.9, times_seen=5
+            )
+        quiet_issue = self._store_event_and_update_group(
+            quiet, "quiet-issue", seer_fixability_score=0.5, times_seen=1
+        )
+
+        with (
+            self.feature("organizations:gen-ai-features"),
+            self.options(
+                {
+                    "seer.night_shift.org_tweaks": {
+                        str(org.id): {
+                            "max_candidates": 1,
+                            "allowed_project_slugs": ["noisy", "quiet"],
+                        }
+                    }
+                }
+            ),
+        ):
+            run_night_shift_for_org(org.id)
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        shard = run.shards.get()
+        candidate_group_ids = self._shard_group_ids(shard)
+
+        # max_candidates=1 would only leave room for one of noisy's higher-scored
+        # issues under the combined strategy; per-project quotas give quiet a
+        # guaranteed slot too.
+        assert len(candidate_group_ids) == 2
+        assert quiet_issue.id in candidate_group_ids
 
     def test_shards_candidates_across_feature_runs(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
## Summary

- `fixability_score_strategy` queries all of an org's eligible projects in one combined search and takes the top `max_candidates` overall, so an org's noisiest projects can crowd out smaller ones before they're ever considered — most visible for orgs with many projects and an explicit `allowed_project_slugs` override, where the intent is to cover a specific set of projects rather than just the busiest ones.
- Add `fixability_score_strategy_per_project`, which queries and scores each project independently and takes up to `max_candidates` from each. Its per-project fetch limit scales with `max_candidates` (capped at the existing `NIGHT_SHIFT_ISSUE_FETCH_LIMIT`) instead of always fetching 100, since each project only needs to fill its own quota rather than compete in a shared pool.
- Wire this up for cron runs whose org has `allowed_project_slugs` set. Manual runs and orgs without the override keep the existing combined strategy.

## Test plan

- [x] `fixability_score_strategy_per_project` gives each project its own quota instead of a shared one
- [x] Per-project fetch limit scales with `max_candidates` and caps at `NIGHT_SHIFT_ISSUE_FETCH_LIMIT`
- [x] Cron runs with `allowed_project_slugs` set route through the per-project strategy; without it, or on manual runs, they use the existing combined strategy