### PR TITLE
feat(explore): Allow pinned range bounds on heat map endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_heatmap.py
+++ b/src/sentry/api/endpoints/organization_events_heatmap.py
@@ -297,6 +297,10 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
         except ValueError:
             raise ParseError("yMin and yMax must be numbers")
 
+        # float() accepts nan/inf, which would poison the bucket math and break JSON serialization.
+        if not math.isfinite(min_bound) or not math.isfinite(max_bound):
+            raise ParseError("yMin and yMax must be finite numbers")
+
         if max_bound < min_bound:
             raise ParseError("yMax must be greater than or equal to yMin")
 

--- a/src/sentry/api/endpoints/organization_events_heatmap.py
+++ b/src/sentry/api/endpoints/organization_events_heatmap.py
@@ -171,10 +171,18 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
                 elif y_buckets > MAX_BUCKETS:
                     raise ParseError(f"yBuckets must be less than {MAX_BUCKETS}")
 
+            # Callers may need to pin the value axis via yMin/yMax to enforce
+            # identical bounds across parallel requests.
+            pinned_bounds = self._parse_pinned_bounds(request)
+
             query = request.GET.get("query", "")
 
         with handle_query_errors():
-            bucket_ranges = self.query_y_bucket_ranges(snuba_params, dataset, query, yAxis)
+            bucket_ranges = (
+                pinned_bounds
+                if pinned_bounds is not None
+                else self.query_y_bucket_ranges(snuba_params, dataset, query, yAxis)
+            )
             use_log_scale: bool = bool(y_log_scale and bucket_ranges.range > 1)
             if bucket_ranges.min_value != bucket_ranges.max_value:
                 yAxes = {}
@@ -270,6 +278,29 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
                 ),
                 status=200,
             )
+
+    @staticmethod
+    def _parse_pinned_bounds(request: Request) -> LimitTuple | None:
+        """Parse optional yMin/yMax into a pinned value domain, or None to auto-derive it."""
+        yMin = request.GET.get("yMin")
+        yMax = request.GET.get("yMax")
+
+        if yMin is None and yMax is None:
+            return None
+
+        if yMin is None or yMax is None:
+            raise ParseError("yMin and yMax must be provided together")
+
+        try:
+            min_bound = float(yMin)
+            max_bound = float(yMax)
+        except ValueError:
+            raise ParseError("yMin and yMax must be numbers")
+
+        if max_bound < min_bound:
+            raise ParseError("yMax must be greater than or equal to yMin")
+
+        return LimitTuple(min_bound, max_bound)
 
     def query_y_bucket_ranges(
         self, snuba_params: SnubaParams, dataset: Any, query: str, yAxis: str

--- a/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
@@ -443,6 +443,71 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
         assert response.data["meta"]["yAxis"]["start"] == pytest.approx(0.000008527, rel=1e-3)
 
 
+    def test_pinned_bounds_applied(self) -> None:
+        # Pinning yMin/yMax wider than the data forces those bounds onto the grid
+        # instead of the auto-derived data min/max (120/720).
+        metric_values = [120, 240, 360, 480, 600, 720]
+        trace_metrics = [
+            self.create_trace_metric(
+                "foo",
+                value,
+                "counter",
+                timestamp=self.start + timedelta(hours=hour),
+            )
+            for hour, value in enumerate(metric_values)
+        ]
+        self.store_eap_items(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.start + timedelta(hours=6),
+                "yAxis": "value",
+                "interval": "1h",
+                "yBuckets": 6,
+                "yMin": 0,
+                "yMax": 1200,
+                "query": "metric.name:foo metric.type:counter",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["yAxis"]["start"] == 0
+        assert response.data["meta"]["yAxis"]["end"] == 1200
+        assert response.data["meta"]["yAxis"]["bucketSize"] == 200
+        # Edges follow the pinned domain (0..1200 in 6 buckets), not the data (120..720).
+        assert sorted({row["yAxis"] for row in response.data["values"]}) == [
+            0,
+            200,
+            400,
+            600,
+            800,
+            1000,
+        ]
+
+    def test_pinned_bounds_validation_errors(self) -> None:
+        base_data = {
+            "start": self.start,
+            "end": self.start + timedelta(hours=6),
+            "yAxis": "value",
+            "interval": "1h",
+            "yBuckets": 6,
+            "query": "metric.name:foo metric.type:counter",
+            "project": self.project.id,
+            "dataset": self.dataset,
+        }
+        cases = [
+            ({"yMin": 120}, "yMin and yMax must be provided together"),
+            ({"yMin": "abc", "yMax": 720}, "yMin and yMax must be numbers"),
+            ({"yMin": 720, "yMax": 120}, "yMax must be greater than or equal to yMin"),
+        ]
+        for params, detail in cases:
+            response = self._do_request(data={**base_data, **params})
+            assert response.status_code == 400, response.content
+            assert response.data["detail"] == detail
+
+
 class TestFormatLongFloat:
     def test_small_number_no_scientific_notation(self) -> None:
         result = OrganizationEventsHeatmapEndpoint._format_long_float(8.527e-06)

--- a/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
@@ -442,7 +442,6 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
         assert response.data["meta"]["yAxis"]["bucketCount"] == 1
         assert response.data["meta"]["yAxis"]["start"] == pytest.approx(0.000008527, rel=1e-3)
 
-
     def test_pinned_bounds_applied(self) -> None:
         # Pinning yMin/yMax wider than the data forces those bounds onto the grid
         # instead of the auto-derived data min/max (120/720).

--- a/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
@@ -500,6 +500,9 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
             ({"yMin": 120}, "yMin and yMax must be provided together"),
             ({"yMin": "abc", "yMax": 720}, "yMin and yMax must be numbers"),
             ({"yMin": 720, "yMax": 120}, "yMax must be greater than or equal to yMin"),
+            # nan/inf pass float() but would break the bucket math and JSON serialization.
+            ({"yMin": "nan", "yMax": "nan"}, "yMin and yMax must be finite numbers"),
+            ({"yMin": 0, "yMax": "inf"}, "yMin and yMax must be finite numbers"),
         ]
         for params, detail in cases:
             response = self._do_request(data={**base_data, **params})

--- a/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
@@ -496,7 +496,7 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
             "project": self.project.id,
             "dataset": self.dataset,
         }
-        cases = [
+        cases: list[tuple[dict[str, object], str]] = [
             ({"yMin": 120}, "yMin and yMax must be provided together"),
             ({"yMin": "abc", "yMax": 720}, "yMin and yMax must be numbers"),
             ({"yMin": 720, "yMax": 120}, "yMax must be greater than or equal to yMin"),


### PR DESCRIPTION
Adds optional `yMin`/`yMax` query params to the Heat Map endpoint that lets the UI pin the Y-axis domain explicitly. This allows the UI to make _chunked_ calls (multiple calls to the heat map endpoint to fetch different time ranges and stitch them together) while still keeping the buckets aligned across calls.

Closes DAIN-1781