### PR TITLE
feat(trace-items): Add endpoint to create/update metric context

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -3,10 +3,14 @@ from typing import Never
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
-    TraceItemAttributeValuesRequest,
-)
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceItemTableRequest
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType as ProtoTraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeAggregation,
+    AttributeValue,
+    Function,
+)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -36,38 +40,71 @@ from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.utils import snuba_rpc
 
 # Metrics are trace items keyed by the value of the `metric.name` attribute, so
-# metric context is stored as context for that attribute value.
+# metric context is stored as context for that attribute value. A metric name
+# can carry more than one type (e.g. both a counter and a gauge named "foo").
 METRIC_NAME_ALIAS = "metric.name"
+METRIC_TYPE_ALIAS = "metric.type"
+
+_TYPE_COLUMN_LABEL = "metric.type"
 
 
 class OrganizationTraceItemMetricContextPutSerializer(serializers.Serializer[Never]):
-    metricType = serializers.ChoiceField(ALLOWED_METRIC_TYPES, source="metric_type")
+    # Optional: when omitted we infer the type from storage, and only require it
+    # when the metric name is ambiguous (stored under more than one type).
+    metricType = serializers.ChoiceField(ALLOWED_METRIC_TYPES, source="metric_type", required=False)
     brief = serializers.CharField(max_length=280)
     additionalContext = serializers.CharField(
         source="additional_context", required=False, allow_null=True, allow_blank=True
     )
 
 
-def metric_name_exists_in_storage(resolver: SearchResolver, metric_name: str) -> bool:
-    """Whether a trace metric with the given name exists in storage for the resolver's params."""
-    resolved_attribute, _ = resolver.resolve_attribute(METRIC_NAME_ALIAS)
+def get_metric_types_in_storage(resolver: SearchResolver, metric_name: str) -> list[str]:
+    """
+    The distinct metric types stored under ``metric_name`` for the resolver's
+    params. An empty list means the metric name was never seen.
+    """
+    name_attribute, _ = resolver.resolve_attribute(METRIC_NAME_ALIAS)
+    type_attribute, _ = resolver.resolve_attribute(METRIC_TYPE_ALIAS)
+    type_key = type_attribute.proto_definition
+
     meta = resolver.resolve_meta(
         referrer=resolve_attribute_values_referrer(SupportedTraceItemType.TRACEMETRICS.value).value
     )
     meta.trace_item_type = ProtoTraceItemType.TRACE_ITEM_TYPE_METRIC
 
-    # The values RPC only substring-matches, so pass the name to narrow the page
-    # then check for an exact hit — a shared prefix can't cause a false positive.
-    rpc_request = TraceItemAttributeValuesRequest(
+    # Exact-match on the name (no substring), grouped by type — this both proves
+    # the metric exists and enumerates its types in a single query.
+    rpc_request = TraceItemTableRequest(
         meta=meta,
-        key=resolved_attribute.proto_definition,
-        value_substring_match=metric_name,
-        limit=10000,
+        filter=TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=name_attribute.proto_definition,
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str=metric_name),
+            )
+        ),
+        columns=[
+            Column(label=_TYPE_COLUMN_LABEL, key=type_key),
+            Column(
+                label="count",
+                aggregation=AttributeAggregation(
+                    aggregate=Function.FUNCTION_COUNT, key=type_key, label="count"
+                ),
+            ),
+        ],
+        group_by=[type_key],
+        limit=len(ALLOWED_METRIC_TYPES) + 1,
     )
     with handle_query_errors():
-        rpc_response = snuba_rpc.attribute_values_rpc(rpc_request)
+        responses = snuba_rpc.table_rpc([rpc_request])
 
-    return metric_name in rpc_response.values
+    column_values = responses[0].column_values
+    type_column = next(
+        (cv for cv in column_values if cv.attribute_name == _TYPE_COLUMN_LABEL), None
+    )
+    if type_column is None:
+        return []
+    return [value.val_str for value in type_column.results if value.val_str]
 
 
 @cell_silo_endpoint
@@ -92,8 +129,6 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         data = serializer.validated_data
-
-        metric_type = data["metric_type"]
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -127,10 +162,27 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
             definitions=get_column_definitions(SupportedTraceItemType.TRACEMETRICS),
         )
 
-        # Confirm the metric has actually been seen in storage before authoring context.
-        if not metric_name_exists_in_storage(resolver, metric):
+        # Confirm the metric exists and resolve which type this context is for.
+        stored_types = get_metric_types_in_storage(resolver, metric)
+        if not stored_types:
+            return Response({"detail": f"Metric `{metric}` was not found."}, status=400)
+
+        requested_type = data.get("metric_type")
+        if requested_type is not None:
+            if requested_type not in stored_types:
+                return Response(
+                    {"detail": f"Metric `{metric}` was not found for type `{requested_type}`."},
+                    status=400,
+                )
+            metric_type = requested_type
+        elif len(stored_types) == 1:
+            metric_type = stored_types[0]
+        else:
             return Response(
-                {"detail": f"Metric `{metric}` was not found."},
+                {
+                    "detail": f"Metric `{metric}` has multiple types "
+                    f"({', '.join(sorted(stored_types))}); pass `metricType` to specify which."
+                },
                 status=400,
             )
 

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -49,8 +49,10 @@ class OrganizationTraceItemMetricContextPutSerializer(serializers.Serializer[Nev
 
 def get_metric_types_in_storage(snuba_params: SnubaParams, metric_name: str) -> list[str]:
     """
-    The distinct metric types stored under ``metric_name`` for the given params.
-    An empty list means the metric name was never seen.
+    The distinct known metric types stored under ``metric_name`` for the given
+    params. An empty list means the metric name was never seen. Stored types
+    outside the known set are ignored so an unexpected value can't later resolve
+    to a null ``attribute_type``.
     """
     # Exact-match the name and group by type via count(); the distinct
     # `metric.type` rows both prove the metric exists and enumerate its types.
@@ -69,7 +71,11 @@ def get_metric_types_in_storage(snuba_params: SnubaParams, metric_name: str) -> 
             config=SearchResolverConfig(),
         )
 
-    return [row[METRIC_TYPE_ALIAS] for row in results["data"] if row.get(METRIC_TYPE_ALIAS)]
+    return [
+        row[METRIC_TYPE_ALIAS]
+        for row in results["data"]
+        if row.get(METRIC_TYPE_ALIAS) in ALLOWED_METRIC_TYPES
+    ]
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -101,8 +101,6 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
             return Response(serializer.errors, status=400)
         data = serializer.validated_data
 
-        # No caller time range is expected; existence is checked over the default
-        # window (up to the 90-day retention max) that get_snuba_params falls back to.
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -1,0 +1,167 @@
+from typing import Never
+
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
+    TraceItemAttributeValuesRequest,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType as ProtoTraceItemType
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases import NoProjects
+from sentry.api.endpoints.organization_trace_item_attributes import (
+    OrganizationTraceItemAttributesEndpointBase,
+    adjust_start_end_window,
+    get_column_definitions,
+    resolve_attribute_values_referrer,
+)
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.trace_item_attribute_value_context import (
+    TraceItemAttributeValueContextSerializer,
+)
+from sentry.api.utils import handle_query_errors
+from sentry.explore.models import (
+    TraceItemAttributeValueContext,
+    TraceItemTypes,
+    TraceMetricTypes,
+)
+from sentry.models.organization import Organization
+from sentry.search.eap.resolver import SearchResolver
+from sentry.search.eap.trace_metrics.config import ALLOWED_METRIC_TYPES
+from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
+from sentry.utils import snuba_rpc
+
+# Metrics are trace items keyed by the value of the `metric.name` attribute, so
+# metric context is stored as context for that attribute value.
+METRIC_NAME_ALIAS = "metric.name"
+
+
+class OrganizationTraceItemMetricContextPutSerializer(serializers.Serializer[Never]):
+    metricType = serializers.ChoiceField(ALLOWED_METRIC_TYPES, source="metric_type")
+    brief = serializers.CharField(max_length=280)
+    additionalContext = serializers.CharField(
+        source="additional_context", required=False, allow_null=True, allow_blank=True
+    )
+
+
+def metric_name_exists_in_storage(resolver: SearchResolver, metric_name: str) -> bool:
+    """Whether a trace metric with the given name exists in storage for the resolver's params."""
+    resolved_attribute, _ = resolver.resolve_attribute(METRIC_NAME_ALIAS)
+    meta = resolver.resolve_meta(
+        referrer=resolve_attribute_values_referrer(SupportedTraceItemType.TRACEMETRICS.value).value
+    )
+    meta.trace_item_type = ProtoTraceItemType.TRACE_ITEM_TYPE_METRIC
+
+    # The values RPC only substring-matches, so pass the name to narrow the page
+    # then check for an exact hit — a shared prefix can't cause a false positive.
+    rpc_request = TraceItemAttributeValuesRequest(
+        meta=meta,
+        key=resolved_attribute.proto_definition,
+        value_substring_match=metric_name,
+        limit=10000,
+    )
+    with handle_query_errors():
+        rpc_response = snuba_rpc.attribute_values_rpc(rpc_request)
+
+    return metric_name in rpc_response.values
+
+
+@cell_silo_endpoint
+class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributesEndpointBase):
+    publish_status = {
+        "PUT": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.DATA_BROWSING
+
+    def put(self, request: Request, organization: Organization, metric: str) -> Response:
+        """Create or update the authored context for a trace metric."""
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
+        # Custom context is gated; sentry conventions context is served separately.
+        if not features.has(
+            "organizations:data-browsing-attribute-context", organization, actor=request.user
+        ):
+            return Response(status=404)
+
+        serializer = OrganizationTraceItemMetricContextPutSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        data = serializer.validated_data
+
+        metric_type = data["metric_type"]
+
+        try:
+            snuba_params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response({"detail": "No projects available."}, status=400)
+
+        # Scope to a single project, or org-wide for the all-projects sentinel
+        # (`-1`/`$all`); no subset in between.
+        if self.get_requested_project_params_unchecked(request).has_all_projects_sentinel:
+            scope_project = None
+        elif len(snuba_params.projects) == 1:
+            scope_project = snuba_params.projects[0]
+        else:
+            return Response(
+                {
+                    "detail": "Pass a single `project`, or all projects "
+                    "(`-1`/`$all`) for organization-wide context."
+                },
+                status=400,
+            )
+
+        adjusted_start, adjusted_end = adjust_start_end_window(
+            snuba_params.start_date, snuba_params.end_date
+        )
+        snuba_params.start = adjusted_start
+        snuba_params.end = adjusted_end
+
+        resolver = SearchResolver(
+            params=snuba_params,
+            config=SearchResolverConfig(),
+            definitions=get_column_definitions(SupportedTraceItemType.TRACEMETRICS),
+        )
+
+        # Confirm the metric has actually been seen in storage before authoring context.
+        if not metric_name_exists_in_storage(resolver, metric):
+            return Response(
+                {"detail": f"Metric `{metric}` was not found."},
+                status=400,
+            )
+
+        # Only persist optional fields that were provided, so a partial update
+        # doesn't clear previously stored context.
+        optional_fields = {field: data[field] for field in ("additional_context",) if field in data}
+        defaults = {
+            "brief": data["brief"],
+            "updated_by_id": request.user.id,
+            **optional_fields,
+        }
+        # Race-safe: the lookup kwargs match the unique constraints, so a losing
+        # concurrent INSERT is caught by update_or_create rather than 500ing.
+        context, created = TraceItemAttributeValueContext.objects.update_or_create(
+            organization=organization,
+            project=scope_project,
+            item_type=TraceItemTypes.get_id_for_type_name(
+                SupportedTraceItemType.TRACEMETRICS.value
+            ),
+            attribute_name=METRIC_NAME_ALIAS,
+            attribute_value=metric,
+            attribute_type=TraceMetricTypes.get_id_for_type_name(metric_type),
+            defaults=defaults,
+            create_defaults={
+                "additional_context": None,
+                **defaults,
+                "created_by_id": request.user.id,
+            },
+        )
+
+        return Response(
+            serialize(context, request.user, TraceItemAttributeValueContextSerializer()),
+            status=201 if created else 200,
+        )

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -3,14 +3,6 @@ from typing import Never
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import Column, TraceItemTableRequest
-from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType as ProtoTraceItemType
-from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
-    AttributeAggregation,
-    AttributeValue,
-    Function,
-)
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
@@ -20,7 +12,6 @@ from sentry.api.bases import NoProjects
 from sentry.api.endpoints.organization_trace_item_attributes import (
     OrganizationTraceItemAttributesEndpointBase,
     adjust_start_end_window,
-    get_column_definitions,
     resolve_attribute_values_referrer,
 )
 from sentry.api.serializers import serialize
@@ -34,18 +25,16 @@ from sentry.explore.models import (
     TraceMetricTypes,
 )
 from sentry.models.organization import Organization
-from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.trace_metrics.config import ALLOWED_METRIC_TYPES
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
-from sentry.utils import snuba_rpc
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.trace_metrics import TraceMetrics
 
 # Metrics are trace items keyed by the value of the `metric.name` attribute, so
 # metric context is stored as context for that attribute value. A metric name
 # can carry more than one type (e.g. both a counter and a gauge named "foo").
 METRIC_NAME_ALIAS = "metric.name"
 METRIC_TYPE_ALIAS = "metric.type"
-
-_TYPE_COLUMN_LABEL = "metric.type"
 
 
 class OrganizationTraceItemMetricContextPutSerializer(serializers.Serializer[Never]):
@@ -58,53 +47,29 @@ class OrganizationTraceItemMetricContextPutSerializer(serializers.Serializer[Nev
     )
 
 
-def get_metric_types_in_storage(resolver: SearchResolver, metric_name: str) -> list[str]:
+def get_metric_types_in_storage(snuba_params: SnubaParams, metric_name: str) -> list[str]:
     """
-    The distinct metric types stored under ``metric_name`` for the resolver's
-    params. An empty list means the metric name was never seen.
+    The distinct metric types stored under ``metric_name`` for the given params.
+    An empty list means the metric name was never seen.
     """
-    name_attribute, _ = resolver.resolve_attribute(METRIC_NAME_ALIAS)
-    type_attribute, _ = resolver.resolve_attribute(METRIC_TYPE_ALIAS)
-    type_key = type_attribute.proto_definition
-
-    meta = resolver.resolve_meta(
-        referrer=resolve_attribute_values_referrer(SupportedTraceItemType.TRACEMETRICS.value).value
-    )
-    meta.trace_item_type = ProtoTraceItemType.TRACE_ITEM_TYPE_METRIC
-
-    # Exact-match on the name (no substring), grouped by type — this both proves
-    # the metric exists and enumerates its types in a single query.
-    rpc_request = TraceItemTableRequest(
-        meta=meta,
-        filter=TraceItemFilter(
-            comparison_filter=ComparisonFilter(
-                key=name_attribute.proto_definition,
-                op=ComparisonFilter.OP_EQUALS,
-                value=AttributeValue(val_str=metric_name),
-            )
-        ),
-        columns=[
-            Column(label=_TYPE_COLUMN_LABEL, key=type_key),
-            Column(
-                label="count",
-                aggregation=AttributeAggregation(
-                    aggregate=Function.FUNCTION_COUNT, key=type_key, label="count"
-                ),
-            ),
-        ],
-        group_by=[type_key],
-        limit=len(ALLOWED_METRIC_TYPES) + 1,
-    )
+    # Exact-match the name and group by type via count(); the distinct
+    # `metric.type` rows both prove the metric exists and enumerate its types.
+    escaped_name = metric_name.replace("\\", "\\\\").replace('"', '\\"')
     with handle_query_errors():
-        responses = snuba_rpc.table_rpc([rpc_request])
+        results = TraceMetrics.run_table_query(
+            params=snuba_params,
+            query_string=f'{METRIC_NAME_ALIAS}:"{escaped_name}"',
+            selected_columns=[METRIC_TYPE_ALIAS, "count(value)"],
+            orderby=None,
+            offset=0,
+            limit=len(ALLOWED_METRIC_TYPES) + 1,
+            referrer=resolve_attribute_values_referrer(
+                SupportedTraceItemType.TRACEMETRICS.value
+            ).value,
+            config=SearchResolverConfig(),
+        )
 
-    column_values = responses[0].column_values
-    type_column = next(
-        (cv for cv in column_values if cv.attribute_name == _TYPE_COLUMN_LABEL), None
-    )
-    if type_column is None:
-        return []
-    return [value.val_str for value in type_column.results if value.val_str]
+    return [row[METRIC_TYPE_ALIAS] for row in results["data"] if row.get(METRIC_TYPE_ALIAS)]
 
 
 @cell_silo_endpoint
@@ -156,14 +121,8 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         snuba_params.start = adjusted_start
         snuba_params.end = adjusted_end
 
-        resolver = SearchResolver(
-            params=snuba_params,
-            config=SearchResolverConfig(),
-            definitions=get_column_definitions(SupportedTraceItemType.TRACEMETRICS),
-        )
-
         # Confirm the metric exists and resolve which type this context is for.
-        stored_types = get_metric_types_in_storage(resolver, metric)
+        stored_types = get_metric_types_in_storage(snuba_params, metric)
         if not stored_types:
             return Response({"detail": f"Metric `{metric}` was not found."}, status=400)
 

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -101,6 +101,8 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
             return Response(serializer.errors, status=400)
         data = serializer.validated_data
 
+        # No caller time range is expected; existence is checked over the default
+        # window (up to the 90-day retention max) that get_snuba_params falls back to.
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:

--- a/src/sentry/api/serializers/models/trace_item_attribute_value_context.py
+++ b/src/sentry/api/serializers/models/trace_item_attribute_value_context.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import Any, TypedDict
+
+from sentry.api.serializers import Serializer, register
+from sentry.explore.models import (
+    TraceItemAttributeValueContext,
+    TraceItemTypes,
+    TraceMetricTypes,
+)
+
+
+class TraceItemAttributeValueContextResponse(TypedDict):
+    id: str
+    attributeName: str
+    attributeValue: str
+    dataset: str | None
+    attributeType: str | None
+    project: str | None
+    brief: str | None
+    additionalContext: str | None
+    dateCreated: datetime
+    dateUpdated: datetime
+
+
+@register(TraceItemAttributeValueContext)
+class TraceItemAttributeValueContextSerializer(Serializer):
+    def serialize(
+        self, obj: TraceItemAttributeValueContext, attrs: Any, user: Any, **kwargs: Any
+    ) -> TraceItemAttributeValueContextResponse:
+        return {
+            "id": str(obj.id),
+            "attributeName": obj.attribute_name,
+            "attributeValue": obj.attribute_value,
+            "dataset": TraceItemTypes.get_type_name(obj.item_type),
+            "attributeType": TraceMetricTypes.get_type_name(obj.attribute_type),
+            "project": str(obj.project_id) if obj.project_id else None,
+            "brief": obj.brief,
+            "additionalContext": obj.additional_context,
+            "dateCreated": obj.date_added,
+            "dateUpdated": obj.date_updated,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -52,6 +52,9 @@ from sentry.api.endpoints.organization_trace_item_attributes import (
 from sentry.api.endpoints.organization_trace_item_attributes_ranked import (
     OrganizationTraceItemsAttributesRankedEndpoint,
 )
+from sentry.api.endpoints.organization_trace_item_metric_context import (
+    OrganizationTraceItemMetricContextEndpoint,
+)
 from sentry.api.endpoints.organization_trace_item_stats import OrganizationTraceItemsStatsEndpoint
 from sentry.api.endpoints.organization_unsubscribe import (
     OrganizationUnsubscribeIssue,
@@ -1740,6 +1743,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/(?P<key>[^/]+)/context/$",
         OrganizationTraceItemAttributeContextEndpoint.as_view(),
         name="sentry-api-0-organization-trace-item-attribute-context",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/trace-items/metrics/(?P<metric>[^/]+)/context/$",
+        OrganizationTraceItemMetricContextEndpoint.as_view(),
+        name="sentry-api-0-organization-trace-item-metric-context",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/trace-items/attributes/(?P<key>[^/]+)/values/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -378,6 +378,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/'
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/ranked/'
   | '/organizations/$organizationIdOrSlug/trace-items/attributes/validate/'
+  | '/organizations/$organizationIdOrSlug/trace-items/metrics/$metric/context/'
   | '/organizations/$organizationIdOrSlug/trace-items/stats/'
   | '/organizations/$organizationIdOrSlug/trace-logs/'
   | '/organizations/$organizationIdOrSlug/trace-meta/$traceId/'

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -133,9 +133,10 @@ class OrganizationTraceItemMetricContextEndpointTest(
         assert response.status_code == 400, response.data
         assert "brief" in response.data
 
-    def test_requires_metric_type(self) -> None:
-        self.store_metric("checkout.requests")
+    def test_infers_type_when_single(self) -> None:
+        self.store_metric("checkout.requests", "counter")
 
+        # metricType is optional: with a single stored type it is inferred.
         response = self.do_request(
             "checkout.requests",
             {
@@ -143,8 +144,56 @@ class OrganizationTraceItemMetricContextEndpointTest(
             },
         )
 
+        assert response.status_code == 201, response.data
+        assert response.data["attributeType"] == "counter"
+
+    def test_requires_type_when_multiple(self) -> None:
+        self.store_eap_items(
+            [
+                self.create_trace_metric(
+                    "checkout.requests", 1, "counter", timestamp=before_now(minutes=10)
+                ),
+                self.create_trace_metric(
+                    "checkout.requests", 1, "gauge", timestamp=before_now(minutes=10)
+                ),
+            ]
+        )
+
+        # Ambiguous: the name exists under two types, so metricType is required.
+        ambiguous = self.do_request(
+            "checkout.requests",
+            {
+                "brief": "Checkout requests",
+            },
+        )
+        assert ambiguous.status_code == 400, ambiguous.data
+        assert "multiple types" in ambiguous.data["detail"]
+
+        # Passing the type disambiguates.
+        resolved = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "gauge",
+                "brief": "Checkout requests",
+            },
+        )
+        assert resolved.status_code == 201, resolved.data
+        assert resolved.data["attributeType"] == "gauge"
+
+    def test_rejects_type_not_in_storage(self) -> None:
+        self.store_metric("checkout.requests", "counter")
+
+        # The name exists, but not under the requested type.
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "gauge",
+                "brief": "Checkout requests",
+            },
+        )
+
         assert response.status_code == 400, response.data
-        assert "metricType" in response.data
+        assert "not found" in response.data["detail"]
 
     def test_rejects_invalid_metric_type(self) -> None:
         self.store_metric("checkout.requests")
@@ -224,12 +273,8 @@ class OrganizationTraceItemMetricContextEndpointTest(
         assert response.status_code == 404
 
     def test_invalid_payload(self) -> None:
-        response = self.do_request(
-            "checkout.requests",
-            {
-                "brief": "Checkout requests",
-            },
-        )
+        # `brief` is required, so an empty body is rejected.
+        response = self.do_request("checkout.requests", {})
 
         assert response.status_code == 400, response.data
-        assert "metricType" in response.data
+        assert "brief" in response.data

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -5,6 +5,7 @@ from sentry.explore.models import (
     TraceItemTypes,
     TraceMetricTypes,
 )
+from sentry.search.eap.trace_metrics.types import TraceMetricType
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TraceMetricsTestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -24,7 +25,7 @@ class OrganizationTraceItemMetricContextEndpointTest(
         super().setUp()
         self.login_as(user=self.user)
 
-    def store_metric(self, metric_name: str, metric_type: str = "counter") -> None:
+    def store_metric(self, metric_name: str, metric_type: TraceMetricType = "counter") -> None:
         self.store_eap_items(
             [
                 self.create_trace_metric(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -41,7 +41,7 @@ class OrganizationTraceItemMetricContextEndpointTest(
         if features is None:
             features = self.feature_flags
         if query is None:
-            query = {"project": self.project.id, "statsPeriod": "7d"}
+            query = {"project": self.project.id}
         url = reverse(
             self.viewname,
             kwargs={"organization_id_or_slug": self.organization.slug, "metric": metric},
@@ -219,7 +219,7 @@ class OrganizationTraceItemMetricContextEndpointTest(
                 "metricType": "counter",
                 "brief": "Checkout requests",
             },
-            query={"project": -1, "statsPeriod": "7d"},
+            query={"project": -1},
         )
 
         assert response.status_code == 201, response.data
@@ -237,7 +237,7 @@ class OrganizationTraceItemMetricContextEndpointTest(
                 "metricType": "counter",
                 "brief": "Checkout requests",
             },
-            query={"project": "$all", "statsPeriod": "7d"},
+            query={"project": "$all"},
         )
 
         assert response.status_code == 201, response.data

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -1,0 +1,235 @@
+from django.urls import reverse
+
+from sentry.explore.models import (
+    TraceItemAttributeValueContext,
+    TraceItemTypes,
+    TraceMetricTypes,
+)
+from sentry.testutils.cases import APITestCase, SnubaTestCase, TraceMetricsTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class OrganizationTraceItemMetricContextEndpointTest(
+    APITestCase, TraceMetricsTestCase, SnubaTestCase
+):
+    viewname = "sentry-api-0-organization-trace-item-metric-context"
+
+    feature_flags = {
+        "organizations:visibility-explore-view": True,
+        "organizations:tracemetrics-enabled": True,
+        "organizations:data-browsing-attribute-context": True,
+    }
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def store_metric(self, metric_name: str, metric_type: str = "counter") -> None:
+        self.store_eap_items(
+            [
+                self.create_trace_metric(
+                    metric_name,
+                    1,
+                    metric_type,
+                    timestamp=before_now(minutes=10),
+                )
+            ]
+        )
+
+    def do_request(self, metric, data, query=None, features=None):
+        if features is None:
+            features = self.feature_flags
+        if query is None:
+            query = {"project": self.project.id, "statsPeriod": "7d"}
+        url = reverse(
+            self.viewname,
+            kwargs={"organization_id_or_slug": self.organization.slug, "metric": metric},
+        )
+        with self.feature(features):
+            return self.client.put(
+                url,
+                data,
+                format="json",
+                QUERY_STRING="&".join(f"{name}={value}" for name, value in query.items()),
+            )
+
+    def test_creates_context(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+                "additionalContext": "Longer notes about the metric.",
+            },
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["attributeName"] == "metric.name"
+        assert response.data["attributeValue"] == "checkout.requests"
+        assert response.data["dataset"] == "tracemetrics"
+        assert response.data["attributeType"] == "counter"
+        assert response.data["project"] == str(self.project.id)
+        assert response.data["brief"] == "Checkout requests"
+        assert response.data["additionalContext"] == "Longer notes about the metric."
+
+        context = TraceItemAttributeValueContext.objects.get(
+            organization=self.organization,
+            project=self.project,
+            attribute_value="checkout.requests",
+        )
+        assert context.attribute_name == "metric.name"
+        assert context.brief == "Checkout requests"
+        assert context.additional_context == "Longer notes about the metric."
+        assert context.item_type == TraceItemTypes.get_id_for_type_name("tracemetrics")
+        assert context.attribute_type == TraceMetricTypes.get_id_for_type_name("counter")
+        assert context.created_by_id == self.user.id
+        assert context.updated_by_id == self.user.id
+
+    def test_updates_existing_context(self) -> None:
+        self.store_metric("checkout.requests")
+
+        first = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "First",
+                "additionalContext": "Longer notes about the metric.",
+            },
+        )
+        assert first.status_code == 201, first.data
+
+        # A brief-only follow-up must not clear the stored optional fields.
+        second = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Second",
+            },
+        )
+        assert second.status_code == 200, second.data
+        assert second.data["id"] == first.data["id"]
+        assert second.data["brief"] == "Second"
+        assert second.data["additionalContext"] == "Longer notes about the metric."
+
+        assert (
+            TraceItemAttributeValueContext.objects.filter(
+                organization=self.organization, attribute_value="checkout.requests"
+            ).count()
+            == 1
+        )
+
+    def test_requires_brief(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert "brief" in response.data
+
+    def test_requires_metric_type(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "brief": "Checkout requests",
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert "metricType" in response.data
+
+    def test_rejects_invalid_metric_type(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "histogram",
+                "brief": "Checkout requests",
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert "metricType" in response.data
+
+    def test_org_wide_context(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+            },
+            query={"project": -1, "statsPeriod": "7d"},
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["project"] is None
+        context = TraceItemAttributeValueContext.objects.get(attribute_value="checkout.requests")
+        assert context.project_id is None
+
+    def test_org_wide_context_all_projects_sentinel(self) -> None:
+        self.store_metric("checkout.requests")
+
+        # `$all` is the other all-projects sentinel and must also scope org-wide.
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+            },
+            query={"project": "$all", "statsPeriod": "7d"},
+        )
+
+        assert response.status_code == 201, response.data
+        assert response.data["project"] is None
+        context = TraceItemAttributeValueContext.objects.get(attribute_value="checkout.requests")
+        assert context.project_id is None
+
+    def test_rejects_nonexistent_metric(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "does.not.exist",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert "not found" in response.data["detail"]
+
+    def test_requires_feature_flag(self) -> None:
+        self.store_metric("checkout.requests")
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+            },
+            features={"organizations:visibility-explore-view": True},
+        )
+
+        assert response.status_code == 404
+
+    def test_invalid_payload(self) -> None:
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "brief": "Checkout requests",
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert "metricType" in response.data

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -258,6 +258,30 @@ class OrganizationTraceItemMetricContextEndpointTest(
         assert response.status_code == 400, response.data
         assert "not found" in response.data["detail"]
 
+    def test_ignores_unknown_stored_type(self) -> None:
+        # A stored type outside counter/gauge/distribution must not resolve to a
+        # null attribute_type — the metric is treated as not found instead.
+        self.store_eap_items(
+            [
+                self.create_trace_metric(
+                    "weird.metric",
+                    1,
+                    "histogram",  # type: ignore[arg-type]
+                    timestamp=before_now(minutes=10),
+                )
+            ]
+        )
+
+        response = self.do_request(
+            "weird.metric",
+            {
+                "brief": "Weird metric",
+            },
+        )
+
+        assert response.status_code == 400, response.data
+        assert "not found" in response.data["detail"]
+
     def test_requires_feature_flag(self) -> None:
         self.store_metric("checkout.requests")
 


### PR DESCRIPTION
Adds `PUT /organizations/{org}/trace-items/metrics/{metric}/context/` to create or update the human/agent-authored context (brief, notes) for a trace **metric**, persisted to the `TraceItemAttributeValueContext` table. This is the metric counterpart to the attribute-context endpoint (#118498).

A metric is a trace item identified by the value of the `metric.name` attribute, so its context is stored as context for that attribute *value*: `attribute_name` = `metric.name`, `attribute_value` = the metric name (from the path), `attribute_type` = the metric type (counter/gauge/distribution), `item_type` = tracemetrics.

## Request

- **Path:** `{metric}` — the metric name.
- **Body:** `metricType` (counter/gauge/distribution, required), `brief` (required), optional `additionalContext`.
- **Scope (query):** a single `project` → project-scoped; the all-projects sentinel (`-1`/`$all`) → org-wide (`project=NULL`); multiple specific projects → 400.

## Behavior

- **Upsert** keyed by (org, project, item_type, attribute_name, attribute_value, attribute_type) — `201` on create, `200` on update, tracking `created_by`/`updated_by`. Race-safe via `update_or_create`. A brief-only update leaves previously stored optional fields untouched.
- **Existence check:** before writing, confirms the metric name has actually been seen in storage, via the trace-metrics attribute-values RPC on `metric.name` (exact match against returned values).
- Gated behind the `data-browsing-attribute-context` feature (else `404`).

## Notes

- Endpoint is `ApiPublishStatus.PRIVATE`, owned by `DATA_BROWSING`; responses use the new `TraceItemAttributeValueContextSerializer`.
- `knownSentryApiUrls.generated.ts` is regenerated for the new route (safe to ship with the backend change).

Backend-only. Refs BROWSE-585.