### PR TITLE
fix(explore): Stop Heat Map drag-to-zoom writing duplicate history entries

### DIFF
--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -9,6 +9,7 @@ import {
 import type {Location} from 'history';
 
 import {defined} from 'sentry/utils/defined';
+import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -69,7 +70,7 @@ export function MultiMetricsQueryParamsProvider({
     (nextQueries: BaseMetricQuery[]) => {
       const target = {...location, query: {...location.query}};
       target.query.metric = encodeMetricQueries(nextQueries);
-      navigate(target);
+      navigateIfQueryChanged(navigate, location, target);
     },
     [location, navigate]
   );


### PR DESCRIPTION
Guard the metrics query-param provider's `setQueries` navigation with the shared `navigateIfQueryChanged` helper so drag-to-zoom on a Heat Map widget no longer writes duplicate browser-history entries. Heat Maps hit a slightly different path from time series zoom actions because a Heat Map zoom _also_ updates the query, so this change check is needed.

Closes [DAIN-1774](https://linear.app/getsentry/issue/DAIN-1774/heat-map-zoom-actions-dont-populate-browser-history-correctly)
