### PR TITLE
feat(preprod): Add install_groups to build-details distribution info

### DIFF
--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -70,6 +70,7 @@ class DistributionInfo(BaseModel):
     is_installable: bool
     download_count: int
     release_notes: str | None = None
+    install_groups: list[str] | None = None
     error_code: str | None = None
     error_message: str | None = None
 
@@ -405,6 +406,7 @@ def transform_preprod_artifact_to_build_details(
         is_installable=is_installable,
         download_count=(get_download_count_for_artifact(artifact) if is_installable else 0),
         release_notes=(artifact.extras.get("release_notes") if artifact.extras else None),
+        install_groups=(artifact.extras.get("install_groups") if artifact.extras else None),
         error_code=error_code_str,
         error_message=artifact.installable_app_error_message,
     )

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -91,6 +91,7 @@ class BuildsEndpointTest(APITestCase):
                     "download_count": 0,
                     "is_installable": False,
                     "release_notes": None,
+                    "install_groups": None,
                     "error_code": None,
                     "error_message": None,
                 },

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -86,7 +86,10 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         assert resp_data["app_info"]["build_number_raw"] == "1.2.3"
 
     def test_get_build_details_distribution_info(self) -> None:
-        self.preprod_artifact.extras = {"release_notes": "Build notes"}
+        self.preprod_artifact.extras = {
+            "release_notes": "Build notes",
+            "install_groups": ["qa", "beta"],
+        }
         self.preprod_artifact.save()
         self.create_installable_preprod_artifact(
             preprod_artifact=self.preprod_artifact, download_count=2
@@ -106,6 +109,7 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         assert distribution_info["is_installable"] is True
         assert distribution_info["download_count"] == 5
         assert distribution_info["release_notes"] == "Build notes"
+        assert distribution_info["install_groups"] == ["qa", "beta"]
 
     def test_get_build_details_distribution_error_fields(self) -> None:
         self.preprod_artifact.installable_app_error_code = (


### PR DESCRIPTION
`install_groups` (the distribution groups a build belongs to) is stored in `PreprodArtifact.extras["install_groups"]` but was never returned by the build-details serialization. It is now exposed as `distribution_info.install_groups`, so the `/install` page can read it directly from build-details instead of going through `private-install-details`.

The field is added to `DistributionInfo` and populated in `transform_preprod_artifact_to_build_details` using the same `extras` read pattern as `release_notes` right above it. Because both the single build-details endpoint and the `/builds/` list endpoint (including `?display=distribution`) share that transform, the field surfaces in all of them from one change. No new query, no migration — this is an additive, non-public serialization field.

Response shape:

```jsonc
"distribution_info": {
  "is_installable": true,
  "download_count": 5,
  "release_notes": "…",
  "install_groups": ["qa", "beta"],  // new; null when absent from extras
  "error_code": null,
  "error_message": null
}
```

Frontend rendering of the new field will follow in a separate PR (per the FE/BE PR split).

Refs EME-1237

_note:_ technically install_group is already available in private-install-details to the frontend, but most frontend is composed of build_details endpoint so wanted it there