### PR TITLE
ref(ui): Collapse normalizeUrl to a two-argument signature

### DIFF
--- a/static/app/scrapsProviders/link.tsx
+++ b/static/app/scrapsProviders/link.tsx
@@ -7,10 +7,8 @@ import {preload} from 'sentry/router/preload';
 import {useRouteConfig} from 'sentry/router/routeConfigContext';
 import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {useLocation} from 'sentry/utils/useLocation';
 
 export function SentryLinkBehaviorProvider({children}: {children: React.ReactNode}) {
-  const location = useLocation();
   const routeConfig = useRouteConfig();
 
   return (
@@ -19,7 +17,7 @@ export function SentryLinkBehaviorProvider({children}: {children: React.ReactNod
         () => ({
           component: RouterLink,
           behavior: ({to, onMouseEnter, onFocus, ...props}: LinkProps) => {
-            const normalizedTo = locationDescriptorToTo(normalizeUrl(to, location));
+            const normalizedTo = locationDescriptorToTo(normalizeUrl(to));
 
             return {
               to: normalizedTo,
@@ -39,7 +37,7 @@ export function SentryLinkBehaviorProvider({children}: {children: React.ReactNod
             };
           },
         }),
-        [routeConfig, location]
+        [routeConfig]
       )}
     >
       {children}

--- a/static/app/utils/url/normalizeUrl.spec.tsx
+++ b/static/app/utils/url/normalizeUrl.spec.tsx
@@ -1,5 +1,3 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -25,7 +23,6 @@ describe('normalizeUrl', () => {
   });
 
   it('replaces paths in strings', () => {
-    const location = LocationFixture();
     const cases = [
       // input, expected
       ['/settings/', '/settings/'],
@@ -118,13 +115,7 @@ describe('normalizeUrl', () => {
       result = normalizeUrl(input!);
       expect(result).toEqual(expected);
 
-      result = normalizeUrl(input!, location);
-      expect(result).toEqual(expected);
-
       result = normalizeUrl(input!, {forceCustomerDomain: false});
-      expect(result).toEqual(expected);
-
-      result = normalizeUrl(input!, location, {forceCustomerDomain: false});
       expect(result).toEqual(expected);
     }
 
@@ -133,63 +124,56 @@ describe('normalizeUrl', () => {
     for (const [input, expected] of cases) {
       result = normalizeUrl(input!, {forceCustomerDomain: true});
       expect(result).toEqual(expected);
-
-      result = normalizeUrl(input!, location, {forceCustomerDomain: true});
-      expect(result).toEqual(expected);
     }
 
     ConfigStore.set('customerDomain', null);
     for (const [input, _expected] of cases) {
       result = normalizeUrl(input!);
       expect(result).toEqual(input);
-
-      result = normalizeUrl(input!, location);
-      expect(result).toEqual(input);
     }
   });
 
   it('replaces pathname in objects', () => {
-    const location = LocationFixture();
-    result = normalizeUrl({pathname: '/settings/acme/'}, location);
+    result = normalizeUrl({pathname: '/settings/acme/'});
     expect(result.pathname).toBe('/settings/organization/');
 
-    result = normalizeUrl({pathname: '/settings/acme/'}, location, {
-      forceCustomerDomain: false,
-    });
+    result = normalizeUrl(
+      {pathname: '/settings/acme/'},
+      {
+        forceCustomerDomain: false,
+      }
+    );
     expect(result.pathname).toBe('/settings/organization/');
 
-    result = normalizeUrl({pathname: '/settings/sentry/members'}, location);
+    result = normalizeUrl({pathname: '/settings/sentry/members'});
     expect(result.pathname).toBe('/settings/members');
 
-    result = normalizeUrl({pathname: '/settings/acme/seer/repos/'}, location);
+    result = normalizeUrl({pathname: '/settings/acme/seer/repos/'});
     expect(result.pathname).toBe('/settings/seer/repos/');
 
-    result = normalizeUrl({pathname: '/organizations/albertos-apples/issues'}, location);
+    result = normalizeUrl({pathname: '/organizations/albertos-apples/issues'});
     expect(result.pathname).toBe('/issues');
 
-    result = normalizeUrl(
-      {
-        pathname: '/organizations/sentry/profiling/profile/sentry/abc123/',
-        query: {sorting: 'call order'},
-      },
-      location
-    );
+    result = normalizeUrl({
+      pathname: '/organizations/sentry/profiling/profile/sentry/abc123/',
+      query: {sorting: 'call order'},
+    });
     expect(result.pathname).toBe('/profiling/profile/sentry/abc123/');
 
-    result = normalizeUrl(
-      {
-        pathname: '/organizations/albertos-apples/issues',
-        query: {q: 'all'},
-      },
-      location
-    );
+    result = normalizeUrl({
+      pathname: '/organizations/albertos-apples/issues',
+      query: {q: 'all'},
+    });
     expect(result.pathname).toBe('/issues');
 
     // Normalizes urls if options.customerDomain is true and orgslug.sentry.io isn't being used
     ConfigStore.set('customerDomain', null);
-    result = normalizeUrl({pathname: '/settings/acme/'}, location, {
-      forceCustomerDomain: true,
-    });
+    result = normalizeUrl(
+      {pathname: '/settings/acme/'},
+      {
+        forceCustomerDomain: true,
+      }
+    );
     expect(result.pathname).toBe('/settings/organization/');
 
     result = normalizeUrl(
@@ -197,7 +181,6 @@ describe('normalizeUrl', () => {
         pathname: '/organizations/albertos-apples/issues',
         query: {q: 'all'},
       },
-      location,
       {
         forceCustomerDomain: true,
       }

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -1,4 +1,4 @@
-import type {Location, LocationDescriptor} from 'history';
+import type {LocationDescriptor} from 'history';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 
@@ -42,20 +42,8 @@ export function normalizeUrl(
 
 export function normalizeUrl(
   path: LocationDescriptor,
-  location?: Location,
-  options?: NormalizeUrlOptions
-): LocationDescriptor;
-
-export function normalizeUrl(
-  path: LocationDescriptor,
-  location?: Location | NormalizeUrlOptions,
   options?: NormalizeUrlOptions
 ): LocationDescriptor {
-  if (location && 'forceCustomerDomain' in location) {
-    options = location;
-    location = undefined;
-  }
-
   const customerDomain = ConfigStore.get('customerDomain');
   if (!options?.forceCustomerDomain && !customerDomain) {
     return path;

--- a/static/app/views/navigation/primary/useActivateNavigationGroupOnHover.tsx
+++ b/static/app/views/navigation/primary/useActivateNavigationGroupOnHover.tsx
@@ -48,7 +48,7 @@ export function useActivateNavigationGroupOnHover({
     activeTo?: string
   ): Omit<Partial<LinkProps>, 'to'> {
     const isActive = isPrimaryNavigationLinkActive(
-      normalizeUrl(activeTo ?? to, location),
+      normalizeUrl(activeTo ?? to),
       location.pathname
     );
 


### PR DESCRIPTION
## Summary

Removes the three-argument `(path, location, options)` overload of `normalizeUrl` so it only accepts `(path, options)`. The middle `location` argument was never read inside the function — it was silently ignored — so dropping it is a no-op at runtime.

## Changes

- **`normalizeUrl.tsx`** — drop the 3-arg overload and the `location`-handling branch; the signature is now just `(path, options?)`. Remove the now-unused `Location` import.
- **`scrapsProviders/link.tsx`** — was passing `useLocation()` into the ignored slot (`normalizeUrl(to, location)`). Drop the argument; `location` was otherwise unused, so also remove the `useLocation()` call, its import, and the stale `useMemo` dependency.
- **`useActivateNavigationGroupOnHover.tsx`** — same: `normalizeUrl(activeTo ?? to, location)` → `normalizeUrl(activeTo ?? to)`. `location` is still used for `location.pathname`, so it stays.
- **`normalizeUrl.spec.tsx`** — stop exercising the removed overload; remove the unused `LocationFixture` import.

No behavior change. Verified: spec passes, ESLint clean, `pnpm typecheck` green.