### PR TITLE
fix(gitlab): Heal webhooks on integration reinstall

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +14,8 @@ from sentry.shared_integrations.exceptions import ApiError
 
 if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration  # NOQA
+
+logger = logging.getLogger("sentry.integrations.gitlab")
 
 
 class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"]):
@@ -58,16 +61,66 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         }
 
     def on_create_repository(self, repo: RpcRepository, organization: RpcOrganization) -> None:
-        if repo.config.get("webhook_id"):
-            return
+        # Emitted on every invocation so we can gauge how often this path runs
+        # (and therefore how many webhook create calls we make to GitLab).
+        existing_webhook_id = repo.config.get("webhook_id")
+        log_extra = {
+            "organization_id": repo.organization_id,
+            "integration_id": repo.integration_id,
+            "repository_id": repo.id,
+            "project_id": repo.config.get("project_id"),
+        }
+        logger.info(
+            "gitlab.repository.on_create_repository",
+            extra={**log_extra, "has_existing_webhook": bool(existing_webhook_id)},
+        )
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
+        project_id = repo.config["project_id"]
+
+        # A stored webhook_id can survive an uninstall/reinstall of the integration
+        # (disassociate_organization_integration clears integration_id but leaves the
+        # config intact and never deletes the GitLab hook). Rather than blindly trust
+        # it, verify the hook still exists on the GitLab project so we can heal:
+        #   - hook present  -> refresh its token + events (heals a rotated webhook
+        #                       secret from reinstalling with a new OAuth app)
+        #   - hook missing  -> fall through and create a fresh one
+        if existing_webhook_id:
+            try:
+                # NOTE: get_project_webhooks returns the first page of hooks only. In
+                # practice a Sentry-managed hook is created per project and lives on the
+                # first page, so matching against that is sufficient; if it isn't found
+                # we recreate rather than paginate further.
+                hooks = client.get_project_webhooks(project_id)
+            except Exception as e:
+                raise installation.raise_error(e)
+
+            if any(hook["id"] == existing_webhook_id for hook in hooks):
+                try:
+                    client.update_project_webhook(project_id, existing_webhook_id)
+                except Exception as e:
+                    raise installation.raise_error(e)
+                logger.info(
+                    "gitlab.repository.webhook_refreshed",
+                    extra={**log_extra, "webhook_id": existing_webhook_id},
+                )
+                return
+
+            logger.info(
+                "gitlab.repository.webhook_stale_recreated",
+                extra={**log_extra, "webhook_id": existing_webhook_id},
+            )
+
         try:
-            hook_id = client.create_project_webhook(repo.config["project_id"])
+            hook_id = client.create_project_webhook(project_id)
         except Exception as e:
             raise installation.raise_error(e)
         repo.config["webhook_id"] = hook_id
         repository_service.update_repository(organization_id=organization.id, update=repo)
+        logger.info(
+            "gitlab.repository.webhook_created",
+            extra={**log_extra, "webhook_id": hook_id},
+        )
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from unittest.mock import call, patch
 
 import orjson
 import pytest
@@ -6,6 +7,7 @@ import responses
 
 from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_RESPONSE
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
+from sentry.integrations.services.repository.service import repository_service
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -102,6 +104,162 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         response = self.create_repository(self.default_repository_config, self.integration.id)
         assert response.status_code == 201
         self.assert_repository(self.default_repository_config)
+
+    @responses.activate
+    def test_on_create_repository_refreshes_existing_webhook(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+
+        repo = repository_service.get_repository(
+            organization_id=self.organization.id, id=response.data["id"]
+        )
+        assert repo is not None
+        webhook_id = repo.config["webhook_id"]
+
+        # The stored hook still exists on the GitLab project, so it should be
+        # refreshed (token + events updated) rather than recreated.
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            json=[{"id": webhook_id, "url": "https://example.com/hook"}],
+        )
+        responses.add(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks/%s" % (self.gitlab_id, webhook_id),
+            json={"id": webhook_id},
+        )
+
+        with patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info:
+            self.provider.on_create_repository(repo, self.organization)
+
+        assert [c.request.method for c in responses.calls] == ["GET", "PUT"]
+        # webhook_id is left untouched when we refresh an existing hook.
+        refreshed = self.get_repository(pk=response.data["id"])
+        assert refreshed.config["webhook_id"] == webhook_id
+        mock_logger_info.assert_has_calls(
+            [
+                call(
+                    "gitlab.repository.on_create_repository",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "has_existing_webhook": True,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_refreshed",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "webhook_id": webhook_id,
+                    },
+                ),
+            ]
+        )
+
+    @responses.activate
+    def test_on_create_repository_recreates_stale_webhook(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+
+        repo = repository_service.get_repository(
+            organization_id=self.organization.id, id=response.data["id"]
+        )
+        assert repo is not None
+        stale_webhook_id = repo.config["webhook_id"]
+
+        # The stored hook no longer exists on the GitLab project (e.g. it was
+        # deleted), so a new hook should be created and its id stored.
+        responses.add(
+            responses.GET,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            json=[],
+        )
+        responses.add(
+            responses.POST,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            json={"id": 200},
+        )
+
+        with patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info:
+            self.provider.on_create_repository(repo, self.organization)
+
+        assert [c.request.method for c in responses.calls] == ["GET", "POST"]
+        recreated = self.get_repository(pk=response.data["id"])
+        assert recreated.config["webhook_id"] == 200
+        mock_logger_info.assert_has_calls(
+            [
+                call(
+                    "gitlab.repository.on_create_repository",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "has_existing_webhook": True,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_stale_recreated",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "webhook_id": stale_webhook_id,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_created",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "webhook_id": 200,
+                    },
+                ),
+            ]
+        )
+
+    @responses.activate
+    def test_on_create_repository_logs_webhook_creation(self) -> None:
+        self.add_create_repository_responses(self.default_repository_config)
+
+        with patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info:
+            response = self.create_repository(self.default_repository_config, self.integration.id)
+
+        assert response.status_code == 201
+        repo = self.get_repository(pk=response.data["id"])
+
+        mock_logger_info.assert_has_calls(
+            [
+                call(
+                    "gitlab.repository.on_create_repository",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "has_existing_webhook": False,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_created",
+                    extra={
+                        "organization_id": self.organization.id,
+                        "integration_id": self.integration.id,
+                        "repository_id": repo.id,
+                        "project_id": repo.config["project_id"],
+                        "webhook_id": repo.config["webhook_id"],
+                    },
+                ),
+            ]
+        )
 
     @responses.activate
     def test_create_repository_verify_payload(self) -> None:


### PR DESCRIPTION
## Summary

Fixes GitLab webhooks not being (re)created after uninstalling and reinstalling the integration.

`GitlabRepositoryProvider.on_create_repository` no longer blindly trusts a stored `webhook_id` and skips. It now **verifies against GitLab and heals**:

| Stored `webhook_id` | Hook present on the GitLab project? | Action |
| --- | --- | --- |
| set | yes | `update_project_webhook` — refresh token + events (heals a rotated secret) |
| set | no (deleted / stale) | create a fresh hook, store the new id |
| unset | — | create a fresh hook |

## Root cause

On uninstall, `disassociate_organization_integration` clears `Repository.integration_id` but leaves `config["webhook_id"]` intact and never deletes the GitLab hook. On reinstall, the base provider merges that stale `webhook_id` forward, and the old guard returned early — so no working webhook existed afterward. Reinstalling with a **new OAuth application** also rotates the webhook secret (`sha1(hostname + client_id)`), so the surviving hook's token stopped matching and incoming events were rejected (`gitlab.webhook.invalid-token-secret`).

The healed path handles both: refresh the surviving hook's token (rotated-secret case) or recreate a missing one.

## Observability

Adds structured logging across the install path (`sentry.integrations.gitlab` logger), so this is traceable in Sentry Logs without Datadog:
- `gitlab.repository.on_create_repository` — every invocation (`has_existing_webhook` splits create vs refresh)
- `gitlab.repository.webhook_refreshed` — surviving hook refreshed
- `gitlab.repository.webhook_stale_recreated` — stored id gone, recreating
- `gitlab.repository.webhook_created` — fresh hook created (= a real GitLab API call)

## Notes

- `get_project_webhooks` returns only the first page; a Sentry-managed hook is one-per-project and lives on page one, so if it isn't found there we recreate rather than paginate (worst case: a duplicate hook, never a missing one — documented in a code comment).
- Scope stays strictly within the GitLab provider; no change to the shared `disassociate_organization_integration`.
- Supersedes the logging-only PR #119333 (this PR includes that instrumentation).

## Test Plan

- `test_on_create_repository_refreshes_existing_webhook` — hook present → GET then PUT, `webhook_id` unchanged.
- `test_on_create_repository_recreates_stale_webhook` — hook missing → GET then POST, new id stored.
- `test_on_create_repository_logs_webhook_creation` — fresh create path.
- `pytest tests/sentry/integrations/gitlab/test_repository.py` → **19 passed**; ruff + mypy clean.