### PR TITLE
ref(action-log): Deduplicate pull request closed action

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -641,14 +641,6 @@ class SeerIterationCompletedAction(GroupAction):
         return GroupActionType.SEER_ITERATION_COMPLETED
 
 
-class RelatedPullRequestClosedAction(GroupAction):
-    pull_request: Optional[int | str] = None
-
-    @classmethod
-    def get_type(cls) -> GroupActionType:
-        return GroupActionType.PULL_REQUEST_CLOSED
-
-
 class ReconcileStatusAction(GroupAction):
     """Force-set the derived status to a known-correct value.
 

--- a/src/sentry/utils/action_log/activity_translator.py
+++ b/src/sentry/utils/action_log/activity_translator.py
@@ -15,8 +15,8 @@ from sentry.issues.action_log.types import (
     MarkReviewedAction,
     MergeFromOtherAction,
     NewProcessingIssuesAction,
+    PullRequestClosedAction,
     ReferencedInCommitAction,
-    RelatedPullRequestClosedAction,
     ReprocessAction,
     ResolveAction,
     ResolvedInPullRequestAction,
@@ -89,7 +89,7 @@ ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE: Mapping[int, type[GroupAction]] = {
     ActivityType.SEER_PR_CREATED.value: SeerPRCreatedAction,
     ActivityType.SEER_ITERATION_STARTED.value: SeerIterationStartedAction,
     ActivityType.SEER_ITERATION_COMPLETED.value: SeerIterationCompletedAction,
-    ActivityType.PULL_REQUEST_CLOSED.value: RelatedPullRequestClosedAction,
+    ActivityType.PULL_REQUEST_CLOSED.value: PullRequestClosedAction,
 }
 
 ACTIVITY_TYPE_TO_ARG_TRANSLATIONS: Mapping[int, Mapping[str, str]] = {

--- a/tests/sentry/utils/action_log/test_activity_translator.py
+++ b/tests/sentry/utils/action_log/test_activity_translator.py
@@ -1,4 +1,4 @@
-from sentry.issues.action_log.types import RelatedPullRequestClosedAction, SetRegressedAction
+from sentry.issues.action_log.types import PullRequestClosedAction, SetRegressedAction
 from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
@@ -60,7 +60,7 @@ class ActivityToActionTest(TestCase):
             data={"pull_request": 123},
         )
 
-        assert activity_to_action(act) == RelatedPullRequestClosedAction(pull_request=123)
+        assert activity_to_action(act) == PullRequestClosedAction(pull_request=123)
 
     def test_extraneous_data(self) -> None:
         act = Factories.create_group_activity(
@@ -69,7 +69,7 @@ class ActivityToActionTest(TestCase):
             data={"pull_request": 123, "extra_data": 456},
         )
 
-        assert activity_to_action(act) == RelatedPullRequestClosedAction(pull_request=123)
+        assert activity_to_action(act) == PullRequestClosedAction(pull_request=123)
 
     def test_optional_field(self) -> None:
         act = Factories.create_group_activity(


### PR DESCRIPTION
I recently added the PullRequestClosed activity and corresponding action log type. It looks like a new translation layer was added recently which added a `RelatedPullRequestClosedAction` which duplicates the existing one.

Went ahead and deleting RelatedPullRequestClosedAction and replaced PullRequestClosedAction