### PR TITLE
chore: Create conventions to report under documents @deprecated symbols, @deprecated callsites

### DIFF
--- a/.sentry-refactor-tasks/conventions/deprecated-needs-replacement.yaml
+++ b/.sentry-refactor-tasks/conventions/deprecated-needs-replacement.yaml
@@ -1,0 +1,132 @@
+name: deprecated-needs-replacement
+severity: warning
+tags: [docs, migration, deprecation]
+
+why: |
+  An `@deprecated` annotation is only useful if it tells the reader what to do
+  instead. A bare `@deprecated`, or one that just says "do not use this",
+  signals that something is on its way out but leaves every caller to guess at
+  the migration path — which symbol, hook, component, or import replaces it, or
+  whether they should simply delete the usage. That guesswork is exactly what
+  the annotation is supposed to remove.
+
+  Requiring an explicit migration note on every deprecation turns the
+  annotation into an actionable instruction: a reader (human or agent) hitting
+  the deprecated symbol can immediately see their next step instead of grepping
+  the codebase or asking around. It also makes the eventual removal tractable,
+  because each call site already documents where it should move.
+
+  See: https://tsdoc.org/pages/tags/deprecated/ (the `@deprecated` tag "should
+  ideally" be accompanied by guidance on what to use instead.)
+
+detect: |
+  Look for `@deprecated` JSDoc/TSDoc tags whose accompanying text does NOT give
+  the reader a concrete next step. Flag the deprecated declaration (the
+  `@deprecated` line and the symbol it documents).
+
+  A deprecation is CONFORMING (do NOT flag) when its text does at least one of:
+    - Names a concrete replacement the caller should move to — a symbol, hook,
+      component, import path, or option. Phrasings like "Use `X` instead",
+      "Prefer `X`", "Switch to `X`", "use `useFoo()`" all qualify, as long as a
+      specific target is named.
+    - Explicitly states the symbol is being removed / is no longer needed AND
+      tells callers what to do about it (e.g. "remove this usage; the value is
+      now always present", "delete the prop, the layout handles this now").
+
+  A deprecation is NON-CONFORMING (FLAG it) when its text:
+    - Is bare: `@deprecated` with no following prose at all.
+    - Only forbids use without redirecting: "Do not use this", "do not use",
+      "don't use in new code" with no named alternative.
+    - Announces removal but leaves callers' next move unstated: "will be removed
+      in new UI", "this is going away" — with no replacement and no instruction
+      to remove the usage (per this convention, removal-only deprecations must
+      still spell out the caller's action).
+    - Names a vague direction but no concrete target: "use a hook instead",
+      "use the new API", "consider a different approach".
+
+  Treat a named target inside backticks, or any clearly-identifiable symbol
+  name, as concrete even if the surrounding sentence is terse.
+
+  Do NOT flag:
+    - `@deprecated` appearing in comments that are documentation ABOUT the tag
+      itself (e.g. this convention, lint rules, or codemods that match on it).
+    - `@deprecated` inside strings, test fixtures, or mocks.
+    - Re-exports / type aliases that merely forward an already-documented
+      deprecation, where the original declaration carries the migration note.
+
+fix: |
+  Add the migration target to the `@deprecated` text so a reader knows their
+  next step without leaving the file.
+
+    - If a replacement exists, name it concretely and link it with backticks:
+        `@deprecated Use \`useProjects()\` instead.`
+    - If the symbol is going away with no replacement, say so AND tell callers
+      what to do:
+        `@deprecated Being removed with the new UI — delete usages; there is no
+        replacement.`
+    - If the deprecation is conditional (e.g. waiting on a backend change),
+      state the trigger and the eventual action:
+        `@deprecated Temporary shim until the API returns corrected timestamps;
+        remove once it does.`
+
+  Prefer a single sentence that answers "what do I do instead?". Keep the
+  existing tag placement (same JSDoc block / line); only the text changes. Do
+  not silently drop a deprecation just because it lacks a replacement — if it is
+  truly safe to use, remove the `@deprecated` tag instead; if not, document the
+  path.
+
+  Gotchas:
+    1. Naming a replacement that is ITSELF deprecated just moves the problem —
+       point at the live target.
+    2. When the replacement is in another package, include the import source
+       (`Use \`Text\` from \`@sentry/scraps/text\``) so callers can find it.
+    3. A `@deprecated` on a type/interface member documents that field; the note
+       should describe the field's replacement, not the whole type's.
+
+examples:
+  bad:
+    - |
+      /** @deprecated */
+      export function getOldThing() {}
+    - |
+      /**
+       * @deprecated Do not use this
+       */
+      export const legacyClient = makeClient();
+    - |
+      /** @deprecated This icon will be removed in new UI. */
+      export function IconLegacy() {}
+    - |
+      /** @deprecated use a hook instead */
+      export function withThing(Component) {}
+  good:
+    - |
+      /** @deprecated Use `useProjects()` instead. */
+      export function getProjects() {}
+    - |
+      /** @deprecated Use `Text` from `@sentry/scraps/text` instead. */
+      export function LegacyText() {}
+    - |
+      /**
+       * @deprecated Being removed with the new UI — delete usages; there is no
+       * replacement.
+       */
+      export function IconLegacy() {}
+    - |
+      /**
+       * @deprecated Temporary shim until the API returns corrected timestamps;
+       * remove once it does.
+       */
+      export function adjustTimestamps() {}
+
+include:
+  - 'static/**/*.tsx'
+  - 'static/**/*.ts'
+exclude:
+  - '**/__fixtures__/**'
+  - '**/__mocks__/**'
+  - '**/*.spec.*'
+  - '**/*.test.*'
+  - '**/test/**'
+
+prefilter: "grep -rl --include='*.tsx' --include='*.ts' '@deprecated' {repo_path}/static/"

--- a/.sentry-refactor-tasks/conventions/no-deprecated-callsite.detect.sh
+++ b/.sentry-refactor-tasks/conventions/no-deprecated-callsite.detect.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Detector for the `no-deprecated-callsite` convention.
+#
+# Flags every callsite that references an `@deprecated` symbol, using the
+# type-aware `@typescript-eslint/no-deprecated` rule. Because the rule resolves
+# each symbol through the TypeScript checker, its message includes the symbol's
+# own `@deprecated` JSDoc text (the migration instruction) — which the scanner
+# surfaces as the finding's explanation.
+#
+# Unlike no-derived-state, this reuses the plugin already installed in the repo
+# (@typescript-eslint, which ships the no-deprecated rule), so it does NOT add
+# any package and does NOT touch package.json / the lockfile. It only writes a
+# temporary flat eslint config and removes it on exit.
+#
+# Usage: no-deprecated-callsite.detect.sh <repo-path>
+#   <repo-path>  checkout of the target repo (cwd for pnpm/eslint)
+#
+# All install/diagnostic output goes to stderr; only the runner's JSON reaches
+# stdout, which the scanner parses.
+set -euo pipefail
+
+repo_path="$1"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+rule="@typescript-eslint/no-deprecated"
+config_path="$repo_path/.no-deprecated-callsite.eslint.config.mjs"
+
+cd "$repo_path"
+
+# Only the temp config is created; nothing else in the tree is mutated.
+cleanup() {
+  rm -f "$config_path"
+}
+trap cleanup EXIT
+
+# Bring up the repo's toolchain. No `pnpm add` — the no-deprecated rule ships
+# with the repo's own @typescript-eslint, so the working tree stays clean.
+pnpm install --frozen-lockfile 1>&2
+
+# Standalone flat config loading only this rule. It lives inside the repo so its
+# imports resolve from the repo's node_modules, and `projectService` discovers
+# the root tsconfig.json (tsconfigRootDir = this config's dir = repo root). The
+# rule is type-aware, so type information is required — hence projectService.
+cat > "$config_path" <<'EOF'
+import parser from '@typescript-eslint/parser';
+import plugin from '@typescript-eslint/eslint-plugin';
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+      },
+    },
+    plugins: { '@typescript-eslint': plugin },
+    rules: { '@typescript-eslint/no-deprecated': 'error' },
+  },
+];
+EOF
+
+# Type-aware linting across all of static/ builds a large type graph — give the
+# eslint process extra heap so it does not OOM on a repo this size.
+export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192"
+
+# Emit only callsites whose deprecation note carries a migration instruction —
+# i.e. `@deprecated` text beyond the bare "`<name>` is deprecated." A bare
+# deprecation gives a caller nothing to act on (that gap is the
+# `deprecated-needs-replacement` convention's concern), so drop those here and
+# report only the instances we can actually tell Seer how to fix.
+pnpm exec node "$script_dir/eslint-json-runner.ts" "$repo_path" "$rule" "$config_path" static \
+  | node --input-type=module -e '
+      let data = "";
+      process.stdin.on("data", chunk => (data += chunk));
+      process.stdin.on("end", () => {
+        const files = JSON.parse(data || "[]");
+        const hasInstruction = m => /is deprecated\.\s*\S/.test(m.message);
+        const filtered = files
+          .map(f => ({...f, messages: f.messages.filter(hasInstruction)}))
+          .filter(f => f.messages.length > 0);
+        process.stdout.write(JSON.stringify(filtered));
+      });
+    '

--- a/.sentry-refactor-tasks/conventions/no-deprecated-callsite.yaml
+++ b/.sentry-refactor-tasks/conventions/no-deprecated-callsite.yaml
@@ -1,0 +1,59 @@
+name: no-deprecated-callsite
+severity: warning
+tags: [migration, deprecation, typescript]
+
+why: |
+  Every call to an `@deprecated` symbol is code that must eventually move to its
+  replacement. Left in place, deprecated APIs accumulate: the old symbol can't
+  be removed while callers remain, new code copies the pattern from existing
+  usages, and the migration note on the declaration goes unread. Each callsite
+  is a small, well-scoped migration whose target is already documented on the
+  symbol itself.
+
+  Fixing callsites — not just annotating declarations — is what actually lets a
+  deprecated symbol be deleted.
+
+  See: https://typescript-eslint.io/rules/no-deprecated/
+
+detect: |
+  Detected by the type-aware eslint rule `@typescript-eslint/no-deprecated`.
+  The TypeScript checker resolves each referenced symbol across files, so the
+  rule reports any use of a symbol whose declaration carries an `@deprecated`
+  JSDoc tag — and includes that tag's migration text in the message. Runs via
+  detect_command; no LLM needed.
+
+fix: |
+  Replace the deprecated symbol at this callsite with the migration target named
+  in the deprecation note. That note is shown in the "Problem" section above —
+  it is the text following "is deprecated."
+
+  Steps:
+    1. Read the migration instruction in the finding's message. It names the
+       symbol, hook, component, option, or import to move to.
+    2. Apply that replacement at this callsite, adjusting imports as needed.
+    3. If the note names no replacement (a bare `@deprecated`), find the intended
+       target from the symbol's declaration or its surrounding docs before
+       changing anything — do not guess.
+
+  Verify the fix by re-running eslint on the changed file (type information is
+  required, so run from the repo root):
+    pnpm eslint --rule '{"@typescript-eslint/no-deprecated": "error"}' <file>
+
+  Gotchas:
+    1. Update the import when the replacement lives in a different module.
+    2. Some deprecations are conditional ("remove once the API returns X") —
+       follow the note's instruction rather than assuming a drop-in symbol.
+    3. Replacing one deprecated symbol with another just moves the problem —
+       confirm the target is not itself deprecated.
+
+examples:
+  bad:
+    - "import {browserHistory} from 'sentry/utils/browserHistory'; browserHistory.push('/foo/');"
+    - 'const organization = useLegacyOrganization();'
+    - '<LegacyButton onClick={handleClick} />'
+  good:
+    - "const navigate = useNavigate(); navigate('/foo/');"
+    - 'const organization = useOrganization();'
+    - '<Button onClick={handleClick} />'
+
+detect_command: 'bash {convention_dir}/no-deprecated-callsite.detect.sh {repo_path}'


### PR DESCRIPTION
These conventions help identify parts of the codebase that need to be upgraded because of their use of the `@deprecated` annotation.

For symbols that are themselves @deprecated we want to make sure that there are sufficient instructions included so that callers know what changes to make. 
The second convention is to identify those callers, pull in the instructions for the change, and see that each callsite is modified to use the newest convention. 

This pair of conventions leverages the existing decorator, which means that many types of changes will be caught. So instead of having a `requestPromise` specific convention, we can (and have) tagged that with the decorator and it'll get picked up by this. Therefore i also removed `no-callback-api-request` because it's covered by this.