### PR TITLE
ref: remove seer-code-review-github-enterprise flag registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -233,8 +233,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:events-sql-grammar-api", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable Seer PR code review for GitHub Enterprise Server organizations
-    manager.add("organizations:seer-code-review-github-enterprise", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable Seer Agent panel for AI-powered data exploration
     manager.add("organizations:seer-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Agent Index job


### PR DESCRIPTION
## Summary

Follow-up to #119260 (which removes the GHE code-review gate + tests). This removes the `organizations:seer-code-review-github-enterprise` **FLAGPOLE feature registration** from `features/temporary.py`.

Split out from #119260 so the registration can be removed **last**, per the documented Flagpole removal order.

## Why this is separate / ordering

Registering a `FLAGPOLE` feature auto-registers a backing option (`feature.organizations:seer-code-review-github-enterprise`) via `FeatureManager.add`. sentry-options-automator sets that option, and every deploy runs `sentry configoptions` against the generated ConfigMap. If the registration is removed while the automator still applies that option, `configoptions` hits `UnknownOption` and reports it as unregistered/invalid across all environments.

So the safe order is:
1. Remove the code gate + tests — #119260 (mergeable now)
2. Remove the Flagpole config — getsentry/sentry-options-automator#8569
3. **Remove this registration — this PR** (merge only after #8569 has deployed)

## Changes

- **`src/sentry/features/temporary.py`** — remove the `organizations:seer-code-review-github-enterprise` registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)