### PR TITLE
ref(sentry-apps): format webhook subscription labels

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,4 +1,5 @@
 import type {WebhookEvent} from 'sentry/types/integrations';
+import {capitalize} from 'sentry/utils/string/capitalize';
 
 export const EVENT_CHOICES = [
   'issue',
@@ -39,12 +40,28 @@ export const RESOURCE_EVENTS = {
 export type WebhookGranularEvent = (typeof RESOURCE_EVENTS)[WebhookEvent][number];
 
 const EVENT_LABEL_OVERRIDES: Partial<Record<WebhookGranularEvent, string>> = {
-  'issue.ignored': 'archived', // the product renamed ignore → archive
-  'comment.updated': 'edited', // the product renamed update → edit
+  'issue.ignored': 'Archived', // the product renamed ignore → archive
+  'comment.updated': 'Edited', // the product renamed update → edit
+  'seer.pr_created': 'PR created', // the transform below would render "Pr created"
 };
 
 export function webhookEventLabel(event: WebhookGranularEvent): string {
-  return EVENT_LABEL_OVERRIDES[event] ?? event.slice(event.indexOf('.') + 1);
+  return (
+    EVENT_LABEL_OVERRIDES[event] ??
+    capitalize(event.slice(event.indexOf('.') + 1).replaceAll('_', ' '))
+  );
+}
+
+const RESOURCE_LABELS: Record<WebhookEvent, string> = {
+  issue: 'Issues',
+  error: 'Errors',
+  comment: 'Comments',
+  seer: 'Seer',
+  preprod_artifact: 'Preprod Artifacts',
+};
+
+export function webhookResourceLabel(resource: WebhookEvent): string {
+  return RESOURCE_LABELS[resource];
 }
 
 export const PERMISSIONS_MAP = {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -12,6 +12,7 @@ import {
   PERMISSIONS_MAP,
   RESOURCE_EVENTS,
   webhookEventLabel,
+  webhookResourceLabel,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 
 type Resource = (typeof EVENT_CHOICES)[number];
@@ -66,7 +67,7 @@ export function SubscriptionBox({
       <SubscriptionGridItem disabled={disabled}>
         <Stack alignSelf="center">
           <SubscriptionTitle>
-            {resource}
+            {webhookResourceLabel(resource)}
             {isNew && <FeatureBadge type="new" />}
           </SubscriptionTitle>
           <SubscriptionDescription>{description}</SubscriptionDescription>


### PR DESCRIPTION
Render event labels as e.g. "Root cause started" instead of the raw `root_cause_started` token.


<img width="1222" height="213" alt="Screenshot 2026-07-09 at 10 23 39 AM" src="https://github.com/user-attachments/assets/88e92238-e716-4b18-bde6-968ce42d6ee6" />
