### PR TITLE
feat(scm): add check_suite and pull_request_review to event stream

### DIFF
--- a/src/sentry/scm/private/event_stream.py
+++ b/src/sentry/scm/private/event_stream.py
@@ -1,21 +1,35 @@
 from collections.abc import Callable
 from typing import Literal, overload
 
-from sentry.scm.types import CheckRunEvent, CommentEvent, PullRequestEvent
+from sentry.scm.types import (
+    CheckRunEvent,
+    CheckSuiteEvent,
+    CommentEvent,
+    PullRequestEvent,
+    PullRequestReviewEvent,
+)
 
 type CheckRunEventListener = Callable[[CheckRunEvent], None]
+type CheckSuiteEventListener = Callable[[CheckSuiteEvent], None]
 type CommentEventListener = Callable[[CommentEvent], None]
 type PullRequestEventListener = Callable[[PullRequestEvent], None]
+type PullRequestReviewEventListener = Callable[[PullRequestReviewEvent], None]
 
 
 class SourceCodeManagerEventStream:
     def __init__(self):
         self.check_run_listeners: dict[str, CheckRunEventListener] = {}
+        self.check_suite_listeners: dict[str, CheckSuiteEventListener] = {}
         self.comment_listeners: dict[str, CommentEventListener] = {}
         self.pull_request_listeners: dict[str, PullRequestEventListener] = {}
+        self.pull_request_review_listeners: dict[str, PullRequestReviewEventListener] = {}
 
     def listen_for_check_run(self, fn: CheckRunEventListener) -> CheckRunEventListener:
         self.check_run_listeners[fn.__name__] = fn
+        return fn
+
+    def listen_for_check_suite(self, fn: CheckSuiteEventListener) -> CheckSuiteEventListener:
+        self.check_suite_listeners[fn.__name__] = fn
         return fn
 
     def listen_for_comment(self, fn: CommentEventListener) -> CommentEventListener:
@@ -26,10 +40,21 @@ class SourceCodeManagerEventStream:
         self.pull_request_listeners[fn.__name__] = fn
         return fn
 
+    def listen_for_pull_request_review(
+        self, fn: PullRequestReviewEventListener
+    ) -> PullRequestReviewEventListener:
+        self.pull_request_review_listeners[fn.__name__] = fn
+        return fn
+
     @overload
     def listen_for(
         self, event_type: Literal["check_run"]
     ) -> Callable[[CheckRunEventListener], CheckRunEventListener]: ...
+
+    @overload
+    def listen_for(
+        self, event_type: Literal["check_suite"]
+    ) -> Callable[[CheckSuiteEventListener], CheckSuiteEventListener]: ...
 
     @overload
     def listen_for(
@@ -41,6 +66,11 @@ class SourceCodeManagerEventStream:
         self, event_type: Literal["pull_request"]
     ) -> Callable[[PullRequestEventListener], PullRequestEventListener]: ...
 
+    @overload
+    def listen_for(
+        self, event_type: Literal["pull_request_review"]
+    ) -> Callable[[PullRequestReviewEventListener], PullRequestReviewEventListener]: ...
+
     def listen_for(self, event_type: str):
         """
         Decorator to register a callback for a specific event type.
@@ -50,6 +80,10 @@ class SourceCodeManagerEventStream:
             def handle_check_run(event: CheckRunEvent) -> None:
                 ...
 
+            @scm_event_stream.listen_for(event_type="check_suite")
+            def handle_check_suite(event: CheckSuiteEvent) -> None:
+                ...
+
             @scm_event_stream.listen_for(event_type="comment")
             def handle_comment(event: CommentEvent) -> None:
                 ...
@@ -57,17 +91,25 @@ class SourceCodeManagerEventStream:
             @scm_event_stream.listen_for(event_type="pull_request")
             def handle_pr(event: PullRequestEvent) -> None:
                 ...
+
+            @scm_event_stream.listen_for(event_type="pull_request_review")
+            def handle_pr_review(event: PullRequestReviewEvent) -> None:
+                ...
         """
         if event_type == "check_run":
             return self.listen_for_check_run
+        elif event_type == "check_suite":
+            return self.listen_for_check_suite
         elif event_type == "comment":
             return self.listen_for_comment
         elif event_type == "pull_request":
             return self.listen_for_pull_request
+        elif event_type == "pull_request_review":
+            return self.listen_for_pull_request_review
         else:
             raise ValueError(
                 f"Invalid event_type: {event_type}. "
-                f"Must be 'check_run', 'comment', or 'pull_request'"
+                f"Must be 'check_run', 'check_suite', 'comment', 'pull_request', or 'pull_request_review'"
             )
 
 
@@ -84,12 +126,20 @@ Listeners can be registered by using the `listen_for` method on the `scm_event_s
 def handle_check_run(event: CheckRunEvent) -> None:
     ...
 
+@scm_event_stream.listen_for(event_type="check_suite")
+def handle_check_suite(event: CheckSuiteEvent) -> None:
+    ...
+
 @scm_event_stream.listen_for(event_type="comment")
 def handle_comment(event: CommentEvent) -> None:
     ...
 
 @scm_event_stream.listen_for(event_type="pull_request")
 def handle_pr(event: PullRequestEvent) -> None:
+    ...
+
+@scm_event_stream.listen_for(event_type="pull_request_review")
+def handle_pr_review(event: PullRequestReviewEvent) -> None:
     ...
 ```
 

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -141,6 +141,8 @@ class PullRequestReviewEventDataParser(msgspec.Struct, gc=False, frozen=True):
 class PullRequestReviewEventParser(msgspec.Struct, gc=False, frozen=True):
     action: PullRequestReviewAction
     pull_request_review: PullRequestReviewEventDataParser
+    author: AuthorParser
+    is_bot: bool
     subscription_event: SubscriptionEventParser
 
 
@@ -275,6 +277,8 @@ def deserialize_pull_request_review_event(event_data: str) -> PullRequestReviewE
             "state": parsed.pull_request_review.state,
             "pull_request_id": parsed.pull_request_review.pull_request_id,
         },
+        author={"id": parsed.author.id, "username": parsed.author.username},
+        is_bot=parsed.is_bot,
         subscription_event=_map_subscription_event(parsed.subscription_event),
     )
 
@@ -374,6 +378,8 @@ def serialize_pull_request_review_event(event: PullRequestReviewEvent) -> str:
     structured_event = PullRequestReviewEventParser(
         action=event.action,
         pull_request_review=review_data,
+        author=AuthorParser(id=event.author["id"], username=event.author["username"]),
+        is_bot=event.is_bot,
         subscription_event=_map_subscription_event_parser(event.subscription_event),
     )
     return encoder.encode(structured_event).decode("utf-8")

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -14,7 +14,18 @@ from collections.abc import Callable
 from typing import assert_never, cast
 
 import msgspec
-from scm.types import CheckRunAction, CommentAction, CommentType, ProviderName, PullRequestAction
+from scm.types import (
+    BuildConclusion,
+    BuildStatus,
+    CheckRunAction,
+    CheckSuiteAction,
+    CommentAction,
+    CommentType,
+    ProviderName,
+    PullRequestAction,
+    PullRequestReviewAction,
+    PullRequestReviewState,
+)
 
 from sentry.scm.errors import SCMProviderEventNotSupported, SCMProviderNotSupported
 from sentry.scm.private.event_stream import SourceCodeManagerEventStream, scm_event_stream
@@ -26,11 +37,13 @@ from sentry.scm.private.helpers import (
 from sentry.scm.private.webhooks.github import deserialize_github_event
 from sentry.scm.types import (
     CheckRunEvent,
+    CheckSuiteEvent,
     CommentEvent,
     EventType,
     EventTypeHint,
     HybridCloudSilo,
     PullRequestEvent,
+    PullRequestReviewEvent,
     SubscriptionEvent,
 )
 from sentry.silo.base import SiloMode
@@ -105,9 +118,37 @@ class PullRequestEventParser(msgspec.Struct, gc=False, frozen=True):
     subscription_event: SubscriptionEventParser
 
 
+class CheckSuiteEventDataParser(msgspec.Struct, gc=False, frozen=True):
+    id: str
+    status: BuildStatus
+    conclusion: BuildConclusion | None
+    html_url: str
+    pull_request_ids: list[str]
+
+
+class CheckSuiteEventParser(msgspec.Struct, gc=False, frozen=True):
+    action: CheckSuiteAction
+    check_suite: CheckSuiteEventDataParser
+    subscription_event: SubscriptionEventParser
+
+
+class PullRequestReviewEventDataParser(msgspec.Struct, gc=False, frozen=True):
+    id: str
+    state: PullRequestReviewState
+    pull_request_id: str
+
+
+class PullRequestReviewEventParser(msgspec.Struct, gc=False, frozen=True):
+    action: PullRequestReviewAction
+    pull_request_review: PullRequestReviewEventDataParser
+    subscription_event: SubscriptionEventParser
+
+
 check_run_event_decoder = msgspec.json.Decoder(CheckRunEventParser)
+check_suite_event_decoder = msgspec.json.Decoder(CheckSuiteEventParser)
 comment_event_decoder = msgspec.json.Decoder(CommentEventParser)
 pull_request_event_decoder = msgspec.json.Decoder(PullRequestEventParser)
+pull_request_review_event_decoder = msgspec.json.Decoder(PullRequestReviewEventParser)
 
 
 def _map_subscription_event(parsed: SubscriptionEventParser) -> SubscriptionEvent:
@@ -210,6 +251,34 @@ def deserialize_pull_request_event(event_data: str) -> PullRequestEvent:
     )
 
 
+def deserialize_check_suite_event(event_data: str) -> CheckSuiteEvent:
+    parsed = check_suite_event_decoder.decode(event_data)
+    return CheckSuiteEvent(
+        action=parsed.action,
+        check_suite={
+            "id": parsed.check_suite.id,
+            "status": parsed.check_suite.status,
+            "conclusion": parsed.check_suite.conclusion,
+            "html_url": parsed.check_suite.html_url,
+            "pull_request_ids": parsed.check_suite.pull_request_ids,
+        },
+        subscription_event=_map_subscription_event(parsed.subscription_event),
+    )
+
+
+def deserialize_pull_request_review_event(event_data: str) -> PullRequestReviewEvent:
+    parsed = pull_request_review_event_decoder.decode(event_data)
+    return PullRequestReviewEvent(
+        action=parsed.action,
+        pull_request_review={
+            "id": parsed.pull_request_review.id,
+            "state": parsed.pull_request_review.state,
+            "pull_request_id": parsed.pull_request_review.pull_request_id,
+        },
+        subscription_event=_map_subscription_event(parsed.subscription_event),
+    )
+
+
 encoder = msgspec.json.Encoder()
 
 
@@ -280,16 +349,50 @@ def serialize_pull_request_event(event: PullRequestEvent) -> str:
     return encoder.encode(structured_event).decode("utf-8")
 
 
+def serialize_check_suite_event(event: CheckSuiteEvent) -> str:
+    check_suite_data = CheckSuiteEventDataParser(
+        id=event.check_suite["id"],
+        status=event.check_suite["status"],
+        conclusion=event.check_suite["conclusion"],
+        html_url=event.check_suite["html_url"],
+        pull_request_ids=event.check_suite["pull_request_ids"],
+    )
+    structured_event = CheckSuiteEventParser(
+        action=event.action,
+        check_suite=check_suite_data,
+        subscription_event=_map_subscription_event_parser(event.subscription_event),
+    )
+    return encoder.encode(structured_event).decode("utf-8")
+
+
+def serialize_pull_request_review_event(event: PullRequestReviewEvent) -> str:
+    review_data = PullRequestReviewEventDataParser(
+        id=event.pull_request_review["id"],
+        state=event.pull_request_review["state"],
+        pull_request_id=event.pull_request_review["pull_request_id"],
+    )
+    structured_event = PullRequestReviewEventParser(
+        action=event.action,
+        pull_request_review=review_data,
+        subscription_event=_map_subscription_event_parser(event.subscription_event),
+    )
+    return encoder.encode(structured_event).decode("utf-8")
+
+
 def deserialize_event(event: str, event_type: EventTypeHint) -> EventType:
     """
     Given an encoded string return a deserialized event.
     """
     if event_type == "check_run":
         return deserialize_check_run_event(event)
+    elif event_type == "check_suite":
+        return deserialize_check_suite_event(event)
     elif event_type == "comment":
         return deserialize_comment_event(event)
     elif event_type == "pull_request":
         return deserialize_pull_request_event(event)
+    elif event_type == "pull_request_review":
+        return deserialize_pull_request_review_event(event)
     else:
         assert_never(event_type)
 
@@ -324,10 +427,14 @@ def serialize_event(event: EventType) -> str:
     """
     if isinstance(event, CheckRunEvent):
         return serialize_check_run_event(event)
+    elif isinstance(event, CheckSuiteEvent):
+        return serialize_check_suite_event(event)
     elif isinstance(event, CommentEvent):
         return serialize_comment_event(event)
     elif isinstance(event, PullRequestEvent):
         return serialize_pull_request_event(event)
+    elif isinstance(event, PullRequestReviewEvent):
+        return serialize_pull_request_review_event(event)
     else:
         assert_never(event)
 
@@ -369,12 +476,18 @@ def produce_to_listeners(
     if isinstance(parsed_event, CheckRunEvent):
         event_type_hint = "check_run"
         listeners = list(stream.check_run_listeners.keys())
+    elif isinstance(parsed_event, CheckSuiteEvent):
+        event_type_hint = "check_suite"
+        listeners = list(stream.check_suite_listeners.keys())
     elif isinstance(parsed_event, CommentEvent):
         event_type_hint = "comment"
         listeners = list(stream.comment_listeners.keys())
     elif isinstance(parsed_event, PullRequestEvent):
         event_type_hint = "pull_request"
         listeners = list(stream.pull_request_listeners.keys())
+    elif isinstance(parsed_event, PullRequestReviewEvent):
+        event_type_hint = "pull_request_review"
+        listeners = list(stream.pull_request_review_listeners.keys())
     else:
         assert_never(parsed_event)
 
@@ -465,10 +578,14 @@ def run_listener(
 
     if isinstance(event, CheckRunEvent):
         exec_listener(listener, stream.check_run_listeners, event, record_count)
+    elif isinstance(event, CheckSuiteEvent):
+        exec_listener(listener, stream.check_suite_listeners, event, record_count)
     elif isinstance(event, CommentEvent):
         exec_listener(listener, stream.comment_listeners, event, record_count)
     elif isinstance(event, PullRequestEvent):
         exec_listener(listener, stream.pull_request_listeners, event, record_count)
+    elif isinstance(event, PullRequestReviewEvent):
+        exec_listener(listener, stream.pull_request_review_listeners, event, record_count)
     else:
         assert_never(event)
 

--- a/src/sentry/scm/private/ipc.py
+++ b/src/sentry/scm/private/ipc.py
@@ -122,7 +122,6 @@ class CheckSuiteEventDataParser(msgspec.Struct, gc=False, frozen=True):
     id: str
     status: BuildStatus
     conclusion: BuildConclusion | None
-    html_url: str
     pull_request_ids: list[str]
 
 
@@ -261,7 +260,7 @@ def deserialize_check_suite_event(event_data: str) -> CheckSuiteEvent:
             "id": parsed.check_suite.id,
             "status": parsed.check_suite.status,
             "conclusion": parsed.check_suite.conclusion,
-            "html_url": parsed.check_suite.html_url,
+            "html_url": "",
             "pull_request_ids": parsed.check_suite.pull_request_ids,
         },
         subscription_event=_map_subscription_event(parsed.subscription_event),
@@ -358,7 +357,6 @@ def serialize_check_suite_event(event: CheckSuiteEvent) -> str:
         id=event.check_suite["id"],
         status=event.check_suite["status"],
         conclusion=event.check_suite["conclusion"],
-        html_url=event.check_suite["html_url"],
         pull_request_ids=event.check_suite["pull_request_ids"],
     )
     structured_event = CheckSuiteEventParser(

--- a/src/sentry/scm/private/webhooks/github.py
+++ b/src/sentry/scm/private/webhooks/github.py
@@ -2,17 +2,24 @@ from typing import Optional
 
 import msgspec
 from scm.types import (
+    BuildConclusion,
+    BuildStatus,
     CheckRunAction,
+    CheckSuiteAction,
     CommentAction,
     EventTypeHint,
     PullRequestAction,
+    PullRequestReviewAction,
+    PullRequestReviewState,
 )
 
 from sentry.scm.types import (
     CheckRunEvent,
+    CheckSuiteEvent,
     CommentEvent,
     EventType,
     PullRequestEvent,
+    PullRequestReviewEvent,
     SubscriptionEvent,
 )
 
@@ -20,7 +27,6 @@ from sentry.scm.types import (
 #   * "installation"
 #   * "installation_repositories"
 #   * "issues"
-#   * "pull_request_review"
 #   * "pull_request_review_comment"
 #   * "push"
 
@@ -96,9 +102,46 @@ class GitHubPullRequestRepo(msgspec.Struct, gc=False):
     private: bool
 
 
+class GitHubCheckSuiteEvent(msgspec.Struct, gc=False):
+    action: CheckSuiteAction
+    check_suite: "GitHubCheckSuite"
+
+
+class GitHubCheckSuitePullRequest(msgspec.Struct, gc=False):
+    id: int
+    number: int
+
+
+class GitHubCheckSuite(msgspec.Struct, gc=False):
+    id: int
+    status: BuildStatus
+    conclusion: BuildConclusion | None
+    url: str
+    pull_requests: list[GitHubCheckSuitePullRequest]
+
+
+class GitHubPullRequestReviewEvent(msgspec.Struct, gc=False):
+    action: PullRequestReviewAction
+    review: "GitHubReview"
+    pull_request: "GitHubPullRequestReviewPullRequest"
+
+
+class GitHubPullRequestReviewPullRequest(msgspec.Struct, gc=False):
+    id: int
+    number: int
+
+
+class GitHubReview(msgspec.Struct, gc=False):
+    id: int
+    state: PullRequestReviewState
+    user: GitHubUser
+
+
 check_run_decoder = msgspec.json.Decoder(GitHubCheckRunEvent)
+check_suite_decoder = msgspec.json.Decoder(GitHubCheckSuiteEvent)
 issue_comment_decoder = msgspec.json.Decoder(GitHubIssueCommentEvent)
 pull_request_decoder = msgspec.json.Decoder(GitHubPullRequestEvent)
+pull_request_review_decoder = msgspec.json.Decoder(GitHubPullRequestReviewEvent)
 
 
 def deserialize_github_check_run_event(event: SubscriptionEvent) -> CheckRunEvent:
@@ -158,6 +201,45 @@ def deserialize_github_pull_request_event(event: SubscriptionEvent) -> PullReque
     )
 
 
+def deserialize_github_check_suite_event(event: SubscriptionEvent) -> CheckSuiteEvent:
+    e = check_suite_decoder.decode(event["event"])
+
+    return CheckSuiteEvent(
+        action=e.action,
+        check_suite={
+            "id": str(e.check_suite.id),
+            "status": e.check_suite.status,
+            "conclusion": e.check_suite.conclusion,
+            "html_url": e.check_suite.url,
+            "pull_request_ids": [str(pr.id) for pr in e.check_suite.pull_requests],
+        },
+        subscription_event=event,
+    )
+
+
+def deserialize_github_pull_request_review_event(
+    event: SubscriptionEvent,
+) -> PullRequestReviewEvent:
+    e = pull_request_review_decoder.decode(event["event"])
+
+    user = e.review.user
+
+    return PullRequestReviewEvent(
+        action=e.action,
+        pull_request_review={
+            "id": str(e.review.id),
+            "state": e.review.state,
+            "pull_request_id": str(e.pull_request.id),
+        },
+        author={
+            "id": str(user.id),
+            "username": user.login,
+        },
+        is_bot=user.type == "Bot" if user.type else False,
+        subscription_event=event,
+    )
+
+
 def deserialize_github_event_type_hint(event: SubscriptionEvent) -> EventTypeHint | None:
     if event["event_type_hint"] == "pull_request":
         return "pull_request"
@@ -165,6 +247,10 @@ def deserialize_github_event_type_hint(event: SubscriptionEvent) -> EventTypeHin
         return "comment"
     elif event["event_type_hint"] == "check_run":
         return "check_run"
+    elif event["event_type_hint"] == "check_suite":
+        return "check_suite"
+    elif event["event_type_hint"] == "pull_request_review":
+        return "pull_request_review"
     else:
         return None
 
@@ -176,7 +262,11 @@ def deserialize_github_event(event: SubscriptionEvent) -> EventType | None:
 
     if event_type_hint == "check_run":
         return deserialize_github_check_run_event(event)
+    elif event_type_hint == "check_suite":
+        return deserialize_github_check_suite_event(event)
     elif event_type_hint == "comment":
         return deserialize_github_comment_event(event)
-    else:
+    elif event_type_hint == "pull_request":
         return deserialize_github_pull_request_event(event)
+    elif event_type_hint == "pull_request_review":
+        return deserialize_github_pull_request_review_event(event)

--- a/src/sentry/scm/private/webhooks/github.py
+++ b/src/sentry/scm/private/webhooks/github.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, assert_never
 
 import msgspec
 from scm.types import (
@@ -116,7 +116,7 @@ class GitHubCheckSuite(msgspec.Struct, gc=False):
     id: int
     status: BuildStatus
     conclusion: BuildConclusion | None
-    url: str
+    html_url: str
     pull_requests: list[GitHubCheckSuitePullRequest]
 
 
@@ -210,8 +210,8 @@ def deserialize_github_check_suite_event(event: SubscriptionEvent) -> CheckSuite
             "id": str(e.check_suite.id),
             "status": e.check_suite.status,
             "conclusion": e.check_suite.conclusion,
-            "html_url": e.check_suite.url,
-            "pull_request_ids": [str(pr.id) for pr in e.check_suite.pull_requests],
+            "html_url": e.check_suite.html_url,
+            "pull_request_ids": [str(pr.number) for pr in e.check_suite.pull_requests],
         },
         subscription_event=event,
     )
@@ -229,7 +229,7 @@ def deserialize_github_pull_request_review_event(
         pull_request_review={
             "id": str(e.review.id),
             "state": e.review.state,
-            "pull_request_id": str(e.pull_request.id),
+            "pull_request_id": str(e.pull_request.number),
         },
         author={
             "id": str(user.id),
@@ -270,3 +270,5 @@ def deserialize_github_event(event: SubscriptionEvent) -> EventType | None:
         return deserialize_github_pull_request_event(event)
     elif event_type_hint == "pull_request_review":
         return deserialize_github_pull_request_review_event(event)
+    else:
+        assert_never(event_type_hint)

--- a/src/sentry/scm/private/webhooks/github.py
+++ b/src/sentry/scm/private/webhooks/github.py
@@ -1,9 +1,9 @@
-from typing import Optional, assert_never
+import logging
+from typing import Literal, Optional, assert_never
 
 import msgspec
+from scm.providers.github.provider import GITHUB_CONCLUSION_MAP, GITHUB_STATUS_MAP
 from scm.types import (
-    BuildConclusion,
-    BuildStatus,
     CheckRunAction,
     CheckSuiteAction,
     CommentAction,
@@ -12,6 +12,20 @@ from scm.types import (
     PullRequestReviewAction,
     PullRequestReviewState,
 )
+
+# Raw GitHub Checks-API enum values, normalized to BuildStatus/BuildConclusion
+# via GITHUB_STATUS_MAP/GITHUB_CONCLUSION_MAP.
+GitHubCheckStatus = Literal["queued", "requested", "waiting", "pending", "in_progress", "completed"]
+GitHubCheckConclusion = Literal[
+    "success",
+    "failure",
+    "neutral",
+    "cancelled",
+    "skipped",
+    "timed_out",
+    "action_required",
+    "stale",
+]
 
 from sentry.scm.types import (
     CheckRunEvent,
@@ -22,6 +36,8 @@ from sentry.scm.types import (
     PullRequestReviewEvent,
     SubscriptionEvent,
 )
+
+logger = logging.getLogger(__name__)
 
 # Remaining types in use:
 #   * "installation"
@@ -114,9 +130,8 @@ class GitHubCheckSuitePullRequest(msgspec.Struct, gc=False):
 
 class GitHubCheckSuite(msgspec.Struct, gc=False):
     id: int
-    status: BuildStatus
-    conclusion: BuildConclusion | None
-    html_url: str
+    status: GitHubCheckStatus
+    conclusion: GitHubCheckConclusion | None
     pull_requests: list[GitHubCheckSuitePullRequest]
 
 
@@ -203,15 +218,20 @@ def deserialize_github_pull_request_event(event: SubscriptionEvent) -> PullReque
 
 def deserialize_github_check_suite_event(event: SubscriptionEvent) -> CheckSuiteEvent:
     e = check_suite_decoder.decode(event["event"])
+    pull_request_ids = [str(pr.number) for pr in e.check_suite.pull_requests]
+    status = GITHUB_STATUS_MAP.get(e.check_suite.status, "pending")
+    conclusion = (
+        GITHUB_CONCLUSION_MAP.get(e.check_suite.conclusion) if e.check_suite.conclusion else None
+    )
 
     return CheckSuiteEvent(
         action=e.action,
         check_suite={
             "id": str(e.check_suite.id),
-            "status": e.check_suite.status,
-            "conclusion": e.check_suite.conclusion,
-            "html_url": e.check_suite.html_url,
-            "pull_request_ids": [str(pr.number) for pr in e.check_suite.pull_requests],
+            "status": status,
+            "conclusion": conclusion,
+            "html_url": "",
+            "pull_request_ids": pull_request_ids,
         },
         subscription_event=event,
     )

--- a/src/sentry/scm/private/webhooks/github.py
+++ b/src/sentry/scm/private/webhooks/github.py
@@ -24,8 +24,11 @@ GitHubCheckConclusion = Literal[
     "skipped",
     "timed_out",
     "action_required",
+    "startup_failure",
     "stale",
 ]
+
+GITHUB_CHECK_SUITE_CONCLUSION_MAP = {**GITHUB_CONCLUSION_MAP, "startup_failure": "failure"}
 
 from sentry.scm.types import (
     CheckRunEvent,
@@ -221,7 +224,9 @@ def deserialize_github_check_suite_event(event: SubscriptionEvent) -> CheckSuite
     pull_request_ids = [str(pr.number) for pr in e.check_suite.pull_requests]
     status = GITHUB_STATUS_MAP.get(e.check_suite.status, "pending")
     conclusion = (
-        GITHUB_CONCLUSION_MAP.get(e.check_suite.conclusion) if e.check_suite.conclusion else None
+        GITHUB_CHECK_SUITE_CONCLUSION_MAP.get(e.check_suite.conclusion)
+        if e.check_suite.conclusion
+        else None
     )
 
     return CheckSuiteEvent(

--- a/src/sentry/scm/stream.py
+++ b/src/sentry/scm/stream.py
@@ -8,9 +8,11 @@
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import (
     CheckRunEvent,
+    CheckSuiteEvent,
     CommentEvent,
     EventType,
     PullRequestEvent,
+    PullRequestReviewEvent,
     SubscriptionEvent,
 )
 
@@ -34,6 +36,16 @@ def listen_for_pull_request(e):
     return None
 
 
+@scm_event_stream.listen_for(event_type="check_suite")
+def listen_for_check_suite(e):
+    return None
+
+
+@scm_event_stream.listen_for(event_type="pull_request_review")
+def listen_for_pull_request_review(e):
+    return None
+
+
 # Do not re-export your listener here.
 __all__ = [
     "scm_event_stream",
@@ -42,4 +54,6 @@ __all__ = [
     "PullRequestEvent",
     "CheckRunEvent",
     "SubscriptionEvent",
+    "CheckSuiteEvent",
+    "PullRequestReviewEvent",
 ]

--- a/src/sentry/scm/types.py
+++ b/src/sentry/scm/types.py
@@ -2,14 +2,19 @@ from dataclasses import dataclass
 from typing import Literal, TypedDict
 
 from scm.types import (
+    Author,
     CheckRunAction,
     CheckRunEventData,
+    CheckSuiteAction,
+    CheckSuiteEventData,
     CommentAction,
     CommentEventData,
     CommentType,
     ProviderName,
     PullRequestAction,
     PullRequestEventData,
+    PullRequestReviewAction,
+    PullRequestReviewEventData,
 )
 
 
@@ -153,6 +158,26 @@ class PullRequestEvent:
     """
 
 
-type EventType = CheckRunEvent | CommentEvent | PullRequestEvent
-type EventTypeHint = Literal["check_run", "comment", "pull_request"]
+@dataclass(frozen=True)
+class CheckSuiteEvent:
+    action: CheckSuiteAction
+    check_suite: CheckSuiteEventData
+    subscription_event: SubscriptionEvent
+
+
+@dataclass(frozen=True)
+class PullRequestReviewEvent:
+    action: PullRequestReviewAction
+    pull_request_review: PullRequestReviewEventData
+    author: Author
+    is_bot: bool
+    subscription_event: SubscriptionEvent
+
+
+type EventType = (
+    CheckRunEvent | CommentEvent | PullRequestEvent | CheckSuiteEvent | PullRequestReviewEvent
+)
+type EventTypeHint = Literal[
+    "check_run", "comment", "pull_request", "check_suite", "pull_request_review"
+]
 type HybridCloudSilo = Literal["control", "region"]

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -9,29 +9,39 @@ from sentry.scm.private.ipc import (
     AuthorParser,
     CheckRunEventDataParser,
     CheckRunEventParser,
+    CheckSuiteEventDataParser,
+    CheckSuiteEventParser,
     CommentEventDataParser,
     CommentEventParser,
     PullRequestBranchParser,
     PullRequestEventDataParser,
     PullRequestEventParser,
+    PullRequestReviewEventDataParser,
+    PullRequestReviewEventParser,
     SubscriptionEventParser,
     deserialize_check_run_event,
+    deserialize_check_suite_event,
     deserialize_comment_event,
     deserialize_event,
     deserialize_pull_request_event,
+    deserialize_pull_request_review_event,
     exec_listener,
     produce_to_listeners,
     run_listener,
     serialize_check_run_event,
+    serialize_check_suite_event,
     serialize_comment_event,
     serialize_event,
     serialize_pull_request_event,
+    serialize_pull_request_review_event,
 )
 from sentry.scm.types import (
     CheckRunEvent,
+    CheckSuiteEvent,
     CommentEvent,
     EventType,
     PullRequestEvent,
+    PullRequestReviewEvent,
     SubscriptionEvent,
 )
 
@@ -207,6 +217,78 @@ def test_run_pull_request_listener() -> None:
     assert event.pull_request["title"] == "Test PR"
     assert event.pull_request["head"]["ref"] == "feature-branch"
     assert event.pull_request["base"]["ref"] == "main"
+
+
+def test_run_check_suite_listener() -> None:
+    event = None
+
+    scm = SourceCodeManagerEventStream()
+
+    @scm.listen_for("check_suite")
+    def call_me_maybe(e):
+        nonlocal event
+        event = e
+
+    check_suite_event = CheckSuiteEventParser(
+        action="completed",
+        check_suite=CheckSuiteEventDataParser(
+            "1", "completed", "success", "https://example.com", ["10", "20"]
+        ),
+        subscription_event=SubscriptionEventParser(None, "", {}, 0, [], "github"),
+    )
+    message = msgspec.json.encode(check_suite_event).decode("utf-8")
+
+    run_listener(
+        "call_me_maybe",
+        message,
+        "check_suite",
+        stream=scm,
+        get_current_time=lambda: 0.0,
+        record_count=lambda a, b, c: None,
+        record_timer=lambda a, b, c: None,
+    )
+
+    assert isinstance(event, CheckSuiteEvent)
+    assert event.action == "completed"
+    assert event.check_suite["id"] == "1"
+    assert event.check_suite["status"] == "completed"
+    assert event.check_suite["conclusion"] == "success"
+    assert event.check_suite["pull_request_ids"] == ["10", "20"]
+    assert event.check_suite["html_url"] == ["https://example.com"]
+
+
+def test_run_pull_request_review_listener() -> None:
+    event = None
+
+    scm = SourceCodeManagerEventStream()
+
+    @scm.listen_for("pull_request_review")
+    def review_handler(e):
+        nonlocal event
+        event = e
+
+    review_event = PullRequestReviewEventParser(
+        action="submitted",
+        pull_request_review=PullRequestReviewEventDataParser("99", "approved", "42"),
+        subscription_event=SubscriptionEventParser(None, "", {}, 0, [], "github"),
+    )
+    message = msgspec.json.encode(review_event).decode("utf-8")
+
+    run_listener(
+        "review_handler",
+        message,
+        "pull_request_review",
+        stream=scm,
+        get_current_time=lambda: 0.0,
+        record_count=lambda a, b, c: None,
+        record_timer=lambda a, b, c: None,
+    )
+
+    assert isinstance(event, PullRequestReviewEvent)
+    assert event.action == "submitted"
+    assert event.pull_request_review["id"] == "99"
+    assert event.pull_request_review["state"] == "approved"
+    assert event.pull_request_review["pull_request_id"] == "42"
 
 
 def test_run_listener_metrics_recorded() -> None:
@@ -526,6 +608,98 @@ def test_serialize_deserialize_pull_request_event_no_author() -> None:
     assert deserialized.pull_request["description"] is None
 
 
+def test_serialize_deserialize_check_suite_event() -> None:
+    event = CheckSuiteEvent(
+        action="completed",
+        check_suite={
+            "id": "suite-1",
+            "status": "completed",
+            "conclusion": "success",
+            "html_url": "https://example.com/check-suite/1",
+            "pull_request_ids": ["10", "20"],
+        },
+        subscription_event={
+            "event": "raw_event_data",
+            "event_type_hint": "check_suite",
+            "extra": {},
+            "received_at": 1234567890,
+            "sentry_meta": [{"id": 1, "integration_id": 100, "organization_id": 200}],
+            "type": "github",
+        },
+    )
+
+    serialized = serialize_check_suite_event(event)
+    assert isinstance(serialized, str)
+
+    deserialized = deserialize_check_suite_event(serialized)
+    assert deserialized.action == event.action
+    assert deserialized.check_suite["id"] == event.check_suite["id"]
+    assert deserialized.check_suite["status"] == event.check_suite["status"]
+    assert deserialized.check_suite["conclusion"] == event.check_suite["conclusion"]
+    assert deserialized.check_suite["html_url"] == event.check_suite["html_url"]
+    assert deserialized.check_suite["pull_request_ids"] == event.check_suite["pull_request_ids"]
+    assert deserialized.subscription_event["type"] == event.subscription_event["type"]
+
+
+def test_serialize_deserialize_check_suite_event_no_conclusion() -> None:
+    event = CheckSuiteEvent(
+        action="requested",
+        check_suite={
+            "id": "suite-2",
+            "status": "pending",
+            "conclusion": None,
+            "html_url": "https://example.com/check-suite/2",
+            "pull_request_ids": [],
+        },
+        subscription_event={
+            "event": "",
+            "event_type_hint": None,
+            "extra": {},
+            "received_at": 0,
+            "sentry_meta": None,
+            "type": "github",
+        },
+    )
+
+    serialized = serialize_check_suite_event(event)
+    deserialized = deserialize_check_suite_event(serialized)
+
+    assert deserialized.check_suite["conclusion"] is None
+    assert deserialized.check_suite["pull_request_ids"] == []
+
+
+def test_serialize_deserialize_pull_request_review_event() -> None:
+    event = PullRequestReviewEvent(
+        action="submitted",
+        pull_request_review={
+            "id": "review-1",
+            "state": "approved",
+            "pull_request_id": "42",
+        },
+        subscription_event={
+            "event": "raw_event_data",
+            "event_type_hint": "pull_request_review",
+            "extra": {"key": "value"},
+            "received_at": 1234567890,
+            "sentry_meta": [{"id": 1, "integration_id": 100, "organization_id": 200}],
+            "type": "github",
+        },
+    )
+
+    serialized = serialize_pull_request_review_event(event)
+    assert isinstance(serialized, str)
+
+    deserialized = deserialize_pull_request_review_event(serialized)
+    assert deserialized.action == event.action
+    assert deserialized.pull_request_review["id"] == event.pull_request_review["id"]
+    assert deserialized.pull_request_review["state"] == event.pull_request_review["state"]
+    assert (
+        deserialized.pull_request_review["pull_request_id"]
+        == event.pull_request_review["pull_request_id"]
+    )
+    assert deserialized.subscription_event["type"] == event.subscription_event["type"]
+
+
 def test_serialize_event_dispatches_correctly() -> None:
     """
     Test that serialize_event dispatches to the correct serializer based on event type.
@@ -580,18 +754,58 @@ def test_serialize_event_dispatches_correctly() -> None:
         },
     )
 
+    check_suite_event = CheckSuiteEvent(
+        action="completed",
+        check_suite={
+            "id": "1",
+            "status": "completed",
+            "conclusion": "success",
+            "html_url": "url",
+            "pull_request_ids": [],
+        },
+        subscription_event={
+            "event": "",
+            "event_type_hint": None,
+            "extra": {},
+            "received_at": 0,
+            "sentry_meta": None,
+            "type": "github",
+        },
+    )
+
+    pr_review_event = PullRequestReviewEvent(
+        action="submitted",
+        pull_request_review={"id": "1", "state": "approved", "pull_request_id": "42"},
+        subscription_event={
+            "event": "",
+            "event_type_hint": None,
+            "extra": {},
+            "received_at": 0,
+            "sentry_meta": None,
+            "type": "github",
+        },
+    )
+
     check_run_bytes = serialize_event(check_run_event)
     comment_bytes = serialize_event(comment_event)
     pr_bytes = serialize_event(pr_event)
+    check_suite_bytes = serialize_event(check_suite_event)
+    pr_review_bytes = serialize_event(pr_review_event)
 
     assert isinstance(check_run_bytes, str)
     assert isinstance(comment_bytes, str)
     assert isinstance(pr_bytes, str)
+    assert isinstance(check_suite_bytes, str)
+    assert isinstance(pr_review_bytes, str)
 
     # Verify they can be deserialized back
     assert isinstance(deserialize_check_run_event(check_run_bytes), CheckRunEvent)
     assert isinstance(deserialize_comment_event(comment_bytes), CommentEvent)
     assert isinstance(deserialize_pull_request_event(pr_bytes), PullRequestEvent)
+    assert isinstance(deserialize_check_suite_event(check_suite_bytes), CheckSuiteEvent)
+    assert isinstance(
+        deserialize_pull_request_review_event(pr_review_bytes), PullRequestReviewEvent
+    )
 
 
 def test_deserialize_event_dispatches_correctly() -> None:
@@ -630,9 +844,27 @@ def test_deserialize_event_dispatches_correctly() -> None:
     )
     pr_bytes = msgspec.json.encode(pr_parser).decode("utf-8")
 
+    check_suite_parser = CheckSuiteEventParser(
+        action="completed",
+        check_suite=CheckSuiteEventDataParser("1", "completed", "success", "url", []),
+        subscription_event=SubscriptionEventParser(None, "", {}, 0, None, "github"),
+    )
+    check_suite_bytes = msgspec.json.encode(check_suite_parser).decode("utf-8")
+
+    pr_review_parser = PullRequestReviewEventParser(
+        action="submitted",
+        pull_request_review=PullRequestReviewEventDataParser("1", "approved", "42"),
+        subscription_event=SubscriptionEventParser(None, "", {}, 0, None, "github"),
+    )
+    pr_review_bytes = msgspec.json.encode(pr_review_parser).decode("utf-8")
+
     assert isinstance(deserialize_event(check_run_bytes, "check_run"), CheckRunEvent)
     assert isinstance(deserialize_event(comment_bytes, "comment"), CommentEvent)
     assert isinstance(deserialize_event(pr_bytes, "pull_request"), PullRequestEvent)
+    assert isinstance(deserialize_event(check_suite_bytes, "check_suite"), CheckSuiteEvent)
+    assert isinstance(
+        deserialize_event(pr_review_bytes, "pull_request_review"), PullRequestReviewEvent
+    )
 
 
 def test_produce_to_listeners_check_run() -> None:
@@ -766,6 +998,84 @@ def test_produce_to_listeners_pull_request() -> None:
 
         assert len(produced_messages) == 1
         assert produced_messages[0][1] == "pull_request"
+        assert produced_messages[0][3] == "control"
+
+
+def test_produce_to_listeners_check_suite() -> None:
+    produced_messages = []
+
+    def mock_produce(message, event_type_hint, listener_name, silo):
+        produced_messages.append((message, event_type_hint, listener_name, silo))
+
+    subscription_event: SubscriptionEvent = {
+        "event": "{}",
+        "event_type_hint": "check_suite",
+        "extra": {},
+        "received_at": 0,
+        "sentry_meta": None,
+        "type": "github",
+    }
+
+    def mock_deserialize(event):
+        return CheckSuiteEvent(
+            action="completed",
+            check_suite={
+                "id": "1",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "url",
+                "pull_request_ids": [],
+            },
+            subscription_event=event,
+        )
+
+    mock_stream = SourceCodeManagerEventStream()
+
+    @mock_stream.listen_for("check_suite")
+    def cs_listener(e):
+        pass
+
+    with mock.patch("sentry.scm.private.ipc.deserialize_raw_event", mock_deserialize):
+        produce_to_listeners(subscription_event, "region", mock_produce, stream=mock_stream)
+
+        assert len(produced_messages) == 1
+        assert produced_messages[0][1] == "check_suite"
+        assert produced_messages[0][3] == "region"
+
+
+def test_produce_to_listeners_pull_request_review() -> None:
+    produced_messages = []
+
+    def mock_produce(message, event_type_hint, listener_name, silo):
+        produced_messages.append((message, event_type_hint, listener_name, silo))
+
+    subscription_event: SubscriptionEvent = {
+        "event": "{}",
+        "event_type_hint": "pull_request_review",
+        "extra": {},
+        "received_at": 0,
+        "sentry_meta": None,
+        "type": "github",
+    }
+
+    def mock_deserialize(event):
+        return PullRequestReviewEvent(
+            action="submitted",
+            pull_request_review={"id": "1", "state": "approved", "pull_request_id": "42"},
+            subscription_event=event,
+        )
+
+    mock_stream = SourceCodeManagerEventStream()
+
+    @mock_stream.listen_for("pull_request_review")
+    def review_listener(e):
+        pass
+
+    with mock.patch("sentry.scm.private.ipc.deserialize_raw_event", mock_deserialize):
+        produce_to_listeners(subscription_event, "control", mock_produce, stream=mock_stream)
+
+        assert len(produced_messages) == 1
+        assert produced_messages[0][1] == "pull_request_review"
         assert produced_messages[0][3] == "control"
 
 

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -254,7 +254,7 @@ def test_run_check_suite_listener() -> None:
     assert event.check_suite["status"] == "completed"
     assert event.check_suite["conclusion"] == "success"
     assert event.check_suite["pull_request_ids"] == ["10", "20"]
-    assert event.check_suite["html_url"] == ["https://example.com"]
+    assert event.check_suite["html_url"] == "https://example.com"
 
 
 def test_run_pull_request_review_listener() -> None:

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -270,6 +270,8 @@ def test_run_pull_request_review_listener() -> None:
     review_event = PullRequestReviewEventParser(
         action="submitted",
         pull_request_review=PullRequestReviewEventDataParser("99", "approved", "42"),
+        author=AuthorParser(id="user-1", username="reviewer"),
+        is_bot=False,
         subscription_event=SubscriptionEventParser(None, "", {}, 0, [], "github"),
     )
     message = msgspec.json.encode(review_event).decode("utf-8")
@@ -676,6 +678,8 @@ def test_serialize_deserialize_pull_request_review_event() -> None:
             "state": "approved",
             "pull_request_id": "42",
         },
+        author={"id": "user-1", "username": "reviewer"},
+        is_bot=False,
         subscription_event={
             "event": "raw_event_data",
             "event_type_hint": "pull_request_review",
@@ -776,6 +780,8 @@ def test_serialize_event_dispatches_correctly() -> None:
     pr_review_event = PullRequestReviewEvent(
         action="submitted",
         pull_request_review={"id": "1", "state": "approved", "pull_request_id": "42"},
+        author={"id": "user-1", "username": "reviewer"},
+        is_bot=False,
         subscription_event={
             "event": "",
             "event_type_hint": None,
@@ -854,6 +860,8 @@ def test_deserialize_event_dispatches_correctly() -> None:
     pr_review_parser = PullRequestReviewEventParser(
         action="submitted",
         pull_request_review=PullRequestReviewEventDataParser("1", "approved", "42"),
+        author=AuthorParser(id="user-1", username="reviewer"),
+        is_bot=False,
         subscription_event=SubscriptionEventParser(None, "", {}, 0, None, "github"),
     )
     pr_review_bytes = msgspec.json.encode(pr_review_parser).decode("utf-8")
@@ -1062,6 +1070,8 @@ def test_produce_to_listeners_pull_request_review() -> None:
         return PullRequestReviewEvent(
             action="submitted",
             pull_request_review={"id": "1", "state": "approved", "pull_request_id": "42"},
+            author={"id": "user-1", "username": "reviewer"},
+            is_bot=False,
             subscription_event=event,
         )
 

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -25,6 +25,7 @@ from sentry.scm.private.ipc import (
     deserialize_event,
     deserialize_pull_request_event,
     deserialize_pull_request_review_event,
+    deserialize_raw_event,
     exec_listener,
     produce_to_listeners,
     run_listener,
@@ -665,6 +666,25 @@ def test_serialize_deserialize_check_suite_event_no_conclusion() -> None:
 
     assert deserialized.check_suite["conclusion"] is None
     assert deserialized.check_suite["pull_request_ids"] == []
+
+
+def test_deserialize_github_check_suite_startup_failure() -> None:
+    event: SubscriptionEvent = {
+        "event": (
+            '{"action":"completed","check_suite":{"id":1,"status":"completed",'
+            '"conclusion":"startup_failure","pull_requests":[]}}'
+        ),
+        "event_type_hint": "check_suite",
+        "extra": {},
+        "received_at": 0,
+        "sentry_meta": [],
+        "type": "github",
+    }
+
+    parsed_event = deserialize_raw_event(event)
+
+    assert isinstance(parsed_event, CheckSuiteEvent)
+    assert parsed_event.check_suite["conclusion"] == "failure"
 
 
 def test_serialize_deserialize_pull_request_review_event() -> None:

--- a/tests/sentry/scm/unit/private/test_ipc.py
+++ b/tests/sentry/scm/unit/private/test_ipc.py
@@ -231,9 +231,7 @@ def test_run_check_suite_listener() -> None:
 
     check_suite_event = CheckSuiteEventParser(
         action="completed",
-        check_suite=CheckSuiteEventDataParser(
-            "1", "completed", "success", "https://example.com", ["10", "20"]
-        ),
+        check_suite=CheckSuiteEventDataParser("1", "completed", "success", ["10", "20"]),
         subscription_event=SubscriptionEventParser(None, "", {}, 0, [], "github"),
     )
     message = msgspec.json.encode(check_suite_event).decode("utf-8")
@@ -254,7 +252,6 @@ def test_run_check_suite_listener() -> None:
     assert event.check_suite["status"] == "completed"
     assert event.check_suite["conclusion"] == "success"
     assert event.check_suite["pull_request_ids"] == ["10", "20"]
-    assert event.check_suite["html_url"] == "https://example.com"
 
 
 def test_run_pull_request_review_listener() -> None:
@@ -638,7 +635,7 @@ def test_serialize_deserialize_check_suite_event() -> None:
     assert deserialized.check_suite["id"] == event.check_suite["id"]
     assert deserialized.check_suite["status"] == event.check_suite["status"]
     assert deserialized.check_suite["conclusion"] == event.check_suite["conclusion"]
-    assert deserialized.check_suite["html_url"] == event.check_suite["html_url"]
+    assert deserialized.check_suite["html_url"] == ""
     assert deserialized.check_suite["pull_request_ids"] == event.check_suite["pull_request_ids"]
     assert deserialized.subscription_event["type"] == event.subscription_event["type"]
 
@@ -852,7 +849,7 @@ def test_deserialize_event_dispatches_correctly() -> None:
 
     check_suite_parser = CheckSuiteEventParser(
         action="completed",
-        check_suite=CheckSuiteEventDataParser("1", "completed", "success", "url", []),
+        check_suite=CheckSuiteEventDataParser("1", "completed", "success", []),
         subscription_event=SubscriptionEventParser(None, "", {}, 0, None, "github"),
     )
     check_suite_bytes = msgspec.json.encode(check_suite_parser).decode("utf-8")

--- a/tests/sentry/scm/unit/test_stream.py
+++ b/tests/sentry/scm/unit/test_stream.py
@@ -20,6 +20,14 @@ def test_listener_registration() -> None:
     def pr_listener_2(event):
         pass
 
+    @scm.listen_for("check_suite")
+    def cs_listener(event):
+        pass
+
+    @scm.listen_for("pull_request_review")
+    def prr_listener(event):
+        pass
+
     # Assert our scm instance had listeners registered to it.
     assert scm.check_run_listeners == {cr_listener.__name__: cr_listener}
     assert scm.comment_listeners == {comment_listener.__name__: comment_listener}
@@ -27,3 +35,5 @@ def test_listener_registration() -> None:
         pr_listener.__name__: pr_listener,
         pr_listener_2.__name__: pr_listener_2,
     }
+    assert scm.check_suite_listeners == {cs_listener.__name__: cs_listener}
+    assert scm.pull_request_review_listeners == {prr_listener.__name__: prr_listener}


### PR DESCRIPTION
re-apply of https://github.com/getsentry/sentry/pull/116326 with bug fix 

add serializers, deserializers and update functions to handle new event types

in a follow up change i will create the concrete listeners that will handle these
events but this just sets it up so in the next change i just have to implement the
listener