### PR TITLE
feat(releases): Improve release bubble interactions

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -370,6 +370,10 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
           version,
         }))
       : [],
+    legendSelected:
+      props.legendSelection === undefined
+        ? undefined
+        : props.legendSelection.Releases !== false,
     yAxisIndex: yAxes.length,
   });
 
@@ -540,6 +544,9 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     Record<string, boolean>
   >({});
   const legendSelection = props.legendSelection ?? localLegendSelection;
+  const normalizedLegendSelection = hasReleaseBubblesSeries
+    ? {...legendSelection, Releases: legendSelection.Releases !== false}
+    : legendSelection;
   const {onLegendSelectionChange} = props;
   const handleLegendSelectionChange = useCallback(
     (selection: Record<string, boolean>) => {
@@ -636,7 +643,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       {showLegend && (
         <ChartLegend
           items={chartLegendItems}
-          selected={legendSelection}
+          selected={normalizedLegendSelection}
           onSelectionChange={handleLegendSelectionChange}
         />
       )}
@@ -661,7 +668,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
             showLegend
               ? {
                   show: false,
-                  selected: legendSelection,
+                  selected: normalizedLegendSelection,
                 }
               : undefined
           }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -353,6 +353,16 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     .toSorted((a, b) => a - b);
   const earliestTimeStamp = allBoundaries.at(0);
   const latestTimeStamp = allBoundaries.at(-1);
+  const bubbleReleases = useMemo(
+    () =>
+      hasReleaseBubbles
+        ? props.releases?.map(({timestamp, version}) => ({
+            date: timestamp,
+            version,
+          }))
+        : [],
+    [hasReleaseBubbles, props.releases]
+  );
 
   const {
     connectReleaseBubbleChartRef,
@@ -364,12 +374,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     chartId: props.id,
     minTime: earliestTimeStamp ? new Date(earliestTimeStamp).getTime() : undefined,
     maxTime: latestTimeStamp ? new Date(latestTimeStamp).getTime() : undefined,
-    releases: hasReleaseBubbles
-      ? props.releases?.map(({timestamp, version}) => ({
-          date: timestamp,
-          version,
-        }))
-      : [],
+    releases: bubbleReleases,
     legendSelected:
       props.legendSelection === undefined
         ? undefined

--- a/static/app/views/explore/releases/releaseBubbles/constants.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/constants.tsx
@@ -1,2 +1,1 @@
 export const BUBBLE_SERIES_ID = '__release_bubble__';
-export const BUBBLE_AREA_SERIES_ID = '__release_bubble_area__';

--- a/static/app/views/explore/releases/releaseBubbles/constants.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/constants.tsx
@@ -1,1 +1,0 @@
-export const BUBBLE_SERIES_ID = '__release_bubble__';

--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -37,6 +37,26 @@ interface LegendSelectChangedParams {
   selected: Record<string, boolean>;
 }
 
+const DEFAULT_BUBBLE_X_AXIS = {
+  axisLine: {onZero: true},
+  offset: 0,
+};
+
+const DEFAULT_BUBBLE_GRID = {
+  bottom: 0,
+};
+
+const RELEASE_BUBBLE_Y_AXIS = {
+  type: 'value' as const,
+  min: 0,
+  max: 100,
+  show: false,
+  // `axisLabel` causes an unwanted whitespace/width on the y-axis.
+  axisLabel: {show: false},
+  // The main y-axis may enable this via `tooltip.trigger=axis`.
+  axisPointer: {show: false},
+};
+
 // This needs to be debounced because some charts (e.g. in TimeseriesWidgets)
 // are in a group and share events. Thus on a page with 4 widgets, clicking on
 // a legend item would result in 4 events.
@@ -53,10 +73,8 @@ interface ReleaseBubbleSeriesProps {
   bubbleSize: number;
   buckets: Bucket[];
   chartRef: React.RefObject<ReactEchartsRef | null>;
-  dateFormatOptions: {
-    timezone: string;
-  };
   theme: Theme;
+  timezone: string;
   onBucketClick?: (bucket: Bucket) => void;
   yAxisIndex?: number;
 }
@@ -70,11 +88,11 @@ function createReleaseBubbleSeries({
   theme,
   bubbleSize,
   bubblePadding,
-  dateFormatOptions,
   alignInMiddle,
+  timezone,
   yAxisIndex,
   onBucketClick,
-}: ReleaseBubbleSeriesProps): CustomSeriesOption | null {
+}: ReleaseBubbleSeriesProps): CustomSeriesOption {
   const totalReleases = buckets.reduce(
     (acc, {releases, flags}) => acc + flags.length + releases.length,
     0
@@ -104,7 +122,7 @@ function createReleaseBubbleSeries({
       year: moment().year() !== moment(timestamp).year(),
     });
 
-    return moment.tz(timestamp, dateFormatOptions.timezone).format(format);
+    return moment.tz(timestamp, timezone).format(format);
   };
 
   /**
@@ -313,7 +331,7 @@ interface UseReleaseBubblesParams {
    */
   bubbleSize?: number;
   /**
-   * Unique ID for chart, used to load and render chart
+   * Unique ID used to associate the releases drawer with this chart.
    */
   chartId?: string;
   datetime?: Parameters<typeof normalizeDateTimeParams>[0];
@@ -374,25 +392,15 @@ export function useReleaseBubbles({
   // case of relative date selection). This is used for the tooltip to show the
   // proper timestamp for releases.
   const endTimeToUse = (datetime || selection.datetime).end;
-  const releasesMaxTime =
-    defined(endTimeToUse) && !Array.isArray(endTimeToUse)
-      ? new Date(endTimeToUse).getTime()
-      : Date.now();
+  const releasesMaxTime = useMemo(
+    () =>
+      defined(endTimeToUse) && !Array.isArray(endTimeToUse)
+        ? new Date(endTimeToUse).getTime()
+        : Date.now(),
+    [endTimeToUse]
+  );
   const chartRef = useRef<ReactEchartsRef | null>(null);
   const totalBubblePaddingY = bubblePadding * 2;
-  const defaultBubbleXAxis = useMemo(
-    () => ({
-      axisLine: {onZero: true},
-      offset: 0,
-    }),
-    []
-  );
-  const defaultBubbleGrid = useMemo(
-    () => ({
-      bottom: 0,
-    }),
-    []
-  );
   const releaseBubbleXAxis = useMemo(
     () => ({
       // configure `axisLine` and `offset` to move axis line below 0 so that
@@ -401,22 +409,6 @@ export function useReleaseBubbles({
       offset: bubbleSize + totalBubblePaddingY - 1,
     }),
     [bubbleSize, totalBubblePaddingY]
-  );
-
-  const releaseBubbleYAxis = useMemo(
-    () => ({
-      type: 'value' as const,
-      min: 0,
-      max: 100,
-      show: false,
-      // `axisLabel` causes an unwanted whitespace/width on the y-axis
-      axisLabel: {show: false},
-      // Hides an axis line + tooltip when hovering on chart
-      // This is default `false`, but the main y-axis has
-      // `tooltip.trigger=axis` which will cause this to be enabled.
-      axisPointer: {show: false},
-    }),
-    []
   );
 
   const releaseBubbleGrid = useMemo(
@@ -501,8 +493,8 @@ export function useReleaseBubbles({
         // adjust the xAxis/grid accordingly when Releases are visible or
         // not
         echartsInstance.setOption({
-          xAxis: selected ? releaseBubbleXAxis : defaultBubbleXAxis,
-          grid: selected ? releaseBubbleGrid : defaultBubbleGrid,
+          xAxis: selected ? releaseBubbleXAxis : DEFAULT_BUBBLE_X_AXIS,
+          grid: selected ? releaseBubbleGrid : DEFAULT_BUBBLE_GRID,
         });
 
         trackLegend(params);
@@ -526,12 +518,34 @@ export function useReleaseBubbles({
         echartsInstance.off('legendselectchanged', handleLegendSelectChanged);
       };
     },
+    [legendSelected, releaseBubbleGrid, releaseBubbleXAxis]
+  );
+
+  const releaseBubbleSeries = useMemo(
+    () =>
+      releases && buckets.length
+        ? createReleaseBubbleSeries({
+            yAxisIndex,
+            alignInMiddle,
+            buckets,
+            bubbleSize,
+            bubblePadding,
+            chartRef,
+            theme,
+            timezone: options.timezone,
+            onBucketClick: handleBucketClick,
+          })
+        : null,
     [
-      defaultBubbleGrid,
-      defaultBubbleXAxis,
-      legendSelected,
-      releaseBubbleGrid,
-      releaseBubbleXAxis,
+      alignInMiddle,
+      bubblePadding,
+      bubbleSize,
+      buckets,
+      handleBucketClick,
+      options.timezone,
+      releases,
+      theme,
+      yAxisIndex,
     ]
   );
 
@@ -551,21 +565,9 @@ export function useReleaseBubbles({
     /**
      * Series to append to a chart's existing `series`
      */
-    releaseBubbleSeries: createReleaseBubbleSeries({
-      yAxisIndex,
-      alignInMiddle,
-      buckets,
-      bubbleSize,
-      bubblePadding,
-      chartRef,
-      theme,
-      onBucketClick: handleBucketClick,
-      dateFormatOptions: {
-        timezone: options.timezone,
-      },
-    }),
+    releaseBubbleSeries,
 
-    releaseBubbleYAxis,
+    releaseBubbleYAxis: RELEASE_BUBBLE_Y_AXIS,
 
     /**
      * ECharts xAxis configuration. Spread/override charts `xAxis` prop.
@@ -577,7 +579,7 @@ export function useReleaseBubbles({
      * selected" state.
      */
     releaseBubbleXAxis:
-      legendSelected === false ? defaultBubbleXAxis : releaseBubbleXAxis,
+      legendSelected === false ? DEFAULT_BUBBLE_X_AXIS : releaseBubbleXAxis,
 
     /**
      * ECharts grid configuration. Spread/override charts `grid` prop.
@@ -588,6 +590,6 @@ export function useReleaseBubbles({
      * undefined if the calling component does not keep its own "legend
      * selected" state.
      */
-    releaseBubbleGrid: legendSelected === false ? defaultBubbleGrid : releaseBubbleGrid,
+    releaseBubbleGrid: legendSelected === false ? DEFAULT_BUBBLE_GRID : releaseBubbleGrid,
   };
 }

--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -6,7 +6,6 @@ import type {
   CustomSeriesRenderItemAPI,
   CustomSeriesRenderItemParams,
   CustomSeriesRenderItemReturn,
-  ElementEvent,
 } from 'echarts';
 import debounce from 'lodash/debounce';
 import moment from 'moment-timezone';
@@ -17,12 +16,7 @@ import type {RawFlag} from 'sentry/components/featureFlags/utils';
 import type {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {t, tn} from 'sentry/locale';
-import type {
-  EChartMouseOutHandler,
-  EChartMouseOverHandler,
-  ReactEchartsRef,
-  Series,
-} from 'sentry/types/echarts';
+import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {ReleaseMetaBasic} from 'sentry/types/release';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFormat} from 'sentry/utils/dates';
@@ -34,10 +28,7 @@ import {
   cleanReleaseCursors,
   ReleasesDrawerFields,
 } from 'sentry/views/explore/releases/drawer/utils';
-import {
-  BUBBLE_AREA_SERIES_ID,
-  BUBBLE_SERIES_ID,
-} from 'sentry/views/explore/releases/releaseBubbles/constants';
+import {BUBBLE_SERIES_ID} from 'sentry/views/explore/releases/releaseBubbles/constants';
 import type {Bucket} from 'sentry/views/explore/releases/releaseBubbles/types';
 import {createReleaseBuckets} from 'sentry/views/explore/releases/releaseBubbles/utils/createReleaseBuckets';
 
@@ -93,6 +84,7 @@ function createReleaseBubbleSeries({
     value: [bucket.start, 0, bucket.end, bucket.releases.length],
     start: bucket.start,
     end: bucket.end,
+    final: bucket.final,
     releases: bucket.releases,
     flags: bucket.flags,
     onClick: (clickSeries: any) => {
@@ -182,19 +174,56 @@ function createReleaseBubbleSeries({
       r: 0,
     };
 
+    const coordinateSystem = params.coordSys as {
+      height?: number;
+      width?: number;
+      x?: number;
+      y?: number;
+    };
+    const highlightStartX = bubbleStartX - (alignInMiddle ? width / 2 : 0);
+    const chartLeft = coordinateSystem.x ?? 0;
+    const chartRight = chartLeft + (coordinateSystem.width ?? 0);
+    const clippedHighlightStartX = Math.max(highlightStartX, chartLeft);
+    const clippedHighlightEndX = Math.min(highlightStartX + width, chartRight);
+
     return {
-      type: 'rect',
-      transition: ['shape'],
-      shape,
-      style: {
-        // Use lineWidth to "fake" padding so that mouse events are triggered
-        // in the "padding" areas (i.e. so tooltips open)
-        lineWidth: bubblePadding,
-        stroke: 'transparent',
-        fill: theme.tokens.graphics.accent.vibrant,
-        // TODO: figure out correct opacity calculations
-        opacity: Math.round((Number(numberReleases) / avgReleases) * 50) / 100,
-      },
+      type: 'group',
+      children: [
+        {
+          // Keep the range highlight in the custom item so ECharts can manage
+          // hover through emphasis without calling `setOption` from mouse events.
+          // It must remain silent so only the bubble itself is a hover target.
+          type: 'rect',
+          silent: true,
+          shape: {
+            x: clippedHighlightStartX,
+            y: coordinateSystem.y ?? 0,
+            width: Math.max(clippedHighlightEndX - clippedHighlightStartX, 0),
+            height: coordinateSystem.height ?? 0,
+          },
+          style: {
+            fill: theme.tokens.graphics.accent.vibrant,
+            opacity: 0,
+          },
+          emphasis: {
+            style: {opacity: 0.1},
+          },
+        },
+        {
+          type: 'rect',
+          transition: ['shape'],
+          shape,
+          style: {
+            // Use lineWidth to "fake" padding so that mouse events are triggered
+            // in the "padding" areas (i.e. so tooltips open)
+            lineWidth: bubblePadding,
+            stroke: 'transparent',
+            fill: theme.tokens.graphics.accent.vibrant,
+            // TODO: figure out correct opacity calculations
+            opacity: Math.round((Number(numberReleases) / avgReleases) * 50) / 100,
+          },
+        },
+      ],
     } satisfies CustomSeriesRenderItemReturn;
   };
 
@@ -207,6 +236,8 @@ function createReleaseBubbleSeries({
     data,
     color: theme.tokens.graphics.accent.vibrant,
     animation: false,
+    // Only hovering an individual bubble should show its emphasized time range.
+    legendHoverLink: false,
     markLine: {
       silent: true,
       symbol: 'none',
@@ -448,134 +479,6 @@ export function useReleaseBubbles({
       chartRef.current = e;
 
       const echartsInstance = e?.getEchartsInstance?.();
-      const highlightedBuckets = new Set();
-
-      const handleMouseMove = (params: ElementEvent) => {
-        if (!echartsInstance) {
-          return;
-        }
-
-        // Tracks movement across the chart and highlights the corresponding release bubble
-        const pointInPixel = [params.offsetX, params.offsetY];
-        const pointInGrid = echartsInstance.convertFromPixel('grid', pointInPixel);
-        const series = echartsInstance.getOption().series as Series[];
-        const seriesIndex = series.findIndex((s: Series) => s?.id === BUBBLE_SERIES_ID);
-
-        // No release bubble series found (shouldn't happen)
-        if (seriesIndex === -1) {
-          return;
-        }
-        const bubbleSeries = series[seriesIndex];
-        const bucketsFromSeries = bubbleSeries?.data;
-
-        if (!bucketsFromSeries) {
-          return;
-        }
-
-        // Try to find the bucket that the mouse is hovered over
-        const bucketIndex = buckets.findIndex(({start, end}: Bucket) => {
-          const ts = pointInGrid[0] ?? -1;
-          return ts >= start && ts < end;
-        });
-
-        // Already highlighted, no need to do anything
-        if (highlightedBuckets.has(bucketIndex)) {
-          return;
-        }
-
-        // If next bucket is not already highlighted, clear all existing
-        // highlights. We also want to clear if bucket was *not* found.
-        if (!highlightedBuckets.has(bucketIndex)) {
-          highlightedBuckets.forEach(dataIndex => {
-            echartsInstance.dispatchAction({
-              type: 'downplay',
-              seriesIndex,
-              dataIndex,
-            });
-          });
-          highlightedBuckets.clear();
-        }
-
-        // A bucket was found, dispatch "highlight" action --
-        // this is styled via `renderReleaseBubble` -> `emphasis`
-        if (bucketIndex > -1) {
-          highlightedBuckets.add(bucketIndex);
-          echartsInstance.dispatchAction({
-            type: 'highlight',
-            seriesIndex,
-            dataIndex: bucketIndex,
-          });
-        }
-      };
-
-      const handleMouseOver = (params: Parameters<EChartMouseOverHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
-          return;
-        }
-
-        const data = params.data as unknown as Bucket;
-
-        // Match behavior of ReleaseBubblSeries
-        const xAxisShift = alignInMiddle ? (data.end - data.start) / 2 : 0;
-
-        // Create an empty series that has a `markArea` which is then
-        // rectangular area of the "release bucket" that was hovered over (in
-        // the release bubbles). This is drawn on the main chart so that users
-        // can visualize the time block of the set of relases.
-        const customSeries: CustomSeriesOption = {
-          id: BUBBLE_AREA_SERIES_ID,
-          type: 'custom',
-          renderItem: () => null,
-          markArea: {
-            itemStyle: {color: theme.tokens.graphics.accent.vibrant, opacity: 0.1},
-            data: [
-              [
-                {
-                  xAxis: data.start - xAxisShift,
-                },
-                {
-                  xAxis: data.end - xAxisShift,
-                },
-              ],
-            ],
-          },
-        };
-        echartsInstance.setOption({series: [customSeries]}, {lazyUpdate: true});
-      };
-
-      const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
-          return;
-        }
-
-        // Clear the `markArea` that was drawn during mouse over
-        echartsInstance.setOption(
-          {
-            series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
-          },
-          {
-            lazyUpdate: true,
-          }
-        );
-      };
-
-      // This fixes a bug where if you hover over a bubble and mouseout via xaxis
-      // (i.e. bottom of chart), the bubble will remain highlighted. This makes it
-      // look buggy and can be misleading especially for bubbles w/ 0 releases.
-      const handleGlobalOut = () => {
-        if (!echartsInstance) {
-          return;
-        }
-
-        const series = echartsInstance.getOption().series as Series[];
-        const seriesIndex = series.findIndex((s: Series) => s?.id === BUBBLE_SERIES_ID);
-        // We could find and include a `dataIndex` to be specific about which
-        // bubble to "downplay", but I think it's ok to downplay everything
-        echartsInstance.dispatchAction({
-          type: 'downplay',
-          seriesIndex,
-        });
-      };
 
       const handleLegendSelectChanged = (params: LegendSelectChangedParams) => {
         if (
@@ -605,22 +508,14 @@ export function useReleaseBubbles({
         trackLegend(params);
       };
 
-      // @ts-expect-error `getModel` is private, but we access it to prevent binding mouse events to an instance of ECharts that hasn't been fully initialized. A more robust pattern is to attach mouse events using `onChartReady` instead of `ref`, but that causes manually bound mouse events to be overridden by the contents of the `onEvents` prop, since `onChartReady` only fires once, while the `ref` fires more often, and the manual events are re-added.
+      // @ts-expect-error `getModel` is private, but we access it to avoid binding
+      // events to an ECharts instance that has not been fully initialized.
       if (echartsInstance?.getModel()) {
         /**
-         * MouseListeners for echarts. This includes drawing a highlighted area on the
-         * main chart when a release bubble is hovered over.
-         *
-         * Attach directly to instance to avoid collisions with React props
+         * Attach directly to the instance to avoid collisions with `onEvents`.
          */
-        // @ts-expect-error not sure what type echarts is expecting here
-        echartsInstance.on('mouseover', handleMouseOver);
-        // @ts-expect-error not sure what type echarts is expecting here
-        echartsInstance.on('mouseout', handleMouseOut);
-        echartsInstance.on('globalout', handleGlobalOut);
         // @ts-expect-error ECharts types `params` as unknown
         echartsInstance.on('legendselectchanged', handleLegendSelectChanged);
-        echartsInstance.getZr().on('mousemove', handleMouseMove);
       }
 
       return () => {
@@ -628,29 +523,22 @@ export function useReleaseBubbles({
           return;
         }
 
-        echartsInstance.off('mouseover', handleMouseOver);
-        echartsInstance.off('mouseout', handleMouseOut);
-        echartsInstance.off('globalout', handleGlobalOut);
         echartsInstance.off('legendselectchanged', handleLegendSelectChanged);
-        echartsInstance.getZr().off('mousemove', handleMouseMove);
       };
     },
     [
-      alignInMiddle,
-      buckets,
       defaultBubbleGrid,
       defaultBubbleXAxis,
       legendSelected,
       releaseBubbleGrid,
       releaseBubbleXAxis,
-      theme.tokens.graphics.accent.vibrant,
     ]
   );
 
   if (!releases || !buckets.length) {
     return {
       connectReleaseBubbleChartRef: () => {},
-      ReleaseBubbleSeries: null,
+      releaseBubbleSeries: null,
       releaseBubbleXAxis: {},
       releaseBubbleGrid: {},
       releaseBubbleYAxis: null,

--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -28,9 +28,10 @@ import {
   cleanReleaseCursors,
   ReleasesDrawerFields,
 } from 'sentry/views/explore/releases/drawer/utils';
-import {BUBBLE_SERIES_ID} from 'sentry/views/explore/releases/releaseBubbles/constants';
 import type {Bucket} from 'sentry/views/explore/releases/releaseBubbles/types';
 import {createReleaseBuckets} from 'sentry/views/explore/releases/releaseBubbles/utils/createReleaseBuckets';
+
+const BUBBLE_SERIES_ID = '__release_bubble__';
 
 interface LegendSelectChangedParams {
   name: string;


### PR DESCRIPTION
Moves the release bubble time-range highlight into the custom ECharts series so hover no longer calls setOption while the chart model is rebuilding. This avoids the marker processing crash and keeps emphasis limited to the bubble itself instead of the legend or the rest of the chart.

Fixes an issue where dashboards held the space for the release bubbles even when disabled, also fixes an issue where toggling releases back on did not actually display the bubbles.

fixes JAVASCRIPT-3AP8
fixes JAVASCRIPT-3AP7