### PR TITLE
fix(ourlogs): stabilize table column widths during scrolling

### DIFF
--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -67,7 +67,7 @@ export function useTableStyles(
   options?: {
     minimumColumnWidth?: number;
     prefixColumnWidth?: 'min-content' | number;
-    staticColumnWidths?: Record<string, number | 'minmax(90px,1fr)'>;
+    staticColumnWidths?: Record<string, number | string>;
   }
 ) {
   const minimumColumnWidth = options?.minimumColumnWidth ?? MINIMUM_COLUMN_WIDTH;
@@ -75,6 +75,7 @@ export function useTableStyles(
     defined(options?.prefixColumnWidth) && typeof options.prefixColumnWidth === 'number'
       ? `${options.prefixColumnWidth}px`
       : options?.prefixColumnWidth;
+  const staticColumnWidths = options?.staticColumnWidths;
 
   const resizingColumnIndex = useRef<number | null>(null);
   const columnWidthsRef = useRef<Array<number | null>>(fields.map(_ => null));
@@ -85,21 +86,33 @@ export function useTableStyles(
     );
   }, [fields]);
 
-  const initialTableStyles = useMemo(() => {
-    const gridTemplateColumns = fields.map(field => {
-      const staticWidth = options?.staticColumnWidths?.[field];
+  const getColumnTemplateWidth = useCallback(
+    (field: string, index: number) => {
+      const resizedWidth = columnWidthsRef.current[index];
+      if (typeof resizedWidth === 'number') {
+        return `${resizedWidth}px`;
+      }
+      const staticWidth = staticColumnWidths?.[field];
       if (staticWidth) {
         return typeof staticWidth === 'number' ? `${staticWidth}px` : staticWidth;
       }
       return `minmax(${minimumColumnWidth}px, auto)`;
-    });
+    },
+    [minimumColumnWidth, staticColumnWidths]
+  );
+
+  const buildGridTemplateColumns = useCallback(() => {
+    const tracks = fields.map(getColumnTemplateWidth);
     if (defined(prefixColumnWidth)) {
-      gridTemplateColumns.unshift(prefixColumnWidth);
+      tracks.unshift(prefixColumnWidth);
     }
-    return {
-      gridTemplateColumns: gridTemplateColumns.join(' '),
-    };
-  }, [fields, minimumColumnWidth, prefixColumnWidth, options?.staticColumnWidths]);
+    return tracks.join(' ');
+  }, [fields, prefixColumnWidth, getColumnTemplateWidth]);
+
+  const initialTableStyles = useMemo(
+    () => ({gridTemplateColumns: buildGridTemplateColumns()}),
+    [buildGridTemplateColumns]
+  );
 
   const onResizeMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>, index: number) => {
@@ -130,16 +143,7 @@ export function useTableStyles(
 
         columnWidthsRef.current[index] = newWidth;
 
-        // Updating the grid's `gridTemplateColumns` directly
-        const gridTemplateColumns = columnWidthsRef.current.map(width => {
-          return typeof width === 'number'
-            ? `${width}px`
-            : `minmax(${minimumColumnWidth}px, auto)`;
-        });
-        if (defined(prefixColumnWidth)) {
-          gridTemplateColumns.unshift(prefixColumnWidth);
-        }
-        gridElement.style.gridTemplateColumns = gridTemplateColumns.join(' ');
+        gridElement.style.gridTemplateColumns = buildGridTemplateColumns();
       }
 
       function onMouseUp() {
@@ -153,7 +157,7 @@ export function useTableStyles(
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
     },
-    [tableRef, minimumColumnWidth, prefixColumnWidth]
+    [buildGridTemplateColumns, minimumColumnWidth, tableRef]
   );
 
   return {initialTableStyles, onResizeMouseDown};

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -64,6 +64,7 @@ import {
 import {calculateLogsTableMinWidth} from 'sentry/views/explore/logs/tables/calculateLogsTableMinWidth';
 import {LogsEmptyResults} from 'sentry/views/explore/logs/tables/logsEmptyResults';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
+import {useLogsTableColumnWidths} from 'sentry/views/explore/logs/tables/useLogsTableColumnWidths';
 import {
   OurLogKnownFieldKey,
   type OurLogsResponseItem,
@@ -245,17 +246,6 @@ export function LogsInfiniteTable({
   const scrollFetchDisabled = isFunctionScrolling || autorefreshEnabled;
 
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const {initialTableStyles, onResizeMouseDown} = useTableStyles(
-    fields.slice(),
-    tableRef,
-    {
-      minimumColumnWidth: 50,
-      prefixColumnWidth: 'min-content',
-      staticColumnWidths: {
-        [OurLogKnownFieldKey.MESSAGE]: 'minmax(90px,1fr)',
-      },
-    }
-  );
 
   const estimateSize = useCallback(
     (index: number) => {
@@ -354,6 +344,24 @@ export function LogsInfiniteTable({
       : [0, 0];
 
   const {scrollDirection, scrollOffset, isScrolling} = virtualizer;
+
+  const staticColumnWidths = useLogsTableColumnWidths({
+    fields,
+    tableRef,
+    isPending,
+    isScrolling,
+    dataLength: data?.length ?? 0,
+  });
+
+  const {initialTableStyles, onResizeMouseDown} = useTableStyles(
+    fields.slice(),
+    tableRef,
+    {
+      minimumColumnWidth: 50,
+      prefixColumnWidth: 'min-content',
+      staticColumnWidths,
+    }
+  );
 
   useEffect(() => {
     if (isFunctionScrolling && !isScrolling && scrollOffset === 0) {

--- a/static/app/views/explore/logs/tables/useLogsTableColumnWidths.spec.tsx
+++ b/static/app/views/explore/logs/tables/useLogsTableColumnWidths.spec.tsx
@@ -1,0 +1,219 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useLogsTableColumnWidths} from 'sentry/views/explore/logs/tables/useLogsTableColumnWidths';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+const MESSAGE = OurLogKnownFieldKey.MESSAGE;
+const FLEX = 'minmax(90px, 1fr)';
+
+function styleWith(value: string) {
+  const style = document.createElement('table').style;
+  style.gridTemplateColumns = value;
+  return style;
+}
+
+function mockGridTemplateColumns(value: string) {
+  jest.spyOn(window, 'getComputedStyle').mockReturnValue(styleWith(value));
+  return {current: document.createElement('table')};
+}
+
+describe('useLogsTableColumnWidths', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the flex message default when not scrolling', () => {
+    const tableRef = mockGridTemplateColumns('60px 175px 500px');
+    const fields = ['timestamp', 'code.file.path', MESSAGE];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: false,
+        isScrolling: false,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({[MESSAGE]: FLEX});
+  });
+
+  it('defaults the last column to flexible before scrolling when there is no message field', () => {
+    const tableRef = mockGridTemplateColumns('60px 175px 500px');
+    const fields = ['timestamp', 'code.file.path'];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: false,
+        isScrolling: false,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({'code.file.path': FLEX});
+  });
+
+  it('locks non-message columns to pixels and keeps message flexible when scrolling', () => {
+    // prefix track is 60px, so field i maps to track i + 1
+    const tableRef = mockGridTemplateColumns('60px 175px 500px 800px');
+    const fields = ['timestamp', 'code.file.path', MESSAGE];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: false,
+        isScrolling: true,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({
+      timestamp: 175,
+      'code.file.path': 500,
+      [MESSAGE]: FLEX,
+    });
+  });
+
+  it('makes the last column flexible when there is no message field', () => {
+    const tableRef = mockGridTemplateColumns('60px 175px 500px');
+    const fields = ['timestamp', 'code.file.path'];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: false,
+        isScrolling: true,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({
+      timestamp: 175,
+      'code.file.path': FLEX,
+    });
+  });
+
+  it('does not lock while data is pending', () => {
+    const tableRef = mockGridTemplateColumns('60px 175px 500px 800px');
+    const fields = ['timestamp', 'code.file.path', MESSAGE];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: true,
+        isScrolling: true,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({[MESSAGE]: FLEX});
+  });
+
+  it('does not lock when a measured track is not a finite pixel value', () => {
+    // getComputedStyle can return non-numeric tracks before layout settles.
+    const tableRef = mockGridTemplateColumns('60px auto 500px 800px');
+    const fields = ['timestamp', 'code.file.path', MESSAGE];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: false,
+        isScrolling: true,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({[MESSAGE]: FLEX});
+  });
+
+  it('does not lock when there are fewer measured tracks than fields', () => {
+    // Missing the leading prefix track means the field-to-track mapping is off.
+    const tableRef = mockGridTemplateColumns('175px 500px 800px');
+    const fields = ['timestamp', 'code.file.path', MESSAGE];
+
+    const {result} = renderHook(() =>
+      useLogsTableColumnWidths({
+        fields,
+        tableRef,
+        isPending: false,
+        isScrolling: true,
+        dataLength: 10,
+      })
+    );
+
+    expect(result.current).toEqual({[MESSAGE]: FLEX});
+  });
+
+  it('keeps the lock when the fields array identity changes but its contents do not', () => {
+    const tableRef = mockGridTemplateColumns('60px 175px 500px 800px');
+
+    const {result, rerender} = renderHook(
+      ({fields}) =>
+        useLogsTableColumnWidths({
+          fields,
+          tableRef,
+          isPending: false,
+          isScrolling: true,
+          dataLength: 10,
+        }),
+      {initialProps: {fields: ['timestamp', 'code.file.path', MESSAGE]}}
+    );
+
+    expect(result.current).toEqual({
+      timestamp: 175,
+      'code.file.path': 500,
+      [MESSAGE]: FLEX,
+    });
+
+    // A new array with identical contents (e.g. from a sort/date change) must
+    // not drop the lock, even though the measurement would now differ.
+    jest.spyOn(window, 'getComputedStyle').mockReturnValue(styleWith('60px 1px 1px 1px'));
+    rerender({fields: ['timestamp', 'code.file.path', MESSAGE]});
+
+    expect(result.current).toEqual({
+      timestamp: 175,
+      'code.file.path': 500,
+      [MESSAGE]: FLEX,
+    });
+  });
+
+  it('re-locks with fresh measurements after fields change', () => {
+    const tableRef = mockGridTemplateColumns('60px 175px 500px 800px');
+
+    const {result, rerender} = renderHook(
+      ({fields}) =>
+        useLogsTableColumnWidths({
+          fields,
+          tableRef,
+          isPending: false,
+          isScrolling: true,
+          dataLength: 10,
+        }),
+      {initialProps: {fields: ['timestamp', 'code.file.path', MESSAGE]}}
+    );
+
+    expect(result.current).toEqual({
+      timestamp: 175,
+      'code.file.path': 500,
+      [MESSAGE]: FLEX,
+    });
+
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockReturnValue(styleWith('60px 200px 600px 900px'));
+    rerender({fields: ['timestamp', 'server.address', MESSAGE]});
+
+    expect(result.current).toEqual({
+      timestamp: 200,
+      'server.address': 600,
+      [MESSAGE]: FLEX,
+    });
+  });
+});

--- a/static/app/views/explore/logs/tables/useLogsTableColumnWidths.tsx
+++ b/static/app/views/explore/logs/tables/useLogsTableColumnWidths.tsx
@@ -1,0 +1,103 @@
+import {useEffect, useState, type RefObject} from 'react';
+
+import {useWindowSize} from 'sentry/utils/window/useWindowSize';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+
+type ColumnWidths = Record<string, number | string>;
+
+const FLEX_COLUMN_WIDTH = 'minmax(90px, 1fr)';
+
+type LogsTableColumnWidthOptions = {
+  dataLength: number;
+  fields: readonly string[];
+  isPending: boolean;
+  isScrolling: boolean;
+  tableRef: RefObject<HTMLElement | null>;
+};
+
+// The flexible track is the message column when present, otherwise the last
+// column so the table stays width-filled. Everything else is locked to pixels
+// while scrolling. Keeping the same flex column before and after locking means
+// no column ever flips between `auto` and `1fr` on the first scroll.
+function flexColumnIndex(fields: readonly string[]) {
+  const messageIndex = fields.indexOf(OurLogKnownFieldKey.MESSAGE);
+  return messageIndex === -1 ? fields.length - 1 : messageIndex;
+}
+
+function getDefaultColumnWidths(fields: readonly string[]) {
+  const flexField = fields[flexColumnIndex(fields)];
+  return flexField ? {[flexField]: FLEX_COLUMN_WIDTH} : {};
+}
+
+function useFieldsColumnWidths(fields: readonly string[]) {
+  const [columnWidths, setColumnWidths] = useState<ColumnWidths | undefined>();
+  const windowSize = useWindowSize();
+
+  const fieldsKey = fields.join('\u0000');
+
+  // Reset only when the fields actually change or the window resizes, not on
+  // every new `fields` array identity (sort/search/date all mint a new array).
+  useEffect(() => {
+    setColumnWidths(undefined);
+  }, [fieldsKey, windowSize]);
+
+  return [columnWidths, setColumnWidths] as const;
+}
+
+export function useLogsTableColumnWidths({
+  fields,
+  tableRef,
+  isPending,
+  isScrolling,
+  dataLength,
+}: LogsTableColumnWidthOptions): ColumnWidths {
+  const [columnWidths, setColumnWidths] = useFieldsColumnWidths(fields);
+
+  useEffect(() => {
+    if (
+      !dataLength ||
+      !isScrolling ||
+      !tableRef.current ||
+      columnWidths !== undefined ||
+      isPending
+    ) {
+      return;
+    }
+
+    // The grid has a leading prefix (chevron) track, so field `i` is track `i + 1`.
+    const domWidths = getComputedStyle(tableRef.current).gridTemplateColumns.split(/\s+/);
+    if (domWidths.length < fields.length + 1) {
+      return;
+    }
+
+    const flexIndex = flexColumnIndex(fields);
+    const widths: ColumnWidths = {};
+
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i]!;
+      if (i === flexIndex) {
+        widths[field] = FLEX_COLUMN_WIDTH;
+        continue;
+      }
+
+      const px = parseFloat(domWidths[i + 1]!);
+      if (!Number.isFinite(px)) {
+        return;
+      }
+
+      widths[field] = px;
+    }
+
+    setColumnWidths(widths);
+  }, [
+    columnWidths,
+    dataLength,
+    fields,
+    isPending,
+    isScrolling,
+    setColumnWidths,
+    tableRef,
+  ]);
+
+  return columnWidths ?? getDefaultColumnWidths(fields);
+}


### PR DESCRIPTION
We don't actually store grid column widths by default / on page load, they're just CSS `minmax` with `auto`. The user dragging a column to manually resize just sets that column in `columnWidthsRef.current`.

As a result, LOGS-796 happens when:

1. There is a column that has not been manually resized
2. The column sometimes has data, sometimes doesn't
3. The user scrolls so that the table switches between having data in the column's cells vs. not having data

When there's content in the column cells, the table's grid gives that column more `auto` width. When there isn't content, less `auto` width.

The fix in this PR is to "lock" the columns when scrolling starts. This is done by measuring the current DOM width and setting it in the DOM styles. The columns get "unlocked" when the page changes from a browser size or field reorder.

Example from https://sentry.sentry.io/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22browser.name%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28message%29%22%5D%7D&logsFields=timestamp&logsFields=message&logsFields=browser.name&logsQuery=%21browser.name%3A%22%22&logsSortBys=-culprit&mode=samples&project=-1&statsPeriod=7d:

<table>
<thead>
<tr>
<th>Before</th>
<td>After</th>
</tr></thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/cb9869db-70ea-44dd-a2e6-581d853e762a"></video>
</td>
<td>
<video src="https://github.com/user-attachments/assets/54036110-80d5-404d-85b8-026798f92403"></video>
</td>
</tbody>
</table>

I'd previously tried this in #115389. That PR's strategy was to add a _second_ `1fr` track on the last column. But that still showed jumps with custom columns. This version keeps a single, stable flex track instead.

Closes LOGS-796.