### PR TITLE
ref(conversations): Remove 900px content max width

### DIFF
--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -16,7 +16,6 @@ const DIVIDER_WIDTH = 1;
 const DEFAULT_STORAGE_KEY = 'conversation-split-size';
 
 const CONTENT_MIN_WIDTH = 400;
-const CONTENT_MAX_WIDTH = 900;
 const DETAIL_MIN_WIDTH = 400;
 const CONTENT_WIDTH_RATIO = 0.6;
 const SPLIT_LAYOUT_STORAGE_KEY = 'conversation-split-layout-size';
@@ -193,7 +192,6 @@ function MeasuredContentSplit({
       defaultSize={defaultContent}
       initialSize={storedSize}
       minSize={CONTENT_MIN_WIDTH}
-      maxSize={CONTENT_MAX_WIDTH}
       fillMinSize={DETAIL_MIN_WIDTH}
       onResizeEnd={({endSize}) => setStoredSize(endSize)}
       sized={
@@ -202,7 +200,6 @@ function MeasuredContentSplit({
           flex="1"
           minWidth="0"
           minHeight="0"
-          maxWidth={`${CONTENT_MAX_WIDTH}px`}
           paddingRight={{xs: '0', md: 'md'}}
           paddingBottom={{xs: 'md', md: '0'}}
         >


### PR DESCRIPTION
The redesigned conversation view now caps the whole container at `1340px`, so the `900px` (`CONTENT_MAX_WIDTH`) cap on the left content pane is no longer needed.

This removes the `CONTENT_MAX_WIDTH` constant and its two usages (the `SplitPanel` `maxSize` and the content `Flex` `maxWidth`) so the content pane can grow up to the container's new max width.