### PR TITLE
fix(conversations): Stop Last Message time bumping on row hover

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -357,7 +357,7 @@ const BodyCell = memo(function BodyCell({
     case 'timestamp':
       return (
         <Text as="div" align="right">
-          <TimeSince unitStyle="extraShort" date={new Date(dataRow.endTimestamp)} />
+          <TimeSince unitStyle="extraShort" date={dataRow.endTimestamp} />
         </Text>
       );
     default:

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -306,7 +306,7 @@ const BodyCell = memo(function BodyCell({
     case 'timestamp':
       return (
         <Text as="div" align="right">
-          <TimeSince unitStyle="extraShort" date={new Date(dataRow.endTimestamp)} />
+          <TimeSince unitStyle="extraShort" date={dataRow.endTimestamp} />
         </Text>
       );
     case 'input':


### PR DESCRIPTION
The **Last Message** column in the Conversations tables bumped its "seconds ago" value forward every time you hovered a row. With several recent (<1m) conversations in view, moving the mouse across rows made each hovered row's timestamp visibly tick up.

Fixes https://linear.app/getsentry/issue/TET-2666/conversations-table-updates-last-message-field-on-hover