### PR TITLE
fix(issues): Show activity after workflow changes

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -62,9 +62,8 @@ import {discardIssueMutationOptions} from 'sentry/views/issueDetails/discardIssu
 import {Divider} from 'sentry/views/issueDetails/divider';
 import {GroupPriorityCommandPaletteAction} from 'sentry/views/issueDetails/groupPriority';
 import {GroupHeaderAssigneeCommandPaletteAction} from 'sentry/views/issueDetails/header/assigneeSelector';
-import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+import {groupQueryKey} from 'sentry/views/issueDetails/useGroup';
 import {useProjectReleaseVersionIsSemver} from 'sentry/views/issueDetails/useProjectReleaseVersionIsSemver';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 type UpdateData =
   | {isBookmarked: boolean; inbox?: boolean}
@@ -115,7 +114,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
-  const environments = useEnvironmentsFromUrl();
   const {mutate: discardIssue} = useMutation(discardIssueMutationOptions({navigate}));
 
   const bookmarkKey = group.isBookmarked ? 'unbookmark' : 'bookmark';
@@ -244,11 +242,10 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
           }
           onComplete?.();
           queryClient.invalidateQueries({
-            queryKey: groupApiOptions({
+            queryKey: groupQueryKey({
               organizationSlug: organization.slug,
               groupId: group.id,
-              environments,
-            }).queryKey,
+            }),
           });
         },
       }

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {Checkbox} from '@sentry/scraps/checkbox';
@@ -24,6 +25,8 @@ import {useApi} from 'sentry/utils/useApi';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {SectionDivider} from 'sentry/views/issueDetails/foldSection';
+import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 interface ShareIssueModalProps extends ModalRenderProps {
   event: Event | null;
@@ -61,6 +64,8 @@ export function ShareIssueModal({
   const groups = useLegacyStore(GroupStore);
   const group = (groups as Group[]).find(item => item.id === groupId);
   const api = useApi({persistInFlight: true});
+  const queryClient = useQueryClient();
+  const environments = useEnvironmentsFromUrl();
   const [loading, setLoading] = useState(false);
   const isPublished = group?.isPublic;
 
@@ -109,6 +114,15 @@ export function ShareIssueModal({
         },
       },
       {
+        success: () => {
+          queryClient.invalidateQueries({
+            queryKey: groupApiOptions({
+              organizationSlug: organization.slug,
+              groupId,
+              environments,
+            }).queryKey,
+          });
+        },
         error: () => {
           addErrorMessage(t('Error sharing'));
         },

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -19,14 +19,13 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getAnalyticsDataForEvent, getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {SectionDivider} from 'sentry/views/issueDetails/foldSection';
-import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 interface ShareIssueModalProps extends ModalRenderProps {
   event: Event | null;
@@ -65,7 +64,6 @@ export function ShareIssueModal({
   const group = (groups as Group[]).find(item => item.id === groupId);
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
-  const environments = useEnvironmentsFromUrl();
   const [loading, setLoading] = useState(false);
   const isPublished = group?.isPublic;
 
@@ -116,11 +114,11 @@ export function ShareIssueModal({
       {
         success: () => {
           queryClient.invalidateQueries({
-            queryKey: groupApiOptions({
-              organizationSlug: organization.slug,
-              groupId,
-              environments,
-            }).queryKey,
+            queryKey: [
+              getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+                path: {organizationIdOrSlug: organization.slug, issueId: groupId},
+              }),
+            ],
           });
         },
         error: () => {

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -19,13 +19,13 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getAnalyticsDataForEvent, getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {SectionDivider} from 'sentry/views/issueDetails/foldSection';
+import {groupQueryKey} from 'sentry/views/issueDetails/useGroup';
 
 interface ShareIssueModalProps extends ModalRenderProps {
   event: Event | null;
@@ -114,11 +114,10 @@ export function ShareIssueModal({
       {
         success: () => {
           queryClient.invalidateQueries({
-            queryKey: [
-              getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-                path: {organizationIdOrSlug: organization.slug, issueId: groupId},
-              }),
-            ],
+            queryKey: groupQueryKey({
+              organizationSlug: organization.slug,
+              groupId,
+            }),
           });
         },
         error: () => {

--- a/static/app/views/issueDetails/activitySection/useMutateActivity.tsx
+++ b/static/app/views/issueDetails/activitySection/useMutateActivity.tsx
@@ -8,7 +8,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
-import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+import {groupQueryKey} from 'sentry/views/issueDetails/useGroup';
 
 type TPayload = {note?: NoteType; noteId?: string};
 type TMethod = 'PUT' | 'POST' | 'DELETE';
@@ -40,15 +40,10 @@ interface Props {
 export function useMutateActivity({organization, group}: Props) {
   const queryClient = useQueryClient();
 
-  // The group's activity is not environment-specific, but the group query key
-  // includes the selected environment. Match every environment variant of the
-  // group query (they share the same URL, which is queryKey[0]) so switching
-  // environments doesn't read a stale cache entry missing the mutated comment.
-  const groupQueryUrl = groupApiOptions({
+  const queryKey = groupQueryKey({
     organizationSlug: organization.slug,
     groupId: group.id,
-    environments: [],
-  }).queryKey[0];
+  });
 
   const {mutateAsync} = useMutation<TData, TError, TVariables>({
     mutationFn: ([{note, noteId}, method]) => {
@@ -66,7 +61,7 @@ export function useMutateActivity({organization, group}: Props) {
     },
     onSuccess: (result, [{noteId}, method]) => {
       queryClient.setQueriesData<ApiResponse<Group>>(
-        {predicate: query => query.queryKey[0] === groupQueryUrl},
+        {queryKey},
         (prev): ApiResponse<Group> | undefined => {
           if (!prev) {
             return prev;

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -14,11 +14,10 @@ import {t} from 'sentry/locale';
 import {IssueListCacheStore} from 'sentry/stores/IssueListCacheStore';
 import {PriorityLevel, type Group} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 type GroupDetailsPriorityProps = {
   group: Group;
@@ -38,7 +37,6 @@ function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) =>
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
   const queryClient = useQueryClient();
-  const environments = useEnvironmentsFromUrl();
 
   return (nextPriority: PriorityLevel) => {
     if (nextPriority === group.priority) {
@@ -67,11 +65,14 @@ function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) =>
       {
         success: () => {
           queryClient.invalidateQueries({
-            queryKey: groupApiOptions({
-              organizationSlug: organization.slug,
-              groupId: group.id,
-              environments,
-            }).queryKey,
+            queryKey: [
+              getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+                path: {
+                  organizationIdOrSlug: organization.slug,
+                  issueId: group.id,
+                },
+              }),
+            ],
           });
           clearIndicators();
           addSuccessMessage(getPriorityUpdateSuccessMessage(nextPriority));

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -1,3 +1,5 @@
+import {useQueryClient} from '@tanstack/react-query';
+
 import {bulkUpdate} from 'sentry/actionCreators/group';
 import {
   addErrorMessage,
@@ -15,6 +17,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 type GroupDetailsPriorityProps = {
   group: Group;
@@ -33,6 +37,8 @@ const getPriorityUpdateSuccessMessage = (priority: PriorityLevel) =>
 function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) => void) {
   const api = useApi({persistInFlight: true});
   const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const environments = useEnvironmentsFromUrl();
 
   return (nextPriority: PriorityLevel) => {
     if (nextPriority === group.priority) {
@@ -60,6 +66,13 @@ function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) =>
       },
       {
         success: () => {
+          queryClient.invalidateQueries({
+            queryKey: groupApiOptions({
+              organizationSlug: organization.slug,
+              groupId: group.id,
+              environments,
+            }).queryKey,
+          });
           clearIndicators();
           addSuccessMessage(getPriorityUpdateSuccessMessage(nextPriority));
           onChange?.(nextPriority);

--- a/static/app/views/issueDetails/groupPriority.tsx
+++ b/static/app/views/issueDetails/groupPriority.tsx
@@ -14,10 +14,10 @@ import {t} from 'sentry/locale';
 import {IssueListCacheStore} from 'sentry/stores/IssueListCacheStore';
 import {PriorityLevel, type Group} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getAnalyticsDataForGroup} from 'sentry/utils/events';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {groupQueryKey} from 'sentry/views/issueDetails/useGroup';
 
 type GroupDetailsPriorityProps = {
   group: Group;
@@ -65,14 +65,10 @@ function useChangePriority(group: Group, onChange?: (priority: PriorityLevel) =>
       {
         success: () => {
           queryClient.invalidateQueries({
-            queryKey: [
-              getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-                path: {
-                  organizationIdOrSlug: organization.slug,
-                  issueId: group.id,
-                },
-              }),
-            ],
+            queryKey: groupQueryKey({
+              organizationSlug: organization.slug,
+              groupId: group.id,
+            }),
           });
           clearIndicators();
           addSuccessMessage(getPriorityUpdateSuccessMessage(nextPriority));

--- a/static/app/views/issueDetails/useAssignIssueMutation.spec.tsx
+++ b/static/app/views/issueDetails/useAssignIssueMutation.spec.tsx
@@ -1,17 +1,15 @@
-import type {ReactNode} from 'react';
-import {QueryClientProvider} from '@tanstack/react-query';
 import {ActorFixture} from 'sentry-fixture/actor';
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {GroupStore} from 'sentry/stores/groupStore';
 import {useAssignIssueMutation} from 'sentry/views/issueDetails/useAssignIssueMutation';
-import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
 describe('useAssignIssueMutation', () => {
-  const organization = {slug: 'org-slug'};
+  const organization = OrganizationFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -28,29 +26,30 @@ describe('useAssignIssueMutation', () => {
       assignedTo: null,
     },
   ])('invalidates the group query after an $name', async ({assignedTo}) => {
-    const queryClient = makeTestQueryClient();
     const group = GroupFixture({id: '1', activity: []});
     const response = {...group, assignedTo};
-    const queryKey = groupApiOptions({
-      organizationSlug: organization.slug,
-      groupId: group.id,
-      environments: [],
-    }).queryKey;
 
-    queryClient.setQueryData(queryKey, {headers: {}, json: group});
     GroupStore.add([group]);
-    MockApiClient.addMockResponse({
+    const assignRequest = MockApiClient.addMockResponse({
       method: 'PUT',
       url: `/organizations/${organization.slug}/issues/${group.id}/`,
       body: response,
     });
-
-    const {result} = renderHookWithProviders(() => useAssignIssueMutation(), {
-      organization,
-      additionalWrapper: ({children}: {children?: ReactNode}) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      ),
+    const groupRequest = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      body: group,
     });
+
+    const {result} = renderHookWithProviders(
+      () => {
+        useGroup({groupId: group.id});
+        return useAssignIssueMutation();
+      },
+      {organization}
+    );
+
+    await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(1));
 
     await act(async () => {
       await result.current.mutateAsync({
@@ -60,8 +59,8 @@ describe('useAssignIssueMutation', () => {
       });
     });
 
-    expect(queryClient.getQueryData(queryKey)?.json.assignedTo).toEqual(assignedTo);
-    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    expect(assignRequest).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(groupRequest).toHaveBeenCalledTimes(2));
     expect(GroupStore.get(group.id)?.assignedTo).toEqual(assignedTo);
   });
 });

--- a/static/app/views/issueDetails/useAssignIssueMutation.spec.tsx
+++ b/static/app/views/issueDetails/useAssignIssueMutation.spec.tsx
@@ -1,0 +1,67 @@
+import type {ReactNode} from 'react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {ActorFixture} from 'sentry-fixture/actor';
+import {GroupFixture} from 'sentry-fixture/group';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {GroupStore} from 'sentry/stores/groupStore';
+import {useAssignIssueMutation} from 'sentry/views/issueDetails/useAssignIssueMutation';
+import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+
+describe('useAssignIssueMutation', () => {
+  const organization = {slug: 'org-slug'};
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    GroupStore.reset();
+  });
+
+  it.each([
+    {
+      name: 'assignment',
+      assignedTo: ActorFixture({id: '2', type: 'user'}),
+    },
+    {
+      name: 'unassignment',
+      assignedTo: null,
+    },
+  ])('invalidates the group query after an $name', async ({assignedTo}) => {
+    const queryClient = makeTestQueryClient();
+    const group = GroupFixture({id: '1', activity: []});
+    const response = {...group, assignedTo};
+    const queryKey = groupApiOptions({
+      organizationSlug: organization.slug,
+      groupId: group.id,
+      environments: [],
+    }).queryKey;
+
+    queryClient.setQueryData(queryKey, {headers: {}, json: group});
+    GroupStore.add([group]);
+    MockApiClient.addMockResponse({
+      method: 'PUT',
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      body: response,
+    });
+
+    const {result} = renderHookWithProviders(() => useAssignIssueMutation(), {
+      organization,
+      additionalWrapper: ({children}: {children?: ReactNode}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        actor: assignedTo,
+        groupId: group.id,
+        orgSlug: organization.slug,
+      });
+    });
+
+    expect(queryClient.getQueryData(queryKey)?.json.assignedTo).toEqual(assignedTo);
+    expect(queryClient.getQueryState(queryKey)?.isInvalidated).toBe(true);
+    expect(GroupStore.get(group.id)?.assignedTo).toEqual(assignedTo);
+  });
+});

--- a/static/app/views/issueDetails/useAssignIssueMutation.spec.tsx
+++ b/static/app/views/issueDetails/useAssignIssueMutation.spec.tsx
@@ -16,6 +16,34 @@ describe('useAssignIssueMutation', () => {
     GroupStore.reset();
   });
 
+  it('assigns an issue', async () => {
+    const group = GroupFixture({id: '1'});
+    const assignee = ActorFixture({id: '2', type: 'user'});
+    const assignRequest = MockApiClient.addMockResponse({
+      method: 'PUT',
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      body: {...group, assignedTo: assignee},
+    });
+    const {result} = renderHookWithProviders(useAssignIssueMutation, {organization});
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        actor: assignee,
+        assignedBy: 'assignee_selector',
+        groupId: group.id,
+        orgSlug: organization.slug,
+      });
+    });
+
+    expect(assignRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/issues/${group.id}/`,
+      expect.objectContaining({
+        method: 'PUT',
+        data: {assignedTo: `user:${assignee.id}`, assignedBy: 'assignee_selector'},
+      })
+    );
+  });
+
   it.each([
     {
       name: 'assignment',

--- a/static/app/views/issueDetails/useAssignIssueMutation.ts
+++ b/static/app/views/issueDetails/useAssignIssueMutation.ts
@@ -16,6 +16,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {uniqueId} from 'sentry/utils/guid';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {groupQueryKey} from 'sentry/views/issueDetails/useGroup';
 
 export type AssignedBy = 'suggested_assignee' | 'assignee_selector';
 
@@ -91,14 +92,10 @@ export function useAssignIssueMutation(
       return {changeId};
     },
     onSuccess: (response, variables, onMutateResult, context) => {
-      const queryKey = [
-        getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-          path: {
-            organizationIdOrSlug: variables.orgSlug,
-            issueId: variables.groupId,
-          },
-        }),
-      ];
+      const queryKey = groupQueryKey({
+        organizationSlug: variables.orgSlug,
+        groupId: variables.groupId,
+      });
 
       // Update react query cache so that useGroup() reflects the new assignee.
       queryClient.setQueriesData<ApiResponse<Group>>({queryKey}, prev =>

--- a/static/app/views/issueDetails/useAssignIssueMutation.ts
+++ b/static/app/views/issueDetails/useAssignIssueMutation.ts
@@ -11,11 +11,11 @@ import {GroupStore} from 'sentry/stores/groupStore';
 import type {Actor} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import {buildTeamId, buildUserId} from 'sentry/utils';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {uniqueId} from 'sentry/utils/guid';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
-import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 export type AssignedBy = 'suggested_assignee' | 'assignee_selector';
 
@@ -64,7 +64,6 @@ export function useAssignIssueMutation(
   > = {}
 ) {
   const queryClient = useQueryClient();
-  const environments = useEnvironmentsFromUrl();
 
   return useMutation<Group, RequestError, AssignIssueVariables, AssignIssueContext>({
     ...options,
@@ -72,7 +71,12 @@ export function useAssignIssueMutation(
       const actorId = variables.actor ? makeActorId(variables.actor) : '';
       return fetchMutation<Group>({
         method: 'PUT',
-        url: `/organizations/${variables.orgSlug}/issues/${variables.groupId}/`,
+        url: getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+          path: {
+            organizationIdOrSlug: variables.orgSlug,
+            issueId: variables.groupId,
+          },
+        }),
         data: {
           assignedTo: actorId,
           assignedBy: variables.assignedBy,
@@ -87,14 +91,17 @@ export function useAssignIssueMutation(
       return {changeId};
     },
     onSuccess: (response, variables, onMutateResult, context) => {
-      const queryKey = groupApiOptions({
-        organizationSlug: variables.orgSlug,
-        groupId: variables.groupId,
-        environments,
-      }).queryKey;
+      const queryKey = [
+        getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+          path: {
+            organizationIdOrSlug: variables.orgSlug,
+            issueId: variables.groupId,
+          },
+        }),
+      ];
 
       // Update react query cache so that useGroup() reflects the new assignee.
-      queryClient.setQueryData(queryKey, prev =>
+      queryClient.setQueriesData<ApiResponse<Group>>({queryKey}, prev =>
         prev ? {...prev, json: {...prev.json, assignedTo: response.assignedTo}} : prev
       );
       // Dual-write to GroupStore

--- a/static/app/views/issueDetails/useAssignIssueMutation.ts
+++ b/static/app/views/issueDetails/useAssignIssueMutation.ts
@@ -87,19 +87,20 @@ export function useAssignIssueMutation(
       return {changeId};
     },
     onSuccess: (response, variables, onMutateResult, context) => {
-      // Update react query cache so that useGroup() reflects the new assignee
-      queryClient.setQueryData(
-        groupApiOptions({
-          organizationSlug: variables.orgSlug,
-          groupId: variables.groupId,
-          environments,
-        }).queryKey,
-        prev =>
-          prev ? {...prev, json: {...prev.json, assignedTo: response.assignedTo}} : prev
+      const queryKey = groupApiOptions({
+        organizationSlug: variables.orgSlug,
+        groupId: variables.groupId,
+        environments,
+      }).queryKey;
+
+      // Update react query cache so that useGroup() reflects the new assignee.
+      queryClient.setQueryData(queryKey, prev =>
+        prev ? {...prev, json: {...prev.json, assignedTo: response.assignedTo}} : prev
       );
       // Dual-write to GroupStore
       // TODO: Remove this when we no longer rely on GroupStore for updates
       GroupStore.onAssignToSuccess(onMutateResult.changeId, variables.groupId, response);
+      queryClient.invalidateQueries({queryKey});
       addSuccessMessage(getAssignIssueSuccessMessage(response.assignedTo));
       options.onSuccess?.(response, variables, onMutateResult, context);
     },

--- a/static/app/views/issueDetails/useGroup.tsx
+++ b/static/app/views/issueDetails/useGroup.tsx
@@ -27,6 +27,15 @@ export function groupApiOptions({
   });
 }
 
+type GroupQueryKeyParameters = Pick<
+  GroupApiOptionsParameters,
+  'groupId' | 'organizationSlug'
+>;
+
+export function groupQueryKey(params: GroupQueryKeyParameters) {
+  return [groupApiOptions({...params, environments: []}).queryKey[0]] as const;
+}
+
 interface UseGroupOptions {
   groupId: string;
   options?: {


### PR DESCRIPTION
When someone assigns or unassigns an issue, changes its priority, or toggles public sharing, the change succeeds but the Activity section can stay stale until they reload the page. This makes the issue timeline look incomplete and can make it unclear whether the action was recorded.

Refresh the issue details after these actions so the new assignment, priority, or sharing activity appears right away.