### PR TITLE
fix(conversations): Fetch more conversation list items

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -30,6 +30,18 @@ describe('useConversations', () => {
     MockApiClient.clearMockResponses();
   });
 
+  it('requests 50 conversations per page', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/`,
+      body: [],
+      match: [MockApiClient.matchQuery({per_page: 50})],
+    });
+
+    const {result} = renderHookWithProviders(() => useConversations(), {organization});
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+  });
+
   it('normalizes firstInput when it is a string', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/ai-conversations/`,

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -44,6 +44,8 @@ interface ConversationApiResponse extends Omit<
   lastOutput?: Array<{text: string; type: string}> | string | null;
 }
 
+const CONVERSATION_LIST_PER_PAGE = 50;
+
 export function useConversations() {
   const organization = useOrganization();
   const {cursor, setCursor} = useTableCursor();
@@ -64,6 +66,7 @@ export function useConversations() {
           query: combinedQuery,
           project: pageFilters.selection.projects,
           environment: pageFilters.selection.environments,
+          per_page: CONVERSATION_LIST_PER_PAGE,
           ...normalizeDateTimeParams(pageFilters.selection.datetime),
         },
         staleTime: 0,


### PR DESCRIPTION
The conversations list now requests 50 rows per page so the table shows more items before pagination.

Closes TET-2648