### PR TITLE
chore(control): Remove last/test-only reader of ExternalActorReplica

### DIFF
--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -7,9 +7,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, TypeGuard
 
 from django.db.models import Subquery
 
-from sentry.hybridcloud.models.externalactorreplica import ExternalActorReplica
 from sentry.integrations.types import ExternalProviderEnum
-from sentry.integrations.utils.providers import PERSONAL_NOTIFICATION_PROVIDERS_AS_INT
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.notifications.defaults import (
@@ -130,21 +128,6 @@ def recipient_is_team(recipient: Actor | Team | RpcUser | User) -> TypeGuard[Act
     if isinstance(recipient, Actor) and recipient.is_team:
         return True
     return isinstance(recipient, Team)
-
-
-def team_is_valid_recipient(team: Team | Actor) -> bool:
-    """
-    A team is a valid recipient if it has a linked integration (ie. linked Slack channel)
-    for any one of the providers allowed for personal notifications.
-    """
-
-    linked_integration = ExternalActorReplica.objects.filter(
-        team_id=team.id,
-        provider__in=PERSONAL_NOTIFICATION_PROVIDERS_AS_INT,
-    )
-    if linked_integration:
-        return True
-    return False
 
 
 def get_team_members(team: Team | Actor) -> list[Actor]:

--- a/tests/sentry/notifications/test_helpers.py
+++ b/tests/sentry/notifications/test_helpers.py
@@ -1,13 +1,11 @@
 from urllib.parse import parse_qs, urlparse
 
-from sentry.integrations.models.external_actor import ExternalActor
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.models.rule import Rule
 from sentry.notifications.helpers import (
     collect_groups_by_project,
     get_subscription_from_attributes,
     get_team_members,
-    team_is_valid_recipient,
     validate,
 )
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
@@ -145,32 +143,3 @@ class NotificationHelpersTest(TestCase):
             assert get_team_members(team1) == [Actor.from_object(user1)]
             assert get_team_members(team2) == [Actor.from_object(user2)]
             assert get_team_members(team3) == []
-
-    def test_team_is_valid_recipient(self) -> None:
-        team1 = self.create_team(organization=self.organization)
-        team2 = self.create_team(organization=self.organization)
-        team3 = self.create_team(organization=self.organization)
-        integration1 = self.create_integration(
-            organization=self.organization, provider="Slack", external_id="slack-id"
-        )
-        integration2 = self.create_integration(
-            organization=self.organization, provider="Jira", external_id="jira-id"
-        )
-        ExternalActor.objects.create(
-            team_id=team1.id,
-            organization=self.organization,
-            integration_id=integration1.id,
-            external_name="valid_integration",
-            provider=110,
-        )
-        ExternalActor.objects.create(
-            team_id=team2.id,
-            organization=self.organization,
-            integration_id=integration2.id,
-            external_name="invalid_integration",
-            provider=0,
-        )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            assert team_is_valid_recipient(team1)
-            assert not team_is_valid_recipient(team2)
-            assert not team_is_valid_recipient(team3)


### PR DESCRIPTION
Control-replicated table only has a single reader in a test. Dead code removal prior to ripping the table itself out (first of 3 PRs)
