### PR TITLE
feat(preprod): Post size analysis results as PR comments

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -929,6 +929,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.preprod.snapshots.tasks",
     "sentry.preprod.snapshots.zip_tasks",
     "sentry.preprod.tasks",
+    "sentry.preprod.vcs.pr_comments.size_tasks",
     "sentry.preprod.vcs.pr_comments.snapshot_tasks",
     "sentry.preprod.vcs.pr_comments.tasks",
     "sentry.preprod.vcs.status_checks.size.tasks",

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -26,6 +26,7 @@ from sentry.preprod.size_analysis.grouptype import (
 from sentry.preprod.size_analysis.models import SizeAnalysisResults
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 from sentry.preprod.size_analysis.webhooks import send_size_analysis_webhook
+from sentry.preprod.vcs.pr_comments.size_tasks import create_preprod_size_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -254,6 +255,12 @@ def compare_preprod_artifact_size_analysis(
                 for artifact_id in preprod_artifact_status_check_updates:
                     # Update all artifact's status check with the new comparison
                     create_preprod_status_check_task.apply_async(
+                        kwargs={
+                            "preprod_artifact_id": artifact_id,
+                            "caller": "compare_completion",
+                        }
+                    )
+                    create_preprod_size_pr_comment_task.apply_async(
                         kwargs={
                             "preprod_artifact_id": artifact_id,
                             "caller": "compare_completion",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -38,6 +38,7 @@ from sentry.preprod.size_analysis.tasks import (
     maybe_emit_issues_from_absolute_size_results,
 )
 from sentry.preprod.size_analysis.webhooks import send_size_analysis_webhook
+from sentry.preprod.vcs.pr_comments.size_tasks import create_preprod_size_pr_comment_task
 from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
@@ -638,6 +639,12 @@ def _assemble_preprod_artifact_size_analysis(
 
         # Always trigger status check update (success or failure)
         create_preprod_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": artifact_id,
+                "caller": "assemble_completion",
+            }
+        )
+        create_preprod_size_pr_comment_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact_id,
                 "caller": "assemble_completion",

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -82,63 +82,70 @@ def create_preprod_size_pr_comment_task(
 
     api_error: Exception | None = None
 
-    with transaction.atomic(router.db_for_write(CommitComparison)):
-        cc, existing_comment_id = lock_pr_comparisons_for_update(
-            organization_id=commit_comparison.organization_id,
-            head_repo_name=head_repo_name,
-            pr_number=pr_number,
-            target_id=commit_comparison.id,
-            comment_type=COMMENT_TYPE,
-        )
-
-        # The trigger check gates first creation only; once a comment exists it is
-        # always updated to reflect current state. With no rules configured, post a
-        # neutral size summary on every PR (an intentional opt-in, feature is off by
-        # default).
-        if not existing_comment_id and rules and not triggered_rules:
-            logger.info(
-                "preprod.size_pr_comments.create.skipped_no_trigger",
-                extra={"preprod_artifact_id": artifact.id},
+    try:
+        with transaction.atomic(router.db_for_write(CommitComparison)):
+            cc, existing_comment_id = lock_pr_comparisons_for_update(
+                organization_id=commit_comparison.organization_id,
+                head_repo_name=head_repo_name,
+                pr_number=pr_number,
+                target_id=commit_comparison.id,
+                comment_type=COMMENT_TYPE,
             )
-            return
 
-        try:
-            if existing_comment_id:
-                client.update_comment(
-                    repo=cc.head_repo_name,
-                    issue_id=str(cc.pr_number),
-                    comment_id=str(existing_comment_id),
-                    data={"body": comment_body},
-                )
-                comment_id = existing_comment_id
+            # The trigger check gates first creation only; once a comment exists it is
+            # always updated to reflect current state. With no rules configured, post a
+            # neutral size summary on every PR (an intentional opt-in, feature is off by
+            # default).
+            if not existing_comment_id and rules and not triggered_rules:
                 logger.info(
-                    "preprod.size_pr_comments.create.updated",
-                    extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
+                    "preprod.size_pr_comments.create.skipped_no_trigger",
+                    extra={"preprod_artifact_id": artifact.id},
                 )
+                return
+
+            try:
+                if existing_comment_id:
+                    client.update_comment(
+                        repo=cc.head_repo_name,
+                        issue_id=str(cc.pr_number),
+                        comment_id=str(existing_comment_id),
+                        data={"body": comment_body},
+                    )
+                    comment_id = existing_comment_id
+                    logger.info(
+                        "preprod.size_pr_comments.create.updated",
+                        extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
+                    )
+                else:
+                    resp = client.create_comment(
+                        repo=cc.head_repo_name,
+                        issue_id=str(cc.pr_number),
+                        data={"body": comment_body},
+                    )
+                    comment_id = str(resp["id"])
+                    logger.info(
+                        "preprod.size_pr_comments.create.created",
+                        extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
+                    )
+            except Exception as e:
+                extra: dict[str, Any] = {
+                    "preprod_artifact_id": artifact.id,
+                    "organization_id": organization.id,
+                    "error_type": type(e).__name__,
+                }
+                if isinstance(e, ApiError):
+                    extra["status_code"] = e.code
+                logger.exception("preprod.size_pr_comments.create.failed", extra=extra)
+                save_pr_comment_result(cc, COMMENT_TYPE, success=False, error=e)
+                api_error = e
             else:
-                resp = client.create_comment(
-                    repo=cc.head_repo_name,
-                    issue_id=str(cc.pr_number),
-                    data={"body": comment_body},
-                )
-                comment_id = str(resp["id"])
-                logger.info(
-                    "preprod.size_pr_comments.create.created",
-                    extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
-                )
-        except Exception as e:
-            extra: dict[str, Any] = {
-                "preprod_artifact_id": artifact.id,
-                "organization_id": organization.id,
-                "error_type": type(e).__name__,
-            }
-            if isinstance(e, ApiError):
-                extra["status_code"] = e.code
-            logger.exception("preprod.size_pr_comments.create.failed", extra=extra)
-            save_pr_comment_result(cc, COMMENT_TYPE, success=False, error=e)
-            api_error = e
-        else:
-            save_pr_comment_result(cc, COMMENT_TYPE, success=True, comment_id=comment_id)
+                save_pr_comment_result(cc, COMMENT_TYPE, success=True, comment_id=comment_id)
+    except CommitComparison.DoesNotExist:
+        logger.info(
+            "preprod.size_pr_comments.create.cc_deleted",
+            extra={"preprod_artifact_id": artifact.id},
+        )
+        return
 
     if api_error is not None:
         raise api_error

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -6,13 +6,12 @@ from typing import Any
 from django.db import router, transaction
 from taskbroker_client.retry import Retry
 
-from sentry import features
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.integration_utils import get_commit_context_client
-from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.vcs.pr_comments.size_templates import format_size_pr_comment
 from sentry.preprod.vcs.pr_comments.tasks import (
     lock_pr_comparisons_for_update,
+    resolve_pr_comment_context,
     save_pr_comment_result,
 )
 from sentry.preprod.vcs.status_checks.size.rules import get_status_check_rules
@@ -40,62 +39,19 @@ RULES_OPTION_KEY = "sentry:preprod_size_pr_comments_rules"
 def create_preprod_size_pr_comment_task(
     preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
 ) -> None:
-    try:
-        artifact = PreprodArtifact.objects.select_related(
-            "mobile_app_info",
-            "build_configuration",
-            "commit_comparison",
-            "project",
-            "project__organization",
-        ).get(id=preprod_artifact_id)
-    except PreprodArtifact.DoesNotExist:
-        logger.exception(
-            "preprod.size_pr_comments.create.artifact_not_found",
-            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
-        )
-        return
-
-    if not artifact.commit_comparison:
-        logger.info(
-            "preprod.size_pr_comments.create.no_commit_comparison",
-            extra={"preprod_artifact_id": artifact.id},
-        )
-        return
-
-    commit_comparison = artifact.commit_comparison
-    if (
-        not commit_comparison.pr_number
-        or not commit_comparison.head_repo_name
-        or not commit_comparison.provider
-    ):
-        logger.info(
-            "preprod.size_pr_comments.create.no_pr_info",
-            extra={
-                "preprod_artifact_id": artifact.id,
-                "pr_number": commit_comparison.pr_number,
-                "head_repo_name": commit_comparison.head_repo_name,
-            },
-        )
-        return
-
-    if not artifact.project.get_option(ENABLED_OPTION_KEY):
-        logger.info(
-            "preprod.size_pr_comments.create.project_disabled",
-            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
-        )
-        return
-
-    organization = artifact.project.organization
-    if not features.has("organizations:preprod-size-analysis-pr-comments", organization):
-        logger.info(
-            "preprod.size_pr_comments.create.feature_disabled",
-            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
-        )
-        return
-
-    client = get_commit_context_client(
-        organization, commit_comparison.head_repo_name, commit_comparison.provider
+    ctx = resolve_pr_comment_context(
+        preprod_artifact_id,
+        log_prefix="preprod.size_pr_comments",
+        enabled_option_key=ENABLED_OPTION_KEY,
+        caller=caller,
+        feature_flag="organizations:preprod-size-analysis-pr-comments",
+        with_build_configuration=True,
     )
+    if ctx is None:
+        return
+    artifact, commit_comparison, organization, head_repo_name, pr_number, provider = ctx
+
+    client = get_commit_context_client(organization, head_repo_name, provider)
     if not client:
         logger.info(
             "preprod.size_pr_comments.create.no_client",
@@ -129,8 +85,8 @@ def create_preprod_size_pr_comment_task(
     with transaction.atomic(router.db_for_write(CommitComparison)):
         cc, existing_comment_id = lock_pr_comparisons_for_update(
             organization_id=commit_comparison.organization_id,
-            head_repo_name=commit_comparison.head_repo_name,
-            pr_number=commit_comparison.pr_number,
+            head_repo_name=head_repo_name,
+            pr_number=pr_number,
             target_id=commit_comparison.id,
             comment_type=COMMENT_TYPE,
         )

--- a/src/sentry/preprod/vcs/pr_comments/size_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_tasks.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.db import router, transaction
+from taskbroker_client.retry import Retry
+
+from sentry import features
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.integration_utils import get_commit_context_client
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.vcs.pr_comments.size_templates import format_size_pr_comment
+from sentry.preprod.vcs.pr_comments.tasks import (
+    lock_pr_comparisons_for_update,
+    save_pr_comment_result,
+)
+from sentry.preprod.vcs.status_checks.size.rules import get_status_check_rules
+from sentry.preprod.vcs.status_checks.size.tasks import evaluate_size_and_format_messages
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import preprod_tasks
+
+logger = logging.getLogger(__name__)
+
+COMMENT_TYPE = "size"
+
+ENABLED_OPTION_KEY = "sentry:preprod_size_pr_comments_enabled"
+RULES_OPTION_KEY = "sentry:preprod_size_pr_comments_rules"
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.create_preprod_size_pr_comment",
+    namespace=preprod_tasks,
+    processing_deadline_duration=30,
+    silo_mode=SiloMode.CELL,
+    retry=Retry(times=5, delay=60 * 5),
+)
+def create_preprod_size_pr_comment_task(
+    preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
+) -> None:
+    try:
+        artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info",
+            "build_configuration",
+            "commit_comparison",
+            "project",
+            "project__organization",
+        ).get(id=preprod_artifact_id)
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "preprod.size_pr_comments.create.artifact_not_found",
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
+        )
+        return
+
+    if not artifact.commit_comparison:
+        logger.info(
+            "preprod.size_pr_comments.create.no_commit_comparison",
+            extra={"preprod_artifact_id": artifact.id},
+        )
+        return
+
+    commit_comparison = artifact.commit_comparison
+    if (
+        not commit_comparison.pr_number
+        or not commit_comparison.head_repo_name
+        or not commit_comparison.provider
+    ):
+        logger.info(
+            "preprod.size_pr_comments.create.no_pr_info",
+            extra={
+                "preprod_artifact_id": artifact.id,
+                "pr_number": commit_comparison.pr_number,
+                "head_repo_name": commit_comparison.head_repo_name,
+            },
+        )
+        return
+
+    if not artifact.project.get_option(ENABLED_OPTION_KEY):
+        logger.info(
+            "preprod.size_pr_comments.create.project_disabled",
+            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
+        )
+        return
+
+    organization = artifact.project.organization
+    if not features.has("organizations:preprod-size-analysis-pr-comments", organization):
+        logger.info(
+            "preprod.size_pr_comments.create.feature_disabled",
+            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
+        )
+        return
+
+    client = get_commit_context_client(
+        organization, commit_comparison.head_repo_name, commit_comparison.provider
+    )
+    if not client:
+        logger.info(
+            "preprod.size_pr_comments.create.no_client",
+            extra={"preprod_artifact_id": artifact.id},
+        )
+        return
+
+    # Compute rules, triggered rules, and the comment body BEFORE taking the lock
+    # so the (DB-heavy) size evaluation stays out of the locked transaction that
+    # holds the GitHub call. Only find-existing -> gate -> post -> save run under
+    # the lock.
+    all_artifacts = list(artifact.get_sibling_artifacts_for_commit())
+    rules = get_status_check_rules(artifact.project, option_key=RULES_OPTION_KEY)
+    evaluation = evaluate_size_and_format_messages(artifact.project, all_artifacts, rules)
+
+    # Unlike the status check (which posts a neutral "skipped" check regardless),
+    # a comment should only exist when there is size data to report. No evaluated
+    # artifacts means every sibling was skipped or had no size metrics.
+    if not evaluation.evaluated_artifacts:
+        logger.info(
+            "preprod.size_pr_comments.create.no_size_data",
+            extra={"preprod_artifact_id": artifact.id},
+        )
+        return
+
+    triggered_rules = evaluation.triggered_rules
+    comment_body = format_size_pr_comment(evaluation.title, evaluation.subtitle, evaluation.summary)
+
+    api_error: Exception | None = None
+
+    with transaction.atomic(router.db_for_write(CommitComparison)):
+        cc, existing_comment_id = lock_pr_comparisons_for_update(
+            organization_id=commit_comparison.organization_id,
+            head_repo_name=commit_comparison.head_repo_name,
+            pr_number=commit_comparison.pr_number,
+            target_id=commit_comparison.id,
+            comment_type=COMMENT_TYPE,
+        )
+
+        # The trigger check gates first creation only; once a comment exists it is
+        # always updated to reflect current state. With no rules configured, post a
+        # neutral size summary on every PR (an intentional opt-in, feature is off by
+        # default).
+        if not existing_comment_id and rules and not triggered_rules:
+            logger.info(
+                "preprod.size_pr_comments.create.skipped_no_trigger",
+                extra={"preprod_artifact_id": artifact.id},
+            )
+            return
+
+        try:
+            if existing_comment_id:
+                client.update_comment(
+                    repo=cc.head_repo_name,
+                    issue_id=str(cc.pr_number),
+                    comment_id=str(existing_comment_id),
+                    data={"body": comment_body},
+                )
+                comment_id = existing_comment_id
+                logger.info(
+                    "preprod.size_pr_comments.create.updated",
+                    extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
+                )
+            else:
+                resp = client.create_comment(
+                    repo=cc.head_repo_name,
+                    issue_id=str(cc.pr_number),
+                    data={"body": comment_body},
+                )
+                comment_id = str(resp["id"])
+                logger.info(
+                    "preprod.size_pr_comments.create.created",
+                    extra={"preprod_artifact_id": artifact.id, "comment_id": comment_id},
+                )
+        except Exception as e:
+            extra: dict[str, Any] = {
+                "preprod_artifact_id": artifact.id,
+                "organization_id": organization.id,
+                "error_type": type(e).__name__,
+            }
+            if isinstance(e, ApiError):
+                extra["status_code"] = e.code
+            logger.exception("preprod.size_pr_comments.create.failed", extra=extra)
+            save_pr_comment_result(cc, COMMENT_TYPE, success=False, error=e)
+            api_error = e
+        else:
+            save_pr_comment_result(cc, COMMENT_TYPE, success=True, comment_id=comment_id)
+
+    if api_error is not None:
+        raise api_error

--- a/src/sentry/preprod/vcs/pr_comments/size_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/size_templates.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+def format_size_pr_comment(title: str, subtitle: str, summary: str) -> str:
+    """Compose the size analysis PR comment body from the status-check pieces.
+
+    Reuses the exact ``(title, subtitle, summary)`` produced by
+    ``format_status_check_messages`` so the comment and the status-check summary
+    can never render differently.
+    """
+    return f"## {title}\n\n{subtitle}\n\n{summary}"

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -252,9 +252,7 @@ register(key="sentry:preprod_snapshot_pr_comments_post_on_changed", default=True
 # When True, treat snapshot renames as a diff worth posting a PR comment.
 register(key="sentry:preprod_snapshot_pr_comments_post_on_renamed", default=False)
 
-# Boolean to enable/disable size analysis PR comments for this project. Default
-# off; when enabled, the task posts/updates a comment based on the comment-specific
-# rules stored in sentry:preprod_size_pr_comments_rules.
+# When True, post/update a PR comment with size analysis results for this project.
 register(key="sentry:preprod_size_pr_comments_enabled", default=False)
 
 # Whether to enable on-demand source context fetching from SCM integrations

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -252,5 +252,10 @@ register(key="sentry:preprod_snapshot_pr_comments_post_on_changed", default=True
 # When True, treat snapshot renames as a diff worth posting a PR comment.
 register(key="sentry:preprod_snapshot_pr_comments_post_on_renamed", default=False)
 
+# Boolean to enable/disable size analysis PR comments for this project. Default
+# off; when enabled, the task posts/updates a comment based on the comment-specific
+# rules stored in sentry:preprod_size_pr_comments_rules.
+register(key="sentry:preprod_size_pr_comments_enabled", default=False)
+
 # Whether to enable on-demand source context fetching from SCM integrations
 register(key="sentry:scm_source_context_enabled", default=False)

--- a/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sentry.integrations.source_code_management.status_check import StatusCheckStatus
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.vcs.status_checks.size.tasks import SizeEvaluation
+from sentry.preprod.vcs.status_checks.size.types import StatusCheckRule, TriggeredRule
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import cell_silo_test
+
+FEATURE = "organizations:preprod-size-analysis-pr-comments"
+ENABLED_OPTION_KEY = "sentry:preprod_size_pr_comments_enabled"
+RULES_OPTION_KEY = "sentry:preprod_size_pr_comments_rules"
+
+# A single valid rule; its contents don't matter when evaluate is patched, only
+# that get_status_check_rules parses a non-empty list from the option.
+_RULES_JSON = '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 1}]'
+
+_EVAL_PATH = "sentry.preprod.vcs.pr_comments.size_tasks.evaluate_size_and_format_messages"
+_CLIENT_PATH = "sentry.preprod.vcs.pr_comments.size_tasks.get_commit_context_client"
+
+
+def _eval_result(
+    *,
+    triggered: bool,
+    status: StatusCheckStatus = StatusCheckStatus.SUCCESS,
+    title: str = "Size Analysis",
+    subtitle: str = "1 component analyzed",
+    summary: str = "size summary body",
+    evaluated_artifacts: list[PreprodArtifact] | None = None,
+) -> SizeEvaluation:
+    """Build a return value matching evaluate_size_and_format_messages."""
+    triggered_rules: list[TriggeredRule] = []
+    if triggered:
+        rule = StatusCheckRule(id="rule1", metric="install_size", measurement="absolute", value=1)
+        triggered_rules = [
+            TriggeredRule(rule=rule, artifact_id=1, app_id="com.example.app", platform="ios")
+        ]
+    if evaluated_artifacts is None:
+        # Contents are irrelevant; the task only checks whether the list is non-empty.
+        evaluated_artifacts = [cast(PreprodArtifact, object())]
+    return SizeEvaluation(
+        status=status,
+        triggered_rules=triggered_rules,
+        title=title,
+        subtitle=subtitle,
+        summary=summary,
+        evaluated_artifacts=evaluated_artifacts,
+    )
+
+
+@cell_silo_test
+@with_feature(FEATURE)
+class CreatePreprodSizePrCommentTaskTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(
+            teams=[self.team], organization=self.organization, name="test_project"
+        )
+
+    def _create_artifact(
+        self,
+        with_commit_comparison=True,
+        pr_number=42,
+        provider="github",
+        app_id="com.example.app",
+        commit_comparison=None,
+    ) -> PreprodArtifact:
+        if with_commit_comparison and commit_comparison is None:
+            commit_comparison = self.create_commit_comparison(
+                organization=self.organization,
+                provider=provider,
+                pr_number=pr_number,
+            )
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            app_id=app_id,
+            commit_comparison=commit_comparison,
+        )
+        return PreprodArtifact.objects.select_related(
+            "mobile_app_info",
+            "build_configuration",
+            "commit_comparison",
+            "project",
+            "project__organization",
+        ).get(id=artifact.id)
+
+    def _enable(self) -> None:
+        self.project.update_option(ENABLED_OPTION_KEY, True)
+
+    def _set_rules(self, raw: str = _RULES_JSON) -> None:
+        self.project.update_option(RULES_OPTION_KEY, raw)
+
+    def _import_task(self):
+        from sentry.preprod.vcs.pr_comments.size_tasks import create_preprod_size_pr_comment_task
+
+        return create_preprod_size_pr_comment_task
+
+    # --- create / update / skip gate ------------------------------------
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_creates_comment_when_rule_triggered(self, mock_eval, mock_get_client) -> None:
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 55555}
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=True)
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_client.create_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            data={"body": "## Size Analysis\n\n1 component analyzed\n\nsize summary body"},
+        )
+        mock_client.update_comment.assert_not_called()
+
+        assert artifact.commit_comparison is not None
+        artifact.commit_comparison.refresh_from_db()
+        size = artifact.commit_comparison.extras["pr_comments"]["size"]
+        assert size["success"] is True
+        assert size["comment_id"] == "55555"
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_creates_comment_when_no_rules_configured(self, mock_eval, mock_get_client) -> None:
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 1}
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=False, status=StatusCheckStatus.NEUTRAL)
+
+        self._enable()
+        # No rules option set -> get_status_check_rules returns []
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_client.create_comment.assert_called_once()
+        mock_client.update_comment.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_rules_set_but_nothing_triggered(self, mock_eval, mock_get_client) -> None:
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=False)
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_client.create_comment.assert_not_called()
+        mock_client.update_comment.assert_not_called()
+
+        assert artifact.commit_comparison is not None
+        artifact.commit_comparison.refresh_from_db()
+        assert (artifact.commit_comparison.extras or {}).get("pr_comments") is None
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_updates_existing_comment_even_without_trigger(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=False)
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": True, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="existing_777",
+            data={"body": "## Size Analysis\n\n1 component analyzed\n\nsize summary body"},
+        )
+        mock_client.create_comment.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_no_size_artifacts(self, mock_eval, mock_get_client) -> None:
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        # No evaluated artifacts: every sibling was skipped or had no size metrics.
+        mock_eval.return_value = _eval_result(
+            triggered=False, status=StatusCheckStatus.NEUTRAL, evaluated_artifacts=[]
+        )
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_client.create_comment.assert_not_called()
+        mock_client.update_comment.assert_not_called()
+
+        assert artifact.commit_comparison is not None
+        artifact.commit_comparison.refresh_from_db()
+        assert (artifact.commit_comparison.extras or {}).get("pr_comments") is None
+
+    # --- early-return skips ---------------------------------------------
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_project_option_disabled(self, mock_eval, mock_get_client) -> None:
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_get_client.assert_not_called()
+        mock_eval.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_no_commit_comparison(self, mock_eval, mock_get_client) -> None:
+        self._enable()
+        artifact = self._create_artifact(with_commit_comparison=False)
+
+        self._import_task()(artifact.id)
+
+        mock_get_client.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_no_pr_number(self, mock_eval, mock_get_client) -> None:
+        self._enable()
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=None
+        )
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        self._import_task()(artifact.id)
+
+        mock_get_client.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_no_client(self, mock_eval, mock_get_client) -> None:
+        mock_get_client.return_value = None
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_eval.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_when_feature_flag_disabled(self, mock_eval, mock_get_client) -> None:
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        with self.feature({FEATURE: False}):
+            self._import_task()(artifact.id)
+
+        mock_get_client.assert_not_called()
+        mock_eval.assert_not_called()
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_skips_nonexistent_artifact(self, mock_eval, mock_get_client) -> None:
+        self._import_task()(1234567)
+
+        mock_get_client.assert_not_called()
+
+    # --- error handling / retry -----------------------------------------
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_handles_api_error_and_reraises(self, mock_eval, mock_get_client) -> None:
+        mock_client = Mock()
+        mock_client.create_comment.side_effect = ApiError("boom", code=500)
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=True)
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        with pytest.raises(ApiError):
+            self._import_task()(artifact.id)
+
+        assert artifact.commit_comparison is not None
+        artifact.commit_comparison.refresh_from_db()
+        size = artifact.commit_comparison.extras["pr_comments"]["size"]
+        assert size["success"] is False
+        assert size["error_type"] == "api_error"
+        assert "comment_id" not in size
+
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_retry_after_update_failure_uses_update_not_create(
+        self, mock_eval, mock_get_client
+    ) -> None:
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=True)
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, provider="github", pr_number=42
+        )
+        commit_comparison.extras = {
+            "pr_comments": {"size": {"success": False, "comment_id": "existing_777"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        self._import_task()(artifact.id)
+
+        mock_client.update_comment.assert_called_once()
+        mock_client.create_comment.assert_not_called()
+
+    # --- end-to-end (real evaluation, unpatched) ------------------------
+
+    @patch(_CLIENT_PATH)
+    def test_end_to_end_triggering_rule_creates_comment(self, mock_get_client) -> None:
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 314}
+        mock_get_client.return_value = mock_client
+
+        self._enable()
+        # install_size absolute >= 100MB; head build is 150MB -> triggers.
+        self._set_rules(
+            '[{"id": "r1", "metric": "install_size", "measurement": "absolute", '
+            '"value": 104857600}]'
+        )
+        artifact = self._create_artifact()
+        self.create_preprod_artifact_size_metrics(
+            preprod_artifact=artifact,
+            min_install_size=150 * 1024 * 1024,
+            max_install_size=150 * 1024 * 1024,
+        )
+
+        self._import_task()(artifact.id)
+
+        mock_client.create_comment.assert_called_once()
+        body = mock_client.create_comment.call_args.kwargs["data"]["body"]
+        assert body.startswith("## Size Analysis")
+
+        assert artifact.commit_comparison is not None
+        artifact.commit_comparison.refresh_from_db()
+        assert artifact.commit_comparison.extras["pr_comments"]["size"]["comment_id"] == "314"
+
+    def test_commit_comparison_extras_isolated_from_status_check(self) -> None:
+        # Sanity: the "size" comment key is independent of build_distribution/snapshots.
+        cc = self.create_commit_comparison(organization=self.organization, pr_number=42)
+        assert isinstance(cc, CommitComparison)
+        assert (cc.extras or {}).get("pr_comments") is None

--- a/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_size_tasks.py
@@ -342,6 +342,27 @@ class CreatePreprodSizePrCommentTaskTest(TestCase):
         mock_client.update_comment.assert_called_once()
         mock_client.create_comment.assert_not_called()
 
+    @patch("sentry.preprod.vcs.pr_comments.size_tasks.lock_pr_comparisons_for_update")
+    @patch(_CLIENT_PATH)
+    @patch(_EVAL_PATH)
+    def test_returns_without_retry_when_commit_comparison_deleted(
+        self, mock_eval, mock_get_client, mock_lock
+    ) -> None:
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_eval.return_value = _eval_result(triggered=True)
+        mock_lock.side_effect = CommitComparison.DoesNotExist()
+
+        self._enable()
+        self._set_rules()
+        artifact = self._create_artifact()
+
+        self._import_task()(artifact.id)
+
+        mock_lock.assert_called_once()
+        mock_client.create_comment.assert_not_called()
+        mock_client.update_comment.assert_not_called()
+
     # --- end-to-end (real evaluation, unpatched) ------------------------
 
     @patch(_CLIENT_PATH)


### PR DESCRIPTION
> Stacked on #119428 (the behavior-preserving extraction of `evaluate_size_and_format_messages`). Review that first; this PR's diff is feature-only and its base retargets to `master` automatically once #119428 merges.

Size analysis results can now be posted as a GitHub PR comment, alongside the existing status check. It's off by default — gated per-project by the `sentry:preprod_size_pr_comments_enabled` option and per-org by the `organizations:preprod-size-analysis-pr-comments` flag (#119409). Comment-specific rules live in `sentry:preprod_size_pr_comments_rules` and use the same rule schema as status checks.

The comment reuses the size status-check rule engine and renders from the same `(title, subtitle, summary)` output (`evaluate_size_and_format_messages`, from #119428), so the two can never render differently. There is one comment per PR — created, then updated in place — with the comment id stored in `CommitComparison.extras["pr_comments"]["size"]`, reusing the build-distribution comment's row-locking primitives.

Posting behavior worth attention during review:

- **No size data to report** (every sibling artifact skipped or without size metrics) → no comment posted. This is a deliberate divergence from the status check, which posts a neutral "skipped" check; as a comment that would just be PR noise. A failed or errored analysis still produces metrics rows, so real failures are still reported.
- The **rule-trigger check gates first creation only.** Once a comment exists it always updates to reflect current state.
- **Enabled with no rules configured** → a neutral size summary is posted on every PR. Intentional opt-in, since the feature is off by default.

Size evaluation is computed before the row lock is acquired, so the GitHub API call is the only work inside the locked transaction. The task is enqueued from the two size-completion paths that already fire the status check.

Start review at `pr_comments/size_tasks.py` — the gate → lock → post flow.

Refs EME-938