### PR TITLE
fix(seer): Don't request embed widgets for entrypoint (Slack) agent runs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -310,6 +310,7 @@ class SeerAgentClient:
             enable_coding: Include code editing tools. When False, the agent cannot make code changes. Default is False. If enable_coding is True and the organization does not have the enable_seer_coding option, a SeerPermissionError will be raised.
             code_review_enabled: Expose the review_code_changes tool, which spawns a reviewer agent to check accumulated code edits before finalizing. Only useful alongside enable_coding. Default is False.
             max_iterations: Optional maximum number of agent iterations. Useful for lightweight/fast runs that don't need full exploration depth.
+            enable_embeds: Allow the agent to emit rich inline embed widgets (e.g. formatted timestamps) as Markdoc tags. Only enable for surfaces that render these embeds (the Explorer chat in the Sentry UI). Disable for plaintext/markdown surfaces like Slack, where the tags would leak as raw text. Default is True.
     """
 
     def __init__(
@@ -330,6 +331,7 @@ class SeerAgentClient:
         enable_code_mode_tools: str = "off",
         code_review_enabled: bool = False,
         max_iterations: int | None = None,
+        enable_embeds: bool = True,
     ):
         self.organization = organization
         self.user = user
@@ -345,6 +347,7 @@ class SeerAgentClient:
         self.enable_code_mode_tools = enable_code_mode_tools
         self.code_review_enabled = code_review_enabled
         self.max_iterations = max_iterations
+        self.enable_embeds = enable_embeds
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
             raise SeerPermissionError("Seer coding is not enabled for this organization")
@@ -613,7 +616,7 @@ class SeerAgentClient:
         ):
             opts["enable_tool_summary"] = True
 
-        if features.has(
+        if self.enable_embeds and features.has(
             "organizations:seer-explorer-embeds",
             self.organization,
             actor=self.user,
@@ -726,7 +729,7 @@ class SeerAgentClient:
         ):
             agent_run_options["enable_tool_summary"] = True
 
-        if features.has(
+        if self.enable_embeds and features.has(
             "organizations:seer-explorer-embeds",
             self.organization,
             actor=self.user,

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -495,6 +495,10 @@ class SeerAgentOperator[CachePayloadT]:
                     is_interactive=True,
                     enable_coding=False,
                     enable_code_mode_tools=enable_code_mode_tools,
+                    # Entrypoints (e.g. Slack) render responses as plain markdown and
+                    # can't display embed widgets, so the raw Markdoc tags would leak as
+                    # text. Don't ask the agent to emit them in the first place.
+                    enable_embeds=False,
                 )
             except SeerPermissionError as e:
                 with SeerOperatorEventLifecycleMetric(

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -256,6 +256,66 @@ class TestSeerAgentClient(TestCase):
         assert body["agent_run_options"]["enable_pr_context_tools"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    @with_feature("organizations:seer-explorer-embeds")
+    def test_start_run_includes_embed_widgets_by_default(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user)
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    @patch("sentry.seer.agent.client.collect_user_org_context")
+    @with_feature("organizations:seer-explorer-embeds")
+    def test_start_run_excludes_embed_widgets_when_disabled(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user, enable_embeds=False)
+        client.start_run("Test query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @with_feature("organizations:seer-explorer-embeds")
+    def test_continue_run_includes_embed_widgets_by_default(self, mock_post, mock_access):
+        mock_access.return_value = (True, None)
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user)
+        client.continue_run(123, "Follow-up query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    @with_feature("organizations:seer-explorer-embeds")
+    def test_continue_run_excludes_embed_widgets_when_disabled(self, mock_post, mock_access):
+        mock_access.return_value = (True, None)
+        mock_post.return_value = self._mock_run_response()
+
+        client = SeerAgentClient(self.organization, self.user, enable_embeds=False)
+        client.continue_run(123, "Follow-up query")
+
+        body = mock_post.call_args[0][0]
+        assert "embed_widgets" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     def test_init_category_key_only_raises_error(self, mock_access):
         """Test that ValueError is raised when only category_key is provided"""
         mock_access.return_value = (True, None)


### PR DESCRIPTION
Seer Agent conversations started from 'text' entrypoints like Slack reuse the same `SeerAgentClient` as the web.
In these cases we should not emit inline embed widgets as Markdoc tags (e.g. formatted timestamps) as Slack renders the response as plain markdown and can't display these, so the raw tags leak into the message as text.

Disable embeds in these cases.

Agent transcript: https://claudescope.sentry.dev/share/EgqobwvsuPhAHUCk0rebsdyKfG4ReFNHoD_E9KIA2dQ