### PR TITLE
feat(preprod): Show install groups on the install page

### DIFF
--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -48,6 +48,7 @@ function makeBuild(
       is_installable: false,
       download_count: 0,
       release_notes: null,
+      install_groups: null,
     },
     vcs_info: {
       head_sha: 'a1b2c3d4e5f6',

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -27,6 +27,7 @@ const baseBuild = {
     is_installable: true,
     download_count: 1234,
     release_notes: null,
+    install_groups: null,
   },
   vcs_info: {
     head_sha: 'abcdef1',

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -27,6 +27,7 @@ const mockBuildDetailsData: BuildDetailsApiResponse = {
     is_installable: true,
     download_count: 5,
     release_notes: 'Release notes',
+    install_groups: null,
   },
   vcs_info: {
     head_sha: 'abc123',

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -240,7 +240,8 @@ describe('InstallDetailsContent', () => {
     );
 
     expect(await screen.findByText('Install Groups')).toBeInTheDocument();
-    expect(screen.getByText('qa, beta')).toBeInTheDocument();
+    expect(screen.getByText('qa')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
   });
 
   it('does not render install groups section when none are provided', async () => {

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -219,4 +219,45 @@ describe('InstallDetailsContent', () => {
     expect(await screen.findByText('5 downloads')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
   });
+
+  it('renders install groups when provided', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        install_url: 'https://example.com/install',
+        is_code_signature_valid: true,
+      },
+    });
+
+    render(
+      <InstallDetailsContent
+        artifactId="artifact-1"
+        projectSlug="my-project"
+        installGroups={['qa', 'beta']}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Install Groups')).toBeInTheDocument();
+    expect(screen.getByText('qa, beta')).toBeInTheDocument();
+  });
+
+  it('does not render install groups section when none are provided', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        install_url: 'https://example.com/install',
+        is_code_signature_valid: true,
+      },
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
+
+    expect(await screen.findByRole('button', {name: 'Download'})).toBeInTheDocument();
+    expect(screen.queryByText('Install Groups')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -1,6 +1,7 @@
 import {Fragment, type ReactNode} from 'react';
 import {useTheme} from '@emotion/react';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
@@ -300,7 +301,13 @@ export function InstallDetailsContent({
                 radius="md"
                 width="100%"
               >
-                <Text>{installGroups.join(', ')}</Text>
+                <Flex gap="sm" wrap="wrap">
+                  {installGroups.map(group => (
+                    <Tag key={group} variant="muted">
+                      {group}
+                    </Tag>
+                  ))}
+                </Flex>
               </Container>
             </Flex>
           )}

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -45,6 +45,7 @@ interface InstallDetailsContentProps {
   projectSlug: string;
   distributionErrorCode?: string | null;
   distributionErrorMessage?: string | null;
+  installGroups?: string[] | null;
   size?: 'sm' | 'lg';
 }
 
@@ -54,6 +55,7 @@ export function InstallDetailsContent({
   size = 'sm',
   distributionErrorCode,
   distributionErrorMessage,
+  installGroups,
 }: InstallDetailsContentProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -288,6 +290,20 @@ export function InstallDetailsContent({
               {t('The install link will expire in 12 hours')}
             </Text>
           </Stack>
+          {installGroups && installGroups.length > 0 && (
+            <Flex direction="column" gap="md" width="100%">
+              <Heading as="h3">{t('Install Groups')}</Heading>
+              <Container
+                padding="xl"
+                background="secondary"
+                border="primary"
+                radius="md"
+                width="100%"
+              >
+                <Text>{installGroups.join(', ')}</Text>
+              </Container>
+            </Flex>
+          )}
           {installDetails.release_notes && (
             <Flex direction="column" gap="md" width="100%">
               <Heading as="h3">{t('Release Notes')}</Heading>

--- a/static/app/views/preprod/install/installPage.spec.tsx
+++ b/static/app/views/preprod/install/installPage.spec.tsx
@@ -81,6 +81,38 @@ describe('InstallPage', () => {
     expect(within(topbarSlot).queryByText('Install')).not.toBeInTheDocument();
   });
 
+  it('surfaces install groups from build details', async () => {
+    MockApiClient.addMockResponse({
+      url: BUILD_DETAILS_URL,
+      method: 'GET',
+      body: PreprodBuildDetailsWithSizeInfoFixture(
+        {
+          state: BuildDetailsSizeAnalysisState.COMPLETED,
+          size_metrics: [],
+          base_size_metrics: [],
+        },
+        {
+          distribution_info: {
+            is_installable: true,
+            download_count: 0,
+            release_notes: null,
+            install_groups: ['qa', 'beta'],
+          },
+        }
+      ),
+    });
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      method: 'GET',
+      body: {platform: 'ios', install_url: 'https://example.com/install'},
+    });
+
+    renderInstallPage();
+
+    expect(await screen.findByText('Install Groups')).toBeInTheDocument();
+    expect(screen.getByText('qa, beta')).toBeInTheDocument();
+  });
+
   it('keeps the Releases breadcrumb clickable when build details fail to load', async () => {
     MockApiClient.addMockResponse({
       url: BUILD_DETAILS_URL,

--- a/static/app/views/preprod/install/installPage.spec.tsx
+++ b/static/app/views/preprod/install/installPage.spec.tsx
@@ -110,7 +110,8 @@ describe('InstallPage', () => {
     renderInstallPage();
 
     expect(await screen.findByText('Install Groups')).toBeInTheDocument();
-    expect(screen.getByText('qa, beta')).toBeInTheDocument();
+    expect(screen.getByText('qa')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
   });
 
   it('keeps the Releases breadcrumb clickable when build details fail to load', async () => {

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -87,6 +87,9 @@ export default function InstallPage() {
                         distributionErrorMessage={
                           buildDetailsQuery.data.distribution_info?.error_message
                         }
+                        installGroups={
+                          buildDetailsQuery.data.distribution_info?.install_groups
+                        }
                       />
                     )}
                   </Container>

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -22,6 +22,7 @@ interface BuildDetailsDistributionInfo {
   is_installable: boolean;
   download_count: number;
   release_notes: string | null;
+  install_groups: string[] | null;
   error_code?: string | null;
   error_message?: string | null;
 }

--- a/tests/js/fixtures/preprod.ts
+++ b/tests/js/fixtures/preprod.ts
@@ -68,6 +68,7 @@ function PreprodBuildDetailsFixture(
       is_installable: false,
       download_count: 0,
       release_notes: null,
+      install_groups: null,
     },
     vcs_info: PreprodVcsInfoFixture(),
     size_info: undefined,


### PR DESCRIPTION
Stacked on #119303. The build-details response now carries `distribution_info.install_groups`; this renders it on the mobile build `/install` page so users can see which distribution groups a build belongs to.

The install component receives the groups (threaded from `installPage`'s build-details fetch) as a new `installGroups` prop and renders them as a comma-joined "Install Groups" section directly above Release Notes, inside the "Download Build" success body. The section is hidden when a build has no groups. `private-install-details` is untouched — the data comes from build-details.

`install_groups` is also made a required field on the `BuildDetailsDistributionInfo` TS type (matching `release_notes` and the always-present backend field), with the shared preprod fixtures backfilled to `null`.

Review #119303 (backend) first, then merge this once it lands.

Refs EME-1237

<img width="2950" height="1320" alt="CleanShot 2026-07-09 at 15 14 17@2x" src="https://github.com/user-attachments/assets/d6ccf9e0-fcc3-4cb0-9514-27c73a1146e1" />
