### PR TITLE
feat(teapot-backend): Integrate Teapot GPU symbolication service with Sentry

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2994,9 +2994,9 @@ SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
 
 # URL of the teapot GPU crash dump symbolication service (sibling to Symbolicator).
-# Left unset by default so the runtime-modifiable `teapot.options["url"]` option is
-# the source of truth (this env var is just a local/deploy override).
-SENTRY_TEAPOT_URL = os.getenv("TEAPOT")
+# In production getsentry sets this from the `SENTRY_TEAPOT_HOST` env var, the same
+# way it sets the other internal service URLs (Tempest, Vroom, ...).
+SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
 
 SENTRY_REPLAYS_SERVICE_URL = "http://localhost:8090"
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2994,7 +2994,9 @@ SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
 
 # URL of the teapot GPU crash dump symbolication service (sibling to Symbolicator).
-SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
+# Left unset by default so the runtime-modifiable `teapot.options["url"]` option is
+# the source of truth (this env var is just a local/deploy override).
+SENTRY_TEAPOT_URL = os.getenv("TEAPOT")
 
 SENTRY_REPLAYS_SERVICE_URL = "http://localhost:8090"
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2993,10 +2993,11 @@ SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
 
-# URL of the teapot GPU crash dump symbolication service (sibling to Symbolicator).
-# In production getsentry sets this from the `SENTRY_TEAPOT_HOST` env var, the same
-# way it sets the other internal service URLs (Tempest, Vroom, ...).
+# URL of the teapot GPU crash dump symbolication service
 SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
+
+# Shared secret used to sign requests to teapot
+SENTRY_TEAPOT_SHARED_SECRET = os.getenv("SENTRY_TEAPOT_SHARED_SECRET", "")
 
 SENTRY_REPLAYS_SERVICE_URL = "http://localhost:8090"
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2993,8 +2993,9 @@ SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
 
-# URL of the teapot GPU crash dump symbolication service
-SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
+# URL of the teapot GPU crash dump symbolication service, derived from the
+# SENTRY_TEAPOT_HOST host:port (the k8s service in SaaS, localhost in dev).
+SENTRY_TEAPOT_URL = f"http://{os.getenv('SENTRY_TEAPOT_HOST', 'localhost:8125')}"
 
 # Shared secret used to sign requests to teapot
 SENTRY_TEAPOT_SHARED_SECRET = os.getenv("SENTRY_TEAPOT_SHARED_SECRET", "")

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -983,6 +983,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.digests",
     "sentry.tasks.email",
     "sentry.tasks.files",
+    "sentry.tasks.gpu_crash",
     "sentry.tasks.groupowner",
     "sentry.tasks.llm_issue_detection.detection",
     "sentry.tasks.llm_issue_detection",
@@ -2991,6 +2992,9 @@ SEER_GHE_ENCRYPT_KEY: str | None = os.getenv("SEER_GHE_ENCRYPT_KEY")
 SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
+
+# URL of the teapot GPU crash dump symbolication service (sibling to Symbolicator).
+SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
 
 SENTRY_REPLAYS_SERVICE_URL = "http://localhost:8090"
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -985,6 +985,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.digests",
     "sentry.tasks.email",
     "sentry.tasks.files",
+    "sentry.tasks.gpu_crash",
     "sentry.tasks.groupowner",
     "sentry.tasks.llm_issue_detection.detection",
     "sentry.tasks.llm_issue_detection",
@@ -2972,6 +2973,9 @@ SEER_GHE_ENCRYPT_KEY: str | None = os.getenv("SEER_GHE_ENCRYPT_KEY")
 SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
+
+# URL of the teapot GPU crash dump symbolication service (sibling to Symbolicator).
+SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
 
 SENTRY_REPLAYS_SERVICE_URL = "http://localhost:8090"
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2975,7 +2975,9 @@ SENTRY_VROOM = os.getenv("VROOM", "http://127.0.0.1:8085")
 SENTRY_TEMPEST_URL = os.getenv("TEMPEST", "http://127.0.0.1:9130")
 
 # URL of the teapot GPU crash dump symbolication service (sibling to Symbolicator).
-SENTRY_TEAPOT_URL = os.getenv("TEAPOT", "http://127.0.0.1:8125")
+# Left unset by default so the runtime-modifiable `teapot.options["url"]` option is
+# the source of truth (this env var is just a local/deploy override).
+SENTRY_TEAPOT_URL = os.getenv("TEAPOT")
 
 SENTRY_REPLAYS_SERVICE_URL = "http://localhost:8090"
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -122,6 +122,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable LLM-generated title and description for external issue details
     manager.add("organizations:external-issues-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:inbound-filters-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable GPU crash dump symbolication via teapot
+    manager.add("organizations:gpu-crash-symbolication", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -126,6 +126,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable LLM-generated title and description for external issue details
     manager.add("organizations:external-issues-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:inbound-filters-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable GPU crash dump symbolication via teapot
+    manager.add("organizations:gpu-crash-symbolication", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -82,6 +82,15 @@ ALL_KILLSWITCH_OPTIONS = {
             "symbolication_function": "process_minidump, process_applecrashreport, process_native_stacktraces, or process_js_stacktraces",
         },
     ),
+    "store.load-shed-gpu-crash-projects": KillswitchInfo(
+        description="Skip routing GPU crash events to the isolated teapot task "
+        "(event is forwarded to normal process/save, unenriched)",
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "event_id": "An event ID as given in the event payload.",
+            "platform": "The event platform as defined in the event payload's platform field.",
+        },
+    ),
     "store.load-shed-save-event-projects": KillswitchInfo(
         description="Drop events in save_event",
         fields={

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -122,6 +122,15 @@ ALL_KILLSWITCH_OPTIONS = {
             "symbolication_function": "process_minidump, process_applecrashreport, process_native_stacktraces, or process_js_stacktraces",
         },
     ),
+    "store.load-shed-gpu-crash-projects": KillswitchInfo(
+        description="Skip routing GPU crash events to the isolated teapot task "
+        "(event is forwarded to normal process/save, unenriched)",
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "event_id": "An event ID as given in the event payload.",
+            "platform": "The event platform as defined in the event payload's platform field.",
+        },
+    ),
     "store.load-shed-save-event-projects": KillswitchInfo(
         description="Drop events in save_event",
         fields={

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -1,12 +1,8 @@
-"""GPU crash dump symbolication — teapot's decode applied to the in-flight event.
+"""Apply teapot's GPU crash decode to the in-flight event.
 
-The GPU crash arrives from Relay as its own native event carrying the
-``.nv-gpudmp`` attachment: Relay split it off the minidump/unreal upload and set
-the event id, trace context, release/environment and the ``cpu_event_id`` link.
-This module runs teapot over that attachment and applies the decode to the event
-in place — exception, grouping fingerprint, GPU contexts, tags and breadcrumbs —
-before it is saved through the normal pipeline. It enriches the event Relay
-created and billed; it never builds or bills one itself.
+Relay splits the ``.nv-gpudmp`` onto its own native event with identity/trace/
+release already set; this maps teapot's decode onto it (exception, fingerprint,
+GPU contexts, tags, breadcrumbs) before save. Enriches only — never bills.
 """
 
 from __future__ import annotations
@@ -21,9 +17,6 @@ logger = logging.getLogger(__name__)
 
 # NVIDIA Aftermath GPU crash dump attachment, decoded by teapot.
 GPU_CRASH_DUMP_ATTACHMENT_TYPE = "event.nv_gpudmp"
-
-
-# ─────────────────────────── public entry point ────────────────────────────
 
 
 def apply_gpu_crash_symbolication(
@@ -57,10 +50,6 @@ def apply_gpu_crash_symbolication(
 
     data["platform"] = "native"
     data["level"] = "fatal"
-    # Relay typed the scope-only event as "default" (the exception is added here,
-    # after normalization). Re-type it as an error so the event title is derived
-    # from the exception below instead of defaulting to "<unlabeled event>";
-    # `get_event_type` trusts `data["type"]` and never re-infers it.
     data["type"] = "error"
     data["fingerprint"] = list(_as_list(response.get("fingerprint"))) or ["gpu", category]
     data["exception"] = {
@@ -85,9 +74,7 @@ def apply_gpu_crash_symbolication(
             "vendor_name": "NVIDIA",
             "api": gpu_state.get("api"),
         }
-    # Only-if-absent: the GPU event inherits the SDK's richer os/app contexts from
-    # the copied scope; teapot's thinner versions just fill the gap when the upload
-    # carried no SDK scope (e.g. a raw minidump).
+    # Only fill os/app if the copied SDK scope didn't (teapot's are thinner).
     if gpu_state.get("os_version") and "os" not in contexts:
         contexts["os"] = {"name": gpu_state["os_version"], "type": "os"}
     if gpu_state.get("application_name") and "app" not in contexts:
@@ -112,26 +99,18 @@ def apply_gpu_crash_symbolication(
     return data
 
 
-# ─────────────────────────── event construction ────────────────────────────
-
-
 def _as_dict(value: Any) -> dict[str, Any]:
-    """Coerce an untrusted teapot JSON value to a dict (``{}`` if it isn't one)."""
+    """Coerce untrusted teapot JSON to a dict (``{}`` otherwise)."""
     return value if isinstance(value, dict) else {}
 
 
 def _as_list(value: Any) -> list[Any]:
-    """Coerce an untrusted teapot JSON value to a list (``[]`` if it isn't one)."""
+    """Coerce untrusted teapot JSON to a list (``[]`` otherwise)."""
     return value if isinstance(value, list) else []
 
 
 def _primary_shader(response: Mapping[str, Any]) -> dict[str, Any]:
-    """First active shader from teapot's response, or ``{}``.
-
-    Every level is untrusted external JSON, so type-check before indexing: a
-    truthy non-list ``active_shaders`` (or a non-dict entry) must not reach
-    ``active_shaders[0]`` / ``primary_shader.get(...)``.
-    """
+    """First active shader, or ``{}`` (every level is untrusted JSON)."""
     active_shaders = _as_dict(response.get("shader_context")).get("active_shaders")
     if not isinstance(active_shaders, list) or not active_shaders:
         return {}
@@ -139,10 +118,10 @@ def _primary_shader(response: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
-    """Flatten teapot's response into a ``contexts.gpu_crash`` dict.
+    """Flatten teapot's response into ``contexts.gpu_crash``.
 
-    Top-level scalars render inline in the context card; nested objects would
-    collapse behind ``> { N items }``, so we flatten fault / gpu_state out.
+    Flat scalars render inline in the context card; nested objects would collapse
+    behind ``> { N items }``.
     """
 
     fault = _as_dict(response.get("fault"))
@@ -152,20 +131,16 @@ def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
     flat: dict[str, Any] = {
         "type": "gpu_crash",
         "status": response.get("status"),
-        # Top-level teapot fields — drive grouping + UX. Always populated
-        # in successful responses; missing only for `failed` ones.
         "fault_category": response.get("fault_category"),
         "title": response.get("title"),
         "handler": response.get("handler"),
         "sdk_version": response.get("sdk_version"),
         "decode_time_ms": response.get("decode_time_ms"),
-        # Fault
         "fault_type": fault.get("type"),
         "fault_description": fault.get("description"),
         "fault_code": fault.get("code"),
         "virtual_address": fault.get("virtual_address"),
         "access_type": fault.get("access_type"),
-        # GPU / host
         "device_name": gpu_state.get("device_name"),
         "device_status": gpu_state.get("device_status"),
         "driver_version": gpu_state.get("driver_version"),
@@ -174,12 +149,9 @@ def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
         "application_name": gpu_state.get("application_name"),
         "engine_reset": gpu_state.get("engine_reset"),
         "adapter_reset": gpu_state.get("adapter_reset"),
-        # Shader (when present)
         "shader_hash": primary_shader.get("shader_hash"),
         "shader_type": primary_shader.get("shader_type"),
         "shader_debug_info_uid": primary_shader.get("shader_debug_info_uid"),
-        # Missing debug files (surface count so users see when they need
-        # to fix their SDK integration).
         "missing_dif_count": len(_as_list(response.get("missing_difs"))),
     }
     warnings = _as_list(response.get("warnings"))
@@ -188,20 +160,9 @@ def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in flat.items() if v is not None}
 
 
-# ─────────────────────────── frame / tag helpers ──────────────────────────
-
-
-def _merge_tags(
-    existing: Any,
-    extra: Mapping[str, str],
-) -> list[tuple[str, str]]:
-    """Merge the event's existing tags with the GPU extras.
-
-    Returns the pipeline's canonical list-of-pairs form — what ``set_tag`` /
-    ``get_tag`` / ``pop_tag`` in ``event_manager`` operate on (a dict would break
-    them). Accepts either the dict or list-of-pairs input shape; extras win on a
-    key collision.
-    """
+def _merge_tags(existing: Any, extra: Mapping[str, str]) -> list[tuple[str, str]]:
+    """Merge existing tags with GPU extras into the pipeline's list-of-pairs form
+    (what ``event_manager``'s tag helpers expect). Extras win on collision."""
 
     merged: dict[str, str] = {}
     if isinstance(existing, dict):
@@ -223,12 +184,8 @@ def _merge_tags(
 
 
 def _markers_to_breadcrumbs(markers: Any) -> list[dict[str, Any]]:
-    """Map teapot's `markers` to breadcrumbs.
-
-    For non-shader crashes these are often the only actionable signal (the
-    CPU-side context that submitted the faulting GPU work).
-    """
-
+    """Map teapot's ``markers`` to breadcrumbs (often the only signal for
+    non-shader crashes)."""
     if not isinstance(markers, list):
         return []
     out: list[dict[str, Any]] = []
@@ -252,14 +209,9 @@ def _markers_to_breadcrumbs(markers: Any) -> list[dict[str, Any]]:
 
 
 def _normalize_gpu_frames(teapot_frames: Any) -> list[dict[str, Any]]:
-    """Map teapot's ``frames[]`` to Sentry stacktrace frames.
-
-    Mostly a pass-through of pre-populated fields, plus two normalisations:
-    force ``symbolicator_status=symbolicated`` (shader frames have no debug
-    image, so the walker would otherwise mark them missing), and synthesise a
-    ``package`` from the shader hash for the module column.
-    """
-
+    """Map teapot's ``frames[]`` to Sentry stacktrace frames: pass through known
+    fields, force ``symbolicator_status=symbolicated`` (shader frames have no
+    debug image), and synthesise ``package`` from the shader hash."""
     if not isinstance(teapot_frames, list):
         return []
 
@@ -284,8 +236,7 @@ def _normalize_gpu_frames(teapot_frames: Any) -> list[dict[str, Any]]:
             value = raw.get(src)
             if value is not None:
                 frame[dst] = value
-        # `data` is external; only trust it if it's a mapping (a truthy
-        # str/list would crash `dict(...)` and the `.get()` below).
+        # `data` is external — only trust a mapping.
         raw_data = raw.get("data")
         if not isinstance(raw_data, dict):
             raw_data = {}

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -33,8 +33,8 @@ def apply_gpu_crash_symbolication(
         metrics.incr("process.gpu.event.skipped", tags={"status": status or "unknown"})
         return None
 
-    fault = _as_dict(response.get("fault"))
-    gpu_state = _as_dict(response.get("gpu_state"))
+    fault = response.get("fault") or {}
+    gpu_state = response.get("gpu_state") or {}
     primary_shader = _primary_shader(response)
     category = response.get("fault_category") or "unknown"
 
@@ -51,13 +51,13 @@ def apply_gpu_crash_symbolication(
     data["platform"] = "native"
     data["level"] = "fatal"
     data["type"] = "error"
-    data["fingerprint"] = list(_as_list(response.get("fingerprint"))) or ["gpu", category]
+    data["fingerprint"] = list(response.get("fingerprint") or []) or ["gpu", category]
     data["exception"] = {
         "values": [
             {
                 "type": exc_type,
                 "value": exc_value,
-                "stacktrace": {"frames": _normalize_gpu_frames(_as_list(response.get("frames")))},
+                "stacktrace": {"frames": _normalize_gpu_frames(response.get("frames") or [])},
                 "mechanism": {"type": "gpu_crash", "handled": False},
             }
         ]
@@ -93,7 +93,7 @@ def apply_gpu_crash_symbolication(
         gpu_tags["gpu.shader_type"] = primary_shader["shader_type"]
     data["tags"] = _merge_tags(data.get("tags"), gpu_tags)
 
-    breadcrumbs = _markers_to_breadcrumbs(_as_list(response.get("markers")))
+    breadcrumbs = _markers_to_breadcrumbs(response.get("markers") or [])
     if breadcrumbs:
         data["breadcrumbs"] = {"values": breadcrumbs}
 
@@ -101,22 +101,10 @@ def apply_gpu_crash_symbolication(
     return data
 
 
-def _as_dict(value: Any) -> dict[str, Any]:
-    """Coerce untrusted teapot JSON to a dict (``{}`` otherwise)."""
-    return value if isinstance(value, dict) else {}
-
-
-def _as_list(value: Any) -> list[Any]:
-    """Coerce untrusted teapot JSON to a list (``[]`` otherwise)."""
-    return value if isinstance(value, list) else []
-
-
 def _primary_shader(response: Mapping[str, Any]) -> dict[str, Any]:
-    """First active shader, or ``{}`` (every level is untrusted JSON)."""
-    active_shaders = _as_dict(response.get("shader_context")).get("active_shaders")
-    if not isinstance(active_shaders, list) or not active_shaders:
-        return {}
-    return _as_dict(active_shaders[0])
+    """First active shader from teapot's response, or ``{}``."""
+    active = (response.get("shader_context") or {}).get("active_shaders") or []
+    return active[0] if active else {}
 
 
 def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
@@ -126,8 +114,8 @@ def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
     behind ``> { N items }``.
     """
 
-    fault = _as_dict(response.get("fault"))
-    gpu_state = _as_dict(response.get("gpu_state"))
+    fault = response.get("fault") or {}
+    gpu_state = response.get("gpu_state") or {}
     primary_shader = _primary_shader(response)
 
     flat: dict[str, Any] = {
@@ -154,9 +142,9 @@ def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
         "shader_hash": primary_shader.get("shader_hash"),
         "shader_type": primary_shader.get("shader_type"),
         "shader_debug_info_uid": primary_shader.get("shader_debug_info_uid"),
-        "missing_dif_count": len(_as_list(response.get("missing_difs"))),
+        "missing_dif_count": len(response.get("missing_difs") or []),
     }
-    warnings = _as_list(response.get("warnings"))
+    warnings = response.get("warnings") or []
     if warnings:
         flat["warnings"] = warnings
     return {k: v for k, v in flat.items() if v is not None}
@@ -185,15 +173,11 @@ def _merge_tags(existing: Any, extra: Mapping[str, str]) -> list[tuple[str, str]
     return list(merged.items())
 
 
-def _markers_to_breadcrumbs(markers: Any) -> list[dict[str, Any]]:
+def _markers_to_breadcrumbs(markers: list[Any]) -> list[dict[str, Any]]:
     """Map teapot's ``markers`` to breadcrumbs (often the only signal for
     non-shader crashes)."""
-    if not isinstance(markers, list):
-        return []
     out: list[dict[str, Any]] = []
     for m in markers:
-        if not isinstance(m, dict):
-            continue
         kind = m.get("kind") or "marker"
         label = m.get("label") or kind
         data = m.get("data")
@@ -210,43 +194,34 @@ def _markers_to_breadcrumbs(markers: Any) -> list[dict[str, Any]]:
     return out
 
 
-def _normalize_gpu_frames(teapot_frames: Any) -> list[dict[str, Any]]:
+def _normalize_gpu_frames(teapot_frames: list[Any]) -> list[dict[str, Any]]:
     """Map teapot's ``frames[]`` to Sentry stacktrace frames: pass through known
     fields, force ``symbolicator_status=symbolicated`` (shader frames have no
     debug image), and synthesise ``package`` from the shader hash."""
-    if not isinstance(teapot_frames, list):
-        return []
-
     normalized: list[dict[str, Any]] = []
     for raw in teapot_frames:
-        if not isinstance(raw, dict):
-            continue
-
         frame: dict[str, Any] = {}
-        for src, dst in (
-            ("function", "function"),
-            ("module", "module"),
-            ("filename", "filename"),
-            ("abs_path", "abs_path"),
-            ("lineno", "lineno"),
-            ("colno", "colno"),
-            ("instruction_addr", "instruction_addr"),
-            ("pre_context", "pre_context"),
-            ("context_line", "context_line"),
-            ("post_context", "post_context"),
+        for field in (
+            "function",
+            "module",
+            "filename",
+            "abs_path",
+            "lineno",
+            "colno",
+            "instruction_addr",
+            "pre_context",
+            "context_line",
+            "post_context",
         ):
-            value = raw.get(src)
+            value = raw.get(field)
             if value is not None:
-                frame[dst] = value
-        # `data` is external — only trust a mapping.
-        raw_data = raw.get("data")
-        if not isinstance(raw_data, dict):
-            raw_data = {}
+                frame[field] = value
+        raw_data = raw.get("data") or {}
         if raw_data:
             frame["data"] = dict(raw_data)
 
         shader_hash = raw_data.get("shader_hash")
-        if isinstance(shader_hash, str) and shader_hash and not frame.get("package"):
+        if shader_hash and not frame.get("package"):
             frame["package"] = (
                 shader_hash if shader_hash.startswith("shader_") else f"shader_{shader_hash}"
             )

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -8,7 +8,7 @@ GPU contexts, tags, breadcrumbs) before save. Enriches only — never bills.
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any
 
 from sentry.utils import metrics
@@ -20,8 +20,8 @@ GPU_CRASH_DUMP_ATTACHMENT_TYPE = "event.nv_gpudmp"
 
 
 def apply_gpu_crash_symbolication(
-    data: dict[str, Any], response: Mapping[str, Any]
-) -> dict[str, Any] | None:
+    data: MutableMapping[str, Any], response: Mapping[str, Any]
+) -> MutableMapping[str, Any] | None:
     """Apply teapot's decode to the in-flight GPU event, mutating ``data``.
 
     Returns the mutated event on success, or ``None`` for a ``failed``/unknown
@@ -75,8 +75,10 @@ def apply_gpu_crash_symbolication(
             "api": gpu_state.get("api"),
         }
     # Only fill os/app if the copied SDK scope didn't (teapot's are thinner).
+    # `os_version` is a combined string ("Windows 10 (19H1)"), so it's the raw
+    # description — not `name` (which drives OS filtering and wants the identity).
     if gpu_state.get("os_version") and "os" not in contexts:
-        contexts["os"] = {"name": gpu_state["os_version"], "type": "os"}
+        contexts["os"] = {"raw_description": str(gpu_state["os_version"]), "type": "os"}
     if gpu_state.get("application_name") and "app" not in contexts:
         contexts["app"] = {"app_name": gpu_state["application_name"], "type": "app"}
     data["contexts"] = contexts

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -68,12 +68,17 @@ def apply_gpu_crash_symbolication(
         contexts = {}
     contexts["gpu_crash"] = _build_flat_gpu_context(response)
     if gpu_state.get("device_name"):
-        contexts["gpu"] = {
-            "name": gpu_state["device_name"],
-            "driver_version": gpu_state.get("driver_version"),
-            "vendor_name": "NVIDIA",
-            "api": gpu_state.get("api"),
-        }
+        # Overlay teapot's crash-dump fields onto any SDK-provided `gpu` context so
+        # SDK-only fields (memory_size, vendor_id, ...) aren't wiped. `api_type` is
+        # the Sentry GPU-context schema field (not `api`).
+        gpu_ctx = dict(contexts.get("gpu") or {})
+        gpu_ctx["name"] = gpu_state["device_name"]
+        gpu_ctx["vendor_name"] = "NVIDIA"
+        if gpu_state.get("driver_version"):
+            gpu_ctx["driver_version"] = gpu_state["driver_version"]
+        if gpu_state.get("api"):
+            gpu_ctx["api_type"] = gpu_state["api"]
+        contexts["gpu"] = gpu_ctx
     # Only fill os/app if the copied SDK scope didn't (teapot's are thinner).
     # `os_version` is a combined string ("Windows 10 (19H1)"), so it's the raw
     # description — not `name` (which drives OS filtering and wants the identity).

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -189,7 +189,10 @@ def _markers_to_breadcrumbs(markers: list[Any]) -> list[dict[str, Any]]:
         kind = m.get("kind") or "marker"
         label = m.get("label") or kind
         data = m.get("data")
-        msg = label if isinstance(data, (dict, list)) else f"{label}: {data}"
+        # Scalar data goes in the message; a dict/list (or none) leaves it label-only.
+        msg = (
+            f"{label}: {data}" if data is not None and not isinstance(data, (dict, list)) else label
+        )
         out.append(
             {
                 "category": f"gpu.{kind}",

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -1,0 +1,296 @@
+"""GPU crash dump symbolication — teapot's decode applied to the in-flight event.
+
+The GPU crash arrives from Relay as its own native event carrying the
+``.nv-gpudmp`` attachment: Relay split it off the minidump/unreal upload and set
+the event id, trace context, release/environment and the ``cpu_event_id`` link.
+This module runs teapot over that attachment and applies the decode to the event
+in place — exception, grouping fingerprint, GPU contexts, tags and breadcrumbs —
+before it is saved through the normal pipeline. It enriches the event Relay
+created and billed; it never builds or bills one itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+# NVIDIA Aftermath GPU crash dump attachment, decoded by teapot.
+GPU_CRASH_DUMP_ATTACHMENT_TYPE = "event.nv_gpudmp"
+
+
+# ─────────────────────────── public entry point ────────────────────────────
+
+
+def apply_gpu_crash_symbolication(
+    data: dict[str, Any], response: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    """Apply teapot's decode to the in-flight GPU event, mutating ``data``.
+
+    Returns the mutated event on success, or ``None`` for a ``failed``/unknown
+    status (the event is still saved, unenriched). Relay owns identity, trace,
+    release and base tags; this only fills the GPU-specific fields.
+    """
+    status = response.get("status")
+    if status not in ("completed", "partial"):
+        metrics.incr("process.gpu.event.skipped", tags={"status": status or "unknown"})
+        return None
+
+    fault = _as_dict(response.get("fault"))
+    gpu_state = _as_dict(response.get("gpu_state"))
+    primary_shader = _primary_shader(response)
+    category = response.get("fault_category") or "unknown"
+
+    exc_type = response.get("title") or f"GPU crash ({category})"
+    subtitle_parts: list[str] = []
+    if fault.get("virtual_address"):
+        subtitle_parts.append(f"@ {fault['virtual_address']}")
+    if gpu_state.get("device_name"):
+        subtitle_parts.append(str(gpu_state["device_name"]))
+    if gpu_state.get("driver_version"):
+        subtitle_parts.append(f"driver {gpu_state['driver_version']}")
+    exc_value = " · ".join(subtitle_parts) or fault.get("description") or category
+
+    data["platform"] = "native"
+    data["level"] = "fatal"
+    data["fingerprint"] = list(_as_list(response.get("fingerprint"))) or ["gpu", category]
+    data["exception"] = {
+        "values": [
+            {
+                "type": exc_type,
+                "value": exc_value,
+                "stacktrace": {"frames": _normalize_gpu_frames(_as_list(response.get("frames")))},
+                "mechanism": {"type": "gpu_crash", "handled": False},
+            }
+        ]
+    }
+
+    contexts = data.get("contexts")
+    if not isinstance(contexts, dict):
+        contexts = {}
+    contexts["gpu_crash"] = _build_flat_gpu_context(response)
+    if gpu_state.get("device_name"):
+        contexts["gpu"] = {
+            "name": gpu_state["device_name"],
+            "driver_version": gpu_state.get("driver_version"),
+            "vendor_name": "NVIDIA",
+            "api": gpu_state.get("api"),
+        }
+    # Only-if-absent: the GPU event inherits the SDK's richer os/app contexts from
+    # the copied scope; teapot's thinner versions just fill the gap when the upload
+    # carried no SDK scope (e.g. a raw minidump).
+    if gpu_state.get("os_version") and "os" not in contexts:
+        contexts["os"] = {"name": gpu_state["os_version"], "type": "os"}
+    if gpu_state.get("application_name") and "app" not in contexts:
+        contexts["app"] = {"app_name": gpu_state["application_name"], "type": "app"}
+    data["contexts"] = contexts
+
+    gpu_tags: dict[str, str] = {
+        "gpu.fault_category": category,
+        "gpu.fault_type": fault.get("type") or "Unknown",
+    }
+    if primary_shader.get("shader_hash"):
+        gpu_tags["gpu.shader_hash"] = primary_shader["shader_hash"]
+    if primary_shader.get("shader_type"):
+        gpu_tags["gpu.shader_type"] = primary_shader["shader_type"]
+    data["tags"] = _merge_tags(data.get("tags"), gpu_tags)
+
+    breadcrumbs = _markers_to_breadcrumbs(_as_list(response.get("markers")))
+    if breadcrumbs:
+        data["breadcrumbs"] = {"values": breadcrumbs}
+
+    metrics.incr("process.gpu.event.symbolicated", tags={"fault_category": category})
+    return data
+
+
+# ─────────────────────────── event construction ────────────────────────────
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Coerce an untrusted teapot JSON value to a dict (``{}`` if it isn't one)."""
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    """Coerce an untrusted teapot JSON value to a list (``[]`` if it isn't one)."""
+    return value if isinstance(value, list) else []
+
+
+def _primary_shader(response: Mapping[str, Any]) -> dict[str, Any]:
+    """First active shader from teapot's response, or ``{}``.
+
+    Every level is untrusted external JSON, so type-check before indexing: a
+    truthy non-list ``active_shaders`` (or a non-dict entry) must not reach
+    ``active_shaders[0]`` / ``primary_shader.get(...)``.
+    """
+    active_shaders = _as_dict(response.get("shader_context")).get("active_shaders")
+    if not isinstance(active_shaders, list) or not active_shaders:
+        return {}
+    return _as_dict(active_shaders[0])
+
+
+def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten teapot's response into a ``contexts.gpu_crash`` dict.
+
+    Top-level scalars render inline in the context card; nested objects would
+    collapse behind ``> { N items }``, so we flatten fault / gpu_state out.
+    """
+
+    fault = _as_dict(response.get("fault"))
+    gpu_state = _as_dict(response.get("gpu_state"))
+    primary_shader = _primary_shader(response)
+
+    flat: dict[str, Any] = {
+        "type": "gpu_crash",
+        "status": response.get("status"),
+        # Top-level teapot fields — drive grouping + UX. Always populated
+        # in successful responses; missing only for `failed` ones.
+        "fault_category": response.get("fault_category"),
+        "title": response.get("title"),
+        "handler": response.get("handler"),
+        "sdk_version": response.get("sdk_version"),
+        "decode_time_ms": response.get("decode_time_ms"),
+        # Fault
+        "fault_type": fault.get("type"),
+        "fault_description": fault.get("description"),
+        "fault_code": fault.get("code"),
+        "virtual_address": fault.get("virtual_address"),
+        "access_type": fault.get("access_type"),
+        # GPU / host
+        "device_name": gpu_state.get("device_name"),
+        "device_status": gpu_state.get("device_status"),
+        "driver_version": gpu_state.get("driver_version"),
+        "graphics_api": gpu_state.get("api"),
+        "os_version": gpu_state.get("os_version"),
+        "application_name": gpu_state.get("application_name"),
+        "engine_reset": gpu_state.get("engine_reset"),
+        "adapter_reset": gpu_state.get("adapter_reset"),
+        # Shader (when present)
+        "shader_hash": primary_shader.get("shader_hash"),
+        "shader_type": primary_shader.get("shader_type"),
+        "shader_debug_info_uid": primary_shader.get("shader_debug_info_uid"),
+        # Missing debug files (surface count so users see when they need
+        # to fix their SDK integration).
+        "missing_dif_count": len(_as_list(response.get("missing_difs"))),
+    }
+    warnings = _as_list(response.get("warnings"))
+    if warnings:
+        flat["warnings"] = warnings
+    return {k: v for k, v in flat.items() if v is not None}
+
+
+# ─────────────────────────── frame / tag helpers ──────────────────────────
+
+
+def _merge_tags(
+    existing: Any,
+    extra: Mapping[str, str],
+) -> dict[str, str]:
+    """Merge the event's existing tags (dict or list-of-pairs form) with extras."""
+
+    merged: dict[str, str] = {}
+    if isinstance(existing, dict):
+        for k, v in existing.items():
+            if k is not None and v is not None:
+                merged[str(k)] = str(v)
+    elif isinstance(existing, list):
+        for entry in existing:
+            if isinstance(entry, (list, tuple)) and len(entry) == 2:
+                key, value = entry
+                if key is not None and value is not None:
+                    merged[str(key)] = str(value)
+            elif isinstance(entry, dict) and "key" in entry and "value" in entry:
+                merged[str(entry["key"])] = str(entry["value"])
+    for k, v in extra.items():
+        if v is not None:
+            merged[k] = str(v)
+    return merged
+
+
+def _markers_to_breadcrumbs(markers: Any) -> list[dict[str, Any]]:
+    """Map teapot's `markers` to breadcrumbs.
+
+    For non-shader crashes these are often the only actionable signal (the
+    CPU-side context that submitted the faulting GPU work).
+    """
+
+    if not isinstance(markers, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for m in markers:
+        if not isinstance(m, dict):
+            continue
+        kind = m.get("kind") or "marker"
+        label = m.get("label") or kind
+        data = m.get("data")
+        msg = label if isinstance(data, (dict, list)) else f"{label}: {data}"
+        out.append(
+            {
+                "category": f"gpu.{kind}",
+                "message": str(msg)[:512],
+                "type": "info",
+                "level": "info",
+                "data": data if isinstance(data, (dict, list)) else None,
+            }
+        )
+    return out
+
+
+def _normalize_gpu_frames(teapot_frames: Any) -> list[dict[str, Any]]:
+    """Map teapot's ``frames[]`` to Sentry stacktrace frames.
+
+    Mostly a pass-through of pre-populated fields, plus two normalisations:
+    force ``symbolicator_status=symbolicated`` (shader frames have no debug
+    image, so the walker would otherwise mark them missing), and synthesise a
+    ``package`` from the shader hash for the module column.
+    """
+
+    if not isinstance(teapot_frames, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for raw in teapot_frames:
+        if not isinstance(raw, dict):
+            continue
+
+        frame: dict[str, Any] = {}
+        for src, dst in (
+            ("function", "function"),
+            ("module", "module"),
+            ("filename", "filename"),
+            ("abs_path", "abs_path"),
+            ("lineno", "lineno"),
+            ("colno", "colno"),
+            ("instruction_addr", "instruction_addr"),
+            ("pre_context", "pre_context"),
+            ("context_line", "context_line"),
+            ("post_context", "post_context"),
+        ):
+            value = raw.get(src)
+            if value is not None:
+                frame[dst] = value
+        # `data` is external; only trust it if it's a mapping (a truthy
+        # str/list would crash `dict(...)` and the `.get()` below).
+        raw_data = raw.get("data")
+        if not isinstance(raw_data, dict):
+            raw_data = {}
+        if raw_data:
+            frame["data"] = dict(raw_data)
+
+        shader_hash = raw_data.get("shader_hash")
+        if isinstance(shader_hash, str) and shader_hash and not frame.get("package"):
+            frame["package"] = (
+                shader_hash if shader_hash.startswith("shader_") else f"shader_{shader_hash}"
+            )
+        if not frame.get("module") and frame.get("package"):
+            frame["module"] = frame["package"]
+
+        frame.setdefault("data", {})
+        frame["data"].setdefault("symbolicator_status", "symbolicated")
+        frame.setdefault("in_app", True)
+        normalized.append(frame)
+    return normalized

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -67,21 +67,16 @@ def apply_gpu_crash_symbolication(
     if not isinstance(contexts, dict):
         contexts = {}
     contexts["gpu_crash"] = _build_flat_gpu_context(response)
-    if gpu_state.get("device_name"):
-        # Overlay teapot's crash-dump fields onto any SDK-provided `gpu` context so
-        # SDK-only fields (memory_size, vendor_id, ...) aren't wiped. `api_type` is
-        # the Sentry GPU-context schema field (not `api`).
+    if any(gpu_state.get(k) for k in ("device_name", "driver_version", "api")):
         gpu_ctx = dict(contexts.get("gpu") or {})
-        gpu_ctx["name"] = gpu_state["device_name"]
-        gpu_ctx["vendor_name"] = "NVIDIA"
+        if gpu_state.get("device_name"):
+            gpu_ctx["name"] = gpu_state["device_name"]
         if gpu_state.get("driver_version"):
             gpu_ctx["driver_version"] = gpu_state["driver_version"]
         if gpu_state.get("api"):
             gpu_ctx["api_type"] = gpu_state["api"]
         contexts["gpu"] = gpu_ctx
-    # Only fill os/app if the copied SDK scope didn't (teapot's are thinner).
-    # `os_version` is a combined string ("Windows 10 (19H1)"), so it's the raw
-    # description — not `name` (which drives OS filtering and wants the identity).
+
     if gpu_state.get("os_version") and "os" not in contexts:
         contexts["os"] = {"raw_description": str(gpu_state["os_version"]), "type": "os"}
     if gpu_state.get("application_name") and "app" not in contexts:
@@ -100,8 +95,6 @@ def apply_gpu_crash_symbolication(
 
     marker_breadcrumbs = _markers_to_breadcrumbs(response.get("markers") or [])
     if marker_breadcrumbs:
-        # Append after any SDK/Relay breadcrumbs already on the split event (GPU
-        # markers are the most crash-proximate) rather than replacing them.
         existing = (data.get("breadcrumbs") or {}).get("values") or []
         data["breadcrumbs"] = {"values": [*existing, *marker_breadcrumbs]}
 
@@ -186,6 +179,8 @@ def _markers_to_breadcrumbs(markers: list[Any]) -> list[dict[str, Any]]:
     non-shader crashes)."""
     out: list[dict[str, Any]] = []
     for m in markers:
+        if not isinstance(m, dict):
+            continue
         kind = m.get("kind") or "marker"
         label = m.get("label") or kind
         data = m.get("data")
@@ -211,6 +206,8 @@ def _normalize_gpu_frames(teapot_frames: list[Any]) -> list[dict[str, Any]]:
     debug image), and synthesise ``package`` from the shader hash."""
     normalized: list[dict[str, Any]] = []
     for raw in teapot_frames:
+        if not isinstance(raw, dict):
+            continue
         frame: dict[str, Any] = {}
         for field in (
             "function",

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -57,6 +57,11 @@ def apply_gpu_crash_symbolication(
 
     data["platform"] = "native"
     data["level"] = "fatal"
+    # Relay typed the scope-only event as "default" (the exception is added here,
+    # after normalization). Re-type it as an error so the event title is derived
+    # from the exception below instead of defaulting to "<unlabeled event>";
+    # `get_event_type` trusts `data["type"]` and never re-infers it.
+    data["type"] = "error"
     data["fingerprint"] = list(_as_list(response.get("fingerprint"))) or ["gpu", category]
     data["exception"] = {
         "values": [

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -189,8 +189,14 @@ def _build_flat_gpu_context(response: Mapping[str, Any]) -> dict[str, Any]:
 def _merge_tags(
     existing: Any,
     extra: Mapping[str, str],
-) -> dict[str, str]:
-    """Merge the event's existing tags (dict or list-of-pairs form) with extras."""
+) -> list[tuple[str, str]]:
+    """Merge the event's existing tags with the GPU extras.
+
+    Returns the pipeline's canonical list-of-pairs form — what ``set_tag`` /
+    ``get_tag`` / ``pop_tag`` in ``event_manager`` operate on (a dict would break
+    them). Accepts either the dict or list-of-pairs input shape; extras win on a
+    key collision.
+    """
 
     merged: dict[str, str] = {}
     if isinstance(existing, dict):
@@ -208,7 +214,7 @@ def _merge_tags(
     for k, v in extra.items():
         if v is not None:
             merged[k] = str(v)
-    return merged
+    return list(merged.items())
 
 
 def _markers_to_breadcrumbs(markers: Any) -> list[dict[str, Any]]:

--- a/src/sentry/lang/native/gpu.py
+++ b/src/sentry/lang/native/gpu.py
@@ -93,9 +93,12 @@ def apply_gpu_crash_symbolication(
         gpu_tags["gpu.shader_type"] = primary_shader["shader_type"]
     data["tags"] = _merge_tags(data.get("tags"), gpu_tags)
 
-    breadcrumbs = _markers_to_breadcrumbs(response.get("markers") or [])
-    if breadcrumbs:
-        data["breadcrumbs"] = {"values": breadcrumbs}
+    marker_breadcrumbs = _markers_to_breadcrumbs(response.get("markers") or [])
+    if marker_breadcrumbs:
+        # Append after any SDK/Relay breadcrumbs already on the split event (GPU
+        # markers are the most crash-proximate) rather than replacing them.
+        existing = (data.get("breadcrumbs") or {}).get("values") or []
+        data["breadcrumbs"] = {"values": [*existing, *marker_breadcrumbs]}
 
     metrics.incr("process.gpu.event.symbolicated", tags={"fault_category": category})
     return data

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -98,11 +98,7 @@ class _RetryableTeapotError(TeapotUnavailable):
 
 def _resolve_url() -> str | None:
     base = getattr(settings, "SENTRY_TEAPOT_URL", None)
-    if base:
-        return base.rstrip("/")
-    configured = options.get("teapot.options") or {}
-    url = configured.get("url") if isinstance(configured, dict) else None
-    return url.rstrip("/") if url else None
+    return base.rstrip("/") if base else None
 
 
 class TeapotClient:

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -90,7 +90,14 @@ def _max_attempts() -> int:
 
 
 class TeapotUnavailable(Exception):
-    """Teapot is down or returned a non-retryable error. Caller should swallow."""
+    """Teapot is unreachable or erroring (network, timeout, exhausted 5xx retries,
+    malformed body) — a genuine outage. The caller trips the circuit breaker."""
+
+
+class TeapotRequestError(Exception):
+    """This request can't succeed regardless of teapot's health: the URL isn't
+    configured, an attachment is missing from objectstore, or teapot rejected the
+    request (4xx). NOT an outage — the caller skips without tripping the breaker."""
 
 
 def _resolve_url() -> str | None:
@@ -107,14 +114,15 @@ class TeapotClient:
 
     Every attachment (the `.nv-gpudmp` and each shader-debug `.nvdbg`) must be in
     objectstore; teapot fetches them by presigned URL. Raises `TeapotUnavailable`
-    on network errors, exhausted 5xx retries, or an attachment missing from
-    objectstore — callers treat that as "skip", never fatal.
+    on a genuine outage (network, exhausted 5xx retries) and `TeapotRequestError`
+    on a request the caller can't complete (unconfigured URL, missing attachment,
+    4xx) — callers treat both as "skip", never fatal.
     """
 
     def __init__(self, project: Any, event_id: str) -> None:
         base_url = _resolve_url()
         if not base_url:
-            raise TeapotUnavailable("SENTRY_TEAPOT_URL not configured")
+            raise TeapotRequestError("teapot url not configured")
         self.base_url = base_url
         self.project = project
         self.event_id = event_id
@@ -157,7 +165,7 @@ class TeapotClient:
         needs an ``HttpRequest`` and we're in a background task.
         """
         if not att.stored_id:
-            raise TeapotUnavailable(f"attachment {att.name!r} is not in objectstore")
+            raise TeapotRequestError(f"attachment {att.name!r} is not in objectstore")
         return maybe_rewrite_url_for_symbolicator(
             session.presigned_object_url("GET", att.stored_id, duration=_PRESIGNED_URL_TTL)
         )
@@ -199,7 +207,12 @@ class TeapotClient:
                         "body": resp.text[:512],
                     },
                 )
-                raise TeapotUnavailable(f"teapot returned {resp.status_code}: {resp.text[:256]}")
+                # A 4xx means teapot rejected this request but is itself healthy;
+                # only a 5xx (retryable ones already exhausted above) is an outage.
+                detail = f"teapot returned {resp.status_code}: {resp.text[:256]}"
+                if resp.status_code < 500:
+                    raise TeapotRequestError(detail)
+                raise TeapotUnavailable(detail)
 
             try:
                 return resp.json()
@@ -218,14 +231,22 @@ def submit_to_teapot(
     dump: TeapotAttachment,
     shader_debug_info: Sequence[TeapotAttachment] | None = None,
 ) -> dict[str, Any] | None:
-    """Best-effort teapot invocation. Returns None on any failure."""
+    """Best-effort teapot invocation.
+
+    Returns the decode on success, or None on a request/data error (unconfigured
+    URL, missing attachment, 4xx) — teapot is healthy, so the caller should not
+    trip the circuit breaker. Raises ``TeapotUnavailable`` on a genuine outage
+    (network, timeout, 5xx) so the caller can.
+    """
 
     try:
         client = TeapotClient(project=project, event_id=event_id)
         return client.symbolicate(dump, shader_debug_info or [])
-    except TeapotUnavailable as e:
-        logger.info("teapot.unavailable", extra={"event_id": event_id, "error": str(e)})
+    except TeapotRequestError as e:
+        logger.info("teapot.request_error", extra={"event_id": event_id, "error": str(e)})
         return None
+    except TeapotUnavailable:
+        raise  # a real outage — let the caller trip the breaker
     except Exception as e:
         sentry_sdk.capture_exception(e)
         logger.warning("teapot.unexpected_error", extra={"event_id": event_id, "error": str(e)})

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -1,9 +1,9 @@
 """HTTP client for teapot, the NVIDIA Aftermath ``.nv-gpudmp`` decode service.
 
 Synchronous request/response with a bounded retry on transient 5xx. Attachments
-are passed by reference: we hand teapot a short-lived presigned GET URL per
-attachment and it fetches the bytes from objectstore itself (self-authenticating
-URL, no bearer token, bytes never pass through the worker).
+are passed by reference: we hand teapot the same objectstore URL Symbolicator
+uses (``get_symbolicator_url``) per attachment and it fetches the bytes itself —
+bytes never pass through the worker.
 """
 
 from __future__ import annotations
@@ -12,7 +12,6 @@ import logging
 import re
 import time
 from collections.abc import Sequence
-from datetime import timedelta
 from typing import Any, Protocol
 
 import orjson
@@ -21,7 +20,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.objectstore import get_attachments_session, maybe_rewrite_url_for_symbolicator
+from sentry.objectstore import get_attachments_session, get_symbolicator_url
 
 logger = logging.getLogger(__name__)
 
@@ -51,9 +50,6 @@ class TeapotAttachment(Protocol):
     name: str
     stored_id: str | None
 
-
-# Presigned URLs live just long enough to cover the request window, then expire.
-_PRESIGNED_URL_TTL = timedelta(seconds=60)
 
 # Fallbacks for the `teapot.timeout-seconds` / `teapot.max-attempts` options.
 # The timeout is tight on purpose: decode is sub-second, so a slow teapot should
@@ -113,10 +109,10 @@ class TeapotClient:
     """Synchronous HTTP client for POST /symbolicate.
 
     Every attachment (the `.nv-gpudmp` and each shader-debug `.nvdbg`) must be in
-    objectstore; teapot fetches them by presigned URL. Raises `TeapotUnavailable`
-    on a genuine outage (network, exhausted 5xx retries) and `TeapotRequestError`
-    on a request the caller can't complete (unconfigured URL, missing attachment,
-    4xx) — callers treat both as "skip", never fatal.
+    objectstore; teapot fetches them by URL. Raises `TeapotUnavailable` on a
+    genuine outage (network, exhausted 5xx retries) and `TeapotRequestError` on a
+    request the caller can't complete (unconfigured URL, missing attachment, 4xx)
+    — callers treat both as "skip", never fatal.
     """
 
     def __init__(self, project: Any, event_id: str) -> None:
@@ -146,29 +142,24 @@ class TeapotClient:
             "event_id": self.event_id,
             "project_id": str(self.project.id),
             "organization_id": str(self.project.organization_id),
-            "dump": {"storage_url": self._presigned_url(session, dump)},
+            "dump": {"storage_url": self._storage_url(session, dump)},
             "shader_debug_info": [
                 {
                     "uid": _uid_from_nvdbg_filename(att.name) or att.name,
-                    "storage_url": self._presigned_url(session, att),
+                    "storage_url": self._storage_url(session, att),
                 }
                 for att in shader_debug_info
             ],
         }
         return self._send(url, headers=headers, data=orjson.dumps(body))
 
-    def _presigned_url(self, session: Any, att: TeapotAttachment) -> str:
-        """Short-lived self-authenticating GET URL for the attachment in objectstore.
-
-        Mirrors the internal-caller branch of
-        ``objectstore.get_download_redirect_url``, inlined because that helper
-        needs an ``HttpRequest`` and we're in a background task.
-        """
+    def _storage_url(self, session: Any, att: TeapotAttachment) -> str:
+        """The URL teapot fetches the attachment from — the same objectstore helper
+        Symbolicator uses (``get_symbolicator_url``), so both sibling decoders read
+        objectstore identically (internal URL, rewritten in dev/test)."""
         if not att.stored_id:
             raise TeapotRequestError(f"attachment {att.name!r} is not in objectstore")
-        return maybe_rewrite_url_for_symbolicator(
-            session.presigned_object_url("GET", att.stored_id, duration=_PRESIGNED_URL_TTL)
-        )
+        return get_symbolicator_url(session, att.stored_id)
 
     def _send(self, url: str, headers: dict[str, str], data: bytes) -> dict[str, Any]:
         last_exc: Exception | None = None

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Sequence
-from datetime import timedelta
 from typing import Any, Protocol
 
 import orjson
@@ -21,7 +20,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.objectstore import get_attachments_session, maybe_rewrite_url_for_symbolicator
+from sentry.objectstore import get_attachments_session, get_internal_download_url
 from sentry.utils.retries import ConditionalRetryPolicy
 
 logger = logging.getLogger(__name__)
@@ -52,9 +51,6 @@ class TeapotAttachment(Protocol):
     name: str
     stored_id: str | None
 
-
-# Presigned URLs live just long enough to cover the request window, then expire.
-_PRESIGNED_URL_TTL = timedelta(seconds=60)
 
 # Fallbacks for the `teapot.timeout-seconds` / `teapot.max-attempts` options.
 # The timeout is tight on purpose: decode is sub-second, so a slow teapot should
@@ -151,12 +147,11 @@ class TeapotClient:
         return self._send(url, headers=headers, data=orjson.dumps(body))
 
     def _storage_url(self, session: Any, att: TeapotAttachment) -> str:
-        """Short-lived self-authenticating (presigned) GET URL for the attachment."""
+        """Short-lived self-authenticating (presigned) GET URL for the attachment —
+        the shared internal objectstore helper (direct link, no auth header)."""
         if not att.stored_id:
             raise TeapotRequestError(f"attachment {att.name!r} is not in objectstore")
-        return maybe_rewrite_url_for_symbolicator(
-            session.object_url(att.stored_id, token_validity=_PRESIGNED_URL_TTL)
-        )
+        return get_internal_download_url(session, att.stored_id)
 
     def _send(self, url: str, headers: dict[str, str], data: bytes) -> dict[str, Any]:
         def attempt() -> dict[str, Any]:

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -1,14 +1,9 @@
-"""HTTP client for the teapot GPU crash dump symbolication service.
+"""HTTP client for teapot, the NVIDIA Aftermath ``.nv-gpudmp`` decode service.
 
-Teapot is a sibling to Symbolicator that decodes NVIDIA Aftermath `.nv-gpudmp`
-dumps. It's synchronous (one request/response, no polling) with a bounded retry
-on transient 5xx.
-
-Attachments are always passed by reference: the dump and each shader-debug
-`.nvdbg` live in objectstore, and we hand teapot a short-lived presigned GET URL
-per attachment. Teapot fetches the bytes directly from objectstore; they never
-pass through the Sentry worker, and no bearer token is exchanged (the presigned
-URL is self-authenticating).
+Synchronous request/response with a bounded retry on transient 5xx. Attachments
+are passed by reference: we hand teapot a short-lived presigned GET URL per
+attachment and it fetches the bytes from objectstore itself (self-authenticating
+URL, no bearer token, bytes never pass through the worker).
 """
 
 from __future__ import annotations
@@ -30,12 +25,9 @@ from sentry.objectstore import get_attachments_session, maybe_rewrite_url_for_sy
 
 logger = logging.getLogger(__name__)
 
-# teapot keys each shader debug attachment by its 32-hex `shader_debug_info_uid`
-# — the value Aftermath asks for via `shaderDebugInfoLookupCb` at decode time.
-# Relay preserves the SDK filename, which carries the uid in one of two shapes:
-#   * `<32-hex-uid>.nvdbg`      — production SDKs ship the full uid.
-#   * `<16-hex>-<16-hex>.nvdbg` — the NVIDIA D3D12HelloNsightAftermath sample
-#                                 splits id[0]/id[1] with a dash; concatenate.
+# teapot keys each shader by its 32-hex `shader_debug_info_uid`, which the SDK
+# encodes in the `.nvdbg` filename as either `<32-hex>.nvdbg` or (the NVIDIA
+# sample's) dash-split `<16-hex>-<16-hex>.nvdbg`.
 _NVDBG_UID_RE = re.compile(r"([0-9a-fA-F]{32})\.nvdbg$")
 _NVDBG_SPLIT_UID_RE = re.compile(r"([0-9a-fA-F]{16})-([0-9a-fA-F]{16})\.nvdbg$")
 
@@ -52,26 +44,20 @@ def _uid_from_nvdbg_filename(name: str) -> str | None:
 
 
 class TeapotAttachment(Protocol):
-    """The ``CachedAttachment`` surface the client needs, as a structural type.
-
-    Lets callers pass a real ``CachedAttachment`` or a test double. ``name`` is
-    the attachment filename — for a shader-debug ``.nvdbg`` it carries the
-    ``shader_debug_info_uid`` teapot looks the bytes back up by. ``stored_id`` is
-    the objectstore key we presign; every GPU-crash attachment must be stored.
-    """
+    """The ``CachedAttachment`` surface the client needs (real or test double):
+    ``name`` (the filename, carrying the uid for a ``.nvdbg``) and ``stored_id``
+    (the objectstore key we presign)."""
 
     name: str
     stored_id: str | None
 
 
-# Presigned GET URLs handed to teapot are valid just long enough to cover the
-# request window (timeout x attempts + backoff), then expire.
+# Presigned URLs live just long enough to cover the request window, then expire.
 _PRESIGNED_URL_TTL = timedelta(seconds=60)
 
-# Fallbacks; live values come from the `teapot.timeout-seconds` /
-# `teapot.max-attempts` options (see `_timeout` / `_max_attempts`). The decode is
-# sub-second in practice, so the timeout is deliberately tight — a slow teapot
-# should fail fast rather than hold a worker (and the circuit breaker takes over).
+# Fallbacks for the `teapot.timeout-seconds` / `teapot.max-attempts` options.
+# The timeout is tight on purpose: decode is sub-second, so a slow teapot should
+# fail fast (the circuit breaker then takes over) rather than hold a worker.
 DEFAULT_TIMEOUT = 5
 DEFAULT_MAX_ATTEMPTS = 2
 
@@ -108,9 +94,6 @@ class TeapotUnavailable(Exception):
 
 
 def _resolve_url() -> str | None:
-    # SENTRY_TEAPOT_URL (sourced from the TEAPOT env var) is the endpoint,
-    # mirroring SENTRY_TEMPEST_URL / SENTRY_VROOM. The automator-modifiable
-    # `teapot.options` url is a fallback for installs that don't set the env var.
     base = getattr(settings, "SENTRY_TEAPOT_URL", None)
     if base:
         return base.rstrip("/")
@@ -147,8 +130,6 @@ class TeapotClient:
             "X-Teapot-Version": "1",
             "X-Request-Id": self.event_id,
             "Content-Type": "application/json",
-            # event_id as idempotency key → teapot replays a cached 200 for a
-            # retried task instead of re-decoding.
             "Idempotency-Key": self.event_id,
         }
 
@@ -169,21 +150,13 @@ class TeapotClient:
         return self._send(url, headers=headers, data=orjson.dumps(body))
 
     def _presigned_url(self, session: Any, att: TeapotAttachment) -> str:
-        """Short-lived, self-authenticating GET URL for the attachment in objectstore.
+        """Short-lived self-authenticating GET URL for the attachment in objectstore.
 
-        This mirrors the internal-caller branch of
-        ``objectstore.get_download_redirect_url`` (the recommended presigned-download
-        path, already used for debug-file downloads). Teapot is an internal service
-        like Symbolicator, so it reads straight from Objectstore's internal URL. We
-        inline the branch rather than call the helper because it needs the
-        ``HttpRequest`` it's redirecting to choose internal-vs-cell-proxy, and we're
-        in a background task with no request. Presigned means teapot issues a plain
-        GET with no auth header — unlike Symbolicator today, which still passes
-        ``object_url`` + a minted bearer token.
+        Mirrors the internal-caller branch of
+        ``objectstore.get_download_redirect_url``, inlined because that helper
+        needs an ``HttpRequest`` and we're in a background task.
         """
         if not att.stored_id:
-            # GPU-crash attachments are always uploaded to objectstore; if one
-            # isn't, we can't build a presigned URL, so skip rather than inline.
             raise TeapotUnavailable(f"attachment {att.name!r} is not in objectstore")
         return maybe_rewrite_url_for_symbolicator(
             session.presigned_object_url("GET", att.stored_id, duration=_PRESIGNED_URL_TTL)

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -12,6 +12,7 @@ on transient 5xx. Two wire formats, picked per request:
 from __future__ import annotations
 
 import logging
+import re
 import time
 from collections.abc import Iterable, Sequence
 from typing import Any, Protocol
@@ -25,6 +26,26 @@ from sentry import options
 from sentry.objectstore import get_attachments_session, get_symbolicator_url
 
 logger = logging.getLogger(__name__)
+
+# teapot keys each shader debug attachment by its 32-hex `shader_debug_info_uid`
+# — the value Aftermath asks for via `shaderDebugInfoLookupCb` at decode time.
+# Relay preserves the SDK filename, which carries the uid in one of two shapes:
+#   * `<32-hex-uid>.nvdbg`      — production SDKs ship the full uid.
+#   * `<16-hex>-<16-hex>.nvdbg` — the NVIDIA D3D12HelloNsightAftermath sample
+#                                 splits id[0]/id[1] with a dash; concatenate.
+_NVDBG_UID_RE = re.compile(r"([0-9a-fA-F]{32})\.nvdbg$")
+_NVDBG_SPLIT_UID_RE = re.compile(r"([0-9a-fA-F]{16})-([0-9a-fA-F]{16})\.nvdbg$")
+
+
+def _uid_from_nvdbg_filename(name: str) -> str | None:
+    """Recover the 32-hex `shader_debug_info_uid` from a `.nvdbg` filename, or None."""
+    m = _NVDBG_UID_RE.search(name)
+    if m is not None:
+        return m.group(1).lower()
+    m = _NVDBG_SPLIT_UID_RE.search(name)
+    if m is not None:
+        return (m.group(1) + m.group(2)).lower()
+    return None
 
 
 class TeapotAttachment(Protocol):
@@ -108,9 +129,10 @@ class TeapotClient:
     """Synchronous HTTP client for POST /symbolicate.
 
     `shader_debug_info` is the list of shader-debug `.nvdbg` attachments (one per
-    shader; an empty list is fine) — teapot recovers each shader's uid from the
-    attachment filename. Raises `TeapotUnavailable` on network errors or
-    exhausted 5xx retries — callers treat that as "skip", never fatal.
+    shader; an empty list is fine); we key each to teapot by the
+    `shader_debug_info_uid` recovered from its filename. Raises `TeapotUnavailable`
+    on network errors or exhausted 5xx retries — callers treat that as "skip",
+    never fatal.
     """
 
     def __init__(self, project: Any, event_id: str) -> None:
@@ -161,7 +183,7 @@ class TeapotClient:
             },
             "shader_debug_info": [
                 {
-                    "filename": att.name,
+                    "uid": _uid_from_nvdbg_filename(att.name) or att.name,
                     "storage_url": get_symbolicator_url(session, _require_stored_id(att)),
                     "storage_token": session.mint_token(),
                 }
@@ -186,8 +208,8 @@ class TeapotClient:
             "project_id": str(self.project.id),
             "organization_id": str(self.project.organization_id),
         }
-        # A repeated `nv_shader_debug` field per shader; the part filename carries
-        # the uid teapot decodes it by. A list-of-tuples lets the field repeat.
+        # One `nv_shader_debug.<uid>` field per shader — teapot keys off the uid
+        # in the field name. A list-of-tuples lets the field name repeat.
         files: list[tuple[str, tuple[str, bytes, str]]] = [
             (
                 "upload_file",
@@ -195,9 +217,10 @@ class TeapotClient:
             ),
         ]
         for att in shader_debug_info:
+            uid = _uid_from_nvdbg_filename(att.name) or att.name
             files.append(
                 (
-                    "nv_shader_debug",
+                    f"nv_shader_debug.{uid}",
                     (
                         att.name,
                         att.load_data(self.project),

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -22,7 +22,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.objectstore import get_attachments_session, get_internal_download_url
+from sentry.objectstore import UsecaseId, get_internal_download_url, get_session
 from sentry.utils import metrics
 from sentry.utils.retries import ConditionalRetryPolicy
 
@@ -143,7 +143,7 @@ class TeapotClient:
         shader_debug_info = shader_debug_info or []
         url = f"{self.base_url}/symbolicate"
 
-        session = get_attachments_session(self.project.organization_id, self.project.id)
+        session = get_session(UsecaseId.ATTACHMENTS, self.project)
         body: dict[str, Any] = {
             "event_id": self.event_id,
             "project_id": str(self.project.id),

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -9,6 +9,8 @@ token, and the bytes never pass through the worker.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import logging
 import re
 from collections.abc import Sequence
@@ -21,6 +23,7 @@ from django.conf import settings
 
 from sentry import options
 from sentry.objectstore import get_attachments_session, get_internal_download_url
+from sentry.utils import metrics
 from sentry.utils.retries import ConditionalRetryPolicy
 
 logger = logging.getLogger(__name__)
@@ -96,9 +99,29 @@ class _RetryableTeapotError(TeapotUnavailable):
     caller as its ``TeapotUnavailable`` base — an outage that trips the breaker."""
 
 
+# Presigned objectstore URLs carry a short-lived read token in their query string.
+# teapot may echo our request body back in an error response, so strip query strings
+# from any URL before it reaches the logs (log retention can outlive the token TTL).
+_URL_QUERY_RE = re.compile(r"(https?://[^\s\"']+?)\?[^\s\"']*")
+
+
+def _redact_urls(text: str) -> str:
+    return _URL_QUERY_RE.sub(r"\1?<redacted>", text)
+
+
 def _resolve_url() -> str | None:
     base = getattr(settings, "SENTRY_TEAPOT_URL", None)
     return base.rstrip("/") if base else None
+
+
+def _auth_headers(body: bytes) -> dict[str, str]:
+    """HMAC-sign the request body with the shared secret"""
+    secret = getattr(settings, "SENTRY_TEAPOT_SHARED_SECRET", "")
+    if not secret:
+        metrics.incr("tasks.gpu_crash.teapot_unsigned_request")
+        return {}
+    signature = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return {"Authorization": f"Rpcsignature rpc0:{signature}"}
 
 
 class TeapotClient:
@@ -119,12 +142,6 @@ class TeapotClient:
     ) -> dict[str, Any]:
         shader_debug_info = shader_debug_info or []
         url = f"{self.base_url}/symbolicate"
-        headers = {
-            "X-Teapot-Version": "1",
-            "X-Request-Id": self.event_id,
-            "Content-Type": "application/json",
-            "Idempotency-Key": self.event_id,
-        }
 
         session = get_attachments_session(self.project.organization_id, self.project.id)
         body: dict[str, Any] = {
@@ -140,7 +157,15 @@ class TeapotClient:
                 for att in shader_debug_info
             ],
         }
-        return self._send(url, headers=headers, data=orjson.dumps(body))
+        data = orjson.dumps(body)
+        headers = {
+            "X-Teapot-Version": "1",
+            "X-Request-Id": self.event_id,
+            "Content-Type": "application/json",
+            "Idempotency-Key": self.event_id,
+            **_auth_headers(data),
+        }
+        return self._send(url, headers=headers, data=data)
 
     def _storage_url(self, session: Any, att: TeapotAttachment) -> str:
         """Short-lived self-authenticating (presigned) GET URL for the attachment —
@@ -160,17 +185,18 @@ class TeapotClient:
                 raise _RetryableTeapotError(f"teapot returned {resp.status_code}")
 
             if resp.status_code >= 400:
+                safe_body = _redact_urls(resp.text[:512])
                 logger.warning(
                     "teapot.request_failed",
                     extra={
                         "event_id": self.event_id,
                         "status": resp.status_code,
-                        "body": resp.text[:512],
+                        "body": safe_body,
                     },
                 )
                 # A 4xx means teapot rejected this request but is itself healthy;
                 # only a 5xx (retryable ones are handled above) is an outage.
-                detail = f"teapot returned {resp.status_code}: {resp.text[:256]}"
+                detail = f"teapot returned {resp.status_code}: {safe_body[:256]}"
                 if resp.status_code < 500:
                     raise TeapotRequestError(detail)
                 raise TeapotUnavailable(detail)

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -31,9 +31,12 @@ class TeapotAttachment(Protocol):
     """The ``CachedAttachment`` surface the client needs, as a structural type.
 
     Lets callers pass a real ``CachedAttachment``, the ``EventAttachment``
-    adapter from the async task, or a test double.
+    adapter from the async task, or a test double. ``name`` is the attachment
+    filename — for a shader-debug ``.nvdbg`` it carries the
+    ``shader_debug_info_uid`` teapot looks the bytes back up by.
     """
 
+    name: str
     stored_id: str | None
 
     def load_data(self, project: Any) -> bytes: ...
@@ -94,20 +97,19 @@ def _resolve_url() -> str | None:
     return url.rstrip("/") if url else None
 
 
-def _all_stored(
-    dump: TeapotAttachment, shader_debug_info: Iterable[tuple[str, TeapotAttachment]]
-) -> bool:
+def _all_stored(dump: TeapotAttachment, shader_debug_info: Iterable[TeapotAttachment]) -> bool:
     # JSON path requires every attachment in objectstore; else fall to multipart.
     if not dump.stored_id:
         return False
-    return all(att.stored_id for _, att in shader_debug_info)
+    return all(att.stored_id for att in shader_debug_info)
 
 
 class TeapotClient:
     """Synchronous HTTP client for POST /symbolicate.
 
-    `shader_debug_info` is a list of (uid, attachment) pairs (one per shader);
-    an empty list is fine. Raises `TeapotUnavailable` on network errors or
+    `shader_debug_info` is the list of shader-debug `.nvdbg` attachments (one per
+    shader; an empty list is fine) — teapot recovers each shader's uid from the
+    attachment filename. Raises `TeapotUnavailable` on network errors or
     exhausted 5xx retries — callers treat that as "skip", never fatal.
     """
 
@@ -122,7 +124,7 @@ class TeapotClient:
     def symbolicate(
         self,
         dump: TeapotAttachment,
-        shader_debug_info: Sequence[tuple[str, TeapotAttachment]] | None = None,
+        shader_debug_info: Sequence[TeapotAttachment] | None = None,
     ) -> dict[str, Any]:
         shader_debug_info = shader_debug_info or []
         url = f"{self.base_url}/symbolicate"
@@ -143,7 +145,7 @@ class TeapotClient:
         url: str,
         headers: dict[str, str],
         dump: TeapotAttachment,
-        shader_debug_info: Sequence[tuple[str, TeapotAttachment]],
+        shader_debug_info: Sequence[TeapotAttachment],
     ) -> dict[str, Any]:
         """Pass attachments to teapot by reference — bytes stay in objectstore."""
 
@@ -159,11 +161,11 @@ class TeapotClient:
             },
             "shader_debug_info": [
                 {
-                    "uid": uid,
+                    "filename": att.name,
                     "storage_url": get_symbolicator_url(session, _require_stored_id(att)),
                     "storage_token": session.mint_token(),
                 }
-                for uid, att in shader_debug_info
+                for att in shader_debug_info
             ],
         }
         return self._send(
@@ -175,7 +177,7 @@ class TeapotClient:
         url: str,
         headers: dict[str, str],
         dump: TeapotAttachment,
-        shader_debug_info: Sequence[tuple[str, TeapotAttachment]],
+        shader_debug_info: Sequence[TeapotAttachment],
     ) -> dict[str, Any]:
         """Fallback: load bytes and POST them inline when not all in objectstore."""
 
@@ -184,19 +186,20 @@ class TeapotClient:
             "project_id": str(self.project.id),
             "organization_id": str(self.project.organization_id),
         }
-        # list-of-tuples lets us send N `nv_shader_debug.<uid>` fields per request.
+        # A repeated `nv_shader_debug` field per shader; the part filename carries
+        # the uid teapot decodes it by. A list-of-tuples lets the field repeat.
         files: list[tuple[str, tuple[str, bytes, str]]] = [
             (
                 "upload_file",
                 ("dump.nv-gpudmp", dump.load_data(self.project), "application/octet-stream"),
             ),
         ]
-        for uid, att in shader_debug_info:
+        for att in shader_debug_info:
             files.append(
                 (
-                    f"nv_shader_debug.{uid}",
+                    "nv_shader_debug",
                     (
-                        f"{uid}.nvdbg",
+                        att.name,
                         att.load_data(self.project),
                         "application/octet-stream",
                     ),
@@ -270,7 +273,7 @@ def submit_to_teapot(
     project: Any,
     event_id: str,
     dump: TeapotAttachment,
-    shader_debug_info: Sequence[tuple[str, TeapotAttachment]] | None = None,
+    shader_debug_info: Sequence[TeapotAttachment] | None = None,
 ) -> dict[str, Any] | None:
     """Best-effort teapot invocation. Returns None on any failure."""
 

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -2,11 +2,13 @@
 
 Teapot is a sibling to Symbolicator that decodes NVIDIA Aftermath `.nv-gpudmp`
 dumps. It's synchronous (one request/response, no polling) with a bounded retry
-on transient 5xx. Two wire formats, picked per request:
+on transient 5xx.
 
-* JSON + storage_url + token when every attachment is in objectstore (bytes
-  stay in objectstore, mirroring Symbolicator's minidump path).
-* multipart raw bytes otherwise (legacy V1 storage / self-hosted).
+Attachments are always passed by reference: the dump and each shader-debug
+`.nvdbg` live in objectstore, and we hand teapot a short-lived presigned GET URL
+per attachment. Teapot fetches the bytes directly from objectstore; they never
+pass through the Sentry worker, and no bearer token is exchanged (the presigned
+URL is self-authenticating).
 """
 
 from __future__ import annotations
@@ -14,7 +16,8 @@ from __future__ import annotations
 import logging
 import re
 import time
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
+from datetime import timedelta
 from typing import Any, Protocol
 
 import orjson
@@ -23,7 +26,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.objectstore import get_attachments_session, get_symbolicator_url
+from sentry.objectstore import get_attachments_session, maybe_rewrite_url_for_symbolicator
 
 logger = logging.getLogger(__name__)
 
@@ -51,27 +54,25 @@ def _uid_from_nvdbg_filename(name: str) -> str | None:
 class TeapotAttachment(Protocol):
     """The ``CachedAttachment`` surface the client needs, as a structural type.
 
-    Lets callers pass a real ``CachedAttachment``, the ``EventAttachment``
-    adapter from the async task, or a test double. ``name`` is the attachment
-    filename — for a shader-debug ``.nvdbg`` it carries the
-    ``shader_debug_info_uid`` teapot looks the bytes back up by.
+    Lets callers pass a real ``CachedAttachment`` or a test double. ``name`` is
+    the attachment filename — for a shader-debug ``.nvdbg`` it carries the
+    ``shader_debug_info_uid`` teapot looks the bytes back up by. ``stored_id`` is
+    the objectstore key we presign; every GPU-crash attachment must be stored.
     """
 
     name: str
     stored_id: str | None
 
-    def load_data(self, project: Any) -> bytes: ...
 
-
-def _require_stored_id(att: TeapotAttachment) -> str:
-    # Only the JSON path calls this, gated on `_all_stored`; narrows str | None.
-    assert att.stored_id is not None
-    return att.stored_id
-
+# Presigned GET URLs handed to teapot are valid just long enough to cover the
+# request window (timeout x attempts + backoff), then expire.
+_PRESIGNED_URL_TTL = timedelta(seconds=60)
 
 # Fallbacks; live values come from the `teapot.timeout-seconds` /
-# `teapot.max-attempts` options (see `_timeout` / `_max_attempts`).
-DEFAULT_TIMEOUT = 25
+# `teapot.max-attempts` options (see `_timeout` / `_max_attempts`). The decode is
+# sub-second in practice, so the timeout is deliberately tight — a slow teapot
+# should fail fast rather than hold a worker (and the circuit breaker takes over).
+DEFAULT_TIMEOUT = 5
 DEFAULT_MAX_ATTEMPTS = 2
 
 RETRYABLE_STATUS = (502, 503, 504)
@@ -118,21 +119,13 @@ def _resolve_url() -> str | None:
     return url.rstrip("/") if url else None
 
 
-def _all_stored(dump: TeapotAttachment, shader_debug_info: Iterable[TeapotAttachment]) -> bool:
-    # JSON path requires every attachment in objectstore; else fall to multipart.
-    if not dump.stored_id:
-        return False
-    return all(att.stored_id for att in shader_debug_info)
-
-
 class TeapotClient:
     """Synchronous HTTP client for POST /symbolicate.
 
-    `shader_debug_info` is the list of shader-debug `.nvdbg` attachments (one per
-    shader; an empty list is fine); we key each to teapot by the
-    `shader_debug_info_uid` recovered from its filename. Raises `TeapotUnavailable`
-    on network errors or exhausted 5xx retries — callers treat that as "skip",
-    never fatal.
+    Every attachment (the `.nv-gpudmp` and each shader-debug `.nvdbg`) must be in
+    objectstore; teapot fetches them by presigned URL. Raises `TeapotUnavailable`
+    on network errors, exhausted 5xx retries, or an attachment missing from
+    objectstore — callers treat that as "skip", never fatal.
     """
 
     def __init__(self, project: Any, event_id: str) -> None:
@@ -153,102 +146,56 @@ class TeapotClient:
         headers = {
             "X-Teapot-Version": "1",
             "X-Request-Id": self.event_id,
+            "Content-Type": "application/json",
             # event_id as idempotency key → teapot replays a cached 200 for a
             # retried task instead of re-decoding.
             "Idempotency-Key": self.event_id,
         }
 
-        if _all_stored(dump, shader_debug_info):
-            return self._post_json(url, headers, dump, shader_debug_info)
-        return self._post_multipart(url, headers, dump, shader_debug_info)
-
-    def _post_json(
-        self,
-        url: str,
-        headers: dict[str, str],
-        dump: TeapotAttachment,
-        shader_debug_info: Sequence[TeapotAttachment],
-    ) -> dict[str, Any]:
-        """Pass attachments to teapot by reference — bytes stay in objectstore."""
-
         session = get_attachments_session(self.project.organization_id, self.project.id)
-        dump_url = get_symbolicator_url(session, _require_stored_id(dump))
         body: dict[str, Any] = {
             "event_id": self.event_id,
             "project_id": str(self.project.id),
             "organization_id": str(self.project.organization_id),
-            "dump": {
-                "storage_url": dump_url,
-                "storage_token": session.mint_token(),
-            },
+            "dump": {"storage_url": self._presigned_url(session, dump)},
             "shader_debug_info": [
                 {
                     "uid": _uid_from_nvdbg_filename(att.name) or att.name,
-                    "storage_url": get_symbolicator_url(session, _require_stored_id(att)),
-                    "storage_token": session.mint_token(),
+                    "storage_url": self._presigned_url(session, att),
                 }
                 for att in shader_debug_info
             ],
         }
-        return self._send(
-            url, headers={**headers, "Content-Type": "application/json"}, data=orjson.dumps(body)
+        return self._send(url, headers=headers, data=orjson.dumps(body))
+
+    def _presigned_url(self, session: Any, att: TeapotAttachment) -> str:
+        """Short-lived, self-authenticating GET URL for the attachment in objectstore.
+
+        This mirrors the internal-caller branch of
+        ``objectstore.get_download_redirect_url`` (the recommended presigned-download
+        path, already used for debug-file downloads). Teapot is an internal service
+        like Symbolicator, so it reads straight from Objectstore's internal URL. We
+        inline the branch rather than call the helper because it needs the
+        ``HttpRequest`` it's redirecting to choose internal-vs-cell-proxy, and we're
+        in a background task with no request. Presigned means teapot issues a plain
+        GET with no auth header — unlike Symbolicator today, which still passes
+        ``object_url`` + a minted bearer token.
+        """
+        if not att.stored_id:
+            # GPU-crash attachments are always uploaded to objectstore; if one
+            # isn't, we can't build a presigned URL, so skip rather than inline.
+            raise TeapotUnavailable(f"attachment {att.name!r} is not in objectstore")
+        return maybe_rewrite_url_for_symbolicator(
+            session.presigned_object_url("GET", att.stored_id, duration=_PRESIGNED_URL_TTL)
         )
 
-    def _post_multipart(
-        self,
-        url: str,
-        headers: dict[str, str],
-        dump: TeapotAttachment,
-        shader_debug_info: Sequence[TeapotAttachment],
-    ) -> dict[str, Any]:
-        """Fallback: load bytes and POST them inline when not all in objectstore."""
-
-        data: dict[str, str] = {
-            "event_id": self.event_id,
-            "project_id": str(self.project.id),
-            "organization_id": str(self.project.organization_id),
-        }
-        # One `nv_shader_debug.<uid>` field per shader — teapot keys off the uid
-        # in the field name. A list-of-tuples lets the field name repeat.
-        files: list[tuple[str, tuple[str, bytes, str]]] = [
-            (
-                "upload_file",
-                ("dump.nv-gpudmp", dump.load_data(self.project), "application/octet-stream"),
-            ),
-        ]
-        for att in shader_debug_info:
-            uid = _uid_from_nvdbg_filename(att.name) or att.name
-            files.append(
-                (
-                    f"nv_shader_debug.{uid}",
-                    (
-                        att.name,
-                        att.load_data(self.project),
-                        "application/octet-stream",
-                    ),
-                )
-            )
-        return self._send(url, headers=headers, data=data, files=files)
-
-    def _send(
-        self,
-        url: str,
-        headers: dict[str, str],
-        data: Any = None,
-        files: Any = None,
-    ) -> dict[str, Any]:
+    def _send(self, url: str, headers: dict[str, str], data: bytes) -> dict[str, Any]:
         last_exc: Exception | None = None
         timeout = _timeout()
         attempts = _max_attempts()
         for attempt in range(attempts):
             try:
-                resp = requests.post(
-                    url,
-                    data=data,
-                    files=files,
-                    headers=headers,
-                    timeout=timeout,
-                )
+                resp = requests.post(url, data=data, headers=headers, timeout=timeout)
             except requests.RequestException as e:
                 last_exc = e
                 logger.info(

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import logging
 import re
-import time
 from collections.abc import Sequence
 from datetime import timedelta
 from typing import Any, Protocol
@@ -23,6 +22,7 @@ from django.conf import settings
 
 from sentry import options
 from sentry.objectstore import get_attachments_session, maybe_rewrite_url_for_symbolicator
+from sentry.utils.retries import ConditionalRetryPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -69,13 +69,6 @@ RETRY_BACKOFF_SECONDS = 0.5
 RETRY_BACKOFF_MAX_SECONDS = 4.0
 
 
-def _sleep_before_retry(attempt: int, attempts: int) -> None:
-    """Back off before the next attempt; no-op after the final one."""
-    if attempt + 1 >= attempts:
-        return
-    time.sleep(min(RETRY_BACKOFF_SECONDS * (2**attempt), RETRY_BACKOFF_MAX_SECONDS))
-
-
 def _timeout() -> int:
     try:
         return int(options.get("teapot.timeout-seconds")) or DEFAULT_TIMEOUT
@@ -99,6 +92,12 @@ class TeapotRequestError(Exception):
     """This request can't succeed regardless of teapot's health: the URL isn't
     configured, an attachment is missing from objectstore, or teapot rejected the
     request (4xx). NOT an outage — the caller skips without tripping the breaker."""
+
+
+class _RetryableTeapotError(TeapotUnavailable):
+    """Internal marker for a transient failure (network error or retryable 5xx).
+    The retry policy retries on it; once attempts are exhausted it surfaces to the
+    caller as its ``TeapotUnavailable`` base — an outage that trips the breaker."""
 
 
 def _resolve_url() -> str | None:
@@ -160,32 +159,14 @@ class TeapotClient:
         )
 
     def _send(self, url: str, headers: dict[str, str], data: bytes) -> dict[str, Any]:
-        last_exc: Exception | None = None
-        timeout = _timeout()
-        attempts = _max_attempts()
-        for attempt in range(attempts):
+        def attempt() -> dict[str, Any]:
             try:
-                resp = requests.post(url, data=data, headers=headers, timeout=timeout)
+                resp = requests.post(url, data=data, headers=headers, timeout=_timeout())
             except requests.RequestException as e:
-                last_exc = e
-                logger.info(
-                    "teapot.request_exception",
-                    extra={"attempt": attempt, "event_id": self.event_id, "error": str(e)},
-                )
-                _sleep_before_retry(attempt, attempts)
-                continue
+                raise _RetryableTeapotError(f"teapot request failed: {e}") from e
 
             if resp.status_code in RETRYABLE_STATUS:
-                logger.info(
-                    "teapot.retryable_status",
-                    extra={
-                        "attempt": attempt,
-                        "event_id": self.event_id,
-                        "status": resp.status_code,
-                    },
-                )
-                _sleep_before_retry(attempt, attempts)
-                continue
+                raise _RetryableTeapotError(f"teapot returned {resp.status_code}")
 
             if resp.status_code >= 400:
                 logger.warning(
@@ -197,7 +178,7 @@ class TeapotClient:
                     },
                 )
                 # A 4xx means teapot rejected this request but is itself healthy;
-                # only a 5xx (retryable ones already exhausted above) is an outage.
+                # only a 5xx (retryable ones are handled above) is an outage.
                 detail = f"teapot returned {resp.status_code}: {resp.text[:256]}"
                 if resp.status_code < 500:
                     raise TeapotRequestError(detail)
@@ -208,10 +189,18 @@ class TeapotClient:
             except ValueError as e:
                 raise TeapotUnavailable(f"teapot returned non-JSON body: {e}") from e
 
-        msg = "teapot exhausted retries"
-        if last_exc is not None:
-            raise TeapotUnavailable(msg) from last_exc
-        raise TeapotUnavailable(msg)
+        attempts = _max_attempts()
+
+        def should_retry(i: int, exc: Exception) -> bool:
+            return i < attempts and isinstance(exc, _RetryableTeapotError)
+
+        def backoff(i: int) -> float:
+            return min(RETRY_BACKOFF_SECONDS * 2 ** (i - 1), RETRY_BACKOFF_MAX_SECONDS)
+
+        try:
+            return ConditionalRetryPolicy(should_retry, backoff)(attempt)
+        except _RetryableTeapotError as e:
+            raise TeapotUnavailable("teapot exhausted retries") from e
 
 
 def submit_to_teapot(

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -1,9 +1,10 @@
 """HTTP client for teapot, the NVIDIA Aftermath ``.nv-gpudmp`` decode service.
 
 Synchronous request/response with a bounded retry on transient 5xx. Attachments
-are passed by reference: we hand teapot the same objectstore URL Symbolicator
-uses (``get_symbolicator_url``) per attachment and it fetches the bytes itself —
-bytes never pass through the worker.
+are passed by reference: we hand teapot a short-lived self-authenticating
+(presigned) GET URL per attachment — the read-only token is embedded in the URL's
+query string, so teapot fetches the bytes from objectstore itself with no bearer
+token, and the bytes never pass through the worker.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import logging
 import re
 import time
 from collections.abc import Sequence
+from datetime import timedelta
 from typing import Any, Protocol
 
 import orjson
@@ -20,7 +22,7 @@ import sentry_sdk
 from django.conf import settings
 
 from sentry import options
-from sentry.objectstore import get_attachments_session, get_symbolicator_url
+from sentry.objectstore import get_attachments_session, maybe_rewrite_url_for_symbolicator
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +52,9 @@ class TeapotAttachment(Protocol):
     name: str
     stored_id: str | None
 
+
+# Presigned URLs live just long enough to cover the request window, then expire.
+_PRESIGNED_URL_TTL = timedelta(seconds=60)
 
 # Fallbacks for the `teapot.timeout-seconds` / `teapot.max-attempts` options.
 # The timeout is tight on purpose: decode is sub-second, so a slow teapot should
@@ -106,14 +111,7 @@ def _resolve_url() -> str | None:
 
 
 class TeapotClient:
-    """Synchronous HTTP client for POST /symbolicate.
-
-    Every attachment (the `.nv-gpudmp` and each shader-debug `.nvdbg`) must be in
-    objectstore; teapot fetches them by URL. Raises `TeapotUnavailable` on a
-    genuine outage (network, exhausted 5xx retries) and `TeapotRequestError` on a
-    request the caller can't complete (unconfigured URL, missing attachment, 4xx)
-    — callers treat both as "skip", never fatal.
-    """
+    """Synchronous HTTP client for POST /symbolicate."""
 
     def __init__(self, project: Any, event_id: str) -> None:
         base_url = _resolve_url()
@@ -154,12 +152,12 @@ class TeapotClient:
         return self._send(url, headers=headers, data=orjson.dumps(body))
 
     def _storage_url(self, session: Any, att: TeapotAttachment) -> str:
-        """The URL teapot fetches the attachment from — the same objectstore helper
-        Symbolicator uses (``get_symbolicator_url``), so both sibling decoders read
-        objectstore identically (internal URL, rewritten in dev/test)."""
+        """Short-lived self-authenticating (presigned) GET URL for the attachment."""
         if not att.stored_id:
             raise TeapotRequestError(f"attachment {att.name!r} is not in objectstore")
-        return get_symbolicator_url(session, att.stored_id)
+        return maybe_rewrite_url_for_symbolicator(
+            session.object_url(att.stored_id, token_validity=_PRESIGNED_URL_TTL)
+        )
 
     def _send(self, url: str, headers: dict[str, str], data: bytes) -> dict[str, Any]:
         last_exc: Exception | None = None

--- a/src/sentry/lang/native/teapot.py
+++ b/src/sentry/lang/native/teapot.py
@@ -1,0 +1,286 @@
+"""HTTP client for the teapot GPU crash dump symbolication service.
+
+Teapot is a sibling to Symbolicator that decodes NVIDIA Aftermath `.nv-gpudmp`
+dumps. It's synchronous (one request/response, no polling) with a bounded retry
+on transient 5xx. Two wire formats, picked per request:
+
+* JSON + storage_url + token when every attachment is in objectstore (bytes
+  stay in objectstore, mirroring Symbolicator's minidump path).
+* multipart raw bytes otherwise (legacy V1 storage / self-hosted).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterable, Sequence
+from typing import Any, Protocol
+
+import orjson
+import requests
+import sentry_sdk
+from django.conf import settings
+
+from sentry import options
+from sentry.objectstore import get_attachments_session, get_symbolicator_url
+
+logger = logging.getLogger(__name__)
+
+
+class TeapotAttachment(Protocol):
+    """The ``CachedAttachment`` surface the client needs, as a structural type.
+
+    Lets callers pass a real ``CachedAttachment``, the ``EventAttachment``
+    adapter from the async task, or a test double.
+    """
+
+    stored_id: str | None
+
+    def load_data(self, project: Any) -> bytes: ...
+
+
+def _require_stored_id(att: TeapotAttachment) -> str:
+    # Only the JSON path calls this, gated on `_all_stored`; narrows str | None.
+    assert att.stored_id is not None
+    return att.stored_id
+
+
+# Fallbacks; live values come from the `teapot.timeout-seconds` /
+# `teapot.max-attempts` options (see `_timeout` / `_max_attempts`).
+DEFAULT_TIMEOUT = 25
+DEFAULT_MAX_ATTEMPTS = 2
+
+RETRYABLE_STATUS = (502, 503, 504)
+
+# Bounded exponential backoff between transient retries.
+RETRY_BACKOFF_SECONDS = 0.5
+RETRY_BACKOFF_MAX_SECONDS = 4.0
+
+
+def _sleep_before_retry(attempt: int, attempts: int) -> None:
+    """Back off before the next attempt; no-op after the final one."""
+    if attempt + 1 >= attempts:
+        return
+    time.sleep(min(RETRY_BACKOFF_SECONDS * (2**attempt), RETRY_BACKOFF_MAX_SECONDS))
+
+
+def _timeout() -> int:
+    try:
+        return int(options.get("teapot.timeout-seconds")) or DEFAULT_TIMEOUT
+    except Exception:
+        return DEFAULT_TIMEOUT
+
+
+def _max_attempts() -> int:
+    try:
+        return max(1, int(options.get("teapot.max-attempts")))
+    except Exception:
+        return DEFAULT_MAX_ATTEMPTS
+
+
+class TeapotUnavailable(Exception):
+    """Teapot is down or returned a non-retryable error. Caller should swallow."""
+
+
+def _resolve_url() -> str | None:
+    # SENTRY_TEAPOT_URL (sourced from the TEAPOT env var) is the endpoint,
+    # mirroring SENTRY_TEMPEST_URL / SENTRY_VROOM. The automator-modifiable
+    # `teapot.options` url is a fallback for installs that don't set the env var.
+    base = getattr(settings, "SENTRY_TEAPOT_URL", None)
+    if base:
+        return base.rstrip("/")
+    configured = options.get("teapot.options") or {}
+    url = configured.get("url") if isinstance(configured, dict) else None
+    return url.rstrip("/") if url else None
+
+
+def _all_stored(
+    dump: TeapotAttachment, shader_debug_info: Iterable[tuple[str, TeapotAttachment]]
+) -> bool:
+    # JSON path requires every attachment in objectstore; else fall to multipart.
+    if not dump.stored_id:
+        return False
+    return all(att.stored_id for _, att in shader_debug_info)
+
+
+class TeapotClient:
+    """Synchronous HTTP client for POST /symbolicate.
+
+    `shader_debug_info` is a list of (uid, attachment) pairs (one per shader);
+    an empty list is fine. Raises `TeapotUnavailable` on network errors or
+    exhausted 5xx retries — callers treat that as "skip", never fatal.
+    """
+
+    def __init__(self, project: Any, event_id: str) -> None:
+        base_url = _resolve_url()
+        if not base_url:
+            raise TeapotUnavailable("SENTRY_TEAPOT_URL not configured")
+        self.base_url = base_url
+        self.project = project
+        self.event_id = event_id
+
+    def symbolicate(
+        self,
+        dump: TeapotAttachment,
+        shader_debug_info: Sequence[tuple[str, TeapotAttachment]] | None = None,
+    ) -> dict[str, Any]:
+        shader_debug_info = shader_debug_info or []
+        url = f"{self.base_url}/symbolicate"
+        headers = {
+            "X-Teapot-Version": "1",
+            "X-Request-Id": self.event_id,
+            # event_id as idempotency key → teapot replays a cached 200 for a
+            # retried task instead of re-decoding.
+            "Idempotency-Key": self.event_id,
+        }
+
+        if _all_stored(dump, shader_debug_info):
+            return self._post_json(url, headers, dump, shader_debug_info)
+        return self._post_multipart(url, headers, dump, shader_debug_info)
+
+    def _post_json(
+        self,
+        url: str,
+        headers: dict[str, str],
+        dump: TeapotAttachment,
+        shader_debug_info: Sequence[tuple[str, TeapotAttachment]],
+    ) -> dict[str, Any]:
+        """Pass attachments to teapot by reference — bytes stay in objectstore."""
+
+        session = get_attachments_session(self.project.organization_id, self.project.id)
+        dump_url = get_symbolicator_url(session, _require_stored_id(dump))
+        body: dict[str, Any] = {
+            "event_id": self.event_id,
+            "project_id": str(self.project.id),
+            "organization_id": str(self.project.organization_id),
+            "dump": {
+                "storage_url": dump_url,
+                "storage_token": session.mint_token(),
+            },
+            "shader_debug_info": [
+                {
+                    "uid": uid,
+                    "storage_url": get_symbolicator_url(session, _require_stored_id(att)),
+                    "storage_token": session.mint_token(),
+                }
+                for uid, att in shader_debug_info
+            ],
+        }
+        return self._send(
+            url, headers={**headers, "Content-Type": "application/json"}, data=orjson.dumps(body)
+        )
+
+    def _post_multipart(
+        self,
+        url: str,
+        headers: dict[str, str],
+        dump: TeapotAttachment,
+        shader_debug_info: Sequence[tuple[str, TeapotAttachment]],
+    ) -> dict[str, Any]:
+        """Fallback: load bytes and POST them inline when not all in objectstore."""
+
+        data: dict[str, str] = {
+            "event_id": self.event_id,
+            "project_id": str(self.project.id),
+            "organization_id": str(self.project.organization_id),
+        }
+        # list-of-tuples lets us send N `nv_shader_debug.<uid>` fields per request.
+        files: list[tuple[str, tuple[str, bytes, str]]] = [
+            (
+                "upload_file",
+                ("dump.nv-gpudmp", dump.load_data(self.project), "application/octet-stream"),
+            ),
+        ]
+        for uid, att in shader_debug_info:
+            files.append(
+                (
+                    f"nv_shader_debug.{uid}",
+                    (
+                        f"{uid}.nvdbg",
+                        att.load_data(self.project),
+                        "application/octet-stream",
+                    ),
+                )
+            )
+        return self._send(url, headers=headers, data=data, files=files)
+
+    def _send(
+        self,
+        url: str,
+        headers: dict[str, str],
+        data: Any = None,
+        files: Any = None,
+    ) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        timeout = _timeout()
+        attempts = _max_attempts()
+        for attempt in range(attempts):
+            try:
+                resp = requests.post(
+                    url,
+                    data=data,
+                    files=files,
+                    headers=headers,
+                    timeout=timeout,
+                )
+            except requests.RequestException as e:
+                last_exc = e
+                logger.info(
+                    "teapot.request_exception",
+                    extra={"attempt": attempt, "event_id": self.event_id, "error": str(e)},
+                )
+                _sleep_before_retry(attempt, attempts)
+                continue
+
+            if resp.status_code in RETRYABLE_STATUS:
+                logger.info(
+                    "teapot.retryable_status",
+                    extra={
+                        "attempt": attempt,
+                        "event_id": self.event_id,
+                        "status": resp.status_code,
+                    },
+                )
+                _sleep_before_retry(attempt, attempts)
+                continue
+
+            if resp.status_code >= 400:
+                logger.warning(
+                    "teapot.request_failed",
+                    extra={
+                        "event_id": self.event_id,
+                        "status": resp.status_code,
+                        "body": resp.text[:512],
+                    },
+                )
+                raise TeapotUnavailable(f"teapot returned {resp.status_code}: {resp.text[:256]}")
+
+            try:
+                return resp.json()
+            except ValueError as e:
+                raise TeapotUnavailable(f"teapot returned non-JSON body: {e}") from e
+
+        msg = "teapot exhausted retries"
+        if last_exc is not None:
+            raise TeapotUnavailable(msg) from last_exc
+        raise TeapotUnavailable(msg)
+
+
+def submit_to_teapot(
+    project: Any,
+    event_id: str,
+    dump: TeapotAttachment,
+    shader_debug_info: Sequence[tuple[str, TeapotAttachment]] | None = None,
+) -> dict[str, Any] | None:
+    """Best-effort teapot invocation. Returns None on any failure."""
+
+    try:
+        client = TeapotClient(project=project, event_id=event_id)
+        return client.symbolicate(dump, shader_debug_info or [])
+    except TeapotUnavailable as e:
+        logger.info("teapot.unavailable", extra={"event_id": event_id, "error": str(e)})
+        return None
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        logger.warning("teapot.unexpected_error", extra={"event_id": event_id, "error": str(e)})
+        return None

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import time
 from collections.abc import Mapping
@@ -7,8 +6,6 @@ from typing import Any, overload
 from sentry.attachments import CachedAttachment, get_attachments_for_event
 from sentry.stacktraces.processing import StacktraceInfo
 from sentry.utils.safe import get_path
-
-logger = logging.getLogger(__name__)
 
 # Regex to guess whether we're dealing with Windows or Unix paths.
 WINDOWS_PATH_RE = re.compile(r"^([a-z]:\\|\\\\)", re.IGNORECASE)
@@ -165,30 +162,15 @@ def is_applecrashreport_event(data):
     return get_path(exceptions, 0, "mechanism", "type") == "applecrashreport"
 
 
-def find_gpu_crash_dump_attachment(data: Any) -> Any:
-    """Return the GPU crash dump attachment for this event, or None.
+def find_gpu_crash_dump_attachment(data: Any) -> CachedAttachment | None:
+    """Return the `.nv-gpudmp` GPU crash dump attachment for this event, or None.
 
-    Matches the canonical `event.nv_gpudmp` type, else any `event.attachment`
-    named `*.nv-gpudmp` — the filename fallback covers Relay versions that
-    downgrade the unknown attachment type until they land native support.
+    Relay classifies it as `event.nv_gpudmp` when it splits the GPU crash onto
+    its own event, so matching that type alone is enough.
     """
     from sentry.lang.native.gpu import GPU_CRASH_DUMP_ATTACHMENT_TYPE
 
-    canonical = get_event_attachment(data, GPU_CRASH_DUMP_ATTACHMENT_TYPE)
-    if canonical is not None:
-        return canonical
-
-    for attachment in get_attachments_for_event(data):
-        if attachment.type != "event.attachment":
-            continue
-        name = getattr(attachment, "name", None) or ""
-        if name.endswith(".nv-gpudmp"):
-            return attachment
-    return None
-
-
-def has_gpu_crash_dump_attachment(data: Any) -> bool:
-    return find_gpu_crash_dump_attachment(data) is not None
+    return get_event_attachment(data, GPU_CRASH_DUMP_ATTACHMENT_TYPE)
 
 
 # CPU crash-report attachment types. Their presence means the event is the CPU
@@ -209,59 +191,21 @@ def is_gpu_crash_event(data: Any) -> bool:
     return all(get_event_attachment(data, ty) is None for ty in _CPU_CRASH_REPORT_TYPES)
 
 
-# Shader debug info accompanies the `.nv-gpudmp`, one `.nvdbg` per shader named
-# by its `shader_debug_info_uid` — the key Aftermath uses to look the bytes back
-# up at decode time. We forward each to teapot keyed by that uid.
+# Shader debug info accompanies the `.nv-gpudmp`, one `.nvdbg` per shader. Relay
+# classifies each as `event.nv_shader_debug`; teapot recovers the shader's
+# `shader_debug_info_uid` from the attachment filename at decode time.
 SHADER_DEBUG_INFO_ATTACHMENT_TYPE = "event.nv_shader_debug"
 
-# The decoder looks up shader debug info by a 32-hex `shader_debug_info_uid`
-# ("{id[0]:016x}{id[1]:016x}"). Two filename shapes carry it (kept in sync with
-# teapot's own `_uid_from_nvdbg_filename`):
-#   * `<32-hex-uid>.nvdbg`      — production SDKs ship the full uid; pass through.
-#   * `<16-hex>-<16-hex>.nvdbg` — the NVIDIA `D3D12HelloNsightAftermath` sample
-#                                 splits id[0]/id[1] with a dash; concatenate.
-_NVDBG_UID_RE = re.compile(r"(?P<uid>[0-9a-fA-F]{32})\.nvdbg$")
-_NVDBG_SPLIT_UID_RE = re.compile(r"(?P<id0>[0-9a-fA-F]{16})-(?P<id1>[0-9a-fA-F]{16})\.nvdbg$")
 
+def find_all_shader_debug_attachments(data: Any) -> list[CachedAttachment]:
+    """Return every shader-debug-info (`.nvdbg`) attachment for this event.
 
-def _uid_from_nvdbg_filename(name: str) -> str | None:
-    """Recover the 32-hex shader_debug_info_uid from a `.nvdbg` filename, or None."""
-    m = _NVDBG_UID_RE.search(name)
-    if m is not None:
-        return m.group("uid").lower()
-    m = _NVDBG_SPLIT_UID_RE.search(name)
-    if m is not None:
-        return (m.group("id0") + m.group("id1")).lower()
-    return None
-
-
-def find_all_shader_debug_attachments(data: Any) -> list[tuple[str, CachedAttachment]]:
-    """Return every shader-debug-info attachment, as `(uid, attachment)` pairs.
-
-    Same type-or-filename fallback as `find_gpu_crash_dump_attachment`; skips
-    attachments whose filename carries no parseable uid.
+    Relay already selected the right set and typed each `event.nv_shader_debug`,
+    so we forward them all untouched — no filename parsing or uid matching here.
     """
-    out: list[tuple[str, CachedAttachment]] = []
-    seen_uids: set[str] = set()
-    for attachment in get_attachments_for_event(data):
-        ty = getattr(attachment, "type", "") or ""
-        name = getattr(attachment, "name", None) or ""
-        if ty != SHADER_DEBUG_INFO_ATTACHMENT_TYPE and not (
-            ty == "event.attachment" and name.endswith(".nvdbg")
-        ):
-            continue
-        uid = _uid_from_nvdbg_filename(name)
-        if uid is None:
-            logger.info(
-                "gpu.shader_debug.unparseable_name",
-                extra={"attachment_name": name, "type": ty},
-            )
-            continue
-        if uid in seen_uids:
-            continue
-        seen_uids.add(uid)
-        out.append((uid, attachment))
-    return out
+    return [
+        a for a in get_attachments_for_event(data) if a.type == SHADER_DEBUG_INFO_ATTACHMENT_TYPE
+    ]
 
 
 class Backoff:

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any, overload
 
 from sentry.attachments import CachedAttachment, get_attachments_for_event
+from sentry.lang.native.gpu import GPU_CRASH_DUMP_ATTACHMENT_TYPE
 from sentry.stacktraces.processing import StacktraceInfo
 from sentry.utils.safe import get_path
 
@@ -168,8 +169,6 @@ def find_gpu_crash_dump_attachment(data: Any) -> CachedAttachment | None:
     Relay classifies it as `event.nv_gpudmp` when it splits the GPU crash onto
     its own event, so matching that type alone is enough.
     """
-    from sentry.lang.native.gpu import GPU_CRASH_DUMP_ATTACHMENT_TYPE
-
     return get_event_attachment(data, GPU_CRASH_DUMP_ATTACHMENT_TYPE)
 
 

--- a/src/sentry/lang/native/utils.py
+++ b/src/sentry/lang/native/utils.py
@@ -165,6 +165,105 @@ def is_applecrashreport_event(data):
     return get_path(exceptions, 0, "mechanism", "type") == "applecrashreport"
 
 
+def find_gpu_crash_dump_attachment(data: Any) -> Any:
+    """Return the GPU crash dump attachment for this event, or None.
+
+    Matches the canonical `event.nv_gpudmp` type, else any `event.attachment`
+    named `*.nv-gpudmp` — the filename fallback covers Relay versions that
+    downgrade the unknown attachment type until they land native support.
+    """
+    from sentry.lang.native.gpu import GPU_CRASH_DUMP_ATTACHMENT_TYPE
+
+    canonical = get_event_attachment(data, GPU_CRASH_DUMP_ATTACHMENT_TYPE)
+    if canonical is not None:
+        return canonical
+
+    for attachment in get_attachments_for_event(data):
+        if attachment.type != "event.attachment":
+            continue
+        name = getattr(attachment, "name", None) or ""
+        if name.endswith(".nv-gpudmp"):
+            return attachment
+    return None
+
+
+def has_gpu_crash_dump_attachment(data: Any) -> bool:
+    return find_gpu_crash_dump_attachment(data) is not None
+
+
+# CPU crash-report attachment types. Their presence means the event is the CPU
+# crash (symbolicator's job), not the GPU event Relay split off.
+_CPU_CRASH_REPORT_TYPES = ("event.minidump", "event.applecrashreport", "playstation.prosperodump")
+
+
+def is_gpu_crash_event(data: Any) -> bool:
+    """True for a GPU crash event that teapot should symbolicate.
+
+    Relay splits a GPU dump onto its own event — a `.nv-gpudmp` and no CPU crash
+    report — for opted-in orgs. When an org hasn't opted in, Relay leaves the dump
+    on the CPU crash event; a crash report on the same event means "leave it to
+    CPU symbolication", so we must not route it to teapot.
+    """
+    if find_gpu_crash_dump_attachment(data) is None:
+        return False
+    return all(get_event_attachment(data, ty) is None for ty in _CPU_CRASH_REPORT_TYPES)
+
+
+# Shader debug info accompanies the `.nv-gpudmp`, one `.nvdbg` per shader named
+# by its `shader_debug_info_uid` — the key Aftermath uses to look the bytes back
+# up at decode time. We forward each to teapot keyed by that uid.
+SHADER_DEBUG_INFO_ATTACHMENT_TYPE = "event.nv_shader_debug"
+
+# The decoder looks up shader debug info by a 32-hex `shader_debug_info_uid`
+# ("{id[0]:016x}{id[1]:016x}"). Two filename shapes carry it (kept in sync with
+# teapot's own `_uid_from_nvdbg_filename`):
+#   * `<32-hex-uid>.nvdbg`      — production SDKs ship the full uid; pass through.
+#   * `<16-hex>-<16-hex>.nvdbg` — the NVIDIA `D3D12HelloNsightAftermath` sample
+#                                 splits id[0]/id[1] with a dash; concatenate.
+_NVDBG_UID_RE = re.compile(r"(?P<uid>[0-9a-fA-F]{32})\.nvdbg$")
+_NVDBG_SPLIT_UID_RE = re.compile(r"(?P<id0>[0-9a-fA-F]{16})-(?P<id1>[0-9a-fA-F]{16})\.nvdbg$")
+
+
+def _uid_from_nvdbg_filename(name: str) -> str | None:
+    """Recover the 32-hex shader_debug_info_uid from a `.nvdbg` filename, or None."""
+    m = _NVDBG_UID_RE.search(name)
+    if m is not None:
+        return m.group("uid").lower()
+    m = _NVDBG_SPLIT_UID_RE.search(name)
+    if m is not None:
+        return (m.group("id0") + m.group("id1")).lower()
+    return None
+
+
+def find_all_shader_debug_attachments(data: Any) -> list[tuple[str, CachedAttachment]]:
+    """Return every shader-debug-info attachment, as `(uid, attachment)` pairs.
+
+    Same type-or-filename fallback as `find_gpu_crash_dump_attachment`; skips
+    attachments whose filename carries no parseable uid.
+    """
+    out: list[tuple[str, CachedAttachment]] = []
+    seen_uids: set[str] = set()
+    for attachment in get_attachments_for_event(data):
+        ty = getattr(attachment, "type", "") or ""
+        name = getattr(attachment, "name", None) or ""
+        if ty != SHADER_DEBUG_INFO_ATTACHMENT_TYPE and not (
+            ty == "event.attachment" and name.endswith(".nvdbg")
+        ):
+            continue
+        uid = _uid_from_nvdbg_filename(name)
+        if uid is None:
+            logger.info(
+                "gpu.shader_debug.unparseable_name",
+                extra={"attachment_name": name, "type": ty},
+            )
+            continue
+        if uid in seen_uids:
+            continue
+        seen_uids.add(uid)
+        out.append((uid, attachment))
+    return out
+
+
 class Backoff:
     """
     Creates a new exponential backoff.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -440,23 +440,20 @@ register(
     default={"url": "http://127.0.0.1:8125"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# The decode is sub-second in practice; keep the timeout tight so a slow teapot
-# fails fast (holds a worker briefly) rather than pinning it. The circuit breaker
-# then trips on sustained failures so tasks skip teapot entirely.
+# Tight timeout: decode is sub-second, so a slow teapot should fail fast.
 register(
     "teapot.timeout-seconds",
     default=5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Retries only on transient 5xx; kept low so a slow teapot can't pile up work.
+# Retries only on transient 5xx; low so a slow teapot can't pile up work.
 register(
     "teapot.max-attempts",
     default=2,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Circuit breaker around teapot: after `error_limit` failures within
-# `error_limit_window` seconds, skip teapot for `broken_state_duration` seconds
-# (events still save, unenriched) so a teapot outage can't back up the GPU pool.
+# After `error_limit` failures in `error_limit_window`s, skip teapot for
+# `broken_state_duration`s so an outage can't back up the GPU pool.
 register(
     "teapot.circuit-breaker-config",
     default={

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -440,15 +440,30 @@ register(
     default={"url": "http://127.0.0.1:8125"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# The decode is sub-second in practice; keep the timeout tight so a slow teapot
+# fails fast (holds a worker briefly) rather than pinning it. The circuit breaker
+# then trips on sustained failures so tasks skip teapot entirely.
 register(
     "teapot.timeout-seconds",
-    default=25,
+    default=5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Retries only on transient 5xx; kept low so a slow teapot can't pile up work.
 register(
     "teapot.max-attempts",
     default=2,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Circuit breaker around teapot: after `error_limit` failures within
+# `error_limit_window` seconds, skip teapot for `broken_state_duration` seconds
+# (events still save, unenriched) so a teapot outage can't back up the GPU pool.
+register(
+    "teapot.circuit-breaker-config",
+    default={
+        "error_limit_window": 60,
+        "error_limit": 20,
+        "broken_state_duration": 60,
+    },
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1588,6 +1588,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "store.load-shed-gpu-crash-projects",
+    type=Any,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "post_process.get-autoassign-owners",
     type=Sequence,
     default=[],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -429,6 +429,29 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Teapot (GPU crash dump symbolication service)
+register(
+    "teapot.enabled",
+    default=False,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "teapot.options",
+    default={"url": "http://127.0.0.1:8125"},
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "teapot.timeout-seconds",
+    default=25,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Retries only on transient 5xx; kept low so a slow teapot can't pile up work.
+register(
+    "teapot.max-attempts",
+    default=2,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch for symbolication sources, based on a list of source IDs. Meant to be used in extreme
 # situations where it is preferable to break symbolication in a few places as opposed to letting
 # it break everywhere.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -435,11 +435,6 @@ register(
     default=False,
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "teapot.options",
-    default={"url": "http://127.0.0.1:8125"},
-    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Tight timeout: decode is sub-second, so a slow teapot should fail fast.
 register(
     "teapot.timeout-seconds",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -394,6 +394,29 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Teapot (GPU crash dump symbolication service)
+register(
+    "teapot.enabled",
+    default=False,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "teapot.options",
+    default={"url": "http://127.0.0.1:8125"},
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "teapot.timeout-seconds",
+    default=25,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Retries only on transient 5xx; kept low so a slow teapot can't pile up work.
+register(
+    "teapot.max-attempts",
+    default=2,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch for symbolication sources, based on a list of source IDs. Meant to be used in extreme
 # situations where it is preferable to break symbolication in a few places as opposed to letting
 # it break everywhere.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1438,6 +1438,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "store.load-shed-gpu-crash-projects",
+    type=Any,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "post_process.get-autoassign-owners",
     type=Sequence,
     default=[],

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -405,15 +405,30 @@ register(
     default={"url": "http://127.0.0.1:8125"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# The decode is sub-second in practice; keep the timeout tight so a slow teapot
+# fails fast (holds a worker briefly) rather than pinning it. The circuit breaker
+# then trips on sustained failures so tasks skip teapot entirely.
 register(
     "teapot.timeout-seconds",
-    default=25,
+    default=5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Retries only on transient 5xx; kept low so a slow teapot can't pile up work.
 register(
     "teapot.max-attempts",
     default=2,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Circuit breaker around teapot: after `error_limit` failures within
+# `error_limit_window` seconds, skip teapot for `broken_state_duration` seconds
+# (events still save, unenriched) so a teapot outage can't back up the GPU pool.
+register(
+    "teapot.circuit-breaker-config",
+    default={
+        "error_limit_window": 60,
+        "error_limit": 20,
+        "broken_state_duration": 60,
+    },
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -405,23 +405,20 @@ register(
     default={"url": "http://127.0.0.1:8125"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# The decode is sub-second in practice; keep the timeout tight so a slow teapot
-# fails fast (holds a worker briefly) rather than pinning it. The circuit breaker
-# then trips on sustained failures so tasks skip teapot entirely.
+# Tight timeout: decode is sub-second, so a slow teapot should fail fast.
 register(
     "teapot.timeout-seconds",
     default=5,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Retries only on transient 5xx; kept low so a slow teapot can't pile up work.
+# Retries only on transient 5xx; low so a slow teapot can't pile up work.
 register(
     "teapot.max-attempts",
     default=2,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Circuit breaker around teapot: after `error_limit` failures within
-# `error_limit_window` seconds, skip teapot for `broken_state_duration` seconds
-# (events still save, unenriched) so a teapot outage can't back up the GPU pool.
+# After `error_limit` failures in `error_limit_window`s, skip teapot for
+# `broken_state_duration`s so an outage can't back up the GPU pool.
 register(
     "teapot.circuit-breaker-config",
     default={

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -62,6 +62,7 @@ EXPOSABLE_FEATURES = [
     "organizations:view-hierarchy-scrubbing",
     "organizations:performance-issues-spans",
     "organizations:relay-playstation-ingestion",
+    "organizations:gpu-crash-symbolication",
     "projects:span-v2-attachment-processing",
     "projects:trace-attachment-processing",
     "projects:relay-minidump-uploads",

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -68,6 +68,7 @@ EXPOSABLE_FEATURES = [
     "organizations:view-hierarchy-scrubbing",
     "organizations:performance-issues-spans",
     "organizations:relay-playstation-ingestion",
+    "organizations:gpu-crash-symbolication",
     "projects:span-v2-experimental-processing",
     "projects:span-v2-attachment-processing",
     "projects:trace-attachment-processing",

--- a/src/sentry/tasks/gpu_crash.py
+++ b/src/sentry/tasks/gpu_crash.py
@@ -1,12 +1,9 @@
 """Isolated GPU crash dump symbolication task.
 
-The GPU crash arrives from Relay as its own native event (see
-``sentry.lang.native.gpu``) carrying the ``.nv-gpudmp`` attachment.
-``preprocess_event`` routes such events here — a dedicated task in the
-``gpu.crash_dump`` namespace, so a slow or unavailable teapot can never back up
-CPU symbolication. We run teapot, apply the decode to the in-flight event, and
-hand it to the normal save pipeline. Best-effort: on any failure the event is
-still saved through ``submit_process``, just unenriched.
+``preprocess_event`` routes GPU events here — a dedicated ``gpu.crash_dump``
+namespace, so a slow/down teapot can't back up CPU symbolication. Runs teapot,
+applies the decode, and hands the event to the normal save pipeline. Best-effort:
+any failure still saves the event (unenriched) via ``submit_process``.
 """
 
 from __future__ import annotations
@@ -58,7 +55,6 @@ def submit_symbolicate_gpu_crash(
 @instrumented_task(
     name="sentry.tasks.symbolicate_gpu_crash_event",
     namespace=gpu_crash_dump_tasks,
-    # Bounds how long a stuck teapot can hold a worker in the GPU pool.
     processing_deadline_duration=120,
     silo_mode=SiloMode.CELL,
 )
@@ -104,11 +100,10 @@ def symbolicate_gpu_crash_event(
 
 
 def _try_symbolicate(data: Any, project_id: int, event_id: str) -> bool:
-    """Best-effort teapot symbolication. Returns whether ``data`` was enriched.
+    """Best-effort teapot symbolication; returns whether ``data`` was enriched.
 
-    Every failure is swallowed: teapot being slow, down, or wrong must never stop
-    the GPU event from saving. The kill switch and feature flag are re-checked
-    here so ops can halt already-queued work.
+    All failures are swallowed — teapot must never block the save. The kill
+    switch and feature flag are re-checked here so ops can halt queued work.
     """
     from sentry.lang.native.gpu import apply_gpu_crash_symbolication
     from sentry.lang.native.teapot import submit_to_teapot

--- a/src/sentry/tasks/gpu_crash.py
+++ b/src/sentry/tasks/gpu_crash.py
@@ -9,11 +9,20 @@ any failure still saves the event (unenriched) via ``submit_process``.
 from __future__ import annotations
 
 import logging
+from collections.abc import MutableMapping
 from typing import Any
 
 import sentry_sdk
 
-from sentry import features, options
+from sentry import options
+from sentry.lang.native.gpu import apply_gpu_crash_symbolication
+from sentry.lang.native.teapot import submit_to_teapot
+from sentry.lang.native.utils import (
+    find_all_shader_debug_attachments,
+    find_gpu_crash_dump_attachment,
+)
+from sentry.models.project import Project
+from sentry.services.eventstore import processing
 from sentry.silo.base import SiloMode
 from sentry.tasks import store
 from sentry.tasks.base import instrumented_task
@@ -35,23 +44,6 @@ def _teapot_circuit_breaker() -> CircuitBreaker:
     return CircuitBreaker(_CIRCUIT_BREAKER_KEY, config, CountBasedTripStrategy.from_config(config))
 
 
-def submit_symbolicate_gpu_crash(
-    cache_key: str,
-    event_id: str | None,
-    start_time: float | None,
-    has_attachments: bool,
-    from_reprocessing: bool,
-) -> None:
-    """Schedule GPU crash symbolication on its dedicated queue (pre-save)."""
-    symbolicate_gpu_crash_event.delay(
-        cache_key=cache_key,
-        start_time=start_time,
-        event_id=event_id,
-        has_attachments=has_attachments,
-        from_reprocessing=from_reprocessing,
-    )
-
-
 @instrumented_task(
     name="sentry.tasks.symbolicate_gpu_crash_event",
     namespace=gpu_crash_dump_tasks,
@@ -62,14 +54,12 @@ def symbolicate_gpu_crash_event(
     cache_key: str,
     start_time: float | None = None,
     event_id: str | None = None,
-    data: Any | None = None,
+    data: MutableMapping[str, Any] | None = None,
     has_attachments: bool = False,
     from_reprocessing: bool = False,
     **kwargs: Any,
 ) -> None:
     """Run teapot over the event's ``.nv-gpudmp`` and apply the decode, pre-save."""
-    from sentry.services.eventstore import processing
-
     if data is None:
         data = processing.event_processing_store.get(cache_key)
     if data is None:
@@ -99,28 +89,16 @@ def symbolicate_gpu_crash_event(
     )
 
 
-def _try_symbolicate(data: Any, project_id: int, event_id: str) -> bool:
+def _try_symbolicate(data: MutableMapping[str, Any], project_id: int, event_id: str) -> bool:
     """Best-effort teapot symbolication; returns whether ``data`` was enriched.
 
     All failures are swallowed — teapot must never block the save. The kill
-    switch and feature flag are re-checked here so ops can halt queued work.
+    switch is re-checked here so ops can halt already-queued work (the feature
+    flag is gated at routing time, where the project is already loaded).
     """
-    from sentry.lang.native.gpu import apply_gpu_crash_symbolication
-    from sentry.lang.native.teapot import submit_to_teapot
-    from sentry.lang.native.utils import (
-        find_all_shader_debug_attachments,
-        find_gpu_crash_dump_attachment,
-    )
-    from sentry.models.project import Project
-
     try:
         if not options.get("teapot.enabled"):
             metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "disabled"})
-            return False
-
-        project = Project.objects.get_from_cache(id=project_id)
-        if not features.has("organizations:gpu-crash-symbolication", project.organization):
-            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "flag_off"})
             return False
 
         dump = find_gpu_crash_dump_attachment(data)
@@ -134,10 +112,12 @@ def _try_symbolicate(data: Any, project_id: int, event_id: str) -> bool:
             metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "circuit_open"})
             return False
 
+        count = len(shaders)
         metrics.incr(
             "tasks.gpu_crash.request",
-            tags={"shader_debug_count": str(min(len(shaders), 10))},
+            tags={"shader_debug_count": str(count) if count < 10 else "10+"},
         )
+        project = Project.objects.get_from_cache(id=project_id)
         with metrics.timer("tasks.gpu_crash.teapot"):
             response = submit_to_teapot(project, event_id, dump, shaders)
         if response is None:

--- a/src/sentry/tasks/gpu_crash.py
+++ b/src/sentry/tasks/gpu_crash.py
@@ -131,7 +131,13 @@ def _try_symbolicate(data: MutableMapping[str, Any], project_id: int, event_id: 
             "tasks.gpu_crash.request",
             tags={"shader_debug_count": str(count) if count < 10 else "10+"},
         )
-        project = Project.objects.get_from_cache(id=project_id)
+        try:
+            project = Project.objects.get_from_cache(id=project_id)
+        except Project.DoesNotExist:
+            # Deleted between routing and execution — routine stale ref, not an error.
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "project_missing"})
+            return False
+
         try:
             with metrics.timer("tasks.gpu_crash.teapot"):
                 response = submit_to_teapot(project, event_id, dump, shaders)

--- a/src/sentry/tasks/gpu_crash.py
+++ b/src/sentry/tasks/gpu_crash.py
@@ -15,8 +15,9 @@ from typing import Any
 import sentry_sdk
 
 from sentry import options
+from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.gpu import apply_gpu_crash_symbolication
-from sentry.lang.native.teapot import submit_to_teapot
+from sentry.lang.native.teapot import TeapotUnavailable, submit_to_teapot
 from sentry.lang.native.utils import (
     find_all_shader_debug_attachments,
     find_gpu_crash_dump_attachment,
@@ -101,6 +102,19 @@ def _try_symbolicate(data: MutableMapping[str, Any], project_id: int, event_id: 
             metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "disabled"})
             return False
 
+        # Re-check the load-shed killswitch (routing only gates new events) so ops
+        # can drain already-queued work when the pool is overwhelmed.
+        if killswitch_matches_context(
+            "store.load-shed-gpu-crash-projects",
+            {
+                "project_id": project_id,
+                "event_id": event_id,
+                "platform": data.get("platform") or "null",
+            },
+        ):
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "load_shed"})
+            return False
+
         dump = find_gpu_crash_dump_attachment(data)
         if dump is None:
             metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "attachment_missing"})
@@ -118,11 +132,19 @@ def _try_symbolicate(data: MutableMapping[str, Any], project_id: int, event_id: 
             tags={"shader_debug_count": str(count) if count < 10 else "10+"},
         )
         project = Project.objects.get_from_cache(id=project_id)
-        with metrics.timer("tasks.gpu_crash.teapot"):
-            response = submit_to_teapot(project, event_id, dump, shaders)
-        if response is None:
+        try:
+            with metrics.timer("tasks.gpu_crash.teapot"):
+                response = submit_to_teapot(project, event_id, dump, shaders)
+        except TeapotUnavailable:
+            # A genuine outage — feed the breaker so repeated failures trip it.
             breaker.record_error()
             metrics.incr("tasks.gpu_crash.teapot_unavailable")
+            return False
+
+        if response is None:
+            # Request/data error (bad request, missing attachment): teapot is
+            # healthy, so don't trip the breaker — just save unenriched.
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "request_error"})
             return False
         breaker.record_success()
 

--- a/src/sentry/tasks/gpu_crash.py
+++ b/src/sentry/tasks/gpu_crash.py
@@ -22,9 +22,20 @@ from sentry.tasks import store
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import gpu_crash_dump_tasks
 from sentry.utils import metrics
+from sentry.utils.circuit_breaker2 import CircuitBreaker, CountBasedTripStrategy
 from sentry.utils.sdk import set_current_event_project
 
 logger = logging.getLogger(__name__)
+
+# Trips after repeated teapot failures so a teapot outage doesn't tie up the GPU
+# pool: while open, tasks skip teapot and save the event unenriched (fail fast,
+# no per-request timeout paid).
+_CIRCUIT_BREAKER_KEY = "teapot.gpu_crash"
+
+
+def _teapot_circuit_breaker() -> CircuitBreaker:
+    config = options.get("teapot.circuit-breaker-config")
+    return CircuitBreaker(_CIRCUIT_BREAKER_KEY, config, CountBasedTripStrategy.from_config(config))
 
 
 def submit_symbolicate_gpu_crash(
@@ -123,6 +134,11 @@ def _try_symbolicate(data: Any, project_id: int, event_id: str) -> bool:
             return False
         shaders = find_all_shader_debug_attachments(data)
 
+        breaker = _teapot_circuit_breaker()
+        if not breaker.should_allow_request():
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "circuit_open"})
+            return False
+
         metrics.incr(
             "tasks.gpu_crash.request",
             tags={"shader_debug_count": str(min(len(shaders), 10))},
@@ -130,8 +146,10 @@ def _try_symbolicate(data: Any, project_id: int, event_id: str) -> bool:
         with metrics.timer("tasks.gpu_crash.teapot"):
             response = submit_to_teapot(project, event_id, dump, shaders)
         if response is None:
+            breaker.record_error()
             metrics.incr("tasks.gpu_crash.teapot_unavailable")
             return False
+        breaker.record_success()
 
         applied = apply_gpu_crash_symbolication(data, response)
         metrics.incr(

--- a/src/sentry/tasks/gpu_crash.py
+++ b/src/sentry/tasks/gpu_crash.py
@@ -1,0 +1,151 @@
+"""Isolated GPU crash dump symbolication task.
+
+The GPU crash arrives from Relay as its own native event (see
+``sentry.lang.native.gpu``) carrying the ``.nv-gpudmp`` attachment.
+``preprocess_event`` routes such events here — a dedicated task in the
+``gpu.crash_dump`` namespace, so a slow or unavailable teapot can never back up
+CPU symbolication. We run teapot, apply the decode to the in-flight event, and
+hand it to the normal save pipeline. Best-effort: on any failure the event is
+still saved through ``submit_process``, just unenriched.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import sentry_sdk
+
+from sentry import features, options
+from sentry.silo.base import SiloMode
+from sentry.tasks import store
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import gpu_crash_dump_tasks
+from sentry.utils import metrics
+from sentry.utils.sdk import set_current_event_project
+
+logger = logging.getLogger(__name__)
+
+
+def submit_symbolicate_gpu_crash(
+    cache_key: str,
+    event_id: str | None,
+    start_time: float | None,
+    has_attachments: bool,
+    from_reprocessing: bool,
+) -> None:
+    """Schedule GPU crash symbolication on its dedicated queue (pre-save)."""
+    symbolicate_gpu_crash_event.delay(
+        cache_key=cache_key,
+        start_time=start_time,
+        event_id=event_id,
+        has_attachments=has_attachments,
+        from_reprocessing=from_reprocessing,
+    )
+
+
+@instrumented_task(
+    name="sentry.tasks.symbolicate_gpu_crash_event",
+    namespace=gpu_crash_dump_tasks,
+    # Bounds how long a stuck teapot can hold a worker in the GPU pool.
+    processing_deadline_duration=120,
+    silo_mode=SiloMode.CELL,
+)
+def symbolicate_gpu_crash_event(
+    cache_key: str,
+    start_time: float | None = None,
+    event_id: str | None = None,
+    data: Any | None = None,
+    has_attachments: bool = False,
+    from_reprocessing: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Run teapot over the event's ``.nv-gpudmp`` and apply the decode, pre-save."""
+    from sentry.services.eventstore import processing
+
+    if data is None:
+        data = processing.event_processing_store.get(cache_key)
+    if data is None:
+        metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "cache"})
+        return
+
+    event_id = str(data["event_id"])
+    project_id = data["project"]
+    set_current_event_project(project_id)
+
+    has_changed = _try_symbolicate(data, project_id, event_id)
+
+    if not isinstance(data, dict):
+        data = dict(data.items())
+    if has_changed:
+        cache_key = processing.event_processing_store.store(data)
+
+    # Always continue to save — the event was ingested (and billed) by Relay.
+    store.submit_process(
+        from_reprocessing=from_reprocessing,
+        cache_key=cache_key,
+        event_id=event_id,
+        start_time=start_time,
+        data_has_changed=has_changed,
+        from_symbolicate=True,
+        has_attachments=has_attachments,
+    )
+
+
+def _try_symbolicate(data: Any, project_id: int, event_id: str) -> bool:
+    """Best-effort teapot symbolication. Returns whether ``data`` was enriched.
+
+    Every failure is swallowed: teapot being slow, down, or wrong must never stop
+    the GPU event from saving. The kill switch and feature flag are re-checked
+    here so ops can halt already-queued work.
+    """
+    from sentry.lang.native.gpu import apply_gpu_crash_symbolication
+    from sentry.lang.native.teapot import submit_to_teapot
+    from sentry.lang.native.utils import (
+        find_all_shader_debug_attachments,
+        find_gpu_crash_dump_attachment,
+    )
+    from sentry.models.project import Project
+
+    try:
+        if not options.get("teapot.enabled"):
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "disabled"})
+            return False
+
+        project = Project.objects.get_from_cache(id=project_id)
+        if not features.has("organizations:gpu-crash-symbolication", project.organization):
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "flag_off"})
+            return False
+
+        dump = find_gpu_crash_dump_attachment(data)
+        if dump is None:
+            metrics.incr("tasks.gpu_crash.skipped", tags={"reason": "attachment_missing"})
+            return False
+        shaders = find_all_shader_debug_attachments(data)
+
+        metrics.incr(
+            "tasks.gpu_crash.request",
+            tags={"shader_debug_count": str(min(len(shaders), 10))},
+        )
+        with metrics.timer("tasks.gpu_crash.teapot"):
+            response = submit_to_teapot(project, event_id, dump, shaders)
+        if response is None:
+            metrics.incr("tasks.gpu_crash.teapot_unavailable")
+            return False
+
+        applied = apply_gpu_crash_symbolication(data, response)
+        metrics.incr(
+            "tasks.gpu_crash.completed",
+            tags={
+                "symbolicated": str(applied is not None),
+                "fault_category": response.get("fault_category") or "unknown",
+            },
+        )
+        return applied is not None
+    except Exception as e:
+        metrics.incr("tasks.gpu_crash.error", tags={"reason": "unexpected"})
+        logger.warning(
+            "tasks.gpu_crash.unexpected_error", extra={"event_id": event_id, "error": repr(e)}
+        )
+        sentry_sdk.capture_exception(e)
+        return False

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -130,7 +130,9 @@ def _do_preprocess_event(
     has_attachments: bool = False,
     inline_save_event: bool = False,
 ) -> None:
+    from sentry.lang.native.utils import is_gpu_crash_event
     from sentry.stacktraces.processing import find_stacktraces_in_data
+    from sentry.tasks.gpu_crash import submit_symbolicate_gpu_crash
     from sentry.tasks.symbolication import (
         submit_symbolicate,
     )
@@ -174,6 +176,22 @@ def _do_preprocess_event(
     )
 
     should_symbolicate = len(symbolicate_functions) > 0
+
+    # A GPU crash dump is its own native event (Relay split it off the minidump
+    # upload) carrying only the `.nv-gpudmp` — no CPU crash report. Route it to
+    # teapot in a dedicated isolated task before symbolication/save, so a slow
+    # teapot can never back up CPU symbolication. The no-crash-report check keeps
+    # us from hijacking a CPU minidump event when the org hasn't opted into the
+    # Relay-side split; `has_attachments` short-circuits the common path cheaply.
+    if has_attachments and is_gpu_crash_event(data):
+        submit_symbolicate_gpu_crash(
+            cache_key=cache_key,
+            event_id=event_id,
+            start_time=start_time,
+            has_attachments=has_attachments,
+            from_reprocessing=from_reprocessing,
+        )
+        return
     if should_symbolicate:
         symbolication_function = symbolicate_functions.pop(0)
         symbolication_function_name = getattr(symbolication_function.function(), "__name__", "none")

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -175,10 +175,13 @@ def _do_preprocess_event(
     # event as-is instead of re-running teapot (the `.nv-gpudmp` isn't reloaded)
     # and dropping the enrichment. The feature flag is checked here (project
     # already loaded), not in the task; the load-shed killswitch drops the routing
-    # (event still saves via the normal path) if the pool is overwhelmed.
+    # (event still saves via the normal path) if the pool is overwhelmed. Order
+    # matters: this runs on every event, so the cheap `has_attachments` bool, the
+    # feature flag, and the killswitch gate first and short-circuit before
+    # `is_gpu_crash_event`, which scans the attachment list — that scan only runs
+    # for the handful of feature-enabled orgs, not the full ingest firehose.
     if (
         has_attachments
-        and is_gpu_crash_event(data)
         and features.has("organizations:gpu-crash-symbolication", project.organization)
         and not killswitch_matches_context(
             "store.load-shed-gpu-crash-projects",
@@ -188,6 +191,7 @@ def _do_preprocess_event(
                 "platform": data.get("platform") or "null",
             },
         )
+        and is_gpu_crash_event(data)
     ):
         symbolicate_gpu_crash_event.delay(
             cache_key=cache_key,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -165,28 +165,16 @@ def _do_preprocess_event(
         "organization", Organization.objects.get_from_cache(id=project.organization_id)
     )
 
-    # Get the list of platforms for which we want to use Symbolicator.
-    # Possible values are `js`, `jvm`, and `native`.
-    # The event will be submitted to Symbolicator for all returned platforms,
-    # one after the other, so we handle mixed stacktraces.
-    stacktraces = find_stacktraces_in_data(data)
-    symbolicate_functions = get_symbolication_functions(data, stacktraces)
-    metrics.incr(
-        "events.to-symbolicate",
-        tags={f.value: True for f in symbolicate_functions},
-        skip_internal=False,
-    )
-
-    should_symbolicate = len(symbolicate_functions) > 0
-
     # A GPU crash dump is its own native event (Relay split it off the minidump
     # upload) carrying only the `.nv-gpudmp` — no CPU crash report. Route it to
     # teapot in a dedicated isolated task before symbolication/save, so a slow
-    # teapot can never back up CPU symbolication. `has_attachments` short-circuits
-    # the common path cheaply; reprocessing never sets it, so fall through on
-    # `from_reprocessing` too. The feature flag is checked here (project already
-    # loaded) rather than in the task. The load-shed killswitch drops the isolated
-    # routing (event still saves via the normal path) if the pool is overwhelmed.
+    # teapot can never back up CPU symbolication. Checked before the stacktrace
+    # lookup below — that work is pointless for an event bound for teapot.
+    # `has_attachments` short-circuits the common path cheaply; reprocessing never
+    # sets it, so fall through on `from_reprocessing` too. The feature flag is
+    # checked here (project already loaded) rather than in the task. The load-shed
+    # killswitch drops the isolated routing (event still saves via the normal
+    # path) if the pool is overwhelmed.
     if (
         (has_attachments or from_reprocessing)
         and is_gpu_crash_event(data)
@@ -209,6 +197,20 @@ def _do_preprocess_event(
             from_reprocessing=from_reprocessing,
         )
         return
+
+    # Get the list of platforms for which we want to use Symbolicator.
+    # Possible values are `js`, `jvm`, and `native`.
+    # The event will be submitted to Symbolicator for all returned platforms,
+    # one after the other, so we handle mixed stacktraces.
+    stacktraces = find_stacktraces_in_data(data)
+    symbolicate_functions = get_symbolication_functions(data, stacktraces)
+    metrics.incr(
+        "events.to-symbolicate",
+        tags={f.value: True for f in symbolicate_functions},
+        skip_internal=False,
+    )
+
+    should_symbolicate = len(symbolicate_functions) > 0
     if should_symbolicate:
         symbolication_function = symbolicate_functions.pop(0)
         symbolication_function_name = getattr(symbolication_function.function(), "__name__", "none")

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -182,8 +182,12 @@ def _do_preprocess_event(
     # teapot in a dedicated isolated task before symbolication/save, so a slow
     # teapot can never back up CPU symbolication. The no-crash-report check keeps
     # us from hijacking a CPU minidump event when the org hasn't opted into the
-    # Relay-side split; `has_attachments` short-circuits the common path cheaply.
-    if has_attachments and is_gpu_crash_event(data):
+    # Relay-side split. `has_attachments` short-circuits the common path cheaply;
+    # reprocessing never sets it, so fall through on `from_reprocessing` too. Back
+    # up the unprocessed event first (as the symbolicate path does) so a later
+    # reprocess can reload it and re-run teapot.
+    if (has_attachments or from_reprocessing) and is_gpu_crash_event(data):
+        reprocessing2.backup_unprocessed_event(data=original_data)
         submit_symbolicate_gpu_crash(
             cache_key=cache_key,
             event_id=event_id,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -9,7 +9,7 @@ from typing import Any
 import orjson
 from sentry_relay.processing import StoreNormalizer
 
-from sentry import options, reprocessing2
+from sentry import features, options, reprocessing2
 from sentry.attachments import delete_cached_and_ratelimited_attachments, get_attachments_for_event
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.event_preprocessors import get_event_preprocessors
@@ -130,9 +130,11 @@ def _do_preprocess_event(
     has_attachments: bool = False,
     inline_save_event: bool = False,
 ) -> None:
+    # Imported here, not at module top, to avoid circular imports back into
+    # sentry.tasks (e.g. sentry.tasks.gpu_crash imports this module).
     from sentry.lang.native.utils import is_gpu_crash_event
     from sentry.stacktraces.processing import find_stacktraces_in_data
-    from sentry.tasks.gpu_crash import submit_symbolicate_gpu_crash
+    from sentry.tasks.gpu_crash import symbolicate_gpu_crash_event
     from sentry.tasks.symbolication import (
         submit_symbolicate,
     )
@@ -180,15 +182,26 @@ def _do_preprocess_event(
     # A GPU crash dump is its own native event (Relay split it off the minidump
     # upload) carrying only the `.nv-gpudmp` — no CPU crash report. Route it to
     # teapot in a dedicated isolated task before symbolication/save, so a slow
-    # teapot can never back up CPU symbolication. The no-crash-report check keeps
-    # us from hijacking a CPU minidump event when the org hasn't opted into the
-    # Relay-side split. `has_attachments` short-circuits the common path cheaply;
-    # reprocessing never sets it, so fall through on `from_reprocessing` too. Back
-    # up the unprocessed event first (as the symbolicate path does) so a later
-    # reprocess can reload it and re-run teapot.
-    if (has_attachments or from_reprocessing) and is_gpu_crash_event(data):
+    # teapot can never back up CPU symbolication. `has_attachments` short-circuits
+    # the common path cheaply; reprocessing never sets it, so fall through on
+    # `from_reprocessing` too. The feature flag is checked here (project already
+    # loaded) rather than in the task. The load-shed killswitch drops the isolated
+    # routing (event still saves via the normal path) if the pool is overwhelmed.
+    if (
+        (has_attachments or from_reprocessing)
+        and is_gpu_crash_event(data)
+        and features.has("organizations:gpu-crash-symbolication", project.organization)
+        and not killswitch_matches_context(
+            "store.load-shed-gpu-crash-projects",
+            {
+                "project_id": project_id,
+                "event_id": event_id,
+                "platform": data.get("platform") or "null",
+            },
+        )
+    ):
         reprocessing2.backup_unprocessed_event(data=original_data)
-        submit_symbolicate_gpu_crash(
+        symbolicate_gpu_crash_event.delay(
             cache_key=cache_key,
             event_id=event_id,
             start_time=start_time,

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -169,14 +169,15 @@ def _do_preprocess_event(
     # upload) carrying only the `.nv-gpudmp` — no CPU crash report. Route it to
     # teapot in a dedicated isolated task before symbolication/save, so a slow
     # teapot can never back up CPU symbolication. Checked before the stacktrace
-    # lookup below — that work is pointless for an event bound for teapot.
-    # `has_attachments` short-circuits the common path cheaply; reprocessing never
-    # sets it, so fall through on `from_reprocessing` too. The feature flag is
-    # checked here (project already loaded) rather than in the task. The load-shed
-    # killswitch drops the isolated routing (event still saves via the normal
-    # path) if the pool is overwhelmed.
+    # lookup below — that work is pointless for an event bound for teapot. Only on
+    # first ingest (`has_attachments`): teapot enriches once, and we deliberately
+    # don't back up the unprocessed payload, so a reprocess keeps the enriched
+    # event as-is instead of re-running teapot (the `.nv-gpudmp` isn't reloaded)
+    # and dropping the enrichment. The feature flag is checked here (project
+    # already loaded), not in the task; the load-shed killswitch drops the routing
+    # (event still saves via the normal path) if the pool is overwhelmed.
     if (
-        (has_attachments or from_reprocessing)
+        has_attachments
         and is_gpu_crash_event(data)
         and features.has("organizations:gpu-crash-symbolication", project.organization)
         and not killswitch_matches_context(
@@ -188,7 +189,6 @@ def _do_preprocess_event(
             },
         )
     ):
-        reprocessing2.backup_unprocessed_event(data=original_data)
         symbolicate_gpu_crash_event.delay(
             cache_key=cache_key,
             event_id=event_id,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -342,6 +342,13 @@ symbolication_jvm_tasks = app.taskregistry.create_namespace(
     app_feature="errors",
 )
 
+# GPU crash symbolication (teapot), isolated from `symbolication` so a slow
+# teapot can't back up the native CPU symbolication queue.
+gpu_crash_dump_tasks = app.taskregistry.create_namespace(
+    "gpu.crash_dump",
+    app_feature="errors",
+)
+
 telemetry_experience_tasks = app.taskregistry.create_namespace(
     "telemetry-experience",
     app_feature="transactions",

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -296,6 +296,13 @@ symbolication_tasks = app.taskregistry.create_namespace(
     app_feature="errors",
 )
 
+# GPU crash symbolication (teapot), isolated from `symbolication` so a slow
+# teapot can't back up the native CPU symbolication queue.
+gpu_crash_dump_tasks = app.taskregistry.create_namespace(
+    "gpu.crash_dump",
+    app_feature="errors",
+)
+
 telemetry_experience_tasks = app.taskregistry.create_namespace(
     "telemetry-experience",
     app_feature="transactions",

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -1,11 +1,5 @@
 """
 Unit tests for the teapot client + GPU event enrichment.
-
-Covers:
-* `TeapotClient.symbolicate` — the presigned-URL wire format
-* `submit_to_teapot` wrapper — best-effort error swallowing
-* `apply_gpu_crash_symbolication` — applying teapot's decode to the event
-* `_normalize_gpu_frames` — frame normalization edge cases
 """
 
 from __future__ import annotations
@@ -41,16 +35,6 @@ class _FakeProject:
 
 
 class _FakeAttachment:
-    """Stand-in for `sentry.attachments.CachedAttachment` in unit tests.
-
-    The client only reads `name` (the filename — for a `.nvdbg` it carries the
-    `shader_debug_info_uid`) and `stored_id` (the objectstore key it presigns).
-    `data` is accepted for call-site convenience but never read: bytes are
-    fetched by teapot from objectstore, never inlined. `stored_id` defaults to a
-    value so the presigned path is exercised; pass `None` to simulate an
-    attachment missing from objectstore.
-    """
-
     def __init__(
         self,
         data: bytes = b"",
@@ -122,11 +106,6 @@ def _skip_retry_backoff() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def mock_objectstore() -> Iterator[mock.Mock]:
-    """Every attachment is fetched by presigned URL, so `symbolicate` always
-    opens an objectstore session. Fake it: `presigned_object_url(method, key,
-    duration=...)` returns a stable URL, and the symbolicator dev-rewrite is a
-    no-op (its real path shells out to `docker`). Autouse so plain client tests
-    work without setup; request it by name to assert on the presign calls."""
     session = mock.Mock()
     session.presigned_object_url.side_effect = (
         lambda _method, key, duration=None: f"http://objectstore/{key}?sig=abc"
@@ -141,15 +120,7 @@ def mock_objectstore() -> Iterator[mock.Mock]:
         yield session
 
 
-# ---------------------------------------------------------------------------
-# apply_gpu_crash_symbolication
-# ---------------------------------------------------------------------------
-
-
 def _relay_gpu_event() -> dict[str, Any]:
-    """The in-flight GPU event as Relay hands it to us: identity, trace, release
-    and the `cpu_event_id` link already set; the `.nv-gpudmp` decode not yet
-    applied."""
     return {
         "event_id": "g" * 32,
         "platform": "native",
@@ -205,13 +176,9 @@ def test_apply_fingerprint_fallback() -> None:
 @pytest.mark.parametrize(
     "response",
     [
-        # active_shaders is a truthy non-list — the reported case (dict / str / int).
         _completed_response(shader_context={"active_shaders": {"shader_hash": "x"}}),
         _completed_response(shader_context={"active_shaders": "nope"}),
         _completed_response(shader_context={"active_shaders": 7}),
-        # shader_context / fault / gpu_state themselves are non-dicts, and the
-        # list fields (missing_difs / fingerprint / warnings) are truthy scalars
-        # — len()/list() over them must not raise.
         _completed_response(
             shader_context="nope", fault="nope", gpu_state=7, missing_difs=5, fingerprint=9
         ),
@@ -221,9 +188,6 @@ def test_apply_fingerprint_fallback() -> None:
     ],
 )
 def test_apply_survives_malformed_teapot_response(response: dict[str, Any]) -> None:
-    # teapot output is unvalidated external JSON: a truthy non-list/non-dict must
-    # never reach active_shaders[0] / primary_shader.get(...) / len() / list(). It
-    # should just drop the offending fields, not raise.
     ctx = _build_flat_gpu_context(response)
     data = _relay_gpu_event()
     out = apply_gpu_crash_symbolication(data, response)
@@ -231,7 +195,6 @@ def test_apply_survives_malformed_teapot_response(response: dict[str, Any]) -> N
     assert out is data
     assert "shader_hash" not in ctx
     assert "gpu.shader_hash" not in dict(data["tags"])
-    # len()/list() over the scalar list fields yielded empties, not a TypeError.
     assert ctx["missing_dif_count"] == 0
     assert isinstance(data["fingerprint"], list)
 
@@ -241,7 +204,6 @@ def test_apply_skips_failed_status() -> None:
     out = apply_gpu_crash_symbolication(data, {"status": "failed"})
 
     assert out is None
-    # The event is left untouched — it still saves, just unenriched.
     assert "exception" not in data
     assert "fingerprint" not in data
 
@@ -251,12 +213,7 @@ def test_apply_skips_failed_status() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_client_sends_presigned_urls() -> None:
-    """The dump and every .nvdbg are passed by presigned GET URL, never inline.
-
-    Teapot fetches the bytes straight from objectstore; only URLs cross the
-    wire, and no bearer token is exchanged (the URL is self-authenticating).
-    """
+def test_client_sends_presigned_urls(mock_objectstore: mock.Mock) -> None:
     project = _FakeProject()
     dump = _FakeAttachment(stored_id="dump-obj-id")
     nvdbg = _FakeAttachment(
@@ -272,47 +229,23 @@ def test_client_sends_presigned_urls() -> None:
         mock_post.return_value = _FakeResponse(200, _completed_response())
         TeapotClient(project, "abc").symbolicate(dump, [nvdbg])
 
-    assert mock_post.call_count == 1
     args, kwargs = mock_post.call_args
     assert args[0] == "http://teapot.test/symbolicate"
-    # JSON body — no multipart `files`, Content-Type set.
-    assert kwargs.get("files") is None
+    assert kwargs.get("files") is None  # JSON, not multipart
     assert kwargs["headers"]["Content-Type"] == "application/json"
-    assert kwargs["headers"]["X-Teapot-Version"] == "1"
-    assert kwargs["headers"]["X-Request-Id"] == "abc"
-    # event_id doubles as the idempotency key so a retried task replays
-    # teapot's cached decode instead of re-running it.
     assert kwargs["headers"]["Idempotency-Key"] == "abc"
 
     body = orjson.loads(kwargs["data"])
     assert body["event_id"] == "abc"
     assert body["project_id"] == "42"
-    assert body["organization_id"] == "7"
-    # A presigned URL per attachment; no inline bytes, no token.
-    assert body["dump"]["storage_url"] == "http://objectstore/dump-obj-id?sig=abc"
+    assert body["dump"] == {"storage_url": "http://objectstore/dump-obj-id?sig=abc"}
     assert "storage_token" not in body["dump"]
-    assert len(body["shader_debug_info"]) == 1
     shader = body["shader_debug_info"][0]
-    # uid recovered from the .nvdbg filename (teapot's shader_debug_info key).
-    assert shader["uid"] == "cafebabecafebabecafebabecafebabe"
+    assert shader["uid"] == "cafebabecafebabecafebabecafebabe"  # recovered from filename
     assert shader["storage_url"] == "http://objectstore/nvdbg-obj-id?sig=abc"
-    assert "storage_token" not in shader
-
-
-def test_client_presigns_get_with_bounded_ttl(mock_objectstore: mock.Mock) -> None:
-    """Each attachment is presigned for GET with the short request-window TTL."""
-    project = _FakeProject()
-    dump = _FakeAttachment(stored_id="dump-obj-id")
-
-    with (
-        _configured_teapot(),
-        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-    ):
-        mock_post.return_value = _FakeResponse(200, _completed_response())
-        TeapotClient(project, "abc").symbolicate(dump)
 
     call = mock_objectstore.presigned_object_url.call_args
-    assert call.args[:2] == ("GET", "dump-obj-id")
+    assert call.args[0] == "GET"
     assert call.kwargs["duration"] == timedelta(seconds=60)
 
 
@@ -333,39 +266,18 @@ def test_uid_from_nvdbg_filename(filename: str, expected: str | None) -> None:
     assert _uid_from_nvdbg_filename(filename) == expected
 
 
-def test_client_retries_on_503() -> None:
-    project = _FakeProject()
-    dump = _FakeAttachment(b"dump")
-
+@pytest.mark.parametrize(
+    "first_attempt",
+    [_FakeResponse(503), requests.ConnectionError("boom")],
+    ids=["retryable_5xx", "network_error"],
+)
+def test_client_retries_then_succeeds(first_attempt: Any) -> None:
     with (
         _configured_teapot(),
         mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
     ):
-        mock_post.side_effect = [
-            _FakeResponse(503),
-            _FakeResponse(200, _completed_response(status="partial")),
-        ]
-
-        result = TeapotClient(project, "abc").symbolicate(dump)
-
-    assert result["status"] == "partial"
-    assert mock_post.call_count == 2
-
-
-def test_client_retries_on_network_error() -> None:
-    project = _FakeProject()
-    dump = _FakeAttachment(b"dump")
-
-    with (
-        _configured_teapot(),
-        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-    ):
-        mock_post.side_effect = [
-            requests.ConnectionError("boom"),
-            _FakeResponse(200, _completed_response()),
-        ]
-
-        result = TeapotClient(project, "abc").symbolicate(dump)
+        mock_post.side_effect = [first_attempt, _FakeResponse(200, _completed_response())]
+        result = TeapotClient(_FakeProject(), "abc").symbolicate(_FakeAttachment())
 
     assert result["status"] == "completed"
     assert mock_post.call_count == 2
@@ -384,8 +296,6 @@ def test_client_exhausts_retries() -> None:
         with pytest.raises(TeapotUnavailable):
             TeapotClient(project, "abc").symbolicate(dump)
 
-    # Default teapot.max-attempts is 2 (kept low so a slow teapot can't pile up
-    # work on the GPU task worker).
     assert mock_post.call_count == 2
 
 
@@ -454,16 +364,7 @@ def test_client_falls_back_to_options() -> None:
     assert mock_post.call_args[0][0] == "http://teapot-from-options.test/symbolicate"
 
 
-# ---------------------------------------------------------------------------
-# TeapotClient — attachment missing from objectstore
-# ---------------------------------------------------------------------------
-
-
 def test_client_skips_when_attachment_not_stored() -> None:
-    """GPU-crash attachments are always uploaded to objectstore. If one is
-    missing a `stored_id` we can't presign it — teapot is skipped rather than
-    sent inline bytes: `symbolicate` raises and `submit_to_teapot` swallows it."""
-
     project = _FakeProject()
     dump = _FakeAttachment(stored_id=None)
 
@@ -475,26 +376,7 @@ def test_client_skips_when_attachment_not_stored() -> None:
             TeapotClient(project, "abc").symbolicate(dump)
         assert submit_to_teapot(project, "abc", dump, []) is None
 
-    # We never reach out to teapot with a partial payload.
     assert mock_post.call_count == 0
-
-
-# ---------------------------------------------------------------------------
-# submit_to_teapot (best-effort wrapper)
-# ---------------------------------------------------------------------------
-
-
-def test_submit_to_teapot_success() -> None:
-    project = _FakeProject()
-    dump = _FakeAttachment(b"dump")
-    with (
-        _configured_teapot(),
-        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-    ):
-        mock_post.return_value = _FakeResponse(200, _completed_response())
-        result = submit_to_teapot(project, "abc", dump, [])
-    assert result is not None
-    assert result["status"] == "completed"
 
 
 def test_submit_to_teapot_returns_none_when_unavailable() -> None:
@@ -524,12 +406,6 @@ def test_submit_to_teapot_swallows_unexpected() -> None:
 
 
 def test_normalize_gpu_frames_tolerates_non_mapping_data() -> None:
-    """teapot's `frames[].data` is external and may not be a dict.
-
-    A truthy non-dict (string/list) must not crash `dict(...)` or the
-    `shader_hash` lookup — the frame is still normalized, just without `data`.
-    """
-
     frames = [
         {"function": "vertex", "data": "not-a-dict"},
         {"function": "pixel", "data": [1, 2, 3]},
@@ -540,10 +416,7 @@ def test_normalize_gpu_frames_tolerates_non_mapping_data() -> None:
     result = _normalize_gpu_frames(frames)
 
     assert [f["function"] for f in result] == ["vertex", "pixel", "compute", "ok"]
-    # Non-dict data is dropped (no crash); no synthetic package is derived.
     assert "package" not in result[0]
     assert "package" not in result[1]
-    # Non-str shader_hash is ignored rather than crashing `.startswith`.
     assert "package" not in result[2]
-    # A well-formed str shader_hash still produces a package.
     assert result[3]["package"] == "shader_abc123"

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -161,6 +161,8 @@ def test_apply_gpu_crash_symbolication_shape() -> None:
     assert data["release"] == "game@1.2.3"
     # teapot's decode is applied.
     assert data["level"] == "fatal"
+    # Typed as an error so the title comes from the exception, not "<unlabeled event>".
+    assert data["type"] == "error"
     exc = data["exception"]["values"][0]
     assert exc["type"] == "GPU hang in vertex_02"
     assert exc["mechanism"] == {"type": "gpu_crash", "handled": False}

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -1,0 +1,575 @@
+"""
+Unit tests for the teapot client + GPU error-event construction.
+
+Covers:
+* `TeapotClient.symbolicate` — both multipart and JSON+storage_url paths
+* `submit_to_teapot` wrapper — best-effort error swallowing
+* `_build_gpu_error_event` / `emit_gpu_crash_event` — synthetic error event shape
+* `_normalize_gpu_frames` — frame normalization edge cases
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+from unittest import mock
+
+import pytest
+import requests
+
+from sentry.lang.native.gpu import (
+    GPU_CRASH_DUMP_ATTACHMENT_TYPE,
+    _build_flat_gpu_context,
+    _normalize_gpu_frames,
+    apply_gpu_crash_symbolication,
+)
+from sentry.lang.native.teapot import (
+    TeapotClient,
+    TeapotUnavailable,
+    submit_to_teapot,
+)
+
+
+class _FakeProject:
+    def __init__(self, id: int = 42, organization_id: int = 7) -> None:
+        self.id = id
+        self.organization_id = organization_id
+
+
+class _FakeAttachment:
+    """Stand-in for `sentry.attachments.CachedAttachment` in unit tests.
+
+    Carries enough surface for the teapot client: bytes via `load_data`,
+    the attachment `type`, the filename `name`, and an optional
+    `stored_id`. When `stored_id` is set teapot's client routes via the
+    JSON+storage_url path; otherwise it falls back to multipart.
+    """
+
+    def __init__(
+        self,
+        data: bytes,
+        attachment_type: str = GPU_CRASH_DUMP_ATTACHMENT_TYPE,
+        name: str = "dump.nv-gpudmp",
+        stored_id: str | None = None,
+    ) -> None:
+        self._data = data
+        self.type = attachment_type
+        self.name = name
+        self.stored_id = stored_id
+
+    def load_data(self, _project: Any) -> bytes:
+        return self._data
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: Any = None, raise_on_json: bool = False) -> None:
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+        self.text = "" if isinstance(body, dict) or body is None else str(body)
+        self._raise_on_json = raise_on_json
+
+    def json(self) -> Any:
+        if self._raise_on_json:
+            raise ValueError("not JSON")
+        return self._body
+
+
+def _completed_response(**overrides: Any) -> dict[str, Any]:
+    """Minimal `status=completed` teapot response with the new top-level fields.
+
+    Tests that care about a specific field can override individual keys.
+    """
+
+    base: dict[str, Any] = {
+        "status": "completed",
+        "handler": "aftermath",
+        "sdk_version": "2025.5.0",
+        "decode_time_ms": 241,
+        "fault_category": "shader_hang",
+        "title": "GPU hang in vertex_02",
+        "fingerprint": ["gpu", "shader_hang", "abc123"],
+        "markers": [],
+        "fault": {"type": "Timeout"},
+        "gpu_state": {"device_name": "RTX 4090"},
+        "shader_context": {
+            "active_shaders": [{"shader_hash": "abc123", "shader_type": "Vertex"}],
+        },
+        "frames": [{"function": "Vertex", "module": "shader_abc123"}],
+        "missing_difs": [],
+    }
+    base.update(overrides)
+    return base
+
+
+@contextlib.contextmanager
+def _configured_teapot(url: str = "http://teapot.test") -> Iterator[None]:
+    """Context manager: sets SENTRY_TEAPOT_URL so the client resolves an endpoint."""
+
+    from django.conf import settings
+
+    with mock.patch.object(settings, "SENTRY_TEAPOT_URL", url, create=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _skip_retry_backoff() -> Iterator[None]:
+    """Skip teapot's inter-retry backoff sleep so retry tests stay instant."""
+    with mock.patch("sentry.lang.native.teapot.time.sleep"):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# apply_gpu_crash_symbolication
+# ---------------------------------------------------------------------------
+
+
+def _relay_gpu_event() -> dict[str, Any]:
+    """The in-flight GPU event as Relay hands it to us: identity, trace, release
+    and the `cpu_event_id` link already set; the `.nv-gpudmp` decode not yet
+    applied."""
+    return {
+        "event_id": "g" * 32,
+        "platform": "native",
+        "contexts": {"trace": {"trace_id": "a" * 32, "span_id": "b" * 16}},
+        "release": "game@1.2.3",
+        "environment": "prod",
+        "tags": [["cpu_event_id", "cpu-1"]],
+    }
+
+
+def test_apply_gpu_crash_symbolication_shape() -> None:
+    data = _relay_gpu_event()
+    response = _completed_response(
+        fault={"type": "PageFault", "virtual_address": "0xdeadbeef", "description": "write"},
+        gpu_state={"device_name": "RTX 4090", "driver_version": "555.1", "api": "D3D12"},
+        shader_context={"active_shaders": [{"shader_hash": "abc123", "shader_type": "Vertex"}]},
+        frames=[{"function": "Vertex", "module": "shader_abc123"}],
+    )
+
+    out = apply_gpu_crash_symbolication(data, response)
+
+    assert out is data  # mutated in place
+    # teapot's fingerprint drives grouping.
+    assert data["fingerprint"] == ["gpu", "shader_hang", "abc123"]
+    # Relay-owned fields are preserved, not overwritten.
+    assert data["contexts"]["trace"]["trace_id"] == "a" * 32
+    assert data["tags"]["cpu_event_id"] == "cpu-1"
+    assert data["release"] == "game@1.2.3"
+    # teapot's decode is applied.
+    assert data["level"] == "fatal"
+    exc = data["exception"]["values"][0]
+    assert exc["type"] == "GPU hang in vertex_02"
+    assert exc["mechanism"] == {"type": "gpu_crash", "handled": False}
+    assert exc["stacktrace"]["frames"][0]["function"] == "Vertex"
+    assert data["contexts"]["gpu_crash"]["fault_category"] == "shader_hang"
+    assert data["tags"]["gpu.fault_category"] == "shader_hang"
+    assert data["tags"]["gpu.shader_hash"] == "abc123"
+
+
+def test_apply_fingerprint_fallback() -> None:
+    """A response without a fingerprint still groups deterministically."""
+    data = _relay_gpu_event()
+    apply_gpu_crash_symbolication(
+        data, _completed_response(fingerprint=[], fault_category="page_fault")
+    )
+    assert data["fingerprint"] == ["gpu", "page_fault"]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        # active_shaders is a truthy non-list — the reported case (dict / str / int).
+        _completed_response(shader_context={"active_shaders": {"shader_hash": "x"}}),
+        _completed_response(shader_context={"active_shaders": "nope"}),
+        _completed_response(shader_context={"active_shaders": 7}),
+        # shader_context / fault / gpu_state themselves are non-dicts, and the
+        # list fields (missing_difs / fingerprint / warnings) are truthy scalars
+        # — len()/list() over them must not raise.
+        _completed_response(
+            shader_context="nope", fault="nope", gpu_state=7, missing_difs=5, fingerprint=9
+        ),
+        _completed_response(
+            shader_context=[], fault=None, gpu_state=[], missing_difs="x", warnings="w"
+        ),
+    ],
+)
+def test_apply_survives_malformed_teapot_response(response: dict[str, Any]) -> None:
+    # teapot output is unvalidated external JSON: a truthy non-list/non-dict must
+    # never reach active_shaders[0] / primary_shader.get(...) / len() / list(). It
+    # should just drop the offending fields, not raise.
+    ctx = _build_flat_gpu_context(response)
+    data = _relay_gpu_event()
+    out = apply_gpu_crash_symbolication(data, response)
+
+    assert out is data
+    assert "shader_hash" not in ctx
+    assert "gpu.shader_hash" not in data["tags"]
+    # len()/list() over the scalar list fields yielded empties, not a TypeError.
+    assert ctx["missing_dif_count"] == 0
+    assert isinstance(data["fingerprint"], list)
+
+
+def test_apply_skips_failed_status() -> None:
+    data = _relay_gpu_event()
+    out = apply_gpu_crash_symbolication(data, {"status": "failed"})
+
+    assert out is None
+    # The event is left untouched — it still saves, just unenriched.
+    assert "exception" not in data
+    assert "fingerprint" not in data
+
+
+# ---------------------------------------------------------------------------
+# TeapotClient — multipart wire format
+# ---------------------------------------------------------------------------
+
+
+def test_client_multipart_success() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dummy-dump-bytes", stored_id=None)
+    expected = _completed_response()
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, expected)
+
+        result = TeapotClient(project, "abc").symbolicate(dump)
+
+    assert result == expected
+    assert mock_post.call_count == 1
+    args, kwargs = mock_post.call_args
+    assert args[0] == "http://teapot.test/symbolicate"
+    # Identifiers carried as multipart form fields, NOT as a `sources` JSON
+    # — we no longer send a source-config block.
+    assert kwargs["data"]["event_id"] == "abc"
+    assert kwargs["data"]["project_id"] == "42"
+    assert kwargs["data"]["organization_id"] == "7"
+    assert "sources" not in kwargs["data"]
+    # Dump arrives as the canonical `upload_file` multipart field.
+    files = dict(kwargs["files"])
+    assert files["upload_file"][1] == b"dummy-dump-bytes"
+    assert kwargs["headers"]["X-Teapot-Version"] == "1"
+    assert kwargs["headers"]["X-Request-Id"] == "abc"
+    # event_id doubles as the idempotency key so a retried task replays
+    # teapot's cached decode instead of re-running it.
+    assert kwargs["headers"]["Idempotency-Key"] == "abc"
+
+
+def test_client_multipart_carries_shader_debug_attachments() -> None:
+    """Each .nvdbg attachment becomes its own `nv_shader_debug.<uid>` field."""
+
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump-bytes")
+    nvdbg1 = _FakeAttachment(
+        b"nvdbg-bytes-1",
+        attachment_type="event.nv_shader_debug",
+        name="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.nvdbg",
+    )
+    nvdbg2 = _FakeAttachment(
+        b"nvdbg-bytes-2",
+        attachment_type="event.nv_shader_debug",
+        name="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.nvdbg",
+    )
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        TeapotClient(project, "abc").symbolicate(
+            dump,
+            [
+                ("a" * 32, nvdbg1),
+                ("b" * 32, nvdbg2),
+            ],
+        )
+
+    files = mock_post.call_args.kwargs["files"]
+    # `files` is a list-of-tuples (the only way to repeat field names),
+    # so map by the first element for ergonomic assertions.
+    by_field = {field_name: payload for field_name, payload in files}
+    assert "upload_file" in by_field
+    assert by_field[f"nv_shader_debug.{'a' * 32}"][1] == b"nvdbg-bytes-1"
+    assert by_field[f"nv_shader_debug.{'b' * 32}"][1] == b"nvdbg-bytes-2"
+
+
+def test_client_retries_on_503() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.side_effect = [
+            _FakeResponse(503),
+            _FakeResponse(200, _completed_response(status="partial")),
+        ]
+
+        result = TeapotClient(project, "abc").symbolicate(dump)
+
+    assert result["status"] == "partial"
+    assert mock_post.call_count == 2
+
+
+def test_client_retries_on_network_error() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.side_effect = [
+            requests.ConnectionError("boom"),
+            _FakeResponse(200, _completed_response()),
+        ]
+
+        result = TeapotClient(project, "abc").symbolicate(dump)
+
+    assert result["status"] == "completed"
+    assert mock_post.call_count == 2
+
+
+def test_client_exhausts_retries() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(503)
+
+        with pytest.raises(TeapotUnavailable):
+            TeapotClient(project, "abc").symbolicate(dump)
+
+    # Default teapot.max-attempts is 2 (kept low so a slow teapot can't pile up
+    # work on the GPU task worker).
+    assert mock_post.call_count == 2
+
+
+def test_client_400_is_not_retried() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(400, "bad request")
+
+        with pytest.raises(TeapotUnavailable):
+            TeapotClient(project, "abc").symbolicate(dump)
+
+    assert mock_post.call_count == 1
+
+
+def test_client_non_json_body() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, "not-json", raise_on_json=True)
+
+        with pytest.raises(TeapotUnavailable):
+            TeapotClient(project, "abc").symbolicate(dump)
+
+
+def test_client_missing_url_raises() -> None:
+    from django.conf import settings
+
+    with (
+        mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True),
+        mock.patch(
+            "sentry.lang.native.teapot.options.get",
+            lambda key: {} if key == "teapot.options" else None,
+        ),
+    ):
+        with pytest.raises(TeapotUnavailable):
+            TeapotClient(_FakeProject(), "abc")
+
+
+def test_client_falls_back_to_options() -> None:
+    from django.conf import settings
+
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+    with (
+        mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True),
+        mock.patch(
+            "sentry.lang.native.teapot.options.get",
+            lambda key: (
+                {"url": "http://teapot-from-options.test"} if key == "teapot.options" else None
+            ),
+        ),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        TeapotClient(project, "abc").symbolicate(dump)
+
+    assert mock_post.call_args[0][0] == "http://teapot-from-options.test/symbolicate"
+
+
+# ---------------------------------------------------------------------------
+# TeapotClient — JSON + storage_url + storage_token (objectstore path)
+# ---------------------------------------------------------------------------
+
+
+def test_client_uses_json_path_when_all_attachments_stored() -> None:
+    """When every attachment has `stored_id`, pass URLs not bytes.
+
+    Mirrors `Symbolicator.process_minidump`'s objectstore path. Teapot
+    fetches the bytes directly from objectstore using the minted tokens.
+    Bytes never pass through the Sentry worker.
+    """
+
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump-bytes-should-not-be-sent", stored_id="dump-obj-id")
+    nvdbg = _FakeAttachment(
+        b"nvdbg-bytes-should-not-be-sent",
+        attachment_type="event.nv_shader_debug",
+        name="cafebabecafebabecafebabecafebabe.nvdbg",
+        stored_id="nvdbg-obj-id",
+    )
+
+    fake_session = mock.Mock()
+    fake_session.mint_token.side_effect = ["token-dump", "token-nvdbg"]
+
+    with (
+        _configured_teapot(),
+        mock.patch(
+            "sentry.lang.native.teapot.get_attachments_session",
+            return_value=fake_session,
+        ),
+        mock.patch(
+            "sentry.lang.native.teapot.get_symbolicator_url",
+            side_effect=lambda _sess, key: f"http://objectstore/{key}",
+        ),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+
+        TeapotClient(project, "abc").symbolicate(dump, [("c" * 32, nvdbg)])
+
+    # JSON path: `files` empty, Content-Type set, body is JSON-encoded.
+    kwargs = mock_post.call_args.kwargs
+    assert kwargs.get("files") is None
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    import orjson
+
+    body = orjson.loads(kwargs["data"])
+    assert body["event_id"] == "abc"
+    assert body["dump"]["storage_url"] == "http://objectstore/dump-obj-id"
+    assert body["dump"]["storage_token"] == "token-dump"
+    assert len(body["shader_debug_info"]) == 1
+    assert body["shader_debug_info"][0]["uid"] == "c" * 32
+    assert body["shader_debug_info"][0]["storage_url"] == "http://objectstore/nvdbg-obj-id"
+    assert body["shader_debug_info"][0]["storage_token"] == "token-nvdbg"
+
+
+def test_client_falls_back_to_multipart_when_any_attachment_lacks_stored_id() -> None:
+    """Mixed-state attachments → multipart (we can't combine wire formats)."""
+
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump-bytes", stored_id="dump-obj-id")
+    # Second attachment has NO stored_id — forces multipart path.
+    nvdbg = _FakeAttachment(
+        b"nvdbg-bytes",
+        attachment_type="event.nv_shader_debug",
+        name="cafebabecafebabecafebabecafebabe.nvdbg",
+        stored_id=None,
+    )
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+        mock.patch("sentry.lang.native.teapot.get_attachments_session") as mock_session_fn,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        TeapotClient(project, "abc").symbolicate(dump, [("c" * 32, nvdbg)])
+
+    # Objectstore session is never opened because the mixed-state check
+    # routes to multipart immediately.
+    assert mock_session_fn.call_count == 0
+    # Multipart: `files` populated with inline bytes.
+    files = mock_post.call_args.kwargs["files"]
+    by_field = {field_name: payload for field_name, payload in files}
+    assert by_field["upload_file"][1] == b"dump-bytes"
+    assert by_field[f"nv_shader_debug.{'c' * 32}"][1] == b"nvdbg-bytes"
+
+
+# ---------------------------------------------------------------------------
+# submit_to_teapot (best-effort wrapper)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_to_teapot_success() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        result = submit_to_teapot(project, "abc", dump, [])
+    assert result is not None
+    assert result["status"] == "completed"
+
+
+def test_submit_to_teapot_returns_none_when_unavailable() -> None:
+    from django.conf import settings
+
+    with (
+        mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True),
+        mock.patch(
+            "sentry.lang.native.teapot.options.get",
+            lambda key: None,
+        ),
+    ):
+        assert submit_to_teapot(_FakeProject(), "abc", _FakeAttachment(b"dump"), []) is None
+
+
+def test_submit_to_teapot_swallows_unexpected() -> None:
+    project = _FakeProject()
+    dump = _FakeAttachment(b"dump")
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.TeapotClient") as mock_client,
+        mock.patch("sentry.lang.native.teapot.sentry_sdk.capture_exception") as cap,
+    ):
+        mock_client.return_value.symbolicate.side_effect = RuntimeError("unexpected")
+        assert submit_to_teapot(project, "abc", dump, []) is None
+        cap.assert_called_once()
+
+
+def test_normalize_gpu_frames_tolerates_non_mapping_data() -> None:
+    """teapot's `frames[].data` is external and may not be a dict.
+
+    A truthy non-dict (string/list) must not crash `dict(...)` or the
+    `shader_hash` lookup — the frame is still normalized, just without `data`.
+    """
+
+    frames = [
+        {"function": "vertex", "data": "not-a-dict"},
+        {"function": "pixel", "data": [1, 2, 3]},
+        {"function": "compute", "data": {"shader_hash": 12345}},  # non-str hash
+        {"function": "ok", "data": {"shader_hash": "abc123"}},
+    ]
+
+    result = _normalize_gpu_frames(frames)
+
+    assert [f["function"] for f in result] == ["vertex", "pixel", "compute", "ok"]
+    # Non-dict data is dropped (no crash); no synthetic package is derived.
+    assert "package" not in result[0]
+    assert "package" not in result[1]
+    # Non-str shader_hash is ignored rather than crashing `.startswith`.
+    assert "package" not in result[2]
+    # A well-formed str shader_hash still produces a package.
+    assert result[3]["package"] == "shader_abc123"

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -158,6 +158,13 @@ def test_apply_gpu_crash_symbolication_shape() -> None:
     assert data["contexts"]["gpu_crash"]["fault_category"] == "shader_hang"
     assert tags["gpu.fault_category"] == "shader_hang"
     assert tags["gpu.shader_hash"] == "abc123"
+    # Standard gpu context uses the schema's `api_type` field, not `api`.
+    assert data["contexts"]["gpu"] == {
+        "name": "RTX 4090",
+        "vendor_name": "NVIDIA",
+        "driver_version": "555.1",
+        "api_type": "D3D12",
+    }
 
 
 def test_apply_fingerprint_fallback() -> None:
@@ -204,6 +211,22 @@ def test_apply_fills_os_from_gpu_state_as_raw_description() -> None:
         data, _completed_response(gpu_state={"os_version": "Windows 10 (19H1)"})
     )
     assert data["contexts"]["os"] == {"raw_description": "Windows 10 (19H1)", "type": "os"}
+
+
+def test_apply_merges_gpu_context_preserving_sdk_fields() -> None:
+    """teapot overlays its crash-dump fields onto an SDK-provided gpu context
+    without wiping SDK-only fields (memory_size, vendor_id)."""
+    data = _relay_gpu_event()
+    data["contexts"] = {"gpu": {"memory_size": 8192, "vendor_id": "0x10de", "name": "old"}}
+    apply_gpu_crash_symbolication(
+        data,
+        _completed_response(gpu_state={"device_name": "RTX 4090", "api": "Vulkan"}),
+    )
+    gpu = data["contexts"]["gpu"]
+    assert gpu["memory_size"] == 8192  # SDK-only field survives
+    assert gpu["vendor_id"] == "0x10de"  # SDK-only field survives
+    assert gpu["name"] == "RTX 4090"  # teapot's crash-dump value wins
+    assert gpu["api_type"] == "Vulkan"
 
 
 def test_apply_appends_markers_to_existing_breadcrumbs() -> None:

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -95,8 +95,8 @@ def _configured_teapot(url: str = "http://teapot.test") -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def _skip_retry_backoff() -> Iterator[None]:
-    """Skip teapot's inter-retry backoff sleep so retry tests stay instant."""
-    with mock.patch("sentry.lang.native.teapot.time.sleep"):
+    """Skip the retry policy's inter-retry backoff sleep so retry tests stay instant."""
+    with mock.patch("sentry.utils.retries.time.sleep"):
         yield
 
 

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator
-from datetime import timedelta
 from typing import Any
 from unittest import mock
 
@@ -102,18 +101,13 @@ def _skip_retry_backoff() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def mock_objectstore() -> Iterator[mock.Mock]:
-    session = mock.Mock()
-    session.object_url.side_effect = (
-        lambda key, token_validity=None: f"http://objectstore/{key}?sig=abc"
-    )
+    # teapot presigns each attachment via objectstore.get_internal_download_url.
+    get_url = mock.Mock(side_effect=lambda _session, key: f"http://objectstore/{key}?sig=abc")
     with (
-        mock.patch("sentry.lang.native.teapot.get_attachments_session", return_value=session),
-        mock.patch(
-            "sentry.lang.native.teapot.maybe_rewrite_url_for_symbolicator",
-            side_effect=lambda url: url,
-        ),
+        mock.patch("sentry.lang.native.teapot.get_attachments_session", return_value=mock.Mock()),
+        mock.patch("sentry.lang.native.teapot.get_internal_download_url", get_url),
     ):
-        yield session
+        yield get_url
 
 
 def _relay_gpu_event() -> dict[str, Any]:
@@ -289,11 +283,13 @@ def test_client_sends_presigned_urls(mock_objectstore: mock.Mock) -> None:
     assert shader["uid"] == "cafebabecafebabecafebabecafebabe"  # recovered from filename
     assert shader["storage_url"] == "http://objectstore/nvdbg-obj-id?sig=abc"
 
-    # Both attachments (dump + shader) get a short-lived presigned URL (embedded
-    # read-only token); the keys are covered by the storage_url asserts above.
-    assert mock_objectstore.object_url.call_count == 2
-    for call in mock_objectstore.object_url.call_args_list:
-        assert call.kwargs["token_validity"] == timedelta(seconds=60)
+    # Both attachments (dump + shader) are presigned via the shared internal
+    # objectstore helper, keyed by their stored_id.
+    assert mock_objectstore.call_count == 2
+    assert {call.args[1] for call in mock_objectstore.call_args_list} == {
+        "dump-obj-id",
+        "nvdbg-obj-id",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -206,6 +206,19 @@ def test_apply_fills_os_from_gpu_state_as_raw_description() -> None:
     assert data["contexts"]["os"] == {"raw_description": "Windows 10 (19H1)", "type": "os"}
 
 
+def test_apply_appends_markers_to_existing_breadcrumbs() -> None:
+    """teapot markers append to (not replace) breadcrumbs already on the split event."""
+    data = _relay_gpu_event()
+    data["breadcrumbs"] = {"values": [{"category": "app.start", "message": "boot"}]}
+    apply_gpu_crash_symbolication(
+        data,
+        _completed_response(markers=[{"kind": "draw", "label": "DrawIndexed", "data": {"n": 3}}]),
+    )
+    values = data["breadcrumbs"]["values"]
+    assert values[0]["message"] == "boot"  # SDK breadcrumb preserved, still first
+    assert values[-1]["category"] == "gpu.draw"  # GPU marker appended last
+
+
 # ---------------------------------------------------------------------------
 # TeapotClient — request wire format
 # ---------------------------------------------------------------------------

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -208,6 +208,16 @@ def test_apply_skips_failed_status() -> None:
     assert "fingerprint" not in data
 
 
+def test_apply_fills_os_from_gpu_state_as_raw_description() -> None:
+    """With no SDK os scope, teapot's combined os string fills `raw_description`
+    (not `name`, which drives OS filtering)."""
+    data = _relay_gpu_event()  # no os context
+    apply_gpu_crash_symbolication(
+        data, _completed_response(gpu_state={"os_version": "Windows 10 (19H1)"})
+    )
+    assert data["contexts"]["os"] == {"raw_description": "Windows 10 (19H1)", "type": "os"}
+
+
 # ---------------------------------------------------------------------------
 # TeapotClient — request wire format
 # ---------------------------------------------------------------------------

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -27,6 +27,7 @@ from sentry.lang.native.gpu import (
 from sentry.lang.native.teapot import (
     TeapotClient,
     TeapotUnavailable,
+    _uid_from_nvdbg_filename,
     submit_to_teapot,
 )
 
@@ -261,8 +262,8 @@ def test_client_multipart_success() -> None:
 
 
 def test_client_multipart_carries_shader_debug_attachments() -> None:
-    """Each .nvdbg is sent as a repeated `nv_shader_debug` field whose part
-    filename carries the uid teapot decodes it by."""
+    """Each .nvdbg becomes its own `nv_shader_debug.<uid>` field, the uid derived
+    from the attachment filename."""
 
     project = _FakeProject()
     dump = _FakeAttachment(b"dump-bytes")
@@ -285,12 +286,29 @@ def test_client_multipart_carries_shader_debug_attachments() -> None:
         TeapotClient(project, "abc").symbolicate(dump, [nvdbg1, nvdbg2])
 
     files = mock_post.call_args.kwargs["files"]
-    # `files` is a list-of-tuples so the `nv_shader_debug` field can repeat; each
-    # entry is (field_name, (filename, bytes, content_type)).
-    assert any(field == "upload_file" for field, _ in files)
-    shaders = {payload[0]: payload[1] for field, payload in files if field == "nv_shader_debug"}
-    assert shaders["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.nvdbg"] == b"nvdbg-bytes-1"
-    assert shaders["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.nvdbg"] == b"nvdbg-bytes-2"
+    # `files` is a list-of-tuples (the only way to repeat field names); teapot
+    # keys each shader by the uid in the `nv_shader_debug.<uid>` field name.
+    by_field = {field_name: payload for field_name, payload in files}
+    assert "upload_file" in by_field
+    assert by_field[f"nv_shader_debug.{'a' * 32}"][1] == b"nvdbg-bytes-1"
+    assert by_field[f"nv_shader_debug.{'b' * 32}"][1] == b"nvdbg-bytes-2"
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        # Production SDKs ship the full 32-hex uid.
+        ("59339c1ea893474000000210749de540.nvdbg", "59339c1ea893474000000210749de540"),
+        # The NVIDIA D3D12HelloNsightAftermath sample splits id[0]/id[1] with a dash.
+        ("shader-59339c1ea8934740-00000210749de540.nvdbg", "59339c1ea893474000000210749de540"),
+        # Uppercase normalizes to the decoder's lowercase key.
+        ("ABCDEF0123456789ABCDEF0123456789.nvdbg", "abcdef0123456789abcdef0123456789"),
+        # No parseable uid (caller falls back to the raw filename).
+        ("garbage.txt", None),
+    ],
+)
+def test_uid_from_nvdbg_filename(filename: str, expected: str | None) -> None:
+    assert _uid_from_nvdbg_filename(filename) == expected
 
 
 def test_client_retries_on_503() -> None:
@@ -466,7 +484,7 @@ def test_client_uses_json_path_when_all_attachments_stored() -> None:
     assert body["dump"]["storage_url"] == "http://objectstore/dump-obj-id"
     assert body["dump"]["storage_token"] == "token-dump"
     assert len(body["shader_debug_info"]) == 1
-    assert body["shader_debug_info"][0]["filename"] == "cafebabecafebabecafebabecafebabe.nvdbg"
+    assert body["shader_debug_info"][0]["uid"] == "cafebabecafebabecafebabecafebabe"
     assert body["shader_debug_info"][0]["storage_url"] == "http://objectstore/nvdbg-obj-id"
     assert body["shader_debug_info"][0]["storage_token"] == "token-nvdbg"
 
@@ -499,9 +517,7 @@ def test_client_falls_back_to_multipart_when_any_attachment_lacks_stored_id() ->
     files = mock_post.call_args.kwargs["files"]
     by_field = {field_name: payload for field_name, payload in files}
     assert by_field["upload_file"][1] == b"dump-bytes"
-    shader = next(payload for field, payload in files if field == "nv_shader_debug")
-    assert shader[0] == "cafebabecafebabecafebabecafebabe.nvdbg"
-    assert shader[1] == b"nvdbg-bytes"
+    assert by_field[f"nv_shader_debug.{'cafebabe' * 4}"][1] == b"nvdbg-bytes"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 
@@ -102,12 +103,13 @@ def _skip_retry_backoff() -> Iterator[None]:
 @pytest.fixture(autouse=True)
 def mock_objectstore() -> Iterator[mock.Mock]:
     session = mock.Mock()
-    session.object_url.side_effect = lambda key: f"http://objectstore/{key}?sig=abc"
+    session.object_url.side_effect = (
+        lambda key, token_validity=None: f"http://objectstore/{key}?sig=abc"
+    )
     with (
         mock.patch("sentry.lang.native.teapot.get_attachments_session", return_value=session),
-        # get_symbolicator_url wraps object_url with this; identity in the test.
         mock.patch(
-            "sentry.objectstore.maybe_rewrite_url_for_symbolicator",
+            "sentry.lang.native.teapot.maybe_rewrite_url_for_symbolicator",
             side_effect=lambda url: url,
         ),
     ):
@@ -209,7 +211,7 @@ def test_apply_fills_os_from_gpu_state_as_raw_description() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_client_sends_storage_urls(mock_objectstore: mock.Mock) -> None:
+def test_client_sends_presigned_urls(mock_objectstore: mock.Mock) -> None:
     project = _FakeProject()
     dump = _FakeAttachment(stored_id="dump-obj-id")
     nvdbg = _FakeAttachment(
@@ -240,11 +242,11 @@ def test_client_sends_storage_urls(mock_objectstore: mock.Mock) -> None:
     assert shader["uid"] == "cafebabecafebabecafebabecafebabe"  # recovered from filename
     assert shader["storage_url"] == "http://objectstore/nvdbg-obj-id?sig=abc"
 
-    # Both attachments (dump + shader) resolve through the same objectstore helper
-    # Symbolicator uses — object_url(key), no token (keys covered above).
+    # Both attachments (dump + shader) get a short-lived presigned URL (embedded
+    # read-only token); the keys are covered by the storage_url asserts above.
     assert mock_objectstore.object_url.call_count == 2
     for call in mock_objectstore.object_url.call_args_list:
-        assert call.kwargs == {}
+        assert call.kwargs["token_validity"] == timedelta(seconds=60)
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -376,36 +376,9 @@ def test_client_non_json_body() -> None:
 def test_client_missing_url_raises() -> None:
     from django.conf import settings
 
-    with (
-        mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True),
-        mock.patch(
-            "sentry.lang.native.teapot.options.get",
-            lambda key: {} if key == "teapot.options" else None,
-        ),
-    ):
+    with mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True):
         with pytest.raises(TeapotRequestError):
             TeapotClient(_FakeProject(), "abc")
-
-
-def test_client_falls_back_to_options() -> None:
-    from django.conf import settings
-
-    project = _FakeProject()
-    dump = _FakeAttachment(b"dump")
-    with (
-        mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True),
-        mock.patch(
-            "sentry.lang.native.teapot.options.get",
-            lambda key: (
-                {"url": "http://teapot-from-options.test"} if key == "teapot.options" else None
-            ),
-        ),
-        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-    ):
-        mock_post.return_value = _FakeResponse(200, _completed_response())
-        TeapotClient(project, "abc").symbolicate(dump)
-
-    assert mock_post.call_args[0][0] == "http://teapot-from-options.test/symbolicate"
 
 
 def test_client_skips_when_attachment_not_stored() -> None:
@@ -430,13 +403,7 @@ def test_submit_to_teapot_returns_none_on_request_error() -> None:
     # (None) so the caller doesn't trip the breaker.
     from django.conf import settings
 
-    with (
-        mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True),
-        mock.patch(
-            "sentry.lang.native.teapot.options.get",
-            lambda key: None,
-        ),
-    ):
+    with mock.patch.object(settings, "SENTRY_TEAPOT_URL", None, create=True):
         assert submit_to_teapot(_FakeProject(), "abc", _FakeAttachment(b"dump"), []) is None
 
 

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -5,6 +5,8 @@ Unit tests for the teapot client + GPU event enrichment.
 from __future__ import annotations
 
 import contextlib
+import hashlib
+import hmac
 from collections.abc import Iterator
 from typing import Any
 from unittest import mock
@@ -155,7 +157,6 @@ def test_apply_gpu_crash_symbolication_shape() -> None:
     # Standard gpu context uses the schema's `api_type` field, not `api`.
     assert data["contexts"]["gpu"] == {
         "name": "RTX 4090",
-        "vendor_name": "NVIDIA",
         "driver_version": "555.1",
         "api_type": "D3D12",
     }
@@ -290,6 +291,37 @@ def test_client_sends_presigned_urls(mock_objectstore: mock.Mock) -> None:
         "dump-obj-id",
         "nvdbg-obj-id",
     }
+
+
+def test_client_signs_request_when_secret_set(mock_objectstore: mock.Mock) -> None:
+    from django.conf import settings
+
+    with (
+        _configured_teapot(),
+        mock.patch.object(settings, "SENTRY_TEAPOT_SHARED_SECRET", "s3cr3t", create=True),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        TeapotClient(_FakeProject(), "abc").symbolicate(_FakeAttachment())
+
+    kwargs = mock_post.call_args.kwargs
+    # Signature is the HMAC-SHA256 of the exact body bytes sent.
+    expected = hmac.new(b"s3cr3t", kwargs["data"], hashlib.sha256).hexdigest()
+    assert kwargs["headers"]["Authorization"] == f"Rpcsignature rpc0:{expected}"
+
+
+def test_client_unsigned_when_secret_unset(mock_objectstore: mock.Mock) -> None:
+    from django.conf import settings
+
+    with (
+        _configured_teapot(),
+        mock.patch.object(settings, "SENTRY_TEAPOT_SHARED_SECRET", "", create=True),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        TeapotClient(_FakeProject(), "abc").symbolicate(_FakeAttachment())
+
+    assert "Authorization" not in mock_post.call_args.kwargs["headers"]
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -14,12 +14,7 @@ import orjson
 import pytest
 import requests
 
-from sentry.lang.native.gpu import (
-    GPU_CRASH_DUMP_ATTACHMENT_TYPE,
-    _build_flat_gpu_context,
-    _normalize_gpu_frames,
-    apply_gpu_crash_symbolication,
-)
+from sentry.lang.native.gpu import GPU_CRASH_DUMP_ATTACHMENT_TYPE, apply_gpu_crash_symbolication
 from sentry.lang.native.teapot import (
     TeapotClient,
     TeapotUnavailable,
@@ -173,30 +168,22 @@ def test_apply_fingerprint_fallback() -> None:
     assert data["fingerprint"] == ["gpu", "page_fault"]
 
 
-@pytest.mark.parametrize(
-    "response",
-    [
-        _completed_response(shader_context={"active_shaders": {"shader_hash": "x"}}),
-        _completed_response(shader_context={"active_shaders": "nope"}),
-        _completed_response(shader_context={"active_shaders": 7}),
-        _completed_response(
-            shader_context="nope", fault="nope", gpu_state=7, missing_difs=5, fingerprint=9
-        ),
-        _completed_response(
-            shader_context=[], fault=None, gpu_state=[], missing_difs="x", warnings="w"
-        ),
-    ],
-)
-def test_apply_survives_malformed_teapot_response(response: dict[str, Any]) -> None:
-    ctx = _build_flat_gpu_context(response)
+def test_apply_handles_missing_optional_fields() -> None:
+    """A minimal completed response (no gpu_state/frames/shader_context) still
+    yields a valid event with sensible defaults."""
     data = _relay_gpu_event()
-    out = apply_gpu_crash_symbolication(data, response)
+    out = apply_gpu_crash_symbolication(
+        data, {"status": "completed", "fault_category": "page_fault"}
+    )
 
     assert out is data
-    assert "shader_hash" not in ctx
+    assert data["type"] == "error"
+    assert data["fingerprint"] == ["gpu", "page_fault"]
+    exc = data["exception"]["values"][0]
+    assert exc["type"] == "GPU crash (page_fault)"  # no title -> synthesized
+    assert exc["stacktrace"]["frames"] == []
+    assert data["contexts"]["gpu_crash"]["missing_dif_count"] == 0
     assert "gpu.shader_hash" not in dict(data["tags"])
-    assert ctx["missing_dif_count"] == 0
-    assert isinstance(data["fingerprint"], list)
 
 
 def test_apply_skips_failed_status() -> None:
@@ -413,20 +400,3 @@ def test_submit_to_teapot_swallows_unexpected() -> None:
         mock_client.return_value.symbolicate.side_effect = RuntimeError("unexpected")
         assert submit_to_teapot(project, "abc", dump, []) is None
         cap.assert_called_once()
-
-
-def test_normalize_gpu_frames_tolerates_non_mapping_data() -> None:
-    frames = [
-        {"function": "vertex", "data": "not-a-dict"},
-        {"function": "pixel", "data": [1, 2, 3]},
-        {"function": "compute", "data": {"shader_hash": 12345}},  # non-str hash
-        {"function": "ok", "data": {"shader_hash": "abc123"}},
-    ]
-
-    result = _normalize_gpu_frames(frames)
-
-    assert [f["function"] for f in result] == ["vertex", "pixel", "compute", "ok"]
-    assert "package" not in result[0]
-    assert "package" not in result[1]
-    assert "package" not in result[2]
-    assert result[3]["package"] == "shader_abc123"

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -17,6 +17,7 @@ import requests
 from sentry.lang.native.gpu import GPU_CRASH_DUMP_ATTACHMENT_TYPE, apply_gpu_crash_symbolication
 from sentry.lang.native.teapot import (
     TeapotClient,
+    TeapotRequestError,
     TeapotUnavailable,
     _uid_from_nvdbg_filename,
     submit_to_teapot,
@@ -306,7 +307,8 @@ def test_client_400_is_not_retried() -> None:
     ):
         mock_post.return_value = _FakeResponse(400, "bad request")
 
-        with pytest.raises(TeapotUnavailable):
+        # A 4xx is a client error, not an outage.
+        with pytest.raises(TeapotRequestError):
             TeapotClient(project, "abc").symbolicate(dump)
 
     assert mock_post.call_count == 1
@@ -336,7 +338,7 @@ def test_client_missing_url_raises() -> None:
             lambda key: {} if key == "teapot.options" else None,
         ),
     ):
-        with pytest.raises(TeapotUnavailable):
+        with pytest.raises(TeapotRequestError):
             TeapotClient(_FakeProject(), "abc")
 
 
@@ -369,14 +371,18 @@ def test_client_skips_when_attachment_not_stored() -> None:
         _configured_teapot(),
         mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
     ):
-        with pytest.raises(TeapotUnavailable):
+        with pytest.raises(TeapotRequestError):
             TeapotClient(project, "abc").symbolicate(dump)
+        # A missing attachment is a data error, so submit_to_teapot skips (None),
+        # never contacting teapot.
         assert submit_to_teapot(project, "abc", dump, []) is None
 
     assert mock_post.call_count == 0
 
 
-def test_submit_to_teapot_returns_none_when_unavailable() -> None:
+def test_submit_to_teapot_returns_none_on_request_error() -> None:
+    # A request/data error (here: URL not configured) is not an outage: skip
+    # (None) so the caller doesn't trip the breaker.
     from django.conf import settings
 
     with (
@@ -387,6 +393,16 @@ def test_submit_to_teapot_returns_none_when_unavailable() -> None:
         ),
     ):
         assert submit_to_teapot(_FakeProject(), "abc", _FakeAttachment(b"dump"), []) is None
+
+
+def test_submit_to_teapot_raises_on_outage() -> None:
+    # A genuine outage (exhausted 5xx) propagates so the caller trips the breaker.
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post", return_value=_FakeResponse(503)),
+    ):
+        with pytest.raises(TeapotUnavailable):
+            submit_to_teapot(_FakeProject(), "abc", _FakeAttachment(b"dump"), [])
 
 
 def test_submit_to_teapot_swallows_unexpected() -> None:

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -1,10 +1,10 @@
 """
-Unit tests for the teapot client + GPU error-event construction.
+Unit tests for the teapot client + GPU event enrichment.
 
 Covers:
 * `TeapotClient.symbolicate` — both multipart and JSON+storage_url paths
 * `submit_to_teapot` wrapper — best-effort error swallowing
-* `_build_gpu_error_event` / `emit_gpu_crash_event` — synthetic error event shape
+* `apply_gpu_crash_symbolication` — applying teapot's decode to the event
 * `_normalize_gpu_frames` — frame normalization edge cases
 """
 
@@ -154,7 +154,9 @@ def test_apply_gpu_crash_symbolication_shape() -> None:
     assert data["fingerprint"] == ["gpu", "shader_hang", "abc123"]
     # Relay-owned fields are preserved, not overwritten.
     assert data["contexts"]["trace"]["trace_id"] == "a" * 32
-    assert data["tags"]["cpu_event_id"] == "cpu-1"
+    # tags are the pipeline's list-of-pairs form; the Relay-set tag survives.
+    tags = dict(data["tags"])
+    assert tags["cpu_event_id"] == "cpu-1"
     assert data["release"] == "game@1.2.3"
     # teapot's decode is applied.
     assert data["level"] == "fatal"
@@ -163,8 +165,8 @@ def test_apply_gpu_crash_symbolication_shape() -> None:
     assert exc["mechanism"] == {"type": "gpu_crash", "handled": False}
     assert exc["stacktrace"]["frames"][0]["function"] == "Vertex"
     assert data["contexts"]["gpu_crash"]["fault_category"] == "shader_hang"
-    assert data["tags"]["gpu.fault_category"] == "shader_hang"
-    assert data["tags"]["gpu.shader_hash"] == "abc123"
+    assert tags["gpu.fault_category"] == "shader_hang"
+    assert tags["gpu.shader_hash"] == "abc123"
 
 
 def test_apply_fingerprint_fallback() -> None:
@@ -204,7 +206,7 @@ def test_apply_survives_malformed_teapot_response(response: dict[str, Any]) -> N
 
     assert out is data
     assert "shader_hash" not in ctx
-    assert "gpu.shader_hash" not in data["tags"]
+    assert "gpu.shader_hash" not in dict(data["tags"])
     # len()/list() over the scalar list fields yielded empties, not a TypeError.
     assert ctx["missing_dif_count"] == 0
     assert isinstance(data["fingerprint"], list)
@@ -259,7 +261,8 @@ def test_client_multipart_success() -> None:
 
 
 def test_client_multipart_carries_shader_debug_attachments() -> None:
-    """Each .nvdbg attachment becomes its own `nv_shader_debug.<uid>` field."""
+    """Each .nvdbg is sent as a repeated `nv_shader_debug` field whose part
+    filename carries the uid teapot decodes it by."""
 
     project = _FakeProject()
     dump = _FakeAttachment(b"dump-bytes")
@@ -279,21 +282,15 @@ def test_client_multipart_carries_shader_debug_attachments() -> None:
         mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
     ):
         mock_post.return_value = _FakeResponse(200, _completed_response())
-        TeapotClient(project, "abc").symbolicate(
-            dump,
-            [
-                ("a" * 32, nvdbg1),
-                ("b" * 32, nvdbg2),
-            ],
-        )
+        TeapotClient(project, "abc").symbolicate(dump, [nvdbg1, nvdbg2])
 
     files = mock_post.call_args.kwargs["files"]
-    # `files` is a list-of-tuples (the only way to repeat field names),
-    # so map by the first element for ergonomic assertions.
-    by_field = {field_name: payload for field_name, payload in files}
-    assert "upload_file" in by_field
-    assert by_field[f"nv_shader_debug.{'a' * 32}"][1] == b"nvdbg-bytes-1"
-    assert by_field[f"nv_shader_debug.{'b' * 32}"][1] == b"nvdbg-bytes-2"
+    # `files` is a list-of-tuples so the `nv_shader_debug` field can repeat; each
+    # entry is (field_name, (filename, bytes, content_type)).
+    assert any(field == "upload_file" for field, _ in files)
+    shaders = {payload[0]: payload[1] for field, payload in files if field == "nv_shader_debug"}
+    assert shaders["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.nvdbg"] == b"nvdbg-bytes-1"
+    assert shaders["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.nvdbg"] == b"nvdbg-bytes-2"
 
 
 def test_client_retries_on_503() -> None:
@@ -456,7 +453,7 @@ def test_client_uses_json_path_when_all_attachments_stored() -> None:
     ):
         mock_post.return_value = _FakeResponse(200, _completed_response())
 
-        TeapotClient(project, "abc").symbolicate(dump, [("c" * 32, nvdbg)])
+        TeapotClient(project, "abc").symbolicate(dump, [nvdbg])
 
     # JSON path: `files` empty, Content-Type set, body is JSON-encoded.
     kwargs = mock_post.call_args.kwargs
@@ -469,7 +466,7 @@ def test_client_uses_json_path_when_all_attachments_stored() -> None:
     assert body["dump"]["storage_url"] == "http://objectstore/dump-obj-id"
     assert body["dump"]["storage_token"] == "token-dump"
     assert len(body["shader_debug_info"]) == 1
-    assert body["shader_debug_info"][0]["uid"] == "c" * 32
+    assert body["shader_debug_info"][0]["filename"] == "cafebabecafebabecafebabecafebabe.nvdbg"
     assert body["shader_debug_info"][0]["storage_url"] == "http://objectstore/nvdbg-obj-id"
     assert body["shader_debug_info"][0]["storage_token"] == "token-nvdbg"
 
@@ -493,7 +490,7 @@ def test_client_falls_back_to_multipart_when_any_attachment_lacks_stored_id() ->
         mock.patch("sentry.lang.native.teapot.get_attachments_session") as mock_session_fn,
     ):
         mock_post.return_value = _FakeResponse(200, _completed_response())
-        TeapotClient(project, "abc").symbolicate(dump, [("c" * 32, nvdbg)])
+        TeapotClient(project, "abc").symbolicate(dump, [nvdbg])
 
     # Objectstore session is never opened because the mixed-state check
     # routes to multipart immediately.
@@ -502,7 +499,9 @@ def test_client_falls_back_to_multipart_when_any_attachment_lacks_stored_id() ->
     files = mock_post.call_args.kwargs["files"]
     by_field = {field_name: payload for field_name, payload in files}
     assert by_field["upload_file"][1] == b"dump-bytes"
-    assert by_field[f"nv_shader_debug.{'c' * 32}"][1] == b"nvdbg-bytes"
+    shader = next(payload for field, payload in files if field == "nv_shader_debug")
+    assert shader[0] == "cafebabecafebabecafebabecafebabe.nvdbg"
+    assert shader[1] == b"nvdbg-bytes"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -2,7 +2,7 @@
 Unit tests for the teapot client + GPU event enrichment.
 
 Covers:
-* `TeapotClient.symbolicate` — both multipart and JSON+storage_url paths
+* `TeapotClient.symbolicate` — the presigned-URL wire format
 * `submit_to_teapot` wrapper — best-effort error swallowing
 * `apply_gpu_crash_symbolication` — applying teapot's decode to the event
 * `_normalize_gpu_frames` — frame normalization edge cases
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 
+import orjson
 import pytest
 import requests
 
@@ -41,26 +43,24 @@ class _FakeProject:
 class _FakeAttachment:
     """Stand-in for `sentry.attachments.CachedAttachment` in unit tests.
 
-    Carries enough surface for the teapot client: bytes via `load_data`,
-    the attachment `type`, the filename `name`, and an optional
-    `stored_id`. When `stored_id` is set teapot's client routes via the
-    JSON+storage_url path; otherwise it falls back to multipart.
+    The client only reads `name` (the filename — for a `.nvdbg` it carries the
+    `shader_debug_info_uid`) and `stored_id` (the objectstore key it presigns).
+    `data` is accepted for call-site convenience but never read: bytes are
+    fetched by teapot from objectstore, never inlined. `stored_id` defaults to a
+    value so the presigned path is exercised; pass `None` to simulate an
+    attachment missing from objectstore.
     """
 
     def __init__(
         self,
-        data: bytes,
+        data: bytes = b"",
         attachment_type: str = GPU_CRASH_DUMP_ATTACHMENT_TYPE,
         name: str = "dump.nv-gpudmp",
-        stored_id: str | None = None,
+        stored_id: str | None = "obj-id",
     ) -> None:
-        self._data = data
         self.type = attachment_type
         self.name = name
         self.stored_id = stored_id
-
-    def load_data(self, _project: Any) -> bytes:
-        return self._data
 
 
 class _FakeResponse:
@@ -118,6 +118,27 @@ def _skip_retry_backoff() -> Iterator[None]:
     """Skip teapot's inter-retry backoff sleep so retry tests stay instant."""
     with mock.patch("sentry.lang.native.teapot.time.sleep"):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_objectstore() -> Iterator[mock.Mock]:
+    """Every attachment is fetched by presigned URL, so `symbolicate` always
+    opens an objectstore session. Fake it: `presigned_object_url(method, key,
+    duration=...)` returns a stable URL, and the symbolicator dev-rewrite is a
+    no-op (its real path shells out to `docker`). Autouse so plain client tests
+    work without setup; request it by name to assert on the presign calls."""
+    session = mock.Mock()
+    session.presigned_object_url.side_effect = (
+        lambda _method, key, duration=None: f"http://objectstore/{key}?sig=abc"
+    )
+    with (
+        mock.patch("sentry.lang.native.teapot.get_attachments_session", return_value=session),
+        mock.patch(
+            "sentry.lang.native.teapot.maybe_rewrite_url_for_symbolicator",
+            side_effect=lambda url: url,
+        ),
+    ):
+        yield session
 
 
 # ---------------------------------------------------------------------------
@@ -226,58 +247,22 @@ def test_apply_skips_failed_status() -> None:
 
 
 # ---------------------------------------------------------------------------
-# TeapotClient — multipart wire format
+# TeapotClient — request wire format
 # ---------------------------------------------------------------------------
 
 
-def test_client_multipart_success() -> None:
+def test_client_sends_presigned_urls() -> None:
+    """The dump and every .nvdbg are passed by presigned GET URL, never inline.
+
+    Teapot fetches the bytes straight from objectstore; only URLs cross the
+    wire, and no bearer token is exchanged (the URL is self-authenticating).
+    """
     project = _FakeProject()
-    dump = _FakeAttachment(b"dummy-dump-bytes", stored_id=None)
-    expected = _completed_response()
-
-    with (
-        _configured_teapot(),
-        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-    ):
-        mock_post.return_value = _FakeResponse(200, expected)
-
-        result = TeapotClient(project, "abc").symbolicate(dump)
-
-    assert result == expected
-    assert mock_post.call_count == 1
-    args, kwargs = mock_post.call_args
-    assert args[0] == "http://teapot.test/symbolicate"
-    # Identifiers carried as multipart form fields, NOT as a `sources` JSON
-    # — we no longer send a source-config block.
-    assert kwargs["data"]["event_id"] == "abc"
-    assert kwargs["data"]["project_id"] == "42"
-    assert kwargs["data"]["organization_id"] == "7"
-    assert "sources" not in kwargs["data"]
-    # Dump arrives as the canonical `upload_file` multipart field.
-    files = dict(kwargs["files"])
-    assert files["upload_file"][1] == b"dummy-dump-bytes"
-    assert kwargs["headers"]["X-Teapot-Version"] == "1"
-    assert kwargs["headers"]["X-Request-Id"] == "abc"
-    # event_id doubles as the idempotency key so a retried task replays
-    # teapot's cached decode instead of re-running it.
-    assert kwargs["headers"]["Idempotency-Key"] == "abc"
-
-
-def test_client_multipart_carries_shader_debug_attachments() -> None:
-    """Each .nvdbg becomes its own `nv_shader_debug.<uid>` field, the uid derived
-    from the attachment filename."""
-
-    project = _FakeProject()
-    dump = _FakeAttachment(b"dump-bytes")
-    nvdbg1 = _FakeAttachment(
-        b"nvdbg-bytes-1",
+    dump = _FakeAttachment(stored_id="dump-obj-id")
+    nvdbg = _FakeAttachment(
         attachment_type="event.nv_shader_debug",
-        name="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.nvdbg",
-    )
-    nvdbg2 = _FakeAttachment(
-        b"nvdbg-bytes-2",
-        attachment_type="event.nv_shader_debug",
-        name="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.nvdbg",
+        name="cafebabecafebabecafebabecafebabe.nvdbg",
+        stored_id="nvdbg-obj-id",
     )
 
     with (
@@ -285,15 +270,50 @@ def test_client_multipart_carries_shader_debug_attachments() -> None:
         mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
     ):
         mock_post.return_value = _FakeResponse(200, _completed_response())
-        TeapotClient(project, "abc").symbolicate(dump, [nvdbg1, nvdbg2])
+        TeapotClient(project, "abc").symbolicate(dump, [nvdbg])
 
-    files = mock_post.call_args.kwargs["files"]
-    # `files` is a list-of-tuples (the only way to repeat field names); teapot
-    # keys each shader by the uid in the `nv_shader_debug.<uid>` field name.
-    by_field = {field_name: payload for field_name, payload in files}
-    assert "upload_file" in by_field
-    assert by_field[f"nv_shader_debug.{'a' * 32}"][1] == b"nvdbg-bytes-1"
-    assert by_field[f"nv_shader_debug.{'b' * 32}"][1] == b"nvdbg-bytes-2"
+    assert mock_post.call_count == 1
+    args, kwargs = mock_post.call_args
+    assert args[0] == "http://teapot.test/symbolicate"
+    # JSON body — no multipart `files`, Content-Type set.
+    assert kwargs.get("files") is None
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert kwargs["headers"]["X-Teapot-Version"] == "1"
+    assert kwargs["headers"]["X-Request-Id"] == "abc"
+    # event_id doubles as the idempotency key so a retried task replays
+    # teapot's cached decode instead of re-running it.
+    assert kwargs["headers"]["Idempotency-Key"] == "abc"
+
+    body = orjson.loads(kwargs["data"])
+    assert body["event_id"] == "abc"
+    assert body["project_id"] == "42"
+    assert body["organization_id"] == "7"
+    # A presigned URL per attachment; no inline bytes, no token.
+    assert body["dump"]["storage_url"] == "http://objectstore/dump-obj-id?sig=abc"
+    assert "storage_token" not in body["dump"]
+    assert len(body["shader_debug_info"]) == 1
+    shader = body["shader_debug_info"][0]
+    # uid recovered from the .nvdbg filename (teapot's shader_debug_info key).
+    assert shader["uid"] == "cafebabecafebabecafebabecafebabe"
+    assert shader["storage_url"] == "http://objectstore/nvdbg-obj-id?sig=abc"
+    assert "storage_token" not in shader
+
+
+def test_client_presigns_get_with_bounded_ttl(mock_objectstore: mock.Mock) -> None:
+    """Each attachment is presigned for GET with the short request-window TTL."""
+    project = _FakeProject()
+    dump = _FakeAttachment(stored_id="dump-obj-id")
+
+    with (
+        _configured_teapot(),
+        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
+    ):
+        mock_post.return_value = _FakeResponse(200, _completed_response())
+        TeapotClient(project, "abc").symbolicate(dump)
+
+    call = mock_objectstore.presigned_object_url.call_args
+    assert call.args[:2] == ("GET", "dump-obj-id")
+    assert call.kwargs["duration"] == timedelta(seconds=60)
 
 
 @pytest.mark.parametrize(
@@ -435,91 +455,28 @@ def test_client_falls_back_to_options() -> None:
 
 
 # ---------------------------------------------------------------------------
-# TeapotClient — JSON + storage_url + storage_token (objectstore path)
+# TeapotClient — attachment missing from objectstore
 # ---------------------------------------------------------------------------
 
 
-def test_client_uses_json_path_when_all_attachments_stored() -> None:
-    """When every attachment has `stored_id`, pass URLs not bytes.
-
-    Mirrors `Symbolicator.process_minidump`'s objectstore path. Teapot
-    fetches the bytes directly from objectstore using the minted tokens.
-    Bytes never pass through the Sentry worker.
-    """
+def test_client_skips_when_attachment_not_stored() -> None:
+    """GPU-crash attachments are always uploaded to objectstore. If one is
+    missing a `stored_id` we can't presign it — teapot is skipped rather than
+    sent inline bytes: `symbolicate` raises and `submit_to_teapot` swallows it."""
 
     project = _FakeProject()
-    dump = _FakeAttachment(b"dump-bytes-should-not-be-sent", stored_id="dump-obj-id")
-    nvdbg = _FakeAttachment(
-        b"nvdbg-bytes-should-not-be-sent",
-        attachment_type="event.nv_shader_debug",
-        name="cafebabecafebabecafebabecafebabe.nvdbg",
-        stored_id="nvdbg-obj-id",
-    )
-
-    fake_session = mock.Mock()
-    fake_session.mint_token.side_effect = ["token-dump", "token-nvdbg"]
-
-    with (
-        _configured_teapot(),
-        mock.patch(
-            "sentry.lang.native.teapot.get_attachments_session",
-            return_value=fake_session,
-        ),
-        mock.patch(
-            "sentry.lang.native.teapot.get_symbolicator_url",
-            side_effect=lambda _sess, key: f"http://objectstore/{key}",
-        ),
-        mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-    ):
-        mock_post.return_value = _FakeResponse(200, _completed_response())
-
-        TeapotClient(project, "abc").symbolicate(dump, [nvdbg])
-
-    # JSON path: `files` empty, Content-Type set, body is JSON-encoded.
-    kwargs = mock_post.call_args.kwargs
-    assert kwargs.get("files") is None
-    assert kwargs["headers"]["Content-Type"] == "application/json"
-    import orjson
-
-    body = orjson.loads(kwargs["data"])
-    assert body["event_id"] == "abc"
-    assert body["dump"]["storage_url"] == "http://objectstore/dump-obj-id"
-    assert body["dump"]["storage_token"] == "token-dump"
-    assert len(body["shader_debug_info"]) == 1
-    assert body["shader_debug_info"][0]["uid"] == "cafebabecafebabecafebabecafebabe"
-    assert body["shader_debug_info"][0]["storage_url"] == "http://objectstore/nvdbg-obj-id"
-    assert body["shader_debug_info"][0]["storage_token"] == "token-nvdbg"
-
-
-def test_client_falls_back_to_multipart_when_any_attachment_lacks_stored_id() -> None:
-    """Mixed-state attachments → multipart (we can't combine wire formats)."""
-
-    project = _FakeProject()
-    dump = _FakeAttachment(b"dump-bytes", stored_id="dump-obj-id")
-    # Second attachment has NO stored_id — forces multipart path.
-    nvdbg = _FakeAttachment(
-        b"nvdbg-bytes",
-        attachment_type="event.nv_shader_debug",
-        name="cafebabecafebabecafebabecafebabe.nvdbg",
-        stored_id=None,
-    )
+    dump = _FakeAttachment(stored_id=None)
 
     with (
         _configured_teapot(),
         mock.patch("sentry.lang.native.teapot.requests.post") as mock_post,
-        mock.patch("sentry.lang.native.teapot.get_attachments_session") as mock_session_fn,
     ):
-        mock_post.return_value = _FakeResponse(200, _completed_response())
-        TeapotClient(project, "abc").symbolicate(dump, [nvdbg])
+        with pytest.raises(TeapotUnavailable):
+            TeapotClient(project, "abc").symbolicate(dump)
+        assert submit_to_teapot(project, "abc", dump, []) is None
 
-    # Objectstore session is never opened because the mixed-state check
-    # routes to multipart immediately.
-    assert mock_session_fn.call_count == 0
-    # Multipart: `files` populated with inline bytes.
-    files = mock_post.call_args.kwargs["files"]
-    by_field = {field_name: payload for field_name, payload in files}
-    assert by_field["upload_file"][1] == b"dump-bytes"
-    assert by_field[f"nv_shader_debug.{'cafebabe' * 4}"][1] == b"nvdbg-bytes"
+    # We never reach out to teapot with a partial payload.
+    assert mock_post.call_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -106,7 +106,7 @@ def mock_objectstore() -> Iterator[mock.Mock]:
     # teapot presigns each attachment via objectstore.get_internal_download_url.
     get_url = mock.Mock(side_effect=lambda _session, key: f"http://objectstore/{key}?sig=abc")
     with (
-        mock.patch("sentry.lang.native.teapot.get_attachments_session", return_value=mock.Mock()),
+        mock.patch("sentry.lang.native.teapot.get_session", return_value=mock.Mock()),
         mock.patch("sentry.lang.native.teapot.get_internal_download_url", get_url),
     ):
         yield get_url

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator
-from datetime import timedelta
 from typing import Any
 from unittest import mock
 
@@ -103,13 +102,12 @@ def _skip_retry_backoff() -> Iterator[None]:
 @pytest.fixture(autouse=True)
 def mock_objectstore() -> Iterator[mock.Mock]:
     session = mock.Mock()
-    session.presigned_object_url.side_effect = (
-        lambda _method, key, duration=None: f"http://objectstore/{key}?sig=abc"
-    )
+    session.object_url.side_effect = lambda key: f"http://objectstore/{key}?sig=abc"
     with (
         mock.patch("sentry.lang.native.teapot.get_attachments_session", return_value=session),
+        # get_symbolicator_url wraps object_url with this; identity in the test.
         mock.patch(
-            "sentry.lang.native.teapot.maybe_rewrite_url_for_symbolicator",
+            "sentry.objectstore.maybe_rewrite_url_for_symbolicator",
             side_effect=lambda url: url,
         ),
     ):
@@ -211,7 +209,7 @@ def test_apply_fills_os_from_gpu_state_as_raw_description() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_client_sends_presigned_urls(mock_objectstore: mock.Mock) -> None:
+def test_client_sends_storage_urls(mock_objectstore: mock.Mock) -> None:
     project = _FakeProject()
     dump = _FakeAttachment(stored_id="dump-obj-id")
     nvdbg = _FakeAttachment(
@@ -242,9 +240,11 @@ def test_client_sends_presigned_urls(mock_objectstore: mock.Mock) -> None:
     assert shader["uid"] == "cafebabecafebabecafebabecafebabe"  # recovered from filename
     assert shader["storage_url"] == "http://objectstore/nvdbg-obj-id?sig=abc"
 
-    call = mock_objectstore.presigned_object_url.call_args
-    assert call.args[0] == "GET"
-    assert call.kwargs["duration"] == timedelta(seconds=60)
+    # Both attachments (dump + shader) resolve through the same objectstore helper
+    # Symbolicator uses — object_url(key), no token (keys covered above).
+    assert mock_objectstore.object_url.call_count == 2
+    for call in mock_objectstore.object_url.call_args_list:
+        assert call.kwargs == {}
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/lang/native/test_teapot.py
+++ b/tests/sentry/lang/native/test_teapot.py
@@ -242,6 +242,17 @@ def test_apply_appends_markers_to_existing_breadcrumbs() -> None:
     assert values[-1]["category"] == "gpu.draw"  # GPU marker appended last
 
 
+def test_apply_marker_without_data_omits_none_from_message() -> None:
+    """A label-only marker (no data) renders just the label, not 'label: None'."""
+    data = _relay_gpu_event()
+    apply_gpu_crash_symbolication(
+        data, _completed_response(markers=[{"kind": "barrier", "label": "PipelineBarrier"}])
+    )
+    bc = data["breadcrumbs"]["values"][0]
+    assert bc["message"] == "PipelineBarrier"
+    assert bc["data"] is None
+
+
 # ---------------------------------------------------------------------------
 # TeapotClient — request wire format
 # ---------------------------------------------------------------------------

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -1,6 +1,14 @@
 from unittest.mock import MagicMock, patch
 
-from sentry.lang.native.utils import Backoff, get_os_from_event, is_minidump_event
+import pytest
+
+from sentry.lang.native.utils import (
+    Backoff,
+    _uid_from_nvdbg_filename,
+    get_os_from_event,
+    is_gpu_crash_event,
+    is_minidump_event,
+)
 
 
 def test_get_os_from_event() -> None:
@@ -33,6 +41,52 @@ def test_is_minidump() -> None:
     assert not is_minidump_event({"exception": {"values": []}})
     assert not is_minidump_event({"exception": {"values": None}})
     assert not is_minidump_event({"exception": None})
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        # Production SDKs ship the full 32-hex uid.
+        ("59339c1ea893474000000210749de540.nvdbg", "59339c1ea893474000000210749de540"),
+        # The NVIDIA D3D12HelloNsightAftermath sample splits id[0]/id[1] with a
+        # dash — the two 16-hex halves concatenate back to the 32-hex uid.
+        (
+            "shader-59339c1ea8934740-00000210749de540.nvdbg",
+            "59339c1ea893474000000210749de540",
+        ),
+        # Uppercase is normalized to lowercase to match the decoder's key.
+        ("ABCDEF0123456789ABCDEF0123456789.nvdbg", "abcdef0123456789abcdef0123456789"),
+        # No parseable uid => None (skipped by the finders).
+        ("garbage.txt", None),
+        ("shader-nope.nvdbg", None),
+    ],
+)
+def test_uid_from_nvdbg_filename(filename: str, expected: str | None) -> None:
+    assert _uid_from_nvdbg_filename(filename) == expected
+
+
+class _Att:
+    def __init__(self, type: str, name: str = "") -> None:
+        self.type = type
+        self.name = name
+
+
+@pytest.mark.parametrize(
+    "attachments,expected",
+    [
+        # A pure GPU event (dump, no CPU crash report) — Relay split it off → teapot.
+        ([_Att("event.nv_gpudmp", "d.nv-gpudmp")], True),
+        # A combined upload (dump + minidump) is the CPU crash → leave it to symbolicator.
+        ([_Att("event.nv_gpudmp", "d.nv-gpudmp"), _Att("event.minidump", "m")], False),
+        # Same for an apple crash report (dump matched via the filename fallback).
+        ([_Att("event.attachment", "d.nv-gpudmp"), _Att("event.applecrashreport", "a")], False),
+        # No GPU dump at all.
+        ([_Att("event.attachment", "log.txt")], False),
+    ],
+)
+def test_is_gpu_crash_event(attachments: list[_Att], expected: bool) -> None:
+    with patch("sentry.lang.native.utils.get_attachments_for_event", return_value=attachments):
+        assert is_gpu_crash_event({}) is expected
 
 
 @patch("time.sleep")

--- a/tests/sentry/lang/native/test_utils.py
+++ b/tests/sentry/lang/native/test_utils.py
@@ -4,7 +4,6 @@ import pytest
 
 from sentry.lang.native.utils import (
     Backoff,
-    _uid_from_nvdbg_filename,
     get_os_from_event,
     is_gpu_crash_event,
     is_minidump_event,
@@ -43,28 +42,6 @@ def test_is_minidump() -> None:
     assert not is_minidump_event({"exception": None})
 
 
-@pytest.mark.parametrize(
-    "filename,expected",
-    [
-        # Production SDKs ship the full 32-hex uid.
-        ("59339c1ea893474000000210749de540.nvdbg", "59339c1ea893474000000210749de540"),
-        # The NVIDIA D3D12HelloNsightAftermath sample splits id[0]/id[1] with a
-        # dash — the two 16-hex halves concatenate back to the 32-hex uid.
-        (
-            "shader-59339c1ea8934740-00000210749de540.nvdbg",
-            "59339c1ea893474000000210749de540",
-        ),
-        # Uppercase is normalized to lowercase to match the decoder's key.
-        ("ABCDEF0123456789ABCDEF0123456789.nvdbg", "abcdef0123456789abcdef0123456789"),
-        # No parseable uid => None (skipped by the finders).
-        ("garbage.txt", None),
-        ("shader-nope.nvdbg", None),
-    ],
-)
-def test_uid_from_nvdbg_filename(filename: str, expected: str | None) -> None:
-    assert _uid_from_nvdbg_filename(filename) == expected
-
-
 class _Att:
     def __init__(self, type: str, name: str = "") -> None:
         self.type = type
@@ -78,10 +55,10 @@ class _Att:
         ([_Att("event.nv_gpudmp", "d.nv-gpudmp")], True),
         # A combined upload (dump + minidump) is the CPU crash → leave it to symbolicator.
         ([_Att("event.nv_gpudmp", "d.nv-gpudmp"), _Att("event.minidump", "m")], False),
-        # Same for an apple crash report (dump matched via the filename fallback).
-        ([_Att("event.attachment", "d.nv-gpudmp"), _Att("event.applecrashreport", "a")], False),
-        # No GPU dump at all.
-        ([_Att("event.attachment", "log.txt")], False),
+        # Same when the dump rides an apple crash report event.
+        ([_Att("event.nv_gpudmp", "d.nv-gpudmp"), _Att("event.applecrashreport", "a")], False),
+        # An untyped `event.attachment` is not a GPU dump (no filename fallback).
+        ([_Att("event.attachment", "d.nv-gpudmp")], False),
     ],
 )
 def test_is_gpu_crash_event(attachments: list[_Att], expected: bool) -> None:

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+from sentry.models.project import Project
+from sentry.tasks.gpu_crash import (
+    _try_symbolicate,
+    submit_symbolicate_gpu_crash,
+    symbolicate_gpu_crash_event,
+)
+from sentry.testutils.helpers import Feature
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
+
+FIND_DUMP = "sentry.lang.native.utils.find_gpu_crash_dump_attachment"
+FIND_SHADERS = "sentry.lang.native.utils.find_all_shader_debug_attachments"
+SUBMIT_TEAPOT = "sentry.lang.native.teapot.submit_to_teapot"
+APPLY = "sentry.lang.native.gpu.apply_gpu_crash_symbolication"
+SUBMIT_PROCESS = "sentry.tasks.store.submit_process"
+
+
+class _FakeAttachment:
+    """A `CachedAttachment` stand-in: name + bytes via `load_data`."""
+
+    def __init__(self, name: str = "dump.nv-gpudmp", data: bytes = b"dump") -> None:
+        self.name = name
+        self.stored_id = None
+        self._data = data
+
+    def load_data(self, project: Any = None) -> bytes:
+        return self._data
+
+
+def _completed() -> dict[str, Any]:
+    return {"status": "completed", "fault_category": "shader_hang"}
+
+
+# ---------------------------------------------------------------------------
+# _try_symbolicate — the teapot call + apply, best-effort
+# ---------------------------------------------------------------------------
+
+
+@django_db_all
+def test_try_symbolicate_happy_path(default_project: Project) -> None:
+    data: dict[str, Any] = {"event_id": "e", "project": default_project.id}
+    with (
+        override_options({"teapot.enabled": True}),
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
+        mock.patch(FIND_SHADERS, return_value=[]),
+        mock.patch(SUBMIT_TEAPOT, return_value=_completed()) as teapot,
+        mock.patch(APPLY, return_value=data) as apply,
+    ):
+        changed = _try_symbolicate(data, default_project.id, "e")
+
+    assert changed is True
+    assert teapot.call_count == 1
+    assert apply.call_count == 1
+
+
+@django_db_all
+def test_try_symbolicate_skipped_when_disabled(default_project: Project) -> None:
+    with (
+        override_options({"teapot.enabled": False}),
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(SUBMIT_TEAPOT) as teapot,
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+    assert teapot.call_count == 0
+
+
+@django_db_all
+def test_try_symbolicate_skipped_when_flag_off(default_project: Project) -> None:
+    with (
+        override_options({"teapot.enabled": True}),
+        mock.patch(SUBMIT_TEAPOT) as teapot,
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+    assert teapot.call_count == 0
+
+
+@django_db_all
+def test_try_symbolicate_skipped_without_dump(default_project: Project) -> None:
+    with (
+        override_options({"teapot.enabled": True}),
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(FIND_DUMP, return_value=None),
+        mock.patch(SUBMIT_TEAPOT) as teapot,
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+    assert teapot.call_count == 0
+
+
+@django_db_all
+def test_try_symbolicate_teapot_unavailable(default_project: Project) -> None:
+    with (
+        override_options({"teapot.enabled": True}),
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
+        mock.patch(FIND_SHADERS, return_value=[]),
+        mock.patch(SUBMIT_TEAPOT, return_value=None),
+        mock.patch(APPLY) as apply,
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+    assert apply.call_count == 0
+
+
+@django_db_all
+def test_try_symbolicate_swallows_errors(default_project: Project) -> None:
+    # A hard failure deep in teapot must never propagate — the event still saves.
+    with (
+        override_options({"teapot.enabled": True}),
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
+        mock.patch(FIND_SHADERS, return_value=[]),
+        mock.patch(SUBMIT_TEAPOT, side_effect=RuntimeError("boom")),
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+
+
+# ---------------------------------------------------------------------------
+# the task always continues to save; the submit helper uses the dedicated queue
+# ---------------------------------------------------------------------------
+
+
+def test_task_always_continues_to_save() -> None:
+    # Whatever teapot does, the event is handed to submit_process — Relay already
+    # ingested and billed it.
+    data = {"event_id": "e" * 32, "project": 1}
+    with (
+        mock.patch("sentry.tasks.gpu_crash._try_symbolicate", return_value=False),
+        mock.patch(SUBMIT_PROCESS) as submit_process,
+    ):
+        symbolicate_gpu_crash_event(cache_key="k", data=data, has_attachments=True)
+
+    assert submit_process.call_count == 1
+    assert submit_process.call_args.kwargs["from_symbolicate"] is True
+    assert submit_process.call_args.kwargs["data_has_changed"] is False
+
+
+def test_submit_schedules_on_dedicated_queue() -> None:
+    with mock.patch("sentry.tasks.gpu_crash.symbolicate_gpu_crash_event.delay") as delay:
+        submit_symbolicate_gpu_crash(
+            cache_key="k",
+            event_id="e",
+            start_time=None,
+            has_attachments=True,
+            from_reprocessing=False,
+        )
+
+    assert delay.call_count == 1
+    assert delay.call_args.kwargs["cache_key"] == "k"
+
+
+# ---------------------------------------------------------------------------
+# preprocess routing: a GPU event goes to the dedicated task, others don't
+# ---------------------------------------------------------------------------
+
+IS_GPU_EVENT = "sentry.lang.native.utils.is_gpu_crash_event"
+SUBMIT_GPU = "sentry.tasks.gpu_crash.submit_symbolicate_gpu_crash"
+
+
+@django_db_all
+def test_preprocess_routes_gpu_event_to_dedicated_task(default_project: Project) -> None:
+    from sentry.tasks.store import _do_preprocess_event
+
+    data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
+    with (
+        mock.patch(IS_GPU_EVENT, return_value=True),
+        mock.patch(SUBMIT_GPU) as submit_gpu,
+    ):
+        _do_preprocess_event(
+            cache_key="k",
+            data=data,
+            start_time=None,
+            event_id="e" * 32,
+            from_reprocessing=False,
+            project=default_project,
+            has_attachments=True,
+        )
+
+    assert submit_gpu.call_count == 1
+
+
+@django_db_all
+def test_preprocess_ignores_non_gpu_event(default_project: Project) -> None:
+    from sentry.tasks.store import _do_preprocess_event
+
+    data = {"event_id": "e" * 32, "project": default_project.id, "platform": "python"}
+    with (
+        mock.patch(IS_GPU_EVENT, return_value=False),
+        mock.patch(SUBMIT_GPU) as submit_gpu,
+        mock.patch("sentry.tasks.store.submit_save_event"),
+        mock.patch("sentry.tasks.store.submit_process"),
+    ):
+        _do_preprocess_event(
+            cache_key="k",
+            data=data,
+            start_time=None,
+            event_id="e" * 32,
+            from_reprocessing=False,
+            project=default_project,
+            has_attachments=False,
+        )
+
+    assert submit_gpu.call_count == 0

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -7,19 +7,17 @@ from unittest import mock
 import pytest
 
 from sentry.models.project import Project
-from sentry.tasks.gpu_crash import (
-    _try_symbolicate,
-    submit_symbolicate_gpu_crash,
-    symbolicate_gpu_crash_event,
-)
+from sentry.tasks.gpu_crash import _try_symbolicate, symbolicate_gpu_crash_event
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 
-FIND_DUMP = "sentry.lang.native.utils.find_gpu_crash_dump_attachment"
-FIND_SHADERS = "sentry.lang.native.utils.find_all_shader_debug_attachments"
-SUBMIT_TEAPOT = "sentry.lang.native.teapot.submit_to_teapot"
-APPLY = "sentry.lang.native.gpu.apply_gpu_crash_symbolication"
+# Patch where used (gpu_crash binds these names via top-level imports), not at
+# their source modules.
+FIND_DUMP = "sentry.tasks.gpu_crash.find_gpu_crash_dump_attachment"
+FIND_SHADERS = "sentry.tasks.gpu_crash.find_all_shader_debug_attachments"
+SUBMIT_TEAPOT = "sentry.tasks.gpu_crash.submit_to_teapot"
+APPLY = "sentry.tasks.gpu_crash.apply_gpu_crash_symbolication"
 SUBMIT_PROCESS = "sentry.tasks.store.submit_process"
 
 
@@ -50,7 +48,6 @@ def test_try_symbolicate_happy_path(default_project: Project, circuit_breaker: m
     data: dict[str, Any] = {"event_id": "e", "project": default_project.id}
     with (
         override_options({"teapot.enabled": True}),
-        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
         mock.patch(FIND_SHADERS, return_value=[]),
         mock.patch(SUBMIT_TEAPOT, return_value=_completed()) as teapot,
@@ -76,7 +73,6 @@ def test_try_symbolicate_skips_when_circuit_open(
     circuit_breaker.should_allow_request.return_value = False
     with (
         override_options({"teapot.enabled": True}),
-        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
         mock.patch(FIND_SHADERS, return_value=[]),
         mock.patch(SUBMIT_TEAPOT) as teapot,
@@ -93,19 +89,6 @@ def test_try_symbolicate_skips_when_circuit_open(
 def test_try_symbolicate_skipped_when_disabled(default_project: Project) -> None:
     with (
         override_options({"teapot.enabled": False}),
-        Feature("organizations:gpu-crash-symbolication"),
-        mock.patch(SUBMIT_TEAPOT) as teapot,
-    ):
-        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
-
-    assert changed is False
-    assert teapot.call_count == 0
-
-
-@django_db_all
-def test_try_symbolicate_skipped_when_flag_off(default_project: Project) -> None:
-    with (
-        override_options({"teapot.enabled": True}),
         mock.patch(SUBMIT_TEAPOT) as teapot,
     ):
         changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
@@ -118,7 +101,6 @@ def test_try_symbolicate_skipped_when_flag_off(default_project: Project) -> None
 def test_try_symbolicate_skipped_without_dump(default_project: Project) -> None:
     with (
         override_options({"teapot.enabled": True}),
-        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(FIND_DUMP, return_value=None),
         mock.patch(SUBMIT_TEAPOT) as teapot,
     ):
@@ -134,7 +116,6 @@ def test_try_symbolicate_teapot_unavailable(
 ) -> None:
     with (
         override_options({"teapot.enabled": True}),
-        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
         mock.patch(FIND_SHADERS, return_value=[]),
         mock.patch(SUBMIT_TEAPOT, return_value=None),
@@ -154,7 +135,6 @@ def test_try_symbolicate_swallows_errors(default_project: Project) -> None:
     # A hard failure deep in teapot must never propagate — the event still saves.
     with (
         override_options({"teapot.enabled": True}),
-        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
         mock.patch(FIND_SHADERS, return_value=[]),
         mock.patch(SUBMIT_TEAPOT, side_effect=RuntimeError("boom")),
@@ -179,24 +159,9 @@ def test_task_always_continues_to_save() -> None:
     assert submit_process.call_args.kwargs["data_has_changed"] is False
 
 
-def test_submit_schedules_on_dedicated_queue() -> None:
-    with mock.patch("sentry.tasks.gpu_crash.symbolicate_gpu_crash_event.delay") as delay:
-        submit_symbolicate_gpu_crash(
-            cache_key="k",
-            event_id="e",
-            start_time=None,
-            has_attachments=True,
-            from_reprocessing=False,
-        )
-
-    assert delay.call_count == 1
-    assert delay.call_args.kwargs["cache_key"] == "k"
-
-
 IS_GPU_EVENT = "sentry.lang.native.utils.is_gpu_crash_event"
-SUBMIT_GPU = "sentry.tasks.gpu_crash.submit_symbolicate_gpu_crash"
-
-
+SUBMIT_GPU = "sentry.tasks.gpu_crash.symbolicate_gpu_crash_event.delay"
+KILLSWITCH = "sentry.tasks.store.killswitch_matches_context"
 BACKUP = "sentry.tasks.store.reprocessing2.backup_unprocessed_event"
 
 
@@ -206,6 +171,7 @@ def test_preprocess_routes_gpu_event_to_dedicated_task(default_project: Project)
 
     data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
     with (
+        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(IS_GPU_EVENT, return_value=True),
         mock.patch(SUBMIT_GPU) as submit_gpu,
         mock.patch(BACKUP) as backup,
@@ -233,6 +199,7 @@ def test_preprocess_routes_gpu_event_on_reprocessing(default_project: Project) -
 
     data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
     with (
+        Feature("organizations:gpu-crash-symbolication"),
         mock.patch(IS_GPU_EVENT, return_value=True),
         mock.patch(SUBMIT_GPU) as submit_gpu,
         mock.patch(BACKUP) as backup,
@@ -270,6 +237,59 @@ def test_preprocess_ignores_non_gpu_event(default_project: Project) -> None:
             from_reprocessing=False,
             project=default_project,
             has_attachments=False,
+        )
+
+    assert submit_gpu.call_count == 0
+
+
+@django_db_all
+def test_preprocess_not_routed_without_feature_flag(default_project: Project) -> None:
+    # Org hasn't opted in: don't route to teapot even for a GPU crash event.
+    from sentry.tasks.store import _do_preprocess_event
+
+    data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
+    with (
+        mock.patch(IS_GPU_EVENT, return_value=True),
+        mock.patch(SUBMIT_GPU) as submit_gpu,
+        mock.patch("sentry.tasks.store.submit_save_event"),
+        mock.patch("sentry.tasks.store.submit_process"),
+    ):
+        _do_preprocess_event(
+            cache_key="k",
+            data=data,
+            start_time=None,
+            event_id="e" * 32,
+            from_reprocessing=False,
+            project=default_project,
+            has_attachments=True,
+        )
+
+    assert submit_gpu.call_count == 0
+
+
+@django_db_all
+def test_preprocess_sheds_gpu_event_when_killswitch_matches(default_project: Project) -> None:
+    # The load-shed killswitch drops the isolated GPU routing so it can't overwhelm
+    # the GPU task pool; the event still continues down the normal path.
+    from sentry.tasks.store import _do_preprocess_event
+
+    data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
+    with (
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(IS_GPU_EVENT, return_value=True),
+        mock.patch(KILLSWITCH, return_value=True),
+        mock.patch(SUBMIT_GPU) as submit_gpu,
+        mock.patch("sentry.tasks.store.submit_save_event"),
+        mock.patch("sentry.tasks.store.submit_process"),
+    ):
+        _do_preprocess_event(
+            cache_key="k",
+            data=data,
+            start_time=None,
+            event_id="e" * 32,
+            from_reprocessing=False,
+            project=default_project,
+            has_attachments=True,
         )
 
     assert submit_gpu.call_count == 0

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -171,6 +171,9 @@ IS_GPU_EVENT = "sentry.lang.native.utils.is_gpu_crash_event"
 SUBMIT_GPU = "sentry.tasks.gpu_crash.submit_symbolicate_gpu_crash"
 
 
+BACKUP = "sentry.tasks.store.reprocessing2.backup_unprocessed_event"
+
+
 @django_db_all
 def test_preprocess_routes_gpu_event_to_dedicated_task(default_project: Project) -> None:
     from sentry.tasks.store import _do_preprocess_event
@@ -179,6 +182,7 @@ def test_preprocess_routes_gpu_event_to_dedicated_task(default_project: Project)
     with (
         mock.patch(IS_GPU_EVENT, return_value=True),
         mock.patch(SUBMIT_GPU) as submit_gpu,
+        mock.patch(BACKUP) as backup,
     ):
         _do_preprocess_event(
             cache_key="k",
@@ -191,6 +195,34 @@ def test_preprocess_routes_gpu_event_to_dedicated_task(default_project: Project)
         )
 
     assert submit_gpu.call_count == 1
+    # The unprocessed event is backed up so a later reprocess can reload + re-run teapot.
+    assert backup.call_count == 1
+
+
+@django_db_all
+def test_preprocess_routes_gpu_event_on_reprocessing(default_project: Project) -> None:
+    # Reprocessing never sets has_attachments, but a restored GPU dump must still
+    # route to teapot (and be backed up) rather than skipping symbolication.
+    from sentry.tasks.store import _do_preprocess_event
+
+    data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
+    with (
+        mock.patch(IS_GPU_EVENT, return_value=True),
+        mock.patch(SUBMIT_GPU) as submit_gpu,
+        mock.patch(BACKUP) as backup,
+    ):
+        _do_preprocess_event(
+            cache_key="k",
+            data=data,
+            start_time=None,
+            event_id="e" * 32,
+            from_reprocessing=True,
+            project=default_project,
+            has_attachments=False,
+        )
+
+    assert submit_gpu.call_count == 1
+    assert backup.call_count == 1
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -171,6 +171,24 @@ def test_try_symbolicate_skips_when_killswitch_matches(
 
 
 @django_db_all
+def test_try_symbolicate_skips_when_project_deleted(circuit_breaker: mock.Mock) -> None:
+    # Project deleted between routing and execution is a routine stale ref — skip
+    # cleanly, don't report it as an unexpected error.
+    with (
+        override_options({"teapot.enabled": True}),
+        mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
+        mock.patch(FIND_SHADERS, return_value=[]),
+        mock.patch(SUBMIT_TEAPOT) as teapot,
+        mock.patch("sentry.tasks.gpu_crash.sentry_sdk.capture_exception") as cap,
+    ):
+        changed = _try_symbolicate({"event_id": "e", "platform": "native"}, 2**31 - 1, "e")
+
+    assert changed is False
+    assert teapot.call_count == 0
+    cap.assert_not_called()
+
+
+@django_db_all
 def test_try_symbolicate_swallows_errors(default_project: Project) -> None:
     # A hard failure deep in teapot must never propagate — the event still saves.
     with (

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from sentry.lang.native.teapot import TeapotUnavailable
 from sentry.models.project import Project
 from sentry.tasks.gpu_crash import _try_symbolicate, symbolicate_gpu_crash_event
 from sentry.testutils.helpers import Feature
@@ -111,9 +112,32 @@ def test_try_symbolicate_skipped_without_dump(default_project: Project) -> None:
 
 
 @django_db_all
-def test_try_symbolicate_teapot_unavailable(
+def test_try_symbolicate_teapot_outage_trips_breaker(
     default_project: Project, circuit_breaker: mock.Mock
 ) -> None:
+    # A genuine outage (submit_to_teapot raises TeapotUnavailable) feeds the
+    # breaker so repeated outages trip it.
+    with (
+        override_options({"teapot.enabled": True}),
+        mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
+        mock.patch(FIND_SHADERS, return_value=[]),
+        mock.patch(SUBMIT_TEAPOT, side_effect=TeapotUnavailable("down")),
+        mock.patch(APPLY) as apply,
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+    assert apply.call_count == 0
+    circuit_breaker.record_error.assert_called_once()
+    circuit_breaker.record_success.assert_not_called()
+
+
+@django_db_all
+def test_try_symbolicate_request_error_does_not_trip_breaker(
+    default_project: Project, circuit_breaker: mock.Mock
+) -> None:
+    # A client/data error (submit_to_teapot returns None) means teapot is healthy;
+    # the breaker must not trip, or a burst of bad events would skip healthy ones.
     with (
         override_options({"teapot.enabled": True}),
         mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
@@ -125,9 +149,25 @@ def test_try_symbolicate_teapot_unavailable(
 
     assert changed is False
     assert apply.call_count == 0
-    # A teapot failure feeds the breaker so repeated outages trip it.
-    circuit_breaker.record_error.assert_called_once()
+    circuit_breaker.record_error.assert_not_called()
     circuit_breaker.record_success.assert_not_called()
+
+
+@django_db_all
+def test_try_symbolicate_skips_when_killswitch_matches(
+    default_project: Project, circuit_breaker: mock.Mock
+) -> None:
+    # Load-shedding must drain already-queued tasks, not just gate new routing:
+    # the task re-checks the killswitch and skips teapot entirely.
+    with (
+        override_options({"teapot.enabled": True}),
+        mock.patch("sentry.tasks.gpu_crash.killswitch_matches_context", return_value=True),
+        mock.patch(SUBMIT_TEAPOT) as teapot,
+    ):
+        changed = _try_symbolicate({"event_id": "e", "platform": "native"}, default_project.id, "e")
+
+    assert changed is False
+    assert teapot.call_count == 0
 
 
 @django_db_all
@@ -187,14 +227,16 @@ def test_preprocess_routes_gpu_event_to_dedicated_task(default_project: Project)
         )
 
     assert submit_gpu.call_count == 1
-    # The unprocessed event is backed up so a later reprocess can reload + re-run teapot.
-    assert backup.call_count == 1
+    # GPU events are enriched once, on ingest — deliberately NOT backed up, so a
+    # later reprocess keeps the enriched event instead of dropping the enrichment.
+    assert backup.call_count == 0
 
 
 @django_db_all
-def test_preprocess_routes_gpu_event_on_reprocessing(default_project: Project) -> None:
-    # Reprocessing never sets has_attachments, but a restored GPU dump must still
-    # route to teapot (and be backed up) rather than skipping symbolication.
+def test_preprocess_not_routed_on_reprocessing(default_project: Project) -> None:
+    # Reprocessing doesn't re-run teapot (the `.nv-gpudmp` isn't reloaded). GPU
+    # events aren't backed up, so pull_event_data raises CannotReprocess and the
+    # already-enriched event is kept as-is — never re-routed here.
     from sentry.tasks.store import _do_preprocess_event
 
     data = {"event_id": "e" * 32, "project": default_project.id, "platform": "native"}
@@ -202,7 +244,8 @@ def test_preprocess_routes_gpu_event_on_reprocessing(default_project: Project) -
         Feature("organizations:gpu-crash-symbolication"),
         mock.patch(IS_GPU_EVENT, return_value=True),
         mock.patch(SUBMIT_GPU) as submit_gpu,
-        mock.patch(BACKUP) as backup,
+        mock.patch("sentry.tasks.store.submit_save_event"),
+        mock.patch("sentry.tasks.store.submit_process"),
     ):
         _do_preprocess_event(
             cache_key="k",
@@ -214,8 +257,7 @@ def test_preprocess_routes_gpu_event_on_reprocessing(default_project: Project) -
             has_attachments=False,
         )
 
-    assert submit_gpu.call_count == 1
-    assert backup.call_count == 1
+    assert submit_gpu.call_count == 0
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 from unittest import mock
+
+import pytest
 
 from sentry.models.project import Project
 from sentry.tasks.gpu_crash import (
@@ -36,13 +39,24 @@ def _completed() -> dict[str, Any]:
     return {"status": "completed", "fault_category": "shader_hang"}
 
 
+@pytest.fixture(autouse=True)
+def circuit_breaker() -> Iterator[mock.Mock]:
+    """A closed (request-allowing) teapot circuit breaker by default, so tests
+    don't couple to redis. Flip `should_allow_request` in a test to simulate an
+    open circuit; assert on `record_success` / `record_error` to check wiring."""
+    breaker = mock.Mock()
+    breaker.should_allow_request.return_value = True
+    with mock.patch("sentry.tasks.gpu_crash._teapot_circuit_breaker", return_value=breaker):
+        yield breaker
+
+
 # ---------------------------------------------------------------------------
 # _try_symbolicate — the teapot call + apply, best-effort
 # ---------------------------------------------------------------------------
 
 
 @django_db_all
-def test_try_symbolicate_happy_path(default_project: Project) -> None:
+def test_try_symbolicate_happy_path(default_project: Project, circuit_breaker: mock.Mock) -> None:
     data: dict[str, Any] = {"event_id": "e", "project": default_project.id}
     with (
         override_options({"teapot.enabled": True}),
@@ -57,6 +71,31 @@ def test_try_symbolicate_happy_path(default_project: Project) -> None:
     assert changed is True
     assert teapot.call_count == 1
     assert apply.call_count == 1
+    # A successful decode closes the loop on the breaker.
+    circuit_breaker.record_success.assert_called_once()
+    circuit_breaker.record_error.assert_not_called()
+
+
+@django_db_all
+def test_try_symbolicate_skips_when_circuit_open(
+    default_project: Project, circuit_breaker: mock.Mock
+) -> None:
+    # An open breaker means teapot is presumed down: skip the call entirely and
+    # save the event unenriched, paying no request timeout.
+    circuit_breaker.should_allow_request.return_value = False
+    with (
+        override_options({"teapot.enabled": True}),
+        Feature("organizations:gpu-crash-symbolication"),
+        mock.patch(FIND_DUMP, return_value=_FakeAttachment()),
+        mock.patch(FIND_SHADERS, return_value=[]),
+        mock.patch(SUBMIT_TEAPOT) as teapot,
+    ):
+        changed = _try_symbolicate({"event_id": "e"}, default_project.id, "e")
+
+    assert changed is False
+    assert teapot.call_count == 0
+    circuit_breaker.record_success.assert_not_called()
+    circuit_breaker.record_error.assert_not_called()
 
 
 @django_db_all
@@ -99,7 +138,9 @@ def test_try_symbolicate_skipped_without_dump(default_project: Project) -> None:
 
 
 @django_db_all
-def test_try_symbolicate_teapot_unavailable(default_project: Project) -> None:
+def test_try_symbolicate_teapot_unavailable(
+    default_project: Project, circuit_breaker: mock.Mock
+) -> None:
     with (
         override_options({"teapot.enabled": True}),
         Feature("organizations:gpu-crash-symbolication"),
@@ -112,6 +153,9 @@ def test_try_symbolicate_teapot_unavailable(default_project: Project) -> None:
 
     assert changed is False
     assert apply.call_count == 0
+    # A teapot failure feeds the breaker so repeated outages trip it.
+    circuit_breaker.record_error.assert_called_once()
+    circuit_breaker.record_success.assert_not_called()
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_gpu_crash.py
+++ b/tests/sentry/tasks/test_gpu_crash.py
@@ -24,8 +24,6 @@ SUBMIT_PROCESS = "sentry.tasks.store.submit_process"
 
 
 class _FakeAttachment:
-    """A `CachedAttachment` stand-in: name + bytes via `load_data`."""
-
     def __init__(self, name: str = "dump.nv-gpudmp", data: bytes = b"dump") -> None:
         self.name = name
         self.stored_id = None
@@ -41,18 +39,10 @@ def _completed() -> dict[str, Any]:
 
 @pytest.fixture(autouse=True)
 def circuit_breaker() -> Iterator[mock.Mock]:
-    """A closed (request-allowing) teapot circuit breaker by default, so tests
-    don't couple to redis. Flip `should_allow_request` in a test to simulate an
-    open circuit; assert on `record_success` / `record_error` to check wiring."""
     breaker = mock.Mock()
     breaker.should_allow_request.return_value = True
     with mock.patch("sentry.tasks.gpu_crash._teapot_circuit_breaker", return_value=breaker):
         yield breaker
-
-
-# ---------------------------------------------------------------------------
-# _try_symbolicate — the teapot call + apply, best-effort
-# ---------------------------------------------------------------------------
 
 
 @django_db_all
@@ -71,6 +61,7 @@ def test_try_symbolicate_happy_path(default_project: Project, circuit_breaker: m
     assert changed is True
     assert teapot.call_count == 1
     assert apply.call_count == 1
+
     # A successful decode closes the loop on the breaker.
     circuit_breaker.record_success.assert_called_once()
     circuit_breaker.record_error.assert_not_called()
@@ -173,11 +164,6 @@ def test_try_symbolicate_swallows_errors(default_project: Project) -> None:
     assert changed is False
 
 
-# ---------------------------------------------------------------------------
-# the task always continues to save; the submit helper uses the dedicated queue
-# ---------------------------------------------------------------------------
-
-
 def test_task_always_continues_to_save() -> None:
     # Whatever teapot does, the event is handed to submit_process — Relay already
     # ingested and billed it.
@@ -206,10 +192,6 @@ def test_submit_schedules_on_dedicated_queue() -> None:
     assert delay.call_count == 1
     assert delay.call_args.kwargs["cache_key"] == "k"
 
-
-# ---------------------------------------------------------------------------
-# preprocess routing: a GPU event goes to the dedicated task, others don't
-# ---------------------------------------------------------------------------
 
 IS_GPU_EVENT = "sentry.lang.native.utils.is_gpu_crash_event"
 SUBMIT_GPU = "sentry.tasks.gpu_crash.submit_symbolicate_gpu_crash"


### PR DESCRIPTION
* Add Teapot client for GPU crash symbolication
* Add separate taskworker for GPU crash symbolication
* Add TEAPOT config to Sentry
* Add feature flags to gate the Teapot runs
* Auto-detect and trigger runs based on .nv-gpudmp and .nvdbg files
* Forward Objectstore credentials to teapot