### PR TITLE
fix(msteams): support single-tenant Azure Bots via new msteams.tenant-id option

### DIFF
--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -146,6 +146,12 @@ class OAuthMsTeamsClient(ApiClient):
         super().__init__()
         self.client_id = client_id
         self.client_secret = client_secret
+        # Single-tenant Azure Bots must request the token from their tenant's
+        # authority. Multi-tenant bots (the historical default) use the shared
+        # botframework.com authority, which Microsoft no longer provisions.
+        tenant_id = options.get("msteams.tenant-id")
+        if tenant_id:
+            self.base_url = f"https://login.microsoftonline.com/{tenant_id}"
 
     def exchange_token(self):
         headers = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -146,9 +146,8 @@ class OAuthMsTeamsClient(ApiClient):
         super().__init__()
         self.client_id = client_id
         self.client_secret = client_secret
-        # Single-tenant Azure Bots must request the token from their tenant's
-        # authority. Multi-tenant bots (the historical default) use the shared
-        # botframework.com authority, which Microsoft no longer provisions.
+        # tenant_id is required for single-tenant bots to authenticate. The bot framework
+        # base_url is specific to multi-tenant bots which microsoft no longer provisions.
         tenant_id = options.get("msteams.tenant-id")
         if tenant_id:
             self.base_url = f"https://login.microsoftonline.com/{tenant_id}"

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -754,6 +754,9 @@ register("vercel.integration-slug", default="sentry", flags=FLAG_AUTOMATOR_MODIF
 register("msteams.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("msteams.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("msteams.app-id")
+# Tenant-specific OAuth authority, required for single-tenant Azure Bots.
+# Empty (default) keeps the historical multi-tenant botframework.com authority.
+register("msteams.tenant-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 
 # Discord Integration
 register("discord.application-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from requests import Request
 
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.msteams.client import MsTeamsClient
+from sentry.integrations.msteams.client import MsTeamsClient, OAuthMsTeamsClient
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
@@ -20,6 +20,7 @@ from sentry.silo.util import (
     PROXY_SIGNATURE_HEADER,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
 
@@ -287,3 +288,18 @@ class MsTeamsProxyApiClientTest(TestCase):
             assert request.headers[PROXY_BASE_URL_HEADER] == "https://smba.trafficmanager.net/amer"
             assert client.base_url not in request.url
             assert_proxy_request(request, is_proxy=True)
+
+
+@control_silo_test
+class OAuthMsTeamsClientTest(TestCase):
+    def test_defaults_to_botframework_authority(self) -> None:
+        client = OAuthMsTeamsClient("client-id", "client-secret")
+        assert client.base_url == "https://login.microsoftonline.com/botframework.com"
+
+    @override_options({"msteams.tenant-id": "00000000-1111-2222-3333-444444444444"})
+    def test_uses_tenant_authority_when_configured(self) -> None:
+        client = OAuthMsTeamsClient("client-id", "client-secret")
+        assert (
+            client.base_url
+            == "https://login.microsoftonline.com/00000000-1111-2222-3333-444444444444"
+        )


### PR DESCRIPTION
Fixes getsentry/sentry#119384

### Problem

`OAuthMsTeamsClient` requests Bot Connector tokens from the **multi-tenant** authority, hardcoded in `src/sentry/integrations/msteams/client.py`:

```python
base_url = "https://login.microsoftonline.com/botframework.com"
```

Microsoft deprecated the creation of multi-tenant Azure Bot resources on **2025-07-31**. The Azure Portal now only offers `Single Tenant` and `User-Assigned Managed Identity`. A single-tenant bot must request its token from the **tenant-specific** authority:

```
https://login.microsoftonline.com/<TENANT_ID>/oauth2/v2.0/token
```

Because the authority is hardcoded, every outbound Bot Connector call from a single-tenant bot returns `401 {"message":"Authorization has been denied for this request."}`. The webhook handler then raises and returns 500, so the integration is never created and no welcome card is sent. **MS Teams cannot be set up on any new self-hosted install.**

Inbound webhook JWT validation is unaffected — only the outbound token authority is wrong.

### Proof

Same credentials, same scope, same conversation; only the issuing authority differs:

<!-- linear:table-colwidths:400,400 -->
| Authority | Bot Connector |
| -- | -- |
| `https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token` | **401** |
| `https://login.microsoftonline.com/<TENANT_ID>/oauth2/v2.0/token` | **200** |

Both tokens carry `aud=https://api.botframework.com` and the correct `appid`.

### Change

Adds an `msteams.tenant-id` option. When set, `OAuthMsTeamsClient` uses the tenant-specific authority; when unset (the default) behaviour is unchanged, so existing multi-tenant deployments are not affected.

### Verification

Applied to a self-hosted 26.6.0 instance backed by a single-tenant Azure Bot (multi-tenant Entra app registration, Teams channel enabled):

* outbound Bot Connector calls: `401` → `200`/`201`
* `POST /extensions/msteams/webhook/`: `500` → `201`
* welcome card delivered, `Integration(provider="msteams")` created, org linked

### Notes for reviewers

* Workarounds that do **not** work: creating a multi-tenant Azure Bot (blocked by Microsoft since 2025-07-31); flipping an existing bot with `az resource update --set properties.msaAppType=MultiTenant` (returns HTTP 200 but silently does not apply the change).
* The docs at [https://develop.sentry.dev/integrations/msteams/](<https://develop.sentry.dev/integrations/msteams/>) should additionally state that an **Azure Bot resource is mandatory** — a bot registered only in the Teams Developer Portal has no Bot Framework identity and can never send outbound messages. Happy to send that as a separate PR to `sentry-docs`.
* Option naming: `msteams.tenant-id` mirrors the existing `msteams.client-id` / `msteams.client-secret`. If you prefer alignment with the Bot Framework SDK (`MicrosoftAppTenantId` / `MicrosoftAppType`), happy to rename.