### PR TITLE
ref(gitlab): Skip webhook refresh when the secret is unchanged

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
@@ -60,6 +61,18 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             "integration_id": data["installation"],
         }
 
+    @staticmethod
+    def _webhook_fingerprint(model: Any) -> str:
+        """One-way digest of the token we push to GitLab (``external_id:webhook_secret``).
+
+        Stored on ``repo.config`` so we can tell, without any GitLab call, whether the
+        token we would push differs from what we last wrote to the hook. The secret is
+        derived from the OAuth ``client_id``, so it rotates when an org reinstalls
+        against a new OAuth app — precisely the case where we must re-push.
+        """
+        token = "{}:{}".format(model.external_id, model.metadata.get("webhook_secret", ""))
+        return hashlib.sha256(token.encode()).hexdigest()
+
     def on_create_repository(self, repo: RpcRepository, organization: RpcOrganization) -> None:
         existing_webhook_id = repo.config.get("webhook_id")
         # Namespaced under "gitlab.repository." so these attributes group together in the
@@ -80,8 +93,28 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             },
         )
         installation = self.get_installation(repo.integration_id, repo.organization_id)
-        client = installation.get_client()
         project_id = repo.config["project_id"]
+        current_fingerprint = self._webhook_fingerprint(installation.model)
+
+        # Steady-state skip: if we already have a hook and the token we'd push is
+        # unchanged since we last wrote it, there is nothing to reconcile — return
+        # before touching GitLab (or even resolving the OAuth client). This is the
+        # common bulk-reactivation path (scm repo sync, auto-link-by-name), which
+        # would otherwise issue a PUT per repo for no reason.
+        #
+        # Trade-off: the fingerprint tracks OUR token, not the hook's existence on
+        # GitLab. A hook deleted out-of-band on GitLab *without* a secret rotation is
+        # not recreated until the secret rotates or the fingerprint is cleared. This
+        # is accepted: external deletion of a Sentry-managed hook is rare, and any
+        # secret change still flows through the heal path below.
+        if existing_webhook_id and repo.config.get("webhook_fingerprint") == current_fingerprint:
+            logger.info(
+                "gitlab.repository.webhook_unchanged",
+                extra={**log_extra, "gitlab.repository.webhook_id": existing_webhook_id},
+            )
+            return
+
+        client = installation.get_client()
 
         # A stored webhook_id can survive an uninstall/reinstall of the integration
         # (disassociate_organization_integration clears integration_id but leaves the
@@ -103,6 +136,8 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             except Exception as e:
                 raise installation.raise_error(e)
             else:
+                repo.config["webhook_fingerprint"] = current_fingerprint
+                repository_service.update_repository(organization_id=organization.id, update=repo)
                 logger.info(
                     "gitlab.repository.webhook_refreshed",
                     extra={**log_extra, "gitlab.repository.webhook_id": existing_webhook_id},
@@ -114,6 +149,7 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         except Exception as e:
             raise installation.raise_error(e)
         repo.config["webhook_id"] = hook_id
+        repo.config["webhook_fingerprint"] = current_fingerprint
         repository_service.update_repository(organization_id=organization.id, update=repo)
         logger.info(
             # A prior webhook_id that 404'd means we replaced a stale hook rather than

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,3 +1,4 @@
+import hashlib
 from functools import cached_property
 from unittest.mock import call, patch
 
@@ -80,6 +81,13 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def get_repository(self, **kwargs) -> Repository:
         return Repository.objects.get(**kwargs)
 
+    def _rotate_webhook_secret(self, new_secret: str = "rotated-secret-value") -> None:
+        """Simulate reinstalling against a new OAuth app: the derived webhook secret
+        rotates, so the stored fingerprint no longer matches and the heal path runs."""
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.metadata["webhook_secret"] = new_secret
+            self.integration.save()
+
     def assert_repository(self, repository_config, organization_id=None):
         instance = self.integration.metadata["instance"]
 
@@ -89,6 +97,11 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             provider=self.provider_name,
             external_id=external_id,
         )
+        expected_fingerprint = hashlib.sha256(
+            "{}:{}".format(
+                self.integration.external_id, self.integration.metadata["webhook_secret"]
+            ).encode()
+        ).hexdigest()
         assert repo.name == repository_config["name_with_namespace"]
         assert repo.url == repository_config["web_url"]
         assert repo.integration_id == self.integration.id
@@ -97,6 +110,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             "path": repository_config["path_with_namespace"],
             "project_id": repository_config["id"],
             "webhook_id": 99,
+            "webhook_fingerprint": expected_fingerprint,
         }
 
     @responses.activate
@@ -115,6 +129,10 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         )
         assert repo is not None
         webhook_id = repo.config["webhook_id"]
+
+        # Rotate the secret so the stored fingerprint no longer matches; otherwise
+        # the unchanged-secret skip would short-circuit before any GitLab call.
+        self._rotate_webhook_secret()
 
         # The stored hook still exists, so we address it by id and update it in
         # place (refreshing its token + events) rather than recreating it. Assert
@@ -141,9 +159,11 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
 
         # Addressed by id: a single PUT, no listing.
         assert [c.request.method for c in responses.calls] == ["PUT"]
-        # webhook_id is left untouched when we refresh an existing hook.
+        # webhook_id is left untouched when we refresh an existing hook, and the
+        # fingerprint is updated so the next reactivation skips the GitLab call.
         refreshed = self.get_repository(pk=response.data["id"])
         assert refreshed.config["webhook_id"] == webhook_id
+        assert refreshed.config.get("webhook_fingerprint")
         mock_logger_info.assert_has_calls(
             [
                 call(
@@ -180,6 +200,10 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         assert repo is not None
         stale_webhook_id = repo.config["webhook_id"]
 
+        # Rotate the secret so we get past the unchanged-secret skip and actually
+        # address the (now-missing) hook.
+        self._rotate_webhook_secret()
+
         # Updating the stored hook by id 404s (it no longer exists on GitLab), so a
         # fresh hook is created and its new id stored.
         responses.add(
@@ -200,6 +224,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         assert [c.request.method for c in responses.calls] == ["PUT", "POST"]
         recreated = self.get_repository(pk=response.data["id"])
         assert recreated.config["webhook_id"] == 200
+        assert recreated.config.get("webhook_fingerprint")
         mock_logger_info.assert_has_calls(
             [
                 call(
@@ -236,6 +261,9 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         assert repo is not None
         webhook_id = repo.config["webhook_id"]
 
+        # Rotate the secret so we get past the unchanged-secret skip and attempt the PUT.
+        self._rotate_webhook_secret()
+
         # A non-404 error while updating the hook surfaces as an error and does NOT
         # fall through to create a duplicate hook.
         responses.add(
@@ -253,6 +281,49 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         assert set(methods) == {"PUT"}
         unchanged = self.get_repository(pk=response.data["id"])
         assert unchanged.config["webhook_id"] == webhook_id
+
+    @responses.activate
+    def test_on_create_repository_skips_when_secret_unchanged(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+
+        repo = repository_service.get_repository(
+            organization_id=self.organization.id, id=response.data["id"]
+        )
+        assert repo is not None
+        webhook_id = repo.config["webhook_id"]
+        # Creating the repo stored a fingerprint for the current secret. Nothing has
+        # rotated, so a subsequent invocation must make zero GitLab calls.
+        assert repo.config.get("webhook_fingerprint")
+
+        with patch("sentry.integrations.gitlab.repository.logger.info") as mock_logger_info:
+            self.provider.on_create_repository(repo, self.organization)
+
+        assert len(responses.calls) == 0
+        mock_logger_info.assert_has_calls(
+            [
+                call(
+                    "gitlab.repository.on_create_repository",
+                    extra={
+                        "gitlab.repository.organization_id": self.organization.id,
+                        "gitlab.repository.integration_id": self.integration.id,
+                        "gitlab.repository.repository_id": repo.id,
+                        "gitlab.repository.project_id": repo.config["project_id"],
+                        "gitlab.repository.has_existing_webhook": True,
+                    },
+                ),
+                call(
+                    "gitlab.repository.webhook_unchanged",
+                    extra={
+                        "gitlab.repository.organization_id": self.organization.id,
+                        "gitlab.repository.integration_id": self.integration.id,
+                        "gitlab.repository.repository_id": repo.id,
+                        "gitlab.repository.project_id": repo.config["project_id"],
+                        "gitlab.repository.webhook_id": webhook_id,
+                    },
+                ),
+            ]
+        )
 
     @responses.activate
     def test_on_create_repository_logs_webhook_creation(self) -> None:


### PR DESCRIPTION
> **Stacked on #119340** (heal webhooks on reinstall). Review that first; this PR is the skip-optimization diff on top.

## Summary

Makes `on_create_repository` skip the GitLab round trip when a repo's webhook is already up to date. Purely a call-volume optimization on top of the heal fix — no change to the heal/recreate behavior itself.

`on_create_repository` now stores a one-way fingerprint of the token it pushes to GitLab (`sha256(external_id:webhook_secret)`) on `repo.config["webhook_fingerprint"]`. On a later invocation, if a `webhook_id` is present **and** the fingerprint still matches, it returns before touching GitLab (or even resolving the OAuth client):

| Stored `webhook_id` | Fingerprint vs current | Action |
| --- | --- | --- |
| set | matches | **skip** — zero GitLab calls (`webhook_unchanged`) |
| set | differs / absent | heal via `update_project_webhook` (404 → recreate), then store the new fingerprint |
| unset | — | create, then store the fingerprint |

## Why

Without this, every reactivation of a repo that already has a `webhook_id` issues a `PUT` — including the bulk paths (`scm_repo_sync_beat`, auto-link-by-name) that feed many repos through `on_create_repository` at once, none of which have rotated. The fingerprint lets us detect "nothing changed" locally: the secret is derived from the OAuth `client_id`, so it rotates exactly when an org reinstalls against a new OAuth app — the one case we must re-push. The fingerprint (and `external_id`) live on `Integration.metadata`, which is region-local, so the check needs no extra network or cross-silo call.

## Trade-off (accepted)

The fingerprint tracks **our token**, not the hook's existence on GitLab. A Sentry-managed hook deleted out-of-band on GitLab **without** a secret rotation will not be recreated until the secret rotates or the fingerprint is cleared. This is accepted: external deletion of a Sentry-managed hook is rare, and any secret change still flows through the heal path in #119340. If we later decide that gap matters more than the saved calls, this whole PR reverts cleanly without touching the correctness fix underneath.

## Notes

- On first deploy, existing repos have no `webhook_fingerprint`, so their next reactivation heals once (one `PUT`) and backfills the fingerprint — self-migrating, no backfill job.
- New telemetry: `gitlab.repository.webhook_unchanged` (the skip). The heal/create events from #119340/#119333 are unchanged.
