### PR TITLE
fix(stories): use default variant for Default button example in button.mdx

### DIFF
--- a/static/app/components/core/button/button.mdx
+++ b/static/app/components/core/button/button.mdx
@@ -73,7 +73,7 @@ To create a basic button, wrap text in a `<Button>` and pass an `onClick` callba
 Buttons come in a few different styles: `primary`, `secondary` (default), `warning`, `danger`, `transparent`, and `link`.
 
 <Storybook.Demo>
-  <Button variant="transparent">Default</Button>
+  <Button>Default (default)</Button>
   <Button variant="primary">Primary</Button>
   <Button variant="warning">Warning</Button>
   <Button variant="danger">Danger</Button>
@@ -83,7 +83,7 @@ Buttons come in a few different styles: `primary`, `secondary` (default), `warni
   </div>
 </Storybook.Demo>
 ```jsx
-<Button variant="transparent">Default (default)</Button>
+<Button>Default (default)</Button>
 <Button variant="primary">Primary</Button>
 <Button variant="warning">Warning</Button>
 <Button variant="danger">Danger</Button>


### PR DESCRIPTION
The Priorities section in `button.mdx` showed `variant="transparent"` on the first button example labeled "Default (default)", which is misleading — `transparent` is its own distinct variant, not the default.

This PR removes the explicit `variant` prop from that button so it renders with the actual default (`secondary`) style, matching the label.

Changed in both the live `<Storybook.Demo>` block and the accompanying `jsx` code snippet.

| Before | After |
| --- | --- |
| <img width="832" height="424" alt="SCR-20260709-makq" src="https://github.com/user-attachments/assets/ff343ff6-f9d1-41f6-b8a9-cc11f72f6d63" /> | <img width="830" height="429" alt="SCR-20260709-mbvj" src="https://github.com/user-attachments/assets/53a50431-1210-4e7f-89ec-26f501bba5ca" />



<!-- junior-session-footer:start -->

--

[View Junior Session in Sentry](https://sentry.sentry.io/explore/conversations/slack%3AD0AN20G5WMS%3A1783628751.460649/?project=4510944073809921)

<!-- junior-session-footer:end -->