### PR TITLE
fix(dashboards): Reset Heat Map aggregate to count on metric fallback

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -701,11 +701,12 @@ describe('useWidgetBuilderState', () => {
 
       // Counters can't be heat-mapped, so the metric is dropped and the slot
       // falls back to the metric-less default (the picker then auto-selects a
-      // distribution metric).
+      // distribution metric). The fallback aggregate is count(), not the
+      // default sum() — heat maps always count() the metric.
       expect(result.current.state.fields).toEqual([
         {
           kind: 'function',
-          function: ['sum', 'value', undefined, undefined],
+          function: ['count', 'value', undefined, undefined],
           alias: undefined,
         },
       ]);

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -583,7 +583,22 @@ export function useWidgetBuilderState(): {
               // to the default. The metric-less placeholder lets the metric
               // picker auto-select the first distribution metric.
               if (nextFields.length === 0) {
-                nextFields.push({...currentDatasetConfig.defaultField, alias: undefined});
+                const fallbackField = {
+                  ...currentDatasetConfig.defaultField,
+                  alias: undefined,
+                };
+                // The shared default field is sum(value), but heat maps always
+                // count(). Coerce it so the fallback seeds count() as the
+                // aggregate; otherwise the auto-selected metric preserves the
+                // sum and the Visualize section shows the wrong aggregate.
+                if (fallbackField.kind === FieldValueKind.FUNCTION) {
+                  fallbackField.function = [
+                    AggregationKey.COUNT,
+                    fallbackField.function[1],
+                    ...fallbackField.function.slice(2),
+                  ];
+                }
+                nextFields.push(fallbackField);
               }
             }
             setFields(nextFields, options);


### PR DESCRIPTION
There's a case where the Widget Builder's "Visualize" section showed `sum` for Heat Map widgets even though Heat Maps always `count()` the metric's value.

The cause is an incorrect reset when the user choses "Heat Map" after currently visualizing a non-distribution metric. We discard the current selection and fall back to the default _but_ the default was using a `sum` aggregate! If the current selection is a heat map, we need a different default, so we _edit_ the current one to use `count` instead.

Fixes DAIN-1773