### PR TITLE
ref(api): type event/group event-type as a Literal

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -16,6 +16,7 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.release import GroupEventReleaseSerializer
 from sentry.api.serializers.models.userreport import UserReportSerializerResponse
 from sentry.api.serializers.types import GroupEventReleaseSerializerResponse
+from sentry.eventtypes import EventTypeStr
 from sentry.grouping.api import GroupingConfig
 from sentry.interfaces.user import EventUserApiContext
 from sentry.issues.issue_occurrence import IssueOccurrenceResponse
@@ -163,7 +164,7 @@ class BaseEventSerializerResponse(TypedDict):
     sdk: dict[str, str]
     context: dict[str, Any] | None
     packages: dict[str, Any]
-    type: str
+    type: EventTypeStr
     metadata: Any
     errors: list[Any]
     occurrence: IssueOccurrenceResponse | None

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -16,6 +16,7 @@ from sentry import tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.constants import LOG_LEVELS
+from sentry.eventtypes import EventTypeStr
 from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.issues.grouptype import GroupCategory
@@ -135,7 +136,7 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     seerAutofixLastTriggered: datetime | None
     seerExplorerAutofixLastTriggered: datetime | None
     project: GroupProjectResponse
-    type: str
+    type: EventTypeStr
     issueType: str
     issueCategory: str
     metadata: dict[str, Any]
@@ -1201,7 +1202,7 @@ class SimpleGroupSerializerResponse(TypedDict):
     substatus: GroupSubStatusStr | None
     platform: str | None
     project: GroupProjectResponse
-    type: str
+    type: EventTypeStr
     issueType: str
     issueCategory: str
     metadata: dict[str, Any]

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -26,6 +26,7 @@ from sentry.api.serializers.models.group import (
     snuba_tsdb,
 )
 from sentry.constants import StatsPeriod
+from sentry.eventtypes import EventTypeStr
 from sentry.integrations.api.serializers.models.external_issue import ExternalIssueSerializer
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.issues.grouptype import GroupCategory
@@ -265,7 +266,7 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     seerAutofixLastTriggered: NotRequired[datetime | None]
     seerExplorerAutofixLastTriggered: NotRequired[datetime | None]
     project: NotRequired[GroupProjectResponse]
-    type: NotRequired[str]
+    type: NotRequired[EventTypeStr]
     issueType: NotRequired[str]
     issueCategory: NotRequired[str]
     metadata: NotRequired[dict[str, Any]]

--- a/src/sentry/eventtypes/__init__.py
+++ b/src/sentry/eventtypes/__init__.py
@@ -1,4 +1,5 @@
 from sentry.eventtypes.base import DefaultEvent
+from sentry.eventtypes.base import EventTypeStr as EventTypeStr
 from sentry.eventtypes.error import ErrorEvent
 from sentry.eventtypes.feedback import FeedbackEvent
 from sentry.eventtypes.generic import GenericEvent

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping, MutableMapping
-from typing import Any
+from typing import Any, ClassVar, Literal
 from warnings import warn
 
 from sentry.utils.safe import get_path
@@ -7,9 +7,22 @@ from sentry.utils.strings import strip, truncatechars
 
 # Note: Detecting eventtypes is implemented in the Relay Rust library.
 
+EventTypeStr = Literal[
+    "default",
+    "error",
+    "csp",
+    "nel",
+    "hpkp",
+    "expectct",
+    "expectstaple",
+    "transaction",
+    "generic",
+    "feedback",
+]
+
 
 class BaseEvent:
-    key: str  # abstract
+    key: ClassVar[EventTypeStr]  # abstract
 
     def get_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         metadata = self.extract_metadata(data)
@@ -42,7 +55,7 @@ class BaseEvent:
 
 
 class DefaultEvent(BaseEvent):
-    key = "default"
+    key: ClassVar[EventTypeStr] = "default"
 
     def extract_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
         message = strip(

--- a/src/sentry/services/eventstore/models.py
+++ b/src/sentry/services/eventstore/models.py
@@ -219,7 +219,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
         return self.get_interface("user")
 
-    def get_event_type(self) -> str:
+    def get_event_type(self) -> eventtypes.EventTypeStr:
         """
         Return the type of this event.
 
@@ -227,8 +227,8 @@ class BaseEvent(metaclass=abc.ABCMeta):
         """
         column = self._get_column_name(Columns.TYPE)
         if column in self._snuba_data:
-            return cast(str, self._snuba_data[column])
-        return cast(str, self.data.get("type", "default"))
+            return cast(eventtypes.EventTypeStr, self._snuba_data[column])
+        return cast(eventtypes.EventTypeStr, self.data.get("type", "default"))
 
     @property
     def ip_address(self) -> str | None:


### PR DESCRIPTION
Add a type for event types, so they can flow to the API schema.

Redux of https://github.com/getsentry/sentry/pull/118927