### PR TITLE
ref(o11y): Start new trace on unparented `trace()` use

### DIFF
--- a/src/sentry/utils/tracing.py
+++ b/src/sentry/utils/tracing.py
@@ -52,6 +52,8 @@ def trace(
             @functools.wraps(f)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
                 if has_span_streaming_enabled(sentry_sdk.get_client().options):
+                    if sentry_sdk.traces.get_current_span() is None:
+                        sentry_sdk.traces.new_trace()
                     return await streaming_wrapped(*args, **kwargs)
                 return await non_streaming_wrapped(*args, **kwargs)
 
@@ -60,6 +62,8 @@ def trace(
         @functools.wraps(f)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             if has_span_streaming_enabled(sentry_sdk.get_client().options):
+                if sentry_sdk.traces.get_current_span() is None:
+                    sentry_sdk.traces.new_trace()
                 return streaming_wrapped(*args, **kwargs)
             return non_streaming_wrapped(*args, **kwargs)
 


### PR DESCRIPTION
Start new trace if there is not parent span.
In this case, the `trace()` decorator results in a new segment span. In the occurrences consumer this continued the trace from a previous message, and the processing of two disjoint messages ended up in the same trace.