### PR TITLE
ref(gitlab): Log `on_create_repository` webhook creation path

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +14,8 @@ from sentry.shared_integrations.exceptions import ApiError
 
 if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration  # NOQA
+
+logger = logging.getLogger("sentry.integrations.gitlab")
 
 
 class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"]):
@@ -58,7 +61,28 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         }
 
     def on_create_repository(self, repo: RpcRepository, organization: RpcOrganization) -> None:
+        # Namespaced under "gitlab.repository." so these attributes group together in the
+        # Sentry Logs UI.
+        log_extra = {
+            "gitlab.repository.organization_id": repo.organization_id,
+            "gitlab.repository.integration_id": repo.integration_id,
+            "gitlab.repository.repository_id": repo.id,
+            "gitlab.repository.project_id": repo.config.get("project_id"),
+        }
+        # Emitted on every invocation so we can gauge how often this path runs
+        # (and therefore how many webhook create calls we make to GitLab).
+        logger.info(
+            "gitlab.repository.on_create_repository",
+            extra={
+                **log_extra,
+                "gitlab.repository.has_existing_webhook": bool(repo.config.get("webhook_id")),
+            },
+        )
         if repo.config.get("webhook_id"):
+            logger.info(
+                "gitlab.repository.webhook_creation_skipped",
+                extra={**log_extra, "gitlab.repository.webhook_id": repo.config.get("webhook_id")},
+            )
             return
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
@@ -68,6 +92,10 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             raise installation.raise_error(e)
         repo.config["webhook_id"] = hook_id
         repository_service.update_repository(organization_id=organization.id, update=repo)
+        logger.info(
+            "gitlab.repository.webhook_created",
+            extra={**log_extra, "gitlab.repository.webhook_id": hook_id},
+        )
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,5 +1,4 @@
 from functools import cached_property
-from unittest.mock import call, patch
 
 import orjson
 import pytest
@@ -103,81 +102,6 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         response = self.create_repository(self.default_repository_config, self.integration.id)
         assert response.status_code == 201
         self.assert_repository(self.default_repository_config)
-
-    @responses.activate
-    def test_on_create_repository_logs_when_webhook_already_configured(self) -> None:
-        response = self.create_repository(self.default_repository_config, self.integration.id)
-        responses.reset()
-
-        repo = self.get_repository(pk=response.data["id"])
-
-        with (
-            patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info,
-            patch.object(self.provider, "get_installation") as mock_get_installation,
-        ):
-            self.provider.on_create_repository(repo, self.organization)
-
-        mock_get_installation.assert_not_called()
-        assert len(responses.calls) == 0
-        mock_logger_info.assert_has_calls(
-            [
-                call(
-                    "gitlab.repository.on_create_repository",
-                    extra={
-                        "gitlab.repository.organization_id": self.organization.id,
-                        "gitlab.repository.integration_id": self.integration.id,
-                        "gitlab.repository.repository_id": repo.id,
-                        "gitlab.repository.project_id": repo.config["project_id"],
-                        "gitlab.repository.has_existing_webhook": True,
-                    },
-                ),
-                call(
-                    "gitlab.repository.webhook_creation_skipped",
-                    extra={
-                        "gitlab.repository.organization_id": self.organization.id,
-                        "gitlab.repository.integration_id": self.integration.id,
-                        "gitlab.repository.repository_id": repo.id,
-                        "gitlab.repository.project_id": repo.config["project_id"],
-                        "gitlab.repository.webhook_id": repo.config["webhook_id"],
-                    },
-                ),
-            ]
-        )
-
-    @responses.activate
-    def test_on_create_repository_logs_webhook_creation(self) -> None:
-        self.add_create_repository_responses(self.default_repository_config)
-
-        with patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info:
-            response = self.create_repository(self.default_repository_config, self.integration.id)
-
-        assert response.status_code == 201
-        repo = self.get_repository(pk=response.data["id"])
-
-        mock_logger_info.assert_has_calls(
-            [
-                call(
-                    "gitlab.repository.on_create_repository",
-                    extra={
-                        "gitlab.repository.organization_id": self.organization.id,
-                        "gitlab.repository.integration_id": self.integration.id,
-                        "gitlab.repository.repository_id": repo.id,
-                        "gitlab.repository.project_id": repo.config["project_id"],
-                        "gitlab.repository.has_existing_webhook": False,
-                    },
-                ),
-                call(
-                    "gitlab.repository.webhook_created",
-                    extra={
-                        "gitlab.repository.organization_id": self.organization.id,
-                        "gitlab.repository.integration_id": self.integration.id,
-                        "gitlab.repository.repository_id": repo.id,
-                        "gitlab.repository.project_id": repo.config["project_id"],
-                        "gitlab.repository.webhook_id": repo.config["webhook_id"],
-                    },
-                ),
-            ]
-        )
 
     @responses.activate
     def test_create_repository_verify_payload(self) -> None:

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from unittest.mock import call, patch
 
 import orjson
 import pytest
@@ -102,6 +103,81 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         response = self.create_repository(self.default_repository_config, self.integration.id)
         assert response.status_code == 201
         self.assert_repository(self.default_repository_config)
+
+    @responses.activate
+    def test_on_create_repository_logs_when_webhook_already_configured(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+
+        repo = self.get_repository(pk=response.data["id"])
+
+        with (
+            patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info,
+            patch.object(self.provider, "get_installation") as mock_get_installation,
+        ):
+            self.provider.on_create_repository(repo, self.organization)
+
+        mock_get_installation.assert_not_called()
+        assert len(responses.calls) == 0
+        mock_logger_info.assert_has_calls(
+            [
+                call(
+                    "gitlab.repository.on_create_repository",
+                    extra={
+                        "gitlab.repository.organization_id": self.organization.id,
+                        "gitlab.repository.integration_id": self.integration.id,
+                        "gitlab.repository.repository_id": repo.id,
+                        "gitlab.repository.project_id": repo.config["project_id"],
+                        "gitlab.repository.has_existing_webhook": True,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_creation_skipped",
+                    extra={
+                        "gitlab.repository.organization_id": self.organization.id,
+                        "gitlab.repository.integration_id": self.integration.id,
+                        "gitlab.repository.repository_id": repo.id,
+                        "gitlab.repository.project_id": repo.config["project_id"],
+                        "gitlab.repository.webhook_id": repo.config["webhook_id"],
+                    },
+                ),
+            ]
+        )
+
+    @responses.activate
+    def test_on_create_repository_logs_webhook_creation(self) -> None:
+        self.add_create_repository_responses(self.default_repository_config)
+
+        with patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info:
+            response = self.create_repository(self.default_repository_config, self.integration.id)
+
+        assert response.status_code == 201
+        repo = self.get_repository(pk=response.data["id"])
+
+        mock_logger_info.assert_has_calls(
+            [
+                call(
+                    "gitlab.repository.on_create_repository",
+                    extra={
+                        "gitlab.repository.organization_id": self.organization.id,
+                        "gitlab.repository.integration_id": self.integration.id,
+                        "gitlab.repository.repository_id": repo.id,
+                        "gitlab.repository.project_id": repo.config["project_id"],
+                        "gitlab.repository.has_existing_webhook": False,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_created",
+                    extra={
+                        "gitlab.repository.organization_id": self.organization.id,
+                        "gitlab.repository.integration_id": self.integration.id,
+                        "gitlab.repository.repository_id": repo.id,
+                        "gitlab.repository.project_id": repo.config["project_id"],
+                        "gitlab.repository.webhook_id": repo.config["webhook_id"],
+                    },
+                ),
+            ]
+        )
 
     @responses.activate
     def test_create_repository_verify_payload(self) -> None:


### PR DESCRIPTION
im going to fix the gitlab reinstall bug but this adds some instrumentation before i make some changes

## Summary

Adds structured logging to `GitlabRepositoryProvider.on_create_repository` so the GitLab webhook install path is observable in **Sentry Logs** (logs-only — no metrics). No change to webhook creation behavior.

Three logs, all on the `sentry.integrations.gitlab` logger:

| Log | Fires | Purpose |
| --- | --- | --- |
| `gitlab.repository.on_create_repository` | every invocation | Gauge how often the path runs. `extra.has_existing_webhook` splits create vs skip. |
| `gitlab.repository.webhook_created` | webhook successfully created | Count actual GitLab hook-creation API calls (request volume). |
| `gitlab.repository.webhook_creation_skipped` | stale `webhook_id` already present | Creation skipped — the signal for the reinstall bug below. |

All three carry `organization_id`, `integration_id`, `repository_id`, `project_id` (and `webhook_id` where relevant).

## Why

While debugging why GitLab webhooks aren't re-added after uninstall → reinstall, we found `on_create_repository` early-returns when a `webhook_id` is already in the repo config. On uninstall, `disassociate_organization_integration` nulls `integration_id` but leaves `config["webhook_id"]` intact, so on reinstall the stale id trips the skip guard and no new hook is created.

This PR only adds the instrumentation to establish a baseline — it does **not** change behavior. It lets us:
1. Confirm reinstalls are silently skipping webhook creation (`webhook_creation_skipped` volume), and
2. Verify any future fix without flooding GitLab with hook-creation requests (`webhook_created` count = real API calls).

### Cross-check
`count(on_create_repository where has_existing_webhook:false)` should equal `count(webhook_created)` — a built-in consistency check.
