### PR TITLE
ref(issues): Shorten Recommended and Progress sort descriptions

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -38,9 +38,9 @@ function getSortTooltip(key: IssueSortOptions) {
     case IssueSortOptions.RECOMMENDED:
     case IssueSortOptions.RECOMMENDED_V1:
     case IssueSortOptions.RECOMMENDED_EXPERIMENTAL:
-      return t('Issues ranked by combined recency, severity, and impact signals.');
+      return t('Relevance and impact.');
     case IssueSortOptions.PROGRESS:
-      return t('Issues ranked by how far along they are toward a fix.');
+      return t('Progress toward a fix.');
     case IssueSortOptions.DATE:
     default:
       return t('Last time the issue occurred.');


### PR DESCRIPTION
Shortens the sort dropdown descriptions for the Recommended and Progress sorts to match the terse phrasing of the other sort options ("Number of events.", "Number of users affected.", etc.):

- Recommended: "Issues ranked by combined recency, severity, and impact signals." → "Relevance and impact."
- Progress: "Issues ranked by how far along they are toward a fix." → "Progress toward a fix."