### PR TITLE
chore(api) Reduce the region pin list

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3207,12 +3207,8 @@ REGION_PINNED_URL_NAMES = {
     # New usage of these is region scoped.
     "sentry-js-sdk-loader",
     "sentry-release-hook",
-    "sentry-api-0-organizations",
     "sentry-api-0-projects",
     "sentry-api-0-accept-project-transfer",
-    "sentry-organization-avatar-url-deprecated",
-    "sentry-chartcuterie-config",
-    "sentry-robots-txt",
 }
 # Used in tests to skip forwarding relay paths to a region silo that does not exist.
 APIGATEWAY_PROXY_SKIP_RELAY = False

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1236,12 +1236,6 @@ urlpatterns += [
         OrganizationAvatarPhotoView.as_view(),
         name="sentry-organization-avatar-url",
     ),
-    # Deprecated because it lacks an organization slug
-    re_path(
-        r"^organization-avatar/(?P<avatar_id>[^/]+)/$",
-        OrganizationAvatarPhotoView.as_view(),
-        name="sentry-organization-avatar-url-deprecated",
-    ),
     re_path(
         r"^team-avatar/(?P<organization_slug>[^/]+)/(?P<avatar_id>[^/]+)/$",
         TeamAvatarPhotoView.as_view(),

--- a/tests/sentry/web/frontend/test_organization_avatar.py
+++ b/tests/sentry/web/frontend/test_organization_avatar.py
@@ -18,21 +18,6 @@ def _png_bytes() -> bytes:
 
 
 class OrganizationAvatarTest(TestCase):
-    def test_headers_deprecated_url(self) -> None:
-        org = self.create_organization()
-        photo = File.objects.create(name="test.png", type="avatar.file")
-        photo.putfile(BytesIO(b"test"))
-        avatar = OrganizationAvatar.objects.create(organization=org, file_id=photo.id)
-        url = reverse(
-            "sentry-organization-avatar-url-deprecated", kwargs={"avatar_id": avatar.ident}
-        )
-        response = self.client.get(url)
-        assert response.status_code == 200
-        assert response["Cache-Control"] == FOREVER_CACHE
-        assert response["Access-Control-Allow-Origin"]
-        assert response.get("Vary") is None
-        assert response.get("Set-Cookie") is None
-
     def test_headers(self) -> None:
         org = self.create_organization()
         photo = File.objects.create(name="test.png", type="avatar.file")


### PR DESCRIPTION
- Remove a few all_silo_views from the region pin list.
- Remove organizations-index as it now has control modes now.
- Remove the deprecated avatar URL, it has been deprecated for over a month, and is currently getting no traffic.

Refs #118963