### PR TITLE
ref(workflow_engine): Refactor `ProcessedDataConditionGroup` as `DataConditionGroupEvaluation`

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -31,7 +31,7 @@ from sentry.workflow_engine.handlers.detector.base import EventData, EvidenceDat
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_source import DataPacket
-from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import (
     DetectorException,
     DetectorGroupKey,
@@ -188,7 +188,7 @@ def get_alert_type_from_aggregate_dataset(
 class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricResult]):
     def build_detector_evidence_data(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[MetricUpdate],
         priority: DetectorPriorityLevel,
     ) -> dict[str, Any]:
@@ -207,7 +207,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
 
     def create_occurrence(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[MetricUpdate],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, EventData]:
@@ -246,7 +246,7 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
                 issue_title=self.detector.name,
                 subtitle=self.construct_title(snuba_query, detector_trigger, priority),
                 evidence_data={
-                    **self.build_detector_evidence_data(evaluation_result, data_packet, priority),
+                    **self.build_detector_evidence_data(group_evaluation, data_packet, priority),
                 },
                 evidence_display=[],  # XXX: may need to pass more info here for the front end
                 type=MetricIssue,

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -20,8 +20,8 @@ from sentry.workflow_engine.handlers.detector.base import (
     GroupedDetectorEvaluationResult,
 )
 from sentry.workflow_engine.models import DataPacket
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.processors.data_condition_group import (
-    ProcessedDataConditionGroup,
     process_data_condition_group,
 )
 from sentry.workflow_engine.types import (
@@ -106,7 +106,7 @@ def _build_identifier_prefix(metadata: SizeAnalysisMetadata | None) -> str:
 
 def _build_evidence_text(
     detector_config: dict[str, Any],
-    evaluation_result: ProcessedDataConditionGroup,
+    evaluation: DataConditionGroupEvaluation,
     data_packet: SizeAnalysisDataPacket,
     platform: str,
 ) -> str:
@@ -124,8 +124,8 @@ def _build_evidence_text(
 
     # Threshold: type > value
     threshold_part = ""
-    if evaluation_result.condition_results:
-        condition = evaluation_result.condition_results[0].condition
+    if evaluation.result:
+        condition = evaluation.result[0].condition
         threshold_label = _THRESHOLD_TYPE_LABELS.get(threshold_type, threshold_type)
 
         if threshold_type == "relative_diff":
@@ -243,24 +243,24 @@ class PreprodSizeAnalysisDetectorHandler(
 
     def _evaluate_conditions(
         self, value: SizeAnalysisEvaluation
-    ) -> tuple[ProcessedDataConditionGroup | None, DetectorPriorityLevel | None]:
+    ) -> tuple[DataConditionGroupEvaluation | None, DetectorPriorityLevel | None]:
         if not self.condition_group:
             metrics.incr("workflow_engine.detector.skipping_invalid_condition_group")
             return None, None
 
-        condition_evaluation, _ = process_data_condition_group(self.condition_group, value)
-        if not condition_evaluation.logic_result.triggered:
+        group_evaluation, _ = process_data_condition_group(self.condition_group, value)
+        if not group_evaluation.outcome.triggered:
             return None, None
 
         priorities = [
-            condition_result.result
-            for condition_result in condition_evaluation.condition_results
-            if isinstance(condition_result.result, DetectorPriorityLevel)
+            condition_evaluation.result
+            for condition_evaluation in group_evaluation.result
+            if isinstance(condition_evaluation.result, DetectorPriorityLevel)
         ]
         if not priorities:
             return None, None
 
-        return condition_evaluation, max(priorities)
+        return group_evaluation, max(priorities)
 
     def _extract_head(self, data_packet: SizeAnalysisDataPacket) -> int:
         measurement = self.detector.config["measurement"]
@@ -300,7 +300,7 @@ class PreprodSizeAnalysisDetectorHandler(
 
     def create_occurrence(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        evaluation: DataConditionGroupEvaluation,
         data_packet: SizeAnalysisDataPacket,
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:
@@ -322,7 +322,8 @@ class PreprodSizeAnalysisDetectorHandler(
             "detector_id": self.detector.id,
             "value": self.extract_value(data_packet),
             "conditions": [
-                result.condition.get_snapshot() for result in evaluation_result.condition_results
+                condition_evaluation.condition.get_snapshot()
+                for condition_evaluation in evaluation.result
             ],
             "config": self.detector.config,
         }
@@ -359,7 +360,7 @@ class PreprodSizeAnalysisDetectorHandler(
                     tags["git.pr_number"] = str(commit_comparison.pr_number)
 
         evidence_text = _build_evidence_text(
-            self.detector.config, evaluation_result, data_packet, platform
+            self.detector.config, evaluation, data_packet, platform
         )
 
         occurrence = DetectorOccurrence(

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -27,7 +27,7 @@ from sentry.workflow_engine.handlers.detector.stateful import (
     StatefulDetectorHandler,
 )
 from sentry.workflow_engine.models import DataPacket, DetectorState
-from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
@@ -127,7 +127,7 @@ class ProcessingErrorDetectorHandler(
     @override
     def create_occurrence(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        evaluation_result: DataConditionGroupEvaluation,
         data_packet: DataPacket[ProcessingErrorPacketValue],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, EventData]:
@@ -179,9 +179,14 @@ class ProcessingErrorDetectorHandler(
         data_value = self.extract_value(data_packet)
         results: dict[DetectorGroupKey, DetectorEvaluationResult] = {}
 
-        condition_results, evaluated_priority = self._evaluation_detector_conditions(data_value)
+        detector_trigger_evaluations, evaluated_priority = self._evaluation_detector_conditions(
+            data_value
+        )
 
-        if condition_results is None or condition_results.logic_result.triggered is False:
+        if (
+            detector_trigger_evaluations is None
+            or detector_trigger_evaluations.outcome.triggered is False
+        ):
             return GroupedDetectorEvaluationResult(result=results, tainted=False)
 
         # Only handle triggering (FAILURE → HIGH). Resolution is handled
@@ -200,7 +205,7 @@ class ProcessingErrorDetectorHandler(
         results[None] = self._build_detector_evaluation_result(
             None,
             DetectorPriorityLevel.HIGH,
-            condition_results,
+            detector_trigger_evaluations,
             data_packet,
             data_value,
         )

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -25,7 +25,7 @@ from sentry.workflow_engine.handlers.detector.stateful import (
     StatefulDetectorHandler,
 )
 from sentry.workflow_engine.models import DataPacket, Detector
-from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
@@ -207,7 +207,7 @@ class UptimeDetectorHandler(StatefulDetectorHandler[UptimePacketValue, CheckStat
     @override
     def create_occurrence(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        _group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[UptimePacketValue],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, EventData]:

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -13,7 +13,7 @@ from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.types.actor import Actor
 from sentry.utils import metrics
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
-from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
@@ -114,6 +114,8 @@ class BaseDetectorHandler(
     DataPacketType is what we've embedded within the data packet.
     DataPacketEvaluationType is the type of the value to be extracted from the data packet and
     used to evaluate the conditions on the detector.
+
+    TODO - Implement a standard DetectorHandler with this base class -- a-la StatefulDetectorHandler
     """
 
     def __init__(self, detector: Detector):
@@ -161,13 +163,15 @@ class BaseDetectorHandler(
     ) -> GroupedDetectorEvaluationResult:
         """
         This method is used to evaluate the data packet's value against the conditions on the detector.
+
+        TODO - rename this to `evaluate` and change current evaluate to `_evaluate`
         """
         pass
 
     @abc.abstractmethod
     def create_occurrence(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[DataPacketType],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, EventData]:

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -25,10 +25,8 @@ from sentry.workflow_engine.handlers.detector.base import (
     GroupedDetectorEvaluationResult,
 )
 from sentry.workflow_engine.models import DataPacket, DataSource, Detector, DetectorState
-from sentry.workflow_engine.processors.data_condition_group import (
-    ProcessedDataConditionGroup,
-    process_data_condition_group,
-)
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
@@ -352,7 +350,7 @@ class StatefulDetectorHandler(
 
     def build_detector_evidence_data(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[DataPacketType],
         priority: DetectorPriorityLevel,
     ) -> dict[str, Any]:
@@ -388,7 +386,7 @@ class StatefulDetectorHandler(
 
     def _build_workflow_engine_evidence_data(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[DataPacketType],
         evaluation_value: DataPacketEvaluationType,
     ) -> dict[str, Any]:
@@ -396,12 +394,15 @@ class StatefulDetectorHandler(
         Build the workflow engine specific evidence data.
         This is data that is common to all detectors.
         """
+
         base: dict[str, Any] = {
             "detector_id": self.detector.id,
             "value": evaluation_value,
             "data_packet_source_id": str(data_packet.source_id),
             "conditions": [
-                result.condition.get_snapshot() for result in evaluation_result.condition_results
+                condition_evaluation.condition.get_snapshot()
+                for condition_evaluation in group_evaluation.result
+                if condition_evaluation.outcome.triggered
             ],
             "config": self.detector.config,
             "data_sources": self._build_evidence_data_sources(data_packet),
@@ -427,14 +428,20 @@ class StatefulDetectorHandler(
 
             self.state_manager.enqueue_dedupe_update(group_key, dedupe_value)
 
-            condition_results, evaluated_priority = self._evaluation_detector_conditions(
+            detector_trigger_evaluation, evaluated_priority = self._evaluation_detector_conditions(
                 group_data_values[group_key]
             )
 
-            if condition_results is not None and condition_results.logic_result.is_tainted():
+            if (
+                detector_trigger_evaluation is not None
+                and detector_trigger_evaluation.outcome.is_tainted()
+            ):
                 tainted = True
 
-            if condition_results is None or condition_results.logic_result.triggered is False:
+            if (
+                detector_trigger_evaluation is None
+                or detector_trigger_evaluation.outcome.triggered is False
+            ):
                 # Invalid condition result, nothing we can do
                 # Or if we didn't match any conditions in the evaluation
                 continue
@@ -478,7 +485,7 @@ class StatefulDetectorHandler(
             results[group_key] = self._build_detector_evaluation_result(
                 group_key,
                 new_priority,
-                condition_results,
+                detector_trigger_evaluation,
                 data_packet,
                 data_value,
             )
@@ -488,7 +495,7 @@ class StatefulDetectorHandler(
 
     def _create_resolve_message(
         self,
-        condition_results: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[DataPacketType],
         evaluation_value: DataPacketEvaluationType,
         group_key: DetectorGroupKey = None,
@@ -500,12 +507,12 @@ class StatefulDetectorHandler(
 
         evidence_data = {
             **self._build_workflow_engine_evidence_data(
-                evaluation_result=condition_results,
-                data_packet=data_packet,
-                evaluation_value=evaluation_value,
+                group_evaluation,
+                data_packet,
+                evaluation_value,
             ),
             **self.build_detector_evidence_data(
-                condition_results,
+                group_evaluation,
                 data_packet,
                 DetectorPriorityLevel.OK,
             ),
@@ -548,7 +555,7 @@ class StatefulDetectorHandler(
         self,
         group_key: DetectorGroupKey,
         new_priority: DetectorPriorityLevel,
-        condition_results: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[DataPacketType],
         evaluation_value: DataPacketEvaluationType,
     ) -> DetectorEvaluationResult:
@@ -558,7 +565,7 @@ class StatefulDetectorHandler(
         if new_priority == DetectorPriorityLevel.OK:
             # Call the `create_resolve_message` method to create the status change.
             detector_result = self._create_resolve_message(
-                condition_results,
+                group_evaluation,
                 data_packet,
                 evaluation_value,
                 group_key,
@@ -566,12 +573,12 @@ class StatefulDetectorHandler(
         else:
             # Call the `create_occurrence` method to create the detector occurrence.
             detector_occurrence, event_data = self.create_occurrence(
-                condition_results, data_packet, new_priority
+                group_evaluation, data_packet, new_priority
             )
             detector_result = self._create_decorated_issue_occurrence(
                 data_packet,
                 detector_occurrence,
-                condition_results,
+                group_evaluation,
                 new_priority,
                 group_key,
                 evaluation_value,
@@ -615,7 +622,7 @@ class StatefulDetectorHandler(
         self,
         data_packet: DataPacket[DataPacketType],
         detector_occurrence: DetectorOccurrence,
-        evaluation_result: ProcessedDataConditionGroup,
+        group_evaluation: DataConditionGroupEvaluation,
         new_priority: DetectorPriorityLevel,
         group_key: DetectorGroupKey,
         data_value: DataPacketEvaluationType,
@@ -624,7 +631,7 @@ class StatefulDetectorHandler(
         Decorate the issue occurrence with the data from the detector's evaluation result.
         """
         evidence_data = self._build_workflow_engine_evidence_data(
-            evaluation_result,
+            group_evaluation,
             data_packet,
             data_value,
         )
@@ -644,7 +651,7 @@ class StatefulDetectorHandler(
 
     def _evaluation_detector_conditions(
         self, value: DataPacketEvaluationType
-    ) -> tuple[ProcessedDataConditionGroup | None, DetectorPriorityLevel]:
+    ) -> tuple[DataConditionGroupEvaluation | None, DetectorPriorityLevel]:
         """
         Evaluate the detector.workflow_condition_group against the value in the data packet.
 
@@ -655,8 +662,9 @@ class StatefulDetectorHandler(
             metrics.incr("workflow_engine.detector.skipping_invalid_condition_group")
             return None, new_priority
 
-        condition_evaluation, remaining_slow_conditions = process_data_condition_group(
-            self.condition_group, value
+        group_evaluation, remaining_slow_conditions = process_data_condition_group(
+            self.condition_group,
+            value,
         )
         if remaining_slow_conditions:
             logger.warning(
@@ -667,17 +675,24 @@ class StatefulDetectorHandler(
                 },
             )
 
-        if condition_evaluation.logic_result.triggered:
+        if group_evaluation.outcome.triggered:
+            """
+            TODO - @saponifi3d - split the conditions results that
+            don't have a DetectorPriorityLevel result.
+
+            Log any of those conditions, as they are likely invalid / misconfigured.
+            """
             validated_condition_results: list[DetectorPriorityLevel] = [
-                condition_result.result
-                for condition_result in condition_evaluation.condition_results
-                if condition_result.result is not None
-                and isinstance(condition_result.result, DetectorPriorityLevel)
+                condition_evaluation.result
+                for condition_evaluation in group_evaluation.result
+                if condition_evaluation.outcome.triggered
+                and isinstance(condition_evaluation.result, DetectorPriorityLevel)
             ]
+
             if validated_condition_results:
                 new_priority = max(new_priority, *validated_condition_results)
 
-        return condition_evaluation, new_priority
+        return group_evaluation, new_priority
 
     def _increment_detector_thresholds(
         self,

--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -168,7 +168,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         group_evaluation, remaining_conditions = process_data_condition_group(
             group, workflow_event_data, when_data_conditions
         )
-        return group_evaluation.logic_result, remaining_conditions
+        return group_evaluation.outcome, remaining_conditions
 
 
 def get_slow_conditions(workflow: Workflow) -> list[DataCondition]:

--- a/src/sentry/workflow_engine/processors/__init__.py
+++ b/src/sentry/workflow_engine/processors/__init__.py
@@ -1,0 +1,6 @@
+__all__ = [
+    "DataConditionEvaluation",
+    "DataConditionGroupEvaluation",
+]
+
+from .evaluations import DataConditionEvaluation, DataConditionGroupEvaluation

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 from typing import TypeVar
 
@@ -7,7 +6,11 @@ from sentry.utils.tracing import trace
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import is_slow_condition
 from sentry.workflow_engine.processors.data_condition import split_conditions_by_speed
-from sentry.workflow_engine.processors.evaluations import DataConditionEvaluation, TriggerResult
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionEvaluation,
+    DataConditionGroupEvaluation,
+    TriggerResult,
+)
 from sentry.workflow_engine.types import ConditionError
 from sentry.workflow_engine.utils import scopedstats
 
@@ -16,13 +19,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-@dataclasses.dataclass()
-class ProcessedDataConditionGroup:
-    logic_result: TriggerResult
-    condition_results: list[DataConditionEvaluation]
-
-
-DataConditionGroupResult = tuple[ProcessedDataConditionGroup, list[DataCondition]]
+DataConditionGroupResult = tuple[DataConditionGroupEvaluation, list[DataCondition]]
 
 
 # We use a defined function rather than a lambda below because otherwise
@@ -68,18 +65,12 @@ def get_slow_conditions_for_groups(
 def evaluate_condition_group_results(
     condition_results: list[DataConditionEvaluation],
     logic_type: DataConditionGroup.Type,
-) -> ProcessedDataConditionGroup:
-    logic_result = TriggerResult.FALSE
+) -> DataConditionGroupEvaluation:
     group_condition_results: list[DataConditionEvaluation] = []
 
-    if logic_type == DataConditionGroup.Type.NONE:
-        # if we get to this point, no conditions were met
-        # because we would have short-circuited
-        logic_result = TriggerResult.none(
-            condition_result.outcome for condition_result in condition_results
-        )
+    # The logic_type DataConditionGroup.Type.NONE is handled by the sentinel value on group_condition_results
 
-    elif logic_type == DataConditionGroup.Type.ANY:
+    if logic_type == DataConditionGroup.Type.ANY:
         logic_result = TriggerResult.any(
             condition_result.outcome for condition_result in condition_results
         )
@@ -102,9 +93,9 @@ def evaluate_condition_group_results(
                 if condition_result.outcome.triggered
             ]
 
-    return ProcessedDataConditionGroup(
-        logic_result=logic_result,
-        condition_results=group_condition_results,
+    # TODO - Should error be `errors` and potentially 1 or many errors?
+    return DataConditionGroupEvaluation(
+        result=group_condition_results,
     )
 
 
@@ -112,7 +103,7 @@ def evaluate_condition_group_results(
 def evaluate_data_conditions(
     conditions_to_evaluate: list[tuple[DataCondition, T]],
     logic_type: DataConditionGroup.Type,
-) -> ProcessedDataConditionGroup:
+) -> DataConditionGroupEvaluation:
     """
     Evaluate a list of conditions. Each condition is a tuple with the value to evaluate the condition against.
     Next we apply the logic_type to get the results of the list of conditions.
@@ -121,7 +112,7 @@ def evaluate_data_conditions(
 
     if len(conditions_to_evaluate) == 0:
         # if we don't have any conditions, always return True
-        return ProcessedDataConditionGroup(logic_result=TriggerResult.TRUE, condition_results=[])
+        return DataConditionGroupEvaluation(result=[])
 
     for condition, value in conditions_to_evaluate:
         condition_evaluation = condition.evaluate_value(value)
@@ -129,18 +120,11 @@ def evaluate_data_conditions(
         # Check for short-circuiting evaluations
         if condition_evaluation.outcome.triggered:
             if logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-                return ProcessedDataConditionGroup(
-                    logic_result=condition_evaluation.outcome,
-                    condition_results=[condition_evaluation],
-                )
+                return DataConditionGroupEvaluation(result=[condition_evaluation])
 
             if logic_type == DataConditionGroup.Type.NONE:
-                return ProcessedDataConditionGroup(
-                    logic_result=TriggerResult(
-                        triggered=False,
-                        error=condition_evaluation.error,
-                    ),
-                    condition_results=[],
+                return DataConditionGroupEvaluation(
+                    error=condition_evaluation.error,
                 )
 
         condition_results.append(condition_evaluation)
@@ -164,10 +148,9 @@ def process_data_condition_group(
             "Invalid DataConditionGroup.logic_type found in process_data_condition_group",
             extra={"logic_type": group.logic_type},
         )
-        trigger_result = TriggerResult(
-            triggered=False, error=ConditionError(msg="Invalid DataConditionGroup.logic_type")
-        )
-        return ProcessedDataConditionGroup(logic_result=trigger_result, condition_results=[]), []
+        return DataConditionGroupEvaluation(
+            error=ConditionError(msg="Invalid DataConditionGroup.logic_type")
+        ), []
 
     # Check if conditions are already prefetched before using cache
     all_conditions: list[DataCondition]
@@ -186,20 +169,17 @@ def process_data_condition_group(
     if not split_conds.fast and split_conds.slow:
         # there are only slow conditions to evaluate, do not evaluate an empty list of conditions
         # which would evaluate to True
-        condition_group_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=condition_results,
-        )
+        condition_group_result = DataConditionGroupEvaluation(result=condition_results)
         return condition_group_result, split_conds.slow
 
     conditions_to_evaluate = [(condition, value) for condition in split_conds.fast]
-    processed_condition_group = evaluate_data_conditions(conditions_to_evaluate, logic_type)
+    group_evaluation = evaluate_data_conditions(conditions_to_evaluate, logic_type)
 
-    logic_result = processed_condition_group.logic_result
+    outcome = group_evaluation.outcome
 
     # Check to see if we should return any remaining conditions based on the results
-    is_short_circuit_all = not logic_result.triggered and logic_type == DataConditionGroup.Type.ALL
-    is_short_circuit_any = logic_result.triggered and logic_type in (
+    is_short_circuit_all = not outcome.triggered and logic_type == DataConditionGroup.Type.ALL
+    is_short_circuit_any = outcome.triggered and logic_type in (
         DataConditionGroup.Type.ANY,
         DataConditionGroup.Type.ANY_SHORT_CIRCUIT,
     )
@@ -208,6 +188,6 @@ def process_data_condition_group(
         # if we have a logic type of all and a False result,
         # or if we have a logic type of any and a True result, then
         #  we can short-circuit any remaining conditions since we have a completed logic result
-        return processed_condition_group, []
+        return group_evaluation, []
 
-    return processed_condition_group, split_conds.slow
+    return group_evaluation, split_conds.slow

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -99,7 +99,6 @@ def evaluate_condition_group_results(
                 if condition_result.outcome.triggered
             ]
 
-    # TODO - Should error be `errors` and potentially 1 or many errors?
     return DataConditionGroupEvaluation(
         result=group_condition_results,
         triggered=logic_result.triggered,

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -66,11 +66,17 @@ def evaluate_condition_group_results(
     condition_results: list[DataConditionEvaluation],
     logic_type: DataConditionGroup.Type,
 ) -> DataConditionGroupEvaluation:
+    logic_result = TriggerResult.FALSE
     group_condition_results: list[DataConditionEvaluation] = []
 
-    # The logic_type DataConditionGroup.Type.NONE is handled by the sentinel value on group_condition_results
+    if logic_type == DataConditionGroup.Type.NONE:
+        # if we get to this point, no conditions were met
+        # because we would have short-circuited
+        logic_result = TriggerResult.none(
+            condition_result.outcome for condition_result in condition_results
+        )
 
-    if logic_type == DataConditionGroup.Type.ANY:
+    elif logic_type == DataConditionGroup.Type.ANY:
         logic_result = TriggerResult.any(
             condition_result.outcome for condition_result in condition_results
         )
@@ -96,6 +102,8 @@ def evaluate_condition_group_results(
     # TODO - Should error be `errors` and potentially 1 or many errors?
     return DataConditionGroupEvaluation(
         result=group_condition_results,
+        triggered=logic_result.triggered,
+        error=logic_result.error,
     )
 
 
@@ -112,7 +120,7 @@ def evaluate_data_conditions(
 
     if len(conditions_to_evaluate) == 0:
         # if we don't have any conditions, always return True
-        return DataConditionGroupEvaluation(result=[])
+        return DataConditionGroupEvaluation(result=[], triggered=True)
 
     for condition, value in conditions_to_evaluate:
         condition_evaluation = condition.evaluate_value(value)
@@ -120,7 +128,11 @@ def evaluate_data_conditions(
         # Check for short-circuiting evaluations
         if condition_evaluation.outcome.triggered:
             if logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-                return DataConditionGroupEvaluation(result=[condition_evaluation])
+                return DataConditionGroupEvaluation(
+                    result=[condition_evaluation],
+                    triggered=True,
+                    error=condition_evaluation.outcome.error,
+                )
 
             if logic_type == DataConditionGroup.Type.NONE:
                 return DataConditionGroupEvaluation(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -45,11 +45,13 @@ from sentry.workflow_engine.models.data_condition import (
     Condition,
 )
 from sentry.workflow_engine.processors.data_condition_group import (
-    ProcessedDataConditionGroup,
     evaluate_data_conditions,
     get_slow_conditions_for_groups,
 )
-from sentry.workflow_engine.processors.evaluations import TriggerResult
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    TriggerResult,
+)
 from sentry.workflow_engine.processors.log_util import track_batch_performance
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
@@ -518,7 +520,7 @@ def _evaluate_group_result_for_dcg(
     group_id: GroupId,
     workflow_env: int | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
-) -> ProcessedDataConditionGroup:
+) -> DataConditionGroupEvaluation:
     slow_conditions = dcg_to_slow_conditions[dcg.id]
     try:
         return _group_result_for_dcg(
@@ -532,12 +534,7 @@ def _evaluate_group_result_for_dcg(
             sample_rate=1.0,
         )
         logger.warning("workflow_engine.delayed_workflow.missing_query_result", exc_info=True)
-        return ProcessedDataConditionGroup(
-            logic_result=TriggerResult(
-                triggered=False, error=ConditionError(msg="Missing query result")
-            ),
-            condition_results=[],
-        )
+        return DataConditionGroupEvaluation(error=ConditionError(msg="Missing query result"))
 
 
 def _group_result_for_dcg(
@@ -546,8 +543,9 @@ def _group_result_for_dcg(
     workflow_env: int | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     slow_conditions: list[DataCondition],
-) -> ProcessedDataConditionGroup:
+) -> DataConditionGroupEvaluation:
     conditions_to_evaluate: list[tuple[DataCondition, list[int | float]]] = []
+
     for condition in slow_conditions:
         query_values = []
         for query in generate_unique_queries(condition, workflow_env):
@@ -653,7 +651,7 @@ def get_groups_to_fire(
                 workflow_env,
                 condition_group_results,
             )
-            when_result = when_group.logic_result
+            when_result = when_group.outcome
             if not when_result.triggered:
                 # If we're not triggering, all action-y if conditions need to be treated
                 # as tainted or not based on the when condition result.
@@ -678,15 +676,17 @@ def get_groups_to_fire(
                     workflow_env,
                     condition_group_results,
                 )
-                if_result = when_result & if_group.logic_result
+                if_result = when_result & if_group.outcome
+
                 if if_result.is_tainted():
                     tainted += 1
                 else:
                     untainted += 1
+
                 if if_result.triggered:
                     groups_to_fire[group_id].add(dcg)
                     if_dcg_passed[workflow_id][group_id][dcg.id] = [
-                        pc.condition.id for pc in if_group.condition_results
+                        pc.condition.id for pc in if_group.result
                     ]
                 else:
                     if_dcg_failed[workflow_id][group_id].append(dcg.id)
@@ -698,6 +698,7 @@ def get_groups_to_fire(
                     tainted += 1
                 else:
                     untainted += 1
+
                 groups_to_fire[group_id].add(dcg)
                 if_dcg_passed[workflow_id][group_id][dcg.id] = [
                     c.id for c in dcg_to_slow_conditions.get(dcg.id, [])

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -1,8 +1,10 @@
 __all__ = [
     "DataConditionEvaluation",
     "DataConditionEvaluationException",
+    "DataConditionGroupEvaluation",
     "TriggerResult",
 ]
 
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
+from .condition_group import DataConditionGroupEvaluation
 from .trigger_result import TriggerResult

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,25 +1,35 @@
 from collections.abc import Collection
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 
 from sentry.workflow_engine.processors.evaluations.trigger_result import TriggerResult
+from sentry.workflow_engine.types import ConditionError
 
 
 @dataclass(frozen=True, kw_only=True)
-class BaseWorkflowEngineEvaluation[R, E]:
+class BaseWorkflowEngineEvaluation[R, E: ConditionError]:
     """
     This is a shared base class for all Evaluation classes.
 
     Should `result` be an abstract property?
-    Should `error` be limited to ConditionError?
     """
 
     result: R
     error: E | None = None
 
+    # The authoritative triggered state, set by the evaluation when `result` alone
+    # can't express it. A group can trigger with an empty `result` - e.g. it has no
+    # conditions, or it's a NONE group where nothing matched - and `len(result)` can't
+    # tell that apart from an ANY/ALL group that failed. When left unset we infer it
+    # from `result`. Excluded from equality so evaluations still compare on `result`
+    # and `error`.
+    triggered: bool | None = field(default=None, compare=False)
+
     @cached_property
     def outcome(self) -> TriggerResult:
-        if isinstance(self.result, Collection):
+        if self.triggered is not None:
+            triggered = self.triggered
+        elif isinstance(self.result, Collection):
             triggered = len(self.result) > 0
         else:
             triggered = self.result is not None

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from dataclasses import dataclass
 from functools import cached_property
 
@@ -8,14 +9,22 @@ from sentry.workflow_engine.processors.evaluations.trigger_result import Trigger
 class BaseWorkflowEngineEvaluation[R, E]:
     """
     This is a shared base class for all Evaluation classes.
+
+    Should `result` be an abstract property?
+    Should `error` be limited to ConditionError?
     """
 
-    result: R | None = None
+    result: R
     error: E | None = None
 
     @cached_property
     def outcome(self) -> TriggerResult:
+        if isinstance(self.result, Collection):
+            triggered = len(self.result) > 0
+        else:
+            triggered = self.result is not None
+
         return TriggerResult(
-            triggered=(self.result is not None),
+            triggered=triggered,
             error=self.error,
         )

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+from functools import cached_property
+
+from sentry.workflow_engine.processors.evaluations.trigger_result import TriggerResult
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -9,3 +12,10 @@ class BaseWorkflowEngineEvaluation[R, E]:
 
     result: R | None = None
     error: E | None = None
+
+    @cached_property
+    def outcome(self) -> TriggerResult:
+        return TriggerResult(
+            triggered=(self.result is not None),
+            error=self.error,
+        )

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from sentry.workflow_engine.types import ConditionError, DataConditionResult
 
 from .base import BaseWorkflowEngineEvaluation
-from .trigger_result import TriggerResult
 
 if TYPE_CHECKING:
     from sentry.workflow_engine.models.data_condition import DataCondition
@@ -33,17 +31,3 @@ class DataConditionEvaluation(BaseWorkflowEngineEvaluation[DataConditionResult, 
 
     value: Any
     condition: DataCondition
-
-    @cached_property
-    def outcome(self) -> TriggerResult:
-        """
-        TODO - @saponifi3d - The TriggerResult and the BaseWorkflowEngineEvaluation
-        can likely serve the same purpose, looking at the result / errors and providing
-        helpful interactions.
-
-        For now, using the `TriggerResult` to move a little faster through the refactoring.
-        """
-        return TriggerResult(
-            triggered=(self.result is not None),
-            error=self.error,
-        )

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -29,5 +29,6 @@ class DataConditionEvaluation(BaseWorkflowEngineEvaluation[DataConditionResult, 
     Inherits `result`, `error`, and `outcome`.
     """
 
+    result: DataConditionResult = None
     value: Any
     condition: DataCondition

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -1,0 +1,25 @@
+from sentry.workflow_engine.processors.evaluations.base import BaseWorkflowEngineEvaluation
+from sentry.workflow_engine.processors.evaluations.condition import DataConditionEvaluation
+from sentry.workflow_engine.types import ConditionError
+
+
+class DataConditionGroupEvaluation(
+    BaseWorkflowEngineEvaluation[
+        list[DataConditionEvaluation],
+        ConditionError,
+    ]
+):
+    """
+    This class is used to track the evaluation of a DataConditionGroup.
+
+    The class is created in `processors/data_condition_group.py`'s
+    `evaluate_condition_group_results` method, and should be utilized
+    anywhere we evaluate a condition group.
+
+    Inherited properties
+    - result: list[DataConditionEvaluation]
+    - error: ConditionError
+    - outcome: TriggerResult
+    """
+
+    pass

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -1,8 +1,12 @@
-from sentry.workflow_engine.processors.evaluations.base import BaseWorkflowEngineEvaluation
-from sentry.workflow_engine.processors.evaluations.condition import DataConditionEvaluation
+from dataclasses import dataclass, field
+
 from sentry.workflow_engine.types import ConditionError
 
+from .base import BaseWorkflowEngineEvaluation
+from .condition import DataConditionEvaluation
 
+
+@dataclass(frozen=True, kw_only=True)
 class DataConditionGroupEvaluation(
     BaseWorkflowEngineEvaluation[
         list[DataConditionEvaluation],
@@ -22,4 +26,4 @@ class DataConditionGroupEvaluation(
     - outcome: TriggerResult
     """
 
-    pass
+    result: list[DataConditionEvaluation] = field(default_factory=list)

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -329,10 +329,11 @@ def evaluate_workflows_action_filters(
             # Only accumulate taint for triggered workflows (not those with slow WHEN conditions)
             if workflow.id in workflow_to_result:
                 workflow_to_result[workflow.id] = TriggerResult.choose_tainted(
-                    workflow_to_result[workflow.id], group_evaluation.logic_result
+                    workflow_to_result[workflow.id],
+                    group_evaluation.outcome,
                 )
 
-            if group_evaluation.logic_result.triggered:
+            if group_evaluation.outcome.triggered:
                 if delayed_workflow_item := queue_items_by_workflow.get(workflow):
                     if delayed_workflow_item.delayed_when_group_id:
                         # If there are already delayed when conditions,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -20,7 +20,7 @@ from sentry.workflow_engine.handlers.detector import (
 )
 from sentry.workflow_engine.handlers.detector.base import EventData
 from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorPriorityLevel,
@@ -59,7 +59,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
 
             def create_occurrence(
                 self,
-                evaluation_result: ProcessedDataConditionGroup,
+                evaluation_result: DataConditionGroupEvaluation,
                 data_packet: DataPacket[dict[Never, Never]],
                 priority: DetectorPriorityLevel,
             ) -> tuple[DetectorOccurrence, EventData]:

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -17,7 +17,7 @@ from sentry.workflow_engine.handlers.detector import (
 from sentry.workflow_engine.handlers.detector.stateful import DetectorCounters
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import (
     DetectorEvaluationResult,
     DetectorGroupKey,
@@ -70,7 +70,7 @@ class MockDetectorStateHandler(StatefulDetectorHandler[dict[str, Any], int | Non
 
     def create_occurrence(
         self,
-        evaluation_result: ProcessedDataConditionGroup,
+        evaluation_result: DataConditionGroupEvaluation,
         data_packet: DataPacket[dict[str, Any]],
         priority: DetectorPriorityLevel,
     ) -> tuple[DetectorOccurrence, dict[str, Any]]:
@@ -113,7 +113,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
             def create_occurrence(
                 self,
-                evaluation_result: ProcessedDataConditionGroup,
+                evaluation_result: DataConditionGroupEvaluation,
                 data_packet: DataPacket[dict[str, Any]],
                 priority: DetectorPriorityLevel,
             ) -> tuple[DetectorOccurrence, dict[str, Any]]:
@@ -145,7 +145,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
             def create_occurrence(
                 self,
-                evaluation_result: ProcessedDataConditionGroup,
+                evaluation_result: DataConditionGroupEvaluation,
                 data_packet: DataPacket[dict[str, Any]],
                 priority: DetectorPriorityLevel,
             ) -> tuple[DetectorOccurrence, dict[str, Any]]:

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -5,13 +5,16 @@ from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.processors.data_condition_group import (
-    ProcessedDataConditionGroup,
     evaluate_data_conditions,
     get_data_conditions_for_group,
     get_slow_conditions_for_groups,
     process_data_condition_group,
 )
-from sentry.workflow_engine.processors.evaluations import DataConditionEvaluation, TriggerResult
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionEvaluation,
+    DataConditionGroupEvaluation,
+    TriggerResult,
+)
 from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel
 
 
@@ -23,88 +26,6 @@ class TestGetDataConditionsForGroup(TestCase):
         data_condition_group = self.create_data_condition_group()
         data_condition = self.create_data_condition(condition_group=data_condition_group)
         assert get_data_conditions_for_group(data_condition_group.id) == [data_condition]
-
-
-class TestProcessDataConditionGroup(TestCase):
-    def test_process_data_condition_group__exists__fails(self) -> None:
-        data_condition_group = self.create_data_condition_group()
-        self.create_data_condition(
-            condition_group=data_condition_group, type=Condition.GREATER, comparison=5
-        )
-
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
-        )
-        expected_remaining_conditions: list[DataCondition] = []
-        assert process_data_condition_group(data_condition_group, 1) == (
-            expected_result,
-            expected_remaining_conditions,
-        )
-
-    def test_process_data_condition_group__exists__passes(self) -> None:
-        data_condition_group = self.create_data_condition_group()
-        input_value = 10
-
-        self.condition = self.create_data_condition(
-            condition_group=data_condition_group,
-            type=Condition.GREATER,
-            comparison=5,
-            condition_result=DetectorPriorityLevel.HIGH,
-        )
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[
-                DataConditionEvaluation(
-                    value=input_value,
-                    condition=self.condition,
-                    result=DetectorPriorityLevel.HIGH,
-                    error=None,
-                )
-            ],
-        )
-
-        assert process_data_condition_group(data_condition_group, input_value) == (
-            expected_result,
-            [],
-        )
-
-    def test__fetch_conditions__no_prefetch(self) -> None:
-        data_condition_group = self.create_data_condition_group()
-        self.condition = self.create_data_condition(
-            condition_group=data_condition_group,
-            type=Condition.GREATER,
-            comparison=5,
-            condition_result=DetectorPriorityLevel.HIGH,
-        )
-
-        with mock.patch(
-            "sentry.workflow_engine.processors.data_condition_group.get_data_conditions_for_group"
-        ) as mock_fetch_conditions:
-            process_data_condition_group(data_condition_group, 10)
-            mock_fetch_conditions.assert_called_once_with(data_condition_group.id)
-
-    def test_fetch_conditions__with_prefetch(self) -> None:
-        data_condition_group = self.create_data_condition_group()
-        self.condition = self.create_data_condition(
-            condition_group=data_condition_group,
-            type=Condition.GREATER,
-            comparison=5,
-            condition_result=DetectorPriorityLevel.HIGH,
-        )
-
-        prefetched_group = (
-            DataConditionGroup.objects.filter(id=data_condition_group.id)
-            .prefetch_related("conditions")
-            .first()
-        )
-        assert prefetched_group is not None
-
-        with mock.patch(
-            "sentry.workflow_engine.processors.data_condition_group.get_data_conditions_for_group"
-        ) as mock_fetch_conditions:
-            process_data_condition_group(prefetched_group, 10)
-            mock_fetch_conditions.assert_not_called()
 
 
 class TestEvaluationConditionCase(TestCase):
@@ -137,9 +58,8 @@ class TestEvaluateConditionGroupTypeAny(TestEvaluationConditionCase):
     def test_evaluate_data_conditions__passes_all(self) -> None:
         input_value = 10
 
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[
+        expected_result = DataConditionGroupEvaluation(
+            result=[
                 DataConditionEvaluation(
                     value=input_value,
                     condition=self.data_condition,
@@ -163,9 +83,8 @@ class TestEvaluateConditionGroupTypeAny(TestEvaluationConditionCase):
     def test_evaluate_data_conditions__passes_one(self) -> None:
         input_value = 4
 
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[
+        expected_result = DataConditionGroupEvaluation(
+            result=[
                 DataConditionEvaluation(
                     condition=self.data_condition_two,
                     result=DetectorPriorityLevel.LOW,
@@ -182,9 +101,8 @@ class TestEvaluateConditionGroupTypeAny(TestEvaluationConditionCase):
         assert result == expected_result
 
     def test_evaluate_data_conditions__fails_all(self) -> None:
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
+        expected_result = DataConditionGroupEvaluation(
+            result=[],
         )
 
         result = evaluate_data_conditions(
@@ -196,10 +114,7 @@ class TestEvaluateConditionGroupTypeAny(TestEvaluationConditionCase):
 
     def test_evaluate_data_conditions__passes_without_conditions(self) -> None:
         result = evaluate_data_conditions([], self.data_condition_group.logic_type)
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[],
-        )
+        expected_result = DataConditionGroupEvaluation(result=[])
 
         assert result == expected_result
 
@@ -214,9 +129,8 @@ class TestEvaluateConditionGroupTypeAnyShortCircuit(TestEvaluationConditionCase)
 
         assert evaluate_data_conditions(
             self.get_conditions_to_evaluate(input_value), self.data_condition_group.logic_type
-        ) == ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[
+        ) == DataConditionGroupEvaluation(
+            result=[
                 DataConditionEvaluation(
                     condition=self.data_condition,
                     result=DetectorPriorityLevel.HIGH,
@@ -232,9 +146,8 @@ class TestEvaluateConditionGroupTypeAnyShortCircuit(TestEvaluationConditionCase)
             self.data_condition_group.logic_type,
         )
 
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[
+        expected_result = DataConditionGroupEvaluation(
+            result=[
                 DataConditionEvaluation(
                     condition=self.data_condition_two,
                     result=DetectorPriorityLevel.LOW,
@@ -249,17 +162,11 @@ class TestEvaluateConditionGroupTypeAnyShortCircuit(TestEvaluationConditionCase)
             self.get_conditions_to_evaluate(1),
             self.data_condition_group.logic_type,
         )
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
-        )
+        expected_result = DataConditionGroupEvaluation(result=[])
         assert result == expected_result
 
     def test_evaluate_data_conditions__passes_without_conditions(self) -> None:
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[],
-        )
+        expected_result = DataConditionGroupEvaluation(result=[])
         result = evaluate_data_conditions([], self.data_condition_group.logic_type)
         assert result == expected_result
 
@@ -276,9 +183,8 @@ class TestEvaluateConditionGroupTypeAll(TestEvaluationConditionCase):
             self.get_conditions_to_evaluate(input_value), self.data_condition_group.logic_type
         )
 
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[
+        expected_result = DataConditionGroupEvaluation(
+            result=[
                 DataConditionEvaluation(
                     condition=self.data_condition,
                     result=DetectorPriorityLevel.HIGH,
@@ -297,29 +203,22 @@ class TestEvaluateConditionGroupTypeAll(TestEvaluationConditionCase):
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(4), self.data_condition_group.logic_type
         )
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
-        )
+        expected_result = DataConditionGroupEvaluation(result=[])
         assert result == expected_result
 
     def test_evaluate_data_conditions__fails_all(self) -> None:
         result = evaluate_data_conditions(
-            self.get_conditions_to_evaluate(1), self.data_condition_group.logic_type
+            self.get_conditions_to_evaluate(1),
+            self.data_condition_group.logic_type,
         )
+        expected_result = DataConditionGroupEvaluation(result=[])
 
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
-        )
         assert result == expected_result
 
     def test_evaluate_data_conditions__passes_without_conditions(self) -> None:
         result = evaluate_data_conditions([], self.data_condition_group.logic_type)
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[],
-        )
+        expected_result = DataConditionGroupEvaluation(result=[])
+
         assert result == expected_result
 
 
@@ -330,34 +229,28 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
 
     def test_evaluate_data_conditions__all_conditions_pass__fails(self) -> None:
         result = evaluate_data_conditions(
-            self.get_conditions_to_evaluate(10), self.data_condition_group.logic_type
+            self.get_conditions_to_evaluate(10),
+            self.data_condition_group.logic_type,
         )
 
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
-        )
+        expected_result = DataConditionGroupEvaluation(result=[])
         assert result == expected_result
 
     def test_evaluate_data_conditions__one_condition_pass__fails(self) -> None:
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(4), self.data_condition_group.logic_type
         )
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.FALSE,
-            condition_results=[],
-        )
+
+        expected_result = DataConditionGroupEvaluation(result=[])
         assert result == expected_result
 
     def test_evaluate_data_conditions__no_conditions_pass__passes(self) -> None:
         result = evaluate_data_conditions(
-            self.get_conditions_to_evaluate(1), self.data_condition_group.logic_type
-        )
-        expected_result = ProcessedDataConditionGroup(
-            logic_result=TriggerResult.TRUE,
-            condition_results=[],
+            self.get_conditions_to_evaluate(1),
+            self.data_condition_group.logic_type,
         )
 
+        expected_result = DataConditionGroupEvaluation(result=[])
         assert result == expected_result
 
     def test_evaluate_data_conditions__error_with_no_pass__tainted_true(self) -> None:
@@ -389,9 +282,9 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                 self.data_condition_group.logic_type,
             )
 
-        assert result.logic_result.triggered is True
-        assert result.logic_result.error == error
-        assert result.condition_results == []
+        assert result.outcome.triggered is True
+        assert result.outcome.error == error
+        assert result.result == []
 
 
 class TestEvaluateConditionGroupWithSlowConditions(TestCase):
@@ -428,11 +321,9 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
             input_value,
         )
 
-        assert group_evaluation.logic_result.triggered is True
-        assert (
-            group_evaluation.condition_results[0].condition.id
-            == expected_condition_result.condition.id
-        )
+        assert group_evaluation.outcome.triggered is True
+        assert isinstance(group_evaluation.result[0], DataConditionEvaluation)
+        assert group_evaluation.result[0].condition.id == expected_condition_result.condition.id
         assert remaining_conditions == [self.slow_condition]
 
     def test_basic_only_slow_conditions(self) -> None:
@@ -442,8 +333,8 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
             10,
         )
 
-        assert group_evaluation.logic_result.triggered is False
-        assert group_evaluation.condition_results == []
+        assert group_evaluation.outcome.triggered is False
+        assert group_evaluation.result == []
         assert remaining_conditions == [self.slow_condition]
 
     def test_short_circuit_with_all(self) -> None:
@@ -452,8 +343,8 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
             1,
         )
 
-        assert group_evaluation.logic_result.triggered is False
-        assert group_evaluation.condition_results == []
+        assert group_evaluation.outcome.triggered is False
+        assert group_evaluation.result == []
         assert remaining_conditions == []
 
     def test_short_circuit_with_any(self) -> None:
@@ -464,9 +355,13 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
             input_value,
         )
 
-        assert group_evaluation.logic_result.triggered is True
-        assert group_evaluation.condition_results == [
-            DataConditionEvaluation(condition=self.data_condition, result=True, value=input_value)
+        assert group_evaluation.outcome.triggered is True
+        assert group_evaluation.result == [
+            DataConditionEvaluation(
+                condition=self.data_condition,
+                result=True,
+                value=input_value,
+            )
         ]
         assert remaining_conditions == []
 

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -37,10 +37,8 @@ from sentry.workflow_engine.models.data_condition import (
     SLOW_CONDITIONS,
     Condition,
 )
-from sentry.workflow_engine.processors.data_condition_group import (
-    ProcessedDataConditionGroup,
-    get_slow_conditions_for_groups,
-)
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors.data_condition_group import get_slow_conditions_for_groups
 from sentry.workflow_engine.processors.delayed_workflow import (
     EventInstance,
     EventKey,
@@ -58,7 +56,6 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     get_group_to_groupevent,
     get_groups_to_fire,
 )
-from sentry.workflow_engine.processors.evaluations import TriggerResult
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 from tests.snuba.rules.conditions.test_event_frequency import BaseEventFrequencyPercentTest
 
@@ -1009,7 +1006,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_fire_actions_for_groups__workflow_fire_history(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            ProcessedDataConditionGroup(logic_result=TriggerResult.TRUE, condition_results=[]),
+            DataConditionGroupEvaluation(result=[]),
             [],
         )
 
@@ -1043,7 +1040,7 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     ) -> None:
         """Verify notification_uuid from WorkflowFireHistory is passed to triggered actions."""
         mock_process.return_value = (
-            ProcessedDataConditionGroup(logic_result=TriggerResult.TRUE, condition_results=[]),
+            DataConditionGroupEvaluation(result=[]),
             [],
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -689,7 +689,7 @@ class TestTaintTracking(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.data_condition_group.process_data_condition_group")
     def test_trigger_stats_tainted_not_triggered(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            DataConditionGroupEvaluation(result=[]),
+            DataConditionGroupEvaluation(result=[], error=ERR),
             [],
         )
 
@@ -713,7 +713,7 @@ class TestTaintTracking(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_action_filter_stats_tainted_from_action_filter(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            DataConditionGroupEvaluation(result=[]),
+            DataConditionGroupEvaluation(result=[], error=ERR),
             [],
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -19,10 +19,12 @@ from sentry.workflow_engine.models import Action, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
 from sentry.workflow_engine.processors.data_condition_group import (
-    ProcessedDataConditionGroup,
     get_data_conditions_for_group,
 )
-from sentry.workflow_engine.processors.evaluations import TriggerResult
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    TriggerResult,
+)
 from sentry.workflow_engine.processors.workflow import (
     EvaluationStats,
     enqueue_workflows,
@@ -687,10 +689,7 @@ class TestTaintTracking(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.data_condition_group.process_data_condition_group")
     def test_trigger_stats_tainted_not_triggered(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            ProcessedDataConditionGroup(
-                logic_result=TriggerResult.FALSE.with_error(ERR),
-                condition_results=[],
-            ),
+            DataConditionGroupEvaluation(result=[]),
             [],
         )
 
@@ -714,10 +713,7 @@ class TestTaintTracking(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_action_filter_stats_tainted_from_action_filter(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            ProcessedDataConditionGroup(
-                logic_result=TriggerResult.TRUE.with_error(ERR),
-                condition_results=[],
-            ),
+            DataConditionGroupEvaluation(result=[]),
             [],
         )
 


### PR DESCRIPTION
# Description
This PR implements the `WorkflowEngineEvaluation` of `DataConditionGroupEvaluation`. The `result` of a `DataConditionGroupEvaluation` is a list of `DataConditionEvaluation`s, the `outcome` was moved to the base class, and the remainder of this PR is adoption of the class in favor of `ProcessedDataConditionGroup`.

Starting to see the wins of having these as consistent results from this PR 🎉, with how simply [`condition_group.py`](https://github.com/getsentry/sentry/blob/0f7cc76be920df9d32544140baf611cd24f5b9d0/src/sentry/workflow_engine/processors/evaluations/condition_group.py) was implemented.