### PR TITLE
fix(issues): Restrict low-value span estimated cost to owners and managers

### DIFF
--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanProblemSection.spec.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanProblemSection.spec.tsx
@@ -1,4 +1,5 @@
 import {EventFixture} from 'sentry-fixture/event';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
@@ -26,7 +27,9 @@ function makeEvent(overrides: Partial<LowValueSpanEvidenceData> = {}) {
 
 describe('LowValueSpanProblemSection', () => {
   it('renders low-value span evidence from the occurrence', () => {
-    render(<LowValueSpanProblemSection event={makeEvent()} />);
+    render(<LowValueSpanProblemSection event={makeEvent()} />, {
+      organization: OrganizationFixture({orgRole: 'owner'}),
+    });
 
     expect(screen.getByText(/frequently created span/)).toBeInTheDocument();
     expect(screen.getByText('Affected span')).toBeInTheDocument();
@@ -39,21 +42,55 @@ describe('LowValueSpanProblemSection', () => {
     expect(screen.getByText('<1ms')).toBeInTheDocument();
   });
 
+  it('renders estimated cost for org managers', () => {
+    render(<LowValueSpanProblemSection event={makeEvent()} />, {
+      organization: OrganizationFixture({orgRole: 'manager'}),
+    });
+
+    expect(screen.getByText('Estimated cost')).toBeInTheDocument();
+    expect(screen.getByText('$12.34')).toBeInTheDocument();
+  });
+
+  it('does not render estimated cost for members', () => {
+    render(<LowValueSpanProblemSection event={makeEvent()} />, {
+      organization: OrganizationFixture({orgRole: 'member'}),
+    });
+
+    expect(screen.queryByText('Estimated cost')).not.toBeInTheDocument();
+    expect(screen.queryByText('$12.34')).not.toBeInTheDocument();
+    // The rest of the evidence is still visible.
+    expect(screen.getByText('Affected span')).toBeInTheDocument();
+  });
+
+  it('does not render estimated cost for admins', () => {
+    render(<LowValueSpanProblemSection event={makeEvent()} />, {
+      organization: OrganizationFixture({orgRole: 'admin'}),
+    });
+
+    expect(screen.queryByText('Estimated cost')).not.toBeInTheDocument();
+  });
+
   it('falls back to the sampled span count when extrapolated count is unavailable', () => {
-    render(<LowValueSpanProblemSection event={makeEvent({extrapolatedCount: null})} />);
+    render(<LowValueSpanProblemSection event={makeEvent({extrapolatedCount: null})} />, {
+      organization: OrganizationFixture({orgRole: 'owner'}),
+    });
 
     expect(screen.getByText('1.2K')).toBeInTheDocument();
     expect(screen.getAllByLabelText('More information')).toHaveLength(1);
   });
 
   it('does not render estimated cost when unavailable', () => {
-    render(<LowValueSpanProblemSection event={makeEvent({estimatedCostUsd: null})} />);
+    render(<LowValueSpanProblemSection event={makeEvent({estimatedCostUsd: null})} />, {
+      organization: OrganizationFixture({orgRole: 'owner'}),
+    });
 
     expect(screen.queryByText('Estimated cost')).not.toBeInTheDocument();
   });
 
   it('does not render estimated cost when zero', () => {
-    render(<LowValueSpanProblemSection event={makeEvent({estimatedCostUsd: 0})} />);
+    render(<LowValueSpanProblemSection event={makeEvent({estimatedCostUsd: 0})} />, {
+      organization: OrganizationFixture({orgRole: 'owner'}),
+    });
 
     expect(screen.queryByText('Estimated cost')).not.toBeInTheDocument();
   });

--- a/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanProblemSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/lowValueSpanIssues/lowValueSpanProblemSection.tsx
@@ -48,8 +48,12 @@ export function LowValueSpanProblemSection({event}: LowValueSpanProblemSectionPr
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const evidenceData = getLowValueSpanEvidenceData(event.occurrence?.evidenceData);
+  // Estimated cost is billing-sensitive, so only expose it to org owners and managers.
+  const canViewEstimatedCost = ['manager', 'owner'].includes(organization.orgRole ?? '');
   const hasEstimatedCost =
-    evidenceData.estimatedCostUsd !== null && evidenceData.estimatedCostUsd > 0;
+    canViewEstimatedCost &&
+    evidenceData.estimatedCostUsd !== null &&
+    evidenceData.estimatedCostUsd > 0;
   const spanCount = evidenceData.extrapolatedCount ?? evidenceData.count;
   const affectedSpanQuery = getAffectedSpanQuery(evidenceData);
   const affectedSpanExploreUrl = affectedSpanQuery


### PR DESCRIPTION
The **Estimated cost** field in the low-value span issue details is now only shown to org owners and managers. Members and admins continue to see the rest of the evidence (affected span, span count, average duration) unchanged.

Fixes TET-2674