### PR TITLE
ref(api): tighten event serializer response types

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import sentry_sdk
 import sqlparse
@@ -18,10 +18,11 @@ from sentry.api.serializers.models.userreport import UserReportSerializerRespons
 from sentry.api.serializers.types import GroupEventReleaseSerializerResponse
 from sentry.eventtypes import EventTypeStr
 from sentry.grouping.api import GroupingConfig
+from sentry.interfaces.sdk import EventSdkApiContext
 from sentry.interfaces.user import EventUserApiContext
 from sentry.issues.issue_occurrence import IssueOccurrenceResponse
 from sentry.models.eventattachment import EventAttachment
-from sentry.models.eventerror import EventError
+from sentry.models.eventerror import EventError, EventErrorApiContext
 from sentry.models.release import Release
 from sentry.models.userreport import UserReport
 from sentry.sdk_updates import SdkSetupState, get_suggested_updates
@@ -52,6 +53,11 @@ class EventTagOptional(TypedDict, total=False):
 class EventTag(EventTagOptional):
     key: str
     value: str
+
+
+class MeasurementValue(TypedDict):
+    value: float
+    unit: NotRequired[str | None]
 
 
 def get_crash_files(events):
@@ -161,12 +167,12 @@ class BaseEventSerializerResponse(TypedDict):
     size: int | None
     entries: list[Any]
     dist: str | None
-    sdk: dict[str, str]
+    sdk: EventSdkApiContext | None
     context: dict[str, Any] | None
     packages: dict[str, Any]
     type: EventTypeStr
-    metadata: Any
-    errors: list[Any]
+    metadata: dict[str, Any]
+    errors: list[EventErrorApiContext]
     occurrence: IssueOccurrenceResponse | None
     _meta: dict[str, Any]
 
@@ -180,10 +186,10 @@ class ErrorEventFields(TypedDict, total=False):
 
 
 class TransactionEventFields(TypedDict, total=False):
-    startTimestamp: datetime
-    endTimestamp: datetime
-    measurements: Any
-    breakdowns: Any
+    startTimestamp: float
+    endTimestamp: float
+    measurements: dict[str, MeasurementValue] | None
+    breakdowns: dict[str, dict[str, MeasurementValue]] | None
 
 
 class EventSerializerResponse(
@@ -600,7 +606,7 @@ SimpleEventSerializerResponse = TypedDict(
         "platform": str | None,
         "dateCreated": datetime,
         "crashFile": str | None,
-        "metadata": dict[str, Any] | None,
+        "metadata": dict[str, Any],
     },
 )
 

--- a/src/sentry/apidocs/examples/event_examples.py
+++ b/src/sentry/apidocs/examples/event_examples.py
@@ -2,9 +2,13 @@ from datetime import datetime
 
 from drf_spectacular.utils import OpenApiExample
 
-from sentry.api.serializers.models.event import EventSerializerResponse, GroupEventDetailsResponse
+from sentry.api.serializers.models.event import (
+    EventSerializerResponse,
+    GroupEventDetailsResponse,
+    SimpleEventSerializerResponse,
+)
 
-SIMPLE_EVENT = {
+SIMPLE_EVENT: SimpleEventSerializerResponse = {
     "eventID": "9fac2ceed9344f2bbfdd1fdacb0ed9b1",
     "tags": [
         {"key": "browser", "value": "Chrome 60.0"},
@@ -16,7 +20,7 @@ SIMPLE_EVENT = {
         {"key": "release", "value": "17642328ead24b51867165985996d04b29310337"},
         {"key": "server_name", "value": "web1.example.com"},
     ],
-    "dateCreated": "2020-09-11T17:46:36Z",
+    "dateCreated": datetime.fromisoformat("2020-09-11T17:46:36Z"),
     "user": None,
     "message": "",
     "title": "This is an example Python exception",
@@ -28,7 +32,10 @@ SIMPLE_EVENT = {
     "location": "example.py:123",
     "culprit": "/books/new/",
     "projectID": "49271",
-    "metadata": None,
+    "metadata": {
+        "type": "ExampleException",
+        "value": "This is an example Python exception",
+    },
 }
 
 GROUP_EVENT: GroupEventDetailsResponse = {

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -956,7 +956,7 @@ class OrganizationExamples:
                     "packages": {"my.package": "1.0.0"},
                     "platform": "python",
                     "projectID": "1",
-                    "sdk": {},
+                    "sdk": {"name": "sentry.python", "version": "2.0.0"},
                     "size": 7055,
                     "tags": [
                         {"key": "browser", "value": "Chrome 28.0"},

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -1,7 +1,14 @@
 __all__ = ("Sdk",)
 
+from typing import TypedDict
+
 from sentry.interfaces.base import Interface
 from sentry.utils.json import prune_empty_keys
+
+
+class EventSdkApiContext(TypedDict):
+    name: str | None
+    version: str | None
 
 
 class Sdk(Interface):
@@ -38,7 +45,7 @@ class Sdk(Interface):
             }
         )
 
-    def get_api_context(self, is_public=False, platform=None):
+    def get_api_context(self, is_public=False, platform=None) -> EventSdkApiContext:
         return {"name": self.name, "version": self.version}
 
     def get_api_meta(self, meta, is_public=False, platform=None):

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from typing import Any, TypedDict
 
 
 class EventErrorType(enum.StrEnum):
@@ -58,6 +59,12 @@ class EventErrorType(enum.StrEnum):
     # Processing: Proguard
     PROGUARD_MISSING_MAPPING = "proguard_missing_mapping"
     PROGUARD_MISSING_LINENO = "proguard_missing_lineno"
+
+
+class EventErrorApiContext(TypedDict):
+    type: str
+    message: str
+    data: dict[str, Any]
 
 
 class EventError:
@@ -125,5 +132,5 @@ class EventError:
     def message(self):
         return self._messages.get(self._data["type"], self._messages["unknown_error"])
 
-    def get_api_context(self):
+    def get_api_context(self) -> EventErrorApiContext:
         return {"type": self.type, "message": self.message, "data": self.data}


### PR DESCRIPTION
Add some slightly more accurate types to docs + dict fields