### PR TITLE
feat(workflow_engine): type WorkflowValidator conditions and action filters

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/action.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/action.py
@@ -6,7 +6,10 @@ from rest_framework import serializers
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.utils.registry import NoRegistrationExistsError
-from sentry.workflow_engine.endpoints.validators.utils import validate_json_schema
+from sentry.workflow_engine.endpoints.validators.utils import (
+    NestedInitialDataMixin,
+    validate_json_schema,
+)
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.action import is_action_permitted
 from sentry.workflow_engine.registry import action_handler_registry
@@ -27,7 +30,7 @@ class ActionInput(TypedDict):
     status: NotRequired[str]
 
 
-class BaseActionValidator(CamelSnakeSerializer[Any]):
+class BaseActionValidator(NestedInitialDataMixin, CamelSnakeSerializer[Any]):
     data = serializers.JSONField()  # type: ignore[assignment]
     config = serializers.JSONField()
     type = serializers.ChoiceField(choices=[(t.value, t.name) for t in Action.Type])

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.endpoints.validators.utils import (
+    NestedInitialDataMixin,
     validate_json_primitive,
     validate_json_schema,
 )
@@ -44,6 +45,7 @@ class AbstractDataConditionValidator(
 
 
 class BaseDataConditionValidator(
+    NestedInitialDataMixin,
     AbstractDataConditionValidator[Any, Any],
 ):
     @property

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -17,6 +17,9 @@ from sentry.workflow_engine.endpoints.validators.api_docs_help_text import (
     WORKFLOW_TRIGGERS_HELP_TEXT,
 )
 from sentry.workflow_engine.endpoints.validators.base.action import ActionInput, BaseActionValidator
+from sentry.workflow_engine.endpoints.validators.base.data_condition import (
+    BaseDataConditionValidator,
+)
 from sentry.workflow_engine.endpoints.validators.base.data_condition_group import (
     BaseDataConditionGroupValidator,
     DataConditionGroupInput,
@@ -58,6 +61,36 @@ class WorkflowInput(TypedDict):
     detectorIds: NotRequired[list[int]]
 
 
+class WorkflowDataConditionGroupValidator(BaseDataConditionGroupValidator):
+    # Type `conditions` as a nested serializer (rather than the base's bare
+    # ListField) so the OpenAPI schema — and the generated SDK — describe each
+    # condition's shape ({type, comparison, conditionResult}). Scoped to the
+    # workflow endpoints so the shared base (used by detectors, metric alerts,
+    # etc.) is unchanged.
+    conditions = BaseDataConditionValidator(many=True, required=False)  # type: ignore[assignment]
+
+    def validate_conditions(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        # The typed `conditions` field already validates each item; override the
+        # base hook (which would re-run BaseDataConditionValidator on the
+        # already-validated data) with a passthrough.
+        return value
+
+
+class ActionValidator(BaseActionValidator):
+    # `id` targets an existing action on updates. The base action validator omits
+    # it, so declare it here to keep it through nested validation. IntegerField
+    # (matching the condition `id` and the `int(action_id)` ownership check) so a
+    # non-numeric id fails as a clean 400 rather than 500ing later.
+    id = serializers.IntegerField(required=False)
+
+
+class ActionFilterValidator(WorkflowDataConditionGroupValidator):
+    # An action filter is a data condition group plus the actions to fire.
+    # Typing `actions` (rather than a bare DictField) lets the OpenAPI schema —
+    # and the generated SDK — describe each action's shape.
+    actions = ActionValidator(many=True)
+
+
 class WorkflowValidator(CamelSnakeSerializer[Any]):
     id = serializers.CharField(required=False, help_text="The ID of the existing alert")
     name = serializers.CharField(required=True, max_length=256, help_text="The name of the alert")
@@ -79,12 +112,12 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         help_text="The name of the environment for the alert to evaluate in",
     )
 
-    triggers = BaseDataConditionGroupValidator(
+    triggers = WorkflowDataConditionGroupValidator(
         required=False,
         help_text=WORKFLOW_TRIGGERS_HELP_TEXT,
     )
-    action_filters = serializers.ListField(
-        child=serializers.DictField(),
+    action_filters = ActionFilterValidator(
+        many=True,
         required=False,
         help_text=ACTION_FILTERS_HELP_TEXT,
     )
@@ -107,28 +140,6 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
     def validate_config(self, value: Any) -> bool:
         schema = Workflow.config_schema
         return validate_json_schema(value, schema)
-
-    def validate_action_filters(self, value: ListInputData) -> ListInputData:
-        for action_filter in value:
-            actions, condition_group = self._split_action_and_condition_group(action_filter)
-            dcg_validator = BaseDataConditionGroupValidator(
-                data=condition_group, context=self.context
-            )
-            dcg_validator.is_valid(raise_exception=True)
-            action_filter.update(dcg_validator.validated_data)
-
-            validated_actions = []
-            for action in actions:
-                action_validator = BaseActionValidator(data=action, context=self.context)
-                action_validator.is_valid(raise_exception=True)
-
-                # update because the validated data does not contain "id" for updates
-                action.update(action_validator.validated_data)
-                validated_actions.append(action)
-
-            action_filter["actions"] = validated_actions
-
-        return value
 
     def has_seer_activity_trigger(self, triggers: InputData | None) -> bool:
         from sentry.workflow_engine.models import DataCondition

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from django.db import router, transaction
 from django.db.models import QuerySet
@@ -28,6 +28,31 @@ logger = logging.getLogger(__name__)
 # Only those with organization write permissions can edit system-created detectors (e.g. error detectors).
 SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write"}
 USER_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write", "alerts:write"}
+
+
+if TYPE_CHECKING:
+    # For typing only: the mixin is always combined with a Serializer, so this
+    # gives mypy `to_internal_value`/`initial_data`. At runtime the base is
+    # `object` and `super()` resolves to the real serializer via the MRO.
+    _SerializerBase = serializers.Serializer[Any]
+else:
+    _SerializerBase = object
+
+
+class NestedInitialDataMixin(_SerializerBase):
+    """
+    Populate ``initial_data`` when a serializer is used as a nested field.
+
+    DRF only sets ``initial_data`` on the top-level serializer instantiated with
+    ``data=...``. Validators whose field-level validation reads a sibling field via
+    ``self.initial_data`` (e.g. to look up a type-specific handler) break when used
+    as nested children (``many=True``). Stashing the raw item here keeps them
+    working both standalone and nested.
+    """
+
+    def to_internal_value(self, data: Any) -> Any:
+        self.initial_data = data
+        return super().to_internal_value(data)
 
 
 def is_system_created_detector(detector: Detector) -> bool:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -780,6 +780,47 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         other_action.refresh_from_db()
         assert other_action.config == original_config
 
+    def test_update_existing_action_preserves_id(self) -> None:
+        """An action referenced by id is updated in place, keeping its id (not duplicated)."""
+        dcg = DataConditionGroup.objects.create(
+            organization=self.organization,
+            logic_type=DataConditionGroup.Type.ANY,
+        )
+        action = Action.objects.create(
+            type=Action.Type.EMAIL,
+            config={"target_type": ActionTarget.TEAM, "target_identifier": "1"},
+            data={},
+        )
+        DataConditionGroupAction.objects.create(action=action, condition_group=dcg)
+        WorkflowDataConditionGroup.objects.create(condition_group=dcg, workflow=self.workflow)
+
+        data = {
+            **self.valid_workflow,
+            "actionFilters": [
+                {
+                    "id": str(dcg.id),
+                    "logicType": "any",
+                    "conditions": [],
+                    "actions": [
+                        {
+                            "id": str(action.id),
+                            "type": "email",
+                            "config": {"targetType": "team", "targetIdentifier": "2"},
+                            "data": {},
+                        }
+                    ],
+                }
+            ],
+        }
+
+        self.get_success_response(self.organization.slug, self.workflow.id, raw_data=data)
+
+        action.refresh_from_db()
+        # Same action updated in place — id preserved and no duplicate created.
+        assert action.config["target_identifier"] == "2"
+        assert DataConditionGroupAction.objects.filter(condition_group=dcg).count() == 1
+        assert Action.objects.filter(id=action.id).exists()
+
     def test_update_trigger_condition_from_different_organization(self) -> None:
         """Test that conditionGroupId in trigger conditions cannot reference another org's group"""
         other_org = self.create_organization()


### PR DESCRIPTION
## Summary

The workflow create/update endpoints (`POST`/`PUT /organizations/{org}/workflows/`) declared `triggers.conditions` and `action_filters` as bare `ListField`/`ListField(child=DictField())`, so drf-spectacular emitted `Array<unknown>` and the generated `@sentry/api` SDK couldn't describe the request body.

This types them with **workflow-local serializers** so the OpenAPI schema — and the SDK — describe each item's shape (`{type, comparison, conditionResult}` for conditions; `{logicType, conditions, actions:[{type, data, config}]}` for action filters).

## Changes (scoped to the workflow endpoints)

- `WorkflowDataConditionGroupValidator`, `ActionFilterValidator`, `ActionValidator` live in `workflow.py` and are used **only** by `WorkflowValidator`. The shared base validators (used by detectors, metric alerts, uptime, crons) are **unchanged** — their schema and validation behavior are untouched.
- `NestedInitialDataMixin`: `BaseDataConditionValidator`/`BaseActionValidator` read a sibling field via `self.initial_data`, which DRF only sets for standalone use. The mixin populates it in `to_internal_value` so they also work as nested (`many=True`) children. **Additive** — standalone callers already had `initial_data`, so existing consumers are unaffected.
- `ActionValidator` adds the optional `id` (`IntegerField`, matching the condition `id` and the `int(action_id)` ownership check) needed to target an existing action on updates.

Envelope-only typing: `comparison`/`data`/`config` stay JSON (polymorphic per type), so the request-body structure is typed without a per-variant schema explosion.

## Why

Backend half of migrating the Sentry CLI's issue-alert create/edit onto the org-scoped workflows endpoint (getsentry/cli#1182). Typed request-body codegen lets the CLI (and other SDK consumers) build workflow bodies against real types.

## Test plan

- `ruff` + `mypy` clean; adds `test_update_existing_action_preserves_id` (action referenced by id is updated in place, id preserved, not duplicated).
- Local functional run blocked by a devservices outage → **relying on CI** for the workflow endpoint suite + api-docs schema diff. Draft until green.
- Deliberately narrow: shared base validators are untouched, so detector/metric/uptime/cron code paths are unaffected.