### PR TITLE
Remove unused customer charge details URL

### DIFF
--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -21,7 +21,6 @@ export type KnownGetsentryApiUrls =
   | '/customers/'
   | '/_admin/customers/$organizationIdOrSlug/contract/'
   | '/customers/$organizationIdOrSlug/'
-  | '/customers/$organizationIdOrSlug/balancechanges/'
   | '/customers/$organizationIdOrSlug/billing-config/'
   | '/customers/$organizationIdOrSlug/billing-details/'
   | '/customers/$organizationIdOrSlug/billing-seats/current/'

--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -26,7 +26,6 @@ export type KnownGetsentryApiUrls =
   | '/customers/$organizationIdOrSlug/billing-details/'
   | '/customers/$organizationIdOrSlug/billing-seats/current/'
   | '/customers/$organizationIdOrSlug/charges/'
-  | '/customers/$organizationIdOrSlug/charges/$chargeId/'
   | '/customers/$organizationIdOrSlug/history/'
   | '/customers/$organizationIdOrSlug/history/current/'
   | '/customers/$organizationIdOrSlug/invoices/'


### PR DESCRIPTION
## Summary

Removes the `/customers/$organizationIdOrSlug/charges/$chargeId/` entry from the known GetSentry API URLs union. It was never referenced by any client — the gsAdmin UI only uses the list endpoint (`charges/`) and links individual charges out to Stripe's dashboard, so the per-charge detail path is dead.

The backend `CustomerChargeDetailsEndpoint` (in getsentry) is still routed and reachable; this only drops the unused frontend URL-type entry.

## Test plan

- Type-only change to a URL union; `knip` and type checks pass via pre-commit/pre-push hooks.