### PR TITLE
chore(scm): upgrade sentry-scm to 0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
   "sentry-protos>=0.42.1",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
-  "sentry-scm==0.30.0",
+  "sentry-scm==0.32.0",
   "sentry-sdk[http2]>=2.63.0",
   "sentry-usage-accountant>=0.0.10",
   # remove once there are no unmarked transitive dependencies on setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.41.2",
+  "sentry-protos>=0.42.1",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.32.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.42.1",
+  "sentry-protos>=0.41.2",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.32.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2414,7 +2414,7 @@ requires-dist = [
     { name = "sentry-protos", specifier = ">=0.42.1" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
-    { name = "sentry-scm", specifier = "==0.30.0" },
+    { name = "sentry-scm", specifier = "==0.32.0" },
     { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.63.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
@@ -2632,14 +2632,14 @@ wheels = [
 
 [[package]]
 name = "sentry-scm"
-version = "0.30.0"
+version = "0.32.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_scm-0.30.0-py3-none-any.whl", hash = "sha256:dd0ee3f8551b6c2ee315184716af8a848da4a1613b5cfa35d61a14d2e6f0fc83" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_scm-0.32.0-py3-none-any.whl", hash = "sha256:c5bbe325a83744e008fd702707ec9a5f076d47fe3e8f2e425e25c1977ecb9675" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.40" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.42.1" },
+    { name = "sentry-protos", specifier = ">=0.41.2" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.32.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.42.1"
+version = "0.41.2"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.42.1-py3-none-any.whl", hash = "sha256:b32f77edc4f55eadc181bb3af27c85f0f02e787c903ba8c918f5bd4787c5d980" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.41.2-py3-none-any.whl", hash = "sha256:d1f79428f060322503419fe8c830bc6873017b6b3467a6226f51d01888ce8ee8" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.40" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.41.2" },
+    { name = "sentry-protos", specifier = ">=0.42.1" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.32.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.41.2"
+version = "0.42.1"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.41.2-py3-none-any.whl", hash = "sha256:d1f79428f060322503419fe8c830bc6873017b6b3467a6226f51d01888ce8ee8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.42.1-py3-none-any.whl", hash = "sha256:b32f77edc4f55eadc181bb3af27c85f0f02e787c903ba8c918f5bd4787c5d980" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `sentry-scm` from `0.30.0` to `0.32.0`.

Release: https://github.com/getsentry/publish/issues/8838

<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AD0AN404SG1X%3A1783622157.859139/?project=4510944073809921)

<!-- junior-session-footer:end -->