### PR TITLE
feat(discover): Errors product relocation info banner

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -105,6 +105,7 @@ import {
 import Table from 'sentry/views/discover/table';
 import {
   generateTitle,
+  getTransactionsDeprecation,
   handleAddQueryToDashboard,
   SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
 } from 'sentry/views/discover/utils';
@@ -692,6 +693,16 @@ export class Results extends Component<Props, State> {
                   savedQueryDataset={savedQueryDataset}
                   selection={selection}
                 />
+                {savedQueryDataset === SavedQueryDatasets.ERRORS &&
+                  getTransactionsDeprecation(organization) && (
+                    <Alert.Container>
+                      <Alert variant="info">
+                        {t(
+                          'Discover \u2192 Errors will be moving soon to Explore \u2192 Errors. Same functionality, just even easier to find.'
+                        )}
+                      </Alert>
+                    </Alert.Container>
+                  )}
 
                 {!hasDatasetSelectorFeature && <SampleDataAlert query={query} />}
 

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -921,3 +921,7 @@ export const SAVED_QUERY_DATASET_TO_WIDGET_TYPE = {
   [SavedQueryDatasets.ERRORS]: WidgetType.ERRORS,
   [SavedQueryDatasets.TRANSACTIONS]: WidgetType.TRANSACTIONS,
 };
+
+export function getTransactionsDeprecation(organization: Organization) {
+  return organization.features.includes('discover-saved-queries-deprecation');
+}


### PR DESCRIPTION
Adding in this banner to notify users that discover errors will be moving up a step in the navigation (for users who won't have transactions)

<img width="1240" height="415" alt="image" src="https://github.com/user-attachments/assets/32c684c2-4e33-4249-b0e1-d0b2a9c193ca" />
