### PR TITLE
fix(conversations): Remove 800px cap from tool and thinking blocks

### DIFF
--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -11,7 +11,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
  */
 
 /** Max width shared by the user and assistant message bubbles. */
-export const AI_MESSAGE_MAX_WIDTH = '800px';
+const AI_MESSAGE_MAX_WIDTH = '800px';
 
 interface MessageBlockProps {
   children: ReactNode;

--- a/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
@@ -3,7 +3,6 @@ import {css, useTheme} from '@emotion/react';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {AI_MESSAGE_MAX_WIDTH} from 'sentry/components/ai/chat/messageBlock';
 import {IconFix} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -100,7 +99,7 @@ export function MessageToolCallsNew({
             }}
           >
             <Flex align="center" justify="between" gap="md" width="100%">
-              <Flex align="center" gap="sm" minWidth={0} maxWidth={AI_MESSAGE_MAX_WIDTH}>
+              <Flex align="center" gap="sm" minWidth={0}>
                 <Flex align="center" flexShrink={0}>
                   <IconFix size="sm" variant="accent" />
                 </Flex>

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -7,7 +7,6 @@ import {Text} from '@sentry/scraps/text';
 
 import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
 import {
-  AI_MESSAGE_MAX_WIDTH,
   AssistantMessageBlock,
   MessageBlock,
   UserMessageBlock,
@@ -239,7 +238,6 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
 
   return (
     <CollapsibleContent
-      maxWidth={AI_MESSAGE_MAX_WIDTH}
       title={
         <Text size="sm" variant="muted" monospace>
           {t('Thinking...')}


### PR DESCRIPTION
Tool-call rows and the "Thinking..." block in the conversation view were pinned to the 800px AI-message max-width, which left them looking oddly narrow when the panel had more room. They now fill the available column width instead. The user and assistant message bubbles keep the 800px cap so message text stays comfortably readable.