### PR TITLE
ref(workflow_engine): Start to migrate ProcessedDataCondition to DataConditionEvaluation

### DIFF
--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -245,9 +245,11 @@ class DataCondition(DefaultFieldsModel):
         metrics.incr("workflow_engine.data_condition.evaluation", tags={"type": self.type})
 
         error: ConditionError | None = None
+
         if isinstance(result, bool):
             result = self.get_condition_result() if result else None
-        elif isinstance(result, ConditionError):
+
+        if isinstance(result, ConditionError):
             error = result
             result = None
 

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -244,16 +244,18 @@ class DataCondition(DefaultFieldsModel):
 
         metrics.incr("workflow_engine.data_condition.evaluation", tags={"type": self.type})
 
+        error: ConditionError | None = None
         if isinstance(result, bool):
-            is_condition_met = result
             result = self.get_condition_result() if result else None
-        else:
-            is_condition_met = False if isinstance(result, ConditionError) else bool(result)
+        elif isinstance(result, ConditionError):
+            error = result
+            result = None
 
         return DataConditionEvaluation(
-            value=value,
-            condition_met=is_condition_met,
+            condition=self,
+            error=error,
             result=result,
+            value=value,
         )
 
 

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -19,7 +19,7 @@ from sentry.workflow_engine.models.data_condition_group import (
     DataConditionGroup,
     DataConditionGroupSnapshot,
 )
-from sentry.workflow_engine.processors.data_condition_group import TriggerResult
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
 from .json_config import JSONConfigBase

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -148,7 +148,10 @@ def evaluate_data_conditions(
 
             if logic_type == DataConditionGroup.Type.NONE:
                 return ProcessedDataConditionGroup(
-                    logic_result=TriggerResult(triggered=False, error=condition_evaluation.error),
+                    logic_result=TriggerResult(
+                        triggered=False,
+                        error=condition_evaluation.error,
+                    ),
                     condition_results=[],
                 )
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -1,181 +1,19 @@
 import dataclasses
 import logging
-from collections.abc import Callable, Iterable
-from typing import ClassVar, NoReturn, TypeVar
+from typing import TypeVar
 
 from sentry.utils.function_cache import cache_func_for_models
 from sentry.utils.tracing import trace
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import is_slow_condition
 from sentry.workflow_engine.processors.data_condition import split_conditions_by_speed
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from sentry.workflow_engine.types import ConditionError, DataConditionResult
 from sentry.workflow_engine.utils import scopedstats
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-
-
-def _find_error(
-    items: list["TriggerResult"], predicate: Callable[["TriggerResult"], bool]
-) -> ConditionError | None:
-    """Helper to find an error from items matching the predicate."""
-    return next((item.error for item in items if predicate(item)), None)
-
-
-@dataclasses.dataclass(frozen=True)
-class TriggerResult:
-    """
-    Represents the result of a trigger evaluation with taint tracking.
-
-    The triggered field indicates whether the trigger condition was met.
-
-    The error field contains error information if the evaluation was tainted.
-    When error is not None, it indicates that the result may not be accurate due to
-    errors encountered during evaluation. Note that there may have been additional
-    errors beyond the one captured here - this field contains a representative error
-    from the evaluation, not necessarily all errors that occurred.
-    """
-
-    triggered: bool
-    error: ConditionError | None
-
-    # Constant untainted TriggerResult values (initialized after class definition).
-    # These represent clean success/failure with no errors.
-    TRUE: ClassVar["TriggerResult"]
-    FALSE: ClassVar["TriggerResult"]
-
-    def is_tainted(self) -> bool:
-        """
-        Returns True if this result is less trustworthy due to an error during
-        evaluation.
-        """
-        return self.error is not None
-
-    def with_error(self, error: ConditionError) -> "TriggerResult":
-        """
-        Returns a new TriggerResult with the same triggered value but the given error.
-        If the result is already tainted, the error is ignored.
-        """
-        if self.is_tainted():
-            return self
-        return TriggerResult(triggered=self.triggered, error=error)
-
-    @staticmethod
-    def choose_tainted(a: "TriggerResult", b: "TriggerResult") -> "TriggerResult":
-        """
-        Returns the first tainted TriggerResult, or `a` if neither is tainted.
-        Useful for tracking whether any evaluation in a series was tainted.
-        """
-        if a.is_tainted():
-            return a
-        if b.is_tainted():
-            return b
-        return a
-
-    @staticmethod
-    def any(items: Iterable["TriggerResult"]) -> "TriggerResult":
-        """
-        Like `any()`, but for TriggerResult. If any inputs had errors that could
-        impact the result, the result will contain an error from one of them.
-        """
-        items_list = list(items)
-        result = any(item.triggered for item in items_list)
-
-        if result:
-            # Result is True. If we have any untainted True, the result is clean.
-            # Only tainted if all Trues are tainted.
-            if any(item.triggered and not item.is_tainted() for item in items_list):
-                return TriggerResult(triggered=True, error=None)
-            # All Trues are tainted
-            return TriggerResult(
-                triggered=True, error=_find_error(items_list, lambda x: x.triggered)
-            )
-        else:
-            # Result is False. Any tainted item could have changed the result.
-            return TriggerResult(
-                triggered=False,
-                error=_find_error(items_list, lambda x: x.is_tainted()),
-            )
-
-    @staticmethod
-    def all(items: Iterable["TriggerResult"]) -> "TriggerResult":
-        """
-        Like `all()`, but for TriggerResult. If any inputs had errors that could
-        impact the result, the result will contain an error from one of them.
-        """
-        items_list = list(items)
-        result = all(item.triggered for item in items_list)
-
-        if result:
-            # Result is True. Any tainted item could have changed the result.
-            return TriggerResult(
-                triggered=True,
-                error=_find_error(items_list, lambda x: x.is_tainted()),
-            )
-        else:
-            # Result is False. If we have any untainted False, the result is clean.
-            # Only tainted if all Falses are tainted.
-            if any(not item.triggered and not item.is_tainted() for item in items_list):
-                return TriggerResult(triggered=False, error=None)
-            # All Falses are tainted
-            return TriggerResult(
-                triggered=False,
-                error=_find_error(items_list, lambda x: not x.triggered),
-            )
-
-    @staticmethod
-    def none(items: Iterable["TriggerResult"]) -> "TriggerResult":
-        """
-        Like `not any()`, but for TriggerResult. If any inputs had errors that could
-        impact the result, the result will contain an error from one of them.
-        """
-        items_list = list(items)
-
-        # No items is guaranteed True, no possible error.
-        if not items_list:
-            return TriggerResult(triggered=True, error=None)
-
-        result = all(not item.triggered for item in items_list)
-
-        if result:
-            # Result is True (no conditions triggered)
-            # Any tainted item could have changed the result
-            return TriggerResult(
-                triggered=True,
-                error=_find_error(items_list, lambda x: x.is_tainted()),
-            )
-        else:
-            # Result is False (at least one condition triggered)
-            # If we have any untainted True, the result is clean
-            if any(item.triggered and not item.is_tainted() for item in items_list):
-                return TriggerResult(triggered=False, error=None)
-            # All triggered items are tainted
-            return TriggerResult(
-                triggered=False,
-                error=_find_error(items_list, lambda x: x.triggered),
-            )
-
-    def __or__(self, other: "TriggerResult") -> "TriggerResult":
-        """
-        OR operation, equivalent to TriggerResult.any([self, other]).
-        """
-        return TriggerResult.any([self, other])
-
-    def __and__(self, other: "TriggerResult") -> "TriggerResult":
-        """
-        AND operation, equivalent to TriggerResult.all([self, other]).
-        """
-        return TriggerResult.all([self, other])
-
-    def __bool__(self) -> NoReturn:
-        raise AssertionError("TriggerResult cannot be used as a boolean")
-
-
-# Constant untainted TriggerResult values for common cases.
-# These are singleton instances representing clean success/failure with no errors.
-TriggerResult.TRUE = TriggerResult(triggered=True, error=None)
-TriggerResult.FALSE = TriggerResult(triggered=False, error=None)
 
 
 @dataclasses.dataclass()
@@ -294,51 +132,30 @@ def evaluate_data_conditions(
 
     for condition, value in conditions_to_evaluate:
         condition_evaluation = condition.evaluate_value(value)
-        cleaned_result: DataConditionResult
-
-        if isinstance(condition_evaluation.result, ConditionError):
-            cleaned_result = None
-        else:
-            cleaned_result = condition_evaluation.result
-
-        trigger_result = TriggerResult(
-            triggered=cleaned_result is not None,
-            error=condition_evaluation.result
-            if isinstance(condition_evaluation.result, ConditionError)
-            else None,
+        result = ProcessedDataCondition(
+            logic_result=condition_evaluation.outcome,
+            condition=condition,
+            result=condition_evaluation.result,
         )
 
-        if trigger_result.triggered:
-            # Check for short-circuiting evaluations
+        # Check for short-circuiting evaluations
+        if condition_evaluation.outcome.triggered:
             if logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-                condition_result = ProcessedDataCondition(
-                    logic_result=trigger_result,
-                    condition=condition,
-                    result=cleaned_result,
-                )
-
                 return ProcessedDataConditionGroup(
-                    logic_result=trigger_result,
-                    condition_results=[condition_result],
+                    logic_result=condition_evaluation.outcome,
+                    condition_results=[result],
                 )
 
             if logic_type == DataConditionGroup.Type.NONE:
                 return ProcessedDataConditionGroup(
-                    logic_result=TriggerResult(triggered=False, error=trigger_result.error),
+                    logic_result=TriggerResult(triggered=False, error=condition_evaluation.error),
                     condition_results=[],
                 )
 
-        result = ProcessedDataCondition(
-            logic_result=trigger_result,
-            condition=condition,
-            result=cleaned_result,
-        )
         condition_results.append(result)
 
-    return evaluate_condition_group_results(
-        condition_results,
-        logic_type,
-    )
+    # Apply the grouping logic to the condition evaluation results.
+    return evaluate_condition_group_results(condition_results, logic_type)
 
 
 @scopedstats.timer()

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -46,10 +46,10 @@ from sentry.workflow_engine.models.data_condition import (
 )
 from sentry.workflow_engine.processors.data_condition_group import (
     ProcessedDataConditionGroup,
-    TriggerResult,
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
 )
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -1,6 +1,8 @@
 __all__ = [
     "DataConditionEvaluation",
     "DataConditionEvaluationException",
+    "TriggerResult",
 ]
 
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
+from .trigger_result import TriggerResult

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,16 +1,11 @@
-from abc import ABC
+from dataclasses import dataclass
 
 
-class BaseWorkflowEngineEvaluation(ABC):
+@dataclass(frozen=True, kw_only=True)
+class BaseWorkflowEngineEvaluation[R, E]:
     """
     This is a shared base class for all Evaluation classes.
-
-    TODO
-    - Once we have a few of these, normalize them here
-
-    Current candidates:
-    - value: Any -- the value used in the evaluation
-    - result: Any -- the value returned as the result
     """
 
-    pass
+    result: R | None
+    error: E | None

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -1,16 +1,23 @@
-from dataclasses import dataclass
-from typing import Any
+from __future__ import annotations
 
-from sentry.workflow_engine.processors.evaluations.base import BaseWorkflowEngineEvaluation
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
 from sentry.workflow_engine.types import ConditionError, DataConditionResult
+
+from .base import BaseWorkflowEngineEvaluation
+from .trigger_result import TriggerResult
+
+if TYPE_CHECKING:
+    from sentry.workflow_engine.models.data_condition import DataCondition
 
 
 class DataConditionEvaluationException(Exception):
     pass
 
 
-@dataclass(frozen=True)
-class DataConditionEvaluation(BaseWorkflowEngineEvaluation):
+@dataclass(frozen=True, kw_only=True)
+class DataConditionEvaluation(BaseWorkflowEngineEvaluation[DataConditionResult, ConditionError]):
     """
     This class is used to track the evaluation of a DataCondition's logic.
 
@@ -20,11 +27,21 @@ class DataConditionEvaluation(BaseWorkflowEngineEvaluation):
     - value: Any - this is the value that was evaluated against.
     - evaluation: bool - this tracks the logical evaluation of the condition
     - result: DataConditionResult - this is the value that is expected to be the result of the evaluation, in general this is the `DataCondition.condition_result`
-
-    TODO
-    - Use this Evaluation to build DataConditionGroupEvaluation
     """
 
     value: Any
-    condition_met: bool
-    result: DataConditionResult | ConditionError
+    condition: DataCondition
+
+    @property
+    def outcome(self) -> TriggerResult:
+        """
+        TODO - @saponifi3d - The TriggerResult and the BaseWorkflowEngineEvaluation
+        can likely serve the same purpose, looking at the result / errors and providing
+        helpful interactions.
+
+        For now, using the `TriggerResult` to move a little faster through the refactoring.
+        """
+        return TriggerResult(
+            triggered=(self.result is not None),
+            error=self.error,
+        )

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from sentry.workflow_engine.types import ConditionError, DataConditionResult
@@ -25,23 +26,21 @@ class DataConditionEvaluation(BaseWorkflowEngineEvaluation[DataConditionResult, 
 
     Attributes
     - value: Any - this is the value that was evaluated against.
-    - evaluation: bool - this tracks the logical evaluation of the condition
-    - result: DataConditionResult - this is the value that is expected to be the result of the evaluation, in general this is the `DataCondition.condition_result`
+    - condition: DataCondition - This is the condition that was evaluated.
+
+    Inherits `result`, `error`, and `outcome`.
     """
 
     value: Any
     condition: DataCondition
 
-    @property
+    @cached_property
     def outcome(self) -> TriggerResult:
         """
-        TODO - @saponifi3d - The TriggerResult and the BaseWorkflowEngineEvaluation
+        #TODO: @saponifi3d - The TriggerResult and the BaseWorkflowEngineEvaluation
         can likely serve the same purpose, looking at the result / errors and providing
         helpful interactions.
 
-        For now, using the `TriggerResult` to move a little faster through the refactoring.
+        For now, using the `TriggerResult` to move more quickly through the refactoring
         """
-        return TriggerResult(
-            triggered=(self.result is not None),
-            error=self.error,
-        )
+        return TriggerResult(triggered=self.result is not None, error=self.error)

--- a/src/sentry/workflow_engine/processors/evaluations/trigger_result.py
+++ b/src/sentry/workflow_engine/processors/evaluations/trigger_result.py
@@ -1,0 +1,167 @@
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import ClassVar, NoReturn
+
+from sentry.workflow_engine.types import ConditionError
+
+
+def _find_error(
+    items: list["TriggerResult"], predicate: Callable[["TriggerResult"], bool]
+) -> ConditionError | None:
+    """Helper to find an error from items matching the predicate."""
+    return next((item.error for item in items if predicate(item)), None)
+
+
+@dataclass(frozen=True)
+class TriggerResult:
+    """
+    Represents the result of a trigger evaluation with taint tracking.
+
+    The triggered field indicates whether the trigger condition was met.
+
+    The error field contains error information if the evaluation was tainted.
+    When error is not None, it indicates that the result may not be accurate due to
+    errors encountered during evaluation. Note that there may have been additional
+    errors beyond the one captured here - this field contains a representative error
+    from the evaluation, not necessarily all errors that occurred.
+    """
+
+    triggered: bool
+    error: ConditionError | None
+
+    # Constant untainted TriggerResult values (initialized after class definition).
+    # These represent clean success/failure with no errors.
+    TRUE: ClassVar["TriggerResult"]
+    FALSE: ClassVar["TriggerResult"]
+
+    def is_tainted(self) -> bool:
+        """
+        Returns True if this result is less trustworthy due to an error during
+        evaluation.
+        """
+        return self.error is not None
+
+    def with_error(self, error: ConditionError) -> "TriggerResult":
+        """
+        Returns a new TriggerResult with the same triggered value but the given error.
+        If the result is already tainted, the error is ignored.
+        """
+        if self.is_tainted():
+            return self
+        return TriggerResult(triggered=self.triggered, error=error)
+
+    @staticmethod
+    def choose_tainted(a: "TriggerResult", b: "TriggerResult") -> "TriggerResult":
+        """
+        Returns the first tainted TriggerResult, or `a` if neither is tainted.
+        Useful for tracking whether any evaluation in a series was tainted.
+        """
+        if a.is_tainted():
+            return a
+        if b.is_tainted():
+            return b
+        return a
+
+    @staticmethod
+    def any(items: Iterable["TriggerResult"]) -> "TriggerResult":
+        """
+        Like `any()`, but for TriggerResult. If any inputs had errors that could
+        impact the result, the result will contain an error from one of them.
+        """
+        items_list = list(items)
+        result = any(item.triggered for item in items_list)
+
+        if result:
+            # Result is True. If we have any untainted True, the result is clean.
+            # Only tainted if all Trues are tainted.
+            if any(item.triggered and not item.is_tainted() for item in items_list):
+                return TriggerResult(triggered=True, error=None)
+            # All Trues are tainted
+            return TriggerResult(
+                triggered=True, error=_find_error(items_list, lambda x: x.triggered)
+            )
+        else:
+            # Result is False. Any tainted item could have changed the result.
+            return TriggerResult(
+                triggered=False,
+                error=_find_error(items_list, lambda x: x.is_tainted()),
+            )
+
+    @staticmethod
+    def all(items: Iterable["TriggerResult"]) -> "TriggerResult":
+        """
+        Like `all()`, but for TriggerResult. If any inputs had errors that could
+        impact the result, the result will contain an error from one of them.
+        """
+        items_list = list(items)
+        result = all(item.triggered for item in items_list)
+
+        if result:
+            # Result is True. Any tainted item could have changed the result.
+            return TriggerResult(
+                triggered=True,
+                error=_find_error(items_list, lambda x: x.is_tainted()),
+            )
+        else:
+            # Result is False. If we have any untainted False, the result is clean.
+            # Only tainted if all Falses are tainted.
+            if any(not item.triggered and not item.is_tainted() for item in items_list):
+                return TriggerResult(triggered=False, error=None)
+            # All Falses are tainted
+            return TriggerResult(
+                triggered=False,
+                error=_find_error(items_list, lambda x: not x.triggered),
+            )
+
+    @staticmethod
+    def none(items: Iterable["TriggerResult"]) -> "TriggerResult":
+        """
+        Like `not any()`, but for TriggerResult. If any inputs had errors that could
+        impact the result, the result will contain an error from one of them.
+        """
+        items_list = list(items)
+
+        # No items is guaranteed True, no possible error.
+        if not items_list:
+            return TriggerResult(triggered=True, error=None)
+
+        result = all(not item.triggered for item in items_list)
+
+        if result:
+            # Result is True (no conditions triggered)
+            # Any tainted item could have changed the result
+            return TriggerResult(
+                triggered=True,
+                error=_find_error(items_list, lambda x: x.is_tainted()),
+            )
+        else:
+            # Result is False (at least one condition triggered)
+            # If we have any untainted True, the result is clean
+            if any(item.triggered and not item.is_tainted() for item in items_list):
+                return TriggerResult(triggered=False, error=None)
+            # All triggered items are tainted
+            return TriggerResult(
+                triggered=False,
+                error=_find_error(items_list, lambda x: x.triggered),
+            )
+
+    def __or__(self, other: "TriggerResult") -> "TriggerResult":
+        """
+        OR operation, equivalent to TriggerResult.any([self, other]).
+        """
+        return TriggerResult.any([self, other])
+
+    def __and__(self, other: "TriggerResult") -> "TriggerResult":
+        """
+        AND operation, equivalent to TriggerResult.all([self, other]).
+        """
+        return TriggerResult.all([self, other])
+
+    def __bool__(self) -> NoReturn:
+        raise AssertionError("TriggerResult cannot be used as a boolean")
+
+
+# Constant untainted TriggerResult values for common cases.
+# These are singleton instances representing clean success/failure with no errors.
+TriggerResult.TRUE = TriggerResult(triggered=True, error=None)
+TriggerResult.FALSE = TriggerResult(triggered=False, error=None)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -22,11 +22,11 @@ from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContextData,
 )
 from sentry.workflow_engine.processors.data_condition_group import (
-    TriggerResult,
     get_data_conditions_for_group,
     process_data_condition_group,
 )
 from sentry.workflow_engine.processors.detector import get_detectors_for_event_data
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
     WorkflowEvaluation,

--- a/tests/sentry/incidents/handlers/condition/test_anomaly_detection_handler.py
+++ b/tests/sentry/incidents/handlers/condition/test_anomaly_detection_handler.py
@@ -202,7 +202,9 @@ class TestAnomalyDetectionHandler(ConditionTestCase):
         )
 
         evaluation = self.dc.evaluate_value(data_packet.packet.values)
-        assert evaluation.result == ConditionError(msg="Error during Seer data evaluation process.")
+        assert evaluation.value is None
+        assert evaluation.error == ConditionError(msg="Error during Seer data evaluation process.")
+        assert evaluation.outcome.triggered is False
 
         mock_logger.warning.assert_called_with(
             "Invalid aggregation value",

--- a/tests/sentry/incidents/handlers/condition/test_anomaly_detection_handler.py
+++ b/tests/sentry/incidents/handlers/condition/test_anomaly_detection_handler.py
@@ -180,7 +180,9 @@ class TestAnomalyDetectionHandler(ConditionTestCase):
     )
     @mock.patch("sentry.seer.anomaly_detection.get_anomaly_data.logger")
     def test_seer_call_nan_aggregation_value(
-        self, mock_logger: mock.MagicMock, mock_seer_request: mock.MagicMock
+        self,
+        mock_logger: mock.MagicMock,
+        mock_seer_request: mock.MagicMock,
     ) -> None:
         seer_return_value = self.high_confidence_seer_response
         mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
@@ -202,7 +204,7 @@ class TestAnomalyDetectionHandler(ConditionTestCase):
         )
 
         evaluation = self.dc.evaluate_value(data_packet.packet.values)
-        assert evaluation.value is None
+        assert evaluation.result is None
         assert evaluation.error == ConditionError(msg="Error during Seer data evaluation process.")
         assert evaluation.outcome.triggered is False
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -32,7 +32,7 @@ class ConditionTestCase(BaseWorkflowTest):
         evaluation = data_condition.evaluate_value(job)
 
         assert evaluation.value == job
-        assert evaluation.condition_met is True
+        assert evaluation.outcome.triggered is True
         assert evaluation.result == data_condition.get_condition_result()
 
     def assert_does_not_pass(
@@ -40,7 +40,7 @@ class ConditionTestCase(BaseWorkflowTest):
     ) -> None:
         evaluation = data_condition.evaluate_value(job)
         assert evaluation.value == job
-        assert evaluation.condition_met is False
+        assert evaluation.outcome.triggered is False
         assert evaluation.result != data_condition.get_condition_result()
 
     def assert_slow_condition_passes(self, data_condition: DataCondition, value: list[int]) -> None:
@@ -51,7 +51,7 @@ class ConditionTestCase(BaseWorkflowTest):
         self, data_condition: DataCondition, value: list[int]
     ) -> None:
         evaluation = data_condition.evaluate_value(value)
-        assert evaluation.condition_met is False
+        assert evaluation.outcome.triggered is False
         assert evaluation.result != data_condition.get_condition_result()
 
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_deescalating_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_priority_deescalating_handler.py
@@ -121,4 +121,5 @@ class TestIssuePriorityGreaterOrEqualCondition(ConditionTestCase):
     def test_missing_open_period_for_supported_type(self) -> None:
         GroupOpenPeriod.objects.filter(group=self.group).delete()
         evaluation = self.deescalating_dc_warning.evaluate_value(self.event_data)
-        assert isinstance(evaluation.result, ConditionError)
+        assert evaluation.result is None
+        assert isinstance(evaluation.error, ConditionError)

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -51,11 +51,11 @@ class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
             type=Condition.GREATER, comparison=1.0, condition_result=DetectorPriorityLevel.HIGH
         )
         evaluation = dc.evaluate_value(2)
-        assert evaluation.condition_met is True
+        assert evaluation.outcome.triggered is True
         assert evaluation.result == DetectorPriorityLevel.HIGH
 
         evaluation = dc.evaluate_value(1)
-        assert evaluation.condition_met is False
+        assert evaluation.outcome.triggered is False
         assert evaluation.result is None
 
     def test_dict_comparison_result(self) -> None:

--- a/tests/sentry/workflow_engine/models/test_data_condition.py
+++ b/tests/sentry/workflow_engine/models/test_data_condition.py
@@ -104,7 +104,8 @@ class EvaluateValueTest(DataConditionHandlerMixin, BaseWorkflowTest):
             condition_result="wrong",
         )
         evaluation = dc.evaluate_value(2)
-        assert evaluation.result == ConditionError(msg="Invalid condition result")
+        assert evaluation.result is None
+        assert evaluation.error == ConditionError(msg="Invalid condition result")
 
     def test_condition_evaluation__data_condition_exception(self) -> None:
         def evaluate_value(value: int, comparison: int) -> bool:

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -7,13 +7,12 @@ from sentry.workflow_engine.models.data_condition import Condition, DataConditio
 from sentry.workflow_engine.processors.data_condition_group import (
     ProcessedDataCondition,
     ProcessedDataConditionGroup,
-    TriggerResult,
     evaluate_data_conditions,
     get_data_conditions_for_group,
     get_slow_conditions_for_groups,
     process_data_condition_group,
 )
-from sentry.workflow_engine.processors.evaluations.condition import DataConditionEvaluation
+from sentry.workflow_engine.processors.evaluations import DataConditionEvaluation, TriggerResult
 from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel
 
 
@@ -353,6 +352,7 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                 self.data_condition,
                 "evaluate_value",
                 return_value=DataConditionEvaluation(
+                    condition=self.data_condition,
                     result=None,
                     error=None,
                     value="error",
@@ -362,6 +362,7 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                 self.data_condition_two,
                 "evaluate_value",
                 return_value=DataConditionEvaluation(
+                    condition=self.data_condition_two,
                     result=None,
                     error=error,
                     value="error",

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -354,7 +354,7 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                 "evaluate_value",
                 return_value=DataConditionEvaluation(
                     result=None,
-                    condition_met=False,
+                    error=None,
                     value="error",
                 ),
             ),
@@ -362,8 +362,8 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                 self.data_condition_two,
                 "evaluate_value",
                 return_value=DataConditionEvaluation(
-                    result=error,
-                    condition_met=False,
+                    result=None,
+                    error=error,
                     value="error",
                 ),
             ),

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -39,7 +39,6 @@ from sentry.workflow_engine.models.data_condition import (
 )
 from sentry.workflow_engine.processors.data_condition_group import (
     ProcessedDataConditionGroup,
-    TriggerResult,
     get_slow_conditions_for_groups,
 )
 from sentry.workflow_engine.processors.delayed_workflow import (
@@ -59,6 +58,7 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     get_group_to_groupevent,
     get_groups_to_fire,
 )
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -20,9 +20,9 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
 from sentry.workflow_engine.processors.data_condition_group import (
     ProcessedDataConditionGroup,
-    TriggerResult,
     get_data_conditions_for_group,
 )
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
     enqueue_workflows,

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -12,7 +12,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.activity import ActivityType
-from sentry.workflow_engine.processors.data_condition_group import TriggerResult
+from sentry.workflow_engine.processors.evaluations import TriggerResult
 from sentry.workflow_engine.processors.workflow import EvaluationStats
 from sentry.workflow_engine.tasks.utils import fetch_event
 from sentry.workflow_engine.tasks.workflows import process_workflow_activity


### PR DESCRIPTION
# Description
- Moves `TriggerResult` into `processors/evaluations` so it can be shared -- i think we'll end up moving a lot of this code to the base workflow class, but it's a lot less work to just use it for now.
- Simplified `evaluate_data_conditions` now that we have separate `results` and `errors`.