### PR TITLE
fix(performance-detection): handle missing 'description' key in MN+1 DB span detector

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,
@@ -280,7 +280,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
                     name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
-                        db_span["description"],
+                        db_span.get("description", ""),
                     ),
                     # Has to be marked important to be displayed in the notifications
                     important=True,


### PR DESCRIPTION
Fixes a `KeyError: 'description'` crash (SENTRY-5QVD) that occurs in the MN+1 DB span detector when a DB span is missing the `description` field.

## Problem

In `mn_plus_one_db_span_detector.py`, the `_maybe_performance_problem` method accessed `db_span["description"]` in two places (lines 258 and 283), raising a `KeyError` whenever a span arrives without that field. This was generating **212k+ error events** in production (sentry region `us`, consumer `process-segments`).

Seer's analysis confirmed: _"Use `.get('description', '')` to safely access the db span description."_

## Fix

Replace `db_span["description"]` with `db_span.get("description", "")` in both call sites:
- `desc=` parameter of `PerformanceProblem()`
- `get_notification_attachment_body()` call in `evidence_display`

This is safe because an empty string is the appropriate fallback for a missing description — no performance problem is skipped and no fingerprint logic is affected (the fingerprint uses `db_span["hash"]`, not description).

## Evidence

- Sentry issue: https://sentry.sentry.io/issues/SENTRY-5QVD
- 212,555 occurrences since 2026-06-25, last seen moments ago
- Seer actionability: **high**
- Stack trace points directly to these two lines
- Triggered by this Claude Code session: https://claude.ai/code/session_01RgDgeGVvxBPx4emrgy1t4w

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgDgeGVvxBPx4emrgy1t4w)_