### PR TITLE
feat(issues): Move Recommended sort to top of sort dropdown

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -74,13 +74,13 @@ export function IssueListSortOptions({
     organization.features.includes('issue-stream-recommended-sort-default') ||
     sortKey === IssueSortOptions.RECOMMENDED;
   const sortKeys = [
+    ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
     ...(FOR_REVIEW_QUERIES.includes(query || '') ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
     IssueSortOptions.NEW,
     IssueSortOptions.TRENDS,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
-    ...(hasRecommendedSort ? [IssueSortOptions.RECOMMENDED] : []),
     ...(hasProgressSort ? [IssueSortOptions.PROGRESS] : []),
   ];
 


### PR DESCRIPTION
The Recommended option in the issue stream sort dropdown now appears first instead of last. 