### PR TITLE
fix(ourlogs): fetch pinned logs with a single `events` request

### DIFF
--- a/static/app/views/explore/logs/pinning/usePinnedLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/pinning/usePinnedLogsQuery.spec.tsx
@@ -87,7 +87,7 @@ describe('usePinnedLogsQuery', () => {
     expect(result.current.isPending).toBe(false);
   });
 
-  it('fetches missing pinned rows from the selected range', async () => {
+  it('fetches missing pinned rows with a single events request', async () => {
     const missingLog = LogFixture({
       [OurLogKnownFieldKey.ID]: 'log-missing',
       [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
@@ -115,6 +115,8 @@ describe('usePinnedLogsQuery', () => {
       expect(result.current.fetchedRows).toHaveLength(1);
     });
 
+    // 'log-missing' is not a decodable v7 id, so the window falls back to 9999d.
+    expect(eventsRequest).toHaveBeenCalledTimes(1);
     expect(eventsRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -122,111 +124,26 @@ describe('usePinnedLogsQuery', () => {
           query: 'id:[log-missing]',
           dataset: 'ourlogs',
           sampling: 'HIGHEST_ACCURACY',
-          statsPeriod: '14d',
+          statsPeriod: '9999d',
         }),
       })
     );
     expect(result.current.fetchedRows[0]?.[OurLogKnownFieldKey.ID]).toBe('log-missing');
   });
 
-  it('does not escalate to the wide window when the selected range resolves every pin', async () => {
-    const inRangeLog = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-in-range',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [inRangeLog], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    const wideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
-    });
-
-    const logsPinning = makeLogsPinning(['log-in-range']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.fetchedRows).toHaveLength(1);
-    });
-
-    expect(wideRequest).not.toHaveBeenCalled();
-  });
-
-  it('escalates only the unresolved ids to the wide window', async () => {
-    const inRangeLog = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-in-range',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-    const outOfRangeLog = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-out-of-range',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [inRangeLog], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    const wideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [outOfRangeLog], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
-    });
-
-    const logsPinning = makeLogsPinning(['log-in-range', 'log-out-of-range']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.fetchedRows).toHaveLength(2);
-    });
-
-    expect(wideRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.objectContaining({query: 'id:[log-out-of-range]'}),
-      })
-    );
-  });
-
-  it('queries the wide window with a narrow range derived from the pin id when the id is a valid v7 timestamp', async () => {
+  it('windows the request to a narrow range derived from the pin id when the id is a valid v7 timestamp', async () => {
     setMockDate(new Date('2026-06-18T05:00:00Z'));
     const v7Id = '019ed8e2be157592b89c4bd51c7bd1e7';
-    const outOfRangeLog = LogFixture({
+    const pinnedLog = LogFixture({
       [OurLogKnownFieldKey.ID]: v7Id,
       [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
       [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
     });
 
-    MockApiClient.addMockResponse({
+    const eventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
-      body: {data: [], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    const wideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [outOfRangeLog], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({start: '2026-06-18T03:54:58'})],
+      body: {data: [pinnedLog], meta: {fields: {id: 'string'}, units: {}}},
     });
 
     const logsPinning = makeLogsPinning([v7Id]);
@@ -240,10 +157,11 @@ describe('usePinnedLogsQuery', () => {
       expect(result.current.fetchedRows).toHaveLength(1);
     });
 
-    expect(wideRequest).toHaveBeenCalledWith(
+    expect(eventsRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
+          query: `id:[${v7Id}]`,
           start: '2026-06-18T03:54:58',
           end: '2026-06-18T04:04:58',
         }),
@@ -251,18 +169,61 @@ describe('usePinnedLogsQuery', () => {
     );
   });
 
-  it('falls back to the 9999d wide window when a missing pin id is not a decodable timestamp', async () => {
-    MockApiClient.addMockResponse({
+  it('covers temporally-spread pins with one HIGHEST_ACCURACY request spanning the whole gap', async () => {
+    setMockDate(new Date('2026-06-18T05:00:00Z'));
+    // Two valid v7 pins ~90 days apart collapse into one request whose window
+    // spans the full gap. A wide window is safe because HIGHEST_ACCURACY scans the
+    // full undownsampled tier, so no rows are dropped as long as the window covers
+    // each pin's timestamp — which the v7-derived window does.
+    const idRecent = '019ed8e2be157592b89c4bd51c7bd1e7'; // 2026-06-18T03:59:58Z
+    const idOld = '019d09666615000000000000000abcde'; // 2026-03-20T03:59:58Z
+    const recentLog = LogFixture({
+      [OurLogKnownFieldKey.ID]: idRecent,
+      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    });
+    const oldLog = LogFixture({
+      [OurLogKnownFieldKey.ID]: idOld,
+      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    });
+
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [recentLog, oldLog], meta: {fields: {id: 'string'}, units: {}}},
+    });
+
+    const logsPinning = makeLogsPinning([idRecent, idOld]);
+
+    const {result} = renderHookWithProviders(
+      () => usePinnedLogsQuery({allRows: [], logsPinning}),
+      {organization, additionalWrapper: AdditionalWrapper}
+    );
+
+    await waitFor(() => {
+      expect(result.current.fetchedRows).toHaveLength(2);
+    });
+
+    expect(eventsRequest).toHaveBeenCalledTimes(1);
+    expect(eventsRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: `id:[${idRecent},${idOld}]`,
+          sampling: 'HIGHEST_ACCURACY',
+          start: '2026-03-20T03:54:58',
+          end: '2026-06-18T04:04:58',
+        }),
+      })
+    );
+  });
+
+  it('falls back to the 9999d window when a missing pin id is not a decodable timestamp', async () => {
+    const eventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
       body: {data: [], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    const wideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [], meta: {fields: {id: 'string'}, units: {}, dataScanned: 'partial'}},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
     });
 
     const logsPinning = makeLogsPinning(['not-a-v7-id']);
@@ -273,53 +234,13 @@ describe('usePinnedLogsQuery', () => {
     });
 
     await waitFor(() => {
-      expect(wideRequest).toHaveBeenCalledWith(
+      expect(eventsRequest).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           query: expect.objectContaining({statsPeriod: '9999d'}),
         })
       );
     });
-  });
-
-  it('falls back to the wide window when the in-range query fails', async () => {
-    const outOfRangeLog = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-out-of-range',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      statusCode: 500,
-      body: {detail: 'Internal Error'},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    const wideRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [outOfRangeLog], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
-    });
-
-    const logsPinning = makeLogsPinning(['log-out-of-range']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.fetchedRows).toHaveLength(1);
-    });
-
-    expect(wideRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.objectContaining({query: 'id:[log-out-of-range]'}),
-      })
-    );
   });
 
   it('reports isError when the pinned logs query fails', async () => {
@@ -340,138 +261,8 @@ describe('usePinnedLogsQuery', () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });
-  });
-
-  it('reports isError when both the in-range and wide queries fail', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      statusCode: 500,
-      body: {detail: 'Internal Error'},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      statusCode: 500,
-      body: {detail: 'Internal Error'},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
-    });
-
-    const logsPinning = makeLogsPinning(['log-out-of-range']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
 
     expect(result.current.fetchedRows).toHaveLength(0);
-    expect(logsPinning.removePinnedRows).not.toHaveBeenCalled();
-  });
-
-  it('keeps the rows found in range when a straggler escalation fails', async () => {
-    const foundA = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-a',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-    const foundB = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-b',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [foundA, foundB], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      statusCode: 500,
-      body: {detail: 'Internal Error'},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
-    });
-
-    const logsPinning = makeLogsPinning(['log-a', 'log-b', 'log-straggler']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(
-      result.current.fetchedRows.map(row => row[OurLogKnownFieldKey.ID]).sort()
-    ).toEqual(['log-a', 'log-b']);
-  });
-
-  it('returns a pin found only in the wide window', async () => {
-    const outOfRangeLog = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-out-of-range',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '14d'})],
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [outOfRangeLog], meta: {fields: {id: 'string'}, units: {}}},
-      match: [MockApiClient.matchQuery({statsPeriod: '9999d'})],
-    });
-
-    const logsPinning = makeLogsPinning(['log-out-of-range']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.fetchedRows).toHaveLength(1);
-    });
-  });
-
-  it('never unpins a pin that cannot be found, leaving it out of fetchedRows', async () => {
-    const foundLog = LogFixture({
-      [OurLogKnownFieldKey.ID]: 'log-found',
-      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
-      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      method: 'GET',
-      body: {data: [foundLog], meta: {fields: {id: 'string'}, units: {}}},
-    });
-
-    const logsPinning = makeLogsPinning(['log-gone-1', 'log-found', 'log-gone-2']);
-
-    const {result} = renderHookWithProviders(
-      () => usePinnedLogsQuery({allRows: [], logsPinning}),
-      {organization, additionalWrapper: AdditionalWrapper}
-    );
-
-    await waitFor(() => {
-      expect(result.current.fetchedRows).toHaveLength(1);
-    });
-
-    expect(result.current.fetchedRows[0]?.[OurLogKnownFieldKey.ID]).toBe('log-found');
     expect(logsPinning.removePinnedRows).not.toHaveBeenCalled();
   });
 
@@ -630,5 +421,33 @@ describe('usePinnedLogsQuery', () => {
     );
 
     expect(eventsRequest).not.toHaveBeenCalled();
+  });
+
+  it('never unpins a pin that cannot be found, leaving it out of fetchedRows', async () => {
+    const foundLog = LogFixture({
+      [OurLogKnownFieldKey.ID]: 'log-found',
+      [OurLogKnownFieldKey.PROJECT_ID]: String(project.id),
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: [foundLog], meta: {fields: {id: 'string'}, units: {}}},
+    });
+
+    const logsPinning = makeLogsPinning(['log-gone-1', 'log-found', 'log-gone-2']);
+
+    const {result} = renderHookWithProviders(
+      () => usePinnedLogsQuery({allRows: [], logsPinning}),
+      {organization, additionalWrapper: AdditionalWrapper}
+    );
+
+    await waitFor(() => {
+      expect(result.current.fetchedRows).toHaveLength(1);
+    });
+
+    expect(result.current.fetchedRows[0]?.[OurLogKnownFieldKey.ID]).toBe('log-found');
+    expect(logsPinning.removePinnedRows).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/explore/logs/pinning/usePinnedLogsQuery.tsx
+++ b/static/app/views/explore/logs/pinning/usePinnedLogsQuery.tsx
@@ -3,7 +3,6 @@ import type {UseQueryResult} from '@tanstack/react-query';
 import {useQueries, useQueryClient} from '@tanstack/react-query';
 import moment from 'moment-timezone';
 
-import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiFetch} from 'sentry/utils/api/apiFetch';
 import {batchedQueryOptions} from 'sentry/utils/api/batching/batchedQueryOptions';
@@ -34,9 +33,9 @@ const PINNED_LOG_ROW_QUERY_KEY = 'pinned-log-row';
 type BatchedQueryStatus = 'error' | 'pending' | 'success';
 
 /**
- * Practically-infinite period so the wide step finds any log still in retention,
- * regardless of the selected range. The backend clamps it to the org's retention.
- * Only used as a fallback when a pin's timestamp can't be derived from its id.
+ * Practically-infinite period so we find any pin still in retention, regardless of
+ * the selected range. The backend clamps it to the org's retention. Only used as a
+ * fallback when a pin's timestamp can't be derived from its id.
  */
 const WIDE_STATS_PERIOD = '9999d';
 
@@ -48,27 +47,27 @@ const WINDOW_BUFFER_MS = 5 * 60 * 1000;
 
 interface PinnedLogsQueryContext {
   baseQuery: Record<string, unknown>;
-  dateParams: Record<string, unknown>;
   organizationSlug: string;
 }
 
 const pinnedLogBatcher = createBatcher<OurLogsResponseItem, PinnedLogsQueryContext>(
-  async (client, {organizationSlug, baseQuery, dateParams}, ids: string[]) => {
+  async (client, {organizationSlug, baseQuery}, ids: string[]) => {
     const url = getApiUrl('/organizations/$organizationIdOrSlug/events/', {
       path: {organizationIdOrSlug: organizationSlug},
     });
 
-    const fetchByIds = (idsForFetch: string[], dp: Record<string, unknown>) =>
-      apiFetch<EventsLogsResult>({
+    const rowsById = new Map<string, OurLogsResponseItem | Error>();
+    try {
+      const {json} = await apiFetch<EventsLogsResult>({
         client,
         queryKey: [
           url,
           {
             query: {
               ...baseQuery,
-              ...dp,
-              query: `id:[${idsForFetch.join(',')}]`,
-              per_page: idsForFetch.length,
+              ...dateParamsFromIds(ids),
+              query: `id:[${ids.join(',')}]`,
+              per_page: ids.length,
             },
           },
           {infinite: false},
@@ -76,37 +75,13 @@ const pinnedLogBatcher = createBatcher<OurLogsResponseItem, PinnedLogsQueryConte
         signal: new AbortController().signal,
         meta: undefined,
       });
-
-    const rowsById = new Map<string, OurLogsResponseItem | Error>();
-    const collect = (result: EventsLogsResult) => {
-      for (const row of result.data) {
+      for (const row of json.data) {
         rowsById.set(row[OurLogKnownFieldKey.ID], row);
       }
-    };
-
-    // Step 1: Search in the parent selected range for pins that are not loaded yet.
-    // Start with this smaller range so we don't have to scan the org's full retention period.
-    let foundInRange = new Set<string>();
-    try {
-      const inRange = (await fetchByIds(ids, dateParams)).json;
-      collect(inRange);
-      foundInRange = new Set(inRange.data.map(row => row[OurLogKnownFieldKey.ID]));
-    } catch {
-      // The selected range failed; let the wide window resolve everything instead.
-    }
-
-    // Step 2: Any IDs not found in the parent selected range escalate to a wider window.
-    // Anything still unfound stays pinned and surfaces as an unavailable row in the UI.
-    const stillMissing = ids.filter(id => !foundInRange.has(id));
-    if (stillMissing.length > 0) {
-      try {
-        const wide = await fetchByIds(stillMissing, wideDateParams(stillMissing));
-        collect(wide.json);
-      } catch (error) {
-        const failure = error instanceof Error ? error : new Error(String(error));
-        for (const id of stillMissing) {
-          rowsById.set(id, failure);
-        }
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      for (const id of ids) {
+        rowsById.set(id, failure);
       }
     }
 
@@ -140,15 +115,8 @@ export function usePinnedLogsQuery({allRows, logsPinning}: PinnedLogsOptions) {
         sampling: SAMPLING_MODE.HIGH_ACCURACY,
         referrer: 'api.explore.logs-pinned',
       },
-      dateParams: normalizeDateTimeParams(selection.datetime),
     }),
-    [
-      fields,
-      organization.slug,
-      selection.datetime,
-      selection.environments,
-      selection.projects,
-    ]
+    [fields, organization.slug, selection.environments, selection.projects]
   );
 
   const enabled = pageFiltersReady && !!logsPinning;
@@ -206,12 +174,13 @@ function combinePinnedRows(
 }
 
 /**
- * Pin ids are UUIDv7, so we can derive a tight window from their timestamps and
- * avoid scanning the org's full retention (which gets downsampled to a partial
- * scan for high-volume orgs, missing the pinned log). Falls back to the wide
- * period if any id isn't a decodable timestamp.
+ * Pin ids are UUIDv7, so we derive a tight window from their timestamps to keep
+ * the scan small instead of covering the org's full retention. HIGHEST_ACCURACY
+ * already guarantees no rows are dropped regardless of window width, so this is
+ * purely to avoid a slow, timeout-prone wide scan. Fall back to the wide period
+ * if any id isn't a decodable timestamp.
  */
-function wideDateParams(ids: string[]): Record<string, unknown> {
+function dateParamsFromIds(ids: string[]): Record<string, unknown> {
   const timestamps = ids.map(logItemIdToTimestamp);
   if (timestamps.length === 0 || timestamps.includes(null)) {
     return {statsPeriod: WIDE_STATS_PERIOD};


### PR DESCRIPTION
Before this, pinned logs not already in the table were fetched in two steps using the general-purpose fetcher: 

1. Over the selected time range
2. Escalating any out-of-range ids to a wider window.

But as determined this week, we can actually use the `events` endpoint. Which is Guaranteed ™️ with `sampling=HIGHEST_ACCURACY` to give the logs (if they exist)! This collapses that into one `events` request windowed directly to the pins' own UUIDv7 timestamps.

Marking as a `fix` rather than a `ref` because it improves performance in the cases that needed to run the two requests.

Closes LOGS-905.