### PR TITLE
fix(ui): Remove double divider line on the secondary nav resizer

### DIFF
--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -180,12 +180,7 @@ function SecondarySidebarWrapper(props: NavigationTourElementProps) {
   const theme = useTheme();
 
   return (
-    <Container
-      background="secondary"
-      borderRight="primary"
-      position="relative"
-      height="100%"
-    >
+    <Container background="secondary" position="relative" height="100%">
       {p => (
         <NavigationTourElement
           {...mergeProps(p, props)}
@@ -200,11 +195,14 @@ const ResizeHandle = styled('div')<{atMaxWidth: boolean; atMinWidth: boolean}>`
   z-index: ${p => p.theme.zIndex.drawer + 2};
   cursor: ${p => (p.atMinWidth ? 'e-resize' : p.atMaxWidth ? 'w-resize' : 'ew-resize')};
 
-  &:hover,
-  &:active {
-    &::after {
-      background: ${p => p.theme.tokens.graphics.accent.vibrant};
-    }
+  &::before {
+    content: '';
+    position: absolute;
+    right: -1px;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    border-right: 1px solid ${p => p.theme.tokens.border.primary};
   }
 
   &::after {
@@ -217,6 +215,16 @@ const ResizeHandle = styled('div')<{atMaxWidth: boolean; atMinWidth: boolean}>`
     opacity: 0.8;
     background: transparent;
     transition: background ${p => p.theme.motion.smooth.slow} 0.1s;
+  }
+
+  &:hover,
+  &:active {
+    &::before {
+      border-color: transparent;
+    }
+    &::after {
+      background: ${p => p.theme.tokens.graphics.accent.vibrant};
+    }
   }
 `;
 


### PR DESCRIPTION
## Summary

The secondary navigation sidebar (Issues/Feed nav, etc.) drew **two lines at its right edge** when the resize handle was hovered/dragged: a grey line beside a purple one.

**Root cause:** two separate elements each render a line at that edge:
- `SecondarySidebarWrapper` has a persistent `borderRight="primary"` (grey).
- The `ResizeHandle`'s `::after` accent bar turns purple on `:hover` / `:active`, offset to `right: -2px`.

Because they live on different elements, the accent never masks the border — both show at once.

## Fix

Make the resize handle own the entire divider:
- `::before` renders the 1px grey resting line (as a `border-right`, so it passes the design-token lint).
- On `:hover` / `:active`, `::before` goes transparent while `::after` shows the purple bar.
- Removed the now-redundant `borderRight` from `SecondarySidebarWrapper`.

Result: exactly one line in every state (grey at rest → purple on interaction).

## Test plan

- Hover/drag the divider between the secondary nav and the content — single line at rest and on interaction, light and dark mode.
- Check a narrow/mobile viewport (resize handle is hidden there): the full-width sidebar looks correct without the wrapper border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)