### PR TITLE
fix(conversations): Show loading instead of stale rows on refetch

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -42,7 +42,7 @@ function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
 function mockConversations(data: Conversation[], overrides = {}) {
   mockUseConversations.mockReturnValue({
     data,
-    isLoading: false,
+    isFetching: false,
     error: null,
     pageLinks: undefined,
     setCursor: jest.fn(),
@@ -89,8 +89,10 @@ describe('ConversationsTable missing messages alert', () => {
     expect(screen.queryByText(MISSING_MESSAGES_TEXT)).not.toBeInTheDocument();
   });
 
-  it('does not show the alert while loading', () => {
-    mockConversations([], {isLoading: true});
+  it('does not show the alert while fetching', () => {
+    mockConversations([makeConversation({firstInput: null, lastOutput: null})], {
+      isFetching: true,
+    });
 
     render(<ConversationsTable />, {organization});
 

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -99,10 +99,10 @@ function ConversationsTableInner() {
     columns: defaultColumnOrder,
   });
 
-  const {data, isLoading, error, pageLinks, setCursor} = useConversations();
+  const {data, isFetching, error, pageLinks, setCursor} = useConversations();
 
   const showMissingMessagesAlert =
-    !isLoading &&
+    !isFetching &&
     !error &&
     data.length > 0 &&
     data.every(conversation => !conversation.firstInput && !conversation.lastOutput);
@@ -152,7 +152,7 @@ function ConversationsTableInner() {
       {showMissingMessagesAlert && <ConversationMissingMessagesAlert />}
       <Container>
         <GridEditable
-          isLoading={isLoading}
+          isLoading={isFetching}
           error={error}
           data={data}
           columnOrder={columnOrder}

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -59,7 +59,7 @@ export function ConversationsTableNew() {
   const {selection} = usePageFilters();
   const {openModal} = useModal();
   const {columns, setColumns} = useConversationsTableColumns();
-  const {data, isLoading, error, pageLinks, setCursor} = useConversations();
+  const {data, isFetching, error, pageLinks, setCursor} = useConversations();
   const [highlightedRowKey, setHighlightedRowKey] = useState<number | undefined>();
 
   const columnOrder = useMemo<Array<GridColumnOrder<ConversationColumnKey>>>(
@@ -97,7 +97,7 @@ export function ConversationsTableNew() {
   );
 
   const showMissingMessagesAlert =
-    !isLoading &&
+    !isFetching &&
     !error &&
     data.length > 0 &&
     data.every(conversation => !conversation.firstInput && !conversation.lastOutput);
@@ -179,7 +179,7 @@ export function ConversationsTableNew() {
         </Button>
       </Flex>
       <GridEditable
-        isLoading={isLoading}
+        isLoading={isFetching}
         error={error}
         data={data}
         columnOrder={columnOrder}

--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -38,7 +38,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.firstInput).toBe('hello');
   });
@@ -60,7 +60,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.firstInput).toBe('hello from array');
   });
@@ -79,7 +79,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.firstInput).toBeNull();
   });
@@ -92,7 +92,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.lastOutput).toBe('world');
   });
@@ -114,7 +114,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     // This was the bug: lastOutput was passed through as an array, causing
     // `.replace is not a function` when rendering the table cell
@@ -135,7 +135,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.lastOutput).toBeNull();
   });
@@ -148,7 +148,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.firstInput).toBeNull();
     expect(result.current.data[0]?.lastOutput).toBeNull();
@@ -165,7 +165,7 @@ describe('useConversations', () => {
 
     const {result} = renderHookWithProviders(() => useConversations(), {organization});
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(result.current.data[0]?.conversationId).toBe('newer');
     expect(result.current.data[1]?.conversationId).toBe('older');

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -52,7 +52,7 @@ export function useConversations() {
 
   const {
     data: response,
-    isLoading,
+    isFetching,
     error,
   } = useQuery({
     ...apiOptions.as<ConversationApiResponse[]>()(
@@ -98,7 +98,7 @@ export function useConversations() {
 
   return {
     data,
-    isLoading,
+    isFetching,
     error,
     pageLinks,
     setCursor,


### PR DESCRIPTION
The conversations list gated its loading state on `isLoading`, which is false once cached data exists, so React Query served stale cached rows during a background refetch and then swapped in the fresh result — making the table appear to change on its own. Gate the loading state on `isFetching` instead (matching the issue stream and replays lists) so a fetch always shows loading rather than stale rows.