### PR TITLE
fix(explore): Import sentry_sdk.ai submodule in conversation onboarding

### DIFF
--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -241,7 +241,7 @@ function getConversationIdStep(integration: string, isPython: boolean): Onboardi
       ? {
           type: 'code' as const,
           language: 'python',
-          code: `import sentry_sdk
+          code: `import sentry_sdk.ai
 
 # Call this at the start of each conversation
 sentry_sdk.ai.set_conversation_id("my-conversation-123")`,


### PR DESCRIPTION
The Python onboarding snippet for setting a conversation ID imported the top-level `sentry_sdk` package but called `sentry_sdk.ai.set_conversation_id`. The `ai` submodule isn't re-exported from `sentry_sdk`'s `__init__`, so following the snippet as written raises `AttributeError`. Import `sentry_sdk.ai` directly instead.