### PR TITLE
test(monitors): failing test for duplicate occurrences on threshold crossing

### DIFF
--- a/tests/sentry/monitors/logic/test_mark_failed.py
+++ b/tests/sentry/monitors/logic/test_mark_failed.py
@@ -402,6 +402,80 @@ class MarkFailedTestCase(TestCase):
         assert group_assignee.user_id == monitor.owner_user_id
 
     @mock.patch("sentry.monitors.logic.incidents.dispatch_incident_occurrence")
+    def test_mark_failed_issue_threshold_simultaneous_timeouts(
+        self, mock_dispatch_incident_occurrence: mock.MagicMock
+    ) -> None:
+        """
+        Regression test for https://github.com/getsentry/sentry/issues/118344
+
+        When failure_issue_threshold > 1 and multiple check-ins time out
+        simultaneously (within the same clock tick), exactly ONE occurrence
+        should be dispatched when the threshold is first crossed — not one
+        occurrence per check-in in the threshold window.
+        """
+        failure_issue_threshold = 2
+        monitor = Monitor.objects.create(
+            name="test monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            config={
+                "schedule": [5, "minute"],
+                "schedule_type": ScheduleType.INTERVAL,
+                "failure_issue_threshold": failure_issue_threshold,
+                "max_runtime": None,
+                "checkin_margin": None,
+            },
+        )
+        monitor_environment = MonitorEnvironment.objects.create(
+            monitor=monitor,
+            environment_id=self.environment.id,
+            status=MonitorStatus.OK,
+        )
+
+        # Prior successful check-in so the threshold window starts clean
+        MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.OK,
+        )
+
+        # Two check-ins that both time out in the same clock minute — the
+        # scenario from the bug report. They are processed sequentially
+        # (Kafka partitioned by monitor_environment_id) but both arrive
+        # before any status change is committed.
+        checkin_1 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.TIMEOUT,
+        )
+        checkin_2 = MonitorCheckIn.objects.create(
+            monitor=monitor,
+            monitor_environment=monitor_environment,
+            project_id=self.project.id,
+            status=CheckInStatus.TIMEOUT,
+        )
+
+        # Processing checkin_1: the window includes the prior OK, so the
+        # threshold is not yet reached.
+        mark_failed(checkin_1, failed_at=checkin_1.date_added)
+        assert mock_dispatch_incident_occurrence.call_count == 0
+
+        # Processing checkin_2: now both failures are in the window — threshold
+        # is crossed. Exactly ONE occurrence should be dispatched, not two.
+        mark_failed(checkin_2, failed_at=checkin_2.date_added)
+
+        monitor_environment.refresh_from_db()
+        assert monitor_environment.status == MonitorStatus.ERROR
+
+        assert mock_dispatch_incident_occurrence.call_count == 1, (
+            "Expected exactly 1 occurrence when threshold is first crossed, "
+            f"got {mock_dispatch_incident_occurrence.call_count}. "
+            "Duplicate occurrences cause duplicate alert notifications."
+        )
+
+    @mock.patch("sentry.monitors.logic.incidents.dispatch_incident_occurrence")
     @mock.patch("sentry.monitors.logic.incident_occurrence.resolve_incident_group")
     def test_mark_failed_fingerprint_after_resolution(
         self, mock_resolve_incident_group, mock_dispatch_incident_occurrence


### PR DESCRIPTION
## What

Adds a failing regression test for https://github.com/getsentry/sentry/issues/118344.

No fix included — just the test, so the bug is clearly documented and the fix can be verified against it.

## Why it fails

When `failure_issue_threshold = 2` and two check-ins time out simultaneously (same clock tick), `try_incident_threshold` in `incidents.py` loops over `previous_checkins` and calls `dispatch_incident_occurrence` **once per check-in in the threshold window** instead of once total:

```python
checkins = list(MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins]))
for checkin in checkins:  # ← fires N times when threshold is first crossed
    dispatch_incident_occurrence(checkin, checkins, incident, received, clock_tick)
```

With threshold=2 this produces 2 `IssueOccurrence`s with the same fingerprint and timestamp → two alert notifications for the same incident.

## Fix (not in this PR)

```python
# Replace the loop with a single call using the triggering check-in
checkins = list(MonitorCheckIn.objects.filter(id__in=[c.id for c in previous_checkins]))
dispatch_incident_occurrence(failed_checkin, checkins, incident, received, clock_tick)
```

`failed_checkin` is already a full `MonitorCheckIn` object. The `checkins` list is still fetched so `get_failure_reason()` renders the correct context (e.g. _"2 timeout check-ins detected"_).

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AC04KZQBNQ2U%3A1783544350.324939/?project=4510944073809921)

<!-- junior-session-footer:end -->