### PR TITLE
fix(conversations): Sort tools in the tool calls breakdown tooltip

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversationToolBreakdown.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationToolBreakdown.tsx
@@ -37,7 +37,7 @@ export function useConversationToolBreakdown({
         'count_if(span.status,equals,internal_error)',
         'count_if(span.status,equals,error)',
       ],
-      orderby: '-count(span.duration)',
+      sorts: [{field: 'count(span.duration)', kind: 'desc'}],
       limit: 50,
       enabled,
     },


### PR DESCRIPTION
Sort the per-tool rows in the conversation "tool calls" breakdown tooltip by call count (descending), so the most-used tools show first instead of arbitrary order.

The query already passed `orderby: '-count(span.duration)'`, but `orderby` is silently dropped by EventView's aggregate-alias sort filter (the sort field never matches the aliased field name), so no sort param actually reached the backend. Switching to the `sorts` option fixes it — `sorts` is applied verbatim and sends `sort=-count(span.duration)`.

Fixes TET-2665