### PR TITLE
fix(seer): Strip embed widget markup from Slack agent responses

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -243,8 +243,9 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
     def _render_agent_response(cls, data: SeerAgentResponse) -> SlackRenderable:
         from sentry import features
         from sentry.models.organization import Organization
+        from sentry.seer.agent.embed_widgets import strip_embed_widgets
 
-        blocks: list[Block] = [MarkdownBlock(text=data.summary)]
+        blocks: list[Block] = [MarkdownBlock(text=strip_embed_widgets(data.summary))]
         try:
             organization = Organization.objects.get_from_cache(id=data.organization_id)
         except Organization.DoesNotExist:

--- a/src/sentry/seer/agent/embed_widgets.py
+++ b/src/sentry/seer/agent/embed_widgets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -31,3 +32,54 @@ def get_embed_widgets(organization: Any = None, actor: Any = None) -> list[dict[
         if "featureFlag" not in w
         or (organization is not None and features.has(w["featureFlag"], organization, actor=actor))
     ]
+
+
+# Embed widgets are emitted as Markdoc-style tags, e.g.
+#   {% timestamp %}{"value": "2026-07-09T17:14:03", "format": "relative"}{% /timestamp %}
+# The Sentry web UI parses these into React components, but plaintext/markdown
+# surfaces (Slack, etc.) show them as raw text.
+#
+# The grammar below mirrors the frontend tokenizer (the source of truth) in
+# static/app/utils/marked/extensions/tag.ts: whitespace is required around the
+# tag name and delimiters, attributes are `key="value"` pairs, and a tag is
+# either self-closing (`{% name /%}`) or a paired block with a matching close
+# (`{% name %}...{% /name %}`). Matching that grammar keeps us from mangling
+# stray `{%`/`%}` that isn't actually a widget.
+_ATTRS = r'(?:\s+[\w-]+="[^"]*")*'
+_PAIRED_EMBED_TAG_RE = re.compile(
+    rf"\{{%\s+(?P<name>[\w-]+){_ATTRS}\s+%\}}[\s\S]*?\{{%\s+/(?P=name)\s+%\}}"
+)
+_SELF_CLOSING_EMBED_TAG_RE = re.compile(rf"\{{%\s+[\w-]+{_ATTRS}\s+/%\}}")
+
+# Code fences and inline code spans are rendered verbatim by the frontend (marked
+# tokenizes them before the tag extension runs), so `{% ... %}` inside them is
+# literal text, not a widget. Skip those regions when stripping. Fenced blocks
+# are matched before inline spans so ``` isn't mistaken for a run of inline
+# backticks; group 1 captures the inline backtick run so its close can match.
+_CODE_SEGMENT_RE = re.compile(r"```[\s\S]*?```|~~~[\s\S]*?~~~|(`+)[\s\S]*?\1")
+
+
+def _strip_tags(chunk: str) -> str:
+    chunk = _PAIRED_EMBED_TAG_RE.sub("", chunk)
+    return _SELF_CLOSING_EMBED_TAG_RE.sub("", chunk)
+
+
+def strip_embed_widgets(text: str) -> str:
+    """Remove Seer embed widget tags from ``text``, leaving code regions intact.
+
+    Defense-in-depth for surfaces that can't render embeds: even when the agent
+    is asked not to emit widgets, an in-flight or continued run may still return
+    them. Strip the tags so the raw markup never reaches the user, but never
+    touch `{% ... %}` inside fenced code blocks or inline code spans — there it's
+    legitimate content (e.g. Jinja/Nunjucks/Liquid examples) that the web UI also
+    renders verbatim. (Indented code blocks are not detected, but Seer uses
+    fenced blocks in practice.)
+    """
+    out: list[str] = []
+    last = 0
+    for match in _CODE_SEGMENT_RE.finditer(text):
+        out.append(_strip_tags(text[last : match.start()]))
+        out.append(match.group(0))  # keep the code region verbatim
+        last = match.end()
+    out.append(_strip_tags(text[last:]))
+    return "".join(out)

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -315,6 +315,20 @@ class SeerSlackRendererAgentTest(TestCase):
         assert isinstance(blocks[0], MarkdownBlock)
         assert "Found a spike in 500 errors from the auth service." in blocks[0].text
 
+    def test_render_agent_response_strips_embed_widgets(self) -> None:
+        data = self._create_agent_response(
+            summary=(
+                'first seen at {% timestamp %}{"value": "2026-07-09T17:14:03", '
+                '"format": "relative"}{% /timestamp %} — done'
+            )
+        )
+        renderable = SeerSlackRenderer._render_agent_response(data)
+
+        block = renderable["blocks"][0]
+        assert isinstance(block, MarkdownBlock)
+        assert "{% timestamp %}" not in block.text
+        assert block.text == "first seen at  — done"
+
     def test_render_agent_response_with_missing_scope_footer(self) -> None:
         data = SeerAgentResponse(
             run_id=MOCK_RUN_ID,

--- a/tests/sentry/seer/agent/test_embed_widgets.py
+++ b/tests/sentry/seer/agent/test_embed_widgets.py
@@ -1,0 +1,65 @@
+from sentry.seer.agent.embed_widgets import strip_embed_widgets
+
+
+def test_strips_paired_widget_tag() -> None:
+    text = (
+        'first seen at {% timestamp %}{"value": "2026-07-09T17:14:03", '
+        '"format": "relative"}{% /timestamp %} ago'
+    )
+    assert strip_embed_widgets(text) == "first seen at  ago"
+
+
+def test_strips_self_closing_widget_tag() -> None:
+    assert strip_embed_widgets('before {% foo bar="x" /%} after') == "before  after"
+
+
+def test_strips_widget_tag_with_attributes() -> None:
+    text = '{% timestamp format="relative" %}{"value": "x"}{% /timestamp %}'
+    assert strip_embed_widgets(text) == ""
+
+
+def test_leaves_plain_text_untouched() -> None:
+    text = "Your most recent issue is SDK-CRASHES-COCOA-15DT, about 2 minutes ago."
+    assert strip_embed_widgets(text) == text
+
+
+def test_ignores_non_tag_braces() -> None:
+    # No whitespace around the name, so the frontend would not treat this as a tag.
+    text = "the value is {%notatag%} here"
+    assert strip_embed_widgets(text) == text
+
+
+def test_preserves_tags_inside_inline_code() -> None:
+    text = "use `{% timestamp %}x{% /timestamp %}` in your template"
+    assert strip_embed_widgets(text) == text
+
+
+def test_preserves_tags_inside_fenced_code_block() -> None:
+    text = "example:\n```\n{% timestamp %}\n{...}\n{% /timestamp %}\n```\ndone"
+    assert strip_embed_widgets(text) == text
+
+
+def test_preserves_tags_inside_tilde_fenced_code_block() -> None:
+    text = "example:\n~~~\n{% foo /%}\n~~~\ndone"
+    assert strip_embed_widgets(text) == text
+
+
+def test_strips_prose_tag_but_keeps_code_tag() -> None:
+    text = "at {% timestamp %}{}{% /timestamp %} — see `{% timestamp %}`"
+    assert strip_embed_widgets(text) == "at  — see `{% timestamp %}`"
+
+
+def test_strips_multiple_widgets() -> None:
+    text = "a {% timestamp %}{}{% /timestamp %} b {% timestamp %}{}{% /timestamp %} c"
+    assert strip_embed_widgets(text) == "a  b  c"
+
+
+def test_leaves_unclosed_tag_in_prose() -> None:
+    # No matching close tag, so the frontend would render this as literal text too.
+    text = "in Jinja you write {% for item in items %} to loop"
+    assert strip_embed_widgets(text) == text
+
+
+def test_preserves_tags_inside_fenced_block_with_language() -> None:
+    text = "```jinja\n{% for x in y %}{% /for %}\n```"
+    assert strip_embed_widgets(text) == text


### PR DESCRIPTION
Defense-in-depth follow-up to #119396 (which stops entrypoint/Slack runs from *requesting* embed widgets).

Even with that in place, an in-flight or continued run started before the change can still return embed markup, and Slack renders it as raw text:

> Your most recent issue is SDK-CRASHES-COCOA-15DT, first seen at `{% timestamp %}{"value": "2026-07-09T17:14:03", "format": "relative"}{% /timestamp %}` — about 2 minutes ago.

## Change

- Add `strip_embed_widgets()` in `embed_widgets.py`, called from `SeerSlackRenderer._render_agent_response` before the summary is placed in a Slack `MarkdownBlock`.
- The matcher mirrors the frontend tokenizer grammar (`static/app/utils/marked/extensions/tag.ts`): whitespace-delimited tags, `key="value"` attributes, self-closing (`{% name /%}`) or paired (`{% name %}...{% /name %}`). This means it strips **only** what the web UI would actually treat as a widget — e.g. `{% for x in y %}` with no matching `{% /for %}` is left alone, exactly as the frontend leaves it.

## Code blocks

Because the frontend registers these as `marked` tokenizer extensions, `{% ... %}` inside a fenced code block or inline code span is rendered verbatim (never as a widget). The stripper skips those regions so legitimate Jinja/Nunjucks/Liquid examples survive. Indented (4-space) code blocks are not detected, but Seer uses fenced blocks in practice; noted in the docstring.

## Test plan

- `test_embed_widgets.py`: paired/self-closing/attributed tags stripped; plain text, non-tag braces, unclosed tags, and tags inside fenced/tilde/inline code preserved; mixed prose+code.
- Renderer test asserting the Slack `MarkdownBlock` no longer contains `{% timestamp %}`.



Agent transcript: https://claudescope.sentry.dev/share/ZYLb9GFys-rg-al5zFy42UF-qRD43fEtwi-D6PCy3CA