### PR TITLE
feat(seer-infra-telemetry): Include non-dismissed available monitoring providers in explorer chat request

### DIFF
--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -258,9 +258,7 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
                         body["monitoring_providers"] = monitoring_provider_connections
 
                     available_monitoring_providers = get_available_monitoring_providers(
-                        organization,
-                        run.user_id,
-                        {c["provider_key"] for c in monitoring_provider_connections},
+                        organization, run.user_id
                     )
                     if available_monitoring_providers:
                         body["available_monitoring_providers"] = available_monitoring_providers

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -36,6 +36,7 @@ from sentry.models.project import Project
 from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.seer.agent.client import (
     _trigger_explorer_indexes_if_needed,
+    get_available_monitoring_providers,
     get_monitoring_provider_connections,
 )
 from sentry.seer.agent.client_utils import (
@@ -246,6 +247,7 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
 
     match run_type:
         case SeerRunType.EXPLORER:
+            # Add connected and available monitoring providers for runs with user context.
             if run.user_id is not None:
                 try:
                     organization = Organization.objects.get_from_cache(id=run.organization_id)
@@ -254,6 +256,14 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
                     )
                     if monitoring_provider_connections:
                         body["monitoring_providers"] = monitoring_provider_connections
+
+                    available_monitoring_providers = get_available_monitoring_providers(
+                        organization,
+                        run.user_id,
+                        {c["provider_key"] for c in monitoring_provider_connections},
+                    )
+                    if available_monitoring_providers:
+                        body["available_monitoring_providers"] = available_monitoring_providers
                 except Organization.DoesNotExist:
                     logger.warning(
                         "seer_run_create.organization_dne",

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -178,10 +178,7 @@ def get_available_monitoring_providers(
     """Catalog of monitoring providers the agent may propose connecting mid-run.
 
     Omits any provider the user has permanently dismissed ("don't ask again").
-    Does not mark which providers are already connected — Seer derives that from the
-    live token-bearing connections payload (built by `get_monitoring_provider_connections`),
-    which is refreshed on connect, so a stale flag can't cause a just-connected provider
-    to be re-proposed.
+    Does not mark which providers are already connected.
     """
     if not features.has("organizations:seer-infra-telemetry", organization):
         return []

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -209,7 +209,6 @@ def get_available_monitoring_providers(
         available_providers.append(
             {
                 "provider_key": provider_type,
-                "name": provider.name,
                 "auth_method": "oauth" if is_oauth_provider else "pat",
             }
         )

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -174,14 +174,14 @@ def get_monitoring_provider_connections(
 def get_available_monitoring_providers(
     organization: Organization,
     user_id: int,
-    connected_provider_types: set[str],
 ) -> list[dict[str, Any]]:
     """Catalog of monitoring providers the agent may propose connecting mid-run.
 
-    Includes connected providers (with `connected=True`) so the agent has a
-    coherent picture, and omits any provider the user has permanently dismissed
-    ("don't ask again"). This is a separate list from the token-bearing
-    connections payload built by `get_monitoring_provider_connections`.
+    Omits any provider the user has permanently dismissed ("don't ask again").
+    Does not mark which providers are already connected — Seer derives that from the
+    live token-bearing connections payload (built by `get_monitoring_provider_connections`),
+    which is refreshed on connect, so a stale flag can't cause a just-connected provider
+    to be re-proposed.
     """
     if not features.has("organizations:seer-infra-telemetry", organization):
         return []
@@ -212,7 +212,6 @@ def get_available_monitoring_providers(
             {
                 "provider_key": provider_type,
                 "name": provider.name,
-                "connected": provider_type in connected_provider_types,
                 "auth_method": "oauth" if is_oauth_provider else "pat",
             }
         )
@@ -757,7 +756,6 @@ class SeerAgentClient:
             available_monitoring_providers = get_available_monitoring_providers(
                 self.organization,
                 self.user.id,
-                {c["provider_key"] for c in monitoring_provider_connections},
             )
             if available_monitoring_providers:
                 chat_body["available_monitoring_providers"] = available_monitoring_providers

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -59,6 +59,10 @@ from sentry.tasks.seer.context_engine_index import build_service_map, index_org_
 from sentry.tasks.seer.explorer_index import dispatch_explorer_index_projects
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.utils.prompts import (
+    get_prompt_activities_for_user,
+    seer_monitoring_provider_dont_ask_feature,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -165,6 +169,56 @@ def get_monitoring_provider_connections(
                 )
 
     return connections
+
+
+def get_available_monitoring_providers(
+    organization: Organization,
+    user_id: int,
+    connected_provider_types: set[str],
+) -> list[dict[str, Any]]:
+    """Catalog of monitoring providers the agent may propose connecting mid-run.
+
+    Includes connected providers (with `connected=True`) so the agent has a
+    coherent picture, and omits any provider the user has permanently dismissed
+    ("don't ask again"). This is a separate list from the token-bearing
+    connections payload built by `get_monitoring_provider_connections`.
+    """
+    if not features.has("organizations:seer-infra-telemetry", organization):
+        return []
+
+    feature_to_provider_map = {
+        seer_monitoring_provider_dont_ask_feature(provider_type): provider_type
+        for provider_type in MONITORING_PROVIDERS
+    }
+    dismissed_providers = {
+        feature_to_provider_map[activity.feature]
+        for activity in get_prompt_activities_for_user(
+            [organization.id], user_id, list(feature_to_provider_map)
+        )
+        if activity.data.get("dismissed_ts")
+    }
+
+    available: list[dict[str, Any]] = []
+    for provider_type in MONITORING_PROVIDERS:
+        if provider_type in dismissed_providers:
+            continue
+
+        provider = identity_manager.get(provider_type)
+        provider_name = provider.name
+        is_oauth_provider = isinstance(provider, OAuth2Provider)
+        if not isinstance(provider, McpIdentityProvider):
+            continue
+
+        available.append(
+            {
+                "provider_key": provider_type,
+                "name": provider_name,
+                "connected": provider_type in connected_provider_types,
+                "auth_method": "oauth" if is_oauth_provider else "pat",
+            }
+        )
+
+    return available
 
 
 class SeerAgentClient:
@@ -693,12 +747,21 @@ class SeerAgentClient:
         if ui_tools:
             chat_body["ui_tools"] = ui_tools
 
+        # Add connected and available monitoring providers for runs with user context.
         if self.user and not isinstance(self.user, AnonymousUser):
             monitoring_provider_connections = get_monitoring_provider_connections(
                 self.organization, self.user.id
             )
             if monitoring_provider_connections:
                 chat_body["monitoring_providers"] = monitoring_provider_connections
+
+            available_monitoring_providers = get_available_monitoring_providers(
+                self.organization,
+                self.user.id,
+                {c["provider_key"] for c in monitoring_provider_connections},
+            )
+            if available_monitoring_providers:
+                chat_body["available_monitoring_providers"] = available_monitoring_providers
 
         # No random rollout here — Seer ANDs this with the persisted value from start_run,
         # so the start_run coin flip is the single source of truth.

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -198,27 +198,26 @@ def get_available_monitoring_providers(
         if activity.data.get("dismissed_ts")
     }
 
-    available: list[dict[str, Any]] = []
+    available_providers: list[dict[str, Any]] = []
     for provider_type in MONITORING_PROVIDERS:
         if provider_type in dismissed_providers:
             continue
 
         provider = identity_manager.get(provider_type)
-        provider_name = provider.name
         is_oauth_provider = isinstance(provider, OAuth2Provider)
         if not isinstance(provider, McpIdentityProvider):
             continue
 
-        available.append(
+        available_providers.append(
             {
                 "provider_key": provider_type,
-                "name": provider_name,
+                "name": provider.name,
                 "connected": provider_type in connected_provider_types,
                 "auth_method": "oauth" if is_oauth_provider else "pat",
             }
         )
 
-    return available
+    return available_providers
 
 
 class SeerAgentClient:

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -175,9 +175,10 @@ def get_available_monitoring_providers(
     organization: Organization,
     user_id: int,
 ) -> list[dict[str, Any]]:
-    """Catalog of monitoring providers the agent may propose connecting mid-run.
+    """
+    Catalog of available monitoring providers that may or may not be connected to Seer.
 
-    Omits any provider the user has permanently dismissed ("don't ask again").
+    Omits any provider that the user has permanently dismissed ("don't ask again").
     Does not mark which providers are already connected.
     """
     if not features.has("organizations:seer-infra-telemetry", organization):

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -88,6 +88,7 @@ class AgentChatRequest(TypedDict):
     proxy_headers: NotRequired[dict[str, str] | None]
     ui_tools: NotRequired[str | None]
     monitoring_providers: NotRequired[list[dict[str, Any]]]
+    available_monitoring_providers: NotRequired[list[dict[str, Any]]]
 
 
 class AgentRunsRequest(TypedDict):

--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -3,6 +3,7 @@ from typing import TypedDict
 
 from django.db.models.query import QuerySet
 
+from sentry.integrations.types import MONITORING_PROVIDERS
 from sentry.models.promptsactivity import PromptsActivity
 
 
@@ -58,7 +59,18 @@ class PromptsConfig:
         return self.prompts[name]["required_fields"]
 
 
+def seer_monitoring_provider_dont_ask_feature(provider_type: str) -> str:
+    return f"seer_dont_ask_{provider_type}"
+
+
 prompt_config = PromptsConfig(DEFAULT_PROMPTS)
+
+# Dynamically register "don't ask again" dismissals for connecting monitoring providers to Seer.
+for provider_type in MONITORING_PROVIDERS:
+    prompt_config.add(
+        seer_monitoring_provider_dont_ask_feature(provider_type),
+        {"required_fields": ["organization_id"]},
+    )
 
 
 def get_prompt_activities_for_user(

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1730,7 +1730,6 @@ class TestGetAvailableMonitoringProviders(TestCase):
         assert set(by_provider) == {"datadog", "datadog_pat", "gcp"}
         assert by_provider["datadog"] == {
             "provider_key": "datadog",
-            "name": "Datadog",
             "auth_method": "oauth",
         }
         assert by_provider["datadog_pat"]["auth_method"] == "pat"

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1721,28 +1721,25 @@ class TestGetAvailableMonitoringProviders(TestCase):
 
     def test_returns_empty_when_feature_disabled(self) -> None:
         with self.feature({"organizations:seer-infra-telemetry": False}):
-            assert get_available_monitoring_providers(self.organization, self.user.id, set()) == []
+            assert get_available_monitoring_providers(self.organization, self.user.id) == []
 
     def test_returns_available_providers(self) -> None:
-        result = get_available_monitoring_providers(self.organization, self.user.id, {"datadog"})
+        result = get_available_monitoring_providers(self.organization, self.user.id)
 
         by_provider = self._result_by_provider(result)
         assert set(by_provider) == {"datadog", "datadog_pat", "gcp"}
         assert by_provider["datadog"] == {
             "provider_key": "datadog",
             "name": "Datadog",
-            "connected": True,
             "auth_method": "oauth",
         }
         assert by_provider["datadog_pat"]["auth_method"] == "pat"
-        assert by_provider["datadog_pat"]["connected"] is False
         assert by_provider["gcp"]["auth_method"] == "oauth"
-        assert by_provider["gcp"]["connected"] is False
 
     def test_excludes_dismissed_provider(self) -> None:
         self._dismiss_provider("gcp")
 
-        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+        result = get_available_monitoring_providers(self.organization, self.user.id)
 
         assert set(self._result_by_provider(result)) == {"datadog", "datadog_pat"}
 
@@ -1755,7 +1752,7 @@ class TestGetAvailableMonitoringProviders(TestCase):
             data={"dismissed_ts": None, "snoozed_ts": None},
         )
 
-        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+        result = get_available_monitoring_providers(self.organization, self.user.id)
 
         assert "gcp" in self._result_by_provider(result)
 
@@ -1770,7 +1767,7 @@ class TestGetAvailableMonitoringProviders(TestCase):
             data={"dismissed_ts": 1234567890},
         )
 
-        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+        result = get_available_monitoring_providers(self.organization, self.user.id)
 
         assert "gcp" in self._result_by_provider(result)
 
@@ -1784,6 +1781,6 @@ class TestGetAvailableMonitoringProviders(TestCase):
             data={"dismissed_ts": 1234567890},
         )
 
-        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+        result = get_available_monitoring_providers(self.organization, self.user.id)
 
         assert "gcp" in self._result_by_provider(result)

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -10,7 +10,12 @@ from pydantic import BaseModel
 from sentry.hybridcloud.models.outbox import CellOutbox
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.rpc.service import RpcException
-from sentry.seer.agent.client import SeerAgentClient, get_monitoring_provider_connections
+from sentry.models.promptsactivity import PromptsActivity
+from sentry.seer.agent.client import (
+    SeerAgentClient,
+    get_available_monitoring_providers,
+    get_monitoring_provider_connections,
+)
 from sentry.seer.agent.client_models import (
     AgentFilePatch,
     FilePatch,
@@ -24,6 +29,7 @@ from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, S
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options, with_feature
 from sentry.testutils.requests import make_request
+from sentry.utils.prompts import seer_monitoring_provider_dont_ask_feature
 
 TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
 
@@ -1692,3 +1698,92 @@ class TestGetMonitoringProviderConnections(TestCase):
 
         assert len(result) == 3
         mock_encrypt.assert_called_once_with("gcp-token")
+
+
+@with_feature("organizations:seer-infra-telemetry")
+class TestGetAvailableMonitoringProviders(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+
+    def _result_by_provider(self, result: list[dict]) -> dict[str, dict]:
+        return {entry["provider_key"]: entry for entry in result}
+
+    def _dismiss_provider(self, provider_type: str) -> None:
+        PromptsActivity.objects.create(
+            organization_id=self.organization.id,
+            project_id=0,
+            user_id=self.user.id,
+            feature=seer_monitoring_provider_dont_ask_feature(provider_type),
+            data={"dismissed_ts": 1234567890},
+        )
+
+    def test_returns_empty_when_feature_disabled(self) -> None:
+        with self.feature({"organizations:seer-infra-telemetry": False}):
+            assert get_available_monitoring_providers(self.organization, self.user.id, set()) == []
+
+    def test_returns_available_providers(self) -> None:
+        result = get_available_monitoring_providers(self.organization, self.user.id, {"datadog"})
+
+        by_provider = self._result_by_provider(result)
+        assert set(by_provider) == {"datadog", "datadog_pat", "gcp"}
+        assert by_provider["datadog"] == {
+            "provider_key": "datadog",
+            "name": "Datadog",
+            "connected": True,
+            "auth_method": "oauth",
+        }
+        assert by_provider["datadog_pat"]["auth_method"] == "pat"
+        assert by_provider["datadog_pat"]["connected"] is False
+        assert by_provider["gcp"]["auth_method"] == "oauth"
+        assert by_provider["gcp"]["connected"] is False
+
+    def test_excludes_dismissed_provider(self) -> None:
+        self._dismiss_provider("gcp")
+
+        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+
+        assert set(self._result_by_provider(result)) == {"datadog", "datadog_pat"}
+
+    def test_includes_visible_row(self) -> None:
+        PromptsActivity.objects.create(
+            organization_id=self.organization.id,
+            project_id=0,
+            user_id=self.user.id,
+            feature=seer_monitoring_provider_dont_ask_feature("gcp"),
+            data={"dismissed_ts": None, "snoozed_ts": None},
+        )
+
+        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+
+        assert "gcp" in self._result_by_provider(result)
+
+    def test_different_user_same_org(self) -> None:
+        other_user = self.create_user()
+        self.create_member(user=other_user, organization=self.organization)
+        PromptsActivity.objects.create(
+            organization_id=self.organization.id,
+            project_id=0,
+            user_id=other_user.id,
+            feature=seer_monitoring_provider_dont_ask_feature("gcp"),
+            data={"dismissed_ts": 1234567890},
+        )
+
+        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+
+        assert "gcp" in self._result_by_provider(result)
+
+    def test_same_user_different_org(self) -> None:
+        other_org = self.create_organization(owner=self.user)
+        PromptsActivity.objects.create(
+            organization_id=other_org.id,
+            project_id=0,
+            user_id=self.user.id,
+            feature=seer_monitoring_provider_dont_ask_feature("gcp"),
+            data={"dismissed_ts": 1234567890},
+        )
+
+        result = get_available_monitoring_providers(self.organization, self.user.id, set())
+
+        assert "gcp" in self._result_by_provider(result)


### PR DESCRIPTION
relates to CW-1580, CW-1512

Build a catalog of available providers to include in the Seer chat request. Filter out any providers dismissed via `PromptsActivity`.