### PR TITLE
ref(seer): Standardize actor_author_mismatch log extra for GitLab

### DIFF
--- a/src/sentry/seer/code_review/webhooks/seat_tracking.py
+++ b/src/sentry/seer/code_review/webhooks/seat_tracking.py
@@ -74,6 +74,30 @@ SEAT_SEEN_KEY_PREFIX = "webhook:gitlab:seat_tracking:"
 SEAT_SEEN_TTL_SECONDS = 20
 
 
+def _actor_author_mismatch_extra(
+    *,
+    organization: RpcOrganization,
+    repo: Repository,
+    integration: RpcIntegration,
+    merge_request_iid: object,
+    merge_request_action: object,
+    author_id: object,
+    actor_id: object,
+    contributor_tracking_stage: str,
+) -> dict[str, object]:
+    return {
+        "seer.webhooks.organization_id": organization.id,
+        "seer.webhooks.provider_name": "gitlab",
+        "seer.webhooks.repository_id": repo.id,
+        "seer.webhooks.integration_id": integration.id,
+        "seer.webhooks.merge_request_iid": merge_request_iid,
+        "seer.webhooks.merge_request_action": merge_request_action,
+        "seer.webhooks.author_id": author_id,
+        "seer.webhooks.actor_id": actor_id,
+        "seer.webhooks.contributor_tracking_stage": contributor_tracking_stage,
+    }
+
+
 def _is_duplicate_delivery(seen_key: str) -> bool:
     """
     True if a delivery with this key was already processed within the TTL window.
@@ -148,7 +172,16 @@ def track_gitlab_contributor_seat_processor(
             logger,
             organization,
             "actor_author_mismatch",
-            {**base_extra, "event_actor_id": event_actor_id},
+            _actor_author_mismatch_extra(
+                organization=organization,
+                repo=repo,
+                integration=integration,
+                merge_request_iid=iid,
+                merge_request_action=object_attributes.get("action"),
+                author_id=user_id,
+                actor_id=event_actor_id,
+                contributor_tracking_stage="seat",
+            ),
             level=logging.WARNING,
         )
         return
@@ -219,13 +252,16 @@ def track_gitlab_contributor_action_processor(
             logger,
             organization,
             "actor_author_mismatch",
-            {
-                "organization_id": organization.id,
-                "repo_id": repo.id,
-                "mr_iid": iid,
-                "author_id": user_id,
-                "event_actor_id": event_actor_id,
-            },
+            _actor_author_mismatch_extra(
+                organization=organization,
+                repo=repo,
+                integration=integration,
+                merge_request_iid=iid,
+                merge_request_action=object_attributes.get("action"),
+                author_id=user_id,
+                actor_id=event_actor_id,
+                contributor_tracking_stage="action",
+            ),
             level=logging.WARNING,
         )
         return

--- a/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
+++ b/tests/sentry/seer/code_review/webhooks/test_seat_tracking.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 from unittest.mock import patch
 
@@ -114,8 +115,9 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         mock_track.assert_not_called()
 
     @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.logger")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
-    def test_no_call_when_actor_is_not_author(self, mock_track: Any) -> None:
+    def test_no_call_when_actor_is_not_author(self, mock_track: Any, mock_logger: Any) -> None:
         # The MR author (object_attributes.author_id) and the webhook actor
         # (event.user) diverge — e.g. an MR opened via the API on behalf of
         # another author. Seeding would store the actor's username as the alias
@@ -124,6 +126,22 @@ class TrackGitlabContributorSeatProcessorTest(GitLabTestCase):
         event["user"]["id"] = event["object_attributes"]["author_id"] + 1
         self._call(event=event)
         mock_track.assert_not_called()
+        mock_logger.log.assert_any_call(
+            logging.WARNING,
+            "actor_author_mismatch",
+            extra={
+                "seer.webhooks.organization_id": self.organization.id,
+                "seer.webhooks.provider_name": "gitlab",
+                "seer.webhooks.repository_id": self.repo.id,
+                "seer.webhooks.integration_id": self.integration.id,
+                "seer.webhooks.merge_request_iid": event["object_attributes"]["iid"],
+                "seer.webhooks.merge_request_action": event["object_attributes"]["action"],
+                "seer.webhooks.author_id": event["object_attributes"]["author_id"],
+                "seer.webhooks.actor_id": event["user"]["id"],
+                "seer.webhooks.contributor_tracking_stage": "seat",
+            },
+            exc_info=False,
+        )
 
     @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.track_contributor_seat")
@@ -285,8 +303,9 @@ class TrackGitlabContributorActionProcessorTest(GitLabTestCase):
         mock_record.assert_not_called()
 
     @with_feature("organizations:seer-gitlab-support")
+    @patch("sentry.seer.code_review.webhooks.seat_tracking.logger")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.record_contributor_action")
-    def test_no_call_when_actor_is_not_author(self, mock_record: Any) -> None:
+    def test_no_call_when_actor_is_not_author(self, mock_record: Any, mock_logger: Any) -> None:
         # The row is keyed by the author id but seeded with the actor's username
         # as the alias, so skip seeding when the actor is not the author.
         event = _make_event()
@@ -298,6 +317,22 @@ class TrackGitlabContributorActionProcessorTest(GitLabTestCase):
             integration=self.integration,
         )
         mock_record.assert_not_called()
+        mock_logger.log.assert_any_call(
+            logging.WARNING,
+            "actor_author_mismatch",
+            extra={
+                "seer.webhooks.organization_id": self.organization.id,
+                "seer.webhooks.provider_name": "gitlab",
+                "seer.webhooks.repository_id": self.repo.id,
+                "seer.webhooks.integration_id": self.integration.id,
+                "seer.webhooks.merge_request_iid": event["object_attributes"]["iid"],
+                "seer.webhooks.merge_request_action": event["object_attributes"]["action"],
+                "seer.webhooks.author_id": event["object_attributes"]["author_id"],
+                "seer.webhooks.actor_id": event["user"]["id"],
+                "seer.webhooks.contributor_tracking_stage": "action",
+            },
+            exc_info=False,
+        )
 
     @with_feature("organizations:seer-gitlab-support")
     @patch("sentry.seer.code_review.webhooks.seat_tracking.record_contributor_action")


### PR DESCRIPTION
Both GitLab seat-tracking call sites that warn on an actor/author mismatch now emit the same structured log payload, built by a single `_actor_author_mismatch_extra()` helper.

Previously the "seat" and "action" stages each assembled their own ad-hoc `extra` dict with divergent key names (`organization_id`/`mr_iid`/`event_actor_id` in one, `event_actor_id` bolted onto a shared base in the other), so the two `actor_author_mismatch` warnings could not be queried or aggregated together. The helper standardizes every field under a `seer.webhooks.*` prefix and adds a `contributor_tracking_stage` discriminator (`"seat"` vs `"action"`).

**Log payload shape**

Both warnings now share these keys, differing only by `contributor_tracking_stage`:

```jsonc
{
  "seer.webhooks.organization_id": 1,
  "seer.webhooks.provider_name": "gitlab",
  "seer.webhooks.repository_id": 2,
  "seer.webhooks.integration_id": 3,
  "seer.webhooks.merge_request_iid": 42,
  "seer.webhooks.merge_request_action": "open",
  "seer.webhooks.author_id": 100,
  "seer.webhooks.actor_id": 101,
  "seer.webhooks.contributor_tracking_stage": "seat" // or "action"
}
```

No behavior change beyond the standardized log fields.