### PR TITLE
feat(pr_metrics): Emit judge-ineligible PRs via a fallback verdict

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -59,6 +59,11 @@ class PullRequestVerdict(models.TextChoices):
     MERGED_UNCHANGED = "merged_unchanged"
     MERGED_WITH_ITERATION = "merged_with_iteration"
     CLOSED_UNMERGED = "closed_unmerged"
+    # Merged with commits after open, decided without a judge — for attribution
+    # too weak to warrant the judge call (e.g. MCP), so it's distinct from
+    # MERGED_WITH_ITERATION, which is a judge verdict on judge-eligible
+    # attribution. See ``select_fallback_verdict``.
+    MERGED_WITH_PUSH_ACTIVITY = "merged_with_push_activity"
     # Transient, internal: a terminal event whose outcome a judge must decide has
     # been claimed and forwarded to Seer, but the judged verdict hasn't returned.
     # Reuses the verdict column as the redelivery guard so a redelivered terminal

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -59,11 +59,6 @@ class PullRequestVerdict(models.TextChoices):
     MERGED_UNCHANGED = "merged_unchanged"
     MERGED_WITH_ITERATION = "merged_with_iteration"
     CLOSED_UNMERGED = "closed_unmerged"
-    # Merged with commits after open, decided without a judge — for attribution
-    # too weak to warrant the judge call (e.g. MCP), so it's distinct from
-    # MERGED_WITH_ITERATION, which is a judge verdict on judge-eligible
-    # attribution. See ``select_fallback_verdict``.
-    MERGED_WITH_PUSH_ACTIVITY = "merged_with_push_activity"
     # Transient, internal: a terminal event whose outcome a judge must decide has
     # been claimed and forwarded to Seer, but the judged verdict hasn't returned.
     # Reuses the verdict column as the redelivery guard so a redelivered terminal

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from enum import Enum
 from typing import Any
 
 from sentry import analytics
@@ -37,36 +38,59 @@ from sentry.utils import json, metrics
 logger = logging.getLogger(__name__)
 
 
+class VerdictDeferral(Enum):
+    """Why ``select_verdict`` couldn't settle a terminal verdict on its own.
+
+    Both are a "needs a judge" signal to ``select_verdict``'s only caller, but
+    they aren't interchangeable for ``select_fallback_verdict``, which settles
+    judge-*ineligible* PRs (e.g. MCP) without ever reaching Seer:
+
+    - ``NEEDS_JUDGE``: real activity/engagement data says the outcome is
+      genuinely ambiguous (commits after open, or discussion on a close).
+      Reliable enough to hand to ``select_fallback_verdict`` directly.
+    - ``INDETERMINATE``: there's no reliable signal to decide from at all —
+      activity tracking is off, or the metrics row is missing — so the data's
+      *absence* can't be read as "nothing happened". Judge-eligible PRs still
+      forward regardless (Seer fetches the diff itself); judge-ineligible PRs
+      have no judge to fall back on and stay unemitted, same as before
+      ``select_fallback_verdict`` existed.
+    """
+
+    NEEDS_JUDGE = "needs_judge"
+    INDETERMINATE = "indeterminate"
+
+
 def select_verdict(
     pull_request: PullRequest, organization: Organization
-) -> PullRequestVerdict | None:
-    """The terminal verdict Sentry can decide on its own, or ``None`` for a judge.
+) -> PullRequestVerdict | VerdictDeferral:
+    """The terminal verdict Sentry can decide on its own, or a ``VerdictDeferral``.
 
     A judge is needed whenever the outcome can't be settled deterministically from
-    data Sentry already holds — so ``None`` is the "needs a judge" signal, and the
-    caller forwards to Seer (the judge path) rather than emitting:
+    data Sentry already holds — so the caller forwards to Seer (the judge path)
+    rather than emitting on either ``VerdictDeferral`` outcome:
 
     - Merged with no commits after it opened → ``merged_unchanged``: the merge head
       is the opened head, so nothing changed, by anyone. A merge with later commits
       is ambiguous (Seer's own iteration vs. external changes) and needs the
-      diff-similarity judge.
+      diff-similarity judge → ``NEEDS_JUDGE``.
     - Closed with no engagement — no later commits, comments, or review comments →
       ``closed_unmerged``: an abandoned PR with nothing to analyze. A close with any
-      engagement needs the conversation judge to decide why it was closed.
+      engagement needs the conversation judge to decide why it was closed →
+      ``NEEDS_JUDGE``.
 
     The commits-after-open signal is a ``SYNCHRONIZED`` activity row, one per push
     to the PR branch after it opened. Those rows are only written under
     ``pr-metrics-activity``, which is flagged independently of emission; without it
     a clean merge is indistinguishable from one with later commits, so we defer
-    every outcome to a judge rather than read its absence as "no later commits". A
-    missing ``PullRequestMetrics`` row is an error state — ``handle_metrics``
-    persists it before emission under the same flag, so its absence means it
-    failed — and we defer to a judge for both outcomes rather than emit zeroed
-    counters (merge) or guess abandoned (close).
+    every outcome (``INDETERMINATE``) rather than read its absence as "no later
+    commits". A missing ``PullRequestMetrics`` row is an error state —
+    ``handle_metrics`` persists it before emission under the same flag, so its
+    absence means it failed — and we defer (``INDETERMINATE``) for both outcomes
+    rather than emit zeroed counters (merge) or guess abandoned (close).
     """
     if not is_activity_tracking_enabled(organization):
         metrics.incr("pr_metrics.select_verdict.activity_disabled")
-        return None
+        return VerdictDeferral.INDETERMINATE
 
     metrics_row = PullRequestMetrics.objects.filter(pull_request=pull_request).first()
     if metrics_row is None:
@@ -79,18 +103,56 @@ def select_verdict(
             },
         )
         metrics.incr("pr_metrics.select_verdict.metrics_row_missing")
-        return None
+        return VerdictDeferral.INDETERMINATE
 
     has_commits_after_open = PullRequestActivity.objects.filter(
         pull_request=pull_request, event_type=PullRequestActivityType.SYNCHRONIZED
     ).exists()
 
     if pull_request.merged_at is not None:
-        return PullRequestVerdict.MERGED_UNCHANGED if not has_commits_after_open else None
+        return (
+            PullRequestVerdict.MERGED_UNCHANGED
+            if not has_commits_after_open
+            else VerdictDeferral.NEEDS_JUDGE
+        )
 
     has_discussion = bool(metrics_row.comments_count or metrics_row.review_comments_count)
     if has_commits_after_open or has_discussion:
-        return None
+        return VerdictDeferral.NEEDS_JUDGE
+    return PullRequestVerdict.CLOSED_UNMERGED
+
+
+def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
+    """The verdict for a ``NEEDS_JUDGE`` PR whose attribution isn't judge-eligible.
+
+    Only valid to call on a ``VerdictDeferral.NEEDS_JUDGE`` outcome — the caller
+    must not call this for ``INDETERMINATE``, since there ``select_verdict`` has no
+    reliable activity/engagement data to have deferred on, and this function would
+    otherwise silently re-derive "no commits after open" from the same absent data
+    and mislabel an actually-iterated PR as unchanged.
+
+    Weak attribution (e.g. MCP) never reaches Seer — see
+    ``JUDGE_ELIGIBLE_SIGNAL_TYPES`` — so without this fallback a ``NEEDS_JUDGE`` row
+    would sit at ``verdict=None`` forever and never emit. Decided directly from
+    push activity rather than the judge's conversation/diff analysis:
+
+    - Merged with commits after open → ``MERGED_WITH_PUSH_ACTIVITY``, distinct from
+      the judge-only ``MERGED_WITH_ITERATION`` since no judge looked at the diff.
+    - Merged with no commits after open → ``MERGED_UNCHANGED``, same as the
+      deterministic case in ``select_verdict``.
+    - Closed unmerged → ``CLOSED_UNMERGED`` unconditionally; there's no
+      judge-eligible equivalent of the conversation judge for weak attribution, so
+      engagement isn't distinguished here.
+    """
+    if pull_request.merged_at is not None:
+        has_commits_after_open = PullRequestActivity.objects.filter(
+            pull_request=pull_request, event_type=PullRequestActivityType.SYNCHRONIZED
+        ).exists()
+        return (
+            PullRequestVerdict.MERGED_WITH_PUSH_ACTIVITY
+            if has_commits_after_open
+            else PullRequestVerdict.MERGED_UNCHANGED
+        )
     return PullRequestVerdict.CLOSED_UNMERGED
 
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -136,8 +136,9 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
     would sit at ``verdict=None`` forever and never emit. Decided directly from
     push activity rather than the judge's conversation/diff analysis:
 
-    - Merged with commits after open → ``MERGED_WITH_PUSH_ACTIVITY``, distinct from
-      the judge-only ``MERGED_WITH_ITERATION`` since no judge looked at the diff.
+    - Merged with commits after open → ``MERGED_WITH_ITERATION``, reusing the
+      judge's verdict label even though no judge looked at the diff here — weak
+      attribution's iteration signal is push activity alone, same outcome bucket.
     - Merged with no commits after open → ``MERGED_UNCHANGED``, same as the
       deterministic case in ``select_verdict``.
     - Closed unmerged → ``CLOSED_UNMERGED`` unconditionally; there's no
@@ -149,7 +150,7 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
             pull_request=pull_request, event_type=PullRequestActivityType.SYNCHRONIZED
         ).exists()
         return (
-            PullRequestVerdict.MERGED_WITH_PUSH_ACTIVITY
+            PullRequestVerdict.MERGED_WITH_ITERATION
             if has_commits_after_open
             else PullRequestVerdict.MERGED_UNCHANGED
         )

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -251,14 +251,22 @@ def _forward_to_judge(
         signal_type__in=JUDGE_ELIGIBLE_SIGNAL_TYPES,
     ).exists():
         if deferral is not VerdictDeferral.NEEDS_JUDGE:
-            metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_eligible_attribution"})
+            # Only reachable with an INDETERMINATE deferral (the other member,
+            # NEEDS_JUDGE, is handled by the fallback-verdict branch below) — no
+            # eligible attribution to forward to a real judge, and no reliable
+            # local data to settle a fallback verdict from either. Tag both
+            # facts: attribution alone doesn't explain why this stays unemitted.
+            metrics.incr(
+                "pr_metrics.emit.skipped",
+                tags={"reason": "no_eligible_attribution_indeterminate"},
+            )
             logger.info(
                 "pr_metrics.emit.needs_judge",
                 extra={
                     "organization_id": organization.id,
                     "repository_id": pr.repository_id,
                     "pull_request_id": pr.id,
-                    "reason": "not_agent_attribution",
+                    "reason": "not_agent_attribution_indeterminate",
                 },
             )
             return

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -230,32 +230,21 @@ def _forward_to_judge(
     """Hand a needs-judge terminal event to Seer, guarded against redelivery.
 
 
-    * Only PRs in orgs that have seer access are forwarded to the judge.
     * Only PRs with attribution in JUDGE_ELIGIBLE_SIGNAL_TYPES are forwarded to
     the judge; anything else (e.g. MCP) is settled here directly via
     ``select_fallback_verdict`` instead, but only when ``deferral`` is
     ``NEEDS_JUDGE`` — real activity/engagement data backs that verdict. An
     ``INDETERMINATE`` deferral has no reliable data to fall back on either, so
     it's skipped exactly as before this fallback existed.
+    * Only PRs in orgs that have seer access are forwarded to the judge. Checked
+    after the eligibility branch above: the fallback never talks to Seer, so it
+    must not be blocked by an org's Seer-access consent gate.
 
     Gated on ``pr-metrics-judge`` independently of emission: until it's enabled
     (and Seer's endpoint exists), a needs-judge PR is skipped — today's behavior.
     Claims the sentinel via the redelivery guard before enqueuing the forward, so
     a redelivered terminal event can't forward to Seer twice.
     """
-    if not has_seer_access(organization):
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_seer_access"})
-        logger.info(
-            "pr_metrics.emit.needs_judge",
-            extra={
-                "organization_id": organization.id,
-                "repository_id": pr.repository_id,
-                "pull_request_id": pr.id,
-                "reason": "no_seer_access",
-            },
-        )
-        return
-
     if not PullRequestAttribution.objects.filter(
         pull_request=pr,
         is_valid=True,
@@ -286,6 +275,19 @@ def _forward_to_judge(
             },
         )
         _claim_and_emit(pr, verdict, "pr_metrics.judge.fallback_emitted")
+        return
+
+    if not has_seer_access(organization):
+        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_seer_access"})
+        logger.info(
+            "pr_metrics.emit.needs_judge",
+            extra={
+                "organization_id": organization.id,
+                "repository_id": pr.repository_id,
+                "pull_request_id": pr.id,
+                "reason": "no_seer_access",
+            },
+        )
         return
 
     if not features.has("organizations:pr-metrics-judge", organization):

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -74,9 +74,11 @@ from sentry.pr_metrics.attribution import (
 )
 from sentry.pr_metrics.emit import (
     CI_FAILING_AT_CLOSE,
+    VerdictDeferral,
     ci_failing_at_close,
     emit_pr_metrics_row,
     is_pr_tracked,
+    select_fallback_verdict,
     select_verdict,
 )
 from sentry.pr_metrics.tasks import emit_pr_metrics_cooldown_task, forward_pr_to_seer_task
@@ -198,9 +200,11 @@ def _claim_terminal_event(pr: PullRequest, verdict: PullRequestVerdict) -> bool:
     close and later merged is thus recorded by its first close — an accepted loss
     on the rare reopened PR.
 
-    Only called once a deterministic ``verdict`` is in hand. A PR that needs a
-    judge is guarded the same way once the forward path lands — it claims the
-    event with a sentinel verdict before forwarding — but that isn't wired yet.
+    Only called once a deterministic ``verdict`` is in hand — either
+    ``select_verdict``'s outcome or, for judge-ineligible attribution,
+    ``select_fallback_verdict``'s. A PR actually forwarded to a judge is guarded
+    the same way but with the ``JUDGE_IN_PROGRESS`` sentinel via
+    ``_claim_for_judge`` instead.
     """
     claimed = PullRequestMetrics.objects.filter(pull_request=pr, verdict__isnull=True).update(
         verdict=verdict
@@ -220,13 +224,19 @@ def _claim_for_judge(pr: PullRequest) -> bool:
     return _claim_terminal_event(pr, PullRequestVerdict.JUDGE_IN_PROGRESS)
 
 
-def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
+def _forward_to_judge(
+    pr: PullRequest, organization: Organization, deferral: VerdictDeferral
+) -> None:
     """Hand a needs-judge terminal event to Seer, guarded against redelivery.
 
 
     * Only PRs in orgs that have seer access are forwarded to the judge.
     * Only PRs with attribution in JUDGE_ELIGIBLE_SIGNAL_TYPES are forwarded to
-    the judge.
+    the judge; anything else (e.g. MCP) is settled here directly via
+    ``select_fallback_verdict`` instead, but only when ``deferral`` is
+    ``NEEDS_JUDGE`` — real activity/engagement data backs that verdict. An
+    ``INDETERMINATE`` deferral has no reliable data to fall back on either, so
+    it's skipped exactly as before this fallback existed.
 
     Gated on ``pr-metrics-judge`` independently of emission: until it's enabled
     (and Seer's endpoint exists), a needs-judge PR is skipped — today's behavior.
@@ -251,16 +261,31 @@ def _forward_to_judge(pr: PullRequest, organization: Organization) -> None:
         is_valid=True,
         signal_type__in=JUDGE_ELIGIBLE_SIGNAL_TYPES,
     ).exists():
-        metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_eligible_attribution"})
+        if deferral is not VerdictDeferral.NEEDS_JUDGE:
+            metrics.incr("pr_metrics.emit.skipped", tags={"reason": "no_eligible_attribution"})
+            logger.info(
+                "pr_metrics.emit.needs_judge",
+                extra={
+                    "organization_id": organization.id,
+                    "repository_id": pr.repository_id,
+                    "pull_request_id": pr.id,
+                    "reason": "not_agent_attribution",
+                },
+            )
+            return
+
+        verdict = select_fallback_verdict(pr)
+        metrics.incr("pr_metrics.judge.fallback_verdict", tags={"verdict": verdict})
         logger.info(
-            "pr_metrics.emit.needs_judge",
+            "pr_metrics.judge.fallback_verdict",
             extra={
                 "organization_id": organization.id,
                 "repository_id": pr.repository_id,
                 "pull_request_id": pr.id,
-                "reason": "not_agent_attribution",
+                "verdict": verdict,
             },
         )
+        _claim_and_emit(pr, verdict, "pr_metrics.judge.fallback_emitted")
         return
 
     if not features.has("organizations:pr-metrics-judge", organization):
@@ -433,10 +458,23 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
         return
 
     verdict = select_verdict(pull_request, organization)
-    if verdict is None:
-        _forward_to_judge(pull_request, organization)
+    if isinstance(verdict, VerdictDeferral):
+        _forward_to_judge(pull_request, organization, verdict)
         return
 
+    _claim_and_emit(pull_request, verdict, "pr_metrics.cooldown.emitted")
+
+
+def _claim_and_emit(
+    pull_request: PullRequest, verdict: PullRequestVerdict, emitted_metric: str
+) -> None:
+    """Claim a deterministic verdict and emit its row, guarded against redelivery.
+
+    Shared by the cooldown task's deterministic path and ``_forward_to_judge``'s
+    judge-ineligible fallback — both settle a verdict Sentry decided on its own
+    (no Seer round trip) and must emit exactly once under the same NULL-verdict
+    claim. ``emitted_metric`` lets each caller keep its own success counter.
+    """
     if not _claim_terminal_event(pull_request, verdict):
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"})
         return
@@ -456,7 +494,7 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
     # claim still stands and the row is forgone — an acceptable loss for telemetry,
     # not worth a rollback that would reopen the redelivery race.
     emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
-    metrics.incr("pr_metrics.cooldown.emitted")
+    metrics.incr(emitted_metric)
 
 
 def handle_metrics(

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -260,7 +260,7 @@ def _forward_to_judge(
                 "pr_metrics.emit.skipped",
                 tags={"reason": "no_eligible_attribution_indeterminate"},
             )
-            logger.info(
+            logger.warning(
                 "pr_metrics.emit.needs_judge",
                 extra={
                     "organization_id": organization.id,
@@ -272,9 +272,9 @@ def _forward_to_judge(
             return
 
         verdict = select_fallback_verdict(pr)
-        metrics.incr("pr_metrics.judge.fallback_verdict", tags={"verdict": verdict})
+        metrics.incr("pr_metrics.emit.fallback_verdict", tags={"verdict": verdict})
         logger.info(
-            "pr_metrics.judge.fallback_verdict",
+            "pr_metrics.emit.fallback_verdict",
             extra={
                 "organization_id": organization.id,
                 "repository_id": pr.repository_id,
@@ -282,7 +282,7 @@ def _forward_to_judge(
                 "verdict": verdict,
             },
         )
-        _claim_and_emit(pr, verdict, "pr_metrics.judge.fallback_emitted")
+        _claim_and_emit(pr, verdict, "pr_metrics.emit.fallback_emitted")
         return
 
     if not has_seer_access(organization):

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -17,6 +17,7 @@ from sentry.models.pullrequest import (
 )
 from sentry.pr_metrics.contracts import PrConversationAnalysis
 from sentry.pr_metrics.emit import (
+    VerdictDeferral,
     _activity_derived_metrics,
     active_attributions,
     build_pr_metrics_row,
@@ -24,6 +25,7 @@ from sentry.pr_metrics.emit import (
     emit_pr_metrics_row,
     is_pr_tracked,
     resolve_autofix_referrers,
+    select_fallback_verdict,
     select_verdict,
 )
 from sentry.pr_metrics.utils import _commit_shas_from_activity, resolved_group_ids
@@ -159,7 +161,7 @@ class PrMetricsEmissionTest(TestCase):
 
     def test_select_verdict_merged_with_later_commits_needs_judge(self) -> None:
         self._add_synchronize()
-        assert select_verdict(self.pull_request, self.organization) is None
+        assert select_verdict(self.pull_request, self.organization) == VerdictDeferral.NEEDS_JUDGE
 
     def test_select_verdict_closed_without_engagement_is_unmerged(self) -> None:
         self.pull_request.merged_at = None
@@ -174,14 +176,18 @@ class PrMetricsEmissionTest(TestCase):
     def test_select_verdict_closed_with_comments_needs_judge(self) -> None:
         # setUp's metrics row carries comments_count=5, i.e. engagement to analyze.
         self.pull_request.merged_at = None
-        assert select_verdict(self.pull_request, self.organization) is None
+        assert select_verdict(self.pull_request, self.organization) == VerdictDeferral.NEEDS_JUDGE
 
-    def test_select_verdict_merged_without_metrics_row_needs_judge(self) -> None:
-        # A missing row is an error state for a merge too: defer rather than emit a
-        # row with zeroed counters.
+    def test_select_verdict_merged_without_metrics_row_is_indeterminate(self) -> None:
+        # A missing row is an error state for a merge too: there's no reliable
+        # activity/engagement data to decide from, so it's indeterminate rather
+        # than a genuine needs-judge ambiguity — and never emit zeroed counters.
         PullRequestMetrics.objects.filter(pull_request=self.pull_request).delete()
         with patch("sentry.pr_metrics.emit.logger") as mock_logger:
-            assert select_verdict(self.pull_request, self.organization) is None
+            assert (
+                select_verdict(self.pull_request, self.organization)
+                == VerdictDeferral.INDETERMINATE
+            )
         mock_logger.warning.assert_called_once_with(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
@@ -191,13 +197,16 @@ class PrMetricsEmissionTest(TestCase):
             },
         )
 
-    def test_select_verdict_closed_without_metrics_row_needs_judge(self) -> None:
+    def test_select_verdict_closed_without_metrics_row_is_indeterminate(self) -> None:
         # A missing row is an error state (handle_metrics failed): warn, and defer
-        # to a judge rather than guess "abandoned".
+        # as indeterminate rather than guess "abandoned".
         self.pull_request.merged_at = None
         PullRequestMetrics.objects.filter(pull_request=self.pull_request).delete()
         with patch("sentry.pr_metrics.emit.logger") as mock_logger:
-            assert select_verdict(self.pull_request, self.organization) is None
+            assert (
+                select_verdict(self.pull_request, self.organization)
+                == VerdictDeferral.INDETERMINATE
+            )
         mock_logger.warning.assert_called_once_with(
             "pr_metrics.select_verdict.metrics_row_missing",
             extra={
@@ -213,14 +222,19 @@ class PrMetricsEmissionTest(TestCase):
             comments_count=0, review_comments_count=0
         )
         self._add_synchronize()
-        assert select_verdict(self.pull_request, self.organization) is None
+        assert select_verdict(self.pull_request, self.organization) == VerdictDeferral.NEEDS_JUDGE
 
-    def test_select_verdict_needs_judge_when_activity_tracking_disabled(self) -> None:
+    def test_select_verdict_indeterminate_when_activity_tracking_disabled(self) -> None:
         # The commits-after-open signal comes from activity rows the org isn't
-        # recording, so an otherwise-clean merge can't be settled deterministically.
+        # recording, so an otherwise-clean merge can't be settled deterministically
+        # — and isn't a genuine needs-judge ambiguity either, since there's no
+        # activity data at all to have found ambiguous.
         with self.feature({"organizations:pr-metrics-activity": False}):
             with patch("sentry.pr_metrics.emit.metrics") as mock_metrics:
-                assert select_verdict(self.pull_request, self.organization) is None
+                assert (
+                    select_verdict(self.pull_request, self.organization)
+                    == VerdictDeferral.INDETERMINATE
+                )
         mock_metrics.incr.assert_called_once_with("pr_metrics.select_verdict.activity_disabled")
 
     def test_ci_failing_at_close_no_check_activity_is_false(self) -> None:
@@ -266,6 +280,23 @@ class PrMetricsEmissionTest(TestCase):
         self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-1")
         self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-2")
         assert ci_failing_at_close(self.pull_request) is True
+
+    def test_select_fallback_verdict_merged_without_later_commits_is_unchanged(self) -> None:
+        assert select_fallback_verdict(self.pull_request) == PullRequestVerdict.MERGED_UNCHANGED
+
+    def test_select_fallback_verdict_merged_with_later_commits_is_push_activity(self) -> None:
+        self._add_synchronize()
+        assert (
+            select_fallback_verdict(self.pull_request)
+            == PullRequestVerdict.MERGED_WITH_PUSH_ACTIVITY
+        )
+
+    def test_select_fallback_verdict_closed_is_unmerged(self) -> None:
+        # setUp's metrics row carries engagement (comments_count=5), which would
+        # need a judge under select_verdict — the fallback has no judge to defer
+        # to, so it settles CLOSED_UNMERGED unconditionally.
+        self.pull_request.merged_at = None
+        assert select_fallback_verdict(self.pull_request) == PullRequestVerdict.CLOSED_UNMERGED
 
     def test_build_row_for_merge(self) -> None:
         row = build_pr_metrics_row(

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -284,11 +284,10 @@ class PrMetricsEmissionTest(TestCase):
     def test_select_fallback_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         assert select_fallback_verdict(self.pull_request) == PullRequestVerdict.MERGED_UNCHANGED
 
-    def test_select_fallback_verdict_merged_with_later_commits_is_push_activity(self) -> None:
+    def test_select_fallback_verdict_merged_with_later_commits_is_iteration(self) -> None:
         self._add_synchronize()
         assert (
-            select_fallback_verdict(self.pull_request)
-            == PullRequestVerdict.MERGED_WITH_PUSH_ACTIVITY
+            select_fallback_verdict(self.pull_request) == PullRequestVerdict.MERGED_WITH_ITERATION
         )
 
     def test_select_fallback_verdict_closed_is_unmerged(self) -> None:

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2087,17 +2087,55 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
 
     @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
-    def test_ineligible_attribution_skips_judge(
+    def test_ineligible_attribution_emits_merged_with_push_activity(
         self, mock_record: MagicMock, mock_delay: MagicMock
     ) -> None:
         # Only SENTRY_APP and SEER_DELEGATED_* attributions qualify for the judge.
-        # A PR tracked only via MCP or REFERENCED_ISSUE is skipped.
+        # A PR tracked only via MCP or REFERENCED_ISSUE settles locally instead of
+        # being dropped: merged with a later commit becomes MERGED_WITH_PUSH_ACTIVITY.
         PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
             signal_type=PullRequestAttributionSignalType.MCP
         )
         self._call()
         assert mock_delay.call_count == 0
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_with_push_activity"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.analytics.record")
+    def test_ineligible_attribution_redelivery_emits_once(
+        self, mock_record: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        # The same NULL-verdict claim that guards the deterministic path also
+        # guards the fallback emit, so a redelivered close/merge settles once.
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
+            signal_type=PullRequestAttributionSignalType.MCP
+        )
+        self._call()
+        self._call()
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.analytics.record")
+    def test_ineligible_attribution_stays_unemitted_when_indeterminate(
+        self, mock_record: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        # Without activity tracking, select_verdict can't tell whether push
+        # activity happened at all (INDETERMINATE), not just that it's genuinely
+        # ambiguous (NEEDS_JUDGE). The fallback only trusts the latter, so an
+        # ineligible-attribution PR here is left unemitted, same as before the
+        # fallback existed — guessing would risk mislabeling an iterated PR as
+        # unchanged.
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
+            signal_type=PullRequestAttributionSignalType.MCP
+        )
+        with self.feature({"organizations:pr-metrics-activity": False}):
+            self._call()
+        assert mock_delay.call_count == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
 
 
 MATCH_RPC = "sentry.pr_metrics.webhooks.make_match_coding_agent_pr_request"

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2105,6 +2105,25 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
 
     @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
+    def test_ineligible_attribution_emits_without_seer_access(
+        self, mock_record: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        # The fallback never talks to Seer, so an org's Seer-access consent gate
+        # (gen-ai-features / hide_ai_features) must not block it — only the actual
+        # forward-to-Seer branch, reached for judge-eligible attribution, needs it.
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
+            signal_type=PullRequestAttributionSignalType.MCP
+        )
+        with self.feature({"organizations:gen-ai-features": False}):
+            self._call()
+        assert mock_delay.call_count == 0
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_with_push_activity"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
+    @patch("sentry.analytics.record")
     def test_ineligible_attribution_redelivery_emits_once(
         self, mock_record: MagicMock, mock_delay: MagicMock
     ) -> None:

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2087,19 +2087,20 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
 
     @patch(f"{MODULE}.forward_pr_to_seer_task.delay")
     @patch("sentry.analytics.record")
-    def test_ineligible_attribution_emits_merged_with_push_activity(
+    def test_ineligible_attribution_emits_merged_with_iteration(
         self, mock_record: MagicMock, mock_delay: MagicMock
     ) -> None:
         # Only SENTRY_APP and SEER_DELEGATED_* attributions qualify for the judge.
         # A PR tracked only via MCP or REFERENCED_ISSUE settles locally instead of
-        # being dropped: merged with a later commit becomes MERGED_WITH_PUSH_ACTIVITY.
+        # being dropped: merged with a later commit becomes MERGED_WITH_ITERATION,
+        # the same label the judge would use, even though no judge looked at it.
         PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
             signal_type=PullRequestAttributionSignalType.MCP
         )
         self._call()
         assert mock_delay.call_count == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
-            "merged_with_push_activity"
+            "merged_with_iteration"
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
 
@@ -2118,7 +2119,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
             self._call()
         assert mock_delay.call_count == 0
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
-            "merged_with_push_activity"
+            "merged_with_iteration"
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
 


### PR DESCRIPTION
PRs whose only attribution is judge-ineligible (e.g. `MCP`) never reach Seer — `JUDGE_ELIGIBLE_SIGNAL_TYPES` excludes them — but `select_verdict` could still leave them needing a judge (a merge with later commits, or a close with engagement). `_forward_to_judge` dropped these silently: it returned before ever claiming a verdict, so the `PullRequestMetrics` row stayed at `verdict=None` forever and `scm.pr.closed` was never emitted.

`select_verdict` now returns a `VerdictDeferral` enum instead of a bare `None`, splitting "needs a judge" into two cases that aren't interchangeable for a fallback:

- `NEEDS_JUDGE` — real activity/engagement data shows genuine ambiguity (commits after open, or discussion on a close).
- `INDETERMINATE` — no reliable signal to decide from at all (activity tracking disabled, or the metrics row missing), so the data's absence can't be read as "nothing happened".

A new `select_fallback_verdict` settles judge-ineligible PRs directly from push activity instead of a judge's conversation/diff analysis, but only for `NEEDS_JUDGE` — an `INDETERMINATE` PR with ineligible attribution stays unemitted, exactly as before this fallback existed:

- Merged with commits after open → `MERGED_WITH_ITERATION`, reusing the judge's verdict label even though no judge looked at the diff — weak attribution's iteration signal is push activity alone, same outcome bucket.
- Merged with no later commits → `MERGED_UNCHANGED`.
- Closed → `CLOSED_UNMERGED` unconditionally — there's no judge-eligible equivalent of the conversation judge for weak attribution, so engagement isn't distinguished.

`_forward_to_judge` claims and emits the fallback verdict under the same NULL-verdict redelivery guard used elsewhere (shared with the cooldown task's deterministic path via a new `_claim_and_emit` helper), rather than returning early. The `has_seer_access` consent gate now only guards the actual forward-to-Seer branch — the fallback never talks to Seer, so it shouldn't be blocked by an org's Seer-access consent. Metrics and logs for the fallback path (`pr_metrics.emit.fallback_verdict`, `pr_metrics.emit.fallback_emitted`) live under `emit.*` rather than `judge.*`, since no judge runs on this path.

No migration: this reuses the existing `MERGED_WITH_ITERATION` verdict rather than adding a new choice.