### PR TITLE
ref(billing): bump sentry-protos to 0.43.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.42.1",
+  "sentry-protos>=0.43.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.32.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.40" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.42.1" },
+    { name = "sentry-protos", specifier = ">=0.43.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.32.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.42.1"
+version = "0.43.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.42.1-py3-none-any.whl", hash = "sha256:b32f77edc4f55eadc181bb3af27c85f0f02e787c903ba8c918f5bd4787c5d980" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.43.0-py3-none-any.whl", hash = "sha256:e8a896b91654fae1bd0e8b4c494b68badd2f89df989792642aea81e1fa988c33" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the `sentry-protos` pin to `>=0.43.0` — the release with [sentry-protos#350](https://github.com/getsentry/sentry-protos/pull/350)'s package catalog + package-scoped rate card protos.

Unblocks CI on [getsentry/getsentry#20974](https://github.com/getsentry/getsentry/pull/20974).

## Test plan

- [ ] `uv lock --refresh` resolves cleanly against the devinfra pypi.
- [ ] CI passes.
