### PR TITLE
fix(dashboards): unify timeseries loading and empty state

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -70,6 +70,7 @@ import {
 } from 'sentry/views/dashboards/widgets/tableWidget/utils';
 import {TextWidgetVisualization} from 'sentry/views/dashboards/widgets/textWidget/textWidgetVisualization';
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
+import {Widget as WidgetComponent} from 'sentry/views/dashboards/widgets/widget/widget';
 import {WidgetError} from 'sentry/views/dashboards/widgets/widget/widgetError';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
@@ -191,7 +192,6 @@ function WidgetCardChart(props: WidgetCardChartProps) {
   if (widget.displayType === DisplayType.HEATMAP) {
     return (
       <TransitionChart loading={loading} reloading={loading}>
-        <LoadingScreen loading={loading} showLoadingText={showLoadingText} />
         <HeatmapSeriesComponent {...props} />
       </TransitionChart>
     );
@@ -465,15 +465,11 @@ function HeatmapSeriesComponent(props: TableComponentProps): React.ReactNode {
   const {heatmapResults, loading} = props;
 
   if (loading || !heatmapResults) {
-    return <LoadingPlaceholder />;
+    return <HeatMapWidgetVisualization.LoadingPlaceholder />;
   }
 
   if (heatmapResults.values.length === 0) {
-    return (
-      <StyledErrorPanel>
-        <IconWarning variant="primary" size="lg" />
-      </StyledErrorPanel>
-    );
+    return <WidgetComponent.WidgetError error={MISSING_DATA_MESSAGE} />;
   }
 
   return (

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -28,6 +28,7 @@ import {defined} from 'sentry/utils/defined';
 import {ECHARTS_MISSING_DATA_VALUE} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {NO_PLOTTABLE_VALUES} from 'sentry/views/dashboards/widgets/common/settings';
+import {WidgetLoadingPanel} from 'sentry/views/dashboards/widgets/common/widgetLoadingPanel';
 import {formatTooltipYAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatTooltipYAxisValue';
 import {formatTooltipZAxisValue} from 'sentry/views/dashboards/widgets/heatMapWidget/formatters/formatTooltipZAxisValue';
 import {
@@ -416,3 +417,5 @@ type HeatMapTooltipContext = HeatMapBucketBounds;
  * Context for a drag-selected region, handed to `onZoom`.
  */
 export type HeatMapZoomContext = HeatMapBucketBounds;
+
+HeatMapWidgetVisualization.LoadingPlaceholder = WidgetLoadingPanel;


### PR DESCRIPTION
aligned the heatmap loading state with the timeseries loading state (aka just the spinner and no loading placeholder shadow) and the empty state with the state of all the other widgets. 

ALSO good to note that all non-timeseries widgets have that loading screen; wondering if we want to change them all just to unify the UI. 
but anyways this is what it looks like:
| Before | After |
|--------|--------|
| <img width="450" height="275" alt="image" src="https://github.com/user-attachments/assets/8521a46a-e209-4606-966b-692fc6718e8a" /> | <img width="450" height="275" alt="image" src="https://github.com/user-attachments/assets/242e2e45-16df-4ca8-8959-897a2ab3bd63" /> |
| <img width="419" height="269" alt="image" src="https://github.com/user-attachments/assets/2b094196-205e-438d-915a-bd1900ca543a" /> | <img width="417" height="275" alt="image" src="https://github.com/user-attachments/assets/0104f966-bb22-41f0-bc36-2fdb1434ac96" /> | 



