### PR TITLE
chore(workflow-engine): Enable activity alerts for resolution

### DIFF
--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -23,10 +23,21 @@ from sentry.notifications.platform.templates.issue import (
 )
 from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
 from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
+from sentry.options.rollout import in_random_rollout
+from sentry.types.activity import ActivityType
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.types import ActionInvocation
 
 logger = logging.getLogger(__name__)
+
+RESOLUTION_ACTIVITY_TYPES = frozenset(
+    {
+        ActivityType.SET_RESOLVED,
+        ActivityType.SET_RESOLVED_IN_RELEASE,
+        ActivityType.SET_RESOLVED_BY_AGE,
+        ActivityType.SET_RESOLVED_IN_COMMIT,
+    }
+)
 
 
 def execute_via_group_type_registry(invocation: ActionInvocation) -> None:
@@ -234,6 +245,10 @@ def execute_via_activity_type_registry(invocation: ActionInvocation) -> None:
     except (Exception, ActivityHandlerValidationError):
         logger.exception("Error validating activity for activity handler", extra=logging_ctx)
         raise
+
+    if ActivityType(activity.type) in RESOLUTION_ACTIVITY_TYPES:
+        if not in_random_rollout("notifications.platform.resolution-notifications.rollout-rate"):
+            return
 
     try:
         handler.invoke_action(invocation=invocation, activity=activity)

--- a/src/sentry/notifications/platform/templates/workflow_engine/activity/base.py
+++ b/src/sentry/notifications/platform/templates/workflow_engine/activity/base.py
@@ -20,11 +20,10 @@ ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
     ActivityType.SEER_PR_CREATED.value: NotificationSource.ACTIVITY_SEER_PR_CREATED,
     ActivityType.SEER_ITERATION_STARTED.value: NotificationSource.ACTIVITY_SEER_ITERATION_STARTED,
     ActivityType.SEER_ITERATION_COMPLETED.value: NotificationSource.ACTIVITY_SEER_ITERATION_COMPLETED,
-    # TODO(Leander): Will be enabled in a follow up, isolated PR
-    # ActivityType.SET_RESOLVED.value: NotificationSource.ACTIVITY_SET_RESOLVED,
-    # ActivityType.SET_RESOLVED_IN_RELEASE.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_RELEASE,
-    # ActivityType.SET_RESOLVED_BY_AGE.value: NotificationSource.ACTIVITY_SET_RESOLVED_BY_AGE,
-    # ActivityType.SET_RESOLVED_IN_COMMIT.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_COMMIT,
+    ActivityType.SET_RESOLVED.value: NotificationSource.ACTIVITY_SET_RESOLVED,
+    ActivityType.SET_RESOLVED_IN_RELEASE.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_RELEASE,
+    ActivityType.SET_RESOLVED_BY_AGE.value: NotificationSource.ACTIVITY_SET_RESOLVED_BY_AGE,
+    ActivityType.SET_RESOLVED_IN_COMMIT.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_COMMIT,
 }
 
 EXAMPLE_ISSUE_URL = "https://sentry.io/organizations/example/issues/1/"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3120,6 +3120,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Rollout rate for resolution activity notifications via the notification platform
+register(
+    "notifications.platform.resolution-notifications.rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch list of NotificationSource values that should be blocked from being
 # dispatched by the notification platform's NotificationService. Values must match
 # the string values of `sentry.notifications.platform.types.NotificationSource`.

--- a/tests/sentry/notifications/platform/templates/workflow_engine/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/workflow_engine/test_activity.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.notifications.platform.templates.workflow_engine.activity import (
@@ -42,7 +40,6 @@ class ActivityAlertBaseTest(TestCase):
         for activity_type in seer_types:
             assert activity_type.value in ACTIVITY_TYPE_TO_SOURCE
 
-    @pytest.mark.skip(reason="Resolution activity renderers will be enabled in a follow-up commit")
     def test_all_resolved_activity_types_mapped(self) -> None:
         resolved_types = [
             ActivityType.SET_RESOLVED,


### PR DESCRIPTION
I have a bit of sneaking suspicion that because the default alert builder has "An issue is resolved" as a trigger, a lot of people have channels set up to receive these notifications that have been failing silently this whole time.

Since they'll be turned on now, I wanted to break out the enablement into its own PR [from rendering](https://github.com/getsentry/sentry/pull/119259) in case we need to revert or something. The other PR had some unrelated refactors so this keeps it a bit simpler to revert-revert and review.

Also per the discussion on the last PR, I will changing all the `NotificationData` types to simplify them quite a bit as a part of a separate ticket: https://linear.app/getsentry/issue/ISWF-2996/refactor-away-from-model-references-in-notificationdata