### PR TITLE
ref(settings): Drop legacy change toast from early features form

### DIFF
--- a/static/app/views/settings/earlyFeatures/settingsForm.tsx
+++ b/static/app/views/settings/earlyFeatures/settingsForm.tsx
@@ -3,10 +3,10 @@ import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Scope} from 'sentry/types/core';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -65,22 +65,6 @@ export function EarlyFeaturesSettingsForm({access}: Props) {
         data,
       }),
     onSuccess: (_response, updatedFlags) => {
-      const previous = queryClient.getQueryData(featureFlagsQueryOptions.queryKey);
-
-      for (const [flag, newValue] of Object.entries(updatedFlags)) {
-        const previousFlag = previous?.json[flag];
-        if (!previousFlag) {
-          continue;
-        }
-        addSuccessMessage(
-          tct('Changed [fieldName] from [oldValue] to [newValue]', {
-            fieldName: <strong>{previousFlag.description}</strong>,
-            oldValue: <em>{previousFlag.value ? t('enabled') : t('disabled')}</em>,
-            newValue: <em>{newValue ? t('enabled') : t('disabled')}</em>,
-          })
-        );
-      }
-
       queryClient.setQueryData(featureFlagsQueryOptions.queryKey, prev => {
         if (!prev) {
           return prev;


### PR DESCRIPTION
The Early Adopter Features settings form was migrated to the new Scraps `AutoSaveForm`, but its `mutationOptions.onSuccess` still hand-rolled the legacy `FormModel` success toast — `"Changed [field] from [old] to [new]"` (the default that lives in `formIndicators.tsx`).

The new `AutoSaveForm` intentionally dropped that per-save change notification: its built-in `onSuccess` just resets the field, and every other migrated form is either silent or shows a plain "Saved"-style message. This form was the only `AutoSaveForm` call site reproducing the old-value → new-value toast.

## Change

- Remove the `addSuccessMessage("Changed … from … to …")` loop from the feature-flag mutation's `onSuccess`.
- Keep the query-cache update (`setQueryData`) — it's what lets a toggle be flipped back after a successful save.
- Drop the now-unused `addSuccessMessage` and `tct` imports.

No behavior change beyond the removed toast; the existing spec (toggle on/off, PUT payloads, toggle-back) still covers the form.
