### PR TITLE
feat(pr_metrics): Handle synchronous delegated-agent-match response

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -21,6 +21,7 @@ from dataclasses import asdict
 from datetime import datetime, timedelta
 from typing import Any
 
+import orjson
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, router, transaction
@@ -69,6 +70,7 @@ from sentry.pr_metrics.activity_types import (
 )
 from sentry.pr_metrics.attribution import (
     JUDGE_ELIGIBLE_SIGNAL_TYPES,
+    DelegatedAgentSignalDetails,
     SentryAppSignalDetails,
     record_attribution_signal,
 )
@@ -86,6 +88,7 @@ from sentry.pr_metrics.utils import (
     resolved_group_ids,
 )
 from sentry.seer.autofix.utils import (
+    DelegatedAgentMatch,
     MatchDelegatedAgentPrRequest,
     make_match_coding_agent_pr_request,
 )
@@ -173,7 +176,10 @@ def handle_attribution(
         _write_author_attribution(pr, github_user, pr_url=pr_url, group_ids=resolved_group_ids(pr))
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
-    if action == "opened" and pull_request is not None:
+    # Checked on open and re-checked on close, mirroring the SENTRY_APP author
+    # attribution above — the same out-of-order/missed-webhook concern applies,
+    # and record_attribution_signal is idempotent against the repeat check.
+    if action in ("opened", "closed") and pull_request is not None:
         _attribute_delegated_agent(pr, pull_request, repo, organization, github_user)
 
 
@@ -1129,7 +1135,9 @@ def _detect_delegated_agent(
     Filter PRs that could have been delegated by Autofix to external coding agents,
     and fire the matching request to Seer if it's a candidate.
 
-    Then Seer calls the RPC "record_pr_attribution" to write the attribution row async.
+    Seer resolves the match either synchronously (a ``200`` with the match body,
+    recorded in-process here) or asynchronously (a ``202``, followed later by the
+    "record_pr_attribution" RPC callback writing the attribution row).
     """
     group_ids = resolved_group_ids(pr)
     if not group_ids:
@@ -1203,7 +1211,33 @@ def _send_seer_delegated_agent_match(
         _record_delegated_candidate(provider_hint, "seer_error_bad_status")
         return
 
-    _record_delegated_candidate(provider_hint, "sent")
+    if response.status != 200:
+        # 202: Seer enqueued the match asynchronously and will call back via the
+        # record_pr_attribution RPC once it resolves.
+        _record_delegated_candidate(provider_hint, "sent")
+        return
+
+    # 200: Seer resolved the match synchronously — record the attribution now,
+    # in-process, instead of waiting for the async RPC callback.
+    try:
+        match = DelegatedAgentMatch.validate(orjson.loads(response.data))
+        signal_type = PullRequestAttributionSignalType(match.signal_type)
+    except Exception:
+        logger.warning("pr_metrics.delegated_agent.seer_match.bad_body", extra=log_extra)
+        _record_delegated_candidate(provider_hint, "seer_error_bad_body")
+        return
+
+    record_attribution_signal(
+        pull_request=pr,
+        signal_type=signal_type,
+        source=PullRequestAttributionSource.SEER_DATA,
+        signal_details=DelegatedAgentSignalDetails(
+            agent_id=match.agent_id,
+            pr_url=request_body.pr_url,
+            run_id=match.run_id,
+        ).dict(),
+    )
+    _record_delegated_candidate(provider_hint, "sync_matched")
 
 
 def _write_mcp_attribution(pr: PullRequest) -> None:

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -27,6 +27,7 @@ from django.core.cache import cache
 from django.db import IntegrityError, router, transaction
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
+from pydantic import ValidationError
 
 from sentry import features, options
 from sentry.integrations.github.webhook_types import GithubWebhookType
@@ -1222,8 +1223,8 @@ def _send_seer_delegated_agent_match(
     try:
         match = DelegatedAgentMatch.validate(orjson.loads(response.data))
         signal_type = PullRequestAttributionSignalType(match.signal_type)
-    except Exception:
-        logger.warning("pr_metrics.delegated_agent.seer_match.bad_body", extra=log_extra)
+    except (orjson.JSONDecodeError, ValidationError, ValueError):
+        logger.exception("pr_metrics.delegated_agent.seer_match.bad_body", extra=log_extra)
         _record_delegated_candidate(provider_hint, "seer_error_bad_body")
         return
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -256,6 +256,20 @@ def make_match_coding_agent_pr_request(
     )
 
 
+class DelegatedAgentMatch(BaseModel):
+    """A match resolved synchronously by ``/v1/pr-metrics/delegated-agent-match``.
+
+    Returned as a ``200`` body instead of the async ``202`` + ``record_pr_attribution``
+    RPC callback. ``match_path`` isn't consumed on the Sentry side today; it's kept
+    here to mirror the full wire contract.
+    """
+
+    run_id: int
+    agent_id: str
+    signal_type: str
+    match_path: str
+
+
 def make_store_coding_agent_states_request(
     body: StoreCodingAgentStatesRequest,
     connection_pool: HTTPConnectionPool | None = None,

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import orjson
 from django.conf import settings
 from django.core.cache import cache
 
@@ -2080,9 +2081,10 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             repo=self.repo,
         )
 
-    def _mock_seer(self, status: int = 202) -> Any:
+    def _mock_seer(self, status: int = 202, body: dict[str, Any] | None = None) -> Any:
         mock_response = MagicMock()
         mock_response.status = status
+        mock_response.data = orjson.dumps(body) if body is not None else b""
         return patch(MATCH_RPC, return_value=mock_response)
 
     def _mock_org_check(self) -> Any:
@@ -2148,6 +2150,94 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             "outcome": "sent",
         }
 
+    # --- Synchronous match (200) ---
+
+    def test_sync_match_records_attribution_in_process(self) -> None:
+        body = {
+            "run_id": 123,
+            "agent_id": "agent-1",
+            "signal_type": PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE.value,
+            "match_path": "some/path",
+        }
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=200, body=body),
+            patch(f"{MODULE}.metrics.incr") as mock_incr,
+        ):
+            self._call(head_ref="claude/fix")
+
+        attribution = PullRequestAttribution.objects.get(
+            pull_request=self.pr,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+            source=PullRequestAttributionSource.SEER_DATA,
+        )
+        assert attribution.signal_details == {
+            "agent_id": "agent-1",
+            "pr_url": "https://github.com/org/repo/pull/42",
+            "run_id": 123,
+        }
+        assert self._candidate_outcome(mock_incr) == {
+            "provider": "claude_code",
+            "outcome": "sync_matched",
+        }
+
+    def test_sync_match_bad_body_records_error_outcome(self) -> None:
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=200, body={"not": "a match"}),
+            patch(f"{MODULE}.metrics.incr") as mock_incr,
+        ):
+            self._call(head_ref="claude/fix")
+
+        assert self._candidate_outcome(mock_incr) == {
+            "provider": "claude_code",
+            "outcome": "seer_error_bad_body",
+        }
+        assert not PullRequestAttribution.objects.filter(
+            pull_request=self.pr, source=PullRequestAttributionSource.SEER_DATA
+        ).exists()
+
+    def test_sync_match_bad_signal_type_records_error_outcome(self) -> None:
+        body = {
+            "run_id": 123,
+            "agent_id": "agent-1",
+            "signal_type": "not_a_real_signal_type",
+            "match_path": "some/path",
+        }
+        with (
+            self._mock_org_check(),
+            self._mock_seer(status=200, body=body),
+            patch(f"{MODULE}.metrics.incr") as mock_incr,
+        ):
+            self._call(head_ref="claude/fix")
+
+        assert self._candidate_outcome(mock_incr) == {
+            "provider": "claude_code",
+            "outcome": "seer_error_bad_body",
+        }
+
+    def test_sync_match_idempotent_across_open_then_close(self) -> None:
+        # Re-checked on close, like the SENTRY_APP case — a PR matched on open
+        # must not gain a second attribution row when re-matched on close.
+        body = {
+            "run_id": 123,
+            "agent_id": "agent-1",
+            "signal_type": PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE.value,
+            "match_path": "some/path",
+        }
+        with self._mock_org_check(), self._mock_seer(status=200, body=body):
+            self._call(action="opened", head_ref="claude/fix")
+            self._call(action="closed", head_ref="claude/fix")
+
+        assert (
+            PullRequestAttribution.objects.filter(
+                pull_request=self.pr,
+                signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+                source=PullRequestAttributionSource.SEER_DATA,
+            ).count()
+            == 1
+        )
+
     # --- Error handling ---
 
     def test_seer_non_2xx_logs_warning_and_error_metric(self) -> None:
@@ -2188,11 +2278,20 @@ class HandleDelegatedAgentDetectionTest(TestCase):
 
         mock_rpc.assert_not_called()
 
-    def test_non_opened_action_does_not_call_seer(self) -> None:
-        for action in ("synchronize", "closed", "labeled", "assigned"):
+    def test_non_opened_or_closed_action_does_not_call_seer(self) -> None:
+        for action in ("synchronize", "labeled", "assigned"):
             with self._mock_seer() as mock_rpc:
                 self._call(action=action, head_ref="claude/fix")
                 mock_rpc.assert_not_called()
+
+    def test_closed_action_sends_to_seer(self) -> None:
+        # Re-checked on close, mirroring the SENTRY_APP author attribution — an
+        # out-of-order or missed "opened" webhook shouldn't lose the match.
+        with self._mock_org_check(), self._mock_seer() as mock_rpc:
+            self._call(action="closed", head_ref="claude/fix")
+
+        mock_rpc.assert_called_once()
+        assert mock_rpc.call_args.args[0].provider == "claude_code"
 
     # --- Gating ---
 


### PR DESCRIPTION
Seer's `/v1/pr-metrics/delegated-agent-match` is moving from an async-only<br>contract (`202` + a task + the `record_pr_attribution` RPC callback) to one<br>that can also resolve synchronously (`200` + a `DelegatedAgentMatch` body).<br>This teaches the Sentry-side caller to record the attribution in-process on<br>a `200`, while leaving the existing `202` handling untouched so both<br>response shapes work correctly during Seer's independent rollout.

This is stage 1 of a 3-stage cross-repo rollout: Sentry needs to tolerate<br>the new synchronous shape before Seer starts sending it (stage 2, tracked<br>separately in the Seer repo), since the two services deploy independently<br>and Seer may return either shape mid-rollout.

Also runs the delegated-agent check on PR close in addition to open,<br>mirroring the existing `SENTRY_APP` author-attribution behavior, so an<br>out-of-order or missed "opened" webhook doesn't lose the match.

Refs [CW-1655](https://linear.app/getsentry/issue/CW-1655/sentry-consume-synchronous-delegated-agent-match-response)