### PR TITLE
ref(ui): Replace Flex direction=column with Stack

### DIFF
--- a/static/app/components/backendJsonFormAdapter/choiceMapperAdapter.tsx
+++ b/static/app/components/backendJsonFormAdapter/choiceMapperAdapter.tsx
@@ -280,7 +280,7 @@ export function ChoiceMapperTable({
           <Flex flex="0 0 200px">{labelMap[itemKey]}</Flex>
           {mappedKeys.map((fieldKey, i) => (
             <Flex align="center" flex="1 0 0" gap="md" key={fieldKey}>
-              <Flex flex="1" direction="column">
+              <Stack flex="1">
                 <Select
                   {...getSelector(itemKey, fieldKey)}
                   options={transformMappedChoices(getSelector(itemKey, fieldKey))}
@@ -290,7 +290,7 @@ export function ChoiceMapperTable({
                   }
                   value={value[itemKey]?.[fieldKey]}
                 />
-              </Flex>
+              </Stack>
               {i === mappedKeys.length - 1 && (
                 <Button
                   icon={<IconDelete />}

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -572,7 +572,7 @@ export function CommandPalette({
 
   const content = (
     <Fragment>
-      <Flex direction="column" align="start" gap="md">
+      <Stack align="start" gap="md">
         <Flex position="relative" direction="row" align="center" gap="xs" width="100%">
           {p => {
             return (
@@ -660,7 +660,7 @@ export function CommandPalette({
             );
           }}
         </Flex>
-      </Flex>
+      </Stack>
 
       {treeState.collection.size === 0 ? (
         isEmptyPromptQuery || isLoading ? null : (
@@ -1231,14 +1231,7 @@ function CommandPaletteHints() {
 
 function CommandPaletteNoResults() {
   return (
-    <Flex
-      direction="column"
-      align="center"
-      justify="center"
-      gap="lg"
-      padding="2xl lg"
-      height="400px"
-    >
+    <Stack align="center" justify="center" gap="lg" padding="2xl lg" height="400px">
       <Image src={errorIllustration} alt="No results" width="400px" />
       <Stack align="center" gap="md">
         <Container padding="0 2xl">
@@ -1262,7 +1255,7 @@ function CommandPaletteNoResults() {
           />
         </Container>
       </Stack>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/core/disclosure/disclosure.tsx
+++ b/static/app/components/core/disclosure/disclosure.tsx
@@ -9,7 +9,7 @@ import {usePress} from '@react-aria/interactions';
 import {useDisclosureState, type DisclosureState} from '@react-stately/disclosure';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
@@ -68,9 +68,9 @@ function DisclosureComponent({
     <DisclosureContext.Provider
       value={{buttonProps, panelProps, panelRef, state, context: {size}}}
     >
-      <Flex data-disclosure direction="column" align="start" ref={ref} {...props}>
+      <Stack data-disclosure align="start" ref={ref} {...props}>
         {children}
-      </Flex>
+      </Stack>
     </DisclosureContext.Provider>
   );
 }

--- a/static/app/components/core/form/field/radioField.tsx
+++ b/static/app/components/core/form/field/radioField.tsx
@@ -2,7 +2,7 @@ import {createContext, useContext, useId} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
 
@@ -95,14 +95,14 @@ function RadioItem({children, value, description}: RadioItemProps) {
         checked={selectedValue === value}
         onChange={() => onChange(value)}
       />
-      <Flex direction="column" gap="xs" paddingTop="xs">
+      <Stack gap="xs" paddingTop="xs">
         <Text>{children}</Text>
         {description && (
           <Text size="sm" variant="muted" id={descriptionId}>
             {description}
           </Text>
         )}
-      </Flex>
+      </Stack>
     </Flex>
   );
 }

--- a/static/app/components/core/inspector.tsx
+++ b/static/app/components/core/inspector.tsx
@@ -326,7 +326,7 @@ export function SentryComponentInspector() {
             maxWidth: '460px',
           }}
         >
-          <Flex direction="column" gap="xs" padding="md">
+          <Stack gap="xs" padding="md">
             <ProfilingContextMenuHeading style={{padding: '0'}}>
               {t('Hovered Components')}
             </ProfilingContextMenuHeading>
@@ -367,7 +367,7 @@ export function SentryComponentInspector() {
                 )}
               </Stack>
             )}
-          </Flex>
+          </Stack>
         </Overlay>
       ) : state.enabled === 'context-menu' && contextMenu.open ? (
         <Fragment>
@@ -384,7 +384,7 @@ export function SentryComponentInspector() {
             }}
           >
             <ProfilingContextMenuGroup>
-              <Flex direction="column" gap="xs" padding="md xs">
+              <Stack gap="xs" padding="md xs">
                 <Flex padding="0 xs">
                   <ProfilingContextMenuHeading style={{padding: '0'}}>
                     {t('Component Trace')}
@@ -418,7 +418,7 @@ export function SentryComponentInspector() {
                         />
                       );
                     })}
-              </Flex>
+              </Stack>
             </ProfilingContextMenuGroup>
           </ProfilingContextMenu>
           <div

--- a/static/app/components/core/markdown/__stories__/components.tsx
+++ b/static/app/components/core/markdown/__stories__/components.tsx
@@ -2,7 +2,7 @@ import {Fragment, useRef, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {InlineCode} from '@sentry/scraps/code';
-import {Flex, Surface} from '@sentry/scraps/layout';
+import {Flex, Stack, Surface} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
@@ -57,7 +57,7 @@ export function StreamingDemo() {
   }
 
   return (
-    <Flex direction="column" gap="lg" flexGrow={1} maxWidth="72ch">
+    <Stack gap="lg" flexGrow={1} maxWidth="72ch">
       <Flex gap="md">
         <Button variant="primary" size="sm" onClick={startStream} disabled={isStreaming}>
           Start Stream
@@ -67,7 +67,7 @@ export function StreamingDemo() {
         </Button>
       </Flex>
       <Markdown raw={text} variant="streaming" />
-    </Flex>
+    </Stack>
   );
 }
 
@@ -133,7 +133,7 @@ export function TagDemo() {
           const typedData = data as Record<string, string> | undefined;
           return (
             <Surface variant="overlay" elevation="medium" padding="lg">
-              <Flex direction="column" gap="lg">
+              <Stack gap="lg">
                 <Flex gap="sm" align="center">
                   <Flex flexGrow={1}>
                     <Text>{attrs.type}</Text>
@@ -146,7 +146,7 @@ export function TagDemo() {
                     <Text>{typedData.description}</Text>
                   </Flex>
                 ) : null}
-              </Flex>
+              </Stack>
             </Surface>
           );
         },

--- a/static/app/components/core/modal/__stories__/demos.tsx
+++ b/static/app/components/core/modal/__stories__/demos.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ModalBody, ModalFooter, useModal} from '@sentry/scraps/modal';
 
 export function BasicDemo() {
@@ -95,7 +95,7 @@ export function HookDemo() {
 
 export function SubComponentsDemo() {
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <ModalBody>
         This is a standalone ModalBody — useful for previewing styles outside a modal.
       </ModalBody>
@@ -103,6 +103,6 @@ export function SubComponentsDemo() {
         <Button variant="secondary">Cancel</Button>
         <Button variant="primary">Confirm</Button>
       </ModalFooter>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useImperativeHandle, useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {Container, Flex, type Responsive} from '@sentry/scraps/layout';
+import {Container, Flex, type Responsive, Stack} from '@sentry/scraps/layout';
 import {useResponsivePropValue} from '@sentry/scraps/layout/styles';
 
 import {useDimensions} from 'sentry/utils/useDimensions';
@@ -80,8 +80,7 @@ function getDividerCursor(
 function Pane({size, children}: {children: React.ReactNode; size: number | null}) {
   const isFilling = size === null;
   return (
-    <Flex
-      direction="column"
+    <Stack
       minHeight="0"
       minWidth="0"
       flexGrow={isFilling ? 1 : 0}
@@ -89,7 +88,7 @@ function Pane({size, children}: {children: React.ReactNode; size: number | null}
       flexBasis={isFilling ? 0 : `${size}px`}
     >
       {children}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/emptyMessage.tsx
+++ b/static/app/components/emptyMessage.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@emotion/react';
 import {mergeProps} from '@react-aria/utils';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
@@ -17,7 +17,7 @@ export function EmptyMessage({title, icon, children, action, size, ...props}: Pr
   const theme = useTheme();
 
   return (
-    <Flex gap="xl" direction="column" padding="3xl">
+    <Stack gap="xl" padding="3xl">
       {stackProps => (
         <Text
           align="center"
@@ -43,6 +43,6 @@ export function EmptyMessage({title, icon, children, action, size, ...props}: Pr
           {action && <Container paddingTop="xl">{action}</Container>}
         </Text>
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
+++ b/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
@@ -1,7 +1,7 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -155,7 +155,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
           marginTop="2xl"
           marginBottom="2xl"
         >
-          <Flex direction="column" gap="lg">
+          <Stack gap="lg">
             <Heading as="h3">
               <Flex direction="row" gap="sm" align="center">
                 <PluginIcon pluginId={config.pluginId} />{' '}
@@ -181,7 +181,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
                 {t('Install %s Integration', config.displayName)}
               </LinkButton>
             </div>
-          </Flex>
+          </Stack>
         </Container>
       );
     }
@@ -195,7 +195,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
           marginTop="2xl"
           marginBottom="2xl"
         >
-          <Flex direction="column" gap="lg">
+          <Stack gap="lg">
             <Heading as="h3">
               <Flex direction="row" gap="sm" align="center">
                 <PluginIcon pluginId={config.pluginId} />{' '}
@@ -221,7 +221,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
                 {t('Set Seer to hand off to %s', config.displayName)}
               </Button>
             </div>
-          </Flex>
+          </Stack>
         </Container>
       );
     }
@@ -234,7 +234,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
         marginTop="2xl"
         marginBottom="2xl"
       >
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Heading as="h3">
             <Flex direction="row" gap="sm" align="center">
               <PluginIcon pluginId={config.pluginId} />{' '}
@@ -250,7 +250,7 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
               }
             )}
           </Text>
-        </Flex>
+        </Stack>
       </Container>
     );
   };

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
@@ -59,7 +59,7 @@ export function GithubCopilotIntegrationCta() {
         marginTop="2xl"
         marginBottom="2xl"
       >
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Heading as="h3">
             <Flex direction="row" gap="sm" align="center">
               <PluginIcon pluginId="github" /> <span>GitHub Copilot Integration</span>
@@ -80,7 +80,7 @@ export function GithubCopilotIntegrationCta() {
               {t('Install GitHub Copilot Integration')}
             </LinkButton>
           </div>
-        </Flex>
+        </Stack>
       </Container>
     );
   }
@@ -93,7 +93,7 @@ export function GithubCopilotIntegrationCta() {
       marginTop="2xl"
       marginBottom="2xl"
     >
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Heading as="h3">
           <Flex direction="row" gap="sm" align="center">
             <PluginIcon pluginId="github" /> <span>GitHub Copilot Integration</span>
@@ -104,7 +104,7 @@ export function GithubCopilotIntegrationCta() {
             'GitHub Copilot integration is installed. You can trigger GitHub Copilot from Issue Fix to create pull requests.'
           )}
         </Text>
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/app/components/events/autofix/v3/artifactCard.tsx
+++ b/static/app/components/events/autofix/v3/artifactCard.tsx
@@ -2,7 +2,7 @@ import {Fragment, type ReactNode} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconRefresh} from 'sentry/icons';
@@ -61,9 +61,7 @@ export function ArtifactCard({
           </Flex>
         </Disclosure.Title>
         <Disclosure.Content>
-          <Flex direction="column" gap="lg">
-            {children}
-          </Flex>
+          <Stack gap="lg">{children}</Stack>
         </Disclosure.Content>
       </Disclosure>
     </Container>

--- a/static/app/components/events/autofix/v3/artifactDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactDetails.tsx
@@ -1,6 +1,6 @@
 import {type ReactNode} from 'react';
 
-import {Flex, type FlexProps} from '@sentry/scraps/layout';
+import {Stack, type FlexProps} from '@sentry/scraps/layout';
 
 interface ArtifactDetailsProps extends FlexProps {
   children: ReactNode;
@@ -8,8 +8,8 @@ interface ArtifactDetailsProps extends FlexProps {
 
 export function ArtifactDetails({children, ...flexProps}: ArtifactDetailsProps) {
   return (
-    <Flex direction="column" borderTop="primary" gap="md" paddingTop="lg" {...flexProps}>
+    <Stack borderTop="primary" gap="md" paddingTop="lg" {...flexProps}>
       {children}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
@@ -25,8 +25,7 @@ export function ArtifactLoadingDetails({
 
   return (
     <ArtifactDetails>
-      <Flex
-        direction="column"
+      <Stack
         gap="md"
         ref={containerRef}
         maxHeight="200px"
@@ -55,7 +54,7 @@ export function ArtifactLoadingDetails({
             {loadingMessage}
           </Text>
         </Flex>
-      </Flex>
+      </Stack>
     </ArtifactDetails>
   );
 }

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
@@ -204,7 +204,7 @@ export function CodingAgentPreview({section}: ArtifactPreviewProps) {
                 : ('success' as const);
 
         return (
-          <Flex key={codingAgent.id} direction="column" gap="md">
+          <Stack key={codingAgent.id} gap="md">
             <Text>{codingAgent.name}</Text>
             <Flex direction="row-reverse" align="center" justify="between">
               <Tag variant={statusVariant}>{codingAgent.status}</Tag>
@@ -220,7 +220,7 @@ export function CodingAgentPreview({section}: ArtifactPreviewProps) {
                 </LinkButton>
               ) : null}
             </Flex>
-          </Flex>
+          </Stack>
         );
       })}
     </ArtifactCard>
@@ -235,13 +235,13 @@ interface ArtifactCardProps {
 
 function ArtifactCard({children, icon, title}: ArtifactCardProps) {
   return (
-    <Flex direction="column" border="primary" radius="md" gap="md" padding="md">
+    <Stack border="primary" radius="md" gap="md" padding="md">
       <Flex gap="md">
         {icon}
         <Text bold>{title}</Text>
       </Flex>
       {children}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
+++ b/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
@@ -1,7 +1,7 @@
 import {useState, type ReactNode} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
@@ -25,7 +25,7 @@ export function AutofixResetPrompt({
   const [userContext, setUserContext] = useState('');
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <Text>{prompt}</Text>
       <TextArea
         autosize
@@ -53,6 +53,6 @@ export function AutofixResetPrompt({
           {t('Re-run from here')}
         </Button>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/events/autofix/v3/autofixStartCard.tsx
+++ b/static/app/components/events/autofix/v3/autofixStartCard.tsx
@@ -5,7 +5,7 @@ import seerConfigConnectImg from 'sentry-images/spot/seer-config-connect-2.svg';
 
 import {Button} from '@sentry/scraps/button';
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {useExplorerAutofix} from 'sentry/components/events/autofix/useExplorerAutofix';
@@ -49,7 +49,7 @@ export function AutofixStartCard({
   };
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Flex
         border="muted"
         radius="md"
@@ -88,7 +88,7 @@ export function AutofixStartCard({
       >
         {t('Start Analysis')}
       </Button>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {UserAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Prose, Text} from '@sentry/scraps/text';
@@ -387,10 +387,10 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
     content = (
       <ArtifactDetails gap="lg">
-        <Flex direction="column" gap="md">
+        <Stack gap="md">
           <Text bold>{t("Seer proposed a fix but couldn't apply it automatically")}</Text>
           <Markdown raw={explanation} />
-        </Flex>
+        </Stack>
         {resetSection}
       </ArtifactDetails>
     );

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -2,7 +2,7 @@ import {Fragment, useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {
   getOrderedAutofixSections,
@@ -46,9 +46,9 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
     (autofix.isPolling && !autofix.runState?.blocks?.length)
   ) {
     return (
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         <Placeholder height="15rem" />
-      </Flex>
+      </Stack>
     );
   }
 
@@ -57,7 +57,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
   }
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <SeerDrawerArtifacts autofix={autofix} sections={sections} groupId={group.id} />
       {(autofix.runState?.status === 'completed' ||
         isLastStepPrIteration(autofix.runState)) && (
@@ -80,7 +80,7 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
           {message}
         </Alert>
       ))}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -2,7 +2,7 @@ import {Fragment, useCallback, useMemo, useRef} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
 
@@ -66,12 +66,11 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
   });
 
   return (
-    <Flex
+    <Stack
       className="seer-drawer-container"
       position="relative"
       height="100%"
       overflowY="hidden"
-      direction="column"
       background="secondary"
     >
       <SeerDrawerHeader
@@ -83,16 +82,16 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
       <AutofixWarnings warnings={aiAutofix.warnings} groupId={group.id} />
       <SeerDrawerBody ref={containerRef} onScroll={onScrollHandler}>
         {aiConfig.isAutofixSetupLoading ? (
-          <Flex data-test-id="ai-setup-loading-indicator" direction="column" gap="xl">
+          <Stack data-test-id="ai-setup-loading-indicator" gap="xl">
             <Placeholder height="10rem" />
             <Placeholder height="15rem" />
             <Placeholder height="15rem" />
-          </Flex>
+          </Stack>
         ) : (
           <SeerDrawerContent group={group} autofix={aiAutofix} aiConfig={aiConfig} />
         )}
       </SeerDrawerBody>
-    </Flex>
+    </Stack>
   );
 }
 
@@ -240,7 +239,7 @@ export function AutofixWarnings({
   ));
 
   return (
-    <Flex direction="column" gap="md" padding="md 2xl 0">
+    <Stack gap="md" padding="md 2xl 0">
       <Alert
         variant="warning"
         trailingItems={
@@ -267,6 +266,6 @@ export function AutofixWarnings({
               'The configured GitHub App is missing permissions. Update the app and ask Seer to retry.'
             )}
       </Alert>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -3,7 +3,7 @@ import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {MenuComponents} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -532,7 +532,7 @@ function NextStepTemplate({
 
   if (clickedNo) {
     return (
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Text>{rethinkPrompt}</Text>
         <TextArea
           autosize
@@ -551,12 +551,12 @@ function NextStepTemplate({
             {labelRethink}
           </Button>
         </Flex>
-      </Flex>
+      </Stack>
     );
   }
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <Text>{prompt}</Text>
       <Flex gap="md">
         <Button disabled={isProcessing} onClick={() => handleClickedNo(true)}>
@@ -594,7 +594,7 @@ function NextStepTemplate({
           )}
         </ButtonBar>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -3,7 +3,7 @@ import {useRef, useState} from 'react';
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -68,7 +68,7 @@ export function PrIterationFeedbackForm({
   };
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <Flex gap="xs" align="center">
         <Text>{prompt}</Text>
         <FeatureBadge type="alpha" />
@@ -112,6 +112,6 @@ export function PrIterationFeedbackForm({
           {isSubmitting ? t('Submitting feedback') : t('Submit')}
         </Button>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/events/autofix/v3/solutionCard.tsx
+++ b/static/app/components/events/autofix/v3/solutionCard.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useMemo} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
@@ -82,12 +82,12 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
               <Container as="ol" margin="0">
                 {artifact.data.steps.map((step, index) => (
                   <li key={index}>
-                    <Flex direction="column">
+                    <Stack>
                       <Markdown raw={step.title} />
                       <Text size="sm" variant="muted">
                         {step.description}
                       </Text>
-                    </Flex>
+                    </Stack>
                   </li>
                 ))}
               </Container>

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {useHotkeys} from '@sentry/scraps/hotkey';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Stack, Grid} from '@sentry/scraps/layout';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Confirm} from 'sentry/components/confirm';
@@ -106,7 +106,7 @@ export function ScreenshotModal({
         <h5>{t('Screenshot')}</h5>
       </Header>
       <Body>
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           {defined(paginationProps) && <ScreenshotPagination {...paginationProps} />}
           <AttachmentComponentWrapper>
             <AttachmentComponent
@@ -150,7 +150,7 @@ export function ScreenshotModal({
               },
             ]}
           />
-        </Flex>
+        </Stack>
       </Body>
       <Footer>
         <Grid flow="column" align="center" gap="md">

--- a/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/androidNativeTombstonesBanner.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {usePrompt} from 'sentry/actionCreators/prompts';
@@ -155,7 +155,7 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
 
   return (
     <BannerWrapper>
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <Heading as="h4">{t('Enable Tombstone Collection')}</Heading>
         <Text as="p" style={{maxWidth: 460}}>
           {t(
@@ -185,7 +185,7 @@ export function AndroidNativeTombstonesBanner({event, projectId}: Props) {
         >
           {t('Learn More')}
         </LinkButton>
-      </Flex>
+      </Stack>
       <CloseDropdownMenu
         position="bottom-end"
         triggerProps={{

--- a/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/flamegraph/stacktraceFlamegraph.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {FlamegraphPreview} from 'sentry/components/profiling/flamegraph/flamegraphPreview';
@@ -71,7 +71,7 @@ export function StacktraceFlamegraph({frames}: StacktraceFlamegraphProps) {
 
   return (
     <FlamegraphThemeProvider>
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <FlamegraphLegend />
         <FlamegraphContainer>
           <FlamegraphPreview
@@ -80,7 +80,7 @@ export function StacktraceFlamegraph({frames}: StacktraceFlamegraphProps) {
             relativeStopTimestamp={duration}
           />
         </FlamegraphContainer>
-      </Flex>
+      </Stack>
     </FlamegraphThemeProvider>
   );
 }

--- a/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/index.tsx
@@ -1,5 +1,5 @@
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -40,7 +40,7 @@ export function DebugImage({image, isLast, onOpenImageDetailsModal}: Props) {
         <Status status={status} />
       </Flex>
       <Flex align="center" minWidth="0" padding="sm 0">
-        <Flex direction="column" minWidth="0" overflow="hidden">
+        <Stack minWidth="0" overflow="hidden">
           <Text ellipsis>
             {codeFilename && <Tooltip title={code_file}>{codeFilename}</Tooltip>}
             {codeFilename !== debugFilename && debugFilename && (
@@ -52,7 +52,7 @@ export function DebugImage({image, isLast, onOpenImageDetailsModal}: Props) {
               {imageAddress}
             </Text>
           )}
-        </Flex>
+        </Stack>
       </Flex>
       <Flex
         align="center"

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -12,7 +12,7 @@ import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Button} from '@sentry/scraps/button';
 import type {SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 import {Text} from '@sentry/scraps/text';
 
@@ -291,8 +291,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
               </div>
             </ScrollArea>
           ) : (
-            <Flex
-              direction="column"
+            <Stack
               align="center"
               justify="center"
               gap="md"
@@ -314,7 +313,7 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
                   {filterSelections.length ? t('Reset filter') : t('Clear search')}
                 </Button>
               )}
-            </Flex>
+            </Stack>
           )}
         </Container>
       </Fragment>

--- a/static/app/components/events/interfaces/threads.tsx
+++ b/static/app/components/events/interfaces/threads.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {
@@ -408,9 +408,7 @@ export function Threads({data, event, projectSlug, groupingCurrentLevel, group}:
       title={tn('Stack Trace', 'Stack Traces', threads.length)}
       disableCollapsePersistence
     >
-      <Flex direction="column" gap="xl">
-        {threadComponent}
-      </Flex>
+      <Stack gap="xl">{threadComponent}</Stack>
     </FoldSection>
   ) : (
     threadComponent

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -2,7 +2,7 @@ import {useEffect, useRef} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS} from 'sentry/components/events/issueDetailsLazyRender';
 import {MetricsDrawer} from 'sentry/components/events/metrics/metricsDrawer';
@@ -146,7 +146,7 @@ function MetricsSectionContent({
 
   return (
     <FoldSection sectionKey={SectionKey.METRICS} title={t('Application Metrics')}>
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         <MetricsSamplesTable
           source="issueDetails"
           overrideTableData={abbreviatedTableData}
@@ -164,7 +164,7 @@ function MetricsSectionContent({
             </Button>
           </div>
         ) : null}
-      </Flex>
+      </Stack>
     </FoldSection>
   );
 }

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -376,7 +376,7 @@ export function ExternalIssueForm({
         gap="0 md"
         borderBottom="primary"
       >
-        <Flex area="content" direction="column" align="stretch" gap="lg" minWidth={0}>
+        <Stack area="content" align="stretch" gap="lg" minWidth={0}>
           <Heading as="h2">{title}</Heading>
           <Tabs value={action} onChange={handleClick} disableOverflow>
             <TabList>
@@ -384,7 +384,7 @@ export function ExternalIssueForm({
               <TabList.Item key="link">{t('Link')}</TabList.Item>
             </TabList>
           </Tabs>
-        </Flex>
+        </Stack>
         <Container area="close" justifySelf="center">
           <CloseButton />
         </Container>

--- a/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
+++ b/static/app/components/group/externalIssuesList/linkedIssueRows.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -23,10 +23,9 @@ const DEFAULT_ICON_OFFSET = -1;
 
 export function LinkedIssueRows({linkedIssues}: LinkedIssueRowsProps) {
   return (
-    <Flex
+    <Stack
       as="ul"
       aria-label={t('Linked issues')}
-      direction="column"
       border="primary"
       radius="md"
       overflow="hidden"
@@ -43,7 +42,7 @@ export function LinkedIssueRows({linkedIssues}: LinkedIssueRowsProps) {
           <LinkedIssueRow linkedIssue={linkedIssue} />
         </Container>
       ))}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Avatar, UserAvatar} from '@sentry/scraps/avatar';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -115,7 +115,7 @@ function LinkedPullRequestRow({
               variant="muted"
             />
           </Flex>
-          <Flex direction="column" gap="xs" minWidth={0}>
+          <Stack gap="xs" minWidth={0}>
             <PullRequestTitle>
               <Text as="span" bold textWrap="nowrap">
                 {pullRequestLabel}
@@ -140,7 +140,7 @@ function LinkedPullRequestRow({
                 />
               </Text>
             </Flex>
-          </Flex>
+          </Stack>
         </Grid>
       </PullRequestRow>
     </Tooltip>
@@ -260,10 +260,9 @@ export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsPr
   }
 
   return (
-    <Flex
+    <Stack
       as="ul"
       aria-label={t('Linked pull requests')}
-      direction="column"
       border="primary"
       radius="md"
       overflow="hidden"
@@ -280,7 +279,7 @@ export function LinkedPullRequests({group, showEmptyState}: LinkedPullRequestsPr
           <LinkedPullRequestRow group={group} pullRequest={pullRequest} />
         </Container>
       ))}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -1,7 +1,7 @@
 import {lazy, useEffect, useRef} from 'react';
 import {skipToken, useQueries} from '@tanstack/react-query';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import {LazyLoad} from 'sentry/components/lazyLoad';
@@ -199,9 +199,9 @@ export function IssueDiff({
 
   if (hasError) {
     return (
-      <Flex background="secondary" overflow="auto" padding="md" direction="column">
+      <Stack background="secondary" overflow="auto" padding="md">
         <LoadingError message={t('Error loading events')} />
-      </Flex>
+      </Stack>
     );
   }
 
@@ -210,7 +210,7 @@ export function IssueDiff({
   }
 
   return (
-    <Flex background="secondary" overflow="auto" padding="md" direction="column">
+    <Stack background="secondary" overflow="auto" padding="md">
       <LazyLoad
         LazyComponent={SplitDiffLazy}
         base={combinedBase}
@@ -218,27 +218,26 @@ export function IssueDiff({
         type="lines"
         loadingFallback={<IssueDiffLoadingSkeletonRows />}
       />
-    </Flex>
+    </Stack>
   );
 }
 
 function IssueDiffLoadingState() {
   return (
-    <Flex
+    <Stack
       background="primary"
       overflow="auto"
       padding="md"
-      direction="column"
       data-test-id="issue-diff-loading-skeleton"
     >
       <IssueDiffLoadingSkeletonRows />
-    </Flex>
+    </Stack>
   );
 }
 
 function IssueDiffLoadingSkeletonRows() {
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       {Array.from({length: SKELETON_ROW_COUNT}).map((_, index) => (
         <Flex key={index} align="center">
           <Placeholder height="18px" style={{flex: 1}} />
@@ -246,6 +245,6 @@ function IssueDiffLoadingSkeletonRows() {
           <Placeholder height="18px" style={{flex: 1}} />
         </Flex>
       ))}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useEffect, useState} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -46,8 +46,8 @@ function RedirectToProjectModal({slug, Header, Body}: Props) {
       <Header>{t('Redirecting to New Project...')}</Header>
 
       <Body>
-        <Flex direction="column" gap="lg">
-          <Flex direction="column" gap="sm">
+        <Stack gap="lg">
+          <Stack gap="sm">
             <Text>{t('The project slug has been changed.')}</Text>
             <Text variant="muted">
               {tct(
@@ -58,13 +58,13 @@ function RedirectToProjectModal({slug, Header, Body}: Props) {
                 }
               )}
             </Text>
-          </Flex>
+          </Stack>
           <Flex justify="end">
             <LinkButton variant="primary" href={newPath}>
               {t('Continue to %s', slug)}
             </LinkButton>
           </Flex>
-        </Flex>
+        </Stack>
       </Body>
     </Fragment>
   );

--- a/static/app/components/noProjectMessage.tsx
+++ b/static/app/components/noProjectMessage.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex, Grid, type GridProps, Container} from '@sentry/scraps/layout';
+import {Flex, Grid, type GridProps, Container, Stack} from '@sentry/scraps/layout';
 
 import {NoProjectEmptyState} from 'sentry/components/illustrations/NoProjectEmptyState';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -88,7 +88,7 @@ export function NoProjectMessage({
         <StyledNoProjectEmptyState />
       </Flex>
 
-      <Flex direction="column" justify="center">
+      <Stack justify="center">
         <Layout.Title>{t('Remain Calm')}</Layout.Title>
         <Container marginBottom="xl">
           {t('You need at least one project to use this view')}
@@ -103,7 +103,7 @@ export function NoProjectMessage({
             createProjectAction
           )}
         </Actions>
-      </Flex>
+      </Stack>
     </Flex>
   );
 }

--- a/static/app/components/onboarding/consoleModal.tsx
+++ b/static/app/components/onboarding/consoleModal.tsx
@@ -4,7 +4,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -17,7 +17,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 
 export const CONSOLE_PLATFORM_INSTRUCTIONS = {
   [ConsolePlatform.PLAYSTATION]: (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <p>
         {t(
           'You can get started using Sentry on PlayStation without any changes to your game, on DevKits as well as Retail devices.'
@@ -35,10 +35,10 @@ export const CONSOLE_PLATFORM_INSTRUCTIONS = {
         )}
       </p>
       <p>{t("We'll receive your request and get back to you with the next steps.")}</p>
-    </Flex>
+    </Stack>
   ),
   [ConsolePlatform.NINTENDO_SWITCH]: (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <p>
         {t(
           'You can get started using Sentry on Nintendo Switch without any changes to your game, on DevKits as well as Retail devices.'
@@ -64,10 +64,10 @@ export const CONSOLE_PLATFORM_INSTRUCTIONS = {
       <Alert variant="info" showIcon>
         {t('Sentry supports both the original Switch and Switch 2.')}
       </Alert>
-    </Flex>
+    </Stack>
   ),
   [ConsolePlatform.XBOX]: (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <p>
         {t(
           'Sentry supports Xbox One and Series X|S, across both DevKits and Retail devices through an SDK.'
@@ -84,7 +84,7 @@ export const CONSOLE_PLATFORM_INSTRUCTIONS = {
         )}
       </p>
       <p>{t("We'll receive your request and get back to you with the next steps.")}</p>
-    </Flex>
+    </Stack>
   ),
 };
 

--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -136,7 +136,7 @@ interface SkipConfirmationProps {
 function SkipConfirmation({onConfirm, onDismiss}: SkipConfirmationProps) {
   return (
     <Alert variant="info">
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         {t("Not sure what to do? We're here for you!")}
         <Flex justify="between" gap="xs" flex={1}>
           <LinkButton external href="https://sentry.io/support/" size="xs">
@@ -164,7 +164,7 @@ function SkipConfirmation({onConfirm, onDismiss}: SkipConfirmationProps) {
             </Button>
           </Grid>
         </Flex>
-      </Flex>
+      </Stack>
     </Alert>
   );
 }

--- a/static/app/components/pageHeadingQuestionTooltip.tsx
+++ b/static/app/components/pageHeadingQuestionTooltip.tsx
@@ -1,5 +1,5 @@
 import {InfoTip} from '@sentry/scraps/info';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -26,10 +26,10 @@ export function PageHeadingQuestionTooltip({
   linkLabel,
 }: PageHeadingQuestionTooltipProps) {
   const contents = (
-    <Flex direction="column" align="start" gap="md">
+    <Stack align="start" gap="md">
       <Text align="left">{title}</Text>
       <ExternalLink href={docsUrl}>{linkLabel ?? t('Read the Docs')}</ExternalLink>
-    </Flex>
+    </Stack>
   );
 
   return <InfoTip title={contents} size="sm" position="right" />;

--- a/static/app/components/pipeline/index.stories.tsx
+++ b/static/app/components/pipeline/index.stories.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useState} from 'react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -37,7 +37,7 @@ function UsePipelineDemo() {
     : null;
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <DropdownMenu
         triggerLabel={parsed ? `${parsed.type} / ${parsed.provider}` : 'Select pipeline'}
         items={pipelineMenuItems}
@@ -46,7 +46,7 @@ function UsePipelineDemo() {
       {parsed && (
         <PipelineRunner key={selected} type={parsed.type} provider={parsed.provider} />
       )}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -79,9 +79,9 @@ function PipelineRunner({
   }
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Container border="primary" padding="md">
-        <Flex direction="column" gap="sm">
+        <Stack gap="sm">
           <Flex gap="lg" align="center">
             <Flex gap="sm" align="center">
               <Text bold>Status:</Text>
@@ -109,7 +109,7 @@ function PipelineRunner({
               {String(!!pipeline.error)}
             </Text>
           </Flex>
-        </Flex>
+        </Stack>
       </Container>
 
       {pipeline.error && <Text variant="muted">Error: {pipeline.error}</Text>}
@@ -122,7 +122,7 @@ function PipelineRunner({
           <StructuredEventData data={pipeline.completionData} />
         </Fragment>
       )}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -130,7 +130,7 @@ function PipelineModalDemo() {
   const [result, setResult] = useState<CompletionDataFor<any, any> | null>(null);
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <DropdownMenu
         triggerLabel="Open pipeline modal"
         items={pipelineMenuItems}
@@ -150,7 +150,7 @@ function PipelineModalDemo() {
           <StructuredEventData data={result} />
         </Fragment>
       )}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -2,7 +2,7 @@ import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {SnapshotStatusBadge} from 'sentry/components/preprod/snapshotStatusBadge';
@@ -93,12 +93,12 @@ export function PreprodBuildsSnapshotTable({
         <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
           <InteractionStateLayer />
           <SimpleTable.RowCell justify="start">
-            <Flex direction="column" gap="2xs">
+            <Stack gap="2xs">
               <Text bold>{appId || t('Snapshot')}</Text>
               <Text size="sm" variant="muted">
                 {t('%s images', info?.image_count ?? 0)}
               </Text>
-            </Flex>
+            </Stack>
           </SimpleTable.RowCell>
           {showProjectColumn && (
             <SimpleTable.RowCell justify="start">
@@ -123,7 +123,7 @@ export function PreprodBuildsSnapshotTable({
             />
           </SimpleTable.RowCell>
           <SimpleTable.RowCell justify="start">
-            <Flex direction="column" gap="2xs">
+            <Stack gap="2xs">
               {build.vcs_info?.head_ref && (
                 <Flex align="center" gap="xs">
                   <Text size="sm" bold>
@@ -142,7 +142,7 @@ export function PreprodBuildsSnapshotTable({
                   {(build.vcs_info?.head_sha?.slice(0, 7) || '–').toUpperCase()}
                 </Text>
               </Flex>
-            </Flex>
+            </Stack>
           </SimpleTable.RowCell>
           <SimpleTable.RowCell>
             {build.app_info?.date_added ? (

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -4,7 +4,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -60,7 +60,7 @@ export function PreprodBuildsRowCells({
       {showInteraction && <InteractionStateLayer />}
       <SimpleTable.RowCell justify="start">
         {build.app_info?.name || build.app_info?.app_id ? (
-          <Flex direction="column" gap="xs">
+          <Stack gap="xs">
             <Flex align="center" gap="2xs">
               {build.app_info?.platform && (
                 <PlatformIcon platform={build.app_info.platform} />
@@ -120,7 +120,7 @@ export function PreprodBuildsRowCells({
                 </Fragment>
               )}
             </Flex>
-          </Flex>
+          </Stack>
         ) : null}
       </SimpleTable.RowCell>
 
@@ -131,7 +131,7 @@ export function PreprodBuildsRowCells({
       )}
 
       <SimpleTable.RowCell justify="start" minWidth={0}>
-        <Flex direction="column" gap="xs" minWidth={0} width="100%">
+        <Stack gap="xs" minWidth={0} width="100%">
           <Flex align="center" gap="xs">
             {build.app_info?.version !== null && (
               <Text size="lg" bold>
@@ -176,7 +176,7 @@ export function PreprodBuildsRowCells({
               </Fragment>
             )}
           </Flex>
-        </Flex>
+        </Stack>
       </SimpleTable.RowCell>
     </Fragment>
   );

--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -2,7 +2,7 @@ import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {StructuredEventData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
@@ -102,7 +102,7 @@ export function BreadcrumbWebVital({
   }
 
   return (
-    <Flex direction="column" gap="sm" align="start">
+    <Stack gap="sm" align="start">
       <NoMarginWrapper>
         <StructuredEventData
           initialExpandedPaths={expandPaths ?? []}
@@ -128,7 +128,7 @@ export function BreadcrumbWebVital({
       >
         {t('All Web Vitals')}
       </NoWrapButton>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/replays/diff/picker/crumbItem.tsx
+++ b/static/app/components/replays/diff/picker/crumbItem.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ReplayTooltipTime} from 'sentry/components/replays/replayTooltipTime';
@@ -42,12 +42,12 @@ export function CrumbItem({
             </LeftAligned>
           }
         >
-          <Flex direction="column" gap="xs">
+          <Stack gap="xs">
             <Flex gap="sm" align="center">
               {icon}
               {formattedDuration}
             </Flex>
-          </Flex>
+          </Stack>
         </Tooltip>
       </ErrorLabel>
     </Container>

--- a/static/app/components/replays/diff/picker/mutationOption.tsx
+++ b/static/app/components/replays/diff/picker/mutationOption.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 
 import {IconClock} from 'sentry/icons/iconClock';
@@ -35,7 +35,7 @@ export function MutationOption({
 
   return (
     <Label htmlFor={id}>
-      <Flex direction="column" gap="xs" align="center">
+      <Stack gap="xs" align="center">
         <Flex gap="sm" align="center">
           <IconClock variant="primary" size="sm" />
           <span>{formattedDuration}</span>
@@ -49,7 +49,7 @@ export function MutationOption({
           value={frame.timestamp - startTimestampMs}
           onChange={onChange}
         />
-      </Flex>
+      </Stack>
     </Label>
   );
 }

--- a/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
+++ b/static/app/components/replays/diff/replaySideBySideImageDiff.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
@@ -15,7 +15,7 @@ export function ReplaySideBySideImageDiff() {
   const {replay, leftOffsetMs, rightOffsetMs} = useDiffCompareContext();
 
   return (
-    <Flex direction="column">
+    <Stack>
       <ContentSliderDiff.Header>
         <Before startTimestampMs={replay.getStartTimestampMs()} offset={leftOffsetMs} />
         <After startTimestampMs={replay.getStartTimestampMs()} offset={rightOffsetMs} />
@@ -41,7 +41,7 @@ export function ReplaySideBySideImageDiff() {
           </ReplayReaderProvider>
         </ReplayPlayerPluginsContextProvider>
       </ReplayGrid>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/replays/list/__stories__/replayList.stories.tsx
+++ b/static/app/components/replays/list/__stories__/replayList.stories.tsx
@@ -3,7 +3,7 @@ import {ClassNames} from '@emotion/react';
 import {useInfiniteQuery} from '@tanstack/react-query';
 import {parseAsString, useQueryState} from 'nuqs';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import {ReplayList} from 'sentry/components/replays/list/__stories__/replayList';
@@ -35,7 +35,7 @@ export default Storybook.story('ReplayList', story => {
     );
 
     return (
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         Selected Replay: {replayId}
         <Flex gap="sm">
           <Storybook.SelectProject projectSlug={project} setProjectSlug={setProject} />
@@ -47,11 +47,11 @@ export default Storybook.story('ReplayList', story => {
           />
         </Flex>
         <Flex height="500px">
-          <Flex direction="column" gap="md" flex="1">
+          <Stack gap="md" flex="1">
             <ReplayList onSelect={setReplayId} queryResult={queryResult} />
-          </Flex>
+          </Stack>
         </Flex>
-      </Flex>
+      </Stack>
     );
   });
 
@@ -81,7 +81,7 @@ export default Storybook.story('ReplayList', story => {
         {({css}) => (
           <Hovercard
             body={
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Flex gap="sm">
                   <Storybook.SelectProject
                     projectSlug={project}
@@ -94,11 +94,11 @@ export default Storybook.story('ReplayList', story => {
                   />
                 </Flex>
                 <Flex height="500px">
-                  <Flex direction="column" gap="md" flex="1">
+                  <Stack gap="md" flex="1">
                     <ReplayList onSelect={setReplayId} queryResult={queryResult} />
-                  </Flex>
+                  </Stack>
                 </Flex>
-              </Flex>
+              </Stack>
             }
             containerClassName={css`
               width: max-content;

--- a/static/app/components/replays/list/__stories__/replayListItem.tsx
+++ b/static/app/components/replays/list/__stories__/replayListItem.tsx
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 
 import {ProjectAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {TimeSince} from 'sentry/components/timeSince';
@@ -39,13 +39,13 @@ export function ReplayListItem({replay, onClick}: Props) {
           <IconDelete variant="primary" size="md" />
         </ArchivedWrapper>
 
-        <Flex direction="column" gap="xs">
+        <Stack gap="xs">
           <DisplayName>{t('Deleted Replay')}</DisplayName>
           <Flex gap="xs" align="center">
             {project ? <ProjectAvatar size={12} project={project} /> : null}
             <Text size="sm">{getShortEventId(replay.id)}</Text>
           </Flex>
-        </Flex>
+        </Stack>
       </Flex>
     );
   }

--- a/static/app/components/replays/player/__stories__/replaySlugChooser.tsx
+++ b/static/app/components/replays/player/__stories__/replaySlugChooser.tsx
@@ -4,7 +4,7 @@ import {useInfiniteQuery} from '@tanstack/react-query';
 import {parseAsString, useQueryState} from 'nuqs';
 
 import {InputGroup} from '@sentry/scraps/input';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Hovercard} from 'sentry/components/hovercard';
@@ -56,13 +56,13 @@ export function ReplaySlugChooser({children}: Props) {
         {({css}) => (
           <Hovercard
             body={
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Flex height="500px">
-                  <Flex direction="column" gap="md" flex="1">
+                  <Stack gap="md" flex="1">
                     <ReplayList onSelect={setReplaySlug} queryResult={queryResult} />
-                  </Flex>
+                  </Stack>
                 </Flex>
-              </Flex>
+              </Stack>
             }
             containerClassName={css`
               width: max-content;

--- a/static/app/components/replays/replayBadge.tsx
+++ b/static/app/components/replays/replayBadge.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import invariant from 'invariant';
 
 import {ProjectAvatar, UserAvatar} from '@sentry/scraps/avatar';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DateTime} from 'sentry/components/dateTime';
@@ -38,7 +38,7 @@ export function ReplayBadge({replay}: Props) {
           <IconDelete variant="primary" size="md" />
         </Flex>
 
-        <Flex direction="column" gap="xs" justify="center">
+        <Stack gap="xs" justify="center">
           <Text size="md" bold>
             {t('Deleted Replay')}
           </Text>
@@ -48,7 +48,7 @@ export function ReplayBadge({replay}: Props) {
               {events.getShortEventId(replay.id)}
             </Text>
           </Flex>
-        </Flex>
+        </Stack>
       </Grid>
     );
   }
@@ -71,7 +71,7 @@ export function ReplayBadge({replay}: Props) {
         size={24}
       />
 
-      <Flex direction="column" gap="xs" justify="center">
+      <Stack gap="xs" justify="center">
         <Flex direction="row" align="center" gap="xs">
           {/* We use div here because the Text component has 100% width and will push live indicator to the far right */}
           <div>
@@ -106,7 +106,7 @@ export function ReplayBadge({replay}: Props) {
             </Text>
           </Flex>
         </Flex>
-      </Flex>
+      </Stack>
     </Wrapper>
   );
 }

--- a/static/app/components/seer/datadogPatConnectModal.tsx
+++ b/static/app/components/seer/datadogPatConnectModal.tsx
@@ -5,7 +5,7 @@ import {useMutation} from '@tanstack/react-query';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
@@ -91,8 +91,8 @@ export function DatadogPatConnectModal({
         </h4>
       </Header>
       <Body>
-        <Flex direction="column" gap="md">
-          <Flex direction="column" gap="xs">
+        <Stack gap="md">
+          <Stack gap="xs">
             <Text as="label" htmlFor="datadog-pat-token">
               {t('Access Token')}
             </Text>
@@ -104,9 +104,9 @@ export function DatadogPatConnectModal({
               placeholder={t('Enter your Datadog personal access token')}
               aria-label={t('Access Token')}
             />
-          </Flex>
+          </Stack>
           {!isReauth && (
-            <Flex direction="column" gap="xs">
+            <Stack gap="xs">
               <Text as="label">{t('Datadog Site')}</Text>
               <StyledCompactSelect
                 value={site}
@@ -119,10 +119,10 @@ export function DatadogPatConnectModal({
                   />
                 )}
               />
-            </Flex>
+            </Stack>
           )}
           {formError ? <ErrorText role="alert">{formError}</ErrorText> : null}
-        </Flex>
+        </Stack>
       </Body>
       <Footer>
         <Flex gap="sm" align="center" justify="end">

--- a/static/app/components/seer/projectDetails/autofixRepositoriesList.stories.tsx
+++ b/static/app/components/seer/projectDetails/autofixRepositoriesList.stories.tsx
@@ -1,6 +1,6 @@
 import {parseAsString, useQueryState} from 'nuqs';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {AutofixRepositoriesList} from 'sentry/components/seer/projectDetails/autofixRepositoriesList';
@@ -14,7 +14,7 @@ export default Storybook.story('AutofixRepositoriesList', story => {
     const project = projects.find(p => p.slug === projectSlug);
 
     return (
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Storybook.SelectProject
           projectSlug={projectSlug}
           setProjectSlug={setProjectSlug}
@@ -30,7 +30,7 @@ export default Storybook.story('AutofixRepositoriesList', story => {
             <Text variant="muted">Select a project to view the story</Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
     );
   });
 
@@ -40,7 +40,7 @@ export default Storybook.story('AutofixRepositoriesList', story => {
     const project = projects.find(p => p.slug === projectSlug);
 
     return (
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Storybook.SelectProject
           projectSlug={projectSlug}
           setProjectSlug={setProjectSlug}
@@ -52,7 +52,7 @@ export default Storybook.story('AutofixRepositoriesList', story => {
             <Text variant="muted">Select a project to view the story</Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
     );
   });
 });

--- a/static/app/components/stackTrace/exceptionGroup.tsx
+++ b/static/app/components/stackTrace/exceptionGroup.tsx
@@ -2,7 +2,7 @@ import {useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t, tn} from 'sentry/locale';
@@ -143,7 +143,7 @@ export function RelatedExceptionsTree({
   }
 
   return (
-    <Flex direction="column" gap="xs" data-test-id="related-exceptions-tree">
+    <Stack gap="xs" data-test-id="related-exceptions-tree">
       <Text variant="muted" size="sm" bold>
         {t('Related Exceptions')}
       </Text>
@@ -172,7 +172,7 @@ export function RelatedExceptionsTree({
           />
         ))}
       </TreePre>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/stackTrace/exceptionHeader.tsx
+++ b/static/app/components/stackTrace/exceptionHeader.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -48,7 +48,7 @@ export function ExceptionDescription({
   const valueMeta = meta?.value?.[''];
 
   return (
-    <Flex direction="column" gap={gap}>
+    <Stack gap={gap}>
       {valueMeta && !value ? (
         <ExceptionValue>
           <AnnotatedText value={value} meta={valueMeta} />
@@ -57,7 +57,7 @@ export function ExceptionDescription({
         <ExceptionValue>{renderLinksInText({exceptionText: value})}</ExceptionValue>
       ) : null}
       {mechanism && <Mechanism data={mechanism} meta={meta?.mechanism} />}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useMemo} from 'react';
 import type {Dispatch, SetStateAction} from 'react';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 
@@ -218,7 +218,7 @@ function IssueStackTraceContent({
   if (view === 'raw') {
     return (
       <FoldSection sectionKey={sectionKey} title="Stack Trace" actions={sectionActions}>
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Panel>
             <RawStackTraceText>
               {formatExceptionsAsText({
@@ -234,7 +234,7 @@ function IssueStackTraceContent({
             group={group}
             projectSlug={projectSlug}
           />
-        </Flex>
+        </Stack>
       </FoldSection>
     );
   }
@@ -248,8 +248,8 @@ function IssueStackTraceContent({
 
     return (
       <FoldSection sectionKey={sectionKey} title="Stack Trace" actions={sectionActions}>
-        <Flex direction="column" gap="lg">
-          <Flex direction="column" gap="sm">
+        <Stack gap="lg">
+          <Stack gap="sm">
             {hasExceptionInfo && (
               <Fragment>
                 <div>
@@ -262,7 +262,7 @@ function IssueStackTraceContent({
                 />
               </Fragment>
             )}
-          </Flex>
+          </Stack>
           <ErrorBoundary customComponent={null}>
             <StacktraceBanners event={event} stacktrace={exc.stacktrace} />
           </ErrorBoundary>
@@ -284,14 +284,14 @@ function IssueStackTraceContent({
             group={group}
             projectSlug={projectSlug}
           />
-        </Flex>
+        </Stack>
       </FoldSection>
     );
   }
 
   return (
     <FoldSection sectionKey={sectionKey} title="Stack Trace" actions={sectionActions}>
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Text variant="muted">
           {tn(
             'There is %s chained exception in this event.',
@@ -334,7 +334,7 @@ function IssueStackTraceContent({
                 <ExceptionHeader type={excType} module={excModule} />
               </Disclosure.Title>
               <Disclosure.Content>
-                <Flex direction="column" gap="sm">
+                <Stack gap="sm">
                   <ExceptionDescription
                     value={excValue}
                     mechanism={exc.mechanism}
@@ -365,7 +365,7 @@ function IssueStackTraceContent({
                       frameActionsComponent={IssueFrameActions}
                     />
                   </StackTraceProvider>
-                </Flex>
+                </Stack>
               </Disclosure.Content>
             </Disclosure>
           );
@@ -375,7 +375,7 @@ function IssueStackTraceContent({
           group={group}
           projectSlug={projectSlug}
         />
-      </Flex>
+      </Stack>
     </FoldSection>
   );
 }

--- a/static/app/components/stackTrace/issueStackTrace/sharedIssueStackTrace.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/sharedIssueStackTrace.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useMemo} from 'react';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 
@@ -195,7 +195,7 @@ function SharedIssueStackTraceContent({
 
     return (
       <FoldSection sectionKey={sectionKey} title="Stack Trace" actions={sectionActions}>
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           {hasExceptionInfo && (
             <Fragment>
               <div>
@@ -217,14 +217,14 @@ function SharedIssueStackTraceContent({
           >
             <StackTraceFrames frameContextComponent={FrameContent} />
           </StackTraceProvider>
-        </Flex>
+        </Stack>
       </FoldSection>
     );
   }
 
   return (
     <FoldSection sectionKey={sectionKey} title="Stack Trace" actions={sectionActions}>
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Text variant="muted">
           {tn(
             'There is %s chained exception in this event.',
@@ -267,7 +267,7 @@ function SharedIssueStackTraceContent({
                 <ExceptionHeader type={excType} module={excModule} />
               </Disclosure.Title>
               <Disclosure.Content>
-                <Flex direction="column" gap="sm">
+                <Stack gap="sm">
                   <ExceptionDescription
                     value={excValue}
                     mechanism={exc.mechanism}
@@ -289,12 +289,12 @@ function SharedIssueStackTraceContent({
                   >
                     <StackTraceFrames frameContextComponent={FrameContent} />
                   </StackTraceProvider>
-                </Flex>
+                </Stack>
               </Disclosure.Content>
             </Disclosure>
           );
         })}
-      </Flex>
+      </Stack>
     </FoldSection>
   );
 }

--- a/static/app/components/stackTrace/stackTrace.stories.tsx
+++ b/static/app/components/stackTrace/stackTrace.stories.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Hovercard} from 'sentry/components/hovercard';
@@ -1063,14 +1063,14 @@ export default Storybook.story('StackTrace', story => {
     };
 
     return (
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <StoryStackTraceProvider event={event} stacktrace={singleFrameStacktrace}>
           <StackTraceFrames
             frameContextComponent={FrameContent}
             frameActionsComponent={StoryFrameActions}
           />
         </StoryStackTraceProvider>
-      </Flex>
+      </Stack>
     );
   });
 

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -7,7 +7,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Input} from '@sentry/scraps/input';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -333,10 +333,10 @@ function TourProvider({
           {...tourProviderProps}
         >
           <Flex gap="xl" align="center">
-            <Flex gap="xl" justify="between" direction="column" align="start">
+            <Stack gap="xl" justify="between" align="start">
               <StartTourButton />
               {children}
-            </Flex>
+            </Stack>
             <Image src={compassImage} />
             <p style={{maxWidth: '300px'}}>
               Lorem ipsum dolor, sit amet consectetur adipisicing elit. Qui nam doloremque

--- a/static/app/components/versionHoverCard.tsx
+++ b/static/app/components/versionHoverCard.tsx
@@ -5,7 +5,7 @@ import {useQuery} from '@tanstack/react-query';
 import {AvatarList} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import {DateTime} from 'sentry/components/dateTime';
@@ -102,7 +102,7 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
       .slice(0, 3);
 
     return (
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         <Flex gap="xl" justify="between">
           <div>
             <h6>{t('New Issues')}</h6>
@@ -114,7 +114,7 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
           </div>
         </Flex>
         {parsedVersion?.package && (
-          <Flex direction="column" gap="xl" justify="between">
+          <Stack gap="xl" justify="between">
             {parsedVersion.package && (
               <div>
                 <h6>{t('Package')}</h6>
@@ -139,11 +139,11 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
                 </Flex>
               </div>
             ) : null}
-          </Flex>
+          </Stack>
         )}
         {release.lastCommit && <LastCommit commit={release.lastCommit} />}
         {deploys.length > 0 && (
-          <Flex direction="column" gap="xs">
+          <Stack gap="xs">
             <h6>{t('Deploys')}</h6>
             {recentDeploysByEnvironment.map(deploy => {
               return (
@@ -153,9 +153,9 @@ function VersionHoverCardBody({organization, releaseVersion, projectSlug}: BodyP
                 </Flex>
               );
             })}
-          </Flex>
+          </Stack>
         )}
-      </Flex>
+      </Stack>
     );
   }
 

--- a/static/app/components/workflowEngine/layout/detail.tsx
+++ b/static/app/components/workflowEngine/layout/detail.tsx
@@ -34,18 +34,14 @@ interface RequiredChildren {
 function Main({children}: RequiredChildren) {
   return (
     <Layout.Main>
-      <Flex direction="column" gap="xl">
-        {children}
-      </Flex>
+      <Stack gap="xl">{children}</Stack>
     </Layout.Main>
   );
 }
 function Sidebar({children}: RequiredChildren) {
   return (
     <Layout.Side>
-      <Flex direction="column" gap="xl">
-        {children}
-      </Flex>
+      <Stack gap="xl">{children}</Stack>
     </Layout.Side>
   );
 }

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -98,10 +98,10 @@ function HeaderContent({children}: RequiredChildren) {
 
 function Title({title, project}: {title: string; project?: AvatarProject}) {
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Layout.Title>{title}</Layout.Title>
       {project && <ProjectBadge project={project} disableLink avatarSize={16} />}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -1,4 +1,4 @@
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
@@ -39,10 +39,10 @@ export function WorkflowEngineListLayout({
         <TopBar.Slot name="actions">{actions}</TopBar.Slot>
         <Layout.Body>
           <Layout.Main width="full">
-            <Flex direction="column" gap="lg">
+            <Stack gap="lg">
               <OnboardingBanner />
               {children}
-            </Flex>
+            </Stack>
           </Layout.Main>
         </Layout.Body>
       </NoProjectMessage>

--- a/static/app/components/workflowEngine/ui/detailSection.tsx
+++ b/static/app/components/workflowEngine/ui/detailSection.tsx
@@ -17,21 +17,20 @@ export function DetailSection({
   trailingItems,
 }: DetailSectionProps) {
   return (
-    <Flex
+    <Stack
       as="section"
       role="region"
-      direction="column"
       gap={description ? 'lg' : 'md'}
       className={className}
     >
-      <Flex direction="column" gap="xs">
+      <Stack gap="xs">
         <Flex justify="between" align="center">
           <Heading as="h3">{title}</Heading>
           {trailingItems ?? null}
         </Flex>
         {description ? <Text variant="muted">{description}</Text> : null}
-      </Flex>
+      </Stack>
       <Stack gap="md">{children}</Stack>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/debug/notifications/components/debugNotificationsLanding.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsLanding.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import heroImg from 'sentry-images/debug/notifications/hero.png';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 // Mimicking useStoriesDarkMode -> Don't use these elsewhere please 🙏
@@ -21,7 +21,7 @@ export function DebugNotificationsLanding() {
     <Fragment>
       <DarkModeProvider>
         <Hero>
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             <Squiggle />
             <HeroHeading as="h1">
               Welcome to the <em>Notification Debugger</em>
@@ -30,7 +30,7 @@ export function DebugNotificationsLanding() {
               This tool is in development! Keep an eye out for internal comms for when
               this is ready for you to use.
             </Text>
-          </Flex>
+          </Stack>
           <img
             alt="A branching integration tree with developers admiring the leaves"
             width={680}

--- a/static/app/debug/notifications/components/debugNotificationsSidebar.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsSidebar.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import {useRegistry} from 'sentry/debug/notifications/hooks/useRegistry';
@@ -12,7 +12,7 @@ export function DebugNotificationsSidebar() {
   const {routeSource, baseRoute} = useRouteSource();
   const {data: registry = {}} = useRegistry();
   return (
-    <Flex direction="column" gap="xl" padding="xl 0">
+    <Stack gap="xl" padding="xl 0">
       {Object.entries(registry).map(([category, registrations], i) => (
         <Fragment key={category}>
           {i !== 0 && <CategoryDivider />}
@@ -42,7 +42,7 @@ export function DebugNotificationsSidebar() {
           </Container>
         </Fragment>
       ))}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/debug/notifications/previews/discordPreview.tsx
+++ b/static/app/debug/notifications/previews/discordPreview.tsx
@@ -4,7 +4,7 @@ import moment from 'moment-timezone';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
@@ -81,7 +81,7 @@ export function DiscordPreview({
         <Disclosure>
           <Disclosure.Title>Discord JSON Payload</Disclosure.Title>
           <Disclosure.Content>
-            <Flex direction="column" gap="xl">
+            <Stack gap="xl">
               <Text>
                 Below is the JSON payload that will be sent to Discord. There is no online
                 preview tool, so we're mocking it here, so use this as an approximation of
@@ -90,7 +90,7 @@ export function DiscordPreview({
               <CodeBlock language="json">
                 {payload ? JSON.stringify(payload, null, 2) : ''}
               </CodeBlock>
-            </Flex>
+            </Stack>
           </Disclosure.Content>
         </Disclosure>
       </Container>

--- a/static/app/debug/notifications/previews/emailPreview.tsx
+++ b/static/app/debug/notifications/previews/emailPreview.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Text} from '@sentry/scraps/text';
 
@@ -44,7 +44,7 @@ export function EmailPreview({
       }
     >
       <Container border="primary" radius="md">
-        <Flex direction="column" padding="xl">
+        <Stack padding="xl">
           <Text bold>{subject}</Text>
           <Text variant="muted">To: user@example.com</Text>
           {emailFormat === EmailFormat.HTML && (
@@ -55,7 +55,7 @@ export function EmailPreview({
               <pre>{text_content}</pre>
             </EmailTextBlock>
           )}
-        </Flex>
+        </Stack>
       </Container>
     </DebugNotificationsPreview>
   );

--- a/static/app/debug/notifications/previews/slackPreview.tsx
+++ b/static/app/debug/notifications/previews/slackPreview.tsx
@@ -5,7 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
@@ -51,7 +51,7 @@ export function SlackPreview({
             <SlackAppBadge bold>APP</SlackAppBadge>
             <SlackTimeText>{previewTime}</SlackTimeText>
           </Flex>
-          <Flex direction="column" align="start" padding="sm 0" gap="md">
+          <Stack align="start" padding="sm 0" gap="md">
             <SlackBlackText size="xl" bold>
               {subject.map(block => block.text).join(' ')}
             </SlackBlackText>
@@ -70,7 +70,7 @@ export function SlackPreview({
               ))}
             </Flex>
             {chart && (
-              <Flex direction="column" gap="xs">
+              <Stack gap="xs">
                 <Flex align="center" gap="xs">
                   <Text size="xs" variant="muted">
                     (17 kB)
@@ -84,19 +84,19 @@ export function SlackPreview({
                   alt={chart.alt_text}
                   objectFit="contain"
                 />
-              </Flex>
+              </Stack>
             )}
             {footer && (
               <SlackBlackText size="xs" variant="muted">
                 {footer.map(block => block.text).join(' ')}
               </SlackBlackText>
             )}
-          </Flex>
+          </Stack>
         </SlackMessageContainer>
         <Disclosure>
           <Disclosure.Title>BlockKit Payload</Disclosure.Title>
           <Disclosure.Content>
-            <Flex direction="column" align="start" gap="xl">
+            <Stack align="start" gap="xl">
               <Text>
                 Below is the BlockKit JSON payload that will be sent to Slack. For a
                 dynamic preview, use the builder link above. The mock here is static, use
@@ -105,7 +105,7 @@ export function SlackPreview({
               <CodeBlock language="json">
                 {blocks ? JSON.stringify(blocks, null, 2) : ''}
               </CodeBlock>
-            </Flex>
+            </Stack>
           </Disclosure.Content>
         </Disclosure>
       </Container>

--- a/static/app/debug/notifications/previews/teamsPreview.tsx
+++ b/static/app/debug/notifications/previews/teamsPreview.tsx
@@ -5,7 +5,7 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DebugNotificationsPreview} from 'sentry/debug/notifications/components/debugNotificationsPreview';
@@ -89,7 +89,7 @@ export function TeamsPreview({
                 ))}
               </Flex>
               {chart && (
-                <Flex direction="column" gap="xs">
+                <Stack gap="xs">
                   <Image
                     height="116px"
                     width="auto"
@@ -97,7 +97,7 @@ export function TeamsPreview({
                     alt={chart.alt_text}
                     objectFit="contain"
                   />
-                </Flex>
+                </Stack>
               )}
               {footer && (
                 <TeamsBlackText size="sm">
@@ -110,7 +110,7 @@ export function TeamsPreview({
         <Disclosure>
           <Disclosure.Title>AdaptiveCard Payload</Disclosure.Title>
           <Disclosure.Content>
-            <Flex direction="column" align="start" gap="xl">
+            <Stack align="start" gap="xl">
               <Text>
                 Below is the AdaptiveCard JSON payload that will be sent to MS Teams. For
                 a dynamic preview, copy the JSON and paste it into the Designer linked
@@ -119,7 +119,7 @@ export function TeamsPreview({
               <CodeBlock language="json">
                 {card ? JSON.stringify(card, null, 2) : ''}
               </CodeBlock>
-            </Flex>
+            </Stack>
           </Disclosure.Content>
         </Disclosure>
       </Container>

--- a/static/app/debug/notifications/views/index.tsx
+++ b/static/app/debug/notifications/views/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import {DebugNotificationsExample} from 'sentry/debug/notifications/components/debugNotificationsExample';
@@ -46,9 +46,9 @@ export default function DebugNotificationsIndex() {
           <SidebarContainer>
             <DebugNotificationsSidebar />
           </SidebarContainer>
-          <Flex direction="column" area="body">
+          <Stack area="body">
             {selectedRegistration ? (
-              <Flex direction="column" gap="xl" padding="2xl" maxWidth="2000px">
+              <Stack gap="xl" padding="2xl" maxWidth="2000px">
                 <Heading as="h2" variant="success">
                   <Flex gap="md" align="center">
                     {selectedRegistration.source}
@@ -60,26 +60,21 @@ export default function DebugNotificationsIndex() {
                   gap="2xl"
                   position="relative"
                 >
-                  <Flex
-                    direction="column"
-                    position="relative"
-                    minWidth="400px"
-                    justify="start"
-                  >
+                  <Stack position="relative" minWidth="400px" justify="start">
                     <EmailPreview registration={selectedRegistration} />
                     <SlackPreview registration={selectedRegistration} />
                     <DiscordPreview registration={selectedRegistration} />
                     <TeamsPreview registration={selectedRegistration} />
-                  </Flex>
+                  </Stack>
                   <ExampleContainer>
                     <DebugNotificationsExample registration={selectedRegistration} />
                   </ExampleContainer>
                 </Grid>
-              </Flex>
+              </Stack>
             ) : (
               <DebugNotificationsLanding />
             )}
-          </Flex>
+          </Stack>
         </Grid>
       </OrganizationContainer>
     </RouteAnalyticsContextProvider>

--- a/static/app/gettingStartedDocs/playstation/onboarding.tsx
+++ b/static/app/gettingStartedDocs/playstation/onboarding.tsx
@@ -5,7 +5,7 @@ import devkitCrashesStep2 from 'sentry-images/tempest/devkit-crashes-step2.png';
 import devkitCrashesStep3 from 'sentry-images/tempest/devkit-crashes-step3.png';
 import windowToolImg from 'sentry-images/tempest/windows-tool-devkit.png';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {RequestSdkAccessButton} from 'sentry/components/gameConsole/RequestSdkAccessButton';
@@ -192,7 +192,7 @@ const onboardingDevkit: OnboardingConfig = {
         {
           type: 'custom',
           content: (
-            <Flex direction="column" gap="lg" align="center">
+            <Stack gap="lg" align="center">
               <CardIllustration
                 src={devkitCrashesStep1}
                 alt={t('DevKit set up screenshot step 1')}
@@ -205,7 +205,7 @@ const onboardingDevkit: OnboardingConfig = {
                 src={devkitCrashesStep3}
                 alt={t('DevKit set up screenshot step 3')}
               />
-            </Flex>
+            </Stack>
           ),
         },
       ],

--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -1645,13 +1645,13 @@ export function IconsStories() {
         .
       </Text>
       <StyledSticky>
-        <Flex padding="xl 0" direction="column" gap="lg">
+        <Stack padding="xl 0" gap="lg">
           <Input
             value={searchTerm}
             placeholder="Search icons by name or keyword"
             onChange={e => setSearchTerm(e.target.value.toLowerCase())}
           />
-        </Flex>
+        </Stack>
       </StyledSticky>
       <Heading as="h5" size="xl" variant="primary">
         Icon Variants
@@ -1903,7 +1903,7 @@ function Section(props: CategorySectionProps) {
   }
 
   return (
-    <Flex as="section" direction="column" gap="xl">
+    <Stack as="section" gap="xl">
       <Container padding="xl 0 0 0">
         <Heading as="h5" size="xl" style={{scrollMarginTop: '128px'}}>
           {props.title}
@@ -1920,7 +1920,7 @@ function Section(props: CategorySectionProps) {
       >
         {filteredIcons.map(icon => props.renderIcon(icon))}
       </Grid>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/stories/playground/slideOverPanel.tsx
+++ b/static/app/stories/playground/slideOverPanel.tsx
@@ -3,7 +3,7 @@ import {AnimatePresence} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -60,24 +60,24 @@ interface PanelContentsProps {
 
 function PanelContents({onClick}: PanelContentsProps) {
   return (
-    <Flex direction="column" border="primary" height="100%" gap="md" padding="md">
+    <Stack border="primary" height="100%" gap="md" padding="md">
       <Button onClick={onClick}>Close Panel</Button>
       <Container>
         <Alert variant="warning">I took a very long time to render!</Alert>
         <ManySlowComponents />
       </Container>
-    </Flex>
+    </Stack>
   );
 }
 
 export function SkeletonPanelContents({onClick}: PanelContentsProps) {
   return (
-    <Flex direction="column" border="primary" height="100%" gap="md" padding="md">
+    <Stack border="primary" height="100%" gap="md" padding="md">
       <Button onClick={onClick}>Close Panel</Button>
       <Container>
         <Placeholder />
       </Container>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/stories/view/landing/index.tsx
+++ b/static/app/stories/view/landing/index.tsx
@@ -8,7 +8,7 @@ import heroImg from 'sentry-images/stories/landing/robopigeon.png';
 
 import type {LinkButtonProps} from '@sentry/scraps/button';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -54,14 +54,14 @@ export function StoryLanding() {
       <StoryDarkModeProvider>
         <Hero>
           <Container>
-            <Flex direction="column" gap="2xl">
-              <Flex direction="column" gap="md">
+            <Stack gap="2xl">
+              <Stack gap="md">
                 <Border />
                 <h1>
                   Welcome to <TitleEmphasis>Scraps</TitleEmphasis>
                 </h1>
                 <p>{frontmatter.hero.tagline}</p>
-              </Flex>
+              </Stack>
               <Flex gap="md">
                 {frontmatter.hero.actions.map(props => {
                   // Normalize internal paths with organization context
@@ -72,7 +72,7 @@ export function StoryLanding() {
                   return <LinkButton {...props} to={to} key={props.to} />;
                 })}
               </Flex>
-            </Flex>
+            </Stack>
             <img
               alt={frontmatter.hero.image.alt}
               width={680}
@@ -88,14 +88,14 @@ export function StoryLanding() {
       </Container>
 
       <Container>
-        <Flex as="section" direction="column" gap="3xl" flex={1}>
-          <Flex direction="column" gap="md">
+        <Stack as="section" gap="3xl" flex={1}>
+          <Stack gap="md">
             <h2>Learn the Foundations</h2>
             <p>
               The following guides will help you understand Sentry's foundational design
               principles.
             </p>
-          </Flex>
+          </Stack>
           <CardGrid>
             <Card
               to={{
@@ -146,7 +146,7 @@ export function StoryLanding() {
               </CardFigure>
             </Card>
           </CardGrid>
-        </Flex>
+        </Stack>
       </Container>
     </Fragment>
   );

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -96,8 +96,7 @@ function MDXStoryTitle(props: {story: MDXStoryDescriptor}) {
     >
       <StoryGrid>
         <StoryContainer style={{gap: theme.space['2xl']}}>
-          <Flex
-            direction="column"
+          <Stack
             gap="xl"
             padding={
               props.story.exports.frontmatter?.layout === 'document'
@@ -128,7 +127,7 @@ function MDXStoryTitle(props: {story: MDXStoryDescriptor}) {
                 {description}
               </Text>
             )}
-          </Flex>
+          </Stack>
 
           <StoryTabList />
         </StoryContainer>

--- a/static/app/stories/view/storyTableOfContents.tsx
+++ b/static/app/stories/view/storyTableOfContents.tsx
@@ -3,7 +3,7 @@ import {useLocation} from 'react-router-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 type Entry = {
@@ -224,7 +224,7 @@ function StoryContentsList({
   const LinkComponent = isChild ? StyledChildLink : StyledLink;
 
   return (
-    <Flex as="li" direction="column" aria-role="listitem">
+    <Stack as="li" aria-role="listitem">
       <LinkComponent
         href={`#${entry.entry.ref.id}`}
         isActive={entry.entry.ref.id === activeId}
@@ -257,7 +257,7 @@ function StoryContentsList({
           ))}
         </StoryIndexList>
       )}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/utils/seer/seerProjectSettings.stories.tsx
+++ b/static/app/utils/seer/seerProjectSettings.stories.tsx
@@ -137,7 +137,7 @@ export default Storybook.story('SeerProjectSettings', story => {
     const [projectSlug, setProjectSlug] = useQueryState('project', parseAsString);
 
     return (
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Storybook.SelectProject
           projectSlug={projectSlug}
           setProjectSlug={setProjectSlug}
@@ -149,7 +149,7 @@ export default Storybook.story('SeerProjectSettings', story => {
             <Text variant="muted">Select a project to view the story</Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
     );
   });
 
@@ -263,7 +263,7 @@ export default Storybook.story('SeerProjectSettings', story => {
     const [projectSlug, setProjectSlug] = useQueryState('project', parseAsString);
 
     return (
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Storybook.SelectProject
           projectSlug={projectSlug}
           setProjectSlug={setProjectSlug}
@@ -275,7 +275,7 @@ export default Storybook.story('SeerProjectSettings', story => {
             <Text variant="muted">Select a project to view the story</Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
     );
   });
 
@@ -468,7 +468,7 @@ export default Storybook.story('SeerProjectSettings', story => {
     );
 
     return (
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Storybook.SelectProjects
           projectSlugs={projectSlugs}
           setProjectSlugs={setProjectSlugs}
@@ -480,7 +480,7 @@ export default Storybook.story('SeerProjectSettings', story => {
             <Text variant="muted">Select a project to view the story</Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
     );
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
@@ -4,7 +4,7 @@ import {motion, type MotionProps} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
@@ -79,7 +79,7 @@ export function OpContainer({
     });
 
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       {flexProps => (
         <AnimatedOp op={op} isDragging={isDragging} ref={setNodeRef} {...flexProps}>
           <Flex gap="xs" align="center">
@@ -109,7 +109,7 @@ export function OpContainer({
           </Grid>
         </AnimatedOp>
       )}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/automations/components/actionFilterBlock.tsx
+++ b/static/app/views/automations/components/actionFilterBlock.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import type {SelectValue} from '@sentry/scraps/select';
 
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
@@ -90,7 +90,7 @@ export function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
   return (
     <IfThenWrapper>
       <Step>
-        <Flex direction="column" gap="md">
+        <Stack gap="md">
           <StepLead data-test-id="action-filter-logic-type">
             {tct('[if: If] [selector] of these filters match', {
               if: <ConditionBadge />,
@@ -146,7 +146,7 @@ export function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
               actions.updateIfCondition(actionFilter.id, id, params)
             }
           />
-        </Flex>
+        </Stack>
       </Step>
       <Step>
         <StepLead>

--- a/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
+++ b/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import type {SelectValue} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
@@ -53,7 +53,7 @@ export function SeerActivityTriggerNode() {
     : SEER_ACTIVITY_STAGE_CHOICES;
 
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       <Text>{t('Seer runs on an issue and reaches the stage...')}</Text>
       <AutomationBuilderSelect
         multiple
@@ -67,7 +67,7 @@ export function SeerActivityTriggerNode() {
           removeError(condition.id);
         }}
       />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/automations/components/actions/discord.tsx
+++ b/static/app/views/automations/components/actions/discord.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
@@ -43,7 +43,7 @@ export function DiscordDetails({
 
 export function DiscordNode() {
   return (
-    <Flex direction="column" gap="md" flex="1">
+    <Stack gap="md" flex="1">
       <RowLine>
         {tct('Send a [logo] Discord message to [server] server, to [channel]', {
           logo: ActionMetadata[ActionType.DISCORD]?.icon,
@@ -64,7 +64,7 @@ export function DiscordNode() {
           }
         )}
       </DismissableInfoAlert>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {AutomationBuilderInput} from 'sentry/components/workflowEngine/form/automationBuilderInput';
@@ -58,7 +58,7 @@ function SlackTagsAndNotes(action: Action) {
 
 export function SlackNode() {
   return (
-    <Flex direction="column" gap="md" flex="1">
+    <Stack gap="md" flex="1">
       <RowLine>
         {tct(
           'Send a [logo] Slack message to the [workspace] workspace, to [channel] (optionally, an ID: [channel_id])',
@@ -86,7 +86,7 @@ export function SlackNode() {
           }
         )}
       </DismissableInfoAlert>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import type {SelectValue} from '@sentry/scraps/select';
 
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
@@ -36,7 +36,7 @@ export function AutomationBuilder() {
 
   return (
     <AutomationBuilderConflictContext.Provider value={conflictData}>
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <Step>
           <StepLead>
             {tct(
@@ -109,7 +109,7 @@ export function AutomationBuilder() {
             {t('If/Then Block')}
           </PurpleTextButton>
         </span>
-      </Flex>
+      </Stack>
     </AutomationBuilderConflictContext.Provider>
   );
 }

--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -68,12 +68,12 @@ function FormBody({closeDrawer, model}: {closeDrawer: () => void; model: FormMod
         <Alert variant="info">
           {t('This alert will only trigger on issues created by this monitor.')}
         </Alert>
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Stack gap="md">
             <AutomationBuilder />
           </Stack>
           <ActionThrottleSelectField />
-        </Flex>
+        </Stack>
         <EmbeddedTextField
           required
           name="name"

--- a/static/app/views/automations/components/automationBuilderRow.tsx
+++ b/static/app/views/automations/components/automationBuilderRow.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {RowLine} from 'sentry/components/workflowEngine/form/automationBuilderRowLine';
 import {IconDelete} from 'sentry/icons';
@@ -24,7 +24,7 @@ export function AutomationBuilderRow({
   warningMessages = [],
 }: RowProps) {
   return (
-    <Flex direction="column" gap="xs">
+    <Stack gap="xs">
       <RowContainer incompatible={hasError}>
         <RowLine>{children}</RowLine>
         <DeleteButton
@@ -51,7 +51,7 @@ export function AutomationBuilderRow({
           {t('This action is incompatible with the current configuration.')}
         </Alert>
       )}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -1,6 +1,6 @@
 import {useCallback} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import type {FormModel} from 'sentry/components/forms/model';
 import {EnvironmentSelector} from 'sentry/components/workflowEngine/form/environmentSelector';
@@ -26,7 +26,7 @@ export function AutomationForm({model}: {model: FormModel}) {
   useSetAutomaticAutomationName();
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <EditConnectedMonitors
         connectedIds={initialConnectedIds || []}
         setConnectedIds={setConnectedIds}
@@ -52,6 +52,6 @@ export function AutomationForm({model}: {model: FormModel}) {
           <ActionThrottleSelectField />
         </FormSection>
       </Card>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import {createContext, useContext} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 import {
@@ -420,7 +420,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
 
 function OccurenceBasedMonitorsWarning() {
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <WarningLine>
         {t('These filters will only apply to some of your monitors and triggers.')}
       </WarningLine>
@@ -429,7 +429,7 @@ function OccurenceBasedMonitorsWarning() {
           'They are only available for occurrence-based monitors (errors, N+1, and replay) and only apply to the triggers "A new event is captured for an issue" and "A new issue is created."'
         )}
       </WarningLine>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/conduit/conduitDemo.stories.tsx
+++ b/static/app/views/conduit/conduitDemo.stories.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from 'react';
 import {useStream} from 'conduit-client';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
@@ -47,7 +47,7 @@ export default Storybook.story('Conduit Demo', story => {
     const fullMessage = messages.map(msg => msg.value).join(' ');
 
     return (
-      <Flex direction="column" gap="lg" padding="lg" align="start">
+      <Stack gap="lg" padding="lg" align="start">
         <Heading as="h1">Conduit Demo</Heading>
         <Button variant="primary" size="md" onClick={() => setIsEnabled(prev => !prev)}>
           {isEnabled ? 'Disable' : 'Enable'}
@@ -61,7 +61,7 @@ export default Storybook.story('Conduit Demo', story => {
             {fullMessage}
           </Text>
         )}
-      </Flex>
+      </Stack>
     );
   });
 });

--- a/static/app/views/dashboards/components/genericOnboarding.tsx
+++ b/static/app/views/dashboards/components/genericOnboarding.tsx
@@ -2,7 +2,7 @@ import emptyStateImg from 'sentry-images/spot/performance-waiting-for-span.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Image} from '@sentry/scraps/image';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {Panel} from 'sentry/components/panels/panel';
@@ -17,7 +17,7 @@ export function GenericOnboarding({heading}: OverviewOnboardingPanelProps) {
     <Panel>
       <Flex justify="center">
         <Flex padding="xl" align="center" wrap="wrap-reverse" gap="3xl" maxWidth="1000px">
-          <Flex direction="column" gap="xl" flex="5" align="start">
+          <Stack gap="xl" flex="5" align="start">
             <Heading as="h3" size="xl">
               {heading}
             </Heading>
@@ -35,7 +35,7 @@ export function GenericOnboarding({heading}: OverviewOnboardingPanelProps) {
             >
               {t('Read the Docs')}
             </LinkButton>
-          </Flex>
+          </Stack>
 
           <Flex flex="3" justify="center">
             <Image src={emptyStateImg} alt="" width="100%" />

--- a/static/app/views/dashboards/createFromSeerLoading.tsx
+++ b/static/app/views/dashboards/createFromSeerLoading.tsx
@@ -1,4 +1,4 @@
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {IndeterminateLoader} from '@sentry/scraps/loader';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -16,8 +16,8 @@ export function CreateFromSeerLoading({blocks, seerRunId}: CreateFromSeerLoading
   const blocksToRender = blocks.slice(-3);
   return (
     <Stack flex={1} padding="2xl 3xl">
-      <Flex direction="column" gap="lg" align="center" justify="center" flex="1">
-        <Flex direction="column" gap="sm" width="640px">
+      <Stack gap="lg" align="center" justify="center" flex="1">
+        <Stack gap="sm" width="640px">
           <Container paddingBottom="lg">
             <IndeterminateLoader />
           </Container>
@@ -41,8 +41,8 @@ export function CreateFromSeerLoading({blocks, seerRunId}: CreateFromSeerLoading
               ))}
             </Stack>
           </Container>
-        </Flex>
-      </Flex>
+        </Stack>
+      </Stack>
     </Stack>
   );
 }

--- a/static/app/views/dashboards/createFromSeerPrompt.tsx
+++ b/static/app/views/dashboards/createFromSeerPrompt.tsx
@@ -1,7 +1,7 @@
 import {useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
@@ -61,16 +61,15 @@ export function CreateFromSeerPrompt() {
 
   return (
     <Stack flex={1} padding="2xl 3xl">
-      <Flex direction="column" gap="lg" align="center" justify="center" flex="1">
-        <Flex direction="column" gap="sm" width="640px">
+      <Stack gap="lg" align="center" justify="center" flex="1">
+        <Stack gap="sm" width="640px">
           <Heading as="h3">{t('Describe your Dashboard')}</Heading>
           <Container paddingTop="lg">
-            <Flex
+            <Stack
               border="primary"
               radius="md"
               background="primary"
               padding="lg"
-              direction="column"
               gap="lg"
               align="end"
             >
@@ -95,10 +94,10 @@ export function CreateFromSeerPrompt() {
                   {t('Generate')}
                 </Button>
               </Container>
-            </Flex>
+            </Stack>
           </Container>
-        </Flex>
-      </Flex>
+        </Stack>
+      </Stack>
     </Stack>
   );
 }

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -4,7 +4,7 @@ import {useMutation} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -110,12 +110,11 @@ function DashboardRevisionsModal({
         ) : isError ? (
           <Alert variant="danger">{t('Failed to load dashboard revisions.')}</Alert>
         ) : (
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             {isRestoreError && (
               <Alert variant="danger">{t('Failed to restore this revision.')}</Alert>
             )}
-            <Flex
-              direction="column"
+            <Stack
               style={{maxHeight: 'min(560px, calc(100vh - 350px))'}}
               overflowY="auto"
             >
@@ -145,8 +144,8 @@ function DashboardRevisionsModal({
                   baseRevisionId={revisions?.[index + 1]?.id ?? null}
                 />
               ))}
-            </Flex>
-          </Flex>
+            </Stack>
+          </Stack>
         )}
       </Body>
       {displayedRevisions.length ? (

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -12,7 +12,7 @@ import {
   MenuComponents,
   type SelectOption,
 } from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -431,7 +431,7 @@ export function FilterSelector({
       }
       menuFooter={
         hasStagedChanges || isFetching ? (
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             {loadingFooter}
             {hasStagedChanges && (
               <Flex gap="md" align="center" justify="end">
@@ -446,7 +446,7 @@ export function FilterSelector({
                 />
               </Flex>
             )}
-          </Flex>
+          </Stack>
         ) : null
       }
       menuTitle={

--- a/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/numericFilterSelector.tsx
@@ -8,7 +8,7 @@ import {
   type SelectOption,
 } from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
@@ -316,7 +316,7 @@ export function NumericFilterSelector({
       }
       menuBody={
         <MenuBodyWrap>
-          <Flex gap="xs" direction="column">
+          <Stack gap="xs">
             <DropdownMenu
               usePortal
               trigger={triggerProps => (
@@ -327,7 +327,7 @@ export function NumericFilterSelector({
               items={operatorItems}
             />
             {filter.renderInputField()}
-          </Flex>
+          </Stack>
         </MenuBodyWrap>
       }
       trigger={triggerProps => (

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
 import {Tag} from '@sentry/scraps/badge';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DateTime} from 'sentry/components/dateTime';
@@ -113,8 +113,8 @@ export function RevisionListItem({
               : formatRevisionSource(revisionSource)
           }
         />
-        <Flex direction="column" gap="md" style={{flex: 1, minWidth: 0}}>
-          <Flex direction="column" gap="xs">
+        <Stack gap="md" style={{flex: 1, minWidth: 0}}>
+          <Stack gap="xs">
             {isCurrentVersion ? (
               <Text bold size="sm" variant="accent">
                 {t('Current Version')}
@@ -131,7 +131,7 @@ export function RevisionListItem({
                 {createdBy ? createdBy.name || createdBy.email : t('Unknown')}
               </Text>
             </Flex>
-          </Flex>
+          </Stack>
 
           <RevisionDiffBody
             isLoading={isAnyLoading}
@@ -140,7 +140,7 @@ export function RevisionListItem({
             baseRevisionId={baseRevisionId}
             baseSnapshot={baseSnapshot}
           />
-        </Flex>
+        </Stack>
       </Flex>
     </RevisionItem>
   );
@@ -181,10 +181,10 @@ export function RevisionDiffBody({
   }
   const base = baseSnapshot ?? EMPTY_SNAPSHOT;
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       <FilterDiffSection base={base} snapshot={snapshot} />
       <WidgetDiffSection widgetChanges={diffWidgets(base, snapshot)} />
-    </Flex>
+    </Stack>
   );
 }
 
@@ -207,7 +207,7 @@ function FilterDiffSection({
   }
 
   return (
-    <Flex direction="column" gap="xs">
+    <Stack gap="xs">
       {changes.map(({label, before, after}) => (
         <Grid key={label} columns="90px 1fr" gap="sm" align="baseline">
           <Text size="sm" variant="muted">
@@ -233,13 +233,13 @@ function FilterDiffSection({
           </Flex>
         </Grid>
       ))}
-    </Flex>
+    </Stack>
   );
 }
 
 function WidgetDiffSection({widgetChanges}: {widgetChanges: WidgetChange[]}) {
   return (
-    <Flex direction="column" gap="xs">
+    <Stack gap="xs">
       {widgetChanges.length === 0 && (
         <Text size="sm" variant="muted">
           {t('No widget changes in this revision.')}
@@ -248,7 +248,7 @@ function WidgetDiffSection({widgetChanges}: {widgetChanges: WidgetChange[]}) {
       {widgetChanges.map((change, i) => (
         <WidgetDiffCard key={i} change={change} />
       ))}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -268,7 +268,7 @@ function WidgetDiffCard({change}: {change: WidgetChange}) {
   const {label: statusLabel, variant: tagVariant} = STATUS_MAP[status];
 
   return (
-    <Flex direction="column" gap="sm" border="secondary" radius="sm" padding="md">
+    <Stack gap="sm" border="secondary" radius="sm" padding="md">
       <Flex align="center" justify="between" gap="sm">
         <Flex align="center" gap="xs" style={{minWidth: 0}}>
           <Flex
@@ -318,7 +318,7 @@ function WidgetDiffCard({change}: {change: WidgetChange}) {
           {t('Layout position or size changed')}
         </Text>
       )}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useEffect} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import type {SelectValue} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -142,7 +142,7 @@ export function WidgetBuilderSortBySelector() {
           flexibleControlStateSize
           stacked
         >
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             {maxLimit > 0 && state.limit && (
               <Select
                 disabled={disableSortDirection && disableSort}
@@ -191,7 +191,7 @@ export function WidgetBuilderSortBySelector() {
               }}
               tags={tags}
             />
-          </Flex>
+          </Stack>
         </FieldGroup>
       </Tooltip>
     </Fragment>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -13,7 +13,7 @@ import isEqual from 'lodash/isEqual';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {useHotkeys} from '@sentry/scraps/hotkey';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
 import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
@@ -328,12 +328,12 @@ function WidgetBuilderSlideoutInner({
           return (
             <Fragment>
               {header}
-              <Flex direction="column" gap="2xl" padding="2xl">
+              <Stack gap="2xl" padding="2xl">
                 <Placeholder height="50px" />
                 <Placeholder height="50px" />
                 <Placeholder height="50px" />
                 <Placeholder height="200px" />
-              </Flex>
+              </Stack>
             </Fragment>
           );
         }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 
-import {Container, Flex, type ContainerProps} from '@sentry/scraps/layout';
+import {Container, Stack, type ContainerProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -441,7 +441,7 @@ function VisualizationWidgetContent({
 
   if (showBreakdownData) {
     return (
-      <Flex direction="column" height="100%">
+      <Stack height="100%">
         <Container overflow="hidden" flex={2} {...timeseriesContainerPadding}>
           <TimeSeriesWidgetVisualization
             plottables={plottables}
@@ -455,17 +455,17 @@ function VisualizationWidgetContent({
           />
         </Container>
         <Container {...timeseriesContainerPadding}>{confidenceFooter}</Container>
-        <Flex flex={1} direction="column" borderTop="primary" overflowY="auto">
+        <Stack flex={1} borderTop="primary" overflowY="auto">
           <Container flex={1} width="100%">
             {footerTable}
           </Container>
-        </Flex>
-      </Flex>
+        </Stack>
+      </Stack>
     );
   }
 
   return (
-    <Flex direction="column" height="100%">
+    <Stack height="100%">
       <Container flex={1} {...timeseriesContainerPadding}>
         <TimeSeriesWidgetVisualization
           plottables={plottables}
@@ -478,7 +478,7 @@ function VisualizationWidgetContent({
         />
       </Container>
       <Container {...timeseriesContainerPadding}>{confidenceFooter}</Container>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/heatMapWidget/heatMapWidgetVisualization.tsx
@@ -8,7 +8,7 @@ import type {
   VisualMapComponentOption,
 } from 'echarts/types/dist/shared';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {useRenderToString} from '@sentry/scraps/renderToString';
 import {Text} from '@sentry/scraps/text';
 
@@ -273,7 +273,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
             }
 
             return (
-              <Flex direction="column" gap="sm" key={param.seriesIndex}>
+              <Stack gap="sm" key={param.seriesIndex}>
                 <Flex justify="between" gap="xl">
                   <Text variant="primary" size="sm">
                     {yAxisLabel}
@@ -295,7 +295,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
                 </Flex>
 
                 {tooltipActions}
-              </Flex>
+              </Stack>
             );
           })}
         </Container>
@@ -313,7 +313,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
   };
 
   return (
-    <Flex direction="column" height="100%">
+    <Stack height="100%">
       <BaseChart
         autoHeightResize
         // will be grouped by date as we only support time as the x-axis right now.
@@ -360,7 +360,7 @@ export function HeatMapWidgetVisualization(props: HeatMapWidgetVisualizationProp
         period={period}
         utc={utc ?? undefined}
       />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -10,7 +10,7 @@ import type {
 import sum from 'lodash/sum';
 import unescape from 'lodash/unescape';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 
 import {BaseChart} from 'sentry/components/charts/baseChart';
 import type {LegendItem} from 'sentry/components/charts/chartLegend';
@@ -631,7 +631,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   };
 
   return (
-    <Flex direction="column" height="100%">
+    <Stack height="100%">
       {ActionMenu}
       {showLegend && (
         <ChartLegend
@@ -696,7 +696,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           onClick={handleClick}
         />
       </Container>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization.tsx
@@ -1,6 +1,6 @@
 import {useTheme} from '@emotion/react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {defined} from 'sentry/utils/defined';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
@@ -30,7 +30,7 @@ export function WheelWidgetVisualization({tableResults}: WheelWidgetVisualizatio
   }
 
   return (
-    <Flex justify="center" align="center" direction="column" height="100%">
+    <Stack justify="center" align="center" height="100%">
       <PerformanceScoreRingWithTooltips
         autoSize
         projectScore={projectScore}
@@ -38,6 +38,6 @@ export function WheelWidgetVisualization({tableResults}: WheelWidgetVisualizatio
         ringBackgroundColors={ringBackgroundColors}
         ringSegmentColors={ringSegmentColors}
       />
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/dashboards/widgets/widget/widgetError.tsx
+++ b/static/app/views/dashboards/widgets/widget/widgetError.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -23,7 +23,7 @@ export function WidgetError({error, action}: WidgetErrorProps) {
   return (
     <Panel>
       <NonShrinkingWarningIcon variant={DEEMPHASIS_VARIANT} size="md" />
-      <Flex direction="column" align="start" gap="md">
+      <Stack align="start" gap="md">
         <ErrorText>
           {typeof error === 'string'
             ? error
@@ -32,7 +32,7 @@ export function WidgetError({error, action}: WidgetErrorProps) {
               t('Error loading data.'))}
         </ErrorText>
         {action}
-      </Flex>
+      </Stack>
     </Panel>
   );
 }

--- a/static/app/views/detectors/components/details/metric/detect.tsx
+++ b/static/app/views/detectors/components/details/metric/detect.tsx
@@ -188,7 +188,7 @@ export function MetricDetectorDetailsDetect({detector}: {detector: MetricDetecto
 
   return (
     <Container>
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <Flex gap="xs" align="baseline">
           <Heading as="h4">{t('Dataset:')}</Heading>
           <Value>{datasetConfig.name}</Value>
@@ -231,7 +231,7 @@ export function MetricDetectorDetailsDetect({detector}: {detector: MetricDetecto
           <Value>{getDetectorTypeLabel(detector)}</Value>
         </Flex>
         <DetectorPriorities detector={detector} />
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/app/views/detectors/components/details/mobileBuild/detect.tsx
+++ b/static/app/views/detectors/components/details/mobileBuild/detect.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {FilterWrapper} from 'sentry/components/searchQueryBuilder/formattedQuery';
@@ -114,7 +114,7 @@ export function MobileBuildDetectorDetailsDetect({
 
   return (
     <Container>
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <Flex gap="xs" align="baseline">
           <Heading as="h4">{t('Measurement:')}</Heading>
           <Value>{getMetricLabel(detector.config.measurement)}</Value>
@@ -147,7 +147,7 @@ export function MobileBuildDetectorDetailsDetect({
           <Value>{t('Static threshold')}</Value>
         </Flex>
         <DetectorPriorities detector={detector} />
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -2,7 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {parseAsStringEnum, useQueryState} from 'nuqs';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
@@ -138,7 +138,7 @@ function MonitorTypeField() {
           return (
             <OptionLabel key={id} aria-checked={checked} disabled={disabled}>
               <OptionBody>
-                <Flex direction="column" gap="sm">
+                <Stack gap="sm">
                   <Radio
                     name="detectorType"
                     checked={checked}
@@ -154,7 +154,7 @@ function MonitorTypeField() {
                       {description}
                     </Text>
                   )}
-                </Flex>
+                </Stack>
                 {visualization && <Visualization>{visualization}</Visualization>}
               </OptionBody>
               {infoBanner && (checked || disabled) && (

--- a/static/app/views/detectors/components/forms/common/detectorIssuePreview.tsx
+++ b/static/app/views/detectors/components/forms/common/detectorIssuePreview.tsx
@@ -1,5 +1,5 @@
 import {ActorAvatar} from '@sentry/scraps/avatar';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {ShortId} from 'sentry/components/group/inboxBadges/shortId';
@@ -37,7 +37,7 @@ export function DetectorIssuePreview({
       </SimpleTable.Header>
       <SimpleTable.Row>
         <SimpleTable.RowCell>
-          <Flex direction="column" gap="xs">
+          <Stack gap="xs">
             <Text bold size="lg">
               {issueTitle}
             </Text>
@@ -48,7 +48,7 @@ export function DetectorIssuePreview({
                 <ShortId shortId={shortId} />
               </Text>
             </Flex>
-          </Flex>
+          </Stack>
         </SimpleTable.RowCell>
         <SimpleTable.RowCell justify="end">2min ago</SimpleTable.RowCell>
         <SimpleTable.RowCell justify="end">4h</SimpleTable.RowCell>

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -424,7 +424,7 @@ function CustomizeMetricSection({step}: {step?: number}) {
   return (
     <Container>
       <FormSection step={step} title={t('Customize Metric')}>
-        <Flex direction="column" gap="xs">
+        <Stack gap="xs">
           <DatasetRow>
             <DatasetField
               placeholder={t('Dataset')}
@@ -482,7 +482,7 @@ function CustomizeMetricSection({step}: {step?: number}) {
               </DisabledSection>
             </Tooltip>
           </DatasetRow>
-        </Flex>
+        </Stack>
         <Tooltip
           title={TRANSACTIONS_DATASET_DEPRECATION_MESSAGE}
           isHoverable
@@ -558,9 +558,9 @@ function DetectSection({step}: {step?: number}) {
         }
       >
         <DetectionType />
-        <Flex direction="column">
+        <Stack>
           {(!detectionType || detectionType === 'static') && (
-            <Flex direction="column">
+            <Stack>
               <DefineThresholdParagraph>
                 <Text bold>{t('Define threshold & set priority')}</Text>
                 <Text variant="muted">
@@ -579,10 +579,10 @@ function DetectSection({step}: {step?: number}) {
                   aggregate={aggregate}
                 />
               </Stack>
-            </Flex>
+            </Stack>
           )}
           {detectionType === 'percent' && (
-            <Flex direction="column">
+            <Stack>
               <DefineThresholdParagraph>
                 <Text bold>{t('Define threshold & set priority')}</Text>
                 <Text variant="muted">
@@ -602,10 +602,10 @@ function DetectSection({step}: {step?: number}) {
                   aggregate={aggregate}
                 />
               </Stack>
-            </Flex>
+            </Stack>
           )}
           {detectionType === 'dynamic' && (
-            <Flex direction="column">
+            <Stack>
               <SelectField
                 required
                 name={METRIC_DETECTOR_FORM_FIELDS.sensitivity}
@@ -638,9 +638,9 @@ function DetectSection({step}: {step?: number}) {
                 }
                 preserveOnUnmount
               />
-            </Flex>
+            </Stack>
           )}
-        </Flex>
+        </Stack>
         {detectionType !== 'dynamic' && (
           <Fragment>
             <DefineThresholdParagraph>

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -215,7 +215,7 @@ export function MetricsVisualize() {
   const hasNoMetrics = isMetricOptionsEmpty && !search;
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Flex gap="md" align="end">
         <Stack flex="1" gap="xs" maxWidth="425px">
           <div>
@@ -275,7 +275,7 @@ export function MetricsVisualize() {
           />
         </Stack>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/detectors/components/forms/metric/queryFilterBuilder.tsx
+++ b/static/app/views/detectors/components/forms/metric/queryFilterBuilder.tsx
@@ -1,7 +1,7 @@
 import {useContext, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FormContext} from 'sentry/components/forms/formContext';
@@ -50,7 +50,7 @@ export function DetectorQueryFilterBuilder() {
       disabled={dataset === DetectorDataset.TRANSACTIONS}
     >
       {({ref: _ref, ...fieldProps}) => (
-        <Flex direction="column" gap="xs" flex={1}>
+        <Stack gap="xs" flex={1}>
           <div>
             <Tooltip
               title={t(
@@ -73,7 +73,7 @@ export function DetectorQueryFilterBuilder() {
               {...fieldProps}
             />
           </QueryFieldRowWrapper>
-        </Flex>
+        </Stack>
       )}
     </NoPaddingFormField>
   );

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -405,7 +405,7 @@ function GenericVisualize() {
   const lockedOption = lockSpanOptions ? LOCKED_SPAN_AGGREGATES[aggregate] : null;
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Flex gap="md" align="end">
         <Stack flex="1" gap="xs" maxWidth="425px">
           <div>
@@ -490,7 +490,7 @@ function GenericVisualize() {
           );
         })}
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/detectors/list/cron.tsx
+++ b/static/app/views/detectors/list/cron.tsx
@@ -167,7 +167,7 @@ function CronEmptyState() {
           {platformGuides
             .filter(({platform}) => !['cli', 'http'].includes(platform))
             .map(({platform, label}) => (
-              <Flex key={platform} direction="column" gap="xs" align="center">
+              <Stack key={platform} gap="xs" align="center">
                 <PlatformLinkButton
                   variant="secondary"
                   to={makeCreateUrl(platform)}
@@ -176,7 +176,7 @@ function CronEmptyState() {
                   <PlatformIcon platform={platform} format="lg" size="100%" />
                 </PlatformLinkButton>
                 <Text variant="muted">{label}</Text>
-              </Flex>
+              </Stack>
             ))}
         </Flex>
         <Flex gap="md">

--- a/static/app/views/discover/results/tags.tsx
+++ b/static/app/views/discover/results/tags.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 import type {Location, LocationDescriptor} from 'history';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import type {Tag, TagSegment} from 'sentry/actionCreators/events';
 import {fetchTagFacets} from 'sentry/actionCreators/events';
@@ -193,7 +193,7 @@ class Tags extends Component<Props, State> {
             (loading ? (
               this.renderPlaceholders()
             ) : (
-              <Flex direction="column" align="center">
+              <Stack align="center">
                 <Button
                   size="xs"
                   variant="primary"
@@ -205,7 +205,7 @@ class Tags extends Component<Props, State> {
                 >
                   {t('Show More')}
                 </Button>
-              </Flex>
+              </Stack>
             ))}
         </Fragment>
       );

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -7,7 +7,7 @@ import type {Location} from 'history';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Flex, Grid, type GridProps} from '@sentry/scraps/layout';
+import {Stack, Grid, type GridProps} from '@sentry/scraps/layout';
 
 import type {Client} from 'sentry/api';
 import Feature from 'sentry/components/acl/feature';
@@ -79,7 +79,7 @@ export function SaveAsDropdown({
             <StyledOverlay arrowProps={arrowProps} animated>
               <FocusScope contain restoreFocus autoFocus>
                 <form onSubmit={modifiedHandleCreateQuery}>
-                  <Flex gap="md" direction="column">
+                  <Stack gap="md">
                     <Input
                       type="text"
                       name="query_name"
@@ -96,7 +96,7 @@ export function SaveAsDropdown({
                     >
                       {t('Save for Organization')}
                     </SaveAsButton>
-                  </Flex>
+                  </Stack>
                 </form>
               </FocusScope>
             </StyledOverlay>

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -2,7 +2,7 @@ import {Fragment, useMemo} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {closeModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -325,7 +325,7 @@ export default function AttributeBreakdownViewerModal(props: Props) {
         </Flex>
       </Header>
       <Body>
-        <Flex direction="column" gap="2xl" height="600px">
+        <Stack gap="2xl" height="600px">
           <Container height={`${MODAL_CHART_HEIGHT}px`}>
             <Container height={`${MODAL_CHART_HEIGHT}px`} position="relative">
               {computedData.mode === 'single' && singleSeries && hasPlottableValues ? (
@@ -409,7 +409,7 @@ export default function AttributeBreakdownViewerModal(props: Props) {
               return [];
             }}
           />
-        </Flex>
+        </Stack>
       </Body>
     </Fragment>
   );

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -138,7 +138,7 @@ export function AttributeDistribution() {
 
   return (
     <Panel>
-      <Flex direction="column" gap="xl" padding="xl">
+      <Stack gap="xl" padding="xl">
         <ChartSelectionAlert />
         <AttributeBreakdownsComponent.ControlsContainer>
           <AttributeBreakdownsComponent.StyledBaseSearchBar
@@ -200,7 +200,7 @@ export function AttributeDistribution() {
         ) : (
           <AttributeBreakdownsComponent.EmptySearchState />
         )}
-      </Flex>
+      </Stack>
     </Panel>
   );
 }

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {Selection} from 'sentry/components/charts/useChartXRangeSelection';
@@ -93,7 +93,7 @@ export function CohortComparison({
 
   return (
     <Panel>
-      <Flex direction="column" gap="2xl" padding="xl">
+      <Stack gap="2xl" padding="xl">
         <AttributeBreakdownsComponent.ControlsContainer>
           <AttributeBreakdownsComponent.StyledBaseSearchBar
             placeholder={t('Search keys')}
@@ -162,7 +162,7 @@ export function CohortComparison({
             )}
           </Fragment>
         )}
-      </Flex>
+      </Stack>
     </Panel>
   );
 }

--- a/static/app/views/explore/components/attributeBreakdowns/styles.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/styles.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import type {BarSeriesOption} from 'echarts';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {BaseChart, type TooltipOption} from 'sentry/components/charts/baseChart';
@@ -110,7 +110,7 @@ function ErrorState({error}: {error: Error}) {
   const config = ERROR_STATE_CONFIG[status] ?? ERROR_STATE_CONFIG.default;
 
   return (
-    <Flex direction="column" gap="2xl" padding="3xl" align="center" justify="center">
+    <Stack gap="2xl" padding="3xl" align="center" justify="center">
       {config.icon}
       <Text size="xl" variant="muted">
         {config.title}
@@ -118,13 +118,13 @@ function ErrorState({error}: {error: Error}) {
       <Text size="md" variant="muted">
         {config.subtitle}
       </Text>
-    </Flex>
+    </Stack>
   );
 }
 
 function EmptySearchState() {
   return (
-    <Flex direction="column" gap="2xl" padding="3xl" align="center" justify="center">
+    <Stack gap="2xl" padding="3xl" align="center" justify="center">
       <StyledIconSearch size="xl" />
       <Text size="xl" variant="muted">
         {t('No matching attributes found')}
@@ -134,7 +134,7 @@ function EmptySearchState() {
           feedbackLink: <FeedbackLink />,
         })}
       </Text>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/components/styles.tsx
+++ b/static/app/views/explore/components/styles.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex, type FlexProps} from '@sentry/scraps/layout';
+import {Stack, type FlexProps} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {TOP_BAR_HEIGHT_CSS_VAR} from 'sentry/views/navigation/constants';
@@ -30,13 +30,12 @@ export const ExploreControlSection = styled('aside')<{expanded: boolean}>`
 
 export function ExploreContentSection(props: FlexProps) {
   return (
-    <Flex
+    <Stack
       {...props}
       background="primary"
       flex="1 1 auto"
       minHeight="0"
       minWidth="0"
-      direction="column"
       padding="xl"
     />
   );

--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -82,9 +82,9 @@ function MeasuredSplitPanel({
 
 export function ConversationLeftPanel({children}: {children: React.ReactNode}) {
   return (
-    <Flex direction="column" flex={1} minWidth="0" minHeight="0" overflow="hidden">
+    <Stack flex={1} minWidth="0" minHeight="0" overflow="hidden">
       {children}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -195,8 +195,7 @@ function MeasuredContentSplit({
       fillMinSize={DETAIL_MIN_WIDTH}
       onResizeEnd={({endSize}) => setStoredSize(endSize)}
       sized={
-        <Flex
-          direction="column"
+        <Stack
           flex="1"
           minWidth="0"
           minHeight="0"
@@ -204,12 +203,11 @@ function MeasuredContentSplit({
           paddingBottom={{xs: 'md', md: '0'}}
         >
           {content}
-        </Flex>
+        </Stack>
       }
       fill={
         detail ? (
-          <Flex
-            direction="column"
+          <Stack
             flex="1"
             minWidth="0"
             minHeight="0"
@@ -217,7 +215,7 @@ function MeasuredContentSplit({
             paddingTop={{xs: 'md', md: '0'}}
           >
             {detail}
-          </Flex>
+          </Stack>
         ) : undefined
       }
     />
@@ -235,8 +233,7 @@ export function ConversationDetailPanel({
 }) {
   const organization = useOrganization();
   return (
-    <Flex
-      direction="column"
+    <Stack
       flex={1}
       minHeight="0"
       background="primary"
@@ -254,7 +251,7 @@ export function ConversationDetailPanel({
         hideNodeActions: true,
         initiallyCollapseAiIO,
       })}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -269,13 +266,13 @@ export function ConversationViewSkeleton() {
               <Placeholder height="14px" width="40px" />
             </Flex>
           </Container>
-          <Flex direction="column" flex="1" gap="md" padding="lg" background="secondary">
-            <Flex direction="column" gap="sm" padding="sm md">
+          <Stack flex="1" gap="md" padding="lg" background="secondary">
+            <Stack gap="sm" padding="sm md">
               <Placeholder height="12px" width="120px" />
               <Placeholder height="12px" width="80%" />
-            </Flex>
+            </Stack>
             <Container background="primary" radius="md" border="primary" padding="sm md">
-              <Flex direction="column" gap="sm">
+              <Stack gap="sm">
                 <Flex align="center" gap="sm">
                   <Placeholder height="12px" width="100px" />
                   <Placeholder height="12px" width="40px" />
@@ -286,48 +283,48 @@ export function ConversationViewSkeleton() {
                 <Placeholder height="12px" width="90%" />
                 <Placeholder height="12px" width="70%" />
                 <Placeholder height="12px" width="60%" />
-              </Flex>
+              </Stack>
             </Container>
-            <Flex direction="column" gap="sm" padding="sm md">
+            <Stack gap="sm" padding="sm md">
               <Placeholder height="12px" width="120px" />
               <Placeholder height="12px" width="60%" />
-            </Flex>
+            </Stack>
             <Container background="primary" radius="md" border="primary" padding="sm md">
-              <Flex direction="column" gap="sm">
+              <Stack gap="sm">
                 <Flex align="center" gap="sm">
                   <Placeholder height="12px" width="80px" />
                   <Placeholder height="12px" width="35px" />
                 </Flex>
                 <Placeholder height="12px" width="85%" />
                 <Placeholder height="12px" width="50%" />
-              </Flex>
+              </Stack>
             </Container>
-          </Flex>
+          </Stack>
         </ConversationLeftPanel>
       }
       right={
-        <Flex direction="column" gap="lg" padding="lg">
-          <Flex direction="column" gap="sm">
+        <Stack gap="lg" padding="lg">
+          <Stack gap="sm">
             <Placeholder height="14px" width="180px" />
             <Placeholder height="16px" width="60px" />
-          </Flex>
-          <Flex direction="column" gap="sm">
+          </Stack>
+          <Stack gap="sm">
             <Placeholder height="12px" width="80px" />
             <Placeholder height="12px" width="200px" />
-          </Flex>
-          <Flex direction="column" gap="sm">
+          </Stack>
+          <Stack gap="sm">
             <Placeholder height="12px" width="60px" />
             <Placeholder height="12px" width="160px" />
-          </Flex>
-          <Flex direction="column" gap="sm">
+          </Stack>
+          <Stack gap="sm">
             <Placeholder height="14px" width="80px" />
             <Placeholder height="80px" width="100%" />
-          </Flex>
-          <Flex direction="column" gap="sm">
+          </Stack>
+          <Stack gap="sm">
             <Placeholder height="14px" width="80px" />
             <Placeholder height="120px" width="100%" />
-          </Flex>
-        </Flex>
+          </Stack>
+        </Stack>
       }
     />
   );

--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {InfoText} from '@sentry/scraps/info';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -287,7 +287,7 @@ export function ConversationSummary({
   }, [nodeTraceMap]);
 
   return (
-    <Flex direction="column" gap="md" flex={1}>
+    <Stack gap="md" flex={1}>
       <Flex align="center" gap="sm" minWidth={0}>
         <Tooltip
           title={conversationId}
@@ -375,7 +375,7 @@ export function ConversationSummary({
           })
         }
       />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -1,7 +1,7 @@
 import {memo, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {CopyAsDropdown} from 'sentry/components/copyAsDropdown';
@@ -128,7 +128,7 @@ function ConversationView({
     <ConversationSplitLayout
       left={
         <ConversationLeftPanel>
-          <Flex direction="column" flex="1" minHeight="0" width="100%" overflow="hidden">
+          <Stack flex="1" minHeight="0" width="100%" overflow="hidden">
             <Flex
               flexShrink={0}
               align="center"
@@ -186,7 +186,7 @@ function ConversationView({
                 </Container>
               )}
             </Flex>
-          </Flex>
+          </Stack>
         </ConversationLeftPanel>
       }
       right={

--- a/static/app/views/explore/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCalls.tsx
@@ -1,7 +1,7 @@
 import {css, useTheme} from '@emotion/react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconFire} from 'sentry/icons';
@@ -35,7 +35,7 @@ export function MessageToolCalls({
   const theme = useTheme();
 
   return (
-    <Flex direction="column" gap="xs" padding="sm md xs md">
+    <Stack gap="xs" padding="sm md xs md">
       {toolCalls.map(tool => {
         const toolNode = nodeMap.get(tool.nodeId);
         const isToolSelected = tool.nodeId === selectedNodeId;
@@ -80,7 +80,7 @@ export function MessageToolCalls({
           </Container>
         );
       })}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
@@ -1,6 +1,6 @@
 import {css, useTheme} from '@emotion/react';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -51,7 +51,7 @@ export function MessageToolCallsNew({
   `;
 
   return (
-    <Flex direction="column" gap="xs" width="100%">
+    <Stack gap="xs" width="100%">
       {toolCalls.map(tool => {
         const toolNode = nodeMap.get(tool.nodeId);
         const isToolSelected = tool.nodeId === selectedNodeId;
@@ -125,7 +125,7 @@ export function MessageToolCallsNew({
           </Container>
         );
       })}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -70,26 +70,14 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
 
   if (messages.length === 0) {
     return (
-      <Flex
-        direction="column"
-        padding="lg md md md"
-        background="secondary"
-        minHeight="100%"
-        width="100%"
-      >
+      <Stack padding="lg md md md" background="secondary" minHeight="100%" width="100%">
         <EmptyMessage>{t('No messages found')}</EmptyMessage>
-      </Flex>
+      </Stack>
     );
   }
 
   return (
-    <Flex
-      direction="column"
-      padding="lg md md md"
-      background="secondary"
-      minHeight="100%"
-      width="100%"
-    >
+    <Stack padding="lg md md md" background="secondary" minHeight="100%" width="100%">
       <Stack gap="md" width="100%">
         {messages.map((message, index) => {
           const isSelected = message.id === effectiveSelectedMessageId;
@@ -160,7 +148,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
           );
         })}
       </Stack>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -2,7 +2,7 @@ import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
@@ -282,20 +282,20 @@ export function MessagesPanelSkeleton() {
           <Placeholder height="14px" width="180px" />
         </UserMessageBlock>
         <AssistantMessageBlock meta={<Placeholder height="12px" width="48px" />}>
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             <Placeholder style={invertedPlaceholderStyle} height="12px" width="320px" />
             <Placeholder style={invertedPlaceholderStyle} height="12px" width="260px" />
             <Placeholder style={invertedPlaceholderStyle} height="12px" width="180px" />
-          </Flex>
+          </Stack>
         </AssistantMessageBlock>
         <UserMessageBlock>
           <Placeholder height="14px" width="120px" />
         </UserMessageBlock>
         <AssistantMessageBlock meta={<Placeholder height="12px" width="48px" />}>
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             <Placeholder style={invertedPlaceholderStyle} height="12px" width="280px" />
             <Placeholder style={invertedPlaceholderStyle} height="12px" width="200px" />
-          </Flex>
+          </Stack>
         </AssistantMessageBlock>
       </Stack>
     </PanelContainer>
@@ -304,15 +304,9 @@ export function MessagesPanelSkeleton() {
 
 function PanelContainer({children}: {children: React.ReactNode}) {
   return (
-    <Flex
-      direction="column"
-      padding="xl 0"
-      background="primary"
-      minHeight="100%"
-      width="100%"
-    >
+    <Stack padding="xl 0" background="primary" minHeight="100%" width="100%">
       {children}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -59,14 +59,14 @@ function ConversationDetailPageLegacy() {
   return (
     <ViewportConstrainedPage background="secondary">
       <Stack flex={1} minHeight="0" overflow="hidden" padding="md 2xl" gap="md">
-        <Flex direction="column" gap="md" flexShrink={0}>
+        <Stack gap="md" flexShrink={0}>
           <ConversationSummary
             nodes={nodes}
             nodeTraceMap={nodeTraceMap}
             conversationId={conversationId}
             isLoading={isLoading}
           />
-        </Flex>
+        </Stack>
         <ConversationViewContainer>
           <ConversationViewContent
             conversation={conversation}

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -3,7 +3,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, type FlexProps} from '@sentry/scraps/layout';
+import {Flex, type FlexProps, Stack} from '@sentry/scraps/layout';
 
 import {HighlightComponent} from 'sentry/components/highlight';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
@@ -376,15 +376,7 @@ export function TableActionsContainer(props: FlexProps) {
 }
 
 export function LogsItemContainer(props: FlexProps) {
-  return (
-    <Flex
-      direction="column"
-      minHeight="0"
-      overflow="hidden"
-      position="relative"
-      {...props}
-    />
-  );
+  return <Stack minHeight="0" overflow="hidden" position="relative" {...props} />;
 }
 
 export function LogsTableActionsContainer(props: FlexProps) {
@@ -400,9 +392,7 @@ export function LogsTableActionsContainer(props: FlexProps) {
 }
 
 export function LogsGraphContainer(props: FlexProps) {
-  return (
-    <Flex direction="column" flex="0 0 auto" overflow="visible" gap="md" {...props} />
-  );
+  return <Stack flex="0 0 auto" overflow="visible" gap="md" {...props} />;
 }
 
 export const AutoRefreshLabel = styled('label')`

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -2,7 +2,7 @@ import {Fragment, useCallback} from 'react';
 import type {DraggableAttributes} from '@dnd-kit/core';
 import type {SyntheticListenerMap} from '@dnd-kit/core/dist/hooks/utilities';
 
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 
 import type {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
@@ -110,8 +110,7 @@ export function MetricToolbar({
     : `${dndGrid}auto 1fr ${removeMetric}`;
 
   return (
-    <Flex
-      direction="column"
+    <Stack
       gap="md"
       width="100%"
       paddingLeft="xl"
@@ -196,6 +195,6 @@ export function MetricToolbar({
           disabled={isVisualizeEquation(visualize) && hasUnresolvedMetrics}
         />
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/explore/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/explore/profiling/landing/functionTrendsWidget.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 import {Pagination} from '@sentry/scraps/pagination';
@@ -146,7 +146,7 @@ export function FunctionTrendsWidget({
         paginationAnalyticsEvent={paginationAnalyticsEvent}
         trendType={trendType}
       />
-      <Flex flex="1 1 auto" direction="column" justify="center">
+      <Stack flex="1 1 auto" justify="center">
         {isLoading && (
           <StatusContainer>
             <LoadingIndicator />
@@ -189,7 +189,7 @@ export function FunctionTrendsWidget({
             })}
           </Accordion>
         )}
-      </Flex>
+      </Stack>
     </WidgetContainer>
   );
 }

--- a/static/app/views/explore/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/explore/profiling/landing/slowestFunctionsWidget.tsx
@@ -8,7 +8,7 @@ import omit from 'lodash/omit';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -256,7 +256,7 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
           paginationAnalyticsEvent={paginationAnalyticsEvent}
         />
       </HeaderContainer>
-      <Flex flex="1 1 auto" direction="column" justify="center">
+      <Stack flex="1 1 auto" justify="center">
         {isLoading && (
           <StatusContainer>
             <LoadingIndicator />
@@ -303,7 +303,7 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
             })}
           </Accordion>
         )}
-      </Flex>
+      </Stack>
     </WidgetContainer>
   );
 }
@@ -457,13 +457,13 @@ function SlowestFunctionEntry<F extends BreakdownFunction>({
         />
       </AccordionItem>
       {isExpanded && (
-        <Flex flex="1 1 auto" direction="column" justify="center">
+        <Stack flex="1 1 auto" justify="center">
           <FunctionChart
             func={func}
             breakdownFunction={breakdownFunction}
             stats={stats}
           />
-        </Flex>
+        </Stack>
       )}
     </Fragment>
   );

--- a/static/app/views/explore/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/explore/replays/detail/breadcrumbs/index.tsx
@@ -2,7 +2,7 @@ import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {Placeholder} from 'sentry/components/placeholder';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
@@ -132,7 +132,7 @@ export function Breadcrumbs() {
   }, [virtualizer]);
 
   return (
-    <Flex direction="column" wrap="nowrap">
+    <Stack wrap="nowrap">
       <BreadcrumbFilters frames={frames} {...filterProps} />
       <TabItemContainer data-test-id="replay-details-breadcrumbs-tab">
         {frames ? (
@@ -186,7 +186,7 @@ export function Breadcrumbs() {
           />
         ) : null}
       </TabItemContainer>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/replays/detail/console/index.tsx
+++ b/static/app/views/explore/replays/detail/console/index.tsx
@@ -2,7 +2,7 @@ import {useCallback, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {Placeholder} from 'sentry/components/placeholder';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
@@ -129,7 +129,7 @@ export function Console() {
   });
 
   return (
-    <Flex direction="column" wrap="nowrap">
+    <Stack wrap="nowrap">
       <ConsoleFilters frames={frames} {...filterProps} />
       <TabItemContainer data-test-id="replay-details-console-tab">
         {frames ? (
@@ -178,7 +178,7 @@ export function Console() {
           />
         ) : null}
       </TabItemContainer>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/replays/detail/errorList/index.tsx
+++ b/static/app/views/explore/replays/detail/errorList/index.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {Placeholder} from 'sentry/components/placeholder';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
@@ -98,7 +98,7 @@ export function ErrorList() {
   });
 
   return (
-    <Flex direction="column" wrap="nowrap">
+    <Stack wrap="nowrap">
       <ErrorFilters errorFrames={errorFrames} {...filterProps} />
       <ErrorTable data-test-id="replay-details-errors-tab">
         {errorFrames ? (
@@ -204,7 +204,7 @@ export function ErrorList() {
           <Placeholder height="100%" />
         )}
       </ErrorTable>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/replays/detail/header/replayDetailsUserBadge.tsx
+++ b/static/app/views/explore/replays/detail/header/replayDetailsUserBadge.tsx
@@ -1,7 +1,7 @@
 import invariant from 'invariant';
 
 import {UserAvatar} from '@sentry/scraps/avatar';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -68,11 +68,11 @@ function ReplayBadge({replay}: {replay: ReplayRecord}) {
           <IconDelete variant="muted" size="md" />
         </Flex>
 
-        <Flex direction="column" gap="xs" justify="center">
+        <Stack gap="xs" justify="center">
           <Text size="md" bold>
             {t('Deleted Replay')}
           </Text>
-        </Flex>
+        </Stack>
       </Grid>
     );
   }
@@ -117,7 +117,7 @@ function ReplayBadge({replay}: {replay: ReplayRecord}) {
         size={24}
       />
 
-      <Flex direction="column" gap="xs" justify="center">
+      <Stack gap="xs" justify="center">
         <Flex direction="row" align="center" gap="sm">
           {/* We use div here because the Text component has width 100% and will take up the
           full width of the container, causing a gap between the text and the badge */}
@@ -142,7 +142,7 @@ function ReplayBadge({replay}: {replay: ReplayRecord}) {
           </Flex>
           {isLive ? <LiveBadge /> : null}
         </Flex>
-      </Flex>
+      </Stack>
     </Flex>
   );
 }

--- a/static/app/views/explore/replays/detail/layout/replayLayout.tsx
+++ b/static/app/views/explore/replays/detail/layout/replayLayout.tsx
@@ -1,7 +1,7 @@
 import {useRef} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {SplitPanel} from '@sentry/scraps/splitPanel';
 import {TooltipContext} from '@sentry/scraps/tooltip';
 
@@ -148,8 +148,7 @@ function ReplayLayoutBody({
               })
             }
             sized={
-              <Flex
-                direction="column"
+              <Stack
                 flex="1"
                 minHeight="0"
                 minWidth="0"
@@ -157,12 +156,11 @@ function ReplayLayoutBody({
                 paddingBottom={isLeftRight ? undefined : 'md'}
               >
                 <PanelContainer>{video}</PanelContainer>
-              </Flex>
+              </Stack>
             }
             fill={
               isFocusAreaCollapsed ? undefined : (
-                <Flex
-                  direction="column"
+                <Stack
                   flex="1"
                   minHeight="0"
                   minWidth="0"
@@ -170,7 +168,7 @@ function ReplayLayoutBody({
                   paddingTop={isLeftRight ? undefined : 'md'}
                 >
                   {focusArea}
-                </Flex>
+                </Stack>
               )
             }
           />

--- a/static/app/views/explore/replays/detail/network/index.tsx
+++ b/static/app/views/explore/replays/detail/network/index.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useMemo, useRef} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -153,7 +153,7 @@ export function NetworkList() {
   const selectedItem = selectedIndex === null ? null : (items[selectedIndex] ?? null);
 
   return (
-    <Flex direction="column" wrap="nowrap">
+    <Stack wrap="nowrap">
       <FilterLoadingIndicator isLoading={!replay}>
         <NetworkFilters networkFrames={networkFrames} {...filterProps} />
       </FilterLoadingIndicator>
@@ -294,6 +294,6 @@ export function NetworkList() {
           />
         </SplitPanel>
       </GridTable>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/explore/replays/detail/page.tsx
+++ b/static/app/views/explore/replays/detail/page.tsx
@@ -1,4 +1,4 @@
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {NotFound} from 'sentry/components/errors/notFound';
 import {ArchivedReplayAlert} from 'sentry/components/replays/alerts/archivedReplayAlert';
@@ -41,9 +41,9 @@ export function ReplayDetailsPage({readerResult}: Props) {
       )}
       renderProcessingError={() => (
         <Stack flex={1} padding="2xl 3xl">
-          <Flex direction="column">
+          <Stack>
             <ReplayProcessingError />
-          </Flex>
+          </Stack>
         </Stack>
       )}
     >

--- a/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
+++ b/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
@@ -73,7 +73,7 @@ function AccordionWidget({
       {isLoading ? (
         <SelectorCardPlaceholder />
       ) : isError || (!isLoading && filteredData.length === 0) ? (
-        <Flex flex="1 1 auto" direction="column" justify="center">
+        <Stack flex="1 1 auto" justify="center">
           <StyledEmptyStateWarning withIcon={false}>
             <EmptyHeader>
               <IconSearch size="sm" />
@@ -86,9 +86,9 @@ function AccordionWidget({
               )}
             </EmptySubtitle>
           </StyledEmptyStateWarning>
-        </Flex>
+        </Stack>
       ) : (
-        <Flex flex="1 1 auto" direction="column" justify="start">
+        <Stack flex="1 1 auto" justify="start">
           <Accordion
             collapsible
             collapsedChevronDirection="right"
@@ -120,7 +120,7 @@ function AccordionWidget({
               };
             })}
           />
-        </Flex>
+        </Stack>
       )}
     </WidgetFrame>
   );
@@ -282,7 +282,7 @@ const EmptySubtitle = styled('div')`
 `;
 
 const LoadingContainer = styled((props: FlexProps) => (
-  <Flex gap="2xs" flex="1 1 auto" direction="column" justify="start" {...props} />
+  <Stack gap="2xs" flex="1 1 auto" justify="start" {...props} />
 ))`
   padding: ${p => p.theme.space.md} ${p => p.theme.space.xs} 4px ${p => p.theme.space.xs};
 `;

--- a/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
@@ -4,7 +4,7 @@ import partition from 'lodash/partition';
 import {PlatformIcon} from 'platformicons';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
@@ -263,7 +263,7 @@ export function MonitorQuickStartGuide({monitorSlug, project}: Props) {
   };
 
   return (
-    <Flex gap="xl" direction="column">
+    <Stack gap="xl">
       <Text>
         {tct(
           'Select an integration method for your monitor. For in-depth instructions on integrating Crons, view [docsLink:our complete documentation].',
@@ -296,6 +296,6 @@ export function MonitorQuickStartGuide({monitorSlug, project}: Props) {
       <div ref={guideContainerRef}>
         <Guide {...guideProps} />
       </div>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/insights/pages/nodeRuntime/onboarding.tsx
+++ b/static/app/views/insights/pages/nodeRuntime/onboarding.tsx
@@ -3,7 +3,7 @@ import emptyStateImg from 'sentry-images/spot/performance-waiting-for-span.svg';
 import {LinkButton} from '@sentry/scraps/button';
 import {CodeBlock, InlineCode} from '@sentry/scraps/code';
 import {Image} from '@sentry/scraps/image';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {Panel} from 'sentry/components/panels/panel';
@@ -24,7 +24,7 @@ export function NodeRuntimeMetricsOnboarding() {
     <Panel>
       <Flex justify="center">
         <Flex padding="xl" align="center" wrap="wrap-reverse" gap="3xl" maxWidth="1000px">
-          <Flex direction="column" gap="xl" flex="5" align="start">
+          <Stack gap="xl" flex="5" align="start">
             <Heading as="h3" size="xl">
               {t('Monitor Node.js Runtime Metrics')}
             </Heading>
@@ -52,7 +52,7 @@ export function NodeRuntimeMetricsOnboarding() {
             <LinkButton variant="primary" external href={DOCS_URL}>
               {t('Read the Docs')}
             </LinkButton>
-          </Flex>
+          </Stack>
 
           <Flex flex="3" justify="center">
             <Image src={emptyStateImg} alt="" width="100%" />

--- a/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
+++ b/static/app/views/insights/uptime/components/overviewTimeline/overviewRow.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link, type LinkProps} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -150,9 +150,9 @@ export function OverviewRow({summary, uptimeDetector, timeWindowConfig, single}:
 function DetailsLink(props: LinkProps) {
   return (
     <Container border="primary" style={{borderWidth: 0, borderRightWidth: 1}}>
-      <Flex direction="column" gap="sm" padding="xl">
+      <Stack gap="sm" padding="xl">
         {flexProps => <InnerDetailsLink {...props} {...flexProps} />}
-      </Flex>
+      </Stack>
     </Container>
   );
 }
@@ -164,7 +164,7 @@ function Name(props: {children: React.ReactNode}) {
 function Details(props: {children: React.ReactNode}) {
   return (
     <IconDefaultsProvider size="xs">
-      <Flex direction="column" gap="xs" {...props} />
+      <Stack gap="xs" {...props} />
     </IconDefaultsProvider>
   );
 }

--- a/static/app/views/insights/uptime/components/percent.tsx
+++ b/static/app/views/insights/uptime/components/percent.tsx
@@ -1,5 +1,5 @@
 import {InfoText} from '@sentry/scraps/info';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Stack, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import type {TextProps} from '@sentry/scraps/text';
 
@@ -33,7 +33,7 @@ export function UptimePercent({summary, note, size}: UptimePercentProps) {
   const percent = Math.floor(percentFull * 1000) / 1000;
 
   const tooltip = (
-    <Flex direction="column" gap="md" style={{textAlign: 'left'}}>
+    <Stack gap="md" style={{textAlign: 'left'}}>
       {note}
       <Grid columns="max-content max-content max-content" gap="xs md">
         <span>
@@ -47,7 +47,7 @@ export function UptimePercent({summary, note, size}: UptimePercentProps) {
         <span>{t('Down Checks')}</span>
         <span>{formatAbbreviatedNumber(summary.downtimeChecks)}</span>
       </Grid>
-    </Flex>
+    </Stack>
   );
 
   return (

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -6,7 +6,7 @@ import * as qs from 'query-string';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Text} from '@sentry/scraps/text';
 
@@ -371,7 +371,7 @@ export default function IntegrationOrganizationLink() {
     return (
       <IntegrationFeatures organization={organization} features={featuresComponents}>
         {({disabled, disabledReason}) => (
-          <Flex direction="column" align="center" justify="center">
+          <Stack align="center" justify="center">
             <Button
               variant="primary"
               disabled={!hasAccess || disabled}
@@ -380,7 +380,7 @@ export default function IntegrationOrganizationLink() {
               {t('Install %s', provider.name)}
             </Button>
             {disabled && <IntegrationLayout.DisabledNotice reason={disabledReason} />}
-          </Flex>
+          </Stack>
         )}
       </IntegrationFeatures>
     );

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 
 import {bulkDelete, bulkUpdate} from 'sentry/actionCreators/group';
@@ -483,7 +483,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
           <Flex align="center" gap="md">
             <ResolvedWrapper>
               <IconCheckmark size="md" />
-              <Flex direction="column">
+              <Stack>
                 {isResolved ? resolvedCopyCap || t('Resolved') : t('Archived')}
                 <ReasonBanner>
                   {group.status === 'resolved' ? (
@@ -500,7 +500,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                       })
                     : null}
                 </ReasonBanner>
-              </Flex>
+              </Stack>
             </ResolvedWrapper>
 
             <Divider />

--- a/static/app/views/issueDetails/eventGraph.tsx
+++ b/static/app/views/issueDetails/eventGraph.tsx
@@ -5,7 +5,7 @@ import {mergeRefs, useResizeObserver} from '@react-aria/utils';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, type ButtonProps} from '@sentry/scraps/button';
-import {Flex, Grid, type FlexProps} from '@sentry/scraps/layout';
+import {Flex, Grid, type FlexProps, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {BarChart, type BarChartSeries} from 'sentry/components/charts/barChart';
@@ -586,22 +586,20 @@ function GraphButton({
 
   return (
     <CalloutButton aria-label={`${t('Toggle graph series')} - ${label}`} {...props}>
-      <Flex direction="column" gap="xs">
+      <Stack gap="xs">
         <Text size="sm" variant={textVariant}>
           {label}
         </Text>
         <Text size="lg" variant={textVariant}>
           {count ? formatAbbreviatedNumber(count) : '-'}
         </Text>
-      </Flex>
+      </Stack>
     </CalloutButton>
   );
 }
 
 function SummaryContainer(props: FlexProps) {
-  return (
-    <Flex padding="lg xs lg lg" direction="column" gap="sm" radius="md" {...props} />
-  );
+  return <Stack padding="lg xs lg lg" gap="sm" radius="md" {...props} />;
 }
 
 const CalloutButton = styled(Button)`

--- a/static/app/views/issueDetails/eventMissingBanner.tsx
+++ b/static/app/views/issueDetails/eventMissingBanner.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import compassImage from 'sentry-images/spot/onboarding-compass.svg';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import {MAX_PICKABLE_DAYS} from 'sentry/constants';
@@ -80,7 +80,7 @@ export function EventMissingBanner() {
     <Flex align="center" justify="center">
       <Flex align="center" gap="3xl">
         <img src={compassImage} alt="Compass illustration" height={122} />
-        <Flex justify="center" direction="column" gap="md">
+        <Stack justify="center" gap="md">
           <MainText>
             {tct("We couldn't track down [prep] event", {
               prep: isReservedEventId ? 'an' : 'that',
@@ -97,7 +97,7 @@ export function EventMissingBanner() {
               ))}
             </ul>
           </SubText>
-        </Flex>
+        </Stack>
       </Flex>
     </Flex>
   );

--- a/static/app/views/issueDetails/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/groupDetailsLayout.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -108,9 +108,8 @@ export function GroupDetailsLayout({
             >
               {tourProps => (
                 <div {...tourProps}>
-                  <Flex
+                  <Stack
                     as="section"
-                    direction="column"
                     background="secondary"
                     borderRight={{'2xs': 'none', lg: 'primary'}}
                     borderBottom={{'2xs': 'primary', lg: 'none'}}
@@ -124,7 +123,7 @@ export function GroupDetailsLayout({
                         </NavigationSidebarWrapper>
                       )}
                     <ContentPadding>{children}</ContentPadding>
-                  </Flex>
+                  </Stack>
                 </div>
               )}
             </SharedTourElement>

--- a/static/app/views/issueDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/issueDetails/groupMerged/mergedItem.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -91,7 +91,7 @@ export function MergedItem({
             </Flex>
           </Tooltip>
 
-          <Flex direction="column" gap="xs" minWidth={0}>
+          <Stack gap="xs" minWidth={0}>
             <Text size="md" data-issue-title-primary>
               {latestEvent.title}
             </Text>
@@ -131,7 +131,7 @@ export function MergedItem({
                 )}
               </Flex>
             )}
-          </Flex>
+          </Stack>
         </Flex>
 
         <Button

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {openDiffModal} from 'sentry/actionCreators/modal';
 import {Count} from 'sentry/components/count';
@@ -65,10 +65,10 @@ export function SimilarStackTraceItem({
     >
       <IssueCell>
         <Checkbox id={issue.id} value={issue.id} checked={checked} onChange={() => {}} />
-        <Flex direction="column" minWidth="0" flex="1">
+        <Stack minWidth="0" flex="1">
           <GroupHeaderRow data={issue} source="similar-issues" />
           <GroupMetaRow data={{...issue, lastSeen: ''}} />
-        </Flex>
+        </Stack>
       </IssueCell>
 
       <CenteredCell>
@@ -126,10 +126,10 @@ export function SimilarStackTraceItemSkeleton({
     <SimpleTable.Row>
       <IssueCell>
         <Placeholder height="16px" width="16px" />
-        <Flex direction="column" gap="xs" flex="1" minWidth="0">
+        <Stack gap="xs" flex="1" minWidth="0">
           <Placeholder height="16px" width="60%" />
           <Placeholder height="12px" width="40%" />
-        </Flex>
+        </Stack>
       </IssueCell>
       <CenteredCell>
         <Placeholder height="16px" width="32px" />

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -2,7 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
 
@@ -102,12 +102,12 @@ export function List({
           ))}
         {isError && (
           <SimpleTable.Empty>
-            <Flex direction="column" align="center" gap="sm">
+            <Stack align="center" gap="sm">
               <Text>{t("Couldn't load similar issues.")}</Text>
               <Button size="xs" onClick={onRetry}>
                 {t('Retry')}
               </Button>
-            </Flex>
+            </Stack>
           </SimpleTable.Empty>
         )}
         {isEmpty && <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>}

--- a/static/app/views/issueDetails/issuePreview/issuePreviewAutofix.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewAutofix.tsx
@@ -1,7 +1,7 @@
 import {useMemo} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {
   getOrderedAutofixSections,
@@ -40,10 +40,10 @@ export function IssuePreviewAutofix({group, project}: IssuePreviewAutofixProps) 
 
   if (aiConfig.isAutofixSetupLoading) {
     return (
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         <Placeholder height="10rem" />
         <Placeholder height="15rem" />
-      </Flex>
+      </Stack>
     );
   }
 
@@ -58,7 +58,7 @@ export function IssuePreviewAutofix({group, project}: IssuePreviewAutofixProps) 
   }
 
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <Flex justify="end" gap="xs">
         <Button
           size="xs"
@@ -80,6 +80,6 @@ export function IssuePreviewAutofix({group, project}: IssuePreviewAutofixProps) 
         />
       </Flex>
       <SeerDrawerContent group={group} autofix={autofix} aiConfig={aiConfig} />
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
+++ b/static/app/views/issueDetails/issuePreview/issuePreviewDrawer.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {DrawerBody, DrawerHeader} from '@sentry/scraps/drawer';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -102,7 +102,7 @@ function IssuePreviewContent() {
   return (
     <Fragment>
       <Container paddingBottom="lg" borderBottom="muted">
-        <Flex direction="column" gap="xs">
+        <Stack gap="xs">
           <div>
             <Tooltip
               title={primaryTitle}
@@ -122,7 +122,7 @@ function IssuePreviewContent() {
             />
           </div>
           <GroupStatusSubtitle group={group} project={project} />
-        </Flex>
+        </Stack>
       </Container>
       <Flex
         paddingTop="lg"

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
@@ -1,5 +1,5 @@
 import {Alert} from '@sentry/scraps/alert';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
@@ -129,7 +129,7 @@ function MetricIssueChartContent({
 
   return (
     <MetricChartSection>
-      <Flex direction="column" paddingTop="md">
+      <Stack paddingTop="md">
         {isRangeLimited ? (
           <Alert variant="warning">
             {t(
@@ -138,7 +138,7 @@ function MetricIssueChartContent({
           </Alert>
         ) : null}
         <AreaChart {...chartProps} />
-      </Flex>
+      </Stack>
     </MetricChartSection>
   );
 }

--- a/static/app/views/issueDetails/occurrenceSummary.tsx
+++ b/static/app/views/issueDetails/occurrenceSummary.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import {ScrollCarousel} from 'sentry/components/scrollCarousel';
@@ -39,35 +39,35 @@ function getEvidenceItem({
   switch (evidenceKey) {
     case KnownEvidence.ENVIRONMENT:
       return (
-        <Flex direction="column">
+        <Stack>
           <ItemTitle>{t('Environment')}</ItemTitle>
           <ItemValue>{evidence.value}</ItemValue>
-        </Flex>
+        </Stack>
       );
     case KnownEvidence.STATUS_CODE:
       return (
-        <Flex direction="column">
+        <Stack>
           <ItemTitle>{t('Status Code')}</ItemTitle>
           <ItemValue>{evidence.value}</ItemValue>
-        </Flex>
+        </Stack>
       );
     case KnownEvidence.FAILURE_REASON:
       return (
-        <Flex direction="column">
+        <Stack>
           <ItemTitle>{t('Reason')}</ItemTitle>
           <ItemValue>{evidence.value}</ItemValue>
-        </Flex>
+        </Stack>
       );
     case KnownEvidence.LAST_SUCCESSFUL_CHECK_IN:
       return (
-        <Flex direction="column">
+        <Stack>
           <ItemTitle>{t('Last Successful Check-In')}</ItemTitle>
           {moment(evidence.value).isValid() ? (
             <ItemTimeSince date={evidence.value} />
           ) : (
             <ItemValue>{evidence.value}</ItemValue>
           )}
-        </Flex>
+        </Stack>
       );
     default:
       return null;
@@ -91,12 +91,12 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
 
   if (issueTypeConfig.header.occurrenceSummary.downtime) {
     items.push(
-      <Flex direction="column">
+      <Stack>
         <ItemTitle>{t('Downtime')}</ItemTitle>
         <ItemValue>
           <DowntimeDuration group={group} />
         </ItemValue>
-      </Flex>
+      </Stack>
     );
   }
 
@@ -109,19 +109,19 @@ export function OccurrenceSummary({group, event, className}: OccurrenceSummaryPr
 
     if (detectorType === 'metric_alert' && detectorPath) {
       items.push(
-        <Flex direction="column">
+        <Stack>
           <ItemTitle>{t('Alert ID')}</ItemTitle>
           <ItemLink to={detectorPath}>{detectorId}</ItemLink>
-        </Flex>
+        </Stack>
       );
     }
 
     if (['cron_monitor', 'uptime_monitor'].includes(detectorType ?? '') && detectorPath) {
       items.push(
-        <Flex direction="column">
+        <Stack>
           <ItemTitle>{t('Monitor ID')}</ItemTitle>
           <ItemLink to={detectorPath}>{detectorId}</ItemLink>
-        </Flex>
+        </Stack>
       );
     }
   }

--- a/static/app/views/issueDetails/sidebar/attributeComparisonSection.tsx
+++ b/static/app/views/issueDetails/sidebar/attributeComparisonSection.tsx
@@ -3,7 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -131,7 +131,7 @@ export function AttributeComparisonSection({
         </LinkButton>
       }
     >
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <AttributeBreakdownsComponent.ControlsContainer>
           <AttributeBreakdownsComponent.StyledBaseSearchBar
             placeholder={t('Search attributes')}
@@ -182,7 +182,7 @@ export function AttributeComparisonSection({
         ) : (
           <AttributeBreakdownsComponent.EmptySearchState />
         )}
-      </Flex>
+      </Stack>
     </FoldSection>
   );
 }

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -201,7 +201,7 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
   if (organization.features.includes('seat-based-seer-enabled')) {
     if (needOrgSetup || needProjSetup) {
       return (
-        <Flex direction="column" border="muted" radius="md" padding="lg" gap="lg">
+        <Stack border="muted" radius="md" padding="lg" gap="lg">
           <Text bold>{t('Finish Configuring Seer')}</Text>
           <Text>
             {t(
@@ -237,7 +237,7 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
               </LinkButton>
             ) : null}
           </Flex>
-        </Flex>
+        </Stack>
       );
     }
   }
@@ -334,7 +334,7 @@ function AutofixPreviews({group, project, sections, referrer}: AutofixPreviewsPr
   });
 
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       {sections.map(section => {
         // there should only be 1 section of each type
         if (isRootCauseSection(section)) {
@@ -383,6 +383,6 @@ function AutofixPreviews({group, project, sections, referrer}: AutofixPreviewsPr
       >
         {t('Open Autofix')}
       </Button>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
+++ b/static/app/views/issueDetails/sidebar/externalIssueSidebarList.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -51,7 +51,7 @@ export function ExternalIssueSidebarList({event, group}: Props) {
       }
       sectionKey={SectionKey.EXTERNAL_ISSUES}
     >
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <ExternalIssueListContent
           integrations={externalIssueData.integrations}
           isLoading={externalIssueData.isLoading}
@@ -75,7 +75,7 @@ export function ExternalIssueSidebarList({event, group}: Props) {
             isLoading={externalIssueData.isLoading}
           />
         )}
-      </Flex>
+      </Stack>
     </SidebarFoldSection>
   );
 }

--- a/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
+++ b/static/app/views/issueDetails/sidebar/firstLastSeenSection.tsx
@@ -69,7 +69,7 @@ export function FirstLastSeenSection({event, group}: {group: Group; event?: Even
         : undefined;
 
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       <Stack>
         <Flex gap="xs" align="baseline">
           <Text bold>{t('Last seen')}</Text>
@@ -110,7 +110,7 @@ export function FirstLastSeenSection({event, group}: {group: Group; event?: Even
           />
         )}
       </Stack>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/issueDetails/sidebar/peopleSection.tsx
+++ b/static/app/views/issueDetails/sidebar/peopleSection.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 import type {TeamParticipant, UserParticipant} from 'sentry/types/group';
@@ -26,7 +26,7 @@ export function PeopleSection({
       title={<Title>{t('People')}</Title>}
       sectionKey={SectionKey.PEOPLE}
     >
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         {hasParticipants && (
           <Flex gap="xs" align="center">
             <ParticipantList
@@ -43,7 +43,7 @@ export function PeopleSection({
             {t('viewed')}
           </Flex>
         )}
-      </Flex>
+      </Stack>
     </SidebarFoldSection>
   );
 }

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -50,20 +50,19 @@ function PrimaryNavigationSidebar({children, ...props}: PrimaryNavigationSidebar
   const theme = useTheme();
 
   return (
-    <Flex
+    <Stack
       as="nav"
       aria-label={t('Primary Navigation')}
       width={`${PRIMARY_SIDEBAR_WIDTH}px`}
       padding="0"
       borderRight="primary"
       background="primary"
-      direction="column"
       align="center"
       style={{zIndex: theme.zIndex.sidebarPanel}}
       {...props}
     >
       {children}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -74,9 +73,8 @@ function PrimaryNavigationSidebarHeader(props: PrimaryNavigationSidebarHeaderPro
 
   return (
     <SizeProvider size="sm">
-      <Flex
+      <Stack
         as="header"
-        direction="column"
         align="center"
         justify="center"
         borderBottom="primary"
@@ -94,7 +92,7 @@ function PrimaryNavigationSidebarHeader(props: PrimaryNavigationSidebarHeaderPro
         {...props}
       >
         {props.children}
-      </Flex>
+      </Stack>
     </SizeProvider>
   );
 }
@@ -426,17 +424,16 @@ function PrimaryNavigationFooterItems(props: PrimaryNavigationFooterItemsProps) 
 
 const DesktopPageFrameNavigationLink = styled((props: LinkProps) => {
   return (
-    <Flex
+    <Stack
       position="relative"
       width="100%"
       align="center"
-      direction="column"
       justify="center"
       gap="xs"
       padding="xs xs md xs"
     >
       {p => <Link {...mergeProps(p, props)} />}
-    </Flex>
+    </Stack>
   );
 })`
   outline: none;

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -154,7 +154,7 @@ export function NewWelcomeUI(props: StepProps) {
                 </Text>
               </Stack>
             ) : (
-              <Flex direction="column" gap="sm" paddingBottom="2xl">
+              <Stack gap="sm" paddingBottom="2xl">
                 <Container>
                   <Heading as="h1" density="comfortable">
                     {t('Welcome to Sentry')}
@@ -165,7 +165,7 @@ export function NewWelcomeUI(props: StepProps) {
                     {t("Your code is probably broken. Let's fix it faster.")}
                   </Text>
                 </Container>
-              </Flex>
+              </Stack>
             )}
 
             {hasScmOnboarding ? null : (

--- a/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.tsx
+++ b/static/app/views/onboarding/components/scmMessagingIntegrationAlertRule.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 
 import {t} from 'sentry/locale';
@@ -50,7 +50,7 @@ export function ScmMessagingIntegrationAlertRule(props: IssueAlertNotificationPr
   }
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       {providerDetails[provider as keyof typeof providerDetails]?.makeSentence({
         providerName: (
           <FullWidthSelect
@@ -94,7 +94,7 @@ export function ScmMessagingIntegrationAlertRule(props: IssueAlertNotificationPr
           </ChannelField>
         ),
       })}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/onboarding/scmConnect.tsx
+++ b/static/app/views/onboarding/scmConnect.tsx
@@ -70,7 +70,7 @@ export function ScmConnect({
   const effectiveIntegration = selectedIntegration ?? activeIntegrationExisting;
 
   return (
-    <Flex direction="column" align="center" gap="3xl" flexGrow={1}>
+    <Stack align="center" gap="3xl" flexGrow={1}>
       <ScmStepHeader
         heading={t('Connect your code')}
         subtitle={t(
@@ -180,7 +180,7 @@ export function ScmConnect({
           </Flex>
         </MotionFlex>
       </LayoutGroup>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -170,7 +170,7 @@ export function ScmPlatformFeatures({
   }
 
   return (
-    <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
+    <Stack align="center" gap="2xl" flexGrow={1}>
       <Stack gap="3xl" maxWidth={SCM_STEP_CONTENT_WIDTH}>
         <Heading as="h2" size="4xl">
           {t('Create your first project')}
@@ -232,7 +232,7 @@ export function ScmPlatformFeatures({
           </MotionFlex>
         </LayoutGroup>
       </Stack>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -74,7 +74,7 @@ export function ScmProjectDetails({
   });
 
   return (
-    <Flex direction="column" align="center" gap="2xl" flexGrow={1}>
+    <Stack align="center" gap="2xl" flexGrow={1}>
       <ScmStepHeader
         heading={t('Project details')}
         subtitle={t(
@@ -114,6 +114,6 @@ export function ScmProjectDetails({
           </Button>
         </Flex>
       </GenericFooter>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/organizationLayout/body.tsx
+++ b/static/app/views/organizationLayout/body.tsx
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import organizationDeletionIllustration from 'sentry-images/organizationDeletion.svg';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -25,8 +25,7 @@ type BodyProps = {
 
 function DeletionInProgress({organization}: OrganizationProps) {
   return (
-    <Flex
-      direction="column"
+    <Stack
       align="center"
       justify="center"
       minHeight="100dvh"
@@ -37,8 +36,7 @@ function DeletionInProgress({organization}: OrganizationProps) {
         backgroundRepeat: 'no-repeat',
       }}
     >
-      <Flex
-        direction="column"
+      <Stack
         align="start"
         gap="md"
         maxWidth="580px"
@@ -63,8 +61,8 @@ function DeletionInProgress({organization}: OrganizationProps) {
             )}
           </Text>
         </Stack>
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -93,8 +91,7 @@ function DeletionPending({organization}: OrganizationProps) {
   };
 
   return (
-    <Flex
-      direction="column"
+    <Stack
       align="center"
       justify="center"
       minHeight="100dvh"
@@ -105,8 +102,7 @@ function DeletionPending({organization}: OrganizationProps) {
         backgroundRepeat: 'no-repeat',
       }}
     >
-      <Flex
-        direction="column"
+      <Stack
         align="start"
         gap="md"
         maxWidth="580px"
@@ -129,11 +125,11 @@ function DeletionPending({organization}: OrganizationProps) {
           </Text>
 
           {organization.access.includes('org:admin') && (
-            <Flex direction="column" gap="sm" paddingTop="xl">
+            <Stack gap="sm" paddingTop="xl">
               <Button variant="primary" onClick={onRestore} disabled={isRestoring}>
                 {t('Restore Organization')}
               </Button>
-            </Flex>
+            </Stack>
           )}
 
           <Text as="p" size="sm" variant="muted">
@@ -142,8 +138,8 @@ function DeletionPending({organization}: OrganizationProps) {
             )}
           </Text>
         </Stack>
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useMemo, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
-import {Flex, type FlexProps} from '@sentry/scraps/layout';
+import {Stack, type FlexProps} from '@sentry/scraps/layout';
 
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -272,10 +272,9 @@ const TraceViewImpl = registerLLMContext('trace', TraceViewImplInner);
 
 function TraceInnerLayout(props: FlexProps) {
   return (
-    <Flex
+    <Stack
       {...props}
       background="primary"
-      direction="column"
       gap="md"
       paddingLeft="xl"
       paddingRight="xl"

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
@@ -60,15 +60,14 @@ function XmlTagBlock({
   }
 
   return (
-    <Flex
-      direction="column"
+    <Stack
       padding="0 0 0 md"
       margin="sm 0"
       style={{borderLeft: `2px solid ${theme.tokens.border.primary}`}}
     >
       <Container margin="0 0 xs 0">{label}</Container>
       {body}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -192,7 +192,7 @@ export function SpanDescription({
         )}
       </Stack>
     ) : resolvedModule === ModuleName.HTTP && span.op === 'http.client' && spanURL ? (
-      <Flex direction="column" width="100%">
+      <Stack width="100%">
         <Flex align="start" justify="between" gap="xs" padding="md">
           <Flex align="start" paddingLeft="md" paddingTop="sm" paddingBottom="sm">
             <Flex gap="xs">
@@ -220,7 +220,7 @@ export function SpanDescription({
             }}
           />
         )}
-      </Flex>
+      </Stack>
     ) : resolvedModule === ModuleName.RESOURCE && span.op === 'resource.img' ? (
       <ResourceImageDescription
         formattedDescription={formattedDescription}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 
 import {EmptyMessage} from 'sentry/components/emptyMessage';
@@ -121,7 +121,7 @@ export function TraceAiConversations({
 
   return (
     <Container flex="1" minHeight="0" border="primary" radius="md" overflow="hidden">
-      <Flex direction="column" height="100%">
+      <Stack height="100%">
         {activeConversationId && (
           <TraceConversationHeader
             conversationId={activeConversationId}
@@ -178,7 +178,7 @@ export function TraceAiConversations({
             )}
           </FullHeightTabPanels>
         </StyledTabs>
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -13,7 +13,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import * as qs from 'query-string';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -683,7 +683,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
   }
 
   return (
-    <Flex direction="column" flex={1}>
+    <Stack flex={1}>
       <Flex gap="md">
         <TraceSearchInput onTraceSearch={onTraceSearch} />
         <TraceLinksNavigation
@@ -761,7 +761,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
           onTabScrollToNode={onTabScrollToNode}
         />
       </TraceGrid>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildComparison/main/buildItem.tsx
+++ b/static/app/views/preprod/buildComparison/main/buildItem.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
@@ -105,7 +105,7 @@ function BuildItemDetails({
   const versionInfo = formatVersionInfo(version, buildNumber);
 
   return (
-    <Flex direction="column" gap="sm" flex={1}>
+    <Stack gap="sm" flex={1}>
       {(hasGitInfo || versionInfo) && (
         <Flex align="center" gap="md">
           {(prNumber || branchName) && <IconBranch size="xs" variant="muted" />}
@@ -160,7 +160,7 @@ function BuildItemDetails({
           </Flex>
         )}
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/fileInsightDiffTable.tsx
@@ -114,7 +114,7 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
 
   let rowIndex = 0;
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <DiffTableWithColumns gridTemplateColumns="150px minmax(200px, 3fr) 180px">
         <DiffTableHeader>
           {tableHeaders.map(header => (
@@ -224,6 +224,6 @@ export function FileInsightItemDiffTable({fileDiffItems}: FileInsightItemDiffTab
           </ButtonBar>
         </Flex>
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/groupInsightDiffTable.tsx
@@ -167,7 +167,7 @@ export function GroupInsightItemDiffTable({
 
   let rowIndex = 0;
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <DiffTableWithColumns gridTemplateColumns="150px minmax(200px, 3fr) 180px">
         <DiffTableHeader>
           {tableHeaders.map(header => (
@@ -287,6 +287,6 @@ export function GroupInsightItemDiffTable({
           </ButtonBar>
         </Flex>
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
@@ -2,7 +2,7 @@ import {useMemo, useState} from 'react';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
@@ -58,9 +58,9 @@ export function InsightDiffRow({
 
   return (
     <Container background="primary" radius="lg" padding="0" border="primary">
-      <Flex direction="column" gap="0">
+      <Stack gap="0">
         <Flex align="center" justify="between" padding="xl">
-          <Flex direction="column" gap="xs" flex={1}>
+          <Stack gap="xs" flex={1}>
             <Flex align="center" gap="sm" justify="between">
               <Flex align="center" gap="sm">
                 <Heading as="h3">{config.name}</Heading>
@@ -82,7 +82,7 @@ export function InsightDiffRow({
               </Flex>
 
               <Flex align="center" gap="sm">
-                <Flex direction="column" align="end" gap="xs">
+                <Stack align="end" gap="xs">
                   <Text>
                     {t(
                       'Potential savings: %s',
@@ -95,7 +95,7 @@ export function InsightDiffRow({
                       {totalSavingsChangePercentage}%)
                     </Text>
                   </Text>
-                </Flex>
+                </Stack>
                 <Button
                   variant="transparent"
                   size="sm"
@@ -115,10 +115,10 @@ export function InsightDiffRow({
             <Text size="sm" variant="muted">
               {config.description}
             </Text>
-          </Flex>
+          </Stack>
         </Flex>
         {isExpanded ? children : null}
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -137,7 +137,7 @@ export function SizeCompareItemDiffTable({
   };
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <DiffTableWithColumns gridTemplateColumns="150px minmax(200px, 3fr) 120px 120px 120px">
         <DiffTableHeader>
           {tableHeaders.map(header => (
@@ -274,6 +274,6 @@ export function SizeCompareItemDiffTable({
           </ButtonBar>
         </Flex>
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -169,14 +169,13 @@ export function SizeCompareMainContent() {
 
   if (sizeComparisonQuery.isLoading || comparisonDataQuery.isLoading || isComparing) {
     return (
-      <Flex
-        direction="column"
+      <Stack
         align="center"
         justify="center"
         style={{minHeight: '60vh', padding: theme.space.md}}
       >
         <LoadingIndicator />
-      </Flex>
+      </Stack>
     );
   }
 
@@ -277,7 +276,7 @@ export function SizeCompareMainContent() {
   }
 
   return (
-    <Flex direction="column" gap="2xl">
+    <Stack gap="2xl">
       <SizeCompareSelectedBuilds
         headBuildDetails={sizeComparisonQuery.data.head_build_details}
         baseBuildDetails={sizeComparisonQuery.data.base_build_details}
@@ -314,7 +313,7 @@ export function SizeCompareMainContent() {
 
       {/* Items Changed Section */}
       <Container background="primary" radius="lg" padding="0" border="primary">
-        <Flex direction="column" gap="0">
+        <Stack gap="0">
           <Flex align="center" justify="between" padding="xl">
             <Flex align="center">
               <Button
@@ -387,7 +386,7 @@ export function SizeCompareMainContent() {
               />
             </Stack>
           )}
-        </Flex>
+        </Stack>
       </Container>
 
       {/* Treemap Diff Section */}
@@ -401,6 +400,6 @@ export function SizeCompareMainContent() {
             </Stack>
           </Stack>
         )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconClose, IconCommit, IconFocus, IconLock, IconTelescope} from 'sentry/icons';
@@ -81,7 +81,7 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
     >
       <ContentWrapper>
         <ClippedContent>
-          <Flex direction="column" gap="xs">
+          <Stack gap="xs">
             <Flex align="center" gap="sm">
               {icon}
               <Text size="sm" variant="accent" bold>
@@ -113,7 +113,7 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
                 {metadataParts.join(' • ')}
               </Text>
             </Flex>
-          </Flex>
+          </Stack>
         </ClippedContent>
         {onRemove && (
           <CloseButtonWrapper>

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
@@ -82,18 +82,12 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
   // might be able to show the release breadcrumb
   if (isBuildDetailsPending) {
     return (
-      <Flex direction="column" padding="0 0 xl 0">
-        {/* Empty header space - no skeleton content */}
-      </Flex>
+      <Stack padding="0 0 xl 0">{/* Empty header space - no skeleton content */}</Stack>
     );
   }
 
   if (isBuildDetailsError || !buildDetailsData) {
-    return (
-      <Flex direction="column" padding="0 0 xl 0">
-        {/* Empty header space during error */}
-      </Flex>
-    );
+    return <Stack padding="0 0 xl 0">{/* Empty header space during error */}</Stack>;
   }
 
   const project = ProjectsStore.getBySlug(projectSlug);

--- a/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/alternativeIconsInsightInfoModal.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {openInsightInfoModal} from 'sentry/actionCreators/modal';
@@ -65,7 +65,7 @@ function AlternativeIconsContent() {
         </CodeBlock>
       </CodeBlockWrapper>
 
-      <Flex direction="column" gap="sm">
+      <Stack gap="sm">
         <Heading as="h3" size="md">
           {t('How to use:')}
         </Heading>
@@ -87,7 +87,7 @@ function AlternativeIconsContent() {
             </Text>
           </li>
         </ol>
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsights.tsx
@@ -2,7 +2,7 @@ import {useCallback} from 'react';
 import {useSearchParams} from 'react-router-dom';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconSettings} from 'sentry/icons';
@@ -71,8 +71,7 @@ export function AppSizeInsights({
           </Button>
         )}
       </Flex>
-      <Flex
-        direction="column"
+      <Stack
         gap="2xs"
         css={theme => ({
           '& > :nth-child(odd)': {
@@ -124,7 +123,7 @@ export function AppSizeInsights({
             </Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
 
       <AppSizeInsightsSidebar
         processedInsights={processedInsights}

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebar.tsx
@@ -4,7 +4,7 @@ import {AnimatePresence} from 'framer-motion';
 
 import {Backdrop} from '@sentry/scraps/backdrop';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
 import {Heading} from '@sentry/scraps/text';
 
@@ -92,7 +92,7 @@ export function AppSizeInsightsSidebar({
           panelWidth={`${constrainedWidth}px`}
           ariaLabel={t('App size insights details')}
         >
-          <Flex height="100%" direction="column">
+          <Stack height="100%">
             <Header padding="xl" align="center" justify="between">
               <Flex align="center" gap="sm">
                 <Heading as="h2" size="xl">
@@ -124,7 +124,7 @@ export function AppSizeInsightsSidebar({
               </ResizeHandle>
 
               <Flex flex={1} overflowY="auto" padding="xl">
-                <Flex direction="column" gap="xl" width="100%">
+                <Stack gap="xl" width="100%">
                   {processedInsights.map(insight => {
                     const isGroupedInsight =
                       insight.key === 'duplicate_files' || insight.key === 'loose_images';
@@ -140,10 +140,10 @@ export function AppSizeInsightsSidebar({
                       />
                     );
                   })}
-                </Flex>
+                </Stack>
               </Flex>
             </Flex>
-          </Flex>
+          </Stack>
         </SlideOverPanel>
       )}
     </Fragment>

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -131,7 +131,7 @@ export function AppSizeInsightsSidebarRow({
   };
 
   return (
-    <Flex border="muted" radius="md" padding="xl" direction="column" gap="md">
+    <Stack border="muted" radius="md" padding="xl" gap="md">
       <Flex align="start" justify="between">
         <Flex align="center" gap="xs">
           <Text variant="primary" size="md" bold>
@@ -228,7 +228,7 @@ export function AppSizeInsightsSidebarRow({
           )}
         </Container>
       )}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -286,7 +286,7 @@ function DuplicateGroupFileRow({
           -{formatBytesBase10(file.savings)}
         </Text>
       </Flex>
-      <Flex direction="column" gap="xs" padding="xs sm">
+      <Stack gap="xs" padding="xs sm">
         <Collapsible
           maxVisibleItems={DUPLICATE_GROUP_VISIBLE_FILE_COUNT}
           expandButton={({onExpand, numberOfHiddenItems}) => (
@@ -317,7 +317,7 @@ function DuplicateGroupFileRow({
             </Flex>
           ))}
         </Collapsible>
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }
@@ -347,13 +347,13 @@ function OptimizableImageFileRow({
     (originalFile.idiom || originalFile.colorspace) && file.data.isDuplicateVariant;
   // TODO (EME-460): Add link to formal documentation about idiom/colorspaces in apple binaries as well as more info about app thinning
   const tooltipContent = hasMetadata && (
-    <Flex direction="column" gap="lg" align="start">
+    <Stack gap="lg" align="start">
       <Text size="xs" align="left">
         {t(
           'This image shows up multiple times because this build likely did not have app thinning applied. That means your asset catalog can include different copies of the same image meant for different device types.'
         )}
       </Text>
-      <Flex direction="column" gap="xs" align="start">
+      <Stack gap="xs" align="start">
         {originalFile.idiom && (
           <Flex align="center" gap="xs">
             <Text size="xs">{t('Idiom:')}</Text>
@@ -366,8 +366,8 @@ function OptimizableImageFileRow({
             <Text size="xs">{originalFile.colorspace}</Text>
           </Flex>
         )}
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   );
 
   return (
@@ -399,7 +399,7 @@ function OptimizableImageFileRow({
           </Text>
         </Flex>
       </Flex>
-      <Flex direction="column" gap="xs" padding="xs sm">
+      <Stack gap="xs" padding="xs sm">
         {hasMinifySavings && (
           <Flex align="center" gap="sm">
             <Text size="xs" variant="muted" style={{minWidth: '100px'}}>
@@ -432,7 +432,7 @@ function OptimizableImageFileRow({
             </Text>
           </Flex>
         )}
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/app/views/preprod/buildDetails/main/insights/mainBinaryExportedSymbolsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/mainBinaryExportedSymbolsModal.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {openInsightInfoModal} from 'sentry/actionCreators/modal';
@@ -7,9 +7,9 @@ import {InlineCode} from 'sentry/views/preprod/buildDetails/main/insights/insigh
 
 function getMainBinaryExportedSymbolsContent() {
   return (
-    <Flex direction="column" gap="2xl">
-      <Flex direction="column" gap="xl">
-        <Flex direction="column" gap="md">
+    <Stack gap="2xl">
+      <Stack gap="xl">
+        <Stack gap="md">
           <Text>
             {t(
               'Binaries that act as entrypoints for your app, such as your main app binary or watchOS app binary, are not linked against by other binaries. This means the export trie information is unnecessary and can be removed.'
@@ -20,9 +20,9 @@ function getMainBinaryExportedSymbolsContent() {
               'You can maintain a minimal allowlist so only required entry points stay exported:'
             )}
           </Text>
-        </Flex>
+        </Stack>
 
-        <Flex direction="column" gap="md">
+        <Stack gap="md">
           <ol>
             <li>
               <Text>
@@ -58,9 +58,9 @@ function getMainBinaryExportedSymbolsContent() {
             </li>
           </ol>
           <Text>{t('Xcode will now limit the export trie to just that allowlist.')}</Text>
-        </Flex>
-      </Flex>
-    </Flex>
+        </Stack>
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/minifyLocalizedStringsModal.tsx
@@ -1,5 +1,5 @@
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -39,15 +39,15 @@ for root, _, files in os.walk(os.environ["BUILT_PRODUCTS_DIR"], followlinks=True
 
 function getMinifyLocalizedStringsContent() {
   return (
-    <Flex direction="column" gap="2xl">
+    <Stack gap="2xl">
       <Text>
         {t(
           'Xcode localized string bundles often ship with translator comments, whitespace, and legacy encodings that the runtime never reads. Trimming that excess reduces download size without touching what users see.'
         )}
       </Text>
 
-      <Flex direction="column" gap="xl">
-        <Flex direction="column" gap="md">
+      <Stack gap="xl">
+        <Stack gap="md">
           <Heading as="h3" size="md">
             {t('Option 1: Keep the format lean')}
           </Heading>
@@ -62,9 +62,9 @@ function getMinifyLocalizedStringsContent() {
               }
             )}
           </Text>
-        </Flex>
+        </Stack>
 
-        <Flex direction="column" gap="md">
+        <Stack gap="md">
           <Heading as="h3" size="md">
             {t('Option 2: Strip comments automatically')}
           </Heading>
@@ -125,9 +125,9 @@ function getMinifyLocalizedStringsContent() {
               'This script strips comments and blank lines after the files are generated, so keep the original annotated copies under version control for translators.'
             )}
           </Text>
-        </Flex>
-      </Flex>
-    </Flex>
+        </Stack>
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {openInsightInfoModal} from 'sentry/actionCreators/modal';
@@ -29,15 +29,15 @@ cwebp -lossless input.jpg -o output.webp`;
 
 function getOptimizeImagesContent(platform?: Platform): ReactNode {
   return platform === 'android' ? (
-    <Flex direction="column" gap="2xl">
+    <Stack gap="2xl">
       <Text>
         {t(
           'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We find all PNG or JPEG files in your resources or assets directory and compare them to lossless WebP versions. If there is a size reduction, we will recommend using WebP.'
         )}
       </Text>
 
-      <Flex direction="column" gap="xl">
-        <Flex direction="column" gap="sm">
+      <Stack gap="xl">
+        <Stack gap="sm">
           <Heading as="h3" size="md">
             {t('Option 1: Use Android Studio')}
           </Heading>
@@ -46,9 +46,9 @@ function getOptimizeImagesContent(platform?: Platform): ReactNode {
               'Right-click an image in Android Studio, select "Convert to WebP", and choose lossless conversion.'
             )}
           </Text>
-        </Flex>
+        </Stack>
 
-        <Flex direction="column" gap="sm">
+        <Stack gap="sm">
           <Heading as="h3" size="md">
             {t('Option 2: Use cwebp (Command-line)')}
           </Heading>
@@ -57,25 +57,25 @@ function getOptimizeImagesContent(platform?: Platform): ReactNode {
               {ANDROID_CWEBP_SCRIPT}
             </CodeBlock>
           </CodeBlockWrapper>
-        </Flex>
+        </Stack>
 
         <Text variant="muted" size="sm">
           {t(
             'Note: Based on minSdkVersion >= 18, lossless WebP is recommended. For versions < 18, assets with alpha channels are skipped.'
           )}
         </Text>
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   ) : (
-    <Flex direction="column" gap="2xl">
+    <Stack gap="2xl">
       <Text>
         {t(
           'We find all large images in your app and determine if their size could be reduced or updated to more optimized image formats. We will show an optimized image insight for any image whose size can be reduced by more than 4KB through lossy compression or converted to HEIC format (for apps targeting iOS 12 or later).'
         )}
       </Text>
 
-      <Flex direction="column" gap="xl">
-        <Flex direction="column" gap="sm">
+      <Stack gap="xl">
+        <Stack gap="sm">
           <Heading as="h3" size="md">
             {t('Option 1: Use Imagemin (Command-line)')}
           </Heading>
@@ -84,9 +84,9 @@ function getOptimizeImagesContent(platform?: Platform): ReactNode {
               {IOS_IMAGEMIN_SCRIPT}
             </CodeBlock>
           </CodeBlockWrapper>
-        </Flex>
+        </Stack>
 
-        <Flex direction="column" gap="sm">
+        <Stack gap="sm">
           <Heading as="h3" size="md">
             {t('Option 2: Use ImageOptim (GUI)')}
           </Heading>
@@ -95,9 +95,9 @@ function getOptimizeImagesContent(platform?: Platform): ReactNode {
               'Download ImageOptim for Mac, drag and drop your images to compress them with lossy compression.'
             )}
           </Text>
-        </Flex>
+        </Stack>
 
-        <Flex direction="column" gap="sm">
+        <Stack gap="sm">
           <Heading as="h3" size="md">
             {t('Option 3: Convert to HEIC')}
           </Heading>
@@ -106,9 +106,9 @@ function getOptimizeImagesContent(platform?: Platform): ReactNode {
               'Open the image in Preview, choose File → Export, then select HEIC from the format dropdown.'
             )}
           </Text>
-        </Flex>
-      </Flex>
-    </Flex>
+        </Stack>
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildDetails/main/insights/stripDebugSymbolsModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/stripDebugSymbolsModal.tsx
@@ -1,6 +1,6 @@
 import {Alert} from '@sentry/scraps/alert';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {openInsightInfoModal} from 'sentry/actionCreators/modal';
@@ -33,7 +33,7 @@ const DSYM_INPUT_FILE =
 
 function getStripDebugSymbolsContent() {
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <Alert variant="warning">
         {t(
           'Stripping symbols before creating a dSYM breaks crash symbolication. Confirm your release build still produces and uploads dSYMs before stripping.'
@@ -78,7 +78,7 @@ function getStripDebugSymbolsContent() {
           {DSYM_INPUT_FILE}
         </CodeBlock>
       </CodeBlockWrapper>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
 import {CodeBlock} from '@sentry/scraps/code';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -35,7 +35,7 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
   });
 
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       <Flex align="center" gap="sm">
         {props.appInfo.name && (
           <Fragment>
@@ -130,7 +130,7 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
           </Tooltip>
         )}
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {Placeholder} from 'sentry/components/placeholder';
 import {BuildDetailsSidebarAppInfo} from 'sentry/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo';
@@ -30,7 +30,7 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
   }
 
   return (
-    <Flex direction="column" gap="2xl">
+    <Stack gap="2xl">
       <BuildDetailsSidebarAppInfo
         appInfo={buildDetailsData.app_info}
         projectId={projectId}
@@ -46,16 +46,16 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
       )}
 
       <BuildVcsInfo buildDetailsData={buildDetailsData} />
-    </Flex>
+    </Stack>
   );
 }
 
 function SidebarLoadingSkeleton(props: {['data-testid']: string}) {
   const theme = useTheme();
   return (
-    <Flex direction="column" gap="2xl" {...props}>
+    <Stack gap="2xl" {...props}>
       {/* App info skeleton - matches BuildDetailsSidebarAppInfo structure */}
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         {/* App icon and name */}
         <Flex align="center" gap="sm">
           <Placeholder width="40px" height="40px" style={{borderRadius: '8px'}} />
@@ -63,7 +63,7 @@ function SidebarLoadingSkeleton(props: {['data-testid']: string}) {
         </Flex>
 
         {/* Additional info */}
-        <Flex direction="column" gap="xs">
+        <Stack gap="xs">
           <Flex align="center" gap="xs">
             <Placeholder width="16px" height="16px" />
             <Placeholder width="100px" height="16px" />
@@ -72,11 +72,11 @@ function SidebarLoadingSkeleton(props: {['data-testid']: string}) {
             <Placeholder width="16px" height="16px" />
             <Placeholder width="120px" height="16px" />
           </Flex>
-        </Flex>
+        </Stack>
 
         {/* Install button */}
         <Placeholder width="80px" height="32px" style={{borderRadius: '4px'}} />
-      </Flex>
+      </Stack>
 
       {/* VCS info skeleton - matches KeyValueData.Card structure */}
       <SkeletonCard>
@@ -85,7 +85,7 @@ function SidebarLoadingSkeleton(props: {['data-testid']: string}) {
           height="18px"
           style={{marginBottom: theme.space['2xl']}}
         />
-        <Flex direction="column" gap="md">
+        <Stack gap="md">
           <Flex justify="between">
             <Placeholder width="40px" height="14px" />
             <Placeholder width="100px" height="14px" />
@@ -110,9 +110,9 @@ function SidebarLoadingSkeleton(props: {['data-testid']: string}) {
             <Placeholder width="80px" height="14px" />
             <Placeholder width="140px" height="14px" />
           </Flex>
-        </Flex>
+        </Stack>
       </SkeletonCard>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx
@@ -1,5 +1,5 @@
 import {Alert} from '@sentry/scraps/alert';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -40,7 +40,7 @@ export function BuildDetailsSidebarStatusCheck({
     const errorMessage = getErrorMessage(statusCheck.error_type, providerName);
     return (
       <Alert variant="muted" showIcon={false}>
-        <Flex direction="column" gap="sm">
+        <Stack gap="sm">
           <Flex align="center" gap="xs">
             <IconWarning size="xs" variant="danger" />
             <Text size="sm" bold>
@@ -55,7 +55,7 @@ export function BuildDetailsSidebarStatusCheck({
               {t('View CI setup docs')}
             </ExternalLink>
           </Text>
-        </Flex>
+        </Stack>
       </Alert>
     );
   }

--- a/static/app/views/preprod/components/buildError.tsx
+++ b/static/app/views/preprod/components/buildError.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import Missing from 'sentry-images/missing.png';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 interface BuildErrorProps {
@@ -13,23 +13,16 @@ interface BuildErrorProps {
 
 export function BuildError({title, message, children}: BuildErrorProps) {
   return (
-    <Flex
-      direction="column"
-      align="center"
-      justify="center"
-      gap="xl"
-      padding="md"
-      minHeight="60vh"
-    >
-      <Flex maxWidth="500px" direction="column" align="center" gap="md" padding="md">
+    <Stack align="center" justify="center" gap="xl" padding="md" minHeight="60vh">
+      <Stack maxWidth="500px" align="center" gap="md" padding="md">
         <AlertImage src={Missing} alt="Error image" />
         <Heading as="h2" align="center">
           {title}
         </Heading>
         <Text align="center">{message}</Text>
-      </Flex>
+      </Stack>
       {children}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/components/buildProcessing.tsx
+++ b/static/app/views/preprod/components/buildProcessing.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconSettings} from 'sentry/icons';
@@ -13,8 +13,7 @@ interface BuildProcessingProps {
 
 export function BuildProcessing({title, message, children}: BuildProcessingProps) {
   return (
-    <Flex
-      direction="column"
+    <Stack
       align="center"
       justify="center"
       gap="xl"
@@ -22,12 +21,12 @@ export function BuildProcessing({title, message, children}: BuildProcessingProps
       minHeight="60vh"
       maxWidth="500px"
     >
-      <Flex direction="column" align="center" gap="md">
+      <Stack align="center" gap="md">
         <Heading as="h2" align="center">
           {title}
         </Heading>
         <Text align="center">{message}</Text>
-      </Flex>
+      </Stack>
       <Flex align="center" justify="center">
         <RotatingIcon>
           <IconSettings size="2xl" />
@@ -37,7 +36,7 @@ export function BuildProcessing({title, message, children}: BuildProcessingProps
         </RotatingIconReverse>
       </Flex>
       {children}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/components/buildVcsInfo.tsx
+++ b/static/app/views/preprod/components/buildVcsInfo.tsx
@@ -1,5 +1,5 @@
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -168,7 +168,7 @@ export function BuildVcsInfo({buildDetailsData}: BuildVcsInfoProps) {
       width="100%"
       marginBottom={{'screen:xs': 'lg', 'screen:lg': '0'}}
     >
-      <Flex direction="column" gap="sm">
+      <Stack gap="sm">
         <Text bold>{t('Missing Git metadata')}</Text>
         <Text variant="muted" size="sm">
           {t('Integrate with CI to automate uploading, diffing, and alerting')}
@@ -180,7 +180,7 @@ export function BuildVcsInfo({buildDetailsData}: BuildVcsInfoProps) {
         >
           {t('View CI setup docs')}
         </LinkButton>
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -95,7 +95,7 @@ export function InstallDetailsContent({
   );
 
   const distributionDisabledBody = (
-    <Flex direction="column" align="center" gap={outerGap}>
+    <Stack align="center" gap={outerGap}>
       <Text>{t('Build distribution is not enabled')}</Text>
       <Text size="sm" variant="muted" align="center">
         {tct(
@@ -109,16 +109,16 @@ export function InstallDetailsContent({
           }
         )}
       </Text>
-    </Flex>
+    </Stack>
   );
 
   let body: ReactNode;
   if (isPending) {
     body = (
-      <Flex direction="column" align="center" gap={outerGap}>
+      <Stack align="center" gap={outerGap}>
         <LoadingIndicator />
         <Text>{t('Loading install details...')}</Text>
-      </Flex>
+      </Stack>
     );
   } else if (isError || !installDetails) {
     if (error?.status === 404) {
@@ -132,24 +132,24 @@ export function InstallDetailsContent({
           ? getDistributionErrorTooltip(distributionErrorCode, distributionErrorMessage)
           : t('No install download link available');
         body = (
-          <Flex direction="column" align="center" gap={outerGap}>
+          <Stack align="center" gap={outerGap}>
             <Text>{message}</Text>
-          </Flex>
+          </Stack>
         );
       }
     } else {
       body = (
-        <Flex direction="column" align="center" gap={outerGap}>
+        <Stack align="center" gap={outerGap}>
           <Text>
             {t('Error: %s', error?.message || 'Failed to fetch install details')}
           </Text>
           <Button onClick={() => refetch()}>{t('Retry')}</Button>
-        </Flex>
+        </Stack>
       );
     }
   } else if (installDetails.codesigning_type === 'appstore') {
     body = (
-      <Flex direction="column" align="center" gap={outerGap}>
+      <Stack align="center" gap={outerGap}>
         <CodeSignatureInfo>
           <Text>{t('This app cannot be installed')}</Text>
           <br />
@@ -162,7 +162,7 @@ export function InstallDetailsContent({
             )}
           </Text>
         </CodeSignatureInfo>
-      </Flex>
+      </Stack>
     );
   } else if (installDetails.install_url) {
     const details = installDetails.is_code_signature_valid !== undefined && (
@@ -182,7 +182,7 @@ export function InstallDetailsContent({
     );
 
     body = (
-      <Flex direction="column" align="center" gap={outerGap} width="100%">
+      <Stack align="center" gap={outerGap} width="100%">
         <Fragment>
           <Stack align="center" gap="md">
             {installDetails.download_count !== undefined &&
@@ -204,13 +204,13 @@ export function InstallDetailsContent({
             </Container>
             {details}
             <Container display={{'screen:xs': 'none', 'screen:sm': 'block'}}>
-              <Flex direction="column" maxWidth="300px" gap="xl" paddingTop="xl">
+              <Stack maxWidth="300px" gap="xl" paddingTop="xl">
                 <Text align="center" size="lg">
                   {t(
                     'Scan the QR code with your device and follow the installation prompts'
                   )}
                 </Text>
-              </Flex>
+              </Stack>
             </Container>
           </Stack>
           <Container display={{'screen:xs': 'none', 'screen:sm': 'block'}} width="100%">
@@ -292,7 +292,7 @@ export function InstallDetailsContent({
             </Text>
           </Stack>
           {installGroups && installGroups.length > 0 && (
-            <Flex direction="column" gap="md" width="100%">
+            <Stack gap="md" width="100%">
               <Heading as="h3">{t('Install Groups')}</Heading>
               <Container
                 padding="xl"
@@ -309,10 +309,10 @@ export function InstallDetailsContent({
                   ))}
                 </Flex>
               </Container>
-            </Flex>
+            </Stack>
           )}
           {installDetails.release_notes && (
-            <Flex direction="column" gap="md" width="100%">
+            <Stack gap="md" width="100%">
               <Heading as="h3">{t('Release Notes')}</Heading>
               <Container
                 padding="xl"
@@ -323,10 +323,10 @@ export function InstallDetailsContent({
               >
                 <MarkedText text={installDetails.release_notes} />
               </Container>
-            </Flex>
+            </Stack>
           )}
         </Fragment>
-      </Flex>
+      </Stack>
     );
   } else if (distributionErrorCode === 'distribution_disabled') {
     body = distributionDisabledBody;
@@ -344,7 +344,7 @@ export function InstallDetailsContent({
     }
 
     body = (
-      <Flex direction="column" align="center" gap={outerGap}>
+      <Stack align="center" gap={outerGap}>
         <Text>{message}</Text>
         {installDetails.code_signature_errors &&
           installDetails.code_signature_errors.length > 0 && (
@@ -356,7 +356,7 @@ export function InstallDetailsContent({
               </Stack>
             </CodeSignatureInfo>
           )}
-      </Flex>
+      </Stack>
     );
   }
 

--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -1,7 +1,7 @@
 import {css} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Stack, Grid} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -17,7 +17,7 @@ interface InstallModalProps {
 
 function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) {
   return (
-    <Flex direction="column">
+    <Stack>
       <Grid display="grid" columns="1fr auto 1fr" align="center">
         <Container />
         <Heading as="h2" style={{textAlign: 'center'}}>
@@ -40,7 +40,7 @@ function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) 
           projectSlug={projectSlug}
         />
       </Container>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/components/missingDsymModal.tsx
+++ b/static/app/views/preprod/components/missingDsymModal.tsx
@@ -16,7 +16,7 @@ interface MissingDsymModalProps {
 
 function MissingDsymModal({binaries, closeModal}: MissingDsymModalProps) {
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <Flex justify="center" align="center" width="100%" position="relative">
         <Heading as="h2">
           {tn('Missing Debug Symbol', 'Missing Debug Symbols', binaries.length)}
@@ -50,7 +50,7 @@ function MissingDsymModal({binaries, closeModal}: MissingDsymModalProps) {
           </BinaryItem>
         ))}
       </BinaryList>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -89,7 +89,7 @@ function FullscreenModalContent({
   };
 
   return (
-    <Flex direction="column" gap="md" height="100%" width="100%">
+    <Stack gap="md" height="100%" width="100%">
       <InputGroup>
         <InputGroup.LeadingItems>
           <IconSearch />
@@ -123,7 +123,7 @@ function FullscreenModalContent({
           insightsAvailable={insightsAvailable}
         />
       </Container>
-    </Flex>
+    </Stack>
   );
 }
 
@@ -546,7 +546,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
   }
 
   return (
-    <Flex direction="column" gap="sm" height="100%" width="100%">
+    <Stack gap="sm" height="100%" width="100%">
       {alertMessage && (
         <ClickableAlert
           variant="warning"
@@ -577,7 +577,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
         />
         <TreemapControlButtons buttons={treemapControlButtons} />
       </Container>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -50,7 +50,7 @@ export default function InstallPage() {
         <Layout.Body>
           <UrlParamBatchProvider>
             <Layout.Main width="full-constrained">
-              <Flex direction="column" gap="xl">
+              <Stack gap="xl">
                 <Container border="primary" radius="lg" overflow="hidden">
                   <Container background="secondary" borderBottom="primary" padding="xl">
                     <Flex justify="center" align="center" width="100%">
@@ -59,12 +59,12 @@ export default function InstallPage() {
                   </Container>
                   <Container padding="2xl">
                     {buildDetailsQuery.isPending ? (
-                      <Flex direction="column" align="center" gap="lg">
+                      <Stack align="center" gap="lg">
                         <LoadingIndicator />
                         <Text>{t('Loading build details...')}</Text>
-                      </Flex>
+                      </Stack>
                     ) : buildDetailsQuery.isError || !buildDetailsQuery.data ? (
-                      <Flex direction="column" align="center" gap="lg">
+                      <Stack align="center" gap="lg">
                         <Text>
                           {t(
                             'Error: %s',
@@ -75,7 +75,7 @@ export default function InstallPage() {
                         <Button onClick={() => buildDetailsQuery.refetch()}>
                           {t('Retry')}
                         </Button>
-                      </Flex>
+                      </Stack>
                     ) : (
                       <InstallDetailsContent
                         artifactId={artifactId}
@@ -97,7 +97,7 @@ export default function InstallPage() {
                 {buildDetailsQuery.data && (
                   <BuildVcsInfo buildDetailsData={buildDetailsQuery.data} />
                 )}
-              </Flex>
+              </Stack>
             </Layout.Main>
           </UrlParamBatchProvider>
         </Layout.Body>

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -2,7 +2,7 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Slider} from '@sentry/scraps/slider';
 import {Text} from '@sentry/scraps/text';
 
@@ -57,7 +57,7 @@ export function DiffImageDisplay({
   const maskSize = computeMaskSize(pair.base_image, pair.head_image);
 
   return (
-    <Flex direction="column" gap="lg" padding="0 xl xl" flex="1" minHeight="0">
+    <Stack gap="lg" padding="0 xl xl" flex="1" minHeight="0">
       <HiddenWhenInactive active={diffMode === 'split'}>
         <SplitView
           baseImageUrl={baseImageUrl}
@@ -87,7 +87,7 @@ export function DiffImageDisplay({
           headLabel={headLabel}
         />
       </HiddenWhenInactive>
-    </Flex>
+    </Stack>
   );
 }
 
@@ -120,7 +120,7 @@ function SplitView({
   return (
     <ZoomableArea>
       <Grid columns="repeat(2, minmax(0, 1fr))" gap="0" height="100%" minHeight="0">
-        <Flex direction="column" minWidth="0" minHeight="0">
+        <Stack minWidth="0" minHeight="0">
           <Container padding="sm xl">
             <Text size="xs" variant="muted" ellipsis monospace>
               {t('Base')}
@@ -144,9 +144,9 @@ function SplitView({
               )}
             </Flex>
           </ZoomContainer>
-        </Flex>
+        </Stack>
 
-        <Flex direction="column" minWidth="0" minHeight="0" borderLeft="secondary">
+        <Stack minWidth="0" minHeight="0" borderLeft="secondary">
           <Container padding="sm xl">
             <Text size="xs" variant="muted" ellipsis monospace>
               {headLabel}
@@ -180,7 +180,7 @@ function SplitView({
               )}
             </Flex>
           </ZoomContainer>
-        </Flex>
+        </Stack>
       </Grid>
       <ZoomControls
         onZoomIn={zoom2.zoomIn}
@@ -259,14 +259,7 @@ function OnionView({
     headImageUrl,
   ]);
   return (
-    <Flex
-      direction="column"
-      gap="md"
-      flex="1"
-      minHeight="0"
-      align="center"
-      justify="center"
-    >
+    <Stack gap="md" flex="1" minHeight="0" align="center" justify="center">
       {displayBaseUrl && displayHeadUrl && (
         <Flex
           justify="center"
@@ -310,7 +303,7 @@ function OnionView({
           {t('Head')}
         </Text>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -243,7 +243,7 @@ export const OnionCardBody = memo(function OnionCardBody({
     height: maxH ? `${((headImage.height || 0) / maxH) * 100}%` : '100%',
   };
   return (
-    <Flex direction="column" gap="md" align="center">
+    <Stack gap="md" align="center">
       <Container
         position="relative"
         width="100%"
@@ -284,7 +284,7 @@ export const OnionCardBody = memo(function OnionCardBody({
           {t('Head')}
         </Text>
       </Flex>
-    </Flex>
+    </Stack>
   );
 });
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -3,7 +3,7 @@ import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -232,14 +232,7 @@ export function SnapshotMainContent({
 
   if (viewMode === 'list') {
     return (
-      <Flex
-        direction="column"
-        gap="0"
-        padding="0"
-        height="100%"
-        width="100%"
-        background="secondary"
-      >
+      <Stack gap="0" padding="0" height="100%" width="100%" background="secondary">
         <ToolbarContainer
           toggle={toggle}
           sortDropdown={sortDropdown}
@@ -262,13 +255,13 @@ export function SnapshotMainContent({
           diffImageBaseUrl={diffImageBaseUrl}
           onVisibleGroupChange={onVisibleGroupChange}
         />
-      </Flex>
+      </Stack>
     );
   }
 
   if (!selectedItem) {
     return (
-      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+      <Stack gap="0" padding="0" height="100%" width="100%">
         <ToolbarContainer
           toggle={toggle}
           sortDropdown={sortDropdown}
@@ -278,7 +271,7 @@ export function SnapshotMainContent({
         <Flex align="center" justify="center" padding="3xl" width="100%" flex="1">
           <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
         </Flex>
-      </Flex>
+      </Stack>
     );
   }
 
@@ -545,14 +538,13 @@ function SingleViewLayout({
         showBottomBorder={false}
       />
       {banner}
-      <Flex direction="column" flex="1" minHeight="0">
+      <Stack flex="1" minHeight="0">
         {body}
-      </Flex>
+      </Stack>
     </SnapshotVariantFrame>
   );
   return (
-    <Flex
-      direction="column"
+    <Stack
       gap="0"
       padding="0"
       height="100%"
@@ -569,13 +561,13 @@ function SingleViewLayout({
       />
       <SingleViewScroll ref={scrollRef}>
         <Flex direction="row" gap="xl" flex="1" minHeight="0" align="stretch">
-          <Flex direction="column" flex="1" minWidth="0">
+          <Stack flex="1" minWidth="0">
             <DarkAware isDark={isDark}>
               <SnapshotCardFrame groupName={groupName} fillHeight>
                 {card}
               </SnapshotCardFrame>
             </DarkAware>
-          </Flex>
+          </Stack>
           <Container
             flexShrink={0}
             onClick={e => e.stopPropagation()}
@@ -606,7 +598,7 @@ function SingleViewLayout({
           </Container>
         </Flex>
       </SingleViewScroll>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/seerExplorer/components/emptyState.tsx
+++ b/static/app/views/seerExplorer/components/emptyState.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconSeer} from 'sentry/icons';
@@ -58,7 +58,7 @@ export function EmptyState({
           <IconSeer size="xl" animation="waiting" />
           <Text>{t('Ask Seer anything about your application.')}</Text>
           {onSuggestionClick && (
-            <Flex direction="column" align="center" gap="md" paddingTop="2xl">
+            <Stack align="center" gap="md" paddingTop="2xl">
               {SUGGESTED_QUESTIONS.map(question => (
                 <SuggestionButton
                   key={question}
@@ -68,7 +68,7 @@ export function EmptyState({
                   {question}
                 </SuggestionButton>
               ))}
-            </Flex>
+            </Stack>
           )}
           {displaySlackAgentReminder && (
             <Text>

--- a/static/app/views/seerExplorer/components/prWidget.tsx
+++ b/static/app/views/seerExplorer/components/prWidget.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -176,8 +176,8 @@ export function usePRWidgetData({
         key: repoName,
         title: repoName,
         description: (
-          <Flex direction="column" gap="lg">
-            <Flex direction="column">
+          <Stack gap="lg">
+            <Stack>
               {files.map((file, idx) => (
                 <Flex
                   key={`${file.path}-${idx}`}
@@ -199,7 +199,7 @@ export function usePRWidgetData({
                   </Text>
                 </Flex>
               ))}
-            </Flex>
+            </Stack>
             <Flex align="center" gap="md">
               {isCreating ? (
                 <Text size="xs" variant="muted">
@@ -231,7 +231,7 @@ export function usePRWidgetData({
                 </Text>
               )}
             </Flex>
-          </Flex>
+          </Stack>
         ),
         handler: () => {
           // If repo has a PR, open it

--- a/static/app/views/seerExplorer/components/reauthMonitoringProviderBlock.tsx
+++ b/static/app/views/seerExplorer/components/reauthMonitoringProviderBlock.tsx
@@ -1,7 +1,7 @@
 import {useMutation} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -85,7 +85,7 @@ export function ReauthMonitoringProviderBlock({
   return (
     <Container padding="xl">
       <Container padding="xl" border="primary" radius="md">
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Text>
             {t('Your %s connection has expired. Reconnect to continue.', providerLabel)}
           </Text>
@@ -99,7 +99,7 @@ export function ReauthMonitoringProviderBlock({
               {t('Reconnect')}
             </Button>
           </Flex>
-        </Flex>
+        </Stack>
       </Container>
     </Container>
   );

--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.tsx
@@ -1,7 +1,7 @@
 import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {SplitPanel, type SplitPanelHandle} from '@sentry/scraps/splitPanel';
 
 import {useDimensions} from 'sentry/utils/useDimensions';
@@ -112,9 +112,8 @@ function SeerExplorerSidebarLayoutInSidebarMode({children}: {children: React.Rea
   // space instead of letting the tall page content grow it — giving Seer's pane
   // a viewport-bounded height.
   return (
-    <Flex
+    <Stack
       ref={sidebarContainerRef}
-      direction="column"
       flex="1"
       minWidth="0"
       minHeight="0"
@@ -133,7 +132,7 @@ function SeerExplorerSidebarLayoutInSidebarMode({children}: {children: React.Rea
         sized={contentPane}
         fill={isOpen ? <SeerExplorerPanel /> : undefined}
       />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -5,7 +5,7 @@ import {useQuery} from '@tanstack/react-query';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Disclosure} from '@sentry/scraps/disclosure';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -221,13 +221,13 @@ function SeerWorkflows() {
 
   return (
     <SentryDocumentTitle title={t('Sentry Workflows')} orgSlug={organization.slug}>
-      <Flex direction="column" gap="lg" padding="xl">
-        <Flex direction="column" gap="2xs">
+      <Stack gap="lg" padding="xl">
+        <Stack gap="2xs">
           <Heading as="h1">{t('Sentry Workflows')}</Heading>
           <Text as="p" variant="muted">
             {t('Historical runs of Sentry workflows for this organization.')}
           </Text>
-        </Flex>
+        </Stack>
 
         {isError ? (
           <LoadingError onRetry={refetch} />
@@ -354,14 +354,14 @@ function SeerWorkflows() {
                           <StatusIcon status={row.status} />
                         </SimpleTable.RowCell>
                         <SimpleTable.RowCell>
-                          <Flex direction="column" gap="2xs">
+                          <Stack gap="2xs">
                             <Text size="sm">
                               <DateTime date={row.dateAdded} />
                             </Text>
                             <Text size="xs" variant="muted">
                               <TimeSince date={row.dateAdded} />
                             </Text>
-                          </Flex>
+                          </Stack>
                         </SimpleTable.RowCell>
                         <SimpleTable.RowCell>
                           <Flex gap="sm" align="center" wrap="wrap">
@@ -422,7 +422,7 @@ function SeerWorkflows() {
             </RunsTable>
           </Container>
         )}
-      </Flex>
+      </Stack>
     </SentryDocumentTitle>
   );
 }
@@ -592,7 +592,7 @@ function RunDetail({
 }) {
   const isSentryEmployee = useIsSentryEmployee();
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       <UserSection row={row} organizationSlug={organizationSlug} />
       {isSentryEmployee ? (
         <Disclosure>
@@ -616,7 +616,7 @@ function RunDetail({
           </Disclosure.Content>
         </Disclosure>
       ) : null}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -628,14 +628,14 @@ function UserSection({
   row: WorkflowRow;
 }) {
   return (
-    <Flex direction="column" gap="lg">
+    <Stack gap="lg">
       {row.summary ? (
         <Text as="p" size="md">
           {row.summary}
         </Text>
       ) : null}
       <TriageIssuesUserPanel row={row} organizationSlug={organizationSlug} />
-    </Flex>
+    </Stack>
   );
 }
 
@@ -659,7 +659,7 @@ function DebugSection({
     max_candidates !== undefined;
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Grid columns="max-content 1fr" gap="sm xl" align="start">
         <Text bold size="xs" variant="muted">
           {t('Run ID')}
@@ -711,7 +711,7 @@ function DebugSection({
         </Text>
       ) : null}
       <TriageIssuesDebugAddendum row={row} organizationSlug={organizationSlug} />
-    </Flex>
+    </Stack>
   );
 }
 
@@ -724,7 +724,7 @@ function TriageIssuesUserPanel({
 }) {
   const issues = row.triage?.issues ?? [];
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       <Text bold size="xs" variant="muted" uppercase>
         {t('Issues (%s)', issues.length)}
       </Text>
@@ -766,7 +766,7 @@ function TriageIssuesUserPanel({
           ])}
         </Grid>
       )}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -782,7 +782,7 @@ function TriageIssuesDebugAddendum({
     return null;
   }
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       <Text bold size="xs" variant="muted" uppercase>
         {t('Per-issue internals')}
       </Text>
@@ -828,7 +828,7 @@ function TriageIssuesDebugAddendum({
           ),
         ])}
       </Grid>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/settings/components/dataScrubbing/modals/dataScrubFormModal.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/dataScrubFormModal.tsx
@@ -256,13 +256,13 @@ export function DataScrubFormModal({
                     hintText={t('The dataset targeted by the scrubbing rule')}
                     variant="compact"
                   >
-                    <Flex direction="column" gap="lg">
+                    <Stack gap="lg">
                       {sortBy(enabledDatasets).map(value => (
                         <field.Radio.Item key={value} value={value}>
                           {getDatasetLabelLong(value)}
                         </field.Radio.Item>
                       ))}
-                    </Flex>
+                    </Stack>
                   </field.Layout.Stack>
                 </field.Radio.Group>
               )}

--- a/static/app/views/settings/dynamicSampling/projectsTable.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -379,7 +379,7 @@ const TableRow = memo(function TableRow({
           )}
         </SubContent>
       </Cell>
-      <Flex direction="column" padding="xl xl md xl" gap="xs" style={{minWidth: 0}}>
+      <Stack padding="xl xl md xl" gap="xs" style={{minWidth: 0}}>
         <FirstCellLine align="center" height="32px">
           <Tooltip disabled={!permissionTooltip} title={permissionTooltip}>
             <PercentInput
@@ -401,7 +401,7 @@ const TableRow = memo(function TableRow({
             {t('previous: %s%%', initialSampleRate)}
           </Text>
         )}
-      </Flex>
+      </Stack>
     </TableRowWrapper>
   );
 });

--- a/static/app/views/settings/organizationDataForwarding/components/dataForwarderOnboarding.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/dataForwarderOnboarding.tsx
@@ -4,7 +4,7 @@ import tracingTelescopeImg from 'sentry-images/spot/tracing-telescope.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {Access} from 'sentry/components/acl/access';
@@ -19,7 +19,7 @@ export function DataForwarderOnboarding({hasFeature}: {hasFeature: boolean}) {
   return (
     <Container border="primary" radius="md" padding="2xl">
       <Flex direction="row" align="center">
-        <Flex direction="column" gap="xl" maxWidth="600px" flex={3} align="start">
+        <Stack gap="xl" maxWidth="600px" flex={3} align="start">
           <Heading as="h2">{t('Keep your data pipeline flowing.')}</Heading>
           <Text variant="muted" size="lg">
             {t(
@@ -48,7 +48,7 @@ export function DataForwarderOnboarding({hasFeature}: {hasFeature: boolean}) {
               </LinkButton>
             )}
           </Access>
-        </Flex>
+        </Stack>
         <OversizedImage
           src={tracingTelescopeImg}
           alt={t('Data jumps between planets, sentry tracks it with a telescope')}

--- a/static/app/views/settings/organizationDataForwarding/components/dataForwarderRow.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/dataForwarderRow.tsx
@@ -1,6 +1,6 @@
 import {Tag} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconDelete, IconEdit} from 'sentry/icons';
@@ -26,7 +26,7 @@ export function DataForwarderRow({
     <Container padding="xl" border="muted" radius="md" key={dataForwarder.id}>
       <Grid columns="auto 1fr auto" align="center" gap="md">
         <PluginIcon pluginId={dataForwarder.provider} size={32} />
-        <Flex direction="column" gap="xs">
+        <Stack gap="xs">
           <Flex align="center" gap="md">
             <Text bold>
               {tct('[provider] Data Forwarder', {
@@ -40,7 +40,7 @@ export function DataForwarderRow({
           <Text size="sm" variant="muted">
             {getDataForwarderProjectText(dataForwarder)}
           </Text>
-        </Flex>
+        </Stack>
         <Grid flow="column" align="center" gap="md">
           <LinkButton
             icon={<IconEdit />}

--- a/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectOverrideForm.tsx
@@ -5,7 +5,7 @@ import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -126,7 +126,7 @@ export function ProjectOverrideForm({
         </Flex>
       </Disclosure.Title>
       <Disclosure.Content>
-        <Flex direction="column" borderTop="primary">
+        <Stack borderTop="primary">
           <form.AppForm form={form}>
             <form.AppField name="is_enabled">
               {field => (
@@ -367,7 +367,7 @@ export function ProjectOverrideForm({
               </form.SubmitButton>
             </Flex>
           </form.AppForm>
-        </Flex>
+        </Stack>
       </Disclosure.Content>
     </Disclosure>
   );

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -4,7 +4,7 @@ import {useMemo} from 'react';
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 import {FieldGroup} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -71,9 +71,9 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
       <SentryDocumentTitle
         title={t('Edit your %s forwarder', ProviderLabels[provider])}
       />
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Flex align="center" justify="between" gap="2xl">
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             <Flex align="center" gap="lg">
               <Heading as="h2">{t('Edit your forwarder')}</Heading>
             </Flex>
@@ -83,7 +83,7 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                 ProviderLabels[provider]
               )}
             </Text>
-          </Flex>
+          </Stack>
           <LinkButton
             size="sm"
             to={`/settings/${organization.slug}/data-forwarding/`}
@@ -203,7 +203,7 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
             </Fragment>
           )}
         </Feature>
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -97,9 +97,9 @@ export default function OrganizationDataForwarding() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Data Forwarding')} />
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Flex align="center" justify="between" gap="2xl">
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             <SettingsPageHeader
               title={t('Data Forwarding')}
               subtitle={tct(
@@ -118,7 +118,7 @@ export default function OrganizationDataForwarding() {
                 }
               )}
             />
-          </Flex>
+          </Stack>
         </Flex>
         {isLoading ? (
           <LoadingIndicator />
@@ -127,7 +127,7 @@ export default function OrganizationDataForwarding() {
         ) : (
           pageContent
         )}
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationDataForwarding/setup.tsx
+++ b/static/app/views/settings/organizationDataForwarding/setup.tsx
@@ -2,7 +2,7 @@ import {Fragment, useMemo, useState} from 'react';
 
 import {AlertLink} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -65,16 +65,16 @@ export default function OrganizationDataForwardingSetup() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Setup Data Forwarding')} />
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Flex align="center" justify="between" gap="2xl">
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             <Flex align="center" gap="lg">
               <Heading as="h2">{t('Setup Data Forwarding')}</Heading>
             </Flex>
             <Text variant="muted">
               {t('Configure the global settings for your data forwarder.')}
             </Text>
-          </Flex>
+          </Stack>
           <LinkButton
             size="sm"
             to={`/settings/${organization.slug}/data-forwarding/`}
@@ -144,7 +144,7 @@ export default function OrganizationDataForwardingSetup() {
             </Fragment>
           )}
         </Feature>
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationMcpCli/index.tsx
+++ b/static/app/views/settings/organizationMcpCli/index.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -23,9 +23,9 @@ export default function OrganizationMcpCli() {
         )}
       />
 
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         <Container padding="xl" border="primary" radius="md">
-          <Flex direction="column" gap="lg">
+          <Stack gap="lg">
             <Heading as="h3">{t('MCP Server')}</Heading>
             <Text variant="muted" size="lg">
               {t(
@@ -51,11 +51,11 @@ export default function OrganizationMcpCli() {
                 {t('MCP Documentation')}
               </LinkButton>
             </div>
-          </Flex>
+          </Stack>
         </Container>
 
         <Container padding="xl" border="primary" radius="md">
-          <Flex direction="column" gap="lg">
+          <Stack gap="lg">
             <Heading as="h3">{t('Sentry CLI')}</Heading>
             <Text variant="muted" size="lg">
               {t(
@@ -69,9 +69,9 @@ export default function OrganizationMcpCli() {
                 {t('CLI Documentation')}
               </LinkButton>
             </div>
-          </Flex>
+          </Stack>
         </Container>
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/components/scmRepositoryTable.stories.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from 'react';
 
 import {Input} from '@sentry/scraps/input';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import * as Storybook from 'sentry/stories';
 import type {
@@ -174,7 +174,7 @@ export default Storybook.story('ScmRepositoryTable', story => {
     const repoMatches = useRepoSearch(allRepos, query);
 
     return (
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <Input
           type="search"
           placeholder="Search repositories"
@@ -186,7 +186,7 @@ export default Storybook.story('ScmRepositoryTable', story => {
           installations={installations.map(i => ({...i, initiallyExpanded: true}))}
           repoMatches={repoMatches}
         />
-      </Flex>
+      </Stack>
     );
   });
 

--- a/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -19,7 +19,7 @@ import {
   FormSearch,
   useScrapsForm,
 } from '@sentry/scraps/form';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Switch} from '@sentry/scraps/switch';
 
@@ -231,7 +231,7 @@ function LegacyBrowserFilterRow({
   };
 
   return (
-    <Flex direction="column" flexGrow={1} width="100%">
+    <Stack flexGrow={1} width="100%">
       <Flex align="center" gap="xs" justify="between">
         <Flex align="center" gap="xs">
           {label}
@@ -279,7 +279,7 @@ function LegacyBrowserFilterRow({
             );
           })}
       </FilterGrid>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/settings/project/projectKeys/credentials/index.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/index.tsx
@@ -3,7 +3,7 @@ import {parseAsBoolean, parseAsStringLiteral, useQueryState} from 'nuqs';
 import {z} from 'zod';
 
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Text} from '@sentry/scraps/text';
@@ -382,14 +382,14 @@ export function ProjectKeyCredentials({
                   {field.state.value}
                 </TextCopyInput>
                 {showDeprecatedDsn && (
-                  <Flex direction="column" gap="sm" paddingTop="2xs">
+                  <Stack gap="sm" paddingTop="2xs">
                     <Text size="sm" variant="muted">
                       {t(
                         'Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language.'
                       )}
                     </Text>
                     <TextCopyInput>{data.dsn.secret}</TextCopyInput>
-                  </Flex>
+                  </Stack>
                 )}
               </field.Layout.Stack>
             )}

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -4,7 +4,7 @@ import {z} from 'zod';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -189,14 +189,14 @@ export function KeySettings({
         {({hasAccess}) => (
           <FieldGroup title={t('Revoke Key')}>
             <Flex direction="row" gap="xl" align="center" justify="between">
-              <Flex direction="column" gap="xs" flex="1">
+              <Stack gap="xs" flex="1">
                 <Text bold>{t('Revoke Key')}</Text>
                 <Text size="sm" variant="muted">
                   {t(
                     'Revoking this key will immediately remove and suspend the credentials. This action is irreversible.'
                   )}
                 </Text>
-              </Flex>
+              </Stack>
               <Confirm
                 priority="danger"
                 message={t(

--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -4,7 +4,7 @@ import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
@@ -82,7 +82,7 @@ export function EmptyState({
                   'Retrieve the Back Office Server Credentials (Client ID and Secret) for the title of interest. To avoid problems with rate limiting it is preferred to have a separate set of credentials that are only used by Sentry.'
                 )}
               </DescriptionWrapper>
-              <Flex direction="column" align="end" gap="xl">
+              <Stack align="end" gap="xl">
                 <StyledPanelTable
                   headers={[
                     t('Client ID'),
@@ -106,7 +106,7 @@ export function EmptyState({
                     />
                   ))}
                 </StyledPanelTable>
-              </Flex>
+              </Stack>
               <GuidedSteps.StepButtons />
             </GuidedSteps.Step>
 

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -4,7 +4,7 @@ import {useMutation} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Stack, Grid} from '@sentry/scraps/layout';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {List} from 'sentry/components/list';
@@ -114,7 +114,7 @@ export function PlayStationSettings({organization, project}: Props) {
       {isLoading ? (
         <LoadingIndicator />
       ) : (
-        <Flex direction="column" gap="md" align="end">
+        <Stack gap="md" align="end">
           <Grid flow="column" align="center" gap="md">
             {hasCredentials && (
               <Button
@@ -167,7 +167,7 @@ export function PlayStationSettings({organization, project}: Props) {
               ))}
             </StyledPanelTable>
           )}
-        </Flex>
+        </Stack>
       )}
     </Fragment>
   );

--- a/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
+++ b/static/app/views/settings/projectPlugins/legacyWebhookDetails.tsx
@@ -4,7 +4,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
-import {Grid} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
@@ -187,7 +187,7 @@ export default function LegacyWebhookDetails() {
           </Grid>
         </PanelHeader>
         <PanelBody withPadding>
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             <TextArea
               autosize
               rows={4}
@@ -212,7 +212,7 @@ export default function LegacyWebhookDetails() {
                 {t('Save Changes')}
               </Button>
             </Flex>
-          </Flex>
+          </Stack>
         </PanelBody>
       </Panel>
     </div>

--- a/static/app/views/settings/projectProguard/index.tsx
+++ b/static/app/views/settings/projectProguard/index.tsx
@@ -2,7 +2,7 @@ import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Pagination} from '@sentry/scraps/pagination';
 
@@ -108,7 +108,7 @@ export default function ProjectProguard() {
         )}
       />
 
-      <Flex direction="column" gap="md">
+      <Stack gap="md">
         <SearchBar
           placeholder={t('Filter mappings')}
           onSearch={handleSearch}
@@ -147,7 +147,7 @@ export default function ProjectProguard() {
             : null}
         </StyledPanelTable>
         <Pagination pageLinks={mappingsPageLinks} />
-      </Flex>
+      </Stack>
     </Fragment>
   );
 }

--- a/static/gsAdmin/components/addToStartupProgramAction.tsx
+++ b/static/gsAdmin/components/addToStartupProgramAction.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useState} from 'react';
 import {useMutation} from '@tanstack/react-query';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -146,7 +146,7 @@ function AddToStartupProgramModal({
             notes: 'sentryforstartups',
           }}
         >
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             <NumberField
               label="Credit Amount"
               name="creditAmount"
@@ -186,7 +186,7 @@ function AddToStartupProgramModal({
                 />
               )}
             </div>
-          </Flex>
+          </Stack>
         </Form>
       </Body>
     </Fragment>

--- a/static/gsAdmin/components/changeBalanceAction.tsx
+++ b/static/gsAdmin/components/changeBalanceAction.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import {useMutation} from '@tanstack/react-query';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -118,7 +118,7 @@ function ChangeBalanceModal({
           cancelLabel="Cancel"
           footerClass="modal-footer"
         >
-          <Flex direction="column" gap="md">
+          <Stack gap="md">
             <NumberField
               label="Credit Amount"
               name="creditAmount"
@@ -145,7 +145,7 @@ function ChangeBalanceModal({
                 disabled={isPending}
               />
             </div>
-          </Flex>
+          </Stack>
         </Form>
       </Body>
     </Fragment>

--- a/static/gsAdmin/views/invoiceComparison.tsx
+++ b/static/gsAdmin/views/invoiceComparison.tsx
@@ -8,7 +8,7 @@ import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
@@ -389,7 +389,7 @@ export function InvoiceComparison() {
         <PanelHeader>Query</PanelHeader>
         <PanelBody withPadding>
           <Flex gap="md" align="end" wrap="wrap">
-            <Flex direction="column" gap="xs">
+            <Stack gap="xs">
               <FieldLabel>Region</FieldLabel>
               <CompactSelect
                 trigger={triggerProps => (
@@ -401,8 +401,8 @@ export function InvoiceComparison() {
                   setCell(cells.find(c => c.locality_url === opt.value) ?? null);
                 }}
               />
-            </Flex>
-            <Flex direction="column" gap="xs">
+            </Stack>
+            <Stack gap="xs">
               <FieldLabel htmlFor="start">Generated since (local)</FieldLabel>
               <Input
                 id="start"
@@ -410,8 +410,8 @@ export function InvoiceComparison() {
                 value={startInput}
                 onChange={e => setStartInput(e.target.value)}
               />
-            </Flex>
-            <Flex direction="column" gap="xs">
+            </Stack>
+            <Stack gap="xs">
               <FieldLabel htmlFor="end">Generated until (local)</FieldLabel>
               <Input
                 id="end"
@@ -419,8 +419,8 @@ export function InvoiceComparison() {
                 value={endInput}
                 onChange={e => setEndInput(e.target.value)}
               />
-            </Flex>
-            <Flex direction="column" gap="xs">
+            </Stack>
+            <Stack gap="xs">
               <FieldLabel>Results per page</FieldLabel>
               <CompactSelect
                 trigger={triggerProps => (
@@ -433,7 +433,7 @@ export function InvoiceComparison() {
                 }))}
                 onChange={opt => setPageSize(Number(opt.value))}
               />
-            </Flex>
+            </Stack>
             <Button variant="primary" onClick={onSubmit} disabled={!cell}>
               Run comparison
             </Button>
@@ -469,23 +469,23 @@ export function InvoiceComparison() {
                   }
                 `}
               >
-                <Flex direction="column">
+                <Stack>
                   <Text size="sm" variant="muted">
                     Legacy invoices
                   </Text>
                   <Text size="lg" bold>
                     {formatCountOrNA(data.summary.legacy_count)}
                   </Text>
-                </Flex>
-                <Flex direction="column">
+                </Stack>
+                <Stack>
                   <Text size="sm" variant="muted">
                     Platform invoices
                   </Text>
                   <Text size="lg" bold>
                     {formatCountOrNA(data.summary.platform_count)}
                   </Text>
-                </Flex>
-                <Flex direction="column">
+                </Stack>
+                <Stack>
                   <Text size="sm" variant="muted">
                     {'>1% diff'}
                   </Text>
@@ -496,7 +496,7 @@ export function InvoiceComparison() {
                       {formatCountOrNA(data.summary.row_count)})
                     </TruncatedNote>
                   </Text>
-                </Flex>
+                </Stack>
               </Grid>
             </PanelBody>
           </Panel>

--- a/static/gsAdmin/views/launchpadAdminPage.tsx
+++ b/static/gsAdmin/views/launchpadAdminPage.tsx
@@ -6,7 +6,7 @@ import {useMutation} from '@tanstack/react-query';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Stack, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -282,7 +282,7 @@ export function LaunchpadAdminPage() {
   return (
     <div>
       <PageHeader title="Launchpad Admin Page" />
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Text as="p">
           This is a launchpad admin page for managing preprod artifacts. Provide the
           preprod artifact ID to perform the desired action.
@@ -317,7 +317,7 @@ export function LaunchpadAdminPage() {
         >
           <form onSubmit={handleFetchInfoSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Heading as="h3">Fetch Artifact Info</Heading>
                 <Text as="p" variant="muted">
                   Retrieve all data and details for a specific preprod artifact (includes
@@ -343,13 +343,13 @@ export function LaunchpadAdminPage() {
                 >
                   Fetch Info
                 </Button>
-              </Flex>
+              </Stack>
             </Container>
           </form>
 
           <form onSubmit={handleDeleteSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Heading as="h3">Delete Artifact Data</Heading>
                 <Text as="p" variant="muted">
                   Delete all associated data for a specific preprod artifact.
@@ -374,13 +374,13 @@ export function LaunchpadAdminPage() {
                 >
                   Delete Data
                 </Button>
-              </Flex>
+              </Stack>
             </Container>
           </form>
 
           <form onSubmit={handleRerunSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Heading as="h3">Batch Rerun Analyses</Heading>
                 <Text as="p" variant="muted">
                   Rerun all enabled analyses (size, snapshots, etc.) for one or more
@@ -406,13 +406,13 @@ export function LaunchpadAdminPage() {
                 >
                   Rerun Analysis
                 </Button>
-              </Flex>
+              </Stack>
             </Container>
           </form>
 
           <form onSubmit={handleBatchDeleteSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Heading as="h3">Batch Delete Artifacts</Heading>
                 <Text as="p" variant="muted">
                   Delete multiple artifacts at once using comma-separated IDs.
@@ -437,13 +437,13 @@ export function LaunchpadAdminPage() {
                 >
                   Batch Delete
                 </Button>
-              </Flex>
+              </Stack>
             </Container>
           </form>
 
           <form onSubmit={handleDownloadSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md">
+              <Stack gap="md">
                 <Heading as="h3">Download Build</Heading>
                 <Text as="p" variant="muted">
                   Download the build file for a specific preprod artifact.
@@ -468,14 +468,14 @@ export function LaunchpadAdminPage() {
                 >
                   Download Build
                 </Button>
-              </Flex>
+              </Stack>
             </Container>
           </form>
         </Grid>
 
         {fetchedArtifactInfo && (
           <Container background="secondary" border="primary" radius="md" padding="lg">
-            <Flex direction="column" gap="md">
+            <Stack gap="md">
               {fetchedArtifactInfo.artifact_info?.project?.organization_slug &&
                 fetchedArtifactInfo.artifact_info?.project?.slug &&
                 fetchedArtifactInfo.artifact_info?.id && (
@@ -485,7 +485,7 @@ export function LaunchpadAdminPage() {
                     radius="sm"
                     padding="md"
                   >
-                    <Flex direction="column" gap="xs">
+                    <Stack gap="xs">
                       <Text bold size="sm">
                         Artifact URL:
                       </Text>
@@ -494,7 +494,7 @@ export function LaunchpadAdminPage() {
                       >
                         {`https://${fetchedArtifactInfo.artifact_info.project.organization_slug}.sentry.io/preprod/${fetchedArtifactInfo.artifact_info.project.slug}/${fetchedArtifactInfo.artifact_info.id}/`}
                       </Link>
-                    </Flex>
+                    </Stack>
                   </Container>
                 )}
               <Heading as="h3">Fetched Artifact Information</Heading>
@@ -504,10 +504,10 @@ export function LaunchpadAdminPage() {
               <Button variant="secondary" onClick={() => setFetchedArtifactInfo(null)}>
                 Clear Info
               </Button>
-            </Flex>
+            </Stack>
           </Container>
         )}
-      </Flex>
+      </Stack>
     </div>
   );
 }

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -5,7 +5,7 @@ import {ThemeProvider} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {GlobalModal} from '@sentry/scraps/modal';
 
@@ -179,7 +179,7 @@ export function Layout() {
                 </ThemeToggle>
               </SidebarActions>
             </Sidebar>
-            <Flex direction="column" minWidth={0} inert={sidebarOpen || undefined}>
+            <Stack minWidth={0} inert={sidebarOpen || undefined}>
               {/* Mobile only: sticky top bar with hamburger and logo */}
               <MobileTopBar>
                 <Button
@@ -202,7 +202,7 @@ export function Layout() {
               >
                 <Outlet />
               </Container>
-            </Flex>
+            </Stack>
           </AppContainer>
         </GlobalAlertProvider>
       </ScrapsProviders>

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -5,7 +5,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Input} from '@sentry/scraps/input';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -71,7 +71,7 @@ export function SeerAdminPage() {
   return (
     <div>
       <PageHeader title="Seer Admin Page" />
-      <Flex direction="column" gap="lg">
+      <Stack gap="lg">
         <Text as="p">
           Admin tools for managing Seer features. Select a region before performing
           actions.
@@ -98,7 +98,7 @@ export function SeerAdminPage() {
         <Grid columns={{'screen:xs': '1fr', 'screen:md': '1fr 1fr'}} gap="xl">
           <form onSubmit={handleNightShiftSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md" align="start">
+              <Stack gap="md" align="start">
                 <Heading as="h3">Trigger Night Shift Run</Heading>
                 <Text as="p" variant="muted">
                   Dispatch a night shift run. Provide an organization ID to scope the run
@@ -152,11 +152,11 @@ export function SeerAdminPage() {
                     ? 'Trigger Night Shift (all orgs)'
                     : 'Trigger Night Shift'}
                 </Button>
-              </Flex>
+              </Stack>
             </Container>
           </form>
         </Grid>
-      </Flex>
+      </Stack>
     </div>
   );
 }

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -165,7 +165,7 @@ export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                     {t('Try Seer for Free')}
                   </StartTrialButton>
                 ) : hasSeerButNeedsPayg ? (
-                  <Flex gap="xl" direction="column">
+                  <Stack gap="xl">
                     <ErrorText>
                       {tct(
                         "You've run out of [budgetTerm] budget. Please add more to keep using Seer.",
@@ -217,7 +217,7 @@ export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                         aria-label={t('Refresh')}
                       />
                     </Flex>
-                  </Flex>
+                  </Stack>
                 ) : (
                   <Button
                     variant="primary"

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.tsx
@@ -1,5 +1,5 @@
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -37,7 +37,7 @@ export function AiConfigureSeerQuotaSidebar({
   const hasBillingPerms = hasAccessToSubscriptionOverview(subscription, organization);
 
   return (
-    <Flex direction="column" border="muted" radius="md" padding="lg" gap="lg">
+    <Stack border="muted" radius="md" padding="lg" gap="lg">
       <Text bold>{t('Meet Seer, your AI assistant')}</Text>
       <Text>
         {t(
@@ -60,6 +60,6 @@ export function AiConfigureSeerQuotaSidebar({
           </LinkButton>
         </Tooltip>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/gsApp/components/billingDetails/form.tsx
+++ b/static/gsApp/components/billingDetails/form.tsx
@@ -4,7 +4,7 @@ import {AddressElement, useElements, useStripe} from '@stripe/react-stripe-js';
 import type {StripeAddressElementChangeEvent} from '@stripe/stripe-js';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {FieldGroupProps} from 'sentry/components/forms/fieldGroup/types';
@@ -131,7 +131,7 @@ function BillingDetailsFormFields({
   }, [stripe, elements, handleStripeLoadError, handleStripeLoadSuccess]);
 
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       {stripeIsBlocked ? (
         <Alert variant="warning">
           {t(
@@ -205,7 +205,7 @@ function BillingDetailsFormFields({
           )}
         </Fragment>
       )}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -225,7 +225,7 @@ function CustomBillingDetailsFormField({
   placeholder?: string;
 }) {
   return (
-    <Flex direction="column" gap="xs">
+    <Stack gap="xs">
       <Flex align="center" gap="xs">
         <Text size="sm" variant="muted">
           {label}
@@ -239,7 +239,7 @@ function CustomBillingDetailsFormField({
         value={value}
         aria-label={label}
       />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {LoadingError} from 'sentry/components/loadingError';
@@ -89,7 +89,7 @@ export function BillingDetailsPanel({
       data-test-id="billing-details-panel"
       maxWidth={maxPanelWidth}
     >
-      <Flex direction="column" gap="lg" width="100%">
+      <Stack gap="lg" width="100%">
         <Heading as="h2" size="lg">
           {t('Business address')}
         </Heading>
@@ -168,7 +168,7 @@ export function BillingDetailsPanel({
         ) : (
           <Text>{t('No business address on file')}</Text>
         )}
-      </Flex>
+      </Stack>
       {!isEditing && (
         <Button
           variant="secondary"

--- a/static/gsApp/components/creditCardEdit/intentForms/innerIntentForm.tsx
+++ b/static/gsApp/components/creditCardEdit/intentForms/innerIntentForm.tsx
@@ -4,7 +4,7 @@ import type {StripePaymentElementChangeEvent} from '@stripe/stripe-js';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -55,7 +55,7 @@ export function InnerIntentForm({
   }, [stripe, elements, handleStripeLoadError]);
 
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       {stripeIsBlocked && (
         <Alert variant="warning">
           {t(
@@ -88,7 +88,7 @@ export function InnerIntentForm({
           marginLeft: 0,
         }}
       >
-        <Flex direction="column" gap="xl">
+        <Stack gap="xl">
           {stripeIsLoading && <LoadingIndicator />}
           <PaymentElement
             onReady={() => setStripeIsLoading(false)}
@@ -101,7 +101,7 @@ export function InnerIntentForm({
               wallets: {applePay: 'never', googlePay: 'never'},
             }}
           />
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             <small>
               {tct('Payments are processed securely through [stripe:Stripe].', {
                 stripe: <ExternalLink href="https://stripe.com/" />,
@@ -122,9 +122,9 @@ export function InnerIntentForm({
                 )}
               </Text>
             )}
-          </Flex>
-        </Flex>
+          </Stack>
+        </Stack>
       </Form>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useState} from 'react';
 import type {Location} from 'history';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -96,7 +96,7 @@ export function CreditCardPanel({
       data-test-id="credit-card-panel"
       maxWidth={maxPanelWidth}
     >
-      <Flex direction="column" gap="lg" width="100%">
+      <Stack gap="lg" width="100%">
         <Heading as="h2" size="lg">
           {t('Payment method')}
         </Heading>
@@ -124,7 +124,7 @@ export function CreditCardPanel({
         ) : (
           <Text>{t('No payment method on file')}</Text>
         )}
-      </Flex>
+      </Stack>
       {!isEditing && (
         <Button
           variant="secondary"

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import {IconLightning} from 'sentry/icons';
@@ -91,7 +91,7 @@ function PowerFeatureHovercard({
 
         return (
           <LearnMoreTextBody data-test-id="power-hovercard">
-            <Flex direction="column" gap="md">
+            <Stack gap="md">
               <div>
                 {partial
                   ? t('Better With %s Plan', planName)
@@ -106,7 +106,7 @@ function PowerFeatureHovercard({
               >
                 {t('Learn More')}
               </Button>
-            </Flex>
+            </Stack>
           </LearnMoreTextBody>
         );
       }}

--- a/static/gsApp/views/amCheckout/components/cart.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.tsx
@@ -397,7 +397,7 @@ function SubtotalSummary({
                 budgetTerm: displayBudgetName(activePlan, {title: true}),
               })}
             </Text>
-            <Flex direction="column" gap="sm" align="end">
+            <Stack gap="sm" align="end">
               <Text align="right" variant="muted">
                 {tct('up to [pricePerMonth]', {
                   pricePerMonth: `${utils.displayPrice({
@@ -423,7 +423,7 @@ function SubtotalSummary({
                   </motion.div>
                 )}
               </AnimatePresence>
-            </Flex>
+            </Stack>
           </Flex>
         )}
       {formData.onDemandBudget?.budgetMode === OnDemandBudgetMode.PER_CATEGORY && (
@@ -950,14 +950,14 @@ export function Cart({
             />
           </Stack>
           {summaryIsOpen && (
-            <Flex direction="column" gap="lg" data-test-id="plan-summary" width="100%">
+            <Stack gap="lg" data-test-id="plan-summary" width="100%">
               {errorMessage && (
                 <Container>
                   <Alert variant="danger">{errorMessage}</Alert>
                 </Container>
               )}
               <ItemsSummary activePlan={activePlan} formData={formData} />
-            </Flex>
+            </Stack>
           )}
           <SubtotalSummary
             activePlan={activePlan}

--- a/static/gsApp/views/amCheckout/components/checkoutOption.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutOption.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 
 export function CheckoutOption({
@@ -44,7 +44,7 @@ export function CheckoutOption({
         }
       }}
     >
-      <Flex direction="column" padding="xl" gap="lg">
+      <Stack padding="xl" gap="lg">
         {!!topDecoration && topDecoration}
         <Flex align="start" justify="between" gap="md">
           <Container paddingTop="2xs">
@@ -60,11 +60,11 @@ export function CheckoutOption({
               />
             )}
           </Container>
-          <Flex direction="column" gap="sm" flexGrow={1}>
+          <Stack gap="sm" flexGrow={1}>
             {optionHeader}
             {/* If there is no divider, line the description up with the header */}
             {!withDivider && !!optionDescription && optionDescription}
-          </Flex>
+          </Stack>
         </Flex>
         {withDivider && (
           <Fragment>
@@ -73,7 +73,7 @@ export function CheckoutOption({
             {!!optionDescription && optionDescription}
           </Fragment>
         )}
-      </Flex>
+      </Stack>
     </Option>
   );
 }

--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -9,7 +9,7 @@ import Barcode from 'sentry-images/checkout/barcode.png';
 import SentryLogo from 'sentry-images/checkout/sentry-receipt-logo.png';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
@@ -115,9 +115,8 @@ function ScheduledChanges({
 }: ScheduledChangesProps) {
   const shortInterval = plan ? utils.getShortInterval(plan.billingInterval) : undefined;
   return (
-    <Flex
+    <Stack
       data-test-id="scheduled-changes"
-      direction="column"
       gap="xl"
       padding="xl 0"
       maxWidth="445px"
@@ -132,7 +131,7 @@ function ScheduledChanges({
         </Heading>
       </Container>
       {(planItem || reservedVolume.length > 0) && (
-        <Flex direction="column" gap="xs" padding="0 xl">
+        <Stack gap="xs" padding="0 xl">
           {planItem && (
             <ScheduledChangeItem
               firstItem={
@@ -189,7 +188,7 @@ function ScheduledChanges({
               />
             );
           })}
-        </Flex>
+        </Stack>
       )}
       {products.map(item => {
         const addOn = utils.reservedInvoiceItemTypeToAddOn(item.type);
@@ -260,7 +259,7 @@ function ScheduledChanges({
           </Text>
         </div>
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 
@@ -328,7 +327,7 @@ function Receipt({
           }}
         >
           <ReceiptPaper background="primary" border="primary">
-            <Flex direction="column" gap="xl" padding="xl" align="center">
+            <Stack gap="xl" padding="xl" align="center">
               <img src={SentryLogo} alt={t('Sentry logo')} />
               <Grid columns="1fr 2fr 1fr" align="center" gap="sm">
                 <DateSeparator />
@@ -489,7 +488,7 @@ function Receipt({
                 </ReceiptSection>
               )}
               <img src={Barcode} alt={t('Barcode')} />
-            </Flex>
+            </Stack>
             <ZigZagEdge />
           </ReceiptPaper>
         </motion.div>
@@ -594,19 +593,11 @@ export function CheckoutSuccess({
       gap="3xl"
       direction={{'screen:sm': 'column', 'screen:md': 'row'}}
     >
-      <Flex
-        direction="column"
-        align={{'screen:sm': 'center', 'screen:md': 'start'}}
-        maxWidth="500px"
-      >
+      <Stack align={{'screen:sm': 'center', 'screen:md': 'start'}} maxWidth="500px">
         <Title size="2xl" as="h1" align="left">
           {contentTitle}
         </Title>
-        <Flex
-          gap="2xl"
-          direction="column"
-          align={{'screen:sm': 'center', 'screen:md': 'start'}}
-        >
+        <Stack gap="2xl" align={{'screen:sm': 'center', 'screen:md': 'start'}}>
           <Description variant="muted" size="lg" align="left">
             {contentDescription}
           </Description>
@@ -626,8 +617,8 @@ export function CheckoutSuccess({
             </LinkButton>
             <FeedbackButton feedbackOptions={checkoutSuccessFeedbackOptions} size="md" />
           </Flex>
-        </Flex>
-      </Flex>
+        </Stack>
+      </Stack>
       {isImmediateCharge ? (
         <Receipt
           {...commonChangesProps}

--- a/static/gsApp/views/amCheckout/components/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/components/planFeatures.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import {useMemo} from 'react';
 
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -287,7 +287,7 @@ function MonitoringAndDataFeatures({
   const activePlanType = activePlan.name.toLowerCase() as PlanType;
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Flex paddingBottom="md">
         <Heading as="h4" size="xs" variant="muted">
           {t('MONITORING & DATA')}
@@ -308,7 +308,7 @@ function MonitoringAndDataFeatures({
               Object.keys(info.displayStringMap)[0] === 'business'
             }
           >
-            <Flex direction="column" gap="xs">
+            <Stack gap="xs">
               {Object.entries(info.displayStringMap).map(([planType, displayString]) => {
                 const isActivePlanType = planType === activePlanType;
                 const planTypeIndex = ORDERED_PLAN_TYPES.indexOf(planType);
@@ -372,11 +372,11 @@ function MonitoringAndDataFeatures({
                   </Text>
                 );
               })}
-            </Flex>
+            </Stack>
           </FeatureItem>
         );
       })}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -387,7 +387,7 @@ function ExpansionPackFeatures({activePlan}: {activePlan: Plan}) {
   );
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Flex paddingBottom="md">
         <Heading as="h4" size="xs" variant="muted">
           {t('EXPANSION PACK')}
@@ -409,7 +409,7 @@ function ExpansionPackFeatures({activePlan}: {activePlan: Plan}) {
             isOnlyOnBusiness={isOnlyOnBusiness}
             isIncluded={hasFeature}
           >
-            <Flex direction="column" gap="xs">
+            <Stack gap="xs">
               {Object.entries(info.displayStringMap).map(([planType, displayString]) => {
                 const hasFeatureVersion = checkHasFeatureVersion({
                   activePlanTypeIndex,
@@ -449,11 +449,11 @@ function ExpansionPackFeatures({activePlan}: {activePlan: Plan}) {
                   </Text>
                 );
               })}
-            </Flex>
+            </Stack>
           </FeatureItem>
         );
       })}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -518,15 +518,8 @@ export function PlanFeatures({
   });
 
   return (
-    <Flex direction="column">
-      <Flex
-        background="secondary"
-        padding="xl"
-        radius="lg"
-        border="primary"
-        gap="xl"
-        direction="column"
-      >
+    <Stack>
+      <Stack background="secondary" padding="xl" radius="lg" border="primary" gap="xl">
         <Grid columns={{'screen:xs': '1fr', 'screen:sm': 'repeat(2, 1fr)'}} gap="xl">
           <MonitoringAndDataFeatures planOptions={planOptions} activePlan={activePlan} />
           <ExpansionPackFeatures activePlan={activePlan} />
@@ -541,7 +534,7 @@ export function PlanFeatures({
             </ExternalLink>
           </Flex>
         )}
-      </Flex>
+      </Stack>
       {Object.entries(perPlanPriceDiffs).map(([planId, info]) => {
         const {plan, ...priceDiffs} = info;
         const planName = plan.name;
@@ -581,6 +574,6 @@ export function PlanFeatures({
           </Container>
         );
       })}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/gsApp/views/amCheckout/components/planSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/components/planSelectCard.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {PAYG_BUSINESS_DEFAULT, PAYG_TEAM_DEFAULT} from 'getsentry/constants';
@@ -77,11 +77,11 @@ export function PlanSelectCard({
         </Flex>
       }
       optionDescription={
-        <Flex direction="column" gap="sm" width="100%">
+        <Stack gap="sm" width="100%">
           <Text size="md" variant="muted" textWrap="balance">
             {description}
           </Text>
-        </Flex>
+        </Stack>
       }
     />
   );

--- a/static/gsApp/views/amCheckout/components/volumeSliders.tsx
+++ b/static/gsApp/views/amCheckout/components/volumeSliders.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {RangeSlider} from 'sentry/components/forms/controls/rangeSlider';
 import {Body, Header, Hovercard} from 'sentry/components/hovercard';
@@ -135,7 +135,7 @@ export function VolumeSliders({
           return (
             <DataVolumeItem key={category} data-test-id={`${category}-volume-item`}>
               <CategoryContainer>
-                <Flex direction="column">
+                <Stack>
                   {showPerformanceUnits && renderPerformanceUnitDecoration()}
                   <Title htmlFor={sliderId}>
                     <div>{getPlanCategoryName({plan: activePlan, category})}</div>
@@ -158,7 +158,7 @@ export function VolumeSliders({
                       </div>
                     </Description>
                   )}
-                </Flex>
+                </Stack>
                 <div>
                   <SpaceBetweenGrid>
                     <VolumeAmount>

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -764,13 +764,7 @@ function AMCheckout(props: Props) {
   );
 
   return (
-    <Flex
-      width="100%"
-      background="primary"
-      justify="center"
-      align="center"
-      direction="column"
-    >
+    <Stack width="100%" background="primary" justify="center" align="center">
       <SentryDocumentTitle title={t('Change Subscription')} orgSlug={organization.slug} />
       {isOnSponsoredPartnerPlan && (
         <Alert.Container>
@@ -821,7 +815,7 @@ function AMCheckout(props: Props) {
       >
         {renderCheckoutContent()}
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/amCheckout/steps/addBillingInfo.tsx
+++ b/static/gsApp/views/amCheckout/steps/addBillingInfo.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -30,7 +30,7 @@ export function AddBillingInformation({
   const showEditBillingInfo = hasBillingInfo(billingDetails, subscription, false);
 
   return (
-    <Flex direction="column" gap="xl" id={`step${stepNumber}`}>
+    <Stack gap="xl" id={`step${stepNumber}`}>
       {billingDetailsError && (
         <Alert variant="danger">{billingDetailsError.message}</Alert>
       )}
@@ -62,6 +62,6 @@ export function AddBillingInformation({
           />
         </Fragment>
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
+++ b/static/gsApp/views/amCheckout/steps/buildYourPlan.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 import moment from 'moment-timezone';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -90,7 +90,7 @@ function PlanSubstep({
   };
 
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       <Grid
         columns={{'screen:xs': '1fr', 'screen:lg': `repeat(${planOptions.length}, 1fr)`}}
         gap="lg"
@@ -122,7 +122,7 @@ function PlanSubstep({
         })}
       </Grid>
       <PlanFeatures planOptions={planOptions} activePlan={activePlan} />
-    </Flex>
+    </Stack>
   );
 }
 
@@ -133,16 +133,16 @@ function AdditionalProductsSubstep({
   subscription,
 }: AdditionalProductsSubstepProps) {
   return (
-    <Flex direction="column" gap="xl" paddingTop="3xl">
-      <Flex direction="column" gap="xl">
+    <Stack gap="xl" paddingTop="3xl">
+      <Stack gap="xl">
         <ProductSelect
           activePlan={activePlan}
           formData={formData}
           onUpdate={onUpdate}
           subscription={subscription}
         />
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.tsx
+++ b/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Stack, Grid} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 
@@ -33,7 +33,7 @@ export function ChooseYourBillingCycle({
 
   let previousPlanPrice = 0;
   return (
-    <Flex direction="column" gap="xl" id={`step${stepNumber}`}>
+    <Stack gap="xl" id={`step${stepNumber}`}>
       <StepHeader title={t('Pay monthly or yearly, your choice')} />
       <Grid
         columns={{
@@ -74,6 +74,6 @@ export function ChooseYourBillingCycle({
           );
         })}
       </Grid>
-    </Flex>
+    </Stack>
   );
 }

--- a/static/gsApp/views/amCheckout/steps/productSelect.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Badge, Tag} from '@sentry/scraps/badge';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconCheckmark, IconSeer, IconWarning} from 'sentry/icons';
@@ -114,7 +114,7 @@ export function ProductSelect({
             },
           };
           return (
-            <Flex direction="column" gap="xl" key={apiName}>
+            <Stack gap="xl" key={apiName}>
               <CheckoutOption
                 ariaLabel={ariaLabel}
                 dataTestId={`product-option-${apiName}`}
@@ -159,7 +159,7 @@ export function ProductSelect({
                   </Flex>
                 }
                 optionDescription={
-                  <Flex direction="column" gap="xl" paddingTop="xl">
+                  <Stack gap="xl" paddingTop="xl">
                     {Object.entries(SUBCATEGORY_TEXT).map(([category, info]) => {
                       const pricingInfo =
                         activePlan.planCategories[category as DataCategory];
@@ -184,7 +184,7 @@ export function ProductSelect({
                           <Flex align="center" marginTop="2xs">
                             <IconCheckmark variant="success" />
                           </Flex>
-                          <Flex direction="column" gap="xs">
+                          <Stack gap="xs">
                             <Text size="md">
                               {getSingularCategoryName({
                                 plan: activePlan,
@@ -198,22 +198,22 @@ export function ProductSelect({
                             <Text size="md" variant="muted">
                               {info.description}
                             </Text>
-                          </Flex>
+                          </Stack>
                         </FeatureItem>
                       );
                     })}
-                  </Flex>
+                  </Stack>
                 }
                 withDivider
               />
-            </Flex>
+            </Stack>
           );
         }
 
         if (apiName === AddOnCategory.SEER) {
           const hasGitLabSupport = organization.features.includes('seer-gitlab-support');
           return (
-            <Flex direction="column" gap="xl" key={apiName}>
+            <Stack gap="xl" key={apiName}>
               <Flex gap="sm" align="start">
                 <Badge variant="new">{t('New')}</Badge>
                 <Heading as="h2" textWrap="pretty">
@@ -252,11 +252,7 @@ export function ProductSelect({
                   </Flex>
                 }
                 optionDescription={
-                  <Flex
-                    direction="column"
-                    gap="lg"
-                    data-test-id="product-option-description"
-                  >
+                  <Stack gap="lg" data-test-id="product-option-description">
                     <Text variant="muted">
                       {hasGitLabSupport
                         ? t(
@@ -266,7 +262,7 @@ export function ProductSelect({
                             'An active contributor is anyone who opens 2 or more PRs in a connected GitHub repository. Count resets each month.'
                           )}
                     </Text>
-                    <Flex direction="column" gap="xs">
+                    <Stack gap="xs">
                       <Text variant="muted">
                         {t(
                           'Setup required: connect repositories after adding to your plan.'
@@ -275,12 +271,12 @@ export function ProductSelect({
                       <Text variant="muted">
                         {t('Billed at month-end and varies with active contributors.')}
                       </Text>
-                    </Flex>
-                  </Flex>
+                    </Stack>
+                  </Stack>
                 }
                 withDivider
               />
-            </Flex>
+            </Stack>
           );
         }
         return null;

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.tsx
@@ -1,4 +1,4 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 
@@ -42,7 +42,7 @@ export function SetSpendLimit({
   };
 
   return (
-    <Flex direction="column" gap="2xl" id={`step${stepNumber}`}>
+    <Stack gap="2xl" id={`step${stepNumber}`}>
       <SpendLimitSettings
         organization={organization}
         subscription={subscription}
@@ -66,6 +66,6 @@ export function SetSpendLimit({
           />
         }
       />
-    </Flex>
+    </Stack>
   );
 }

--- a/static/gsApp/views/invoiceDetails/paymentForm.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -40,7 +40,7 @@ export default function InvoiceDetailsPaymentForm({
     <Fragment>
       <Header>{t('Pay Bill')}</Header>
       <Body>
-        <Flex direction="column" gap="sm">
+        <Stack gap="sm">
           <Text as="p">
             {tct('Complete payment for [amount] USD', {
               amount: displayPriceWithCents({cents: invoice.amountBilled ?? 0}),
@@ -64,7 +64,7 @@ export default function InvoiceDetailsPaymentForm({
             referrer={decodeScalar(location?.query?.referrer)}
             buttonText={t('Pay Now')}
           />
-        </Flex>
+        </Stack>
       </Body>
     </Fragment>
   );

--- a/static/gsApp/views/seerAutomation/components/connectorRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/connectorRow.tsx
@@ -1,5 +1,5 @@
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {PanelItem} from 'sentry/components/panels/panelItem';
@@ -44,10 +44,10 @@ export function ConnectorRow({
     <PanelItem center>
       <Flex align="center" gap="md" flex="1">
         <PluginIcon size={36} pluginId={pluginId} />
-        <Flex direction="column">
+        <Stack>
           <Text bold>{provider.name}</Text>
           <ConnectorStatus status={status} />
-        </Flex>
+        </Stack>
       </Flex>
       {status === 'connected' ? (
         <Button

--- a/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
+++ b/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
@@ -1,7 +1,7 @@
 import type {Dispatch} from 'react';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import type {Client} from 'sentry/api';
 import {Panel} from 'sentry/components/panels/panel';
@@ -42,8 +42,7 @@ export function EnableSpendAllocations({
 
   return (
     <Panel>
-      <Flex
-        direction="column"
+      <Stack
         justify="center"
         align="center"
         padding="3xl"
@@ -68,7 +67,7 @@ export function EnableSpendAllocations({
             </strong>
           </p>
         )}
-      </Flex>
+      </Stack>
     </Panel>
   );
 }

--- a/static/gsApp/views/spendLimits/pricingModal.tsx
+++ b/static/gsApp/views/spendLimits/pricingModal.tsx
@@ -1,6 +1,6 @@
 import {css, type Theme} from '@emotion/react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -31,7 +31,7 @@ function SpendLimitsPricingModal({
       .map(([category, categoryInfo]) => [category, categoryInfo.reserved ?? 0])
   );
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       <Heading as="h2">
         {tct('[budgetTerm] pricing', {
           budgetTerm: displayBudgetName(subscription.planDetails, {title: true}),
@@ -51,7 +51,7 @@ function SpendLimitsPricingModal({
         includedAddOns={includedAddOns}
         currentReserved={currentReserved}
       />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -408,7 +408,7 @@ function InnerSpendLimitSettings({
       category => !addOnCategories.includes(category)
     );
     inputs = (
-      <Flex direction="column" gap="xl" padding="0 xl xl">
+      <Stack gap="xl" padding="0 xl xl">
         <Container>
           {baseCategories.map((category, index) => {
             const reserved = currentReserved[category] ?? 0;
@@ -561,12 +561,12 @@ function InnerSpendLimitSettings({
             {t('* starting rate')}
           </Text>
         </Container>
-      </Flex>
+      </Stack>
     );
   } else {
     inputs = (
       <Fragment>
-        <Flex direction="column" gap="lg" padding="0 xl sm">
+        <Stack gap="lg" padding="0 xl sm">
           <SpendLimitInput
             activePlan={activePlan}
             budgetMode={OnDemandBudgetMode.SHARED}
@@ -582,7 +582,7 @@ function InnerSpendLimitSettings({
               )}
             </Text>
           </Container>
-        </Flex>
+        </Stack>
         <SharedSpendLimitPriceTable
           activePlan={activePlan}
           currentReserved={currentReserved}
@@ -594,7 +594,7 @@ function InnerSpendLimitSettings({
   }
 
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       <Container padding="xl xl 0">
         <Heading as="h2" size="lg">
           {tct('Monthly spending [limitTerm]', {
@@ -607,7 +607,7 @@ function InnerSpendLimitSettings({
         </Heading>
       </Container>
       {inputs}
-    </Flex>
+    </Stack>
   );
 }
 
@@ -666,7 +666,7 @@ export function SpendLimitSettings({
   subscription,
 }: SpendLimitSettingsProps) {
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       {header}
       <Grid gap="2xl">
         <Text variant="muted">
@@ -702,7 +702,7 @@ export function SpendLimitSettings({
           {footer}
         </InnerContainer>
       </Grid>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -1,6 +1,6 @@
 import {useTheme} from '@emotion/react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Redirect} from 'sentry/components/redirect';
@@ -41,7 +41,7 @@ function BillingInformation({subscription}: Props) {
       <SettingsPageHeader title={t('Billing Information')} />
       {hasBillingPerms ? (
         subscription ? (
-          <Flex direction="column" gap="xl">
+          <Stack gap="xl">
             <CreditCardPanel
               organization={organization}
               subscription={subscription}
@@ -57,7 +57,7 @@ function BillingInformation({subscription}: Props) {
               shouldExpandInitially
               maxPanelWidth={maxPanelWidth}
             />
-          </Flex>
+          </Stack>
         ) : (
           <LoadingIndicator />
         )

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -1,5 +1,5 @@
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -28,16 +28,10 @@ export function BillingInfoCard({
     <SubscriptionHeaderCard
       title={t('Billing information')}
       sections={[
-        <Flex
-          key="billing-info"
-          direction="column"
-          gap="md"
-          align="start"
-          maxWidth="100%"
-        >
+        <Stack key="billing-info" gap="md" align="start" maxWidth="100%">
           <BillingDetailsInfo subscription={subscription} />
           <PaymentSourceInfo subscription={subscription} />
-        </Flex>,
+        </Stack>,
         <LinkButton
           key="edit-billing-information"
           aria-label={t('Edit billing information')}
@@ -61,10 +55,10 @@ function BillingDetailsInfo({subscription}: {subscription: Subscription}) {
 
   if (isLoading) {
     return (
-      <Flex direction="column" gap="sm">
+      <Stack gap="sm">
         <Placeholder height="14px" />
         <Placeholder height="14px" />
-      </Flex>
+      </Stack>
     );
   }
 
@@ -105,12 +99,7 @@ function BillingDetailsInfo({subscription}: {subscription: Subscription}) {
       : formatCurrency(subscription.accountBalance);
 
   return (
-    <Flex
-      overflow="hidden"
-      direction="column"
-      gap="sm"
-      maxWidth={isMobile ? MAX_WIDTH : '100%'}
-    >
+    <Stack overflow="hidden" gap="sm" maxWidth={isMobile ? MAX_WIDTH : '100%'}>
       {!!subscription.accountBalance && (
         <Text ellipsis size="sm" variant="muted">
           {tct('Account balance: [balance]', {
@@ -128,7 +117,7 @@ function BillingDetailsInfo({subscription}: {subscription: Subscription}) {
           ? secondaryDetails.join('. ')
           : t('No billing email or tax number on file')}
       </Text>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {IconList, IconSubscribed, IconTimer} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -18,7 +18,7 @@ export function LinksCard({organization}: {organization: Organization}) {
     <SubscriptionHeaderCard
       title={hasBillingPerms ? t('Receipts & notifications') : t('Activity log')}
       sections={[
-        <Flex key="links" direction="column" gap="sm" align="start">
+        <Stack key="links" gap="sm" align="start">
           {hasBillingPerms ? (
             <Fragment>
               <LinkButton
@@ -58,7 +58,7 @@ export function LinksCard({organization}: {organization: Organization}) {
               {t('View activity')}
             </LinkButton>
           )}
-        </Flex>,
+        </Stack>,
       ]}
     />
   );

--- a/static/gsApp/views/subscriptionPage/headerCards/nextBillCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/nextBillCard.tsx
@@ -2,7 +2,7 @@ import moment from 'moment-timezone';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {Placeholder} from 'sentry/components/placeholder';
@@ -107,11 +107,11 @@ export function NextBillCard({
             {t('Could not compute next bill. Please try again later.')}
           </Alert>
         ) : (
-          <Flex direction="column" gap="lg" width="100%">
+          <Stack gap="lg" width="100%">
             <Text size="2xl" variant="accent" bold>
               {displayPriceWithCents({cents: nextBill?.billedAmount ?? 0})}
             </Text>
-            <Flex direction="column" gap="xs">
+            <Stack gap="xs">
               {reservedTotal > 0 && (
                 <Flex justify="between" align="center">
                   <Text variant="muted" size="sm">
@@ -164,8 +164,8 @@ export function NextBillCard({
                   </Text>
                 </Flex>
               )}
-            </Flex>
-          </Flex>
+            </Stack>
+          </Stack>
         ),
       ]}
     />

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -7,7 +7,7 @@ import moment from 'moment-timezone';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {ProgressBar} from 'sentry/components/progressBar';
@@ -139,7 +139,7 @@ export function PaygCard({
       sections={
         isEditing
           ? [
-              <Flex key="payg-form" direction="column" gap="xl" width="100%">
+              <Stack key="payg-form" gap="xl" width="100%">
                 {error && (
                   <Alert variant="danger" key="error">
                     {error}
@@ -193,7 +193,7 @@ export function PaygCard({
                     })}
                   </Button>
                 </Flex>
-              </Flex>,
+              </Stack>,
             ]
           : [
               <Flex justify="between" align="start" key="title" width="100%" gap="sm">

--- a/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/subscriptionHeaderCard.tsx
@@ -1,6 +1,6 @@
 import React, {Fragment} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 interface SubscriptionHeaderCardProps {
@@ -19,8 +19,7 @@ export function SubscriptionHeaderCard({
   isHighlighted = false,
 }: SubscriptionHeaderCardProps) {
   return (
-    <Flex
-      direction="column"
+    <Stack
       padding="xl"
       background={isMainCard ? 'secondary' : 'primary'}
       border={isHighlighted ? 'accent' : 'primary'}
@@ -36,11 +35,11 @@ export function SubscriptionHeaderCard({
       )}
 
       {subtitle && <Text variant="muted">{subtitle}</Text>}
-      <Flex direction="column" gap="lg" align="start" height="100%">
+      <Stack gap="lg" align="start" height="100%">
         {sections.map((section, index) => {
           return <Fragment key={index}>{section}</Fragment>;
         })}
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   );
 }

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -3,7 +3,7 @@ import {z} from 'zod';
 
 import {AlertLink} from '@sentry/scraps/alert';
 import {defaultFormOptions, FieldGroup, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -84,7 +84,7 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
           "Receive notifications when your organization's usage exceeds a threshold"
         )}
       />
-      <Flex direction="column" gap="2xl">
+      <Stack gap="2xl">
         <AlertLink
           to="/settings/account/notifications/quota/"
           variant="info"
@@ -109,7 +109,7 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
         ) : (
           <ContactBillingMembers />
         )}
-      </Flex>
+      </Stack>
     </SubscriptionPageContainer>
   );
 }

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useEffect} from 'react';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -87,7 +87,7 @@ function Overview({subscription}: Props) {
         ) : isError ? (
           <LoadingError onRetry={refetchUsage} />
         ) : (
-          <Flex direction="column" gap="xl" paddingTop="xl">
+          <Stack gap="xl" paddingTop="xl">
             {/**
              * It's important to separate the views for folks with billing permissions (org:billing) and those without.
              * Only owners and billing admins have the billing scope, everyone else including managers, admins, and members lack that scope.
@@ -126,7 +126,7 @@ function Overview({subscription}: Props) {
             />
             <TrialEnded subscription={subscription} />
             <Footer subscription={subscription} />
-          </Flex>
+          </Stack>
         )}
       </SubscriptionPageContainer>
     </Fragment>
@@ -138,13 +138,7 @@ function Footer({subscription}: {subscription: Subscription}) {
     return null;
   }
   return (
-    <Flex
-      direction="column"
-      gap="sm"
-      padding="xl 0"
-      background="primary"
-      borderTop="primary"
-    >
+    <Stack gap="sm" padding="xl 0" background="primary" borderTop="primary">
       <Flex align="center" gap="sm">
         <Text bold>{t('Having trouble?')}</Text>
       </Flex>
@@ -162,7 +156,7 @@ function Footer({subscription}: {subscription: Subscription}) {
           ),
         })}
       </Text>
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/paymentHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.tsx
@@ -5,7 +5,7 @@ import moment from 'moment-timezone';
 
 import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
@@ -133,10 +133,9 @@ function ReceiptGrid({
 
   return (
     <Fragment>
-      <Flex
+      <Stack
         border="primary"
         radius="md"
-        direction="column"
         background="primary"
         data-test-id="payment-list"
       >
@@ -190,7 +189,7 @@ function ReceiptGrid({
             </Grid>
           );
         })}
-      </Flex>
+      </Stack>
       {payments.length === 0 && <Text>{t('No receipts found')}</Text>}
       {paymentsPageLinks && <Pagination pageLinks={paymentsPageLinks} />}
     </Fragment>

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
@@ -1,7 +1,7 @@
 import {cloneElement, Fragment, isValidElement} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -37,16 +37,10 @@ export function SubscriptionHeader(props: Props) {
   const planIcon = getPlanIcon(subscription.planDetails);
 
   return (
-    <Flex direction="column" gap="xl" background="secondary">
+    <Stack gap="xl" background="secondary">
       <SentryDocumentTitle title={t('Subscription')} orgSlug={organization.slug} />
 
-      <Flex
-        direction="column"
-        gap="md"
-        background="primary"
-        borderBottom="primary"
-        padding="2xl 3xl"
-      >
+      <Stack gap="md" background="primary" borderBottom="primary" padding="2xl 3xl">
         <Flex
           justify="between"
           align={{'screen:xs': 'start', 'screen:sm': 'center'}}
@@ -74,8 +68,8 @@ export function SubscriptionHeader(props: Props) {
             )}
           </Flex>
         </Flex>
-      </Flex>
-      <Flex direction="column" padding="0 2xl xl" gap="xl" borderBottom="primary">
+      </Stack>
+      <Stack padding="0 2xl xl" gap="xl" borderBottom="primary">
         <SubscriptionUpsellBanner
           organization={organization}
           subscription={subscription}
@@ -87,8 +81,8 @@ export function SubscriptionHeader(props: Props) {
         ) : (
           <BodyWithoutBillingPerms {...props} />
         )}
-      </Flex>
-    </Flex>
+      </Stack>
+    </Stack>
   );
 }
 
@@ -105,7 +99,7 @@ function BodyWithBillingPerms({
   subscription: Subscription;
 }) {
   return (
-    <Flex direction="column" gap="xl">
+    <Stack gap="xl">
       {subscription.pendingChanges ? (
         <DecidePendingChanges subscription={subscription} organization={organization} />
       ) : null}
@@ -118,7 +112,7 @@ function BodyWithBillingPerms({
       )}
       <HeaderCards organization={organization} subscription={subscription} />
       <ManagedNote subscription={subscription} />
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 
 import {IconFire, IconStats} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -264,10 +264,10 @@ export function UsageAlert({subscription, usage}: Props) {
   const showProjected = !hasExceeded;
 
   return (
-    <Flex direction="column" gap="xl" data-test-id="usage-alert">
+    <Stack gap="xl" data-test-id="usage-alert">
       {hasExceeded && renderExceededInfo()}
       {showProjected && renderProjectedInfo(projectedOverages)}
-    </Flex>
+    </Stack>
   );
 }
 

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -6,7 +6,7 @@ import moment from 'moment-timezone';
 import {Badge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
@@ -234,7 +234,7 @@ function UsageHistoryRow({history}: RowProps) {
             icon={<IconChevron direction={expanded ? 'up' : 'down'} />}
             aria-label={t('Expand history')}
           />
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             <Flex gap="sm" align="center">
               <Text variant="muted">
                 {moment(history.periodStart).format('ll')} -{' '}
@@ -243,7 +243,7 @@ function UsageHistoryRow({history}: RowProps) {
               {history.isCurrent && <Badge variant="muted">{t('Current')}</Badge>}
             </Flex>
             <Text bold>{tct('[planName] Plan', {planName: history.planName})}</Text>
-          </Flex>
+          </Stack>
         </Flex>
         <Grid flow="column" align="center" gap="md">
           <Button

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/breakdownInfo.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/breakdownInfo.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {QuestionTooltip} from 'sentry/components/questionTooltip';
@@ -67,7 +67,7 @@ function UsageBreakdownField({
   help?: React.ReactNode;
 }) {
   return (
-    <Flex direction="column" gap="sm">
+    <Stack gap="sm">
       <Flex gap="sm">
         <Text variant="muted" bold uppercase size="sm">
           {field}
@@ -75,7 +75,7 @@ function UsageBreakdownField({
         {help && <QuestionTooltip title={help} size="xs" />}
       </Flex>
       <Text size="lg">{value}</Text>
-    </Flex>
+    </Stack>
   );
 }
 
@@ -119,7 +119,7 @@ function UsageBreakdownInfo({
   return (
     <Grid columns="repeat(2, 1fr)" gap="md lg" padding="xl">
       {shouldShowIncludedVolume && (
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Text bold>{t('Included volume')}</Text>
           {activeProductTrial && (
             <UsageBreakdownField field={t('Trial')} value={t('Unlimited')} />
@@ -139,10 +139,10 @@ function UsageBreakdownInfo({
           {formattedGifted && (
             <UsageBreakdownField field={t('Gifted')} value={formattedGifted} />
           )}
-        </Flex>
+        </Stack>
       )}
       {shouldShowAdditionalSpend && (
-        <Flex direction="column" gap="lg">
+        <Stack gap="lg">
           <Text bold>{t('Additional spend')}</Text>
           {formattedSoftCapType && (
             <UsageBreakdownField
@@ -184,7 +184,7 @@ function UsageBreakdownInfo({
             />
           )}
           {formattedOtherSpend}
-        </Flex>
+        </Stack>
       )}
     </Grid>
   );

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/charts.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/charts.tsx
@@ -1,4 +1,4 @@
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 
 import {OptionSelector} from 'sentry/components/charts/optionSelector';
 import {ChartControls, InlineContainer} from 'sentry/components/charts/styles';
@@ -131,7 +131,7 @@ export function UsageCharts({
         usagePeriodEnd={usageData.periodEnd}
         footer={renderFooter()}
       />
-      <Flex direction="column" gap="xl">
+      <Stack gap="xl">
         <UsageTotalsTable
           category={category}
           subscription={subscription}
@@ -150,7 +150,7 @@ export function UsageCharts({
               />
             );
           })}
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -5,7 +5,7 @@ import seerConfigSeerImg from 'sentry-images/spot/seer-config-seer.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconLightning, IconLock, IconOpen, IconSeer, IconUpload} from 'sentry/icons';
@@ -57,7 +57,7 @@ function Cta({
       justify={isBanner ? 'between' : 'center'}
       height={heightOverride ?? (isBanner ? undefined : '100%')}
     >
-      <Flex direction="column" gap="lg" align={isBanner ? 'start' : 'center'}>
+      <Stack gap="lg" align={isBanner ? 'start' : 'center'}>
         {icon && <Flex align="center">{icon}</Flex>}
         {image && (
           <Flex align="center">
@@ -81,16 +81,15 @@ function Cta({
             {subtitle}
           </Text>
         </Container>
-      </Flex>
+      </Stack>
       {buttons && (
-        <Flex
-          direction="column"
+        <Stack
           gap={isBanner ? 'sm' : 'lg'}
           align="center"
           flexGrow={isBanner ? 1 : undefined}
         >
           {buttons}
-        </Flex>
+        </Stack>
       )}
     </Flex>
   );
@@ -127,18 +126,11 @@ function SeerCta({action, footerText}: {action: React.ReactNode; footerText?: st
   // add copy to BILLED_DATA_CATEGORY_INFO or serialize them in some endpoint
   return (
     <Container background="secondary" height="100%" radius="md" alignSelf="stretch">
-      <Flex
-        direction="column"
-        gap="xl"
-        align="center"
-        justify="center"
-        justifySelf="center"
-        height="100%"
-      >
+      <Stack gap="xl" align="center" justify="center" justifySelf="center" height="100%">
         <Container>
           <Image src={seerConfigMainImg} alt="" />
         </Container>
-        <Flex direction="column" gap="md">
+        <Stack gap="md">
           <Text align="center" size="xl" bold>
             {t('Find and fix issues anywhere with Seer AI debugger')}
           </Text>
@@ -147,14 +139,14 @@ function SeerCta({action, footerText}: {action: React.ReactNode; footerText?: st
             <Text>$40 </Text>
             <Text variant="muted">{t('per active contributor / month')}</Text>
           </Text>
-        </Flex>
+        </Stack>
         {action}
         {footerText && (
           <Text align="center" variant="muted" size="sm">
             {footerText}
           </Text>
         )}
-      </Flex>
+      </Stack>
     </Container>
   );
 }

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/productTrialRibbon.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/productTrialRibbon.tsx
@@ -1,7 +1,7 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconClock, IconLightning} from 'sentry/icons';
@@ -46,10 +46,10 @@ export function ProductTrialRibbon({
           )}
         </Tooltip>
       </RibbonBase>
-      <Flex direction="column" position="relative">
+      <Stack position="relative">
         <TopRibbonEdge ribbonColor={ribbonColor} />
         <BottomRibbonEdge ribbonColor={ribbonColor} />
-      </Flex>
+      </Stack>
     </RibbonContainer>
   );
 }

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import moment from 'moment-timezone';
 
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import {tct} from 'sentry/locale';
@@ -116,13 +116,13 @@ export function UsageOverview({
           gap="xl"
           height={USAGE_OVERVIEW_PANEL_HEADER_HEIGHT}
         >
-          <Flex direction="column" gap="sm">
+          <Stack gap="sm">
             <Heading as="h3" size="lg">
               {tct('Usage: [period]', {
                 period: `${startDate.format(startsAndEndsSameYear ? 'MMM D' : 'MMM D, YYYY')} - ${endDate.format('MMM D, YYYY')}`,
               })}
             </Heading>
-          </Flex>
+          </Stack>
           <UsageOverviewActions organization={organization} />
         </Flex>
         <UsageOverviewTable

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import type {TooltipProps} from '@sentry/scraps/tooltip';
 
@@ -197,7 +197,7 @@ function IngestionSummary({
     .reduce((acc, [_, value]) => acc + value, 0);
 
   return (
-    <Flex direction="column" gap="md">
+    <Stack gap="md">
       <Heading as="h4">{t('Total ingested')}</Heading>
       <Flex justify="between" align="center" gap="lg">
         <Text wrap="nowrap">
@@ -213,7 +213,7 @@ function IngestionSummary({
           outcomeToBarColor={outcomeToBarColor}
         />
       </Flex>
-    </Flex>
+    </Stack>
   );
 }
 
@@ -290,7 +290,7 @@ export function UsageTotalsTable({
   const hasSpikeProtection = categoryInfo?.hasSpikeProtection ?? false;
 
   return (
-    <Flex direction="column" gap="md" padding="md">
+    <Stack gap="md" padding="md">
       <IngestionSummary
         category={category}
         totals={totals}
@@ -343,7 +343,7 @@ export function UsageTotalsTable({
           />
         </OutcomeSection>
       </OutcomeTable>
-    </Flex>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
`Stack` is `Flex` with `direction="column"` by default, so a column-oriented `Flex` is more clearly expressed as a `Stack`. Because we have no static analysis enforcing this, column-direction `Flex` usages had accumulated across the app.

This converts every `<Flex direction="column">` to `<Stack>`, dropping the now-redundant `direction` prop and updating the `@sentry/scraps/layout` imports (`Stack` added, `Flex` dropped where no longer used).

### Scope
- **271 files, 495 conversions.** No behavior change — `Stack` is `Flex` defaulted to column direction.
- Generated via an AST codemod, then normalized with `oxfmt` + `eslint --fix`.

### Left untouched (out of scope)
- Responsive/dynamic direction (`direction={{'screen:xs': 'column', ...}}`) — can't be a static `Stack`.
- Non-`Flex` components with a `direction` prop, and `styled(Flex)` / `motion.create(Flex)` bases.
- Test/snapshot files (`*.spec.tsx`, `*.snapshots.tsx`).
- Redundant `<Stack direction="column">` (already `Stack`) — can be cleaned up separately.

### Verification
- `pnpm run typecheck` — passes
- `eslint` on all changed files — passes
- `oxfmt --check` — clean
