### PR TITLE
test(objectstore): try host.docker.internal:8888 as dev base_url

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2362,7 +2362,7 @@ SENTRY_REGION_API_URL_TEMPLATE: str | None = os.environ.get("SENTRY_REGION_API_U
 SENTRY_INTERCOM_API_SECRET = ""
 SENTRY_RELAY_STATIC_AUTH: dict[str, Any] = {}
 SENTRY_OBJECTSTORE_CONFIG: dict[str, Any] = {
-    "base_url": "http://127.0.0.1:8888",
+    "base_url": "http://host.docker.internal:8888",
     # Test-only token generator with no permissions. Only active when no real
     # objectstore config is deployed. Exists so mint_token() does not raise in
     # test/dev environments that lack signing keys.


### PR DESCRIPTION
## Experiment

Testing whether pointing the dev/test objectstore `base_url` at `host.docker.internal:8888` (instead of `127.0.0.1:8888`) removes the need for the symbolicator URL rewriting (`maybe_rewrite_url_for_symbolicator` / `docker ps` heuristic).

## Local result (macOS)

**Fails.** `sentry` runs on the host, where `host.docker.internal` does not resolve, so the very first objectstore call (upload) dies:

```
NameResolutionError: Failed to resolve 'host.docker.internal' (port 8888)
```

Pushing to observe Linux CI behavior — where `host.docker.internal` also isn't in the runner's `/etc/hosts` by default, so the same host-side failure is expected in the objectstore-backed tests.

Not for merge. Draft to gather CI evidence.