### PR TITLE
style(weekly-report): Minor UI fixes

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -519,16 +519,14 @@ group_status_to_color = {
 }
 
 
-def _pct_change(current: int, previous: int) -> str | None:
-    """Returns a formatted string like '▲ 50%' or '▼ 25%', or None if not meaningful."""
+def _pct_change(current: int, previous: int) -> dict[str, str] | None:
     if previous == 0:
         return None
     change = (current - previous) / previous
     pct = round(change * 100)
     if pct == 0:
         return None
-    arrow = "▲" if change > 0 else "▼"
-    return f"{arrow} {abs(pct)}%"
+    return {"direction": "up" if change > 0 else "down", "pct": f"{abs(pct)}%"}
 
 
 def get_group_status_badge(group: Group) -> tuple[str, str, str]:
@@ -889,6 +887,7 @@ def render_template_context(
         "show_week_over_week_metric": features.has(
             "organizations:weekly-report-week-over-week-metric", ctx.organization
         ),
+        "notification_settings_link": "/settings/account/notifications/reports/",
     }
 
 

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -479,7 +479,7 @@ class _DuplicateDeliveryCheck:
         return is_duplicate_detected
 
 
-project_breakdown_colors = ["#7553FF", "#7C2282", "#F0369A", "#FF9838", "#FFD00E"]
+project_breakdown_colors = ["#7553FF", "#3A1873", "#F0369A", "#FF9838", "#FFD00E"]
 total_color = """
 linear-gradient(
     -45deg,
@@ -526,7 +526,9 @@ def _pct_change(current: int, previous: int) -> dict[str, str] | None:
     pct = round(change * 100)
     if pct == 0:
         return None
-    return {"direction": "up" if change > 0 else "down", "pct": f"{abs(pct)}%"}
+    if change > 0:
+        return {"arrow": "↑", "pct": f"{abs(pct)}%", "bg_color": "#F9F0D2", "text_color": "#A45200"}
+    return {"arrow": "↓", "pct": f"{abs(pct)}%", "bg_color": "#E3F7E3", "text_color": "#008900"}
 
 
 def get_group_status_badge(group: Group) -> tuple[str, str, str]:

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -202,7 +202,10 @@
     <h1 style="margin: 0;" class="total-count">
       {{ trends.total_issue_count|small_count:1 }}
       {% if show_week_over_week_metric and trends.issue_pct_change %}
-      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.issue_pct_change }}</span>
+      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873; display: inline-block;">
+        {% if trends.issue_pct_change.direction == "up" %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-increase.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="up">{% else %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-decrease.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="down">{% endif %}
+        <span style="vertical-align: middle; display: inline-block;">{{ trends.issue_pct_change.pct }}</span>
+      </span>
       {% endif %}
     </h1>
     {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
@@ -243,7 +246,10 @@
     <h1 style="margin: 0;" class="total-count">
       {{ trends.total_error_count|small_count:1 }}
       {% if show_week_over_week_metric and trends.error_pct_change %}
-      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 12px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873;">{{ trends.error_pct_change }}</span>
+      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873; display: inline-block;">
+        {% if trends.error_pct_change.direction == "up" %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-increase.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="up">{% else %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-decrease.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="down">{% endif %}
+        <span style="vertical-align: middle; display: inline-block;">{{ trends.error_pct_change.pct }}</span>
+      </span>
       {% endif %}
     </h1>
     <a href="{% org_url organization '/explore/discover/homepage/' query=errors_discover_query %}"
@@ -396,7 +402,7 @@
   <div id="key-errors">
     <h4>Issues with the most errors</h4>
     {% for a in key_errors %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: center;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0; overflow: hidden;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
@@ -419,7 +425,7 @@
   <div id="key-performance-issues">
     <h4>Most frequent performance issues</h4>
     {% for a in key_performance_issues %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: center;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0; overflow: hidden;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
@@ -442,7 +448,7 @@
   <div id="past-resolved-issues">
     <h4>Resolved last week</h4>
     {% for a in past_issues %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: center;">
       <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
@@ -459,4 +465,19 @@
   {% endif %}
 
 </div>
+{% endblock %}
+
+{% block footer %}
+  <a href="{% absolute_uri %}" style="float:right">Home</a>
+
+  {% if notification_settings_link %}
+  <a href="{% absolute_uri notification_settings_link %}">Notification Settings</a>
+  {% else %}
+  {% url 'sentry-account-settings-notifications' as settings_link %}
+  <a href="{% absolute_uri settings_link %}">Notification Settings</a>
+  {% endif %}
+
+  {% if notification_settings_link %}
+  &middot; <a href="{% absolute_uri notification_settings_link %}">Customize projects in weekly report</a>
+  {% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -484,6 +484,12 @@
   </div>
   {% endif %}
 
+  {% if notification_settings_link %}
+  <div style="padding: 12px 16px; margin: 16px 0; background-color: #F5F3F7; border-radius: 4px; font-size: 14px; color: #80708F;">
+    Want to choose the projects you see in the weekly report? <a href="{% absolute_uri notification_settings_link %}">Customize your project preferences here!</a>
+  </div>
+  {% endif %}
+
 </div>
 {% endblock %}
 

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -108,8 +108,8 @@
     }
 
     .project-breakdown .graph .label {
-      font-size: 14px;
-      color: #848296;
+      font-size: 10px;
+      color: #000;
       text-align: center;
       padding-top: 10px;
     }
@@ -117,8 +117,8 @@
     .project-breakdown .summary thead th {
       font-size: 12px;
       text-transform: uppercase;
-      color: #2f2936;
-      font-weight: 500;
+      color: #80708F;
+      font-weight: 700;
     }
 
     .project-breakdown .summary tr {
@@ -134,6 +134,32 @@
 
     .project-breakdown .summary .numeric {
       text-align: center;
+    }
+
+    .issue-title {
+      display: block;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 1.2;
+      margin-bottom: 2px;
+    }
+
+    .issue-message {
+      display: block;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      font-size: 14px;
+      color: #80708F;
+      line-height: 1.2;
+      margin-bottom: 2px;
+    }
+
+    .issue-count {
+      font-size: 16px;
     }
 
   </style>
@@ -198,20 +224,17 @@
     <table class="project-breakdown-graph-deck"><tbody><tr>
 
     <td class="project-breakdown-graph-cell issues">
-    <h4 class="total-count-title">Total Project Issues</h4>
-    <h1 style="margin: 0;" class="total-count">
+    <h4 class="total-count-title" style="font-weight: bold;">Total Issues</h4>
+    <h1 style="margin: 0; font-weight: bold;" class="total-count">
       {{ trends.total_issue_count|small_count:1 }}
       {% if show_week_over_week_metric and trends.issue_pct_change %}
-      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873; display: inline-block;">
-        {% if trends.issue_pct_change.direction == "up" %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-increase.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="up">{% else %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-decrease.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="down">{% endif %}
-        <span style="vertical-align: middle; display: inline-block;">{{ trends.issue_pct_change.pct }}</span>
-      </span>
+      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: {{ trends.issue_pct_change.bg_color }}; color: {{ trends.issue_pct_change.text_color }};">{{ trends.issue_pct_change.arrow }}&nbsp;{{ trends.issue_pct_change.pct }}</span>
       {% endif %}
     </h1>
     {% url 'sentry-organization-issue-list' organization.slug as issue_list %}
     {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
     <a href="{% org_url organization issue_list query=query %}"
-       style="font-size: 12px; margin-bottom: 16px; display: block;">View All Issues</a>
+       style="font-size: 12px; margin-bottom: 16px; display: block; font-weight: bold;">View All Issues</a>
 
     <table class="graph">
       <tr>
@@ -234,7 +257,7 @@
       <tr>
         {% for timestamp, project_values in trends.series %}
           <td class="label" style="width: {% widthratio 1 trends.series|length 100 %}%">
-            {{ timestamp|date:"D" }}
+            {{ timestamp|day_initial }}
           </td>
         {% endfor %}
       </tr>
@@ -242,18 +265,15 @@
     </td>
 
     <td class="project-breakdown-graph-cell errors">
-    <h4 class="total-count-title">Total Project Errors</h4>
-    <h1 style="margin: 0;" class="total-count">
+    <h4 class="total-count-title" style="font-weight: bold;">Total Errors</h4>
+    <h1 style="margin: 0; font-weight: bold;" class="total-count">
       {{ trends.total_error_count|small_count:1 }}
       {% if show_week_over_week_metric and trends.error_pct_change %}
-      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: #F2F0FA; color: #3A1873; display: inline-block;">
-        {% if trends.error_pct_change.direction == "up" %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-increase.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="up">{% else %}<img src="{% absolute_asset_url 'sentry' 'images/email/arrow-decrease.png' %}" width="10" height="5" style="vertical-align: middle; display: inline-block;" alt="down">{% endif %}
-        <span style="vertical-align: middle; display: inline-block;">{{ trends.error_pct_change.pct }}</span>
-      </span>
+      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: {{ trends.error_pct_change.bg_color }}; color: {{ trends.error_pct_change.text_color }};">{{ trends.error_pct_change.arrow }}&nbsp;{{ trends.error_pct_change.pct }}</span>
       {% endif %}
     </h1>
     <a href="{% org_url organization '/explore/discover/homepage/' query=errors_discover_query %}"
-       style="font-size: 12px; margin-bottom: 16px; display: block;">View All Errors</a>
+       style="font-size: 12px; margin-bottom: 16px; display: block; font-weight: bold;">View All Errors</a>
 
     <table class="graph">
       <tr>
@@ -276,7 +296,7 @@
       <tr>
         {% for timestamp, project_values in trends.series %}
           <td class="label" style="width: {% widthratio 1 trends.series|length 100 %}%">
-            {{ timestamp|date:"D" }}
+            {{ timestamp|day_initial }}
           </td>
         {% endfor %}
       </tr>
@@ -302,13 +322,13 @@
           <td>
               {% if project.color %}<span style="background: {{ project.color }}; display: inline-block; height: 1em; width: 1em;">&nbsp;</span>{% endif %}
           </td>
-          <td>
-              {% if project.url %}<a href="{{ project.url }}">{% endif %}{{ project.slug }}{% if project.url %}</a>{% endif %}
+          <td style="font-weight: 700;">
+              {% if project.url %}<a href="{{ project.url }}" style="font-weight: 700;">{% endif %}{{ project.slug }}{% if project.url %}</a>{% endif %}
           </td>
-          <td class="numeric" style="text-align: right;">{{ project.accepted_error_count|small_count:1 }}</td>
-          <td class="numeric" style="text-align: right;">{{ project.new_substatus_count|small_count:1 }}</td>
-          <td class="numeric" style="text-align: right;">{{ project.escalating_substatus_count|small_count:1 }}</td>
-          <td class="numeric" style="text-align: right;">{{ project.regression_substatus_count|small_count:1 }}</td>
+          <td class="numeric" style="text-align: right; color: #4674ca;">{{ project.accepted_error_count|small_count:1 }}</td>
+          <td class="numeric" style="text-align: right; color: #4674ca;">{{ project.new_substatus_count|small_count:1 }}</td>
+          <td class="numeric" style="text-align: right; color: #4674ca;">{{ project.escalating_substatus_count|small_count:1 }}</td>
+          <td class="numeric" style="text-align: right; color: #4674ca;">{{ project.regression_substatus_count|small_count:1 }}</td>
         </tr>
       {% endfor %}
       </tbody>
@@ -402,20 +422,20 @@
   <div id="key-errors">
     <h4>Issues with the most errors</h4>
     {% for a in key_errors %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: center;">
-      <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+      <div style="width: 10%;" class="issue-count">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0; overflow: hidden;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
         {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 21px; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
+        <a title="{{a.title}}" class="issue-title"
            href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
-        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 17px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
+        <div title="{{a.message}}" class="issue-message">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{a.status}}</span>
       {% endif %}
       </div>
     {% endfor %}
@@ -425,20 +445,20 @@
   <div id="key-performance-issues">
     <h4>Most frequent performance issues</h4>
     {% for a in key_performance_issues %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: center;">
-      <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+      <div style="width: 10%;" class="issue-count">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0; overflow: hidden;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
         {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 21px; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
+        <a title="{{a.title}}" class="issue-title"
            href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
-        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; max-height: 17px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
+        <div title="{{a.message}}" class="issue-message">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
       {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.group_substatus}}</span>
+      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{a.group_substatus}}</span>
       {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">{{a.status}}</span>
+      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{a.status}}</span>
       {% endif %}
     </div>
     {% endfor %}
@@ -448,17 +468,17 @@
   <div id="past-resolved-issues">
     <h4>Resolved last week</h4>
     {% for a in past_issues %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: center;">
-      <div style="width: 10%; font-size: 17px;">{{a.count|small_count:1}}</div>
+    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
+      <div style="width: 10%;" class="issue-count">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0;">
         {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
         {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a title="{{a.title}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; font-size: 17px; line-height: 1.2; margin-bottom: 2px;"
+        <a title="{{a.title}}" class="issue-title"
            href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
-        <div title="{{a.message}}" style="display: block; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; width: auto; max-width: 100%; max-height: 38px; line-height: 1.2; font-size: 14px; color: #80708F; margin-bottom: 2px;">{{a.message}}</div>
+        <div title="{{a.message}}" class="issue-message">{{a.message}}</div>
         <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
       </div>
-      <span style="background-color: #E3F7E3; color: #008900; border-radius: 8px; font-size: 12px; align-self: center; padding: 2px 10px; margin-left: auto; text-align: center; line-height: 16px; white-space: nowrap; height: 20px;">Resolved</span>
+      <span style="background-color: #E3F7E3; color: #008900; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">Resolved</span>
     </div>
     {% endfor %}
   </div>

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -295,6 +295,14 @@ def date(dt, arg=None):
     return date(dt, arg)
 
 
+@register.filter
+def day_initial(dt):
+    """Returns the single-letter day-of-week initial (M, T, W, T, F, S, S)."""
+    if isinstance(dt, datetime) and not django_timezone.is_aware(dt):
+        dt = dt.replace(tzinfo=timezone.utc)
+    return "MTWTFSS"[dt.weekday()]
+
+
 @register.simple_tag
 def percent(value, total, format=None):
     if not (value and total):

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1280,7 +1280,12 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            assert context["trends"]["issue_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["issue_pct_change"] == {
+                "arrow": "↑",
+                "pct": "100%",
+                "bg_color": "#F9F0D2",
+                "text_color": "#A45200",
+            }
 
     @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -1347,13 +1352,25 @@ class WeeklyReportsTest(
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
             # e/t come from cache: current 10 vs prev 5, current 20 vs prev 40
-            assert context["trends"]["error_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["error_pct_change"] == {
+                "arrow": "↑",
+                "pct": "100%",
+                "bg_color": "#F9F0D2",
+                "text_color": "#A45200",
+            }
             assert context["trends"]["transaction_pct_change"] == {
-                "direction": "down",
+                "arrow": "↓",
                 "pct": "50%",
+                "bg_color": "#E3F7E3",
+                "text_color": "#008900",
             }
             # i comes from ORM fallback: current 1 vs prev 2
-            assert context["trends"]["issue_pct_change"] == {"direction": "down", "pct": "50%"}
+            assert context["trends"]["issue_pct_change"] == {
+                "arrow": "↓",
+                "pct": "50%",
+                "bg_color": "#E3F7E3",
+                "text_color": "#008900",
+            }
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_issue_counts_multi_project(self, message_builder: mock.MagicMock) -> None:
@@ -2083,7 +2100,7 @@ class WeeklyReportsTest(
 
             assert "sensitive error title xyz123" not in html
             assert "enhanced privacy" in html.lower()
-            assert "Total Project Errors" in html
+            assert "Total Errors" in html
 
     @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -2118,10 +2135,17 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            assert context["trends"]["error_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["error_pct_change"] == {
+                "arrow": "↑",
+                "pct": "100%",
+                "bg_color": "#F9F0D2",
+                "text_color": "#A45200",
+            }
             assert context["trends"]["transaction_pct_change"] == {
-                "direction": "down",
+                "arrow": "↓",
                 "pct": "50%",
+                "bg_color": "#E3F7E3",
+                "text_color": "#008900",
             }
             assert context["show_week_over_week_metric"] is True
 
@@ -2197,16 +2221,38 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            assert context["trends"]["error_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["error_pct_change"] == {
+                "arrow": "↑",
+                "pct": "100%",
+                "bg_color": "#F9F0D2",
+                "text_color": "#A45200",
+            }
             assert context["trends"]["transaction_pct_change"] == {
-                "direction": "down",
+                "arrow": "↓",
                 "pct": "50%",
+                "bg_color": "#E3F7E3",
+                "text_color": "#008900",
             }
 
     def test_pct_change_helper(self) -> None:
-        assert _pct_change(150, 100) == {"direction": "up", "pct": "50%"}
-        assert _pct_change(50, 100) == {"direction": "down", "pct": "50%"}
-        assert _pct_change(0, 100) == {"direction": "down", "pct": "100%"}
+        assert _pct_change(150, 100) == {
+            "arrow": "↑",
+            "pct": "50%",
+            "bg_color": "#F9F0D2",
+            "text_color": "#A45200",
+        }
+        assert _pct_change(50, 100) == {
+            "arrow": "↓",
+            "pct": "50%",
+            "bg_color": "#E3F7E3",
+            "text_color": "#008900",
+        }
+        assert _pct_change(0, 100) == {
+            "arrow": "↓",
+            "pct": "100%",
+            "bg_color": "#E3F7E3",
+            "text_color": "#008900",
+        }
         assert _pct_change(100, 0) is None
         assert _pct_change(0, 0) is None
         assert _pct_change(100, 100) is None

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1280,7 +1280,7 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            assert context["trends"]["issue_pct_change"] == "▲ 100%"
+            assert context["trends"]["issue_pct_change"] == {"direction": "up", "pct": "100%"}
 
     @with_feature("organizations:weekly-report-week-over-week-metric")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -1347,10 +1347,13 @@ class WeeklyReportsTest(
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
             # e/t come from cache: current 10 vs prev 5, current 20 vs prev 40
-            assert context["trends"]["error_pct_change"] == "▲ 100%"
-            assert context["trends"]["transaction_pct_change"] == "▼ 50%"
+            assert context["trends"]["error_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["transaction_pct_change"] == {
+                "direction": "down",
+                "pct": "50%",
+            }
             # i comes from ORM fallback: current 1 vs prev 2
-            assert context["trends"]["issue_pct_change"] == "▼ 50%"
+            assert context["trends"]["issue_pct_change"] == {"direction": "down", "pct": "50%"}
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
     def test_issue_counts_multi_project(self, message_builder: mock.MagicMock) -> None:
@@ -2115,8 +2118,11 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            assert context["trends"]["error_pct_change"] == "▲ 100%"
-            assert context["trends"]["transaction_pct_change"] == "▼ 50%"
+            assert context["trends"]["error_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["transaction_pct_change"] == {
+                "direction": "down",
+                "pct": "50%",
+            }
             assert context["show_week_over_week_metric"] is True
 
     @with_feature("organizations:weekly-report-week-over-week-metric")
@@ -2191,13 +2197,16 @@ class WeeklyReportsTest(
 
         for call_args in message_builder.call_args_list:
             context = call_args.kwargs["context"]
-            assert context["trends"]["error_pct_change"] == "▲ 100%"
-            assert context["trends"]["transaction_pct_change"] == "▼ 50%"
+            assert context["trends"]["error_pct_change"] == {"direction": "up", "pct": "100%"}
+            assert context["trends"]["transaction_pct_change"] == {
+                "direction": "down",
+                "pct": "50%",
+            }
 
     def test_pct_change_helper(self) -> None:
-        assert _pct_change(150, 100) == "▲ 50%"
-        assert _pct_change(50, 100) == "▼ 50%"
-        assert _pct_change(0, 100) == "▼ 100%"
+        assert _pct_change(150, 100) == {"direction": "up", "pct": "50%"}
+        assert _pct_change(50, 100) == {"direction": "down", "pct": "50%"}
+        assert _pct_change(0, 100) == {"direction": "down", "pct": "100%"}
         assert _pct_change(100, 0) is None
         assert _pct_change(0, 0) is None
         assert _pct_change(100, 100) is None


### PR DESCRIPTION
Resolves [ID-1690](https://linear.app/getsentry/issue/ID-1690/minor-ui-fixes-to-weekly-report)

Goal: minor UI changes to weekly report following [Figma design ](https://www.figma.com/design/Y4QqC8bEsHlcIlIEIiYgSd/Weekly-Update-Email?node-id=2752-446&p=f)

Also, added a callout FYI section for customizing the projects at the end of the email

To test:
- Start dev environment
- Go to `debug/mail/weekly-reports/?seed=90`

Before:
<img width="1050" height="1472" alt="image" src="https://github.com/user-attachments/assets/70204968-ba44-4765-a442-001be364fd68" />

After:
<img width="1032" height="1448" alt="image" src="https://github.com/user-attachments/assets/02895247-fa25-425b-94b8-942d3fb46899" />
<img width="1298" height="642" alt="image" src="https://github.com/user-attachments/assets/cdbb3628-055b-4604-8234-2f21dc33408c" />