### PR TITLE
feat(data-export): Pass query Filter to EAP's EndpointExportTraceItem

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -101,12 +101,12 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
             base_fields = [base_fields]
 
         is_jsonl_trace_item_full_export = query_type == ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR
-
-        if len(base_fields) > MAX_FIELDS:
-            detail = f"You can export up to {MAX_FIELDS} fields at a time. Please delete some and try again."
-            raise serializers.ValidationError(detail)
-        elif len(base_fields) == 0 and not is_jsonl_trace_item_full_export:
-            raise serializers.ValidationError("at least one field is required to export")
+        if not is_jsonl_trace_item_full_export:
+            if len(base_fields) > MAX_FIELDS:
+                detail = f"You can export up to {MAX_FIELDS} fields at a time. Please delete some and try again."
+                raise serializers.ValidationError(detail)
+            elif len(base_fields) == 0:
+                raise serializers.ValidationError("at least one field is required to export")
 
         if "query" not in query_info:
             if is_jsonl_trace_item_full_export:
@@ -161,6 +161,43 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
                         f"sampling mode: {sampling_mode} is not supported"
                     )
         return query_info
+
+    def _validate_explore_eqs_query(
+        self,
+        organization: Organization,
+        query_type: str,
+        query_info: dict[str, Any],
+        full_export: bool = False,
+    ) -> None:
+        # Validate the RPC query params, to avoid runtime failures later.
+        query_info = self._validate_query_info(query_type, query_info)
+        query_info = self._validate_dataset(query_type, query_info)
+        try:
+            explore_processor = ExploreProcessor(
+                explore_query=query_info,
+                organization=organization,
+            )
+
+            # ignore sort clause if full export.
+            sort = query_info.get("sort", []) if not full_export else []
+            orderby = [sort] if isinstance(sort, str) else sort
+
+            explore_processor.validate_export_query(
+                rpc_dataset_common.TableQuery(
+                    query_string=query_info["query"],
+                    selected_columns=query_info["field"],
+                    orderby=orderby,
+                    offset=0,
+                    limit=1,
+                    referrer=Referrer.DATA_EXPORT_TASKS_EXPLORE,
+                    sampling_mode=explore_processor.sampling_mode,
+                    resolver=explore_processor.search_resolver,
+                    equations=query_info.get("equations", []),
+                )
+            )
+        except InvalidSearchQuery as err:
+            sentry_sdk.capture_exception(err)
+            raise serializers.ValidationError("Invalid table query.")
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         organization = self.context["organization"]
@@ -220,37 +257,9 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
                 raise serializers.ValidationError("Invalid search query.")
 
         elif query_type == ExportQueryType.EXPLORE_STR:
-            query_info = self._validate_query_info(query_type, query_info)
-            query_info = self._validate_dataset(query_type, query_info)
-            explore_output_mode = OutputMode.from_value(export_format)
-            try:
-                explore_processor = ExploreProcessor(
-                    explore_query=query_info,
-                    organization=organization,
-                    output_mode=explore_output_mode,
-                )
-                sort = query_info.get("sort", [])
-                orderby = [sort] if isinstance(sort, str) else sort
-
-                explore_processor.validate_export_query(
-                    rpc_dataset_common.TableQuery(
-                        query_string=query_info["query"],
-                        selected_columns=query_info["field"],
-                        orderby=orderby,
-                        offset=0,
-                        limit=1,
-                        referrer=Referrer.DATA_EXPORT_TASKS_EXPLORE,
-                        sampling_mode=explore_processor.sampling_mode,
-                        resolver=explore_processor.search_resolver,
-                        equations=query_info.get("equations", []),
-                    )
-                )
-            except InvalidSearchQuery as err:
-                sentry_sdk.capture_exception(err)
-                raise serializers.ValidationError("Invalid table query.")
+            self._validate_explore_eqs_query(organization, query_type, query_info)
         elif query_type == ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR:
-            query_info = self._validate_query_info(query_type, query_info)
-            query_info = self._validate_dataset(query_type, query_info)
+            self._validate_explore_eqs_query(organization, query_type, query_info, full_export=True)
             explore_output_mode = OutputMode.from_value(export_format)
             if explore_output_mode != OutputMode.JSONL:
                 raise serializers.ValidationError("For full export, output mode must be JSONL.")

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -168,7 +168,7 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
         query_type: str,
         query_info: dict[str, Any],
         full_export: bool = False,
-    ) -> None:
+    ) -> dict[str, Any]:
         # Validate the RPC query params, to avoid runtime failures later.
         query_info = self._validate_query_info(query_type, query_info)
         query_info = self._validate_dataset(query_type, query_info)
@@ -198,6 +198,7 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
         except InvalidSearchQuery as err:
             sentry_sdk.capture_exception(err)
             raise serializers.ValidationError("Invalid table query.")
+        return query_info
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         organization = self.context["organization"]
@@ -257,9 +258,11 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
                 raise serializers.ValidationError("Invalid search query.")
 
         elif query_type == ExportQueryType.EXPLORE_STR:
-            self._validate_explore_eqs_query(organization, query_type, query_info)
+            query_info = self._validate_explore_eqs_query(organization, query_type, query_info)
         elif query_type == ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR:
-            self._validate_explore_eqs_query(organization, query_type, query_info, full_export=True)
+            query_info = self._validate_explore_eqs_query(
+                organization, query_type, query_info, full_export=True
+            )
             explore_output_mode = OutputMode.from_value(export_format)
             if explore_output_mode != OutputMode.JSONL:
                 raise serializers.ValidationError("For full export, output mode must be JSONL.")

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -7,6 +7,7 @@ from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken, RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
 
 from sentry.api.utils import get_date_range_from_params
 from sentry.data_export.base import ExportError
@@ -215,7 +216,7 @@ class TraceItemFullExportProcessor(ExploreProcessor):
             ),
         )
 
-    def _create_trace_item_filter(self):
+    def _create_trace_item_filter(self) -> TraceItemFilter | None:
         where, _, _ = self.search_resolver.resolve_query_with_columns(
             querystring=self.explore_query.get("query", ""),
             selected_columns=None,

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -184,10 +184,24 @@ class TraceItemFullExportProcessor(ExploreProcessor):
     ):
         super().__init__(organization, explore_query, output_mode=output_mode)
         self.page_token = page_token
+        self._request_meta = self._create_export_rpc_meta()
+        self._trace_filter = self._create_trace_item_filter()
 
-    def _create_logs_export_rpc_meta(self) -> RequestMeta:
+    def _sync_page_token_from_snuba_response(self, http_resp: ExportTraceItemsResponse) -> None:
+        """Mirror Snuba's response page_token: continuation bytes or terminal (end_pagination)."""
+        if not http_resp.HasField("page_token"):
+            self.page_token = None
+            return
+        pt = http_resp.page_token
+        if pt.HasField("end_pagination") and pt.end_pagination:
+            self.page_token = None
+        else:
+            self.page_token = pt.SerializeToString()
+
+    def _create_export_rpc_meta(self) -> RequestMeta:
         if self.snuba_params.organization_id is None:
             raise ExportError("Organization ID must be provided")
+
         return RequestMeta(
             organization_id=self.snuba_params.organization_id,
             project_ids=self.snuba_params.project_ids,
@@ -201,20 +215,18 @@ class TraceItemFullExportProcessor(ExploreProcessor):
             ),
         )
 
-    def _sync_page_token_from_snuba_response(self, http_resp: ExportTraceItemsResponse) -> None:
-        """Mirror Snuba's response page_token: continuation bytes or terminal (end_pagination)."""
-        if not http_resp.HasField("page_token"):
-            self.page_token = None
-            return
-        pt = http_resp.page_token
-        if pt.HasField("end_pagination") and pt.end_pagination:
-            self.page_token = None
-        else:
-            self.page_token = pt.SerializeToString()
+    def _create_trace_item_filter(self):
+        where, _, _ = self.search_resolver.resolve_query_with_columns(
+            querystring=self.explore_query.get("query", ""),
+            selected_columns=None,
+            equations=None,
+        )
+        return where
 
     def run_query(self, _offset: int, limit: int) -> list[dict[str, Any]]:
-        meta = self._create_logs_export_rpc_meta()
-        request = ExportTraceItemsRequest(meta=meta, limit=limit)
+        request = ExportTraceItemsRequest(
+            meta=self._request_meta, limit=limit, filter=self._trace_filter
+        )
         if self.page_token:
             token = PageToken()
             token.ParseFromString(self.page_token)

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -2,7 +2,6 @@ from typing import Any, Iterable, cast
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import pytest
 from django.db import IntegrityError
 from django.http import StreamingHttpResponse
 from django.urls import reverse
@@ -1205,12 +1204,6 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         assert {row[output_key] for row in rows} == {matching_value}
         assert emailer.called
 
-    @pytest.mark.skip(
-        reason=(
-            "Snuba's EndpointExportTraceItems does not yet apply request filters on "
-            "first-class columns like trace_id. Skipping until it is supported"
-        )
-    )
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_logs_jsonl_full_export_respects_trace_filter(self, emailer: MagicMock) -> None:
         """

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, cast
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
+import pytest
 from django.db import IntegrityError
 from django.http import StreamingHttpResponse
 from django.urls import reverse
@@ -829,7 +831,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
             assert_row_equals_export(rows_by_agent[user_agent], expected_rows_by_agent[user_agent])
 
     def _explore_logs_jsonl_rich_field_api_request_body(
-        self, start: str, end: str, *, limit: int | None = None
+        self, start: str, end: str, *, limit: int | None = None, query: str = ""
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "query_type": ExportQueryType.TRACE_ITEM_FULL_EXPORT_STR,
@@ -838,7 +840,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                 "project": [self.project.id],
                 "field": [],
                 "equations": [],
-                "query": "",
+                "query": query,
                 "dataset": "logs",
                 "start": start,
                 "end": end,
@@ -849,14 +851,16 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         return body
 
     def _post_explore_logs_jsonl_rich_field_export(
-        self, start: str, end: str, *, limit: int | None = None
+        self, start: str, end: str, *, limit: int | None = None, query: str = ""
     ) -> dict[str, Any]:
         self.login_as(self.user)
         url = reverse(
             "sentry-api-0-organization-data-export",
             kwargs={"organization_id_or_slug": self.org.slug},
         )
-        request_body = self._explore_logs_jsonl_rich_field_api_request_body(start, end, limit=limit)
+        request_body = self._explore_logs_jsonl_rich_field_api_request_body(
+            start, end, limit=limit, query=query
+        )
         with self.feature("organizations:discover-query"):
             response = self.client.post(
                 url,
@@ -1125,6 +1129,129 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
             raw, expected_rows_by_agent, ignored_keys
         )
         assert not emailer.called
+
+    def _store_two_groups_of_logs_fixture(
+        self,
+        *,
+        matching_fields: dict[str, Any] | None = None,
+        other_fields: dict[str, Any] | None = None,
+        matching_attributes: dict[str, Any] | None = None,
+        other_attributes: dict[str, Any] | None = None,
+        matching: int = 3,
+        other: int = 4,
+    ) -> tuple[str, str, int]:
+        """
+        Store `matching` logs in one group and `other` logs in a second group, where the
+        groups are distinguished by first-class fields (e.g. trace_id) and/or attributes.
+        Returns (start_iso, end_iso, matching) spanning the stored logs.
+        """
+        logs = [
+            self.create_ourlog(
+                {"body": f"match-{i}", **(matching_fields or {})},
+                timestamp=before_now(minutes=10, seconds=i),
+                organization=self.org,
+                project=self.project,
+                attributes=matching_attributes or {},
+            )
+            for i in range(matching)
+        ] + [
+            self.create_ourlog(
+                {"body": f"other-{i}", **(other_fields or {})},
+                timestamp=before_now(minutes=10, seconds=i),
+                organization=self.org,
+                project=self.project,
+                attributes=other_attributes or {},
+            )
+            for i in range(other)
+        ]
+        self.store_eap_items(logs)
+
+        start = before_now(minutes=15).isoformat()
+        end = before_now(seconds=30).isoformat()
+        return start, end, matching
+
+    def _assert_full_export_respects_filter(
+        self,
+        emailer: MagicMock,
+        *,
+        start: str,
+        end: str,
+        query: str,
+        output_key: str,
+        matching_value: str,
+        matching_count: int,
+    ) -> None:
+        """
+        Run a full JSONL trace-item export with `query` and assert it returns exactly
+        `matching_count` rows, all carrying `matching_value` under `output_key`.
+        """
+        payload = self._post_explore_logs_jsonl_rich_field_export(start, end, query=query)
+        de = self._assert_explore_logs_jsonl_export_create_payload(payload)
+
+        with self.tasks():
+            assemble_download(de.id, batch_size=2, export_limit=100)
+
+        de = ExportedData.objects.get(id=de.id)
+        assert de.date_finished is not None
+        file = de._get_file()
+        assert isinstance(file, File)
+        assert file.headers == {"Content-Type": "application/x-ndjson"}
+
+        with file.getfile() as f:
+            content = f.read().strip()
+
+        rows = [json.loads(ln.decode("utf-8")) for ln in content.split(b"\n") if ln]
+        assert len(rows) == matching_count
+        assert {row[output_key] for row in rows} == {matching_value}
+        assert emailer.called
+
+    @pytest.mark.skip(
+        reason=(
+            "Snuba's EndpointExportTraceItems does not yet apply request filters on "
+            "first-class columns like trace_id. Skipping until it is supported"
+        )
+    )
+    @patch("sentry.data_export.models.ExportedData.email_success")
+    def test_explore_logs_jsonl_full_export_respects_trace_filter(self, emailer: MagicMock) -> None:
+        """
+        Full trace-item export with a `trace:<id>` filter
+        """
+        matching_trace = uuid4().hex
+        start, end, matching_count = self._store_two_groups_of_logs_fixture(
+            matching_fields={"trace_id": matching_trace},
+            other_fields={"trace_id": uuid4().hex},
+        )
+        self._assert_full_export_respects_filter(
+            emailer,
+            start=start,
+            end=end,
+            query=f"trace:{matching_trace}",
+            output_key="trace",
+            matching_value=matching_trace,
+            matching_count=matching_count,
+        )
+
+    @patch("sentry.data_export.models.ExportedData.email_success")
+    def test_explore_logs_jsonl_full_export_respects_attribute_filter(
+        self, emailer: MagicMock
+    ) -> None:
+        """
+        Full trace-item export honors a query filter on a regular attribute
+        """
+        matching_agent = "chrome"
+        start, end, matching_count = self._store_two_groups_of_logs_fixture(
+            matching_attributes={"user_agent": matching_agent},
+            other_attributes={"user_agent": "firefox"},
+        )
+        self._assert_full_export_respects_filter(
+            emailer,
+            start=start,
+            end=end,
+            query=f"user_agent:{matching_agent}",
+            output_key="user_agent",
+            matching_value=matching_agent,
+            matching_count=matching_count,
+        )
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_datasets_isolation(self, emailer: MagicMock) -> None:

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1146,7 +1146,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         """
         logs = [
             self.create_ourlog(
-                {"body": f"match-{i}", **(matching_fields or {})},
+                {"body": f"match-{i}", **(matching_fields or {})},  # type: ignore[arg-type,typeddict-item]
                 timestamp=before_now(minutes=10, seconds=i),
                 organization=self.org,
                 project=self.project,
@@ -1155,7 +1155,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
             for i in range(matching)
         ] + [
             self.create_ourlog(
-                {"body": f"other-{i}", **(other_fields or {})},
+                {"body": f"other-{i}", **(other_fields or {})},  # type: ignore[arg-type,typeddict-item]
                 timestamp=before_now(minutes=10, seconds=i),
                 organization=self.org,
                 project=self.project,


### PR DESCRIPTION
Full JSONL trace-item exports (TRACE_ITEM_FULL_EXPORT) was ignoring the user's query because downstream EAP endpoint didn't support query filter. EAP has updated `ExportTraceItemsRequest` to support `TraceItemFilter`. 

Updating full trace item export path to respect user query filter. 

Export processor resolves the query string into a `TraceItemFilter` via the search resolver, like `events` endpoint. 

