### PR TITLE
ref(weekly-report): Remove "Top Transaction" queries

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -74,22 +74,18 @@ class OrganizationReportContextFactory:
                 )
                 total = data["total"]
                 timestamp = int(parse_snuba_datetime(data["time"]).timestamp())
-                if data["category"] == DataCategory.TRANSACTION:
-                    project_ctx.accepted_transaction_count += total
-                    project_ctx.transaction_count_by_day[timestamp] = total
-                else:
-                    project_ctx.accepted_error_count += total
-                    project_ctx.error_count_by_day[timestamp] = (
-                        project_ctx.error_count_by_day.get(timestamp, 0) + total
-                    )
+                project_ctx.accepted_error_count += total
+                project_ctx.error_count_by_day[timestamp] = (
+                    project_ctx.error_count_by_day.get(timestamp, 0) + total
+                )
 
     @metrics.wraps("weekly_report.create_context.previous_week_counts")
     def _append_previous_week_counts(self, ctx: OrganizationReportContext) -> None:
         """Populate previous-week error/transaction/issue counts for week-over-week comparison.
 
         Reads from Redis cache first (written by cache_project_metrics() at the end of each
-        weekly report run), then falls back to Snuba (errors/transactions) and Django ORM
-        (issues) for any cache misses.
+        weekly report run), then falls back to Snuba (errors) and Django ORM (issues) for
+        any cache misses.
         """
         with start_span(
             op="weekly_reports.previous_week_counts",
@@ -99,7 +95,6 @@ class OrganizationReportContextFactory:
             cached = read_project_metrics(ctx.organization.id, project_ids)
 
             error_missed_project_ids: set[int] = set()
-            transaction_missed_project_ids: set[int] = set()
             issue_missed_project_ids: set[int] = set()
 
             for project_id, values in cached.items():
@@ -108,10 +103,6 @@ class OrganizationReportContextFactory:
                     project_ctx.prev_week_accepted_error_count = values["e"]
                 else:
                     error_missed_project_ids.add(project_id)
-                if "t" in values:
-                    project_ctx.prev_week_accepted_transaction_count = values["t"]
-                else:
-                    transaction_missed_project_ids.add(project_id)
                 if "i" in values:
                     project_ctx.prev_week_total_substatus_count = values["i"]
                 else:
@@ -119,14 +110,12 @@ class OrganizationReportContextFactory:
 
             no_cache_project_ids = set(project_ids) - set(cached.keys())
             error_missed_project_ids |= no_cache_project_ids
-            transaction_missed_project_ids |= no_cache_project_ids
             issue_missed_project_ids |= no_cache_project_ids
 
             prev_start = ctx.start - (ctx.end - ctx.start)
             prev_end = ctx.start
 
-            snuba_project_ids = error_missed_project_ids | transaction_missed_project_ids
-            if snuba_project_ids:
+            if error_missed_project_ids:
                 event_counts = project_event_counts_for_organization(
                     start=prev_start,
                     end=prev_end,
@@ -141,10 +130,7 @@ class OrganizationReportContextFactory:
                     total = data["total"]
                     if data["outcome"] != Outcome.ACCEPTED:
                         continue
-                    if data["category"] == DataCategory.TRANSACTION:
-                        if project_id in transaction_missed_project_ids:
-                            project_ctx.prev_week_accepted_transaction_count += total
-                    elif data["category"] in DataCategory.error_categories():
+                    if data["category"] in DataCategory.error_categories():
                         if project_id in error_missed_project_ids:
                             project_ctx.prev_week_accepted_error_count += total
 

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -73,9 +73,7 @@ class OrganizationReportContext:
 
 class ProjectContext:
     accepted_error_count = 0
-    accepted_transaction_count = 0
     prev_week_accepted_error_count = 0
-    prev_week_accepted_transaction_count = 0
 
     new_substatus_count = 0
     ongoing_substatus_count = 0
@@ -99,8 +97,6 @@ class ProjectContext:
         # Dictionary of { timestamp: count }
         self.error_count_by_day = {}
         # Dictionary of { timestamp: count }
-        self.transaction_count_by_day = {}
-        # Dictionary of { timestamp: count }
         self.issue_count_by_day = {}
 
     def __repr__(self) -> str:
@@ -108,7 +104,6 @@ class ProjectContext:
             [
                 f"{self.key_errors_by_group}, ",
                 f"Errors: [Accepted {self.accepted_error_count}]",
-                f"Transactions: [Accepted {self.accepted_transaction_count}]",
             ]
         )
 
@@ -118,7 +113,6 @@ class ProjectContext:
             and not self.key_performance_issues
             and not self.past_resolved_issues
             and not self.accepted_error_count
-            and not self.accepted_transaction_count
         )
 
 
@@ -637,7 +631,7 @@ def project_event_counts_for_organization(start, end, ctx, referrer: str) -> lis
             Condition(
                 Column("category"),
                 Op.IN,
-                [*DataCategory.error_categories(), DataCategory.TRANSACTION],
+                [*DataCategory.error_categories()],
             ),
         ],
         groupby=[Column("outcome"), Column("category"), Column("project_id"), Column("time")],

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -253,7 +253,6 @@ def prepare_organization_report(
                 for project_id, project_ctx in ctx.projects_context_map.items():
                     project_metrics[project_id] = {
                         "e": project_ctx.accepted_error_count,
-                        "t": project_ctx.accepted_transaction_count,
                         "i": project_ctx.total_substatus_count,
                     }
                 if project_metrics:
@@ -616,27 +615,17 @@ def render_template_context(
     # number of accepted errors/transactions for each project.
     def trends():
         # Given an iterator of event counts, sum up their accepted errors/transaction counts.
-        def sum_event_counts(project_ctxs):
-            event_counts = [
-                (
-                    project_ctx.accepted_error_count,
-                    project_ctx.accepted_transaction_count,
-                )
-                for project_ctx in project_ctxs
-            ]
-            return tuple(sum(event[i] for event in event_counts) for i in range(2))
+        def sum_error_counts(project_ctxs):
+            return sum(project_ctx.accepted_error_count for project_ctx in project_ctxs)
 
         # Highest volume projects go first
         projects_associated_with_user = sorted(
             user_projects,
             reverse=True,
-            key=lambda item: item.accepted_error_count + (item.accepted_transaction_count / 10),
+            key=lambda item: item.accepted_error_count,
         )
         # Calculate total
-        (
-            total_error,
-            total_transaction,
-        ) = sum_event_counts(projects_associated_with_user)
+        total_error = sum_error_counts(projects_associated_with_user)
 
         # The number of reports to keep is the same as the number of colors
         # available to use in the legend.
@@ -655,7 +644,6 @@ def render_template_context(
                 ),
                 "color": project_breakdown_colors[i],
                 "accepted_error_count": project_ctx.accepted_error_count,
-                "accepted_transaction_count": project_ctx.accepted_transaction_count,
                 "new_substatus_count": project_ctx.new_substatus_count,
                 "escalating_substatus_count": project_ctx.escalating_substatus_count,
                 "regression_substatus_count": project_ctx.regression_substatus_count,
@@ -664,16 +652,12 @@ def render_template_context(
         ]
 
         if len(projects_not_taken) > 0:
-            (
-                others_error,
-                others_transaction,
-            ) = sum_event_counts(projects_not_taken)
+            others_error = sum_error_counts(projects_not_taken)
             legend.append(
                 {
                     "slug": f"Other ({len(projects_not_taken)})",
                     "color": other_color,
                     "accepted_error_count": others_error,
-                    "accepted_transaction_count": others_transaction,
                     "new_substatus_count": sum(p.new_substatus_count for p in projects_not_taken),
                     "escalating_substatus_count": sum(
                         p.escalating_substatus_count for p in projects_not_taken
@@ -689,7 +673,6 @@ def render_template_context(
                     "slug": f"Total ({len(projects_associated_with_user)})",
                     "color": total_color,
                     "accepted_error_count": total_error,
-                    "accepted_transaction_count": total_transaction,
                     "new_substatus_count": sum(
                         p.new_substatus_count for p in projects_associated_with_user
                     ),
@@ -710,7 +693,6 @@ def render_template_context(
                 {
                     "color": project_breakdown_colors[i],
                     "error_count": project_ctx.error_count_by_day.get(t, 0),
-                    "transaction_count": project_ctx.transaction_count_by_day.get(t, 0),
                     "issue_count": project_ctx.issue_count_by_day.get(t, 0),
                 }
                 for i, project_ctx in enumerate(projects_taken)
@@ -723,10 +705,6 @@ def render_template_context(
                             project_ctx.error_count_by_day.get(t, 0)
                             for project_ctx in projects_not_taken
                         ),
-                        "transaction_count": sum(
-                            project_ctx.transaction_count_by_day.get(t, 0)
-                            for project_ctx in projects_not_taken
-                        ),
                         "issue_count": sum(
                             project_ctx.issue_count_by_day.get(t, 0)
                             for project_ctx in projects_not_taken
@@ -737,9 +715,6 @@ def render_template_context(
         prev_week_error = sum(
             p.prev_week_accepted_error_count for p in projects_associated_with_user
         )
-        prev_week_transaction = sum(
-            p.prev_week_accepted_transaction_count for p in projects_associated_with_user
-        )
         prev_week_issue = sum(
             p.prev_week_total_substatus_count for p in projects_associated_with_user
         )
@@ -748,16 +723,11 @@ def render_template_context(
             "legend": legend,
             "series": series,
             "total_error_count": total_error,
-            "total_transaction_count": total_transaction,
             "total_issue_count": total_issue,
             "error_pct_change": _pct_change(total_error, prev_week_error),
-            "transaction_pct_change": _pct_change(total_transaction, prev_week_transaction),
             "issue_pct_change": _pct_change(total_issue, prev_week_issue),
             "error_maximum": max(  # The max error count on any single day
                 sum(value["error_count"] for value in values) for timestamp, values in series
-            ),
-            "transaction_maximum": max(  # The max transaction count on any single day
-                sum(value["transaction_count"] for value in values) for timestamp, values in series
             ),
             "issue_maximum": max(  # The max issue count on any single day
                 sum(value["issue_count"] for value in values) for timestamp, values in series

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -107,24 +107,14 @@ class DebugWeeklyReportView(MailPreviewView):
                 start_timestamp + (i * ONE_DAY): random.randint(0, daily_maximum)
                 for i in range(0, 7)
             }
-            project_context.transaction_count_by_day = {
-                start_timestamp + (i * ONE_DAY): random.randint(0, daily_maximum)
-                for i in range(0, 7)
-            }
             project_context.issue_count_by_day = {
                 start_timestamp + (i * ONE_DAY): random.randint(0, daily_maximum // 10)
                 for i in range(0, 7)
             }
 
             project_context.accepted_error_count = sum(project_context.error_count_by_day.values())
-            project_context.accepted_transaction_count = sum(
-                project_context.transaction_count_by_day.values()
-            )
             project_context.prev_week_accepted_error_count = int(
                 project_context.accepted_error_count * random.uniform(0.5, 1.5)
-            )
-            project_context.prev_week_accepted_transaction_count = int(
-                project_context.accepted_transaction_count * random.uniform(0.5, 1.5)
             )
             substatuses = [
                 (GroupStatus.UNRESOLVED, GroupSubStatus.NEW),

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -623,13 +623,6 @@ class WeeklyReportsTest(
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=2
         )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=10,
-            category=DataCategory.TRANSACTION,
-        )
 
         group1 = event1.group
         group2 = event2.group
@@ -679,7 +672,7 @@ class WeeklyReportsTest(
             assert len(context["key_errors"]) == 0
             assert len(context["key_performance_issues"]) == 2
             assert context["trends"]["total_error_count"] == 2
-            assert context["trends"]["total_transaction_count"] == 10
+
             assert "Weekly Report for" in message_params["subject"]
 
             assert isinstance(context["notification_uuid"], str)
@@ -727,13 +720,6 @@ class WeeklyReportsTest(
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=2
         )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=10,
-            category=DataCategory.TRANSACTION,
-        )
 
         self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group1")
         self.create_performance_issue(fingerprint=f"{PerformanceNPlusOneGroupType.type_id}-group2")
@@ -762,7 +748,7 @@ class WeeklyReportsTest(
             assert len(context["key_errors"]) == 2
             assert len(context["key_performance_issues"]) == 2
             assert context["trends"]["total_error_count"] == 2
-            assert context["trends"]["total_transaction_count"] == 10
+
             assert "Weekly Report for" in message_params["subject"]
 
             assert isinstance(context["notification_uuid"], str)
@@ -808,13 +794,6 @@ class WeeklyReportsTest(
         )
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=2
-        )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=10,
-            category=DataCategory.TRANSACTION,
         )
 
         prepare_organization_report(
@@ -869,13 +848,6 @@ class WeeklyReportsTest(
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=2
         )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=10,
-            category=DataCategory.TRANSACTION,
-        )
 
         group1 = event1.group
         group2 = event2.group
@@ -929,7 +901,7 @@ class WeeklyReportsTest(
             }
             assert len(context["key_errors"]) == 0
             assert context["trends"]["total_error_count"] == 2
-            assert context["trends"]["total_transaction_count"] == 10
+
             assert "Weekly Report for" in message_params["subject"]
 
             assert isinstance(context["notification_uuid"], str)
@@ -1014,10 +986,6 @@ class WeeklyReportsTest(
         for outcome, category, num in [
             (Outcome.ACCEPTED, DataCategory.ERROR, 1),
             (Outcome.RATE_LIMITED, DataCategory.ERROR, 2),
-            (Outcome.ACCEPTED, DataCategory.TRANSACTION, 3),
-            (Outcome.RATE_LIMITED, DataCategory.TRANSACTION, 4),
-            # Filtered should be ignored in these emails
-            (Outcome.FILTERED, DataCategory.TRANSACTION, 5),
         ]:
             self.store_event_outcomes(
                 self.organization.id,
@@ -1057,7 +1025,6 @@ class WeeklyReportsTest(
             "url": f"http://testserver/organizations/baz/issues/?referrer=weekly_report&notification_uuid={ctx['notification_uuid']}&project={self.project.id}",
             "color": "#7553FF",
             "accepted_error_count": 1,
-            "accepted_transaction_count": 3,
             "new_substatus_count": 0,
             "escalating_substatus_count": 0,
             "regression_substatus_count": 0,
@@ -1066,7 +1033,6 @@ class WeeklyReportsTest(
         assert ctx["trends"]["series"][-2][1][0] == {
             "color": "#7553FF",
             "error_count": 1,
-            "transaction_count": 3,
             "issue_count": 0,
         }
 
@@ -1302,13 +1268,6 @@ class WeeklyReportsTest(
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=10
         )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=20,
-            category=DataCategory.TRANSACTION,
-        )
 
         event1 = self.store_event(
             data={
@@ -1339,10 +1298,10 @@ class WeeklyReportsTest(
             first_seen=prev_week,
         )
 
-        # Cache only has "e"/"t", missing "i" — ORM fallback should fill issues
+        # Cache only has "e", missing "i" — ORM fallback should fill issues
         cache_project_metrics(
             self.organization.id,
-            {self.project.id: {"e": 5, "t": 40}},
+            {self.project.id: {"e": 5}},
         )
 
         prepare_organization_report(
@@ -1351,18 +1310,12 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            # e/t come from cache: current 10 vs prev 5, current 20 vs prev 40
+            # e comes from cache: current 10 vs prev 5
             assert context["trends"]["error_pct_change"] == {
                 "arrow": "↑",
                 "pct": "100%",
                 "bg_color": "#F9F0D2",
                 "text_color": "#A45200",
-            }
-            assert context["trends"]["transaction_pct_change"] == {
-                "arrow": "↓",
-                "pct": "50%",
-                "bg_color": "#E3F7E3",
-                "text_color": "#008900",
             }
             # i comes from ORM fallback: current 1 vs prev 2
             assert context["trends"]["issue_pct_change"] == {
@@ -2111,23 +2064,9 @@ class WeeklyReportsTest(
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=10
         )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=20,
-            category=DataCategory.TRANSACTION,
-        )
 
         prev_week = self.three_days_ago - timedelta(days=7)
         self.store_event_outcomes(self.organization.id, self.project.id, prev_week, num_times=5)
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            prev_week,
-            num_times=40,
-            category=DataCategory.TRANSACTION,
-        )
 
         prepare_organization_report(
             self.timestamp, ONE_DAY * 7, self.organization.id, self._dummy_batch_id
@@ -2140,12 +2079,6 @@ class WeeklyReportsTest(
                 "pct": "100%",
                 "bg_color": "#F9F0D2",
                 "text_color": "#A45200",
-            }
-            assert context["trends"]["transaction_pct_change"] == {
-                "arrow": "↓",
-                "pct": "50%",
-                "bg_color": "#E3F7E3",
-                "text_color": "#008900",
             }
             assert context["show_week_over_week_metric"] is True
 
@@ -2166,7 +2099,6 @@ class WeeklyReportsTest(
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
             assert context["trends"]["error_pct_change"] is None
-            assert context["trends"]["transaction_pct_change"] is None
             assert context["show_week_over_week_metric"] is True
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -2188,7 +2120,6 @@ class WeeklyReportsTest(
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
             assert context["trends"]["error_pct_change"] is None
-            assert context["trends"]["transaction_pct_change"] is None
             assert context["show_week_over_week_metric"] is False
 
     @with_feature("organizations:weekly-report-week-over-week-metric")
@@ -2202,17 +2133,10 @@ class WeeklyReportsTest(
         self.store_event_outcomes(
             self.organization.id, self.project.id, self.three_days_ago, num_times=10
         )
-        self.store_event_outcomes(
-            self.organization.id,
-            self.project.id,
-            self.three_days_ago,
-            num_times=20,
-            category=DataCategory.TRANSACTION,
-        )
 
         cache_project_metrics(
             self.organization.id,
-            {self.project.id: {"e": 5, "t": 40}},
+            {self.project.id: {"e": 5}},
         )
 
         prepare_organization_report(
@@ -2226,12 +2150,6 @@ class WeeklyReportsTest(
                 "pct": "100%",
                 "bg_color": "#F9F0D2",
                 "text_color": "#A45200",
-            }
-            assert context["trends"]["transaction_pct_change"] == {
-                "arrow": "↓",
-                "pct": "50%",
-                "bg_color": "#E3F7E3",
-                "text_color": "#008900",
             }
 
     def test_pct_change_helper(self) -> None:


### PR DESCRIPTION
Resolves [ID-1694](https://linear.app/getsentry/issue/ID-1694/remove-total-transactions-chart-dead-code)

Goal: remove methods / logic related to the "Total Transactions" graph. We have already removed the graph from the email rendering template [via this PR](https://github.com/getsentry/sentry/pull/119229). This PR just removes dead code and prevents extra DB queries from creating the weekly reports