### PR TITLE
fix(seer): Stop conflating night-shift run id with Seer's run id in logs

### DIFF
--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -45,7 +45,7 @@ def deliver_night_shift_result(
         SeerNightShiftRunShard.objects.filter(
             seer_run__uuid=run_uuid, run__organization_id=organization_id
         )
-        .select_related("run", "run__organization")
+        .select_related("run", "run__organization", "seer_run")
         .first()
     )
     if shard is None:
@@ -63,7 +63,9 @@ def deliver_night_shift_result(
 
     log_extra: dict[str, object] = {
         "organization_id": run.organization_id,
-        "run_id": run.id,
+        "run_id": shard.seer_run.seer_run_state_id,
+        "sentry_run_id": run_uuid,
+        "night_shift_run_id": run.id,
     }
 
     if status == "error" or result is None:

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -55,6 +55,8 @@ def deliver_night_shift_result(
         )
         return
     run = shard.run
+    # Guaranteed by the seer_run__uuid filter above: a null FK can't match a uuid.
+    assert shard.seer_run is not None
 
     # Per-delivery error_message lives on the shard so a sibling shard's success
     # can't clear it.

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -268,7 +268,7 @@ def run_night_shift_execution(
     (from run_night_shift_for_org) and async dispatch (apply_async)."""
     run = SeerNightShiftRun.objects.select_related("organization").filter(id=run_id).first()
     if run is None:
-        logger.info("night_shift.missing_run", extra={"run_id": run_id})
+        logger.info("night_shift.missing_run", extra={"night_shift_run_id": run_id})
         return None
 
     organization = run.organization
@@ -277,7 +277,7 @@ def run_night_shift_execution(
     log_extra: dict[str, object] = {
         "organization_id": organization.id,
         "organization_slug": organization.slug,
-        "run_id": run.id,
+        "night_shift_run_id": run.id,
     }
     if project_ids is not None:
         log_extra["project_ids"] = project_ids


### PR DESCRIPTION
## Summary
- `delivery.py` and `cron.py` both logged a `run_id` key that actually held `SeerNightShiftRun.id`, colliding with the convention used everywhere else in the Seer codebase where `run_id` means Seer's own `seer_run_state_id` and `sentry_run_id` is the uuid mirror (see e.g. `search_agent_state.py`, `group_ai_autofix.py`).
- This made cross-log correlation misleading — a `night_shift.delivery.no_result` log with `status:completed` couldn't be traced back to the Seer-side run that produced no artifact without an extra manual DB hop.
- Renamed the `SeerNightShiftRun.id` field to `night_shift_run_id` in both files, and in `delivery.py` added the real `run_id` (`seer_run_state_id`) and `sentry_run_id` (`run_uuid`) alongside it, matching convention.

## Test plan
- [x] `pytest tests/sentry/seer/night_shift/test_delivery.py tests/sentry/tasks/seer/test_night_shift.py` — 64 passed
- [x] `prek run -q ruff` / mypy clean