### PR TITLE
feat(autofix): Add optional user param to trigger_autofix_agent

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -58,9 +58,13 @@ from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.utils import json, metrics
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import AnonymousUser
+
     from sentry.models.group import Group
     from sentry.models.organization import Organization
     from sentry.seer.agent.client_models import MemoryBlock
+    from sentry.users.models.user import User
+    from sentry.users.services.user import RpcUser
 
 logger = logging.getLogger(__name__)
 
@@ -267,6 +271,7 @@ def get_autofix_agent_client(
     enable_coding: bool = False,
     code_review_enabled: bool = False,
     enable_pr_context_tools: bool = False,
+    user: User | RpcUser | AnonymousUser | None = None,
 ) -> SeerAgentClient:
     from sentry.seer.autofix.on_completion_hook import (
         AutofixOnCompletionHook,  # nested to avoid circular import
@@ -276,7 +281,7 @@ def get_autofix_agent_client(
         organization=group.organization,
         project=group.project,
         group=group,
-        user=None,  # No user personalization for autofix
+        user=user,
         category_key="autofix",
         category_value=str(group.id),
         intelligence_level=intelligence_level,
@@ -359,6 +364,7 @@ def trigger_autofix_agent(
     user_context: str | None = None,
     insert_index: int | None = None,
     feedback: Sequence[Feedback] | None = None,
+    user: User | RpcUser | AnonymousUser | None = None,
 ) -> int:
     """
     Start or continue an agent-based autofix run.
@@ -390,6 +396,7 @@ def trigger_autofix_agent(
         group,
         enable_coding=config.enable_coding,
         enable_pr_context_tools=is_iteration_step,
+        user=user,
     )
 
     run_state: SeerRunState | None = None

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -400,6 +400,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                         run_id=resolved_run_id,
                         user_context=user_context,
                         insert_index=data.get("insert_index"),
+                        user=request.user,
                     )
                 except NoSeerQuotaException:
                     return Response(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -218,6 +218,7 @@ class SeerAutofixOperator[CachePayloadT]:
                         step=AutofixStep.ROOT_CAUSE,
                         referrer=AutofixReferrer.SLACK,
                         run_id=None,
+                        user=user,
                     )
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
                     trigger_push_changes(
@@ -235,6 +236,7 @@ class SeerAutofixOperator[CachePayloadT]:
                         step=AutofixStep.from_autofix_stopping_point(stopping_point),
                         referrer=AutofixReferrer.SLACK,
                         run_id=run_id,
+                        user=user,
                     )
             except NoSeerQuotaException:
                 error = "No budget for Seer Autofix"

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.issues.action_log.types import TriggerAutofixAction
@@ -292,6 +292,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             run_id=None,
             user_context=None,
             insert_index=None,
+            user=ANY,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
@@ -316,6 +317,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             run_id=42,
             user_context=None,
             insert_index=3,
+            user=ANY,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)


### PR DESCRIPTION
Plumb an optional `user` argument through `trigger_autofix_agent` and
`get_autofix_agent_client` to `SeerAgentClient`, which already accepts it for
viewer context, permission checks, and feature flag evaluation.

Callers with an authenticated user (the API endpoint and the Slack operator) now
forward it. Callers without a user (on_completion_hook, issue_summary,
pr_iteration, night shift) keep the existing `None` default.