### PR TITLE
fix(scraps): Shadow not extending fully to the right

### DIFF
--- a/static/app/views/issueDetails/sidebar/toggleSidebar.tsx
+++ b/static/app/views/issueDetails/sidebar/toggleSidebar.tsx
@@ -40,10 +40,14 @@ const ToggleButton = styled(Button)<{expanded: boolean}>`
     p.expanded &&
     css`
       margin-right: calc(-${p.theme.space.xl} - 1px);
+      /* Square the right corners on both layers so the shadow (::before) reaches the edge like the surface (::after) */
+      &::before,
       &::after {
-        border-right-color: transparent;
         border-top-right-radius: 0px;
         border-bottom-right-radius: 0px;
+      }
+      &::after {
+        border-right-color: transparent;
       }
     `}
 `;


### PR DESCRIPTION
**Before**
<img width="171" height="182" alt="image" src="https://github.com/user-attachments/assets/eedd9e0d-12f5-43b3-b1ff-a32a1fce17e4" />


**After**


<img width="197" height="216" alt="image" src="https://github.com/user-attachments/assets/1c1fe024-2ecd-4a25-8108-1b78e6d21126" />


Fixes DE-1354