### PR TITLE
ref: Point AI-assisted setup at the Sentry plugin instrument skill

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -87,7 +87,7 @@ export function getUploadSourceMapsStep({
   };
 }
 
-const SENTRY_FOR_AI_BASE_URL = 'https://skills.sentry.dev';
+const SENTRY_INSTRUMENT_SKILL_URL = 'https://skills.sentry.dev/instrument';
 
 function CopyPromptButton({prompt}: {prompt: string}) {
   const {copy} = useCopyToClipboard();
@@ -102,9 +102,9 @@ function CopyPromptButton({prompt}: {prompt: string}) {
   );
 }
 
-export function getAISetupStep({skillPath}: {skillPath: string}): OnboardingStep {
-  const skillUrl = `${SENTRY_FOR_AI_BASE_URL}/${skillPath}/SKILL.md`;
-  const prompt = `Read and follow: ${skillUrl}`;
+export function getAISetupStep({sdkName}: {sdkName?: string}): OnboardingStep {
+  const target = sdkName ? `the Sentry ${sdkName} SDK` : 'Sentry';
+  const prompt = `Use curl to download, read and follow ${SENTRY_INSTRUMENT_SKILL_URL} to set up ${target}.`;
 
   return {
     collapsible: true,

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
@@ -55,7 +55,7 @@ export const onboarding: OnboardingConfig = {
         copyDsnFieldBlock(params),
       ],
     },
-    getAISetupStep({skillPath: 'sentry-nextjs-sdk'}),
+    getAISetupStep({sdkName: 'Next.js'}),
   ],
   verify: () => [
     {

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
@@ -97,7 +97,7 @@ export const onboarding: OnboardingConfig = {
       guideLink: 'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/',
       ...params,
     }),
-    getAISetupStep({skillPath: 'sentry-react-sdk'}),
+    getAISetupStep({sdkName: 'React'}),
   ],
   verify: (params: DocsParams) => [
     {

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -178,7 +178,7 @@ const getVerifySnippetBlock = (params: Params): ContentBlock[] => [
 ];
 
 export const getAiSetupConfig = (): OnboardingStep =>
-  getAISetupStep({skillPath: 'sentry-sdk-setup'});
+  getAISetupStep({sdkName: 'JavaScript'});
 
 const getVerifyConfig = (params: Params) => [
   {

--- a/static/app/gettingStartedDocs/node/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.tsx
@@ -105,7 +105,7 @@ export const onboarding: OnboardingConfig = {
       guideLink: 'https://docs.sentry.io/platforms/javascript/guides/node/sourcemaps/',
       ...params,
     }),
-    getAISetupStep({skillPath: 'sentry-sdk-setup'}),
+    getAISetupStep({sdkName: 'Node.js'}),
   ],
   verify: (params: DocsParams) => [
     {

--- a/static/app/views/insights/pages/agents/llmOnboardingInstructions.tsx
+++ b/static/app/views/insights/pages/agents/llmOnboardingInstructions.tsx
@@ -74,10 +74,5 @@ export const LLM_ONBOARDING_COPY_MARKDOWN = `
 
 # Instrument Sentry AI Agent Monitoring
 
-Use these skills as the source of truth:
-
-## Skill References
-
-- Source repository: https://github.com/getsentry/sentry-for-ai
-- Agent-monitoring skill: https://skills.sentry.dev/sentry-setup-ai-monitoring/SKILL.md
+Use curl to download, read and follow https://skills.sentry.dev/instrument to set up Sentry AI agent monitoring for this app.
 `;


### PR DESCRIPTION
Sentry's AI skills now ship as a single plugin, so the onboarding AI-setup prompts should point at the plugin instead of linking to individual skill `SKILL.md` files. This mirrors the equivalent change in sentry-docs.

- `getAISetupStep` (the "AI-Assisted Setup (Optional)" onboarding step) now takes an `sdkName` display name and builds a prompt that curls the single `https://skills.sentry.dev/instrument` entrypoint, naming the SDK in prose. Callers pass `Next.js`, `React`, `Node.js`, and `JavaScript` instead of per-skill paths.
- The AI agent-monitoring instrumentation prompt (`llmOnboardingInstructions`) points at the same `/instrument` entrypoint instead of `skills.sentry.dev/sentry-setup-ai-monitoring/SKILL.md`.

Affected onboarding specs pass (`javascript-nextjs`, `javascript-react`, `node`, and `llmOnboardingInstructions`); no test assertions referenced the prompt text.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
