### PR TITLE
feat(GAL): Add reset_and_backfill task for group action log

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -71,12 +71,12 @@ def reset_and_backfill_group_action_log(
         )
         return
 
+    invalidate_group_derived_data(group_id)
+
     deleted_count, _ = GroupActionLogEntry.objects.filter(
         group_id=group_id,
         source="backfill:activity",
     ).delete()
-
-    invalidate_group_derived_data(group_id)
 
     logger.info(
         "backfill_group_action_log.reset_completed",

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -59,8 +59,8 @@ def reset_and_backfill_group_action_log(
     group_id: int,
     **kwargs: object,
 ) -> None:
-    from sentry.issues.derived.processing import invalidate_group_derived_data
     from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
 
     try:
         group = Group.objects.get(id=group_id)
@@ -71,7 +71,7 @@ def reset_and_backfill_group_action_log(
         )
         return
 
-    invalidate_group_derived_data(group_id)
+    GroupDerivedData.objects.filter(group_id=group_id).delete()
 
     deleted_count, _ = GroupActionLogEntry.objects.filter(
         group_id=group_id,

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -48,3 +48,43 @@ def backfill_group_action_log_for_group(
             "total_created": total,
         },
     )
+
+
+@instrumented_task(
+    name="sentry.tasks.backfill_group_action_log.reset_and_backfill_group_action_log",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def reset_and_backfill_group_action_log(
+    group_id: int,
+    **kwargs: object,
+) -> None:
+    from sentry.issues.derived.processing import invalidate_group_derived_data
+    from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+
+    try:
+        group = Group.objects.get(id=group_id)
+    except Group.DoesNotExist:
+        logger.warning(
+            "backfill_group_action_log.group_not_found",
+            extra={"group_id": group_id},
+        )
+        return
+
+    deleted_count, _ = GroupActionLogEntry.objects.filter(
+        group_id=group_id,
+        source="backfill:activity",
+    ).delete()
+
+    invalidate_group_derived_data(group_id)
+
+    logger.info(
+        "backfill_group_action_log.reset_completed",
+        extra={
+            "group_id": group_id,
+            "project_id": group.project_id,
+            "deleted_count": deleted_count,
+        },
+    )
+
+    backfill_group_action_log_for_group.delay(group_id=group_id)

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -9,7 +9,10 @@ from django.utils import timezone
 
 from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
-from sentry.tasks.backfill_group_action_log import backfill_group_action_log_for_group
+from sentry.tasks.backfill_group_action_log import (
+    backfill_group_action_log_for_group,
+    reset_and_backfill_group_action_log,
+)
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 
@@ -132,3 +135,57 @@ class BackfillGroupActionLogForGroupTest(TestCase):
 
         with pytest.raises(RuntimeError):
             backfill_group_action_log_for_group(self.group.id)
+
+
+class ResetAndBackfillGroupActionLogTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.now = timezone.now()
+
+    def _backfill_group(self) -> None:
+        self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+            user_id=self.user.id,
+            datetime=self.now - timedelta(minutes=1),
+        )
+        backfill_group_action_log_for_group(self.group.id)
+
+    def test_deletes_backfilled_entries_and_retriggers(self) -> None:
+        self._backfill_group()
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
+
+        with patch.object(backfill_group_action_log_for_group, "delay") as mock_delay:
+            reset_and_backfill_group_action_log(self.group.id)
+
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
+        mock_delay.assert_called_once_with(group_id=self.group.id)
+
+    def test_preserves_non_backfill_entries(self) -> None:
+        self._backfill_group()
+
+        GroupActionLogEntry.objects.create(
+            group_id=self.group.id,
+            project_id=self.group.project_id,
+            type=GroupActionType.VIEW.value,
+            actor_type=GroupActorType.USER.value,
+            actor_id=self.user.id,
+            source="web",
+            data={},
+        )
+        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 2
+
+        with patch.object(backfill_group_action_log_for_group, "delay"):
+            reset_and_backfill_group_action_log(self.group.id)
+
+        remaining = GroupActionLogEntry.objects.filter(group_id=self.group.id)
+        assert remaining.count() == 1
+        assert remaining[0].source == "web"
+
+    def test_noop_for_nonexistent_group(self) -> None:
+        with patch.object(backfill_group_action_log_for_group, "delay") as mock_delay:
+            reset_and_backfill_group_action_log(999999999)
+
+        mock_delay.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `reset_and_backfill_group_action_log(group_id)` task that clears previously backfilled entries and re-runs the backfill for a single group
- Only deletes entries with `source="backfill:activity"` — preserves live-written entries (from web, API, MCP, etc.)
- Invalidates derived data so it rebuilds from scratch after re-backfill
- Delegates to the existing `backfill_group_action_log_for_group` task

### Use case
When the translator logic changes or a backfill produced incorrect data, this provides a clean "redo" without losing real-time action log entries.

## Test plan
- [x] Deletes backfilled entries and re-triggers backfill task
- [x] Preserves non-backfill entries (e.g. source="web")
- [x] Noop for nonexistent group