### PR TITLE
fix(issues): Show deleted team names in activity

### DIFF
--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/assigneeChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/assigneeChip.tsx
@@ -1,11 +1,14 @@
 import {TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
 
-import type {Actor} from 'sentry/types/core';
 import type {Team} from 'sentry/types/organization';
 
 import {InlineChip} from './inlineChip';
 
-export function AssigneePill({assignee}: {assignee: Actor | string | Team}) {
+export function AssigneePill({
+  assignee,
+}: {
+  assignee: React.ComponentProps<typeof UserAvatar>['user'] | string | Team;
+}) {
   if (typeof assignee === 'string') {
     return <InlineChip variant="constrained">{assignee}</InlineChip>;
   }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/chips/assigneeChip.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/chips/assigneeChip.tsx
@@ -1,20 +1,16 @@
 import {TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
 
+import type {Actor} from 'sentry/types/core';
 import type {Team} from 'sentry/types/organization';
-import type {AvatarUser} from 'sentry/types/user';
 
 import {InlineChip} from './inlineChip';
 
-function isTeam(value: AvatarUser | Team): value is Team {
-  return 'slug' in value;
-}
-
-export function AssigneePill({assignee}: {assignee: AvatarUser | string | Team}) {
+export function AssigneePill({assignee}: {assignee: Actor | string | Team}) {
   if (typeof assignee === 'string') {
     return <InlineChip variant="constrained">{assignee}</InlineChip>;
   }
 
-  if (isTeam(assignee)) {
+  if ('slug' in assignee) {
     return (
       <InlineChip variant="constrainedCompactLeading">
         <TeamAvatar team={assignee} size={16} hasTooltip={false} />#{assignee.slug}
@@ -25,7 +21,7 @@ export function AssigneePill({assignee}: {assignee: AvatarUser | string | Team})
   return (
     <InlineChip variant="constrainedCompactLeading">
       <UserAvatar user={assignee} size={16} />
-      {assignee.name || assignee.email || assignee.username}
+      {assignee.name || assignee.email}
     </InlineChip>
   );
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -502,7 +502,7 @@ export function getCompactGroupActivityItem({
           : null,
       };
     case GroupActivityType.ASSIGNED:
-      return getAssignedActivityItem({activity, author});
+      return getAssignedActivityItem({activity});
     case GroupActivityType.UNASSIGNED:
       return {
         title: t('Issue unassigned'),

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -50,7 +50,16 @@ function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
   const {data} = activity;
 
   if (data.assigneeType === 'team') {
-    return teams.find(({id}) => id === data.assignee) ?? '<unknown-team>';
+    const team = teams.find(({id}) => id === data.assignee);
+    if (team) {
+      return team;
+    }
+
+    if (data.assigneeName) {
+      return t('#%s (deleted)', data.assigneeName);
+    }
+
+    return t('Deleted team');
   }
 
   if (data.assignee === activity.user?.id) {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -78,14 +78,6 @@ function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
   return t('an unknown user');
 }
 
-function RuleSource({children}: {children: React.ReactNode}) {
-  return (
-    <Text as="span" variant="muted" bold={false} density="comfortable" wrap="nowrap">
-      {children}
-    </Text>
-  );
-}
-
 function RuleText({children}: {children: React.ReactNode}) {
   return (
     <Text
@@ -117,7 +109,7 @@ function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) 
   if (integrationName) {
     return tct('to [assignee] due to [rule]', {
       assignee,
-      rule: <RuleSource>{integrationName}</RuleSource>,
+      rule: integrationName,
     });
   }
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -1,54 +1,17 @@
 import {Text} from '@sentry/scraps/text';
 
 import {t, tct} from 'sentry/locale';
+import type {Actor} from 'sentry/types/core';
 import type {GroupActivityAssigned} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
-import type {AvatarUser, User} from 'sentry/types/user';
+import type {User} from 'sentry/types/user';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {AssigneePill} from 'sentry/views/issueDetails/activitySection/activityLineItem/chips/assigneeChip';
 import {getAssignmentIntegrationName} from 'sentry/views/issueDetails/activitySection/assignmentIntegration';
 
 import type {CompactGroupActivityItem} from './types';
 
-interface GetAssignedActivityItemParams {
-  activity: GroupActivityAssigned;
-  author: string;
-}
-
-function isTeam(value: Team | User): value is Team {
-  return 'slug' in value;
-}
-
-function getAssignedUser(activity: GroupActivityAssigned): AvatarUser | null {
-  const {data} = activity;
-
-  if (data.assigneeType !== 'user') {
-    return null;
-  }
-
-  if (data.user && !isTeam(data.user)) {
-    return data.user;
-  }
-
-  const email = data.assigneeEmail ?? '';
-  const name = data.assigneeName ?? email;
-
-  if (!email && !name) {
-    return null;
-  }
-
-  return {
-    email,
-    id: data.assignee,
-    ip_address: '',
-    name,
-    username: email,
-  };
-}
-
-function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
-  const {data} = activity;
-
+function getAssignee(data: GroupActivityAssigned['data'], teams: Team[]) {
   if (data.assigneeType === 'team') {
     const team = teams.find(({id}) => id === data.assignee);
     if (team) {
@@ -62,17 +25,19 @@ function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
     return t('Deleted team');
   }
 
-  if (data.assignee === activity.user?.id) {
-    return t('themselves');
+  let user: User | undefined;
+  if (data.user && !('slug' in data.user)) {
+    user = data.user;
   }
 
-  const assignedUser = getAssignedUser(activity);
-  if (assignedUser) {
-    return assignedUser;
-  }
-
-  if (data.assigneeType === 'user' && data.assigneeEmail) {
-    return data.assigneeEmail;
+  const name = user?.name || data.assigneeName || user?.email || data.assigneeEmail;
+  if (name) {
+    return {
+      email: user?.email ?? data.assigneeEmail,
+      id: user?.id ?? data.assignee,
+      name,
+      type: 'user',
+    } satisfies Actor;
   }
 
   return t('an unknown user');
@@ -81,13 +46,12 @@ function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
 function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) {
   const {teams} = useTeamsById();
   const {data} = activity;
-  const assignedToSelf =
-    data.assigneeType === 'user' && data.assignee === activity.user?.id;
-  const assignee = assignedToSelf ? (
-    t('themselves')
-  ) : (
-    <AssigneePill assignee={getAssignedAssignee(activity, teams)} />
-  );
+  let assignee: React.ReactNode;
+  if (data.assigneeType === 'user' && data.assignee === activity.user?.id) {
+    assignee = t('themselves');
+  } else {
+    assignee = <AssigneePill assignee={getAssignee(data, teams)} />;
+  }
   const integrationName = getAssignmentIntegrationName(data.integration);
 
   if (integrationName) {
@@ -102,25 +66,23 @@ function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) 
 
 export function getAssignedActivityItem({
   activity,
-}: GetAssignedActivityItemParams): CompactGroupActivityItem {
+}: {
+  activity: GroupActivityAssigned;
+}): CompactGroupActivityItem {
   const integrationName = getAssignmentIntegrationName(activity.data.integration);
+  let subtext: React.ReactNode = null;
+
+  if (integrationName && activity.data.rule) {
+    subtext = (
+      <Text variant="inherit" monospace wordBreak="break-all">
+        {activity.data.rule}
+      </Text>
+    );
+  }
 
   return {
     title: t('Issue assigned'),
     details: <AssignedActivityDetails activity={activity} />,
-    subtext:
-      integrationName && activity.data.rule ? (
-        <Text
-          as="span"
-          variant="muted"
-          size="sm"
-          monospace
-          bold={false}
-          density="comfortable"
-          wordBreak="break-all"
-        >
-          {activity.data.rule}
-        </Text>
-      ) : null,
+    subtext,
   };
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -3,19 +3,24 @@ import {Text} from '@sentry/scraps/text';
 import {t, tct} from 'sentry/locale';
 import type {Actor} from 'sentry/types/core';
 import type {GroupActivityAssigned} from 'sentry/types/group';
-import type {Team} from 'sentry/types/organization';
-import type {User} from 'sentry/types/user';
 import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {AssigneePill} from 'sentry/views/issueDetails/activitySection/activityLineItem/chips/assigneeChip';
 import {getAssignmentIntegrationName} from 'sentry/views/issueDetails/activitySection/assignmentIntegration';
 
 import type {CompactGroupActivityItem} from './types';
 
-function getAssignee(data: GroupActivityAssigned['data'], teams: Team[]) {
+function getAssignee(
+  data: GroupActivityAssigned['data'],
+  {teams, isLoading, isError}: ReturnType<typeof useTeamsById>
+) {
   if (data.assigneeType === 'team') {
     const team = teams.find(({id}) => id === data.assignee);
     if (team) {
       return team;
+    }
+
+    if (isLoading || isError) {
+      return data.assigneeName ? t('#%s', data.assigneeName) : t('Team');
     }
 
     if (data.assigneeName) {
@@ -25,16 +30,15 @@ function getAssignee(data: GroupActivityAssigned['data'], teams: Team[]) {
     return t('Deleted team');
   }
 
-  let user: User | undefined;
   if (data.user && !('slug' in data.user)) {
-    user = data.user;
+    return data.user;
   }
 
-  const name = user?.name || data.assigneeName || user?.email || data.assigneeEmail;
+  const name = data.assigneeName || data.assigneeEmail;
   if (name) {
     return {
-      email: user?.email ?? data.assigneeEmail,
-      id: user?.id ?? data.assignee,
+      email: data.assigneeEmail,
+      id: data.assignee,
       name,
       type: 'user',
     } satisfies Actor;
@@ -44,13 +48,18 @@ function getAssignee(data: GroupActivityAssigned['data'], teams: Team[]) {
 }
 
 function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) {
-  const {teams} = useTeamsById();
   const {data} = activity;
+  let teamIds: string[] | undefined;
+  if (data.assigneeType === 'team') {
+    teamIds = [data.assignee];
+  }
+  const teamLookup = useTeamsById({ids: teamIds});
+
   let assignee: React.ReactNode;
   if (data.assigneeType === 'user' && data.assignee === activity.user?.id) {
     assignee = t('themselves');
   } else {
-    assignee = <AssigneePill assignee={getAssignee(data, teams)} />;
+    assignee = <AssigneePill assignee={getAssignee(data, teamLookup)} />;
   }
   const integrationName = getAssignmentIntegrationName(data.integration);
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -49,18 +49,16 @@ function getAssignee(
 
 function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) {
   const {data} = activity;
-  let teamIds: string[] | undefined;
-  if (data.assigneeType === 'team') {
-    teamIds = [data.assignee];
-  }
-  const teamLookup = useTeamsById({ids: teamIds});
+  const teamLookup = useTeamsById({
+    ids: data.assigneeType === 'team' ? [data.assignee] : undefined,
+  });
 
-  let assignee: React.ReactNode;
-  if (data.assigneeType === 'user' && data.assignee === activity.user?.id) {
-    assignee = t('themselves');
-  } else {
-    assignee = <AssigneePill assignee={getAssignee(data, teamLookup)} />;
-  }
+  const assignee =
+    data.assigneeType === 'user' && data.assignee === activity.user?.id ? (
+      t('themselves')
+    ) : (
+      <AssigneePill assignee={getAssignee(data, teamLookup)} />
+    );
   const integrationName = getAssignmentIntegrationName(data.integration);
 
   if (integrationName) {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem/assignment.tsx
@@ -78,22 +78,6 @@ function getAssignedAssignee(activity: GroupActivityAssigned, teams: Team[]) {
   return t('an unknown user');
 }
 
-function RuleText({children}: {children: React.ReactNode}) {
-  return (
-    <Text
-      as="span"
-      variant="muted"
-      size="sm"
-      monospace
-      bold={false}
-      density="comfortable"
-      wordBreak="break-all"
-    >
-      {children}
-    </Text>
-  );
-}
-
 function AssignedActivityDetails({activity}: {activity: GroupActivityAssigned}) {
   const {teams} = useTeamsById();
   const {data} = activity;
@@ -126,7 +110,17 @@ export function getAssignedActivityItem({
     details: <AssignedActivityDetails activity={activity} />,
     subtext:
       integrationName && activity.data.rule ? (
-        <RuleText>{activity.data.rule}</RuleText>
+        <Text
+          as="span"
+          variant="muted"
+          size="sm"
+          monospace
+          bold={false}
+          density="comfortable"
+          wordBreak="break-all"
+        >
+          {activity.data.rule}
+        </Text>
       ) : null,
   };
 }

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -419,6 +419,10 @@ describe('ActivitySection', () => {
   it('renders team assignment in activity line items when team id matches the actor id', async () => {
     const assigningUser = UserFixture({id: '1', name: 'Taylor'});
     const team = TeamFixture({id: assigningUser.id, slug: 'frontend'});
+    const teamRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [team],
+    });
     TeamStore.loadInitialData([team]);
 
     const assignedGroup = GroupFixture({
@@ -451,9 +455,69 @@ describe('ActivitySection', () => {
     expect(timeline).toHaveTextContent('Issue assigned');
     expect(timeline).toHaveTextContent('#frontend');
     expect(timeline).not.toHaveTextContent('themselves');
+    expect(teamRequest).not.toHaveBeenCalled();
+  });
+
+  it('loads an assigned team missing from the team store', async () => {
+    const team = TeamFixture({
+      id: '123',
+      slug: 'backend',
+      avatar: {
+        avatarType: 'upload',
+        avatarUrl: 'https://example.com/team-avatar.jpg',
+        avatarUuid: '123',
+      },
+    });
+    const teamRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [team],
+    });
+    TeamStore.loadInitialData([]);
+
+    const assignedGroup = GroupFixture({
+      id: '1347',
+      activity: [
+        {
+          type: GroupActivityType.ASSIGNED,
+          id: 'team-assignment-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            assignee: team.id,
+            assigneeName: team.name,
+            assigneeType: 'team',
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={assignedGroup} project={assignedGroup.project}>
+        <ActivitySection group={assignedGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(await screen.findByRole('img', {name: 'backend'})).toHaveAttribute(
+      'src',
+      'https://example.com/team-avatar.jpg?s=120'
+    );
+    expect(teamRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({query: {query: 'id:123'}})
+    );
   });
 
   it('renders the stored name for a deleted team assignment', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [],
+    });
+    TeamStore.loadInitialData([]);
+
     const assignedGroup = GroupFixture({
       id: '1347',
       activity: [
@@ -481,9 +545,50 @@ describe('ActivitySection', () => {
       }
     );
 
-    const timeline = await screen.findByTestId('activity-timeline');
-    expect(timeline).toHaveTextContent('Issue assigned');
-    expect(timeline).toHaveTextContent('#frontend (deleted)');
+    expect(await screen.findByText('#frontend (deleted)')).toBeInTheDocument();
+  });
+
+  it('preserves the assigned user avatar from activity data', async () => {
+    const assignedUser = UserFixture({
+      id: '123',
+      name: 'Assigned User',
+      avatar: {
+        avatarType: 'upload',
+        avatarUrl: 'https://example.com/avatar.jpg',
+        avatarUuid: '123',
+      },
+    });
+    const assignedGroup = GroupFixture({
+      id: '1347',
+      activity: [
+        {
+          type: GroupActivityType.ASSIGNED,
+          id: 'user-assignment-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            assignee: assignedUser.id,
+            assigneeType: 'user',
+            user: assignedUser,
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={assignedGroup} project={assignedGroup.project}>
+        <ActivitySection group={assignedGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(await screen.findByRole('img', {name: 'Assigned User'})).toHaveAttribute(
+      'src',
+      'https://example.com/avatar.jpg?s=120'
+    );
   });
 
   it('renders auto-resolved activity age as an inactivity duration', async () => {

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -453,6 +453,39 @@ describe('ActivitySection', () => {
     expect(timeline).not.toHaveTextContent('themselves');
   });
 
+  it('renders the stored name for a deleted team assignment', async () => {
+    const assignedGroup = GroupFixture({
+      id: '1347',
+      activity: [
+        {
+          type: GroupActivityType.ASSIGNED,
+          id: 'deleted-team-assignment',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            assignee: '123',
+            assigneeName: 'frontend',
+            assigneeType: 'team',
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={assignedGroup} project={assignedGroup.project}>
+        <ActivitySection group={assignedGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    const timeline = await screen.findByTestId('activity-timeline');
+    expect(timeline).toHaveTextContent('Issue assigned');
+    expect(timeline).toHaveTextContent('#frontend (deleted)');
+  });
+
   it('renders auto-resolved activity age as an inactivity duration', async () => {
     const autoResolvedGroup = GroupFixture({
       id: '1347',


### PR DESCRIPTION
Preserves deleted team names and some code cleanup.

before

<img width="504" height="56" alt="image" src="https://github.com/user-attachments/assets/d5e57a7f-4782-42ae-a42f-1ef2c052fffb" />

after

<img width="529" height="56" alt="image" src="https://github.com/user-attachments/assets/17539cad-095a-48ac-b44e-f339e2ce1ffc" />
