### PR TITLE
feat(explore): highlight every matching search term in logs and spans

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -33,6 +33,7 @@ import {LOGS_DRAWER_QUERY_PARAM} from 'sentry/views/explore/logs/constants';
 import type {LogsFrozenContextProviderProps} from 'sentry/views/explore/logs/logsFrozenContext';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
+import {getLogBodySearchTerms} from 'sentry/views/explore/logs/utils';
 import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
@@ -139,6 +140,7 @@ function OurlogsSectionContent({
   const feature = organization.features.includes('ourlogs-enabled');
   const tableData = useLogsPageDataQueryResult();
   const logsSearch = useQueryParamsSearch();
+  const highlightTerms = useMemo(() => getLogBodySearchTerms(logsSearch), [logsSearch]);
   const abbreviatedTableData = (tableData.data ?? []).slice(0, 5);
   const {openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
@@ -244,7 +246,7 @@ function OurlogsSectionContent({
               <LogRowContent
                 dataRow={row}
                 meta={tableData.meta}
-                highlightTerms={[]}
+                highlightTerms={highlightTerms}
                 embedded
                 sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                 key={index}

--- a/static/app/components/highlight.spec.tsx
+++ b/static/app/components/highlight.spec.tsx
@@ -1,54 +1,83 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {HighlightComponent} from 'sentry/components/highlight';
+import {MultiHighlight} from 'sentry/components/highlight';
 
-describe('Highlight', () => {
-  it('highlights text', () => {
-    const wrapper = render(
-      <HighlightComponent text="ILL">billy@sentry.io</HighlightComponent>
+describe('MultiHighlight', () => {
+  it('highlights every provided term when the text contains multiple terms', () => {
+    render(
+      <MultiHighlight terms={['error', 'timeout']}>
+        request failed with error after timeout
+      </MultiHighlight>
     );
-    expect(wrapper.container.childNodes).toHaveLength(3);
-    expect(wrapper.container.childNodes[0]).toHaveTextContent('b');
-    expect(wrapper.container.childNodes[1]).toHaveTextContent('ill');
-    expect(wrapper.container.childNodes[2]).toHaveTextContent('y@sentry.io');
+
+    expect(screen.getByText('error').tagName.toLowerCase()).toBe('span');
+    expect(screen.getByText('timeout').tagName.toLowerCase()).toBe('span');
   });
 
-  it('highlights with a case-insensitive match when caseSensitive is falsy', () => {
-    const wrapper = render(
-      <HighlightComponent text="Apple">apple Apple APPLE</HighlightComponent>
+  it('highlights every occurrence of a term when it repeats', () => {
+    render(<MultiHighlight terms={['db']}>db read then db write</MultiHighlight>);
+
+    const highlighted = screen.getAllByText('db');
+
+    expect(highlighted).toHaveLength(2);
+    expect(highlighted.every(el => el.tagName.toLowerCase() === 'span')).toBe(true);
+  });
+
+  it('escapes regex special characters in terms', () => {
+    render(
+      <MultiHighlight terms={['[ERR-1+2]', '.*']}>
+        got [ERR-1+2] and a .* glob
+      </MultiHighlight>
     );
-    expect(wrapper.container.childNodes).toHaveLength(2);
-    expect(wrapper.container.childNodes[0]).toHaveTextContent('apple');
-    expect(wrapper.container.childNodes[1]).toHaveTextContent('Apple APPLE');
+
+    expect(screen.getByText('[ERR-1+2]').tagName.toLowerCase()).toBe('span');
+    expect(screen.getByText('.*').tagName.toLowerCase()).toBe('span');
   });
 
-  it('highlights with a case-sensitive match when caseSensitive is true', () => {
-    const wrapper = render(
-      <HighlightComponent caseSensitive text="Apple">
-        apple Apple APPLE
-      </HighlightComponent>
+  it('matches regardless of case when caseSensitive is not set', () => {
+    render(<MultiHighlight terms={['error']}>ERROR occurred</MultiHighlight>);
+
+    expect(screen.getByText('ERROR').tagName.toLowerCase()).toBe('span');
+  });
+
+  it('matches only the exact case when caseSensitive is set', () => {
+    render(
+      <MultiHighlight caseSensitive terms={['error']}>
+        ERROR then error
+      </MultiHighlight>
     );
-    expect(wrapper.container.childNodes).toHaveLength(3);
-    expect(wrapper.container.childNodes[0]).toHaveTextContent('apple');
-    expect(wrapper.container.childNodes[1]).toHaveTextContent('Apple');
-    expect(wrapper.container.childNodes[2]).toHaveTextContent('APPLE');
+
+    expect(screen.getByText('error').tagName.toLowerCase()).toBe('span');
+    expect(screen.queryByText('ERROR')).not.toBeInTheDocument();
   });
 
-  it('does not have highlighted text if `text` prop is not found in main text', () => {
-    render(<HighlightComponent text="invalid">billy@sentry.io</HighlightComponent>);
+  it('renders plain text when no terms are provided', () => {
+    render(<MultiHighlight terms={[]}>nothing to highlight</MultiHighlight>);
 
-    expect(screen.getByText('billy@sentry.io')).toBeInTheDocument();
+    expect(screen.getByText('nothing to highlight').tagName.toLowerCase()).not.toBe(
+      'span'
+    );
   });
 
-  it('does not have highlighted text if `text` prop is empty', () => {
-    render(<HighlightComponent text="">billy@sentry.io</HighlightComponent>);
+  it('renders plain text when disabled', () => {
+    render(
+      <MultiHighlight disabled terms={['error']}>
+        error occurred
+      </MultiHighlight>
+    );
 
-    expect(screen.getByText('billy@sentry.io')).toBeInTheDocument();
+    expect(screen.getByText('error occurred').tagName.toLowerCase()).not.toBe('span');
   });
 
-  it('does not have highlighted text if `disabled` prop is true', () => {
-    render(<HighlightComponent text="">billy@sentry.io</HighlightComponent>);
+  it('highlights the longest term when a shorter term overlaps it', () => {
+    render(
+      <MultiHighlight terms={['work', 'workflow']}>workflow then work</MultiHighlight>
+    );
 
-    expect(screen.getByText('billy@sentry.io')).toBeInTheDocument();
+    // The longer term wins where both could match, so "workflow" stays intact
+    // (a broken order would split it into "work" + an orphaned "flow").
+    expect(screen.getByText('workflow').tagName.toLowerCase()).toBe('span');
+    expect(screen.getByText('work').tagName.toLowerCase()).toBe('span');
+    expect(screen.queryByText('flow')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/highlight.tsx
+++ b/static/app/components/highlight.tsx
@@ -1,48 +1,70 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 
-type HighlightProps = {
+interface MultiHighlightProps {
   /**
    * The original text
    */
   children: string;
   /**
-   * The text to highlight
+   * The terms to highlight
    */
-  text: string;
+  terms: string[];
   /**
    * Whether to only highlight text that matches case too
    */
   caseSensitive?: boolean;
+  className?: string;
   /**
    * Should highlighting be disabled?
    */
   disabled?: boolean;
-};
+}
 
-type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof HighlightProps> &
-  HighlightProps;
+export function MultiHighlight({
+  caseSensitive,
+  className,
+  children,
+  disabled,
+  terms,
+}: MultiHighlightProps) {
+  const {validTerms, pattern} = useMemo(() => {
+    // Longer terms first so an overlapping shorter term can't win the alternation.
+    const sorted = terms.filter(Boolean).sort((a, b) => b.length - a.length);
+    if (sorted.length === 0) {
+      return {validTerms: sorted, pattern: null};
+    }
+    const escaped = sorted.map(term => RegExp.escape(term));
+    return {
+      validTerms: sorted,
+      pattern: new RegExp(`(${escaped.join('|')})`, caseSensitive ? 'g' : 'gi'),
+    };
+  }, [terms, caseSensitive]);
 
-function HighlightComponent({caseSensitive, className, children, disabled, text}: Props) {
-  // There are instances when children is not string in breadcrumbs but not caught by TS
-  if (!text || disabled || typeof children !== 'string') {
-    return <Fragment>{children}</Fragment>;
+  if (disabled || !pattern || typeof children !== 'string') {
+    return children;
   }
 
-  const idx = caseSensitive
-    ? children.indexOf(text)
-    : children.toLowerCase().indexOf(text.toLowerCase());
-
-  if (idx === -1) {
-    return <Fragment>{children}</Fragment>;
+  const parts = children.split(pattern);
+  if (parts.length === 1) {
+    return children;
   }
+
+  const isMatch = (part: string) =>
+    validTerms.some(term =>
+      caseSensitive ? part === term : part.toLowerCase() === term.toLowerCase()
+    );
 
   return (
     <Fragment>
-      {children.substring(0, idx)}
-      <span className={className}>{children.substring(idx, idx + text.length)}</span>
-      {children.substring(idx + text.length)}
+      {parts.map((part, index) =>
+        isMatch(part) ? (
+          <span key={index} className={className}>
+            {part}
+          </span>
+        ) : (
+          <Fragment key={index}>{part}</Fragment>
+        )
+      )}
     </Fragment>
   );
 }
-
-export {HighlightComponent};

--- a/static/app/views/explore/bodySearchTerms.spec.tsx
+++ b/static/app/views/explore/bodySearchTerms.spec.tsx
@@ -1,0 +1,49 @@
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {getBodySearchTerms} from 'sentry/views/explore/bodySearchTerms';
+
+describe('getBodySearchTerms', () => {
+  it('returns each free-text token', () => {
+    const terms = getBodySearchTerms(new MutableSearch('billing success'), 'message');
+
+    expect(terms).toEqual(['billing', 'success']);
+  });
+
+  it('splits a wildcard filter value into a term per segment', () => {
+    const terms = getBodySearchTerms(
+      new MutableSearch('message:*billing*success*'),
+      'message'
+    );
+
+    expect(terms).toEqual(['billing', 'success']);
+  });
+
+  it('splits a free-text token that contains wildcards', () => {
+    const terms = getBodySearchTerms(new MutableSearch('foo*bar'), 'message');
+
+    expect(terms).toEqual(['foo', 'bar']);
+  });
+
+  it('keeps a filter value with no wildcards as a single term', () => {
+    const terms = getBodySearchTerms(new MutableSearch('message:api.access'), 'message');
+
+    expect(terms).toEqual(['api.access']);
+  });
+
+  it('reads the given body field for span descriptions', () => {
+    const terms = getBodySearchTerms(
+      new MutableSearch('span.description:*db*query*'),
+      'span.description'
+    );
+
+    expect(terms).toEqual(['db', 'query']);
+  });
+
+  it('skips negated and list filter values', () => {
+    const terms = getBodySearchTerms(
+      new MutableSearch('!message:noise message:[a,b]'),
+      'message'
+    );
+
+    expect(terms).toEqual([]);
+  });
+});

--- a/static/app/views/explore/bodySearchTerms.tsx
+++ b/static/app/views/explore/bodySearchTerms.tsx
@@ -1,0 +1,27 @@
+import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
+
+export function getBodySearchTerms(search: MutableSearch, bodyField: string): string[] {
+  const terms: string[] = [];
+
+  // Raw text search is stored as a wildcard filter (`*billing*success*`), so
+  // split on `*` and highlight each segment rather than the joined string.
+  const addSegments = (value: string) => {
+    for (const segment of value.split('*')) {
+      if (segment) {
+        terms.push(segment);
+      }
+    }
+  };
+
+  search.freeText.forEach(addSegments);
+
+  for (const filter of search.getFilterValues(bodyField)) {
+    // Skip negated (`!term`) and list (`[a,b]`) filter values: neither is a
+    // literal substring that should be highlighted in the body.
+    if (!filter.startsWith('!') && !filter.startsWith('[')) {
+      addSegments(filter);
+    }
+  }
+
+  return terms;
+}

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -442,7 +442,7 @@ function ReleaseRenderer(props: LogFieldRendererProps) {
 
 export function LogBodyRenderer(props: LogFieldRendererProps) {
   const attribute_value = props.item.value as string;
-  const highlightTerm = props.extra?.highlightTerms[0] ?? '';
+  const highlightTerms = props.extra?.highlightTerms ?? [];
   const template = props.extra.attributes?.[OurLogKnownFieldKey.TEMPLATE];
   const templateText =
     props.extra.canAppendTemplateToBody && template ? template : undefined;
@@ -457,7 +457,7 @@ export function LogBodyRenderer(props: LogFieldRendererProps) {
       <WrappingText wrapText={props.extra.wrapBody}>
         <LogsHighlight
           caseSensitive={props.extra.caseSensitiveHighlighting}
-          text={highlightTerm}
+          terms={highlightTerms}
         >
           {stripAnsi(attribute_value)}
         </LogsHighlight>

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
 
-import {HighlightComponent} from 'sentry/components/highlight';
+import {MultiHighlight} from 'sentry/components/highlight';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {Panel} from 'sentry/components/panels/panel';
 import {GRID_BODY_ROW_HEIGHT} from 'sentry/components/tables/gridEditable/styles';
@@ -302,7 +302,7 @@ export const LogDate = styled('span')<{align?: 'left' | 'center' | 'right'}>`
   text-align: ${p => p.align || 'left'};
 `;
 
-export const LogsHighlight = styled(HighlightComponent)`
+export const LogsHighlight = styled(MultiHighlight)`
   font-weight: ${p => p.theme.font.weight.sans.medium};
   background-color: ${p => p.theme.colors.gray200};
   margin-right: 2px;

--- a/static/app/views/explore/logs/utils.tsx
+++ b/static/app/views/explore/logs/utils.tsx
@@ -21,6 +21,7 @@ import {
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {getBodySearchTerms} from 'sentry/views/explore/bodySearchTerms';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {
   LOGS_AGGREGATE_FN_KEY,
@@ -151,14 +152,7 @@ export function severityLevelToText(level: SeverityLevel) {
 }
 
 export function getLogBodySearchTerms(search: MutableSearch): string[] {
-  const searchTerms: string[] = search.freeText.map(text => text.replaceAll('*', ''));
-  const bodyFilters = search.getFilterValues('log.body');
-  for (const filter of bodyFilters) {
-    if (!filter.startsWith('!') && !filter.startsWith('[')) {
-      searchTerms.push(filter);
-    }
-  }
-  return searchTerms;
+  return getBodySearchTerms(search, OurLogKnownFieldKey.MESSAGE);
 }
 
 export function logsFieldAlignment(...args: Parameters<typeof fieldAlignment>) {

--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -9,6 +9,7 @@ import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {MultiHighlight} from 'sentry/components/highlight';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
@@ -47,7 +48,15 @@ export const ProjectBadgeWrapper = styled('span')`
   min-width: 32px;
 `;
 
-export function SpanDescriptionRenderer({span}: {span: SpanResult<Field>}) {
+export function SpanDescriptionRenderer({
+  span,
+  highlightTerms = [],
+  caseSensitiveHighlighting = false,
+}: {
+  span: SpanResult<Field>;
+  caseSensitiveHighlighting?: boolean;
+  highlightTerms?: string[];
+}) {
   return (
     <Description data-test-id="span-description">
       <ProjectBadgeWrapper>
@@ -55,7 +64,14 @@ export function SpanDescriptionRenderer({span}: {span: SpanResult<Field>}) {
       </ProjectBadgeWrapper>
       <strong>{span['span.op']}</strong>
       <em>{'\u2014'}</em>
-      <WrappingText>{span['span.description']}</WrappingText>
+      <WrappingText>
+        <SpanDescriptionHighlight
+          caseSensitive={caseSensitiveHighlighting}
+          terms={highlightTerms}
+        >
+          {span['span.description']}
+        </SpanDescriptionHighlight>
+      </WrappingText>
       {<StatusTag status={span['span.status']} />}
     </Description>
   );
@@ -198,6 +214,13 @@ const WrappingText = styled('div')`
   overflow: hidden;
   text-overflow: ellipsis;
   width: auto;
+`;
+
+const SpanDescriptionHighlight = styled(MultiHighlight)`
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  background-color: ${p => p.theme.colors.gray200};
+  margin-right: 2px;
+  margin-left: 2px;
 `;
 
 export const TraceBreakdownContainer = styled('div')<{hoveredIndex?: number}>`

--- a/static/app/views/explore/tables/tracesTable/spansTable.tsx
+++ b/static/app/views/explore/tables/tracesTable/spansTable.tsx
@@ -7,6 +7,7 @@ import {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {PerformanceDuration} from 'sentry/components/performanceDuration';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tct} from 'sentry/locale';
 import type {NewQuery, Organization} from 'sentry/types/organization';
@@ -16,6 +17,7 @@ import {EventView} from 'sentry/utils/discover/eventView';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useQueryParamsQuery} from 'sentry/views/explore//queryParams/context';
+import {getBodySearchTerms} from 'sentry/views/explore/bodySearchTerms';
 import type {TraceResult} from 'sentry/views/explore/hooks/useTraces';
 import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 import {FIELDS, SORTS, type Field} from 'sentry/views/explore/tables/tracesTable/data';
@@ -55,6 +57,13 @@ export function SpanTable({trace}: {trace: TraceResult}) {
   });
 
   const spans = useMemo(() => data?.data ?? [], [data]);
+
+  const [caseInsensitive] = useCaseInsensitivity();
+
+  const highlightTerms = useMemo(
+    () => getBodySearchTerms(new MutableSearch(query), 'span.description'),
+    [query]
+  );
 
   const showErrorState = useMemo(() => {
     return !isPending && isError;
@@ -99,6 +108,8 @@ export function SpanTable({trace}: {trace: TraceResult}) {
               key={span.id}
               span={span}
               trace={trace}
+              highlightTerms={highlightTerms}
+              caseSensitiveHighlighting={!caseInsensitive}
             />
           ))}
           {hasData && spans.length < trace.matchingSpans && (
@@ -120,7 +131,11 @@ function SpanRow({
   organization,
   span,
   trace,
+  highlightTerms,
+  caseSensitiveHighlighting,
 }: {
+  caseSensitiveHighlighting: boolean;
+  highlightTerms: string[];
   organization: Organization;
   span: SpanResult<Field>;
   trace: TraceResult;
@@ -146,7 +161,11 @@ function SpanRow({
         />
       </StyledSpanPanelItem>
       <StyledSpanPanelItem align="left" overflow>
-        <SpanDescriptionRenderer span={span} />
+        <SpanDescriptionRenderer
+          span={span}
+          highlightTerms={highlightTerms}
+          caseSensitiveHighlighting={caseSensitiveHighlighting}
+        />
       </StyledSpanPanelItem>
       <StyledSpanPanelItem align="right">
         <TraceBreakdownContainer>


### PR DESCRIPTION
Search terms are now highlighted everywhere they appear in a log body or span description, not just the first occurrence. Previously it was literally just a singular one:

https://github.com/getsentry/sentry/blob/55afe17774014d8355a3c22f827b7ac0dcf2f463/static/app/views/explore/logs/fieldRenderers.tsx#L445

This PR changes things to:

1. Extract all the search terms with a new `getBodySearchTerms`
2. Pipe them all through `highlightTerms`, plural
3. Render them all as highlighted a new `MultiHighlight` component that replaces `Highlight`
 
This is for both logs and span descriptions. It's also case sensitive now.

<table>
<thead>
<tr>
<th>Area</th>
<th>Before</th>
<th>After</th>
</thead>
<tbody>
<tr>
<td>Logs</td>
<td>
<img width="1920" height="907" alt="logs_before" src="https://github.com/user-attachments/assets/340c2fab-bf47-4531-a22f-2a17c8074933" />
</td>
<td>
<img width="1920" height="907" alt="logs_after" src="https://github.com/user-attachments/assets/623c2ef4-010e-4509-834a-599932a90393" />
</td>
</tr>
<tr>
<td>Spans</td>
<td>
<img width="1920" height="907" alt="spans_before" src="https://github.com/user-attachments/assets/8faccb79-b9f5-4456-bd20-f058396354a9" />
</td>
<td>
<img width="1920" height="907" alt="spans_after" src="https://github.com/user-attachments/assets/e4440ea1-1877-4e8b-bcdc-18c8f58c12c1" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-55.