### PR TITLE
feat(sentry-apps): per-event webhook subscription checkboxes

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -267,6 +267,9 @@ export type SentryApp = {
     id: number;
     slug: string;
   };
+  // The stored subscriptions as exact event tokens, where `events` consolidates
+  // them to resource names. Absent on older API responses.
+  webhookEvents?: string[];
   // Each entry is a "Header-Name: value" line. Saved values are masked by the API
   webhookHeaders?: string[];
 };

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -9,7 +9,11 @@ export const EVENT_CHOICES = [
   'preprod_artifact',
 ] as const satisfies readonly WebhookEvent[];
 
-// Mirrors EVENT_EXPANSION on the backend (sentry_apps/utils/webhooks.py)
+// The subscribable webhook vocabulary, mirroring EVENT_EXPANSION on the
+// backend (sentry_apps/utils/webhooks.py). A subscription is a whole resource
+// ("issue") or, with granular events enabled, an individual event
+// ("issue.created"). Needs to be backwards compatible with old stored
+// subscriptions.
 export const RESOURCE_EVENTS = {
   issue: [
     'issue.created',
@@ -38,6 +42,35 @@ export const RESOURCE_EVENTS = {
 } as const satisfies Record<WebhookEvent, readonly string[]>;
 
 export type WebhookGranularEvent = (typeof RESOURCE_EVENTS)[WebhookEvent][number];
+
+export type WebhookSubscription = WebhookEvent | WebhookGranularEvent;
+
+export const WEBHOOK_GRANULAR_EVENT_CHOICES = [
+  ...RESOURCE_EVENTS.issue,
+  ...RESOURCE_EVENTS.error,
+  ...RESOURCE_EVENTS.comment,
+  ...RESOURCE_EVENTS.seer,
+  ...RESOURCE_EVENTS.preprod_artifact,
+] as const;
+
+const LEGACY_EVENT_ALIASES: Record<string, WebhookGranularEvent> = {
+  'issue.archived': 'issue.ignored',
+};
+
+/** The granular events an app's stored subscriptions cover, whether stored as exact events or whole resources. */
+export function granularWebhookEvents(subscriptions: string[]): WebhookGranularEvent[] {
+  const stored = new Set<string>(
+    subscriptions.map(subscription => LEGACY_EVENT_ALIASES[subscription] ?? subscription)
+  );
+  for (const resource of EVENT_CHOICES) {
+    if (stored.has(resource)) {
+      for (const event of RESOURCE_EVENTS[resource]) {
+        stored.add(event);
+      }
+    }
+  }
+  return WEBHOOK_GRANULAR_EVENT_CHOICES.filter(event => stored.has(event));
+}
 
 const EVENT_LABEL_OVERRIDES: Partial<Record<WebhookGranularEvent, string>> = {
   'issue.ignored': 'Archived', // the product renamed ignore → archive

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -8,15 +8,12 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {CONTINUOUS_INTEGRATION_SENTRY_APP_PERMISSION} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
-import type {
-  PermissionResource,
-  Permissions,
-  WebhookEvent,
-} from 'sentry/types/integrations';
+import type {PermissionResource, Permissions} from 'sentry/types/integrations';
 import {
   comparePermissionLevels,
   toResourcePermissions,
 } from 'sentry/utils/consolidatedScopes';
+import type {WebhookSubscription} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
   PermissionSelection,
   permissionStateToList,
@@ -24,12 +21,12 @@ import {
 import {Subscriptions} from 'sentry/views/settings/organizationDeveloperSettings/resourceSubscriptions';
 
 type Props = {
-  events: WebhookEvent[];
+  events: WebhookSubscription[];
   newApp: boolean;
   scopes: Scope[];
   appPublished?: boolean;
   continuousIntegrationError?: string;
-  onEventsChange?: (events: WebhookEvent[]) => void;
+  onEventsChange?: (events: WebhookSubscription[]) => void;
   onScopesChange?: (scopes: Scope[]) => void;
   permissionErrors?: Partial<Record<PermissionResource, string>>;
   webhookDisabled?: boolean;
@@ -91,7 +88,7 @@ export function PermissionsObserver({
     setElevating(isElevating);
   };
 
-  const handleEventChange = (newEvents: WebhookEvent[]) => {
+  const handleEventChange = (newEvents: WebhookSubscription[]) => {
     setEvents(newEvents);
     onEventsChange?.(newEvents);
   };

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -1,9 +1,11 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Form} from 'sentry/components/forms/form';
 import type {Permissions} from 'sentry/types/integrations';
+import type {WebhookSubscription} from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import {RESOURCE_EVENTS} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {Subscriptions} from 'sentry/views/settings/organizationDeveloperSettings/resourceSubscriptions';
 
 const basePermissions: Permissions = {
@@ -66,6 +68,73 @@ describe('Resource Subscriptions', () => {
       expect(screen.getByRole('checkbox', {name: 'issue'})).toBeEnabled();
       expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'comment'})).toBeEnabled();
+    });
+  });
+
+  describe('granular event subscriptions', () => {
+    const organization = OrganizationFixture({
+      features: ['sentry-apps-granular-events'],
+    });
+
+    function renderSubscriptions(
+      events: WebhookSubscription[],
+      permissions: Permissions = basePermissions
+    ) {
+      const onChange = jest.fn();
+      render(
+        <Form>
+          <Subscriptions events={events} permissions={permissions} onChange={onChange} />
+        </Form>,
+        {organization}
+      );
+      return onChange;
+    }
+
+    it('describes webhook delivery and links the docs', () => {
+      renderSubscriptions([]);
+
+      expect(
+        screen.getByRole('link', {name: 'webhook documentation'})
+      ).toBeInTheDocument();
+    });
+
+    it('marks a partially subscribed resource as mixed', () => {
+      renderSubscriptions(['issue.created']);
+
+      expect(screen.getByRole('checkbox', {name: 'issue'})).toBePartiallyChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.resolved'})).not.toBeChecked();
+    });
+
+    it('toggles a single event', async () => {
+      const onChange = renderSubscriptions(['issue.created']);
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'issue.resolved'}));
+      expect(onChange).toHaveBeenCalledWith(['issue.created', 'issue.resolved']);
+    });
+
+    it('selects every event when checking the resource', async () => {
+      const onChange = renderSubscriptions(['issue.created']);
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'issue'}));
+      expect(onChange).toHaveBeenCalledWith([...RESOURCE_EVENTS.issue]);
+    });
+
+    it('clears every event when unchecking the resource', async () => {
+      const onChange = renderSubscriptions([...RESOURCE_EVENTS.issue, 'comment.created']);
+
+      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeChecked();
+      await userEvent.click(screen.getByRole('checkbox', {name: 'issue'}));
+      expect(onChange).toHaveBeenCalledWith(['comment.created']);
+    });
+
+    it('strips events whose permission is revoked', () => {
+      const onChange = renderSubscriptions(
+        ['issue.created', 'preprod_artifact.size_analysis_completed'],
+        {...basePermissions, Event: 'no-access'}
+      );
+
+      expect(onChange).toHaveBeenCalledWith(['preprod_artifact.size_analysis_completed']);
     });
   });
 

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -1,18 +1,29 @@
-import {Fragment, useEffect} from 'react';
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import type {Permissions, WebhookEvent} from 'sentry/types/integrations';
+import {Container} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {tct} from 'sentry/locale';
+import type {Permissions} from 'sentry/types/integrations';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {
+  WebhookGranularEvent,
+  WebhookSubscription,
+} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
   EVENT_CHOICES,
   PERMISSIONS_MAP,
+  RESOURCE_EVENTS,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {SubscriptionBox} from 'sentry/views/settings/organizationDeveloperSettings/subscriptionBox';
 
 type Resource = (typeof EVENT_CHOICES)[number];
 
 type Props = {
-  events: WebhookEvent[];
-  onChange: (events: WebhookEvent[]) => void;
+  events: WebhookSubscription[];
+  onChange: (events: WebhookSubscription[]) => void;
   permissions: Permissions;
   webhookDisabled?: boolean;
 };
@@ -23,6 +34,9 @@ export function Subscriptions({
   permissions,
   webhookDisabled = false,
 }: Props) {
+  const organization = useOrganization();
+  const granular = organization.features.includes('sentry-apps-granular-events');
+
   // Keep the subscription consistent with the rest of the form: webhooks
   // disabled means no events, and every event needs its backing permission.
   useEffect(() => {
@@ -31,45 +45,90 @@ export function Subscriptions({
       return;
     }
 
-    const permittedEvents = events.filter(
-      resource => permissions[PERMISSIONS_MAP[resource]] !== 'no-access'
+    const permitted = new Set<string>(
+      EVENT_CHOICES.filter(
+        resource => permissions[PERMISSIONS_MAP[resource]] !== 'no-access'
+      ).flatMap(resource => [resource, ...RESOURCE_EVENTS[resource]])
     );
+    const permittedEvents = events.filter(subscription => permitted.has(subscription));
 
     if (JSON.stringify(events) !== JSON.stringify(permittedEvents)) {
       onChange(permittedEvents);
     }
   }, [webhookDisabled, permissions, events, onChange]);
 
-  const handleChange = (resource: Resource, checked: boolean) => {
+  const handleResourceChange = (resource: Resource, checked: boolean) => {
+    const owned = new Set<string>([resource, ...RESOURCE_EVENTS[resource]]);
+    const others = events.filter(subscription => !owned.has(subscription));
+    if (!checked) {
+      onChange(others);
+      return;
+    }
+    onChange([...others, ...(granular ? RESOURCE_EVENTS[resource] : [resource])]);
+  };
+
+  const handleEventChange = (event: WebhookGranularEvent, checked: boolean) => {
     const newEvents = new Set(events);
     if (checked) {
-      newEvents.add(resource);
+      newEvents.add(event);
     } else {
-      newEvents.delete(resource);
+      newEvents.delete(event);
     }
     onChange(Array.from(newEvents));
   };
 
+  const boxes = EVENT_CHOICES.map(choice => {
+    const disabledFromPermissions = permissions[PERMISSIONS_MAP[choice]] === 'no-access';
+    const selectedEvents = disabledFromPermissions
+      ? []
+      : RESOURCE_EVENTS[choice].filter(event => events.includes(event));
+
+    let checked: boolean | 'indeterminate' = false;
+    if (!disabledFromPermissions) {
+      if (!granular) {
+        checked = events.includes(choice);
+      } else if (selectedEvents.length === RESOURCE_EVENTS[choice].length) {
+        checked = true;
+      } else if (selectedEvents.length > 0) {
+        checked = 'indeterminate';
+      }
+    }
+
+    return (
+      <SubscriptionBox
+        key={choice}
+        disabledFromPermissions={disabledFromPermissions}
+        webhookDisabled={webhookDisabled}
+        checked={checked}
+        selectedEvents={selectedEvents}
+        resource={choice}
+        onChange={handleResourceChange}
+        onEventChange={handleEventChange}
+        isNew={false}
+      />
+    );
+  });
+
+  if (!granular) {
+    return <SubscriptionGrid>{boxes}</SubscriptionGrid>;
+  }
+
   return (
-    <SubscriptionGrid>
-      {EVENT_CHOICES.map(choice => {
-        const disabledFromPermissions =
-          permissions[PERMISSIONS_MAP[choice]] === 'no-access';
-        return (
-          <Fragment key={choice}>
-            <SubscriptionBox
-              key={choice}
-              disabledFromPermissions={disabledFromPermissions}
-              webhookDisabled={webhookDisabled}
-              checked={events.includes(choice) && !disabledFromPermissions}
-              resource={choice}
-              onChange={handleChange}
-              isNew={false}
-            />
-          </Fragment>
-        );
-      })}
-    </SubscriptionGrid>
+    <SubscriptionList>
+      <Container padding="lg md" maxWidth="80ch">
+        <Text variant="muted">
+          {tct(
+            'Each time a subscribed event occurs, Sentry sends a POST request to the Webhook URL specified above. Subscribing requires at least Read access to the resource. See the [link:webhook documentation] for event payloads.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/webhooks/" />
+              ),
+            }
+          )}
+        </Text>
+      </Container>
+      {boxes}
+    </SubscriptionList>
   );
 }
 
@@ -78,5 +137,15 @@ const SubscriptionGrid = styled('div')`
   grid-template: auto / 1fr 1fr 1fr;
   @media (max-width: ${props => props.theme.breakpoints.lg}) {
     grid-template: 1fr 1fr 1fr / auto;
+  }
+`;
+
+const SubscriptionList = styled('div')`
+  display: flex;
+  flex-direction: column;
+  padding: ${p => p.theme.space.md};
+
+  > * + * {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
   }
 `;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -604,6 +604,128 @@ describe('Sentry Application Details', () => {
     });
   });
 
+  describe('Editing granular event subscriptions', () => {
+    const organization = OrganizationFixture({
+      features: ['sentry-apps-granular-events'],
+    });
+    const initialRouterConfig: RouterConfig = {
+      location: {
+        pathname: '/sentry-apps/sample-app/',
+      },
+      route: '/sentry-apps/:appSlug/',
+    };
+    function renderComponent() {
+      return render(<SentryApplicationDetails />, {initialRouterConfig, organization});
+    }
+
+    beforeEach(() => {
+      sentryApp = SentryAppFixture({
+        events: ['issue'],
+        webhookEvents: ['issue.created', 'issue.resolved'],
+        scopes: ['project:read', 'event:read'],
+      });
+
+      editAppRequest = MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        method: 'PUT',
+        body: [],
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
+        body: [],
+      });
+    });
+
+    it('seeds the checkboxes from webhookEvents and submits them exactly', async () => {
+      renderComponent();
+      await screen.findByRole('button', {name: 'Save Changes'});
+
+      expect(screen.getByRole('checkbox', {name: 'issue'})).toBePartiallyChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.resolved'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.assigned'})).not.toBeChecked();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+      expect(editAppRequest).toHaveBeenCalledWith(
+        `/sentry-apps/${sentryApp.slug}/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            events: ['issue.created', 'issue.resolved'],
+          }),
+          method: 'PUT',
+        })
+      );
+    });
+
+    it('submits individual events after toggling', async () => {
+      renderComponent();
+      await screen.findByRole('button', {name: 'Save Changes'});
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'issue.created'}));
+      await userEvent.click(screen.getByRole('checkbox', {name: 'comment.created'}));
+
+      await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+      expect(editAppRequest).toHaveBeenCalledWith(
+        `/sentry-apps/${sentryApp.slug}/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            events: ['issue.resolved', 'comment.created'],
+          }),
+          method: 'PUT',
+        })
+      );
+    });
+
+    it('maps the legacy issue.archived token to issue.ignored', async () => {
+      sentryApp.webhookEvents = ['issue.archived'];
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      renderComponent();
+      await screen.findByRole('button', {name: 'Save Changes'});
+
+      expect(screen.getByRole('checkbox', {name: 'issue.ignored'})).toBeChecked();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+      expect(editAppRequest).toHaveBeenCalledWith(
+        `/sentry-apps/${sentryApp.slug}/`,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            events: ['issue.ignored'],
+          }),
+          method: 'PUT',
+        })
+      );
+    });
+
+    it('expands the consolidated events when webhookEvents is absent', async () => {
+      sentryApp.webhookEvents = undefined;
+      MockApiClient.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      renderComponent();
+      await screen.findByRole('button', {name: 'Save Changes'});
+
+      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.unresolved'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'comment.created'})).not.toBeChecked();
+    });
+  });
+
   describe('Editing an existing public Sentry App with a scope error', () => {
     const initialRouterConfig: RouterConfig = {
       location: {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -59,7 +59,12 @@ import {useParams} from 'sentry/utils/useParams';
 import {ApiTokenRow} from 'sentry/views/settings/account/apiTokenRow';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
-import {EVENT_CHOICES} from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import type {WebhookSubscription} from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import {
+  EVENT_CHOICES,
+  granularWebhookEvents,
+  WEBHOOK_GRANULAR_EVENT_CHOICES,
+} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 
 const AVATAR_STYLES = {
@@ -96,7 +101,9 @@ const sentryAppFormSchema = z
     organization: z.string(),
     isInternal: z.boolean(),
     scopes: z.array(z.enum(ALLOWED_SCOPES)),
-    events: z.array(z.enum(EVENT_CHOICES)),
+    events: z.array(
+      z.union([z.enum(EVENT_CHOICES), z.enum(WEBHOOK_GRANULAR_EVENT_CHOICES)])
+    ),
   })
   .superRefine((data, ctx) => {
     if (!data.name.trim()) {
@@ -351,6 +358,15 @@ function SentryApplicationForm({
     return events.map(event => event.split('.').shift() as WebhookEvent);
   };
 
+  const granular = organization.features.includes('sentry-apps-granular-events');
+
+  // Older API responses only send the consolidated resource list
+  const initialEvents: WebhookSubscription[] = app
+    ? granular
+      ? granularWebhookEvents(app.webhookEvents ?? app.events)
+      : normalize(app.events)
+    : [];
+
   const hasTokenAccess = () => {
     return organization.access.includes('org:write');
   };
@@ -522,7 +538,7 @@ function SentryApplicationForm({
     organization: organization.slug,
     isInternal,
     scopes: app ? [...app.scopes] : [],
-    events: app ? normalize(app.events) : [],
+    events: initialEvents,
   };
 
   const saveSentryAppMutation = useMutation({
@@ -840,7 +856,7 @@ function SentryApplicationForm({
             webhookDisabled={webhookDisabled}
             appPublished={app ? app.status === 'published' : false}
             scopes={app ? [...app.scopes] : []}
-            events={app ? normalize(app.events) : []}
+            events={initialEvents}
             newApp={!app}
             permissionErrors={scopeErrors.permissions}
             continuousIntegrationError={scopeErrors.continuousIntegration}

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -7,9 +7,11 @@ import {SubscriptionBox} from 'sentry/views/settings/organizationDeveloperSettin
 
 describe('SubscriptionBox', () => {
   const onChange = jest.fn();
+  const onEventChange = jest.fn();
 
   beforeEach(() => {
     onChange.mockReset();
+    onEventChange.mockReset();
   });
   function renderComponent(
     props: Partial<ComponentProps<typeof SubscriptionBox>> = {},
@@ -19,8 +21,10 @@ describe('SubscriptionBox', () => {
       <SubscriptionBox
         resource="issue"
         checked={false}
+        selectedEvents={[]}
         disabledFromPermissions={false}
         onChange={onChange}
+        onEventChange={onEventChange}
         isNew={false}
         {...props}
       />,
@@ -85,6 +89,34 @@ describe('SubscriptionBox', () => {
         'Cannot enable webhook subscription without specifying a webhook url'
       )
     ).toBeInTheDocument();
+  });
+
+  describe('granular event subscriptions', () => {
+    const organization = OrganizationFixture({
+      features: ['sentry-apps-granular-events'],
+    });
+
+    it('renders a checkbox per event', () => {
+      renderComponent({selectedEvents: ['issue.created']}, {organization});
+
+      expect(screen.getAllByRole('checkbox')).toHaveLength(6);
+      expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
+      expect(screen.getByRole('checkbox', {name: 'issue.resolved'})).not.toBeChecked();
+    });
+
+    it('calls onEventChange when toggling an event', async () => {
+      renderComponent({}, {organization});
+
+      await userEvent.click(screen.getByRole('checkbox', {name: 'issue.resolved'}));
+      expect(onEventChange).toHaveBeenCalledWith('issue.resolved', true);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not render event checkboxes without the flag', () => {
+      renderComponent({selectedEvents: ['issue.created']});
+
+      expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+    });
   });
 
   describe('preprod_artifact resource subscription', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -2,12 +2,16 @@ import styled from '@emotion/styled';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {EVENT_CHOICES} from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import type {
+  EVENT_CHOICES,
+  WebhookGranularEvent,
+} from 'sentry/views/settings/organizationDeveloperSettings/constants';
 import {
   PERMISSIONS_MAP,
   RESOURCE_EVENTS,
@@ -18,11 +22,13 @@ import {
 type Resource = (typeof EVENT_CHOICES)[number];
 
 type Props = {
-  checked: boolean;
+  checked: boolean | 'indeterminate';
   disabledFromPermissions: boolean;
   isNew: boolean;
   onChange: (resource: Resource, checked: boolean) => void;
+  onEventChange: (event: WebhookGranularEvent, checked: boolean) => void;
   resource: Resource;
+  selectedEvents: WebhookGranularEvent[];
   webhookDisabled?: boolean;
 };
 
@@ -31,7 +37,9 @@ export function SubscriptionBox({
   disabledFromPermissions,
   isNew,
   onChange,
+  onEventChange,
   resource,
+  selectedEvents,
   webhookDisabled = false,
 }: Props) {
   const {features} = useOrganization();
@@ -60,7 +68,58 @@ export function SubscriptionBox({
     message = t('Cannot enable webhook subscription without specifying a webhook url');
   }
 
+  const granular = features.includes('sentry-apps-granular-events');
   const description = RESOURCE_EVENTS[resource].map(webhookEventLabel).join(', ');
+
+  if (granular) {
+    return (
+      <SubscriptionRow
+        align="start"
+        gap="2xl"
+        padding="lg md"
+        direction={{'screen:xs': 'column', 'screen:md': 'row'}}
+        data-disabled={disabled || undefined}
+      >
+        <Tooltip disabled={!disabled} title={message}>
+          <Flex
+            as="label"
+            align="center"
+            gap="md"
+            flex="none"
+            width={{'screen:xs': '100%', 'screen:md': '180px'}}
+          >
+            <Checkbox
+              aria-label={resource}
+              disabled={disabled}
+              checked={checked}
+              onChange={evt => onChange(resource, evt.target.checked)}
+            />
+            <Text size="md" bold>
+              {webhookResourceLabel(resource)}
+              {isNew && <FeatureBadge type="new" />}
+            </Text>
+          </Flex>
+        </Tooltip>
+        <Grid flex="1" columns="repeat(auto-fill, 220px)" gap="md lg">
+          {RESOURCE_EVENTS[resource].map(event => (
+            <Tooltip key={event} disabled={!disabled} title={message}>
+              <Flex as="label" align="center" gap="sm">
+                <Checkbox
+                  aria-label={event}
+                  disabled={disabled}
+                  checked={selectedEvents.includes(event)}
+                  onChange={evt => onEventChange(event, evt.target.checked)}
+                />
+                <Text size="md" variant="muted">
+                  {webhookEventLabel(event)}
+                </Text>
+              </Flex>
+            </Tooltip>
+          ))}
+        </Grid>
+      </SubscriptionRow>
+    );
+  }
 
   return (
     <Tooltip disabled={!disabled} title={message} key={resource}>
@@ -97,6 +156,13 @@ const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
   margin: ${p => p.theme.space.lg};
   padding: ${p => p.theme.space.lg};
   box-sizing: border-box;
+`;
+
+const SubscriptionRow = styled(Flex)`
+  &[data-disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 `;
 
 const SubscriptionDescription = styled('div')`

--- a/tests/js/fixtures/sentryApp.ts
+++ b/tests/js/fixtures/sentryApp.ts
@@ -7,6 +7,7 @@ export function SentryAppFixture(params: Partial<SentryApp> = {}): SentryApp {
     slug: 'sample-app',
     scopes: ['project:read'],
     events: [],
+    webhookEvents: [],
     status: 'unpublished',
     uuid: '123456123456123456123456',
     webhookUrl: 'https://example.com/webhook',


### PR DESCRIPTION
Update the webhooks panel in custom integrations to be a stacked list, behind `sentry-apps-granular-events`. The form uses the new `webhookEvents` field from https://github.com/getsentry/sentry/pull/118940, and submits granular event subscriptions. Without the flag the form is unchanged.


<img width="1208" height="415" alt="Screenshot 2026-07-09 at 10 46 55 AM" src="https://github.com/user-attachments/assets/2ada4d65-3e8a-40ff-90c9-94dfae070c43" />
