### PR TITLE
feat(seer): Include five_whys reasoning in Slack autofix root cause u…

### DIFF
--- a/fixtures/seer/webhooks.py
+++ b/fixtures/seer/webhooks.py
@@ -9,6 +9,7 @@ MOCK_SEER_WEBHOOKS = {
         "root_cause": {
             "description": "Test description",
             "steps": [{"title": "Step 1"}, {"title": "Step 2"}],
+            "five_whys": ["First reason", "Second reason"],
         },
     },
     SentryAppEventType.SEER_SOLUTION_COMPLETED: {

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -192,6 +192,11 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
 
         if data.summary:
             blocks.append(SectionBlock(text=MarkdownTextObject(text=data.summary)))
+        if data.reasoning:
+            parts = [RichTextElementParts.Text(text=item) for item in data.reasoning[:MAX_STEPS]]
+            sections = [RichTextSectionElement(elements=[part]) for part in parts]
+            list_element = RichTextListElement(style="ordered", indent=0, elements=sections)
+            blocks.append(RichTextBlock(elements=[list_element]))
         if data.steps:
             parts = [RichTextElementParts.Text(text=step) for step in data.steps[:MAX_STEPS]]
             sections = [RichTextSectionElement(elements=[part]) for part in parts]

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -73,6 +73,7 @@ class SeerAutofixUpdate(NotificationData):
     current_point: AutofixStoppingPoint
     group_link: str
     steps: list[str] = Field(default_factory=list)
+    reasoning: list[str] = Field(default_factory=list)
     changes: list[SeerAutofixCodeChange] = Field(default_factory=list)
     pull_requests: list[SeerAutofixPullRequest] = Field(default_factory=list)
     summary: str | None = None

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -366,6 +366,7 @@ class SlackAutofixEntrypoint(
                         "current_point": AutofixStoppingPoint.ROOT_CAUSE,
                         "summary": summary,
                         "steps": steps,
+                        "reasoning": root_cause.get("five_whys", []),
                         "handoff_target": cache_payload.get("handoff_target"),
                     }
                 )

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -9,6 +9,8 @@ from slack_sdk.models.blocks import (
     MarkdownBlock,
     MarkdownTextObject,
     PlainTextObject,
+    RichTextBlock,
+    RichTextListElement,
     SectionBlock,
 )
 
@@ -31,6 +33,7 @@ class SeerSlackRendererTest(TestCase):
         current_point: AutofixStoppingPoint,
         summary: str | None = None,
         steps: list[str] | None = None,
+        reasoning: list[str] | None = None,
         changes: list[SeerAutofixCodeChange] | None = None,
         pull_requests: list[SeerAutofixPullRequest] | None = None,
         handoff_target: str | None = None,
@@ -44,6 +47,7 @@ class SeerSlackRendererTest(TestCase):
             group_link=f"https://sentry.io/issues/{MOCK_GROUP_ID}?seerDrawer=true",
             summary=summary,
             steps=steps or [],
+            reasoning=reasoning or [],
             changes=changes or [],
             pull_requests=pull_requests or [],
             handoff_target=handoff_target,
@@ -212,6 +216,20 @@ class SeerSlackRendererTest(TestCase):
         assert handoff_button.text.text == "Hand off to Cursor"
         assert handoff_button.action_id is not None
         assert handoff_button.action_id.startswith("seer_autofix_handoff::")
+
+    def test_render_autofix_update_root_cause_with_reasoning(self) -> None:
+        data = self._create_update(
+            current_point=AutofixStoppingPoint.ROOT_CAUSE,
+            summary="Test summary",
+            reasoning=["First reason", "Second reason", "Third reason"],
+        )
+        renderable = SeerSlackRenderer._render_autofix_update(data)
+        rich_text_blocks = [b for b in renderable["blocks"] if isinstance(b, RichTextBlock)]
+        assert len(rich_text_blocks) == 1
+        list_element = rich_text_blocks[0].elements[0]
+        assert isinstance(list_element, RichTextListElement)
+        assert list_element.style == "ordered"
+        assert len(list_element.elements) == 3
 
     @patch(
         "sentry.notifications.platform.templates.seer.organization_service.get_option",


### PR DESCRIPTION
…pdates

Add a generic `reasoning` field to `SeerAutofixUpdate` and populate it from the root cause artifact's `five_whys` chain. The Slack renderer shows this as an ordered list between the summary and reproduction steps, giving reviewers the causal chain that led to the root cause.

The field is named generically so other autofix stages can reuse it for their own rationale in the future.

Closes SEE-216