### PR TITLE
fix(issue-views): Stop view sort changes from overwriting the feed sort

### DIFF
--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -28,6 +28,7 @@ import {
   DEFAULT_QUERY,
   getStoredIssueSort,
   IssueSortOptions,
+  setStoredIssueSort,
 } from 'sentry/views/issueList/utils';
 
 const DEFAULT_LINKS_HEADER =
@@ -383,6 +384,36 @@ describe('IssueList', () => {
       await userEvent.click(await screen.findByRole('button', {name: /Recommended/}));
       await userEvent.click(screen.getByRole('option', {name: 'Events'}));
 
+      expect(getStoredIssueSort(featureOrg.slug)).toBe(IssueSortOptions.FREQ);
+    });
+
+    it('does not read or write the stored sort on a view page', async () => {
+      const featureOrg = OrganizationFixture({
+        ...organization,
+        features: ['issue-stream-recommended-sort-default'],
+      });
+      setStoredIssueSort(featureOrg.slug, IssueSortOptions.FREQ);
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/group-search-views/1/',
+        body: GroupSearchViewFixture({querySort: IssueSortOptions.DATE}),
+      });
+
+      render(<IssueListOverview />, {
+        organization: featureOrg,
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            pathname: '/organizations/org-slug/issues/views/1/',
+          },
+        },
+      });
+
+      // The view's saved sort applies, not the stored feed sort
+      await userEvent.click(await screen.findByRole('button', {name: 'Last Seen'}));
+      await userEvent.click(screen.getByRole('option', {name: 'Users'}));
+
+      // Changing the sort within a view does not overwrite the feed's stored sort
       expect(getStoredIssueSort(featureOrg.slug)).toBe(IssueSortOptions.FREQ);
     });
 

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -157,6 +157,7 @@ function IssueListOverviewInner({
   const {openIssuePreview} = useIssuePreviewDrawer({enabled: isPreviewMode});
   const api = useApi();
   const urlParams = useParams<{viewId?: string}>();
+  const {data: groupSearchView} = useSelectedGroupSearchView();
   const realtimeActiveCookie = Cookies.get('realtimeActive');
   const [realtimeActive, setRealtimeActive] = useState(
     realtimeActiveCookie === undefined || urlParams.viewId
@@ -229,8 +230,11 @@ function IssueListOverviewInner({
   const hasRecommendedSortDefault = organization.features.includes(
     'issue-stream-recommended-sort-default'
   );
-  const defaultSort =
-    initialSort === DEFAULT_ISSUE_STREAM_SORT
+  // The stored sort is the user's preferred sort for the unsaved feed.
+  // Saved views persist their own sort, so they neither read nor write it.
+  const defaultSort = urlParams.viewId
+    ? (groupSearchView?.querySort ?? DEFAULT_ISSUE_STREAM_SORT)
+    : initialSort === DEFAULT_ISSUE_STREAM_SORT
       ? hasRecommendedSortDefault
         ? (getStoredIssueSort(organization.slug) ?? IssueSortOptions.RECOMMENDED)
         : DEFAULT_ISSUE_STREAM_SORT
@@ -709,7 +713,11 @@ function IssueListOverviewInner({
       organization,
       sort: newSort,
     });
-    if (hasRecommendedSortDefault && initialSort === DEFAULT_ISSUE_STREAM_SORT) {
+    if (
+      hasRecommendedSortDefault &&
+      !urlParams.viewId &&
+      initialSort === DEFAULT_ISSUE_STREAM_SORT
+    ) {
       setStoredIssueSort(organization.slug, newSort as IssueSortOptions);
     }
     transitionTo({sort: newSort});
@@ -920,8 +928,6 @@ function IssueListOverviewInner({
   // Derive from query (URL state) not initialQuery (prop) so the hint
   // stays accurate if the user edits the search bar.
   const isTaxonomyView = query.includes('issue.category:');
-
-  const {data: groupSearchView} = useSelectedGroupSearchView();
 
   useLLMContext({
     contextHint:


### PR DESCRIPTION
Changing the sort inside a saved issue view wrote to the same localStorage key that provides the default sort for the issues feed, so a sort picked while in a view unexpectedly followed you back to the feed. The stored sort also leaked the other way: loading a view URL that has page filter params but no `sort` param skips query param hydration, so the feed's stored sort silently overrode the view's saved sort.

The stored sort is now feed-only. View pages neither write it on sort change nor read it as a default — they fall back to the view's saved `querySort` instead. This mirrors how views already opt out of page filter persistence (`disablePersistence` / `skipLoadLastUsed` on `PageFiltersContainer`).