### PR TITLE
refactor(preprod): extract shared size evaluation core

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -20,6 +20,7 @@ from sentry.preprod.vcs.pr_comments.snapshot_templates import (
 )
 from sentry.preprod.vcs.pr_comments.tasks import (
     lock_pr_comparisons_for_update,
+    resolve_pr_comment_context,
     save_pr_comment_result,
 )
 from sentry.shared_integrations.exceptions import ApiError
@@ -49,54 +50,19 @@ def create_preprod_snapshot_pr_comment_task(
     is_timeout_check: bool = False,
     **kwargs: Any,
 ) -> None:
-    try:
-        artifact = PreprodArtifact.objects.select_related(
-            "mobile_app_info",
-            "commit_comparison",
-            "project",
-            "project__organization",
-        ).get(id=preprod_artifact_id)
-    except PreprodArtifact.DoesNotExist:
-        logger.exception(
-            "preprod.snapshot_pr_comments.create.artifact_not_found",
-            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
-        )
-        return
-
-    if not artifact.commit_comparison:
-        logger.info(
-            "preprod.snapshot_pr_comments.create.no_commit_comparison",
-            extra={"preprod_artifact_id": artifact.id},
-        )
-        return
-
-    commit_comparison = artifact.commit_comparison
-    if (
-        not commit_comparison.pr_number
-        or not commit_comparison.head_repo_name
-        or not commit_comparison.provider
-    ):
-        logger.info(
-            "preprod.snapshot_pr_comments.create.no_pr_info",
-            extra={
-                "preprod_artifact_id": artifact.id,
-                "pr_number": commit_comparison.pr_number,
-                "head_repo_name": commit_comparison.head_repo_name,
-            },
-        )
-        return
-
-    if not artifact.project.get_option(ENABLED_OPTION_KEY):
-        logger.info(
-            "preprod.snapshot_pr_comments.create.project_disabled",
-            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
-        )
-        return
-
-    organization = artifact.project.organization
-    client = get_commit_context_client(
-        organization, commit_comparison.head_repo_name, commit_comparison.provider
+    ctx = resolve_pr_comment_context(
+        preprod_artifact_id,
+        log_prefix="preprod.snapshot_pr_comments",
+        enabled_option_key=ENABLED_OPTION_KEY,
+        caller=caller,
+        feature_flag=None,
+        with_build_configuration=False,
     )
+    if ctx is None:
+        return
+    artifact, commit_comparison, organization, head_repo_name, pr_number, provider = ctx
+
+    client = get_commit_context_client(organization, head_repo_name, provider)
     if not client:
         logger.info(
             "preprod.snapshot_pr_comments.create.no_client",
@@ -109,8 +75,8 @@ def create_preprod_snapshot_pr_comment_task(
     with transaction.atomic(db_alias):
         cc, existing_comment_id = lock_pr_comparisons_for_update(
             organization_id=commit_comparison.organization_id,
-            head_repo_name=commit_comparison.head_repo_name,
-            pr_number=commit_comparison.pr_number,
+            head_repo_name=head_repo_name,
+            pr_number=pr_number,
             target_id=commit_comparison.id,
             comment_type="snapshots",
         )
@@ -222,9 +188,9 @@ def create_preprod_snapshot_pr_comment_task(
 
     post_snapshot_pr_comment_task.delay(
         organization_id=organization.id,
-        repo_name=commit_comparison.head_repo_name,
-        provider=commit_comparison.provider,
-        pr_number=commit_comparison.pr_number,
+        repo_name=head_repo_name,
+        provider=provider,
+        pr_number=pr_number,
         commit_comparison_id=cc_id,
         artifact_id=artifact.id,
         comment_body=comment_body,

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from enum import StrEnum
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.db import router, transaction
 from taskbroker_client.retry import Retry
 
 from sentry import features
 from sentry.models.commitcomparison import CommitComparison
+from sentry.models.organization import Organization
 from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.integration_utils import get_commit_context_client
 from sentry.preprod.models import PreprodArtifact
@@ -22,6 +23,106 @@ from sentry.taskworker.namespaces import preprod_tasks
 logger = logging.getLogger(__name__)
 
 
+class PrCommentContext(NamedTuple):
+    artifact: PreprodArtifact
+    commit_comparison: CommitComparison
+    organization: Organization
+    # Validated non-None on the commit comparison by the guard below, surfaced
+    # here so callers get the narrowed types at their typed call sites.
+    head_repo_name: str
+    pr_number: int
+    provider: str
+
+
+def resolve_pr_comment_context(
+    preprod_artifact_id: int,
+    *,
+    log_prefix: str,
+    enabled_option_key: str,
+    caller: str | None = None,
+    feature_flag: str | None = None,
+    with_build_configuration: bool = True,
+) -> PrCommentContext | None:
+    """Run the shared guard for PR-comment tasks and resolve their common inputs.
+
+    Fetches the artifact and validates that it has a commit comparison with PR
+    info, that the project option is enabled, and that the org feature flag is on
+    (when ``feature_flag`` is provided). Returns ``None`` (after logging the
+    matching skip event) when any guard fails, otherwise a ``PrCommentContext``
+    (artifact, commit comparison, organization, and the guard-validated
+    non-None PR scalars). The caller fetches its own SCM client so tests can
+    continue patching ``get_commit_context_client`` per task module.
+
+    ``log_prefix`` scopes the structured-log event names per feature (e.g.
+    ``preprod.size_pr_comments``); ``feature_flag=None`` skips the org-flag gate;
+    ``with_build_configuration`` controls whether the build configuration is
+    prefetched.
+    """
+    select_related = ["mobile_app_info", "commit_comparison", "project", "project__organization"]
+    if with_build_configuration:
+        select_related.insert(1, "build_configuration")
+
+    try:
+        artifact = PreprodArtifact.objects.select_related(*select_related).get(
+            id=preprod_artifact_id
+        )
+    except PreprodArtifact.DoesNotExist:
+        event = log_prefix + ".create.artifact_not_found"
+        logger.exception(
+            event,
+            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
+        )
+        return None
+
+    if not artifact.commit_comparison:
+        event = log_prefix + ".create.no_commit_comparison"
+        logger.info(event, extra={"preprod_artifact_id": artifact.id})
+        return None
+
+    commit_comparison = artifact.commit_comparison
+    if (
+        not commit_comparison.pr_number
+        or not commit_comparison.head_repo_name
+        or not commit_comparison.provider
+    ):
+        event = log_prefix + ".create.no_pr_info"
+        logger.info(
+            event,
+            extra={
+                "preprod_artifact_id": artifact.id,
+                "pr_number": commit_comparison.pr_number,
+                "head_repo_name": commit_comparison.head_repo_name,
+            },
+        )
+        return None
+
+    if not artifact.project.get_option(enabled_option_key):
+        event = log_prefix + ".create.project_disabled"
+        logger.info(
+            event,
+            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
+        )
+        return None
+
+    organization = artifact.project.organization
+    if feature_flag is not None and not features.has(feature_flag, organization):
+        event = log_prefix + ".create.feature_disabled"
+        logger.info(
+            event,
+            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
+        )
+        return None
+
+    return PrCommentContext(
+        artifact,
+        commit_comparison,
+        organization,
+        commit_comparison.head_repo_name,
+        commit_comparison.pr_number,
+        commit_comparison.provider,
+    )
+
+
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_pr_comment",
     namespace=preprod_tasks,
@@ -32,64 +133,19 @@ logger = logging.getLogger(__name__)
 def create_preprod_pr_comment_task(
     preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
 ) -> None:
-    try:
-        artifact = PreprodArtifact.objects.select_related(
-            "mobile_app_info",
-            "build_configuration",
-            "commit_comparison",
-            "project",
-            "project__organization",
-        ).get(id=preprod_artifact_id)
-    except PreprodArtifact.DoesNotExist:
-        logger.exception(
-            "preprod.pr_comments.create.artifact_not_found",
-            extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
-        )
-        return
-
-    if not artifact.commit_comparison:
-        logger.info(
-            "preprod.pr_comments.create.no_commit_comparison",
-            extra={"preprod_artifact_id": artifact.id},
-        )
-        return
-
-    commit_comparison = artifact.commit_comparison
-    if (
-        not commit_comparison.pr_number
-        or not commit_comparison.head_repo_name
-        or not commit_comparison.provider
-    ):
-        logger.info(
-            "preprod.pr_comments.create.no_pr_info",
-            extra={
-                "preprod_artifact_id": artifact.id,
-                "pr_number": commit_comparison.pr_number,
-                "head_repo_name": commit_comparison.head_repo_name,
-            },
-        )
-        return
-
-    if not artifact.project.get_option(
-        "sentry:preprod_distribution_pr_comments_enabled_by_customer"
-    ):
-        logger.info(
-            "preprod.pr_comments.create.project_disabled",
-            extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
-        )
-        return
-
-    organization = artifact.project.organization
-    if not features.has("organizations:preprod-build-distribution-pr-comments", organization):
-        logger.info(
-            "preprod.pr_comments.create.feature_disabled",
-            extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
-        )
-        return
-
-    client = get_commit_context_client(
-        organization, commit_comparison.head_repo_name, commit_comparison.provider
+    ctx = resolve_pr_comment_context(
+        preprod_artifact_id,
+        log_prefix="preprod.pr_comments",
+        enabled_option_key="sentry:preprod_distribution_pr_comments_enabled_by_customer",
+        caller=caller,
+        feature_flag="organizations:preprod-build-distribution-pr-comments",
+        with_build_configuration=True,
     )
+    if ctx is None:
+        return
+    artifact, commit_comparison, organization, head_repo_name, pr_number, provider = ctx
+
+    client = get_commit_context_client(organization, head_repo_name, provider)
     if not client:
         logger.info(
             "preprod.pr_comments.create.no_client",

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -43,21 +43,15 @@ def resolve_pr_comment_context(
     feature_flag: str | None = None,
     with_build_configuration: bool = True,
 ) -> PrCommentContext | None:
-    """Run the shared guard for PR-comment tasks and resolve their common inputs.
+    """Resolve common PR-comment inputs after applying the shared task guards.
 
-    Fetches the artifact and validates that it has a commit comparison with PR
-    info, that the project option is enabled, and that the org feature flag is on
-    (when ``feature_flag`` is provided). Returns ``None`` (after logging the
-    matching skip event) when any guard fails, otherwise a ``PrCommentContext``
-    (artifact, commit comparison, organization, and the guard-validated
-    non-None PR scalars). The caller fetches its own SCM client so tests can
-    continue patching ``get_commit_context_client`` per task module.
-
-    ``log_prefix`` scopes the structured-log event names per feature (e.g.
-    ``preprod.size_pr_comments``); ``feature_flag=None`` skips the org-flag gate;
-    ``with_build_configuration`` controls whether the build configuration is
-    prefetched.
+    Returns ``None`` after logging when the artifact or required PR information
+    is missing, the project option is disabled, or the optional feature gate fails.
     """
+
+    def event_name(suffix: str) -> str:
+        return log_prefix + ".create." + suffix
+
     select_related = ["mobile_app_info", "commit_comparison", "project", "project__organization"]
     if with_build_configuration:
         select_related.insert(1, "build_configuration")
@@ -67,16 +61,14 @@ def resolve_pr_comment_context(
             id=preprod_artifact_id
         )
     except PreprodArtifact.DoesNotExist:
-        event = log_prefix + ".create.artifact_not_found"
         logger.exception(
-            event,
+            event_name("artifact_not_found"),
             extra={"preprod_artifact_id": preprod_artifact_id, "caller": caller},
         )
         return None
 
     if not artifact.commit_comparison:
-        event = log_prefix + ".create.no_commit_comparison"
-        logger.info(event, extra={"preprod_artifact_id": artifact.id})
+        logger.info(event_name("no_commit_comparison"), extra={"preprod_artifact_id": artifact.id})
         return None
 
     commit_comparison = artifact.commit_comparison
@@ -85,9 +77,8 @@ def resolve_pr_comment_context(
         or not commit_comparison.head_repo_name
         or not commit_comparison.provider
     ):
-        event = log_prefix + ".create.no_pr_info"
         logger.info(
-            event,
+            event_name("no_pr_info"),
             extra={
                 "preprod_artifact_id": artifact.id,
                 "pr_number": commit_comparison.pr_number,
@@ -97,18 +88,16 @@ def resolve_pr_comment_context(
         return None
 
     if not artifact.project.get_option(enabled_option_key):
-        event = log_prefix + ".create.project_disabled"
         logger.info(
-            event,
+            event_name("project_disabled"),
             extra={"preprod_artifact_id": artifact.id, "project_id": artifact.project.id},
         )
         return None
 
     organization = artifact.project.organization
     if feature_flag is not None and not features.has(feature_flag, organization):
-        event = log_prefix + ".create.feature_disabled"
         logger.info(
-            event,
+            event_name("feature_disabled"),
             extra={"preprod_artifact_id": artifact.id, "organization_id": organization.id},
         )
         return None

--- a/src/sentry/preprod/vcs/status_checks/size/rules.py
+++ b/src/sentry/preprod/vcs/status_checks/size/rules.py
@@ -50,14 +50,20 @@ def get_status_checks_enabled(project: Project) -> bool:
     return bool(project.get_option(ENABLED_OPTION_KEY, default=True))
 
 
-def get_status_check_rules(project: Project) -> list[StatusCheckRule]:
+def get_status_check_rules(
+    project: Project, option_key: str = RULES_OPTION_KEY
+) -> list[StatusCheckRule]:
     """
-    Fetch and parse status check rules from project options.
+    Fetch and parse size rules from a project option.
+
+    ``option_key`` defaults to the status-check rules option; callers that store
+    a separate rule set (e.g. PR comments) pass their own key. The rule schema is
+    identical across option keys.
 
     Returns an empty list if feature is disabled or no rules configured.
     """
 
-    raw = project.get_option(RULES_OPTION_KEY, default=None)
+    raw = project.get_option(option_key, default=None)
     if not raw:
         return []
 

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 from sentry import analytics as sentry_analytics
 from sentry.api.event_search import SearchFilter, parse_search_query
@@ -12,6 +12,7 @@ from sentry.integrations.source_code_management.status_check import (
     StatusCheckStatus,
 )
 from sentry.models.commitcomparison import CommitComparison
+from sentry.models.project import Project
 from sentry.preprod.analytics import PreprodStatusCheckTriggeredRulePostedEvent
 from sentry.preprod.models import (
     PreprodArtifact,
@@ -106,6 +107,105 @@ def _get_matching_base_metric(
     )
 
 
+class SizeEvaluation(NamedTuple):
+    status: StatusCheckStatus
+    triggered_rules: list[TriggeredRule]
+    title: str
+    subtitle: str
+    summary: str
+    # The filtered artifacts actually evaluated; empty when every artifact was
+    # skipped or had no size metrics (i.e. there is no size data to report).
+    evaluated_artifacts: list[PreprodArtifact]
+
+
+def evaluate_size_and_format_messages(
+    project: Project,
+    all_artifacts: list[PreprodArtifact],
+    rules: list[StatusCheckRule],
+) -> SizeEvaluation:
+    """Evaluate size rules for a commit's artifacts and render the summary.
+
+    Shared by the size status check and the size PR comment so the two can never
+    render differently. Given the sibling ``all_artifacts`` and the ``rules`` the
+    caller loaded (callers choose the option source), this assembles size metrics
+    and approvals, filters to size-analyzed artifacts, and returns a
+    ``SizeEvaluation``. ``evaluated_artifacts`` is the filtered list actually
+    evaluated (empty when every artifact was skipped/non-size). Caller-specific
+    concerns (target_url, completed_at, posting) are intentionally excluded.
+    """
+    size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]] = {}
+    approvals_map: dict[int, PreprodComparisonApproval] = {}
+    if all_artifacts:
+        artifact_ids = [artifact.id for artifact in all_artifacts]
+        size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact_id__in=artifact_ids,
+        ).select_related("preprod_artifact")
+
+        for metrics in size_metrics_qs:
+            if metrics.preprod_artifact_id not in size_metrics_map:
+                size_metrics_map[metrics.preprod_artifact_id] = []
+            size_metrics_map[metrics.preprod_artifact_id].append(metrics)
+
+        approval_qs = PreprodComparisonApproval.objects.filter(
+            preprod_artifact_id__in=artifact_ids,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+        for approval in approval_qs:
+            approvals_map[approval.preprod_artifact_id] = approval
+
+    # Filter out artifacts not in the size analysis pipeline (e.g., snapshot-only artifacts).
+    # Symmetric with snapshots/tasks.py which filters to snapshot-only artifacts.
+    all_artifacts = [a for a in all_artifacts if a.id in size_metrics_map]
+
+    # Filter out SKIPPED artifacts (user didn't request size analysis)
+    all_artifacts = [
+        a for a in all_artifacts if not _is_artifact_size_skipped(size_metrics_map.get(a.id, []))
+    ]
+
+    triggered_rules: list[TriggeredRule] = []
+    if not all_artifacts:
+        title, subtitle, summary = format_all_skipped_messages(project)
+        return SizeEvaluation(
+            StatusCheckStatus.NEUTRAL, triggered_rules, title, subtitle, summary, all_artifacts
+        )
+
+    # Check if any artifact hit quota limits - show neutral status with quota message
+    if _has_no_quota_artifact(all_artifacts, size_metrics_map):
+        title, subtitle, summary = format_no_quota_messages()
+        return SizeEvaluation(
+            StatusCheckStatus.NEUTRAL, triggered_rules, title, subtitle, summary, all_artifacts
+        )
+
+    base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(all_artifacts)
+
+    status, triggered_rules = _compute_overall_status(
+        all_artifacts,
+        size_metrics_map,
+        rules=rules,
+        base_artifact_map=base_artifact_map,
+        base_metrics_by_artifact=base_size_metrics_map,
+        approvals_map=approvals_map,
+    )
+
+    title, subtitle, summary = format_status_check_messages(
+        all_artifacts,
+        size_metrics_map,
+        status,
+        project,
+        base_artifact_map,
+        base_size_metrics_map,
+        triggered_rules,
+    )
+
+    # When no rules are configured, always show neutral status.
+    # When rules exist, show actual status (in_progress, failure, success).
+    if not rules:
+        status = StatusCheckStatus.NEUTRAL
+
+    return SizeEvaluation(status, triggered_rules, title, subtitle, summary, all_artifacts)
+
+
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_status_check",
     namespace=preprod_tasks,
@@ -194,106 +294,47 @@ def create_preprod_status_check_task(
         )
         return
 
-    size_metrics_map: dict[int, list[PreprodArtifactSizeMetrics]] = {}
-    approvals_map: dict[int, PreprodComparisonApproval] = {}
-    if all_artifacts:
-        artifact_ids = [artifact.id for artifact in all_artifacts]
-        size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact_id__in=artifact_ids,
-        ).select_related("preprod_artifact")
+    rules = get_status_check_rules(preprod_artifact.project)
+    evaluation = evaluate_size_and_format_messages(preprod_artifact.project, all_artifacts, rules)
 
-        for metrics in size_metrics_qs:
-            if metrics.preprod_artifact_id not in size_metrics_map:
-                size_metrics_map[metrics.preprod_artifact_id] = []
-            size_metrics_map[metrics.preprod_artifact_id].append(metrics)
-
-        approval_qs = PreprodComparisonApproval.objects.filter(
-            preprod_artifact_id__in=artifact_ids,
-            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
-            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
-        )
-        for approval in approval_qs:
-            approvals_map[approval.preprod_artifact_id] = approval
-
-    # Filter out artifacts not in the size analysis pipeline (e.g., snapshot-only artifacts).
-    # Symmetric with snapshots/tasks.py which filters to snapshot-only artifacts.
-    all_artifacts = [a for a in all_artifacts if a.id in size_metrics_map]
-
-    # Filter out SKIPPED artifacts (user didn't request size analysis)
-    all_artifacts = [
-        a for a in all_artifacts if not _is_artifact_size_skipped(size_metrics_map.get(a.id, []))
-    ]
-    if not all_artifacts:
+    if not evaluation.evaluated_artifacts:
         logger.info(
             "preprod.status_checks.create.all_skipped",
             extra={"preprod_artifact_id": preprod_artifact.id},
         )
-        title, subtitle, summary = format_all_skipped_messages(preprod_artifact.project)
-        status = StatusCheckStatus.NEUTRAL
-        completed_at = preprod_artifact.date_updated
         target_url = get_preprod_artifact_url(preprod_artifact)
-        triggered_rules: list[TriggeredRule] = []
     else:
         url_artifact = (
             preprod_artifact
-            if preprod_artifact.id in {a.id for a in all_artifacts}
-            else all_artifacts[0]
+            if preprod_artifact.id in {a.id for a in evaluation.evaluated_artifacts}
+            else evaluation.evaluated_artifacts[0]
         )
         target_url = get_preprod_artifact_url(url_artifact)
-        completed_at = None
 
-        # Check if any artifact hit quota limits - show neutral status with quota message
-        if _has_no_quota_artifact(all_artifacts, size_metrics_map):
-            title, subtitle, summary = format_no_quota_messages()
-            status = StatusCheckStatus.NEUTRAL
-            completed_at = preprod_artifact.date_updated
-            triggered_rules = []
-        else:
-            rules = get_status_check_rules(preprod_artifact.project)
-            base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(all_artifacts)
-
-            status, triggered_rules = _compute_overall_status(
-                all_artifacts,
-                size_metrics_map,
-                rules=rules,
-                base_artifact_map=base_artifact_map,
-                base_metrics_by_artifact=base_size_metrics_map,
-                approvals_map=approvals_map,
-            )
-
-            title, subtitle, summary = format_status_check_messages(
-                all_artifacts,
-                size_metrics_map,
-                status,
-                preprod_artifact.project,
-                base_artifact_map,
-                base_size_metrics_map,
-                triggered_rules,
-            )
-
-            if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
-                completed_at = preprod_artifact.date_updated
-
-            # When no rules are configured, always show neutral status.
-            # When rules exist, show actual status (in_progress, failure, success).
-            if not rules:
-                status = StatusCheckStatus.NEUTRAL
-                completed_at = preprod_artifact.date_updated
+    # NEUTRAL (all-skipped, no-quota, no-rules) and terminal states map to a
+    # COMPLETED GitHub check, so completed_at is derived from the final status.
+    completed_at = (
+        preprod_artifact.date_updated
+        if GITHUB_STATUS_CHECK_STATUS_MAPPING[evaluation.status] == GitHubCheckStatus.COMPLETED
+        else None
+    )
 
     try:
         check_id = provider.create_status_check(
             repo=commit_comparison.head_repo_name,
             sha=commit_comparison.head_sha,
-            status=status,
-            title=title,
-            subtitle=subtitle,
+            status=evaluation.status,
+            title=evaluation.title,
+            subtitle=evaluation.subtitle,
             text=None,  # TODO(telkins): add text field support
-            summary=summary,
+            summary=evaluation.summary,
             external_id=str(preprod_artifact.id),
             target_url=target_url,
             started_at=preprod_artifact.date_added,
             completed_at=completed_at,
-            approve_action_identifier=APPROVE_SIZE_ACTION_IDENTIFIER if triggered_rules else None,
+            approve_action_identifier=(
+                APPROVE_SIZE_ACTION_IDENTIFIER if evaluation.triggered_rules else None
+            ),
         )
     except Exception as e:
         extra: dict[str, Any] = {
@@ -326,7 +367,7 @@ def create_preprod_status_check_task(
 
     update_posted_status_check(preprod_artifact, check_type="size", success=True, check_id=check_id)
 
-    if triggered_rules:
+    if evaluation.triggered_rules:
         sentry_analytics.record(
             PreprodStatusCheckTriggeredRulePostedEvent(
                 organization_id=preprod_artifact.project.organization_id,
@@ -340,7 +381,7 @@ def create_preprod_status_check_task(
         "preprod.status_checks.create.success",
         extra={
             "preprod_artifact_id": preprod_artifact.id,
-            "status": status.value,
+            "status": evaluation.status.value,
             "check_id": check_id,
             "organization_id": preprod_artifact.project.organization_id,
             "organization_slug": preprod_artifact.project.organization.slug,

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -156,31 +156,43 @@ def evaluate_size_and_format_messages(
 
     # Filter out artifacts not in the size analysis pipeline (e.g., snapshot-only artifacts).
     # Symmetric with snapshots/tasks.py which filters to snapshot-only artifacts.
-    all_artifacts = [a for a in all_artifacts if a.id in size_metrics_map]
+    evaluated_artifacts = [a for a in all_artifacts if a.id in size_metrics_map]
 
     # Filter out SKIPPED artifacts (user didn't request size analysis)
-    all_artifacts = [
-        a for a in all_artifacts if not _is_artifact_size_skipped(size_metrics_map.get(a.id, []))
+    evaluated_artifacts = [
+        a
+        for a in evaluated_artifacts
+        if not _is_artifact_size_skipped(size_metrics_map.get(a.id, []))
     ]
 
     triggered_rules: list[TriggeredRule] = []
-    if not all_artifacts:
+    if not evaluated_artifacts:
         title, subtitle, summary = format_all_skipped_messages(project)
         return SizeEvaluation(
-            StatusCheckStatus.NEUTRAL, triggered_rules, title, subtitle, summary, all_artifacts
+            StatusCheckStatus.NEUTRAL,
+            triggered_rules,
+            title,
+            subtitle,
+            summary,
+            evaluated_artifacts,
         )
 
     # Check if any artifact hit quota limits - show neutral status with quota message
-    if _has_no_quota_artifact(all_artifacts, size_metrics_map):
+    if _has_no_quota_artifact(evaluated_artifacts, size_metrics_map):
         title, subtitle, summary = format_no_quota_messages()
         return SizeEvaluation(
-            StatusCheckStatus.NEUTRAL, triggered_rules, title, subtitle, summary, all_artifacts
+            StatusCheckStatus.NEUTRAL,
+            triggered_rules,
+            title,
+            subtitle,
+            summary,
+            evaluated_artifacts,
         )
 
-    base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(all_artifacts)
+    base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(evaluated_artifacts)
 
     status, triggered_rules = _compute_overall_status(
-        all_artifacts,
+        evaluated_artifacts,
         size_metrics_map,
         rules=rules,
         base_artifact_map=base_artifact_map,
@@ -189,7 +201,7 @@ def evaluate_size_and_format_messages(
     )
 
     title, subtitle, summary = format_status_check_messages(
-        all_artifacts,
+        evaluated_artifacts,
         size_metrics_map,
         status,
         project,
@@ -203,7 +215,7 @@ def evaluate_size_and_format_messages(
     if not rules:
         status = StatusCheckStatus.NEUTRAL
 
-    return SizeEvaluation(status, triggered_rules, title, subtitle, summary, all_artifacts)
+    return SizeEvaluation(status, triggered_rules, title, subtitle, summary, evaluated_artifacts)
 
 
 @instrumented_task(


### PR DESCRIPTION
Extracts size-rule evaluation and message formatting out of `create_preprod_status_check_task` into a standalone `evaluate_size_and_format_messages()`, which returns a `SizeEvaluation` NamedTuple: status, triggered rules, the `(title, subtitle, summary)` strings, and the artifacts actually evaluated after skip/no-metric filtering. `get_status_check_rules()` also gains an `option_key` argument so a caller can load rules from a different project option.

Behavior is unchanged — the status-check task now calls the extracted function and produces the same status, messages, and analytics it did before (covered by the existing status-check task tests). The extraction exists so the size PR comment task stacked on top (#119422) can reuse the exact same evaluation and rendering, so the comment and the status check can never drift.

Refs EME-938