### PR TITLE
feat(action log): Use derived data for search and sort

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -16,7 +16,6 @@ from sentry import features, quotas
 from sentry.api.event_search import SearchFilter
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.issues.progress import PROGRESS_RESET_ACTIVITY_TYPES, IssueProgressState
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
@@ -278,7 +277,7 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
 
       identified -> assigned -> diagnosed -> fix_proposed -> fix_applied
 
-    When every project in scope has the ``projects:issue-action-log-write-to-db``
+    When every project in scope has the ``projects:issue-stream-derived-progress``
     flag enabled, AND the backfill has been run for all groups in the project(s),
     progress is read from the materialized GroupDerivedData.progress column.
     Otherwise it's reconstructed from Activity records.
@@ -299,25 +298,11 @@ def _issue_progress_filter_from_derived_data(
     null column (closed issues) counts as fix_applied, and a group without a derived-data
     row counts as identified.
     """
-    project_ids = [p.id for p in projects]
-    q = Q(
-        id__in=GroupDerivedData.objects.filter(
-            progress__in=progress_values,
-            group__project_id__in=project_ids,
-        ).values_list("group_id", flat=True)
-    )
+    q = Q(groupderiveddata__progress__in=progress_values)
     if IssueProgressState.FIX_APPLIED.value in progress_values:
-        q |= Q(
-            id__in=GroupDerivedData.objects.filter(
-                progress__isnull=True,
-                group__project_id__in=project_ids,
-            ).values_list("group_id", flat=True)
-        )
+        q |= Q(groupderiveddata__isnull=False, groupderiveddata__progress__isnull=True)
     if IssueProgressState.IDENTIFIED.value in progress_values:
-        derived_data_group_ids = GroupDerivedData.objects.filter(
-            group__project_id__in=project_ids,
-        ).values_list("group_id", flat=True)
-        q |= Q(project_id__in=project_ids) & ~Q(id__in=derived_data_group_ids)
+        q |= Q(groupderiveddata__isnull=True)
     return q
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -284,7 +284,7 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
     Otherwise it's reconstructed from Activity records.
     """
     if projects and all(
-        features.has("projects:issue-action-log-write-to-db", project) for project in projects
+        features.has("projects:issue-stream-derived-progress", project) for project in projects
     ):
         return _issue_progress_filter_from_derived_data(progress_values, projects)
     return _issue_progress_filter_from_activity(progress_values, projects)

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -17,7 +17,7 @@ from sentry.api.event_search import SearchFilter
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidSearchQuery
 from sentry.issues.models.groupderiveddata import GroupDerivedData
-from sentry.issues.progress import PROGRESS_RESET_ACTIVITY_TYPES
+from sentry.issues.progress import PROGRESS_RESET_ACTIVITY_TYPES, IssueProgressState
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
@@ -286,22 +286,32 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
     if projects and all(
         features.has("projects:issue-action-log-write-to-db", project) for project in projects
     ):
-        return _issue_progress_filter_from_db(progress_values, projects)
+        return _issue_progress_filter_from_derived_data(progress_values, projects)
     return _issue_progress_filter_from_activity(progress_values, projects)
 
 
-def _issue_progress_filter_from_db(progress_values: list[str], projects: Sequence[Project]) -> Q:
+def _issue_progress_filter_from_derived_data(
+    progress_values: list[str], projects: Sequence[Project]
+) -> Q:
     """
     Reads progress from the materialized GroupDerivedData.progress column. The
     column stores the IssueProgressState value verbatim, so progress_values maps
     directly onto it.
     """
-    return Q(
+    project_ids = [p.id for p in projects]
+    q = Q(
         id__in=GroupDerivedData.objects.filter(
             progress__in=progress_values,
-            group__project_id__in=[p.id for p in projects],
+            group__project_id__in=project_ids,
         ).values_list("group_id", flat=True)
     )
+    if IssueProgressState.IDENTIFIED.value in progress_values:
+        explicit_progress_group_ids = GroupDerivedData.objects.filter(
+            progress__isnull=False,
+            group__project_id__in=project_ids,
+        ).values_list("group_id", flat=True)
+        q |= Q(project_id__in=project_ids) & ~Q(id__in=explicit_progress_group_ids)
+    return q
 
 
 def _issue_progress_filter_from_activity(

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -294,9 +294,10 @@ def _issue_progress_filter_from_derived_data(
     progress_values: list[str], projects: Sequence[Project]
 ) -> Q:
     """
-    Reads progress from the materialized GroupDerivedData.progress column. The
-    column stores the IssueProgressState value verbatim, so progress_values maps
-    directly onto it.
+    Reads progress from the materialized GroupDerivedData.progress column, mirroring
+    _get_derived_progress: the column stores the IssueProgressState value verbatim, a
+    null column (closed issues) counts as fix_applied, and a group without a derived-data
+    row counts as identified.
     """
     project_ids = [p.id for p in projects]
     q = Q(
@@ -305,12 +306,18 @@ def _issue_progress_filter_from_derived_data(
             group__project_id__in=project_ids,
         ).values_list("group_id", flat=True)
     )
+    if IssueProgressState.FIX_APPLIED.value in progress_values:
+        q |= Q(
+            id__in=GroupDerivedData.objects.filter(
+                progress__isnull=True,
+                group__project_id__in=project_ids,
+            ).values_list("group_id", flat=True)
+        )
     if IssueProgressState.IDENTIFIED.value in progress_values:
-        explicit_progress_group_ids = GroupDerivedData.objects.filter(
-            progress__isnull=False,
+        derived_data_group_ids = GroupDerivedData.objects.filter(
             group__project_id__in=project_ids,
         ).values_list("group_id", flat=True)
-        q |= Q(project_id__in=project_ids) & ~Q(id__in=explicit_progress_group_ids)
+        q |= Q(project_id__in=project_ids) & ~Q(id__in=derived_data_group_ids)
     return q
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -12,10 +12,11 @@ from django.db.models import F, Max, Q
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 
-from sentry import quotas
+from sentry import features, quotas
 from sentry.api.event_search import SearchFilter
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.exceptions import InvalidSearchQuery
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.issues.progress import PROGRESS_RESET_ACTIVITY_TYPES
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
@@ -277,6 +278,36 @@ def issue_progress_filter(progress_values: list[str], projects: Sequence[Project
 
       identified -> assigned -> diagnosed -> fix_proposed -> fix_applied
 
+    When every project in scope has the ``projects:issue-action-log-write-to-db``
+    flag enabled, AND the backfill has been run for all groups in the project(s),
+    progress is read from the materialized GroupDerivedData.progress column.
+    Otherwise it's reconstructed from Activity records.
+    """
+    if projects and all(
+        features.has("projects:issue-action-log-write-to-db", project) for project in projects
+    ):
+        return _issue_progress_filter_from_db(progress_values, projects)
+    return _issue_progress_filter_from_activity(progress_values, projects)
+
+
+def _issue_progress_filter_from_db(progress_values: list[str], projects: Sequence[Project]) -> Q:
+    """
+    Reads progress from the materialized GroupDerivedData.progress column. The
+    column stores the IssueProgressState value verbatim, so progress_values maps
+    directly onto it.
+    """
+    return Q(
+        id__in=GroupDerivedData.objects.filter(
+            progress__in=progress_values,
+            group__project_id__in=[p.id for p in projects],
+        ).values_list("group_id", flat=True)
+    )
+
+
+def _issue_progress_filter_from_activity(
+    progress_values: list[str], projects: Sequence[Project]
+) -> Q:
+    """
     "diagnosed" and above are determined by seer/resolution activity types (see
     ISSUE_PROGRESS_TO_ACTIVITY_TYPES). A regression or manual unresolve resets an issue
     back, so only activities *after* the latest reset count.

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -24,6 +24,7 @@ from sentry.api.serializers.models.group import SKIP_SNUBA_FIELDS
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.issues.grouptype import GroupCategory
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.issues.progress import IssueProgressState, get_group_progress_states
 from sentry.issues.search import (
     SEARCH_FILTER_UPDATERS,
@@ -1067,12 +1068,34 @@ PROGRESS_STATE_SORT_RANK: dict[IssueProgressState, int] = {
 LAST_SEEN_TIEBREAK_DIVISOR = 10**13
 
 
+def _get_group_progress_states_from_db(group_ids: list[int]) -> dict[int, str]:
+    """Read progress from the materialized GroupDerivedData.progress column. The column
+    stores the IssueProgressState value verbatim. Groups without a derived row (or a null
+    progress) fall back to identified so every group still gets a rank."""
+    stored = dict(
+        GroupDerivedData.objects.filter(group_id__in=group_ids).values_list("group_id", "progress")
+    )
+    return {
+        group_id: stored.get(group_id) or IssueProgressState.IDENTIFIED.value
+        for group_id in group_ids
+    }
+
+
 def resolve_progress_signal(
     actor: Any | None, organization: Organization, projects: Sequence[Project], group_ids: list[int]
 ) -> dict[int, int]:
-    """Progress-cycle rank per group (identified=1 .. fix_applied=5), derived from the same
-    Activity records as the ``issue.progress`` filter. Every group gets a rank."""
-    states = get_group_progress_states(group_ids)
+    """Progress-cycle rank per group (identified=1 .. fix_applied=5). When every project in
+    scope has the ``projects:issue-action-log-write-to-db`` flag enabled, progress is read
+    from the materialized GroupDerivedData.progress column; otherwise it's derived from the
+    same Activity records as the ``issue.progress`` filter. Every group gets a rank."""
+    project_ids = set(Group.objects.filter(id__in=group_ids).values_list("project_id", flat=True))
+    projects = list(Project.objects.filter(id__in=project_ids))
+    if projects and all(
+        features.has("projects:issue-action-log-write-to-db", project) for project in projects
+    ):
+        states = _get_group_progress_states_from_db(group_ids)
+    else:
+        states = get_group_progress_states(group_ids)
     return {
         group_id: PROGRESS_STATE_SORT_RANK[IssueProgressState(state)]
         for group_id, state in states.items()

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1085,14 +1085,10 @@ def resolve_progress_signal(
     actor: Any | None, organization: Organization, projects: Sequence[Project], group_ids: list[int]
 ) -> dict[int, int]:
     """Progress-cycle rank per group (identified=1 .. fix_applied=5). When every project in
-    scope has the ``projects:issue-action-log-write-to-db`` flag enabled, progress is read
+    scope has the ``projects:issue-stream-derived-progress`` flag enabled, progress is read
     from the materialized GroupDerivedData.progress column; otherwise it's derived from the
     same Activity records as the ``issue.progress`` filter. Every group gets a rank."""
-    project_ids = set(Group.objects.filter(id__in=group_ids).values_list("project_id", flat=True))
-    projects = list(Project.objects.filter(id__in=project_ids))
-    if projects and all(
-        features.has("projects:issue-action-log-write-to-db", project) for project in projects
-    ):
+    if all(features.has("projects:issue-stream-derived-progress", project) for project in projects):
         states = _get_group_progress_states_from_derived_data(group_ids)
     else:
         states = get_group_progress_states(group_ids)
@@ -1100,6 +1096,22 @@ def resolve_progress_signal(
         group_id: PROGRESS_STATE_SORT_RANK[IssueProgressState(state)]
         for group_id, state in states.items()
     }
+
+
+def _resolve_last_progressed_at(
+    actor: Any | None, organization: Organization, projects: Sequence[Project], group_ids: list[int]
+) -> dict[int, float]:
+    """Epoch-millisecond timestamp of the last progress change per group, read from
+    GroupDerivedData.last_progressed_at. Groups without a value are omitted; score_fn
+    falls through to last_seen for them."""
+    if not all(
+        features.has("projects:issue-stream-derived-progress", project) for project in projects
+    ):
+        return {}
+    rows = GroupDerivedData.objects.filter(
+        group_id__in=group_ids, last_progressed_at__isnull=False
+    ).values_list("group_id", "last_progressed_at")
+    return {group_id: ts.timestamp() * 1000 for group_id, ts in rows if ts is not None}
 
 
 def progress_strategy() -> PostgresSortStrategy:
@@ -1110,13 +1122,20 @@ def progress_strategy() -> PostgresSortStrategy:
 
     def score_fn(data: dict[str, Any]) -> float:
         rank = data.get("progress_rank") or 0
+        last_progressed = data.get("last_progressed_at") or 0
+        if last_progressed:
+            return rank + last_progressed / LAST_SEEN_TIEBREAK_DIVISOR
+
         last_seen = data.get("last_seen") or 0
         return rank + last_seen / LAST_SEEN_TIEBREAK_DIVISOR
 
     return PostgresSortStrategy(
         postgres_fields={},
         snuba_aggregations=["last_seen"],
-        signal_resolvers={"progress_rank": resolve_progress_signal},
+        signal_resolvers={
+            "progress_rank": resolve_progress_signal,
+            "last_progressed_at": _resolve_last_progressed_at,
+        },
         score_fn=score_fn,
     )
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1096,7 +1096,9 @@ def resolve_progress_signal(
     scope has the ``projects:issue-stream-derived-progress`` flag enabled, progress is read
     from the materialized GroupDerivedData.progress column; otherwise it's derived from the
     same Activity records as the ``issue.progress`` filter. Every group gets a rank."""
-    if all(features.has("projects:issue-stream-derived-progress", project) for project in projects):
+    if projects and all(
+        features.has("projects:issue-stream-derived-progress", project) for project in projects
+    ):
         states = _get_group_progress_states_from_derived_data(group_ids)
     else:
         states = get_group_progress_states(group_ids)

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1069,16 +1069,24 @@ LAST_SEEN_TIEBREAK_DIVISOR = 10**13
 
 
 def _get_group_progress_states_from_derived_data(group_ids: list[int]) -> dict[int, str]:
-    """Read progress from the materialized GroupDerivedData.progress column. The column
-    stores the IssueProgressState value verbatim. Groups without a derived row (or a null
-    progress) fall back to identified so every group still gets a rank."""
+    """Read progress from the materialized GroupDerivedData.progress column, mirroring
+    _get_derived_progress: the column stores the IssueProgressState value verbatim, a null
+    column (closed issues) counts as fix_applied, and a group without a derived row counts
+    as identified, so every group still gets a rank."""
     stored = dict(
         GroupDerivedData.objects.filter(group_id__in=group_ids).values_list("group_id", "progress")
     )
-    return {
-        group_id: stored.get(group_id) or IssueProgressState.IDENTIFIED.value
-        for group_id in group_ids
-    }
+    result: dict[int, str] = {}
+    for group_id in group_ids:
+        if group_id not in stored:
+            result[group_id] = IssueProgressState.IDENTIFIED.value
+            continue
+        progress = stored[group_id]
+        if progress is None:
+            result[group_id] = IssueProgressState.FIX_APPLIED.value
+        else:
+            result[group_id] = progress
+    return result
 
 
 def resolve_progress_signal(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1068,7 +1068,7 @@ PROGRESS_STATE_SORT_RANK: dict[IssueProgressState, int] = {
 LAST_SEEN_TIEBREAK_DIVISOR = 10**13
 
 
-def _get_group_progress_states_from_db(group_ids: list[int]) -> dict[int, str]:
+def _get_group_progress_states_from_derived_data(group_ids: list[int]) -> dict[int, str]:
     """Read progress from the materialized GroupDerivedData.progress column. The column
     stores the IssueProgressState value verbatim. Groups without a derived row (or a null
     progress) fall back to identified so every group still gets a rank."""
@@ -1093,7 +1093,7 @@ def resolve_progress_signal(
     if projects and all(
         features.has("projects:issue-action-log-write-to-db", project) for project in projects
     ):
-        states = _get_group_progress_states_from_db(group_ids)
+        states = _get_group_progress_states_from_derived_data(group_ids)
     else:
         states = get_group_progress_states(group_ids)
     return {

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1125,15 +1125,17 @@ def _resolve_last_progressed_at(
 
 
 def progress_strategy() -> PostgresSortStrategy:
-    """Progress sort: primary by fix-cycle rank (fix_applied > fix_proposed > diagnosed >
-    assigned > identified), secondary by last_seen. The secondary key stands in for
-    ``issue.last_progressed_at`` until that field exists; for now most-recently-active issues
-    rank highest within a tier."""
+    """
+    Progress sort: primary by fix-cycle rank (fix_applied > fix_proposed > diagnosed >
+    assigned > identified), secondary by last_progressed_at (falling back to last_seen
+    when last_progressed_at is absent).
+    """
 
     def score_fn(data: dict[str, Any]) -> float:
         rank = data.get("progress_rank") or 0
         last_progressed = data.get("last_progressed_at") or 0
         if last_progressed:
+            # divisor used here as it happens to share units
             return rank + last_progressed / LAST_SEEN_TIEBREAK_DIVISOR
 
         last_seen = data.get("last_seen") or 0

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1097,7 +1097,8 @@ def resolve_progress_signal(
     from the materialized GroupDerivedData.progress column; otherwise it's derived from the
     same Activity records as the ``issue.progress`` filter. Every group gets a rank."""
     if projects and all(
-        features.has("projects:issue-stream-derived-progress", project) for project in projects
+        features.has("projects:issue-stream-derived-progress", project, actor=actor)
+        for project in projects
     ):
         states = _get_group_progress_states_from_derived_data(group_ids)
     else:
@@ -1115,7 +1116,8 @@ def _resolve_last_progressed_at(
     GroupDerivedData.last_progressed_at. Groups without a value are omitted; score_fn
     falls through to last_seen for them."""
     if not all(
-        features.has("projects:issue-stream-derived-progress", project) for project in projects
+        features.has("projects:issue-stream-derived-progress", project, actor=actor)
+        for project in projects
     ):
         return {}
     rows = GroupDerivedData.objects.filter(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -78,6 +78,7 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.grouptype import get_group_type_by_type_id
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
@@ -1309,6 +1310,11 @@ class Factories:
             team=team,
             **kwargs,
         )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_group_derived_data(group, **kwargs) -> GroupDerivedData:
+        return GroupDerivedData.objects.create(group=group, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -21,6 +21,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.custominboundfilter import CustomInboundFilter
@@ -378,6 +379,11 @@ class Fixtures:
         if group is None:
             group = self.group
         return Factories.create_group_action_log_entry(group, *args, **kwargs)
+
+    def create_group_derived_data(self, group=None, **kwargs) -> GroupDerivedData:
+        if group is None:
+            group = self.group
+        return Factories.create_group_derived_data(group, **kwargs)
 
     def create_n_groups_with_hashes(
         self, number_of_groups: int, project: Project, group_type: int | None = None

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1145,7 +1145,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(search_filter_query="issue.progress:fix_proposed")
         assert self.group1 not in set(results)
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_issue_progress_from_db(self) -> None:
         self.create_group_derived_data(group=self.group1, progress=IssueProgressState.DIAGNOSED)
         self.create_group_derived_data(group=self.group2, progress=IssueProgressState.FIX_PROPOSED)
@@ -1169,7 +1169,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == set()
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_issue_progress_from_db_multiple_values(self) -> None:
         self.create_group_derived_data(group=self.group1, progress=IssueProgressState.DIAGNOSED)
         self.create_group_derived_data(group=self.group2, progress=IssueProgressState.FIX_PROPOSED)
@@ -1181,7 +1181,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == {self.group1, self.group2}
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_issue_progress_from_db_base_states(self) -> None:
         self.create_group_derived_data(group=self.group1, progress=IssueProgressState.IDENTIFIED)
         self.create_group_derived_data(group=self.group2, progress=IssueProgressState.ASSIGNED)
@@ -1196,7 +1196,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == {self.group2}
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_issue_progress_from_db_missing_row_is_identified(self) -> None:
         # A group with no GroupDerivedData row is implicitly "identified" on the DB
         # path, matching the sort resolver, so it's returned alongside groups with
@@ -1208,7 +1208,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == {self.group1, self.group2}
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_issue_progress_from_db_negation(self) -> None:
         self.create_group_derived_data(group=self.group1, progress=IssueProgressState.DIAGNOSED)
         self.create_group_derived_data(group=self.group2, progress=IssueProgressState.FIX_PROPOSED)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -17,6 +17,7 @@ from sentry.issues.grouptype import (
 )
 from sentry.issues.ingest import send_issue_occurrence_to_eventstream
 from sentry.issues.issue_search import convert_query_values, issue_search_config, parse_search_query
+from sentry.issues.progress_state import IssueProgressState
 from sentry.models.environment import Environment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
@@ -32,6 +33,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import snuba
@@ -1141,6 +1143,80 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         assert self.group1 in set(results)
 
         results = self.make_query(search_filter_query="issue.progress:fix_proposed")
+        assert self.group1 not in set(results)
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_issue_progress_from_db(self) -> None:
+        self.create_group_derived_data(group=self.group1, progress=IssueProgressState.DIAGNOSED)
+        self.create_group_derived_data(group=self.group2, progress=IssueProgressState.FIX_PROPOSED)
+        # group1 has a SEER_PR_CREATED activity that
+        # would make it "fix_proposed" on the activity path, but its column says
+        # "diagnosed", so it must only match "diagnosed".
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+
+        results = self.make_query(
+            search_filter_query=f"issue.progress:{IssueProgressState.DIAGNOSED}"
+        )
+        assert set(results) == {self.group1}
+
+        results = self.make_query(
+            search_filter_query=f"issue.progress:{IssueProgressState.FIX_PROPOSED}"
+        )
+        assert set(results) == {self.group2}
+
+        results = self.make_query(
+            search_filter_query=f"issue.progress:{IssueProgressState.FIX_APPLIED}"
+        )
+        assert set(results) == set()
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_issue_progress_from_db_multiple_values(self) -> None:
+        self.create_group_derived_data(group=self.group1, progress=IssueProgressState.DIAGNOSED)
+        self.create_group_derived_data(group=self.group2, progress=IssueProgressState.FIX_PROPOSED)
+
+        results = self.make_query(
+            search_filter_query=(
+                f"issue.progress:[{IssueProgressState.DIAGNOSED}, {IssueProgressState.FIX_PROPOSED}]"
+            )
+        )
+        assert set(results) == {self.group1, self.group2}
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_issue_progress_from_db_base_states(self) -> None:
+        self.create_group_derived_data(group=self.group1, progress=IssueProgressState.IDENTIFIED)
+        self.create_group_derived_data(group=self.group2, progress=IssueProgressState.ASSIGNED)
+
+        results = self.make_query(
+            search_filter_query=f"issue.progress:{IssueProgressState.IDENTIFIED}"
+        )
+        assert set(results) == {self.group1}
+
+        results = self.make_query(
+            search_filter_query=f"issue.progress:{IssueProgressState.ASSIGNED}"
+        )
+        assert set(results) == {self.group2}
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_issue_progress_from_db_missing_row_not_matched(self) -> None:
+        # A group with no GroupDerivedData row matches nothing on the DB path,
+        # even for the base "identified" state that the activity path would infer.
+        self.create_group_derived_data(group=self.group1, progress=IssueProgressState.IDENTIFIED)
+
+        results = self.make_query(
+            search_filter_query=f"issue.progress:{IssueProgressState.IDENTIFIED}"
+        )
+        assert set(results) == {self.group1}
+        assert self.group2 not in set(results)
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_issue_progress_from_db_negation(self) -> None:
+        self.create_group_derived_data(group=self.group1, progress=IssueProgressState.DIAGNOSED)
+        self.create_group_derived_data(group=self.group2, progress=IssueProgressState.FIX_PROPOSED)
+
+        results = self.make_query(
+            search_filter_query=f"!issue.progress:{IssueProgressState.DIAGNOSED}"
+        )
+        assert self.group2 in set(results)
         assert self.group1 not in set(results)
 
     def test_unassigned(self) -> None:

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1197,16 +1197,16 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         assert set(results) == {self.group2}
 
     @with_feature("projects:issue-action-log-write-to-db")
-    def test_issue_progress_from_db_missing_row_not_matched(self) -> None:
-        # A group with no GroupDerivedData row matches nothing on the DB path,
-        # even for the base "identified" state that the activity path would infer.
+    def test_issue_progress_from_db_missing_row_is_identified(self) -> None:
+        # A group with no GroupDerivedData row is implicitly "identified" on the DB
+        # path, matching the sort resolver, so it's returned alongside groups with
+        # an explicit "identified" row.
         self.create_group_derived_data(group=self.group1, progress=IssueProgressState.IDENTIFIED)
 
         results = self.make_query(
             search_filter_query=f"issue.progress:{IssueProgressState.IDENTIFIED}"
         )
-        assert set(results) == {self.group1}
-        assert self.group2 not in set(results)
+        assert set(results) == {self.group1, self.group2}
 
     @with_feature("projects:issue-action-log-write-to-db")
     def test_issue_progress_from_db_negation(self) -> None:

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -23,6 +23,7 @@ from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
 
@@ -569,6 +570,32 @@ class TestProgressSort(PostgresSortTestBase):
         self.create_group_activity(group=self.groups[0], type=ActivityType.SEER_RCA_COMPLETED.value)
         self.create_group_activity(group=self.groups[1], type=ActivityType.SEER_RCA_COMPLETED.value)
         assert self._query() == [self.groups[1], self.groups[0], self.groups[2]]
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_reads_from_derived_data_when_flag_enabled(self):
+        # With the flag on, rank comes from GroupDerivedData.progress, not Activity.
+        # groups[0] would be fix_proposed from Activity, but its derived row says identified,
+        # so it must rank last.
+        self.create_group_activity(group=self.groups[0], type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_derived_data(group=self.groups[0], progress="identified")
+        self.create_group_derived_data(group=self.groups[1], progress="diagnosed")
+        self.create_group_derived_data(group=self.groups[2], progress="fix_applied")
+        assert self._query() == [self.groups[2], self.groups[1], self.groups[0]]
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_derived_data_missing_row_defaults_to_identified(self):
+        # Only groups[0] has a derived row; the others default to identified and fall back
+        # to last_seen ordering (groups[2] newer than groups[1]).
+        self.create_group_derived_data(group=self.groups[0], progress="fix_applied")
+        assert self._query() == [self.groups[0], self.groups[2], self.groups[1]]
+
+    def test_ignores_derived_data_when_flag_disabled(self):
+        # Flag off: rank comes from Activity, not the derived column. The derived rows claim
+        # the reverse order but Activity (groups[0] fix_proposed) must win.
+        self.create_group_activity(group=self.groups[0], type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_derived_data(group=self.groups[0], progress="identified")
+        self.create_group_derived_data(group=self.groups[1], progress="fix_applied")
+        assert self._query() == [self.groups[0], self.groups[2], self.groups[1]]
 
 
 class TestDefaultPostgresSortStrategies(TestCase):

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -571,7 +571,7 @@ class TestProgressSort(PostgresSortTestBase):
         self.create_group_activity(group=self.groups[1], type=ActivityType.SEER_RCA_COMPLETED.value)
         assert self._query() == [self.groups[1], self.groups[0], self.groups[2]]
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_reads_from_derived_data_when_flag_enabled(self):
         # With the flag on, rank comes from GroupDerivedData.progress, not Activity.
         # groups[0] would be fix_proposed from Activity, but its derived row says identified,
@@ -582,7 +582,7 @@ class TestProgressSort(PostgresSortTestBase):
         self.create_group_derived_data(group=self.groups[2], progress="fix_applied")
         assert self._query() == [self.groups[2], self.groups[1], self.groups[0]]
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-stream-derived-progress")
     def test_derived_data_missing_row_defaults_to_identified(self):
         # Only groups[0] has a derived row; the others default to identified and fall back
         # to last_seen ordering (groups[2] newer than groups[1]).
@@ -596,6 +596,19 @@ class TestProgressSort(PostgresSortTestBase):
         self.create_group_derived_data(group=self.groups[0], progress="identified")
         self.create_group_derived_data(group=self.groups[1], progress="fix_applied")
         assert self._query() == [self.groups[0], self.groups[2], self.groups[1]]
+
+    @with_feature("projects:issue-stream-derived-progress")
+    def test_last_progressed_at_breaks_ties(self):
+        # Both groups have the same rank but different last_progressed_at values;
+        # the more recently progressed group sorts first.
+        self.create_group_derived_data(
+            group=self.groups[0], progress="diagnosed", last_progressed_at=before_now(days=5)
+        )
+        self.create_group_derived_data(
+            group=self.groups[1], progress="diagnosed", last_progressed_at=before_now(days=1)
+        )
+        # groups[2] has no derived data -> identified (lowest rank), sorts last.
+        assert self._query() == [self.groups[1], self.groups[0], self.groups[2]]
 
 
 class TestDefaultPostgresSortStrategies(TestCase):
@@ -618,7 +631,7 @@ class TestDefaultPostgresSortStrategies(TestCase):
         strategies = PostgresSnubaQueryExecutor().postgres_sort_strategies
         strategy = strategies["progress"]
         assert strategy.snuba_aggregations == ["last_seen"]
-        assert set(strategy.signal_resolvers) == {"progress_rank"}
+        assert set(strategy.signal_resolvers) == {"progress_rank", "last_progressed_at"}
         # progress maps to last_seen in sort_strategies so the chunked Snuba path has a
         # real aggregation to fall back to on candidate overflow.
         assert PostgresSnubaQueryExecutor.sort_strategies["progress"] == "last_seen"


### PR DESCRIPTION
Conditionally query `GroupDerivedData` rather than `Activity` if we have group derived data to read from for searching and sorting groups. `issue_progress_filter` is for search queries like `issue.progress is diagnosed` and `resolve_progress_signal` is for sorting groups in order of progress if using the "Progress" sort option in the issue stream, where "identified" has the last progress and "fix applied" is the most progress. 

I ran it locally and didn't have any Seer statuses so I was only able to test "identified" and "assigned" but those seem to be working fine: 

**Filtering by issue.progress assigned**
<img width="1188" height="344" alt="Screenshot 2026-07-10 at 2 47 52 PM" src="https://github.com/user-attachments/assets/1583d1ef-d7f9-42f2-a043-615ed949d301" />

**Filtering by issue.progress identified**

<img width="1183" height="693" alt="Screenshot 2026-07-10 at 2 48 16 PM" src="https://github.com/user-attachments/assets/87bb7a71-f5c7-45fa-8df0-302d55d320b6" />


**Filtering by issue.progress assigned or identified, and sorting by progress so assigned is first**

<img width="1186" height="687" alt="Screenshot 2026-07-10 at 2 48 33 PM" src="https://github.com/user-attachments/assets/19288c5d-f73b-4034-b219-acb2b288ca9b" />
