### PR TITLE
ref(o11y): Dual write remaining tags and context

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -155,6 +155,15 @@ class CompositeRuleStore:
                     "discarded_rules": sorted_rules[self.MERGE_MAX_RULES :],
                 },
             )
+            sentry_sdk.get_isolation_scope().set_attribute(
+                "clustering_rules_max.num_existing_rules", len(rules)
+            )
+            sentry_sdk.get_isolation_scope().set_attribute(
+                "clustering_rules_max.max_amount", self.MERGE_MAX_RULES
+            )
+            sentry_sdk.get_isolation_scope().set_attribute(
+                "clustering_rules_max.discarded_rules", repr(sorted_rules[self.MERGE_MAX_RULES :])
+            )
             sentry_sdk.set_tag("namespace", self._namespace.value.name)
             sentry_sdk.set_attribute("namespace", self._namespace.value.name)
             sentry_sdk.capture_message("Clusterer discarded rules", level="warning")

--- a/src/sentry/integrations/api/bases/doc_integrations.py
+++ b/src/sentry/integrations/api/bases/doc_integrations.py
@@ -90,6 +90,7 @@ class DocIntegrationBaseEndpoint(DocIntegrationsBaseEndpoint):
         self.check_object_permissions(request, doc_integration)
 
         sentry_sdk.get_isolation_scope().set_tag("doc_integration", doc_integration.slug)
+        sentry_sdk.get_isolation_scope().set_attribute("doc_integration", doc_integration.slug)
 
         kwargs["doc_integration"] = doc_integration
         return (args, kwargs)

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
 
+import sentry_sdk
 from django.db import router, transaction
 from google.api_core.exceptions import DeadlineExceeded
 from sentry_sdk import set_tag, set_user
@@ -60,9 +61,11 @@ def process_event(
     project = Project.objects.get(id=project_id)
     org = Organization.objects.get(id=project.organization_id)
     set_tag("organization.slug", org.slug)
+    sentry_sdk.set_attribute("organization.slug", org.slug)
     # When you look at the performance page the user is a default column
     set_user({"username": org.slug})
     set_tag("project.slug", project.slug)
+    sentry_sdk.set_attribute("project.slug", project.slug)
     extra = {
         "organization.slug": org.slug,
         "project_id": project_id,
@@ -77,6 +80,7 @@ def process_event(
     platform = event.platform
     assert platform is not None
     set_tag("platform", platform)
+    sentry_sdk.set_attribute("platform", platform)
 
     platform_config = PlatformConfig(platform)
     if not platform_config.is_supported():

--- a/src/sentry/issues/endpoints/bases/group.py
+++ b/src/sentry/issues/endpoints/bases/group.py
@@ -92,6 +92,7 @@ class GroupEndpoint(Endpoint):
         self.check_object_permissions(request, group)
 
         sentry_sdk.get_isolation_scope().set_tag("project", group.project_id)
+        sentry_sdk.get_isolation_scope().set_attribute("project", group.project_id)
 
         # we didn't bind context above, so do it now
         if not organization:

--- a/src/sentry/issues/endpoints/project_stacktrace_link.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_link.py
@@ -198,6 +198,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             serialized_config = serialize(result["current_config"]["config"], request.user)
             provider = serialized_config["provider"]["key"]
             scope.set_tag("integration_provider", provider)  # e.g. github
+            scope.set_attribute("integration_provider", provider)
 
             if not result["source_url"]:
                 error = result["current_config"]["outcome"].get("error")

--- a/src/sentry/monitors/endpoints/base.py
+++ b/src/sentry/monitors/endpoints/base.py
@@ -67,6 +67,7 @@ class MonitorEndpoint(Endpoint):
         self.check_object_permissions(request, project)
 
         Scope.get_isolation_scope().set_tag("project", project.id)
+        Scope.get_isolation_scope().set_attribute("project", project.id)
 
         bind_organization_context(project.organization)
 

--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -115,6 +115,7 @@ class PreprodArtifactEndpoint(OrganizationEndpoint):
         kwargs["head_artifact"] = head_artifact
         kwargs["project"] = project
         sentry_sdk.get_isolation_scope().set_tag("project", project.id)
+        sentry_sdk.get_isolation_scope().set_attribute("project", project.id)
 
         base_artifact_id = kwargs.get("base_artifact_id")
         if base_artifact_id is None:

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -503,18 +503,21 @@ class OrganizationReleaseDetailsEndpoint(
             projects = release.projects.all()
         except Release.DoesNotExist:
             scope.set_tag("failure_reason", "Release.DoesNotExist")
+            scope.set_attribute("failure_reason", "Release.DoesNotExist")
             raise ResourceDoesNotExist
 
         if not self.has_release_permission(
             request, organization, release, require_all_projects=True
         ):
             scope.set_tag("failure_reason", "no_release_permission")
+            scope.set_attribute("failure_reason", "no_release_permission")
             raise ResourceDoesNotExist
 
         serializer = OrganizationReleaseSerializer(data=request.data)
 
         if not serializer.is_valid():
             scope.set_tag("failure_reason", "serializer_error")
+            scope.set_attribute("failure_reason", "serializer_error")
             return Response(as_validation_errors(serializer), status=400)
 
         result = serializer.validated_data
@@ -569,6 +572,7 @@ class OrganizationReleaseDetailsEndpoint(
         if refs:
             if not request.user.is_authenticated and not request.auth:
                 scope.set_tag("failure_reason", "user_not_authenticated")
+                scope.set_attribute("failure_reason", "user_not_authenticated")
                 return Response(
                     {"refs": ["You must use an authenticated API token to fetch refs"]},
                     status=400,
@@ -578,6 +582,7 @@ class OrganizationReleaseDetailsEndpoint(
                 release.set_refs(refs, request.user.id, fetch=fetch_commits)
             except InvalidRepository as e:
                 scope.set_tag("failure_reason", "InvalidRepository")
+                scope.set_attribute("failure_reason", "InvalidRepository")
                 return Response({"refs": [str(e)]}, status=400)
 
         if not was_released and release.date_released:

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -131,12 +131,14 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             )
         except Release.DoesNotExist:
             scope.set_tag("failure_reason", "Release.DoesNotExist")
+            scope.set_attribute("failure_reason", "Release.DoesNotExist")
             raise ResourceDoesNotExist
 
         serializer = ReleaseSerializer(data=request.data, partial=True)
 
         if not serializer.is_valid():
             scope.set_tag("failure_reason", "serializer_error")
+            scope.set_attribute("failure_reason", "serializer_error")
             return Response(as_validation_errors(serializer), status=400)
 
         result = serializer.validated_data

--- a/src/sentry/releases/endpoints/project_releases.py
+++ b/src/sentry/releases/endpoints/project_releases.py
@@ -154,6 +154,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
         if serializer.is_valid():
             result = serializer.validated_data
             scope.set_tag("version", result["version"])
+            scope.set_attribute("version", result["version"])
 
             new_status = result.get("status")
 
@@ -235,6 +236,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint):
                 update_org_auth_token_last_used(request.auth, [project.id])
 
             scope.set_tag("success_status", status)
+            scope.set_attribute("success_status", status)
 
             # Disable snuba here as it often causes 429s when overloaded and
             # a freshly created release won't have health data anyways.

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -112,7 +112,9 @@ def process_message(message: bytes) -> ProcessedEvent | None:
     try:
         recording_event = parse_recording_event(message)
         set_tag("org_id", recording_event["context"]["org_id"])
+        sentry_sdk.set_attribute("org_id", recording_event["context"]["org_id"])
         set_tag("project_id", recording_event["context"]["project_id"])
+        sentry_sdk.set_attribute("project_id", recording_event["context"]["project_id"])
         return process_recording_event(
             recording_event,
             use_new_recording_parser=options.get("replay.consumer.msgspec_recording_parser"),

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1427,6 +1427,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             pg_overflow_fallback = True
             # Surface the silent ranking degradation on the trace, next to `search.sort`.
             sentry_sdk.set_tag("search.sort_fallback", sort_by)
+            sentry_sdk.set_attribute("search.sort_fallback", sort_by)
             # Keep the original sort only if it maps to a real Snuba aggregation for the
             # chunked path. Keys absent from sort_strategies, or mapped to "" (Postgres-only
             # sorts like "inbox"), have no aggregation and must fall back to `date` instead

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -272,6 +272,7 @@ class SeerRpcSignatureAuthentication(StandardAuthentication):
             raise AuthenticationFailed("Invalid signature")
 
         sentry_sdk.get_isolation_scope().set_tag("seer_rpc_auth", True)
+        sentry_sdk.get_isolation_scope().set_attribute("seer_rpc_auth", True)
 
         return (AnonymousUser(), token)
 
@@ -315,6 +316,7 @@ class SeerRpcViewerContextAuthentication(BaseAuthentication):
                 user = resolved
 
         sentry_sdk.get_isolation_scope().set_tag("seer_rpc_viewer_context_auth", True)
+        sentry_sdk.get_isolation_scope().set_attribute("seer_rpc_viewer_context_auth", True)
 
         # Stash the verified context so the org-binding guard reads the signed
         # value directly. (The middleware contextvar can drop organization_id when

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -308,6 +308,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
         _check_sentry_app_disabled(self, request, sentry_app)
 
         sentry_sdk.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
+        sentry_sdk.get_isolation_scope().set_attribute("sentry_app", sentry_app.slug)
 
         kwargs["sentry_app"] = sentry_app
         return (args, kwargs)
@@ -328,6 +329,7 @@ class CellSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
         _check_sentry_app_disabled(self, request, sentry_app)
 
         sentry_sdk.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
+        sentry_sdk.get_isolation_scope().set_attribute("sentry_app", sentry_app.slug)
 
         kwargs["sentry_app"] = sentry_app
         return (args, kwargs)
@@ -455,6 +457,7 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
         _check_sentry_app_disabled(self, request, installation.sentry_app)
 
         sentry_sdk.get_isolation_scope().set_tag("sentry_app_installation", installation.uuid)
+        sentry_sdk.get_isolation_scope().set_attribute("sentry_app_installation", installation.uuid)
 
         kwargs["installation"] = installation
         return (args, kwargs)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -316,6 +316,7 @@ class BaseApiClient:
 
         if self.integration_type:
             sentry_sdk.get_isolation_scope().set_tag(self.integration_type, self.name)
+            sentry_sdk.get_isolation_scope().set_attribute(self.integration_type, self.name)
 
         request = Request(
             method=method.upper(),

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -652,7 +652,9 @@ def check_tag_for_scope_bleed(
         }
         if add_to_scope:
             scope.set_tag("possible_mistag", True)
+            scope.set_attribute("possible_mistag", True)
             scope.set_tag(f"scope_bleed.{tag_key}", True)
+            scope.set_attribute(f"scope_bleed.{tag_key}", True)
             merge_context_into_scope("scope_bleed", extra, scope)
         logger.warning("Tag already set and different (%s).", tag_key, extra=extra)
 
@@ -730,6 +732,7 @@ def capture_exception_with_scope_check(
         # TODO: We probably should add this data to the scope in `check_current_scope_transaction`
         # instead, but the whole point is that right now it's unclear how trustworthy ambient scope is
         extra_scope.set_tag("scope_bleed.transaction", True)
+        extra_scope.set_attribute("scope_bleed.transaction", True)
         merge_context_into_scope("scope_bleed", transaction_mismatch, extra_scope)
 
     return sentry_sdk.capture_exception(error, scope=extra_scope)
@@ -748,7 +751,9 @@ def bind_organization_context(organization: Organization | RpcOrganization) -> N
         check_tag_for_scope_bleed("organization.slug", organization.slug)
 
         scope.set_tag("organization", organization.id)
+        scope.set_attribute("organization", organization.id)
         scope.set_tag("organization.slug", organization.slug)
+        scope.set_attribute("organization.slug", organization.slug)
         scope.set_context("organization", {"id": organization.id, "slug": organization.slug})
         if helper:
             try:

--- a/src/sentry/web/frontend/csrf_failure.py
+++ b/src/sentry/web/frontend/csrf_failure.py
@@ -51,10 +51,13 @@ def view(request: HttpRequest, reason: str = "") -> HttpResponse:
 
         if is_staff:
             scope.set_tag("is_staff", "yes")
+            scope.set_attribute("is_staff", "yes")
         if is_superuser:
             scope.set_tag("is_superuser", "yes")
+            scope.set_attribute("is_superuser", "yes")
         if is_staff or is_superuser:
             scope.set_tag("csrf_failure", "yes")
+            scope.set_attribute("csrf_failure", "yes")
             logging.error("CSRF failure for staff or superuser")
 
     logger.info("csrf_failure", extra=extras)

--- a/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
+++ b/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
@@ -99,6 +99,9 @@ def track_alert_endpoint_execution(
                 sentry_sdk.get_isolation_scope().set_tag(
                     "legacy_models", str(legacy_models).lower()
                 )
+                sentry_sdk.get_isolation_scope().set_attribute(
+                    "legacy_models", str(legacy_models).lower()
+                )
                 # Reset the context var
                 _legacy_models_used.reset(token)
 


### PR DESCRIPTION
These were added since the last round or simply missed.
Tags and context must be written to attributes to appear on streamed spans.