### PR TITLE
ref(ui): Extract pure normalizeUrlWithCustomerDomain, keep normalizeUrl wrapper

### DIFF
--- a/static/app/utils/url/normalizeUrl.spec.tsx
+++ b/static/app/utils/url/normalizeUrl.spec.tsx
@@ -1,6 +1,9 @@
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {
+  normalizeUrl,
+  normalizeUrlWithCustomerDomain,
+} from 'sentry/utils/url/normalizeUrl';
 
 describe('normalizeUrl', () => {
   let configState: Config;
@@ -186,5 +189,53 @@ describe('normalizeUrl', () => {
       }
     );
     expect(result.pathname).toBe('/issues');
+  });
+});
+
+describe('normalizeUrlWithCustomerDomain', () => {
+  let configState: Config;
+  let result: any;
+
+  const customerDomain = {
+    subdomain: 'albertos-apples',
+    organizationUrl: 'https://albertos-apples.sentry.io',
+    sentryUrl: 'https://sentry.io',
+  };
+
+  beforeEach(() => {
+    // Set a customer domain in global config to prove the pure function does
+    // NOT read it — only the value passed in as an argument is used.
+    configState = ConfigStore.getState();
+    ConfigStore.loadInitialData({...configState, customerDomain});
+  });
+
+  afterEach(() => {
+    ConfigStore.loadInitialData(configState);
+  });
+
+  it('normalizes when a customer domain is provided', () => {
+    expect(normalizeUrlWithCustomerDomain('/settings/acme/', {customerDomain})).toBe(
+      '/settings/organization/'
+    );
+    result = normalizeUrlWithCustomerDomain(
+      {pathname: '/organizations/albertos-apples/issues'},
+      {customerDomain}
+    );
+    expect(result.pathname).toBe('/issues');
+  });
+
+  it('normalizes when forced, without a customer domain', () => {
+    expect(normalizeUrlWithCustomerDomain('/settings/acme/', {force: true})).toBe(
+      '/settings/organization/'
+    );
+  });
+
+  it('returns the path unchanged without a customer domain or force', () => {
+    expect(normalizeUrlWithCustomerDomain('/settings/acme/')).toBe('/settings/acme/');
+    expect(
+      normalizeUrlWithCustomerDomain('/settings/acme/', {customerDomain: null})
+    ).toBe('/settings/acme/');
+    result = normalizeUrlWithCustomerDomain({pathname: '/settings/acme/'});
+    expect(result.pathname).toBe('/settings/acme/');
   });
 });

--- a/static/app/utils/url/normalizeUrl.tsx
+++ b/static/app/utils/url/normalizeUrl.tsx
@@ -1,6 +1,7 @@
 import type {LocationDescriptor} from 'history';
 
 import {ConfigStore} from 'sentry/stores/configStore';
+import type {Config} from 'sentry/types/system';
 
 // If you change this also update the patterns in sentry.api.utils
 const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
@@ -25,27 +26,49 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   [/^\/?checkout\/[^/]+\/(.*)/, '/checkout/$1'],
 ];
 
+type NormalizeUrlWithCustomerDomainOptions = {
+  /**
+   * The active customer domain. When set (non-null) org/settings slugs are
+   * stripped from the path.
+   */
+  customerDomain?: Config['customerDomain'];
+  /**
+   * Normalize regardless of whether a customer domain is provided. Used where a
+   * slugless path is needed independent of the current domain (e.g. deriving
+   * redirect targets, normalizing telemetry span names).
+   */
+  force?: boolean;
+};
+
 type NormalizeUrlOptions = {
-  forceCustomerDomain: boolean;
+  /**
+   * Normalize regardless of whether a customer domain is active. See
+   * {@link NormalizeUrlWithCustomerDomainOptions.force}.
+   */
+  forceCustomerDomain?: boolean;
 };
 
 /**
- * Normalize a URL for customer domains based on the organization that was
- * present in the initial page load.
+ * Pure version of {@link normalizeUrl}: normalize a URL using an explicitly
+ * provided customer domain instead of reading it from global config. Prefer
+ * `normalizeUrl` unless you need to supply the customer domain yourself (e.g.
+ * in tests, or when normalizing for a domain other than the active one).
  */
-export function normalizeUrl(path: string, options?: NormalizeUrlOptions): string;
+export function normalizeUrlWithCustomerDomain(
+  path: string,
+  options?: NormalizeUrlWithCustomerDomainOptions
+): string;
 
-export function normalizeUrl(
+export function normalizeUrlWithCustomerDomain(
   path: LocationDescriptor,
-  options?: NormalizeUrlOptions
+  options?: NormalizeUrlWithCustomerDomainOptions
 ): LocationDescriptor;
 
-export function normalizeUrl(
+export function normalizeUrlWithCustomerDomain(
   path: LocationDescriptor,
-  options?: NormalizeUrlOptions
+  options?: NormalizeUrlWithCustomerDomainOptions
 ): LocationDescriptor {
-  const customerDomain = ConfigStore.get('customerDomain');
-  if (!options?.forceCustomerDomain && !customerDomain) {
+  if (!options?.force && !options?.customerDomain) {
     return path;
   }
 
@@ -74,4 +97,28 @@ export function normalizeUrl(
   }
 
   return resolved;
+}
+
+/**
+ * Normalize a URL for customer domains based on the organization that was
+ * present in the initial page load.
+ *
+ * Thin wrapper around {@link normalizeUrlWithCustomerDomain} that injects the
+ * active customer domain from `ConfigStore`.
+ */
+export function normalizeUrl(path: string, options?: NormalizeUrlOptions): string;
+
+export function normalizeUrl(
+  path: LocationDescriptor,
+  options?: NormalizeUrlOptions
+): LocationDescriptor;
+
+export function normalizeUrl(
+  path: LocationDescriptor,
+  options?: NormalizeUrlOptions
+): LocationDescriptor {
+  return normalizeUrlWithCustomerDomain(path, {
+    customerDomain: ConfigStore.get('customerDomain'),
+    force: options?.forceCustomerDomain,
+  });
 }


### PR DESCRIPTION
## Summary

Splits `normalizeUrl` into a **pure core** plus a **thin wrapper**, so the customer-domain lookup is decoupled from the global config store *without* churning every callsite.

- **`normalizeUrlWithCustomerDomain(path, {customerDomain, force})`** — pure. Takes the customer domain as an argument instead of reading `ConfigStore`, so it's trivially testable and reusable (e.g. normalizing for a domain other than the active one).
- **`normalizeUrl(path, {forceCustomerDomain})`** — unchanged public API. Now delegates to the pure function, injecting `ConfigStore.get('customerDomain')`.

## Why this shape

An earlier revision of this PR pushed `ConfigStore.get('customerDomain')` out to all ~240 callsites. That worked but was a huge, noisy diff. The wrapper keeps the ergonomic `normalizeUrl(path)` API every callsite already uses while still exposing a pure function for callers that want to supply the domain themselves.

## Scope

**Every existing callsite is unchanged.** The diff is two files: the util and its spec. No behavior change — the wrapper reproduces the original `force-or-active-domain` gate exactly.

## Verification

- `pnpm typecheck` — green (0 errors), confirming all existing callsites still compile against the wrapper
- ESLint clean, oxfmt applied
- Spec passes (5 tests): wrapper behavior via `ConfigStore` + pure-function behavior (including that the pure fn ignores global config)