### PR TITLE
logging(seer-infra-telemetry): Log upstream error details for failure in token refresh logic

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -201,7 +201,16 @@ class OAuth2Provider(Provider):
             error_resp = e.response
             exc = ApiError.from_response(error_resp, url=url)
             if isinstance(exc, ApiUnauthorized) or isinstance(exc, ApiInvalidRequestError):
-                raise IdentityNotValid from e
+                logger.warning(
+                    "oauth2.refresh_token.rejected",
+                    extra={
+                        "identity_id": identity.id,
+                        "status_code": error_resp.status_code,
+                        "response_body": error_resp.text[:512],
+                        "url": url,
+                    },
+                )
+                raise IdentityNotValid(error_resp.text[:256]) from e
             raise exc from e
 
         return req

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -201,16 +201,7 @@ class OAuth2Provider(Provider):
             error_resp = e.response
             exc = ApiError.from_response(error_resp, url=url)
             if isinstance(exc, ApiUnauthorized) or isinstance(exc, ApiInvalidRequestError):
-                logger.warning(
-                    "oauth2.refresh_token.rejected",
-                    extra={
-                        "identity_id": identity.id,
-                        "status_code": error_resp.status_code,
-                        "response_body": error_resp.text[:512],
-                        "url": url,
-                    },
-                )
-                raise IdentityNotValid(error_resp.text[:256]) from e
+                raise IdentityNotValid from e
             raise exc from e
 
         return req

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1130,13 +1130,14 @@ def refresh_monitoring_provider_token(
 
     try:
         provider.refresh_identity(identity)
-    except IdentityNotValid:
+    except IdentityNotValid as exc:
         logger.exception(
             "monitoring_provider.refresh.identity_not_valid",
             extra={
                 "identity_id": identity_id,
                 "provider": idp.type,
                 "has_refresh_token": "refresh_token" in identity.data,
+                "upstream_error": str(exc),
             },
         )
         return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_valid")

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -1131,13 +1131,17 @@ def refresh_monitoring_provider_token(
     try:
         provider.refresh_identity(identity)
     except IdentityNotValid as exc:
+        upstream_error = ""
+        cause = exc.__cause__
+        if cause is not None and hasattr(cause, "response") and cause.response is not None:
+            upstream_error = cause.response.text[:512]
         logger.exception(
             "monitoring_provider.refresh.identity_not_valid",
             extra={
                 "identity_id": identity_id,
                 "provider": idp.type,
                 "has_refresh_token": "refresh_token" in identity.data,
-                "upstream_error": str(exc),
+                "upstream_error": upstream_error,
             },
         )
         return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_valid")


### PR DESCRIPTION
Capturing the upstream error details in this log so that we can debug why the token refresh logic is failing.