### PR TITLE
feat(issues): Add new-feature badge to the Recommended dropdown option

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -96,7 +96,7 @@ export function IssueListSortOptions({
         value: key,
         label: getSortLabel(key),
         details: getSortTooltip(key),
-        ...(key === IssueSortOptions.RECOMMENDED && hasRecommendedSortDefault
+        ...(key === IssueSortOptions.RECOMMENDED
           ? {trailingItems: <FeatureBadge type="new" />}
           : {}),
       }))}

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -56,6 +56,9 @@ export function IssueListSortOptions({
   showIcon = true,
 }: Props) {
   const organization = useOrganization();
+  const hasRecommendedSortDefault = organization.features.includes(
+    'issue-stream-recommended-sort-default'
+  );
   const hasProgressSort =
     organization.features.includes('issue-stream-progress-sort') ||
     sort === IssueSortOptions.PROGRESS;
@@ -93,6 +96,9 @@ export function IssueListSortOptions({
         value: key,
         label: getSortLabel(key),
         details: getSortTooltip(key),
+        ...(key === IssueSortOptions.RECOMMENDED && hasRecommendedSortDefault
+          ? {trailingItems: <FeatureBadge type="new" />}
+          : {}),
       }))}
       menuWidth={240}
       value={sortKey}
@@ -102,8 +108,7 @@ export function IssueListSortOptions({
           size={triggerSize}
           icon={showIcon && <IconSort />}
         >
-          {organization.features.includes('issue-stream-recommended-sort-default') &&
-          sortKey === IssueSortOptions.RECOMMENDED ? (
+          {hasRecommendedSortDefault && sortKey === IssueSortOptions.RECOMMENDED ? (
             <Flex as="span" gap="sm" align="center">
               {triggerProps.children}
               <FeatureBadge

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -8,7 +8,14 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {SearchFixture} from 'sentry-fixture/search';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
@@ -390,6 +397,11 @@ describe('IssueList', () => {
         await screen.findByRole('button', {name: /Recommended/})
       ).toBeInTheDocument();
       expect(screen.getByLabelText('new')).toBeInTheDocument();
+
+      // The Recommended option inside the dropdown carries the badge too
+      await userEvent.click(screen.getByRole('button', {name: /Recommended/}));
+      const recommendedOption = screen.getByRole('option', {name: /Recommended/});
+      expect(within(recommendedOption).getByLabelText('new')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
The "Recommended" option inside the issue stream sort dropdown now carries a `FeatureBadge type="new"` whenever the option is shown, flagging the sort itself as new while browsing the menu. It uses the badge's standard tooltip.