### PR TITLE
fix(perf-detection): handle missing description in MN+1 DB detector; downgrade noisy DetectorGroup log

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,
@@ -280,7 +280,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
                     name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
-                        db_span["description"],
+                        db_span.get("description", ""),
                     ),
                     # Has to be marked important to be displayed in the notifications
                     important=True,

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -152,7 +152,7 @@ def _get_detector_for_group(group: Group) -> Detector:
         if detector is not None:
             return detector
     except DetectorGroup.DoesNotExist:
-        logger.exception(
+        logger.warning(
             "DetectorGroup not found for group",
             extra={"group_id": group.id},
         )


### PR DESCRIPTION
Fixes two Sentry-reported production errors found during automated alert triage.

---

## Fix 1 — KeyError: 'description' in MN+1 DB span detector (SENTRY-5QVD, **high severity**)

**Issue:** [`SENTRY-5QVD`](https://sentry.sentry.io/issues/SENTRY-5QVD) — 210K+ events, ongoing since 2026-06-25.

**Root cause:** `ContinuingMNPlusOne._maybe_performance_problem` accessed `db_span["description"]` directly in two places. The segment consumer (`spans.consumers.process_segments`) processes spans from the `process-segments` Kafka consumer, and some spans in this path do not include a `description` key (e.g. downsampled spans, spans with stripped fields). This caused `KeyError: 'description'`, which was caught by the outer `detect_performance_problems` handler and logged as "Failed to detect performance problems" — silently dropping all N+1 detection for affected segments.

**Fix:** Use `db_span.get("description", "")` in both callsites (`desc=` argument and `get_notification_attachment_body` call) in `mn_plus_one_db_span_detector.py:258,283`.

---

## Fix 2 — DetectorGroup.DoesNotExist logged as exception (SENTRY-5R4N, **medium severity**)

**Issue:** [`SENTRY-5R4N`](https://sentry.sentry.io/issues/SENTRY-5R4N) — 24K+ events, 4K+ users impacted, ongoing since 2026-07-01.

**Root cause:** `_get_detector_for_group` in `workflow_engine/processors/detector.py` used `logger.exception(...)` inside the `except DetectorGroup.DoesNotExist` handler. `logger.exception` logs at ERROR level and includes the full traceback. The Seer root cause analysis confirms this is an **expected condition** for legacy groups that predate DetectorGroup associations — the code already handles the missing record gracefully by falling through to look up a detector by `(project, type)` or the issue stream detector.

**Fix:** Change `logger.exception` → `logger.warning` so the expected fallback path doesn't generate noisy ERROR-level events with full tracebacks.

---

## Evidence

- SENTRY-5QVD: 210,514 events, Seer actionability: **high**, Seer recommendation: "Use .get('description', '') to safely access the db span description."
- SENTRY-5R4N: 24,547 events / 4,362 users affected, Seer root cause: "Legacy groups without DetectorGroup associations trigger a logged exception when resolved."

## Session

https://claude.ai/code/session_01AY6kMQotceHm8vtMtSkdBc

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6kMQotceHm8vtMtSkdBc)_