### PR TITLE
fix(conversations): Stop 'Add a Column' from appending Conv. ID forever

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTableEditModal.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableEditModal.tsx
@@ -42,14 +42,11 @@ export function ConversationsTableEditModal({
   return (
     <DragNDropContext columns={tempColumns} setColumns={setTempColumns}>
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => {
-        // Default the new row to the first column not already shown, falling back
-        // to the first column so a duplicate is allowed once they're all in use.
+        // Add the first column not already shown. Conversations have a fixed set
+        // of columns, so once they're all in use there's nothing left to add and
+        // the button is disabled (rather than appending duplicate columns).
         const usedColumns = new Set(editableColumns.map(c => c.column.key));
-        const nextColumn: ConversationColumn = {
-          key:
-            ALL_CONVERSATION_COLUMNS.find(key => !usedColumns.has(key)) ??
-            'conversationId',
-        };
+        const nextColumnKey = ALL_CONVERSATION_COLUMNS.find(key => !usedColumns.has(key));
 
         return (
           <Fragment>
@@ -70,8 +67,14 @@ export function ConversationsTableEditModal({
                 <Flex>
                   <Button
                     size="sm"
-                    onClick={() => insertColumn(nextColumn)}
+                    disabled={!nextColumnKey}
+                    onClick={() => nextColumnKey && insertColumn({key: nextColumnKey})}
                     icon={<IconAdd />}
+                    tooltipProps={{
+                      title: nextColumnKey
+                        ? undefined
+                        : t('All columns are already in use'),
+                    }}
                   >
                     {t('Add a Column')}
                   </Button>


### PR DESCRIPTION

**Before**


<img width="632" height="913" alt="image" src="https://github.com/user-attachments/assets/066942f0-1f1e-4ffa-a9bc-746bfb6944bf" />


**After**

<img width="612" height="730" alt="image" src="https://github.com/user-attachments/assets/902786a3-48d9-4b5d-8bea-9ee22f6bd52e" />