### PR TITLE
feat(splitPanel): Accept percentage and responsive pane sizes

### DIFF
--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useImperativeHandle, useRef} from 'react';
+import {useCallback, useImperativeHandle, useLayoutEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex, type Responsive} from '@sentry/scraps/layout';
@@ -9,8 +9,33 @@ import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 
 type Orientation = 'horizontal' | 'vertical';
 
+/**
+ * A pane size expressed as either pixels (a bare number, the component's
+ * long-standing convention) or a percentage string (`"60%"`). Percentages
+ * resolve against the measured extent of the active axis — width in a row,
+ * height in a column — so a single value stays correct across orientations.
+ */
+type SplitSize = number | `${number}%`;
+
 // The divider renders as a 1px border; account for it when deriving the max.
 const DIVIDER_SIZE = 1;
+
+// Resolve a SplitSize to pixels against the measured axis. Percentages need a
+// measurement, so they collapse to 0 until `available > 0` (the panel stays
+// hidden until then). Returns undefined only for an undefined input.
+function resolveSplitSize(
+  value: SplitSize | undefined,
+  available: number
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  const percent = parseFloat(value);
+  return Number.isFinite(percent) ? Math.round((percent / 100) * available) : undefined;
+}
 
 export interface SplitPanelHandle {
   /**
@@ -22,18 +47,26 @@ export interface SplitPanelHandle {
 }
 
 interface SplitPanelProps {
-  /** Initial size of the `sized` pane in pixels; restored on double-click. */
-  defaultSize: number;
+  /**
+   * Size of the `sized` pane when unset/reset (double-click). Pixels or a
+   * percentage of the active axis (`"60%"`). Accepts a responsive value.
+   */
+  defaultSize: Responsive<SplitSize>;
   /** The pane with a draggable size. */
   sized: React.ReactNode;
   /** The pane that fills the remaining space. Omit to render a single pane. */
   fill?: React.ReactNode;
-  /** Minimum size of the `fill` pane in pixels. */
-  fillMinSize?: number;
-  /** Starting size, e.g. restored from persistence. Defaults to `defaultSize`. */
+  /** Minimum size of the `fill` pane. Pixels or a percentage; responsive. */
+  fillMinSize?: Responsive<SplitSize>;
+  /**
+   * Starting size in pixels, e.g. restored from persistence. Falls back to
+   * `defaultSize` when omitted. Pixels only — it's a measured/persisted value.
+   */
   initialSize?: number;
-  maxSize?: number;
-  minSize?: number;
+  /** Maximum size of the `sized` pane. Pixels or a percentage; responsive. */
+  maxSize?: Responsive<SplitSize>;
+  /** Minimum size of the `sized` pane. Pixels or a percentage; responsive. */
+  minSize?: Responsive<SplitSize>;
   /** Fires during drag with the new size. */
   onResize?: (newSize: number) => void;
   /** Fires once when a drag ends. */
@@ -152,8 +185,8 @@ export function SplitPanel({
   ref,
   orientation: orientationProp = 'horizontal',
   placement = 'start',
-  defaultSize,
-  initialSize = defaultSize,
+  defaultSize: defaultSizeProp,
+  initialSize,
   minSize = 0,
   maxSize,
   fillMinSize = 0,
@@ -170,13 +203,27 @@ export function SplitPanel({
   const dims = useDimensions({elementRef: containerRef});
   const availableSize = orientation === 'horizontal' ? dims.width : dims.height;
 
-  const min = minSize;
-  const explicitMax = maxSize ?? Number.POSITIVE_INFINITY;
+  // Resolve the responsive layer first (breakpoint → single value, container-
+  // aware, in step with `orientation`), then percentages → px off the measured
+  // axis. Order matters: `{xs: '50%', md: 400}` must pick the breakpoint before
+  // it can know whether the winner is a percentage.
+  // The hook's return type keeps the responsive shape; narrow to the scalar it
+  // actually resolves to (as `orientation` above does via a value comparison).
+  const defaultSizeValue = useResponsivePropValue(defaultSizeProp) as SplitSize;
+  const minSizeValue = useResponsivePropValue(minSize) as SplitSize;
+  const maxSizeValue = useResponsivePropValue(maxSize) as SplitSize | undefined;
+  const fillMinSizeValue = useResponsivePropValue(fillMinSize) as SplitSize;
+
+  const resolvedDefault = resolveSplitSize(defaultSizeValue, availableSize) ?? 0;
+  const min = resolveSplitSize(minSizeValue, availableSize) ?? 0;
+  const fillMin = resolveSplitSize(fillMinSizeValue, availableSize) ?? 0;
+  const explicitMax =
+    resolveSplitSize(maxSizeValue, availableSize) ?? Number.POSITIVE_INFINITY;
   // Cap so the sized pane can't overflow or push the fill pane below its min.
   // Floored at min; falls back to the explicit max until we've measured.
   const max =
     availableSize > 0
-      ? Math.max(min, Math.min(explicitMax, availableSize - fillMinSize - DIVIDER_SIZE))
+      ? Math.max(min, Math.min(explicitMax, availableSize - fillMin - DIVIDER_SIZE))
       : explicitMax;
 
   const handleResizeEnd = useCallback(
@@ -208,7 +255,9 @@ export function SplitPanel({
         : isSizedFirst
           ? 'down'
           : 'up',
-    initialSize,
+    // Percentages can't resolve until measured, so an unset % default seeds as
+    // 0 here and is corrected by the effect below once `availableSize` is known.
+    initialSize: initialSize ?? resolvedDefault,
     min,
     max,
     onResize: newSize => onResize?.(newSize),
@@ -216,6 +265,26 @@ export function SplitPanel({
   });
 
   useImperativeHandle(ref, () => ({setSize}), [setSize]);
+
+  // A percentage default has no correct value before measurement, so seed it
+  // once `availableSize` lands. Skipped when the consumer passed an explicit
+  // (persisted) `initialSize`, or when the default is px (already seeded right).
+  const defaultIsPercent = typeof defaultSizeValue === 'string';
+  const seededRef = useRef(initialSize !== undefined);
+  useLayoutEffect(() => {
+    if (seededRef.current) {
+      return;
+    }
+    if (!defaultIsPercent) {
+      seededRef.current = true;
+      return;
+    }
+    if (availableSize <= 0) {
+      return;
+    }
+    seededRef.current = true;
+    setSize(Math.max(min, Math.min(resolvedDefault, max)));
+  }, [defaultIsPercent, availableSize, resolvedDefault, min, max, setSize]);
 
   // Clamped to [min, max] so the pane basis and divider aria-valuenow stay in
   // step — and never go negative when a seeded/persisted size is below min
@@ -225,10 +294,10 @@ export function SplitPanel({
   const visibleSize = Math.max(min, Math.min(containerSize, max));
 
   const handleDoubleClick = useCallback(() => {
-    const target = Math.max(min, Math.min(defaultSize, max));
+    const target = Math.max(min, Math.min(resolvedDefault, max));
     setSize(target, true);
     handleResizeEnd(visibleSize, target);
-  }, [visibleSize, max, min, defaultSize, setSize, handleResizeEnd]);
+  }, [visibleSize, max, min, resolvedDefault, setSize, handleResizeEnd]);
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {

--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import {useRef} from 'react';
 
-import {Container, Flex, Stack, useContainerBreakpoint} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {SplitPanel} from '@sentry/scraps/splitPanel';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -17,10 +17,11 @@ const DEFAULT_STORAGE_KEY = 'conversation-split-size';
 
 const CONTENT_MIN_WIDTH = 400;
 const CONTENT_MIN_HEIGHT = 180;
-const CONTENT_MAX_WIDTH = 900;
 const DETAIL_MIN_WIDTH = 400;
 const DETAIL_MIN_HEIGHT = 200;
-const CONTENT_WIDTH_RATIO = 0.6;
+// The content pane defaults to 60% of the active axis (width in a row, height
+// when stacked); SplitPanel resolves the percentage off its own measurement.
+const CONTENT_DEFAULT_SIZE = '60%';
 const SPLIT_LAYOUT_STORAGE_KEY = 'conversation-split-layout-size';
 
 /**
@@ -129,8 +130,13 @@ export function ConversationContentLayout({
   leftPadding?: React.ComponentProps<typeof Container>['padding'];
   right?: React.ReactNode;
 }) {
-  const measureRef = useRef<HTMLDivElement>(null);
-  const {width, height} = useDimensions({elementRef: measureRef});
+  // Side by side above md, stacked below. SplitPanel resolves the orientation
+  // container-aware and, in step with it, picks the axis-appropriate min sizes
+  // and the percentage default — so no measurement dance is needed here.
+  const [storedSize, setStoredSize] = useLocalStorageState<number | null>(
+    SPLIT_LAYOUT_STORAGE_KEY,
+    null
+  );
 
   return (
     <Flex flex="1" minWidth="0" minHeight="0" overflow="hidden">
@@ -142,13 +148,23 @@ export function ConversationContentLayout({
           width="100%"
           background="secondary"
         >
-          <Flex ref={measureRef} height="100%" width="100%" minHeight="0" minWidth="0">
-            {width > 0 && height > 0 ? (
-              <MeasuredContentSplit
-                width={width}
-                height={height}
-                detail={right}
-                content={
+          <Flex height="100%" width="100%" minHeight="0" minWidth="0">
+            <SplitPanel
+              orientation={{xs: 'vertical', md: 'horizontal'}}
+              defaultSize={CONTENT_DEFAULT_SIZE}
+              initialSize={storedSize ?? undefined}
+              minSize={{xs: CONTENT_MIN_HEIGHT, md: CONTENT_MIN_WIDTH}}
+              fillMinSize={{xs: DETAIL_MIN_HEIGHT, md: DETAIL_MIN_WIDTH}}
+              onResizeEnd={({endSize}) => setStoredSize(endSize)}
+              sized={
+                <Flex
+                  direction="column"
+                  flex="1"
+                  minWidth="0"
+                  minHeight="0"
+                  paddingRight={{xs: '0', md: 'md'}}
+                  paddingBottom={{xs: 'md', md: '0'}}
+                >
                   <Container
                     flex="1"
                     minWidth="0"
@@ -162,79 +178,27 @@ export function ConversationContentLayout({
                   >
                     {left}
                   </Container>
-                }
-              />
-            ) : null}
+                </Flex>
+              }
+              fill={
+                right ? (
+                  <Flex
+                    direction="column"
+                    flex="1"
+                    minWidth="0"
+                    minHeight="0"
+                    paddingLeft={{xs: '0', md: 'md'}}
+                    paddingTop={{xs: 'md', md: '0'}}
+                  >
+                    {right}
+                  </Flex>
+                ) : undefined
+              }
+            />
           </Flex>
         </Container>
       </ConversationLeftPanel>
     </Flex>
-  );
-}
-
-function MeasuredContentSplit({
-  content,
-  detail,
-  width,
-  height,
-}: {
-  content: React.ReactNode;
-  height: number;
-  width: number;
-  detail?: React.ReactNode;
-}) {
-  // Side by side above md, stacked below. The panes are sized by width in a row
-  // and by height in a column, so the min/default track the active axis —
-  // otherwise the width-based 400px min becomes a min-height that can't fit on
-  // short screens and the divider locks up.
-  const isRow = !['2xs', 'xs', 'sm'].includes(useContainerBreakpoint());
-  const available = isRow ? width : height;
-  const defaultContent = Math.max(
-    isRow ? CONTENT_MIN_WIDTH : CONTENT_MIN_HEIGHT,
-    Math.round((available - DIVIDER_WIDTH) * CONTENT_WIDTH_RATIO)
-  );
-  const [storedSize, setStoredSize] = useLocalStorageState(
-    SPLIT_LAYOUT_STORAGE_KEY,
-    defaultContent
-  );
-
-  return (
-    <SplitPanel
-      orientation={isRow ? 'horizontal' : 'vertical'}
-      defaultSize={defaultContent}
-      initialSize={storedSize}
-      minSize={isRow ? CONTENT_MIN_WIDTH : CONTENT_MIN_HEIGHT}
-      maxSize={isRow ? CONTENT_MAX_WIDTH : undefined}
-      fillMinSize={isRow ? DETAIL_MIN_WIDTH : DETAIL_MIN_HEIGHT}
-      onResizeEnd={({endSize}) => setStoredSize(endSize)}
-      sized={
-        <Flex
-          direction="column"
-          flex="1"
-          minWidth="0"
-          minHeight="0"
-          maxWidth={`${CONTENT_MAX_WIDTH}px`}
-          paddingRight={{xs: '0', md: 'md'}}
-          paddingBottom={{xs: 'md', md: '0'}}
-        >
-          {content}
-        </Flex>
-      }
-      fill={
-        detail ? (
-          <Flex
-            direction="column"
-            flex="1"
-            minWidth="0"
-            minHeight="0"
-            paddingLeft={{xs: '0', md: 'md'}}
-            paddingTop={{xs: 'md', md: '0'}}
-          >
-            {detail}
-          </Flex>
-        ) : undefined
-      }
-    />
   );
 }
 


### PR DESCRIPTION
Makes `SplitPanel`'s pane-size constraints orientation-aware, so a single declaration stays correct whether the split is a row or a column.

### Problem
`defaultSize`, `minSize`, `maxSize`, and `fillMinSize` were plain pixel numbers, but a pane's size means width in a row and height in a column. So when `orientation` was responsive, there was no matching way to feed axis-appropriate constraints — the width-based `400px` min became an unsatisfiable min-height once the split stacked, collapsing the draggable range.

### Changes
- **`SplitPanel`**: those four props now accept `number | \`${number}%\``, wrapped in `Responsive<…>`. Resolution is two-step: the responsive layer picks the breakpoint (container-aware, in step with `orientation`), then percentages resolve to pixels off the measured active axis. A percentage default is seeded once the panel is measured.
  - Backward compatible: a bare number still means pixels, and `initialSize` stays pixel-only (it's a measured/persisted value), so existing consumers are untouched.
- **Conversation content layout**: adopts the new API and drops its measure-then-mount wrapper — it now declares `orientation`, a `"60%"` default, and per-axis min sizes directly, replacing the hand-resolved container breakpoint and ratio math.

### Notes
- Stacked on `priscilaandredeoliveira/de-1357-conversations-stacked-resize`; this supersedes that PR's consumer-side workaround by moving the axis handling into the primitive.
- Frontend-only.

Refs DE-1357
