### PR TITLE
fix: guard against None target_type in WorkflowEngineActionSerializer and missing description in MNPlusOne detector

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_action.py
@@ -57,7 +57,7 @@ class WorkflowEngineActionSerializer(Serializer[dict[str, Any]]):
         type_value: int | None = ActionService.get_value(obj.type)
         target = attrs.get("target")
 
-        target_type: int = obj.config.get("target_type")
+        target_type: int | None = obj.config.get("target_type")
         target_identifier: str | None = obj.config.get("target_identifier")
         target_display: str | None = obj.config.get("target_display")
 
@@ -75,7 +75,9 @@ class WorkflowEngineActionSerializer(Serializer[dict[str, Any]]):
             ),
             "alertRuleTriggerId": str(alert_rule_trigger_id),
             "type": obj.type,
-            "targetType": ACTION_TARGET_TYPE_TO_STRING[ActionTarget(target_type)],
+            "targetType": ACTION_TARGET_TYPE_TO_STRING[ActionTarget(target_type)]
+            if target_type is not None
+            else None,
             "targetIdentifier": get_identifier_from_action(
                 type_value, str(target_identifier), target_display
             ),

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,


### PR DESCRIPTION
Fixes two production errors surfaced by automated Sentry alert monitoring.

Claude session: https://claude.ai/code/session_01SibgpfAgzvJRtry63iYB3c

---

## Fix 1: SENTRY-5NQG — `ValueError: None is not a valid ActionTarget` (medium severity)

**Issue:** [`SENTRY-5NQG`](https://sentry.sentry.io/issues/SENTRY-5NQG) — 6,500+ events, ongoing since Apr 22

**Root cause:** `WorkflowEngineActionSerializer` calls `ActionTarget(target_type)` where `target_type` is `None` for webhook-type actions (they have no target). The enum constructor raises `ValueError: None is not a valid ActionTarget`, which propagates through `SentryAppMetricAlertHandler → invoke_legacy_registry → get_incident_serializer`, causing metric alert webhook notifications to silently fail to serialize.

**Fix:** Guard the `ActionTarget()` call with a `None` check, returning `None` for `targetType` when no target type is configured — consistent with how `desc` is already handled on the line below it.

**Files changed:**
- `src/sentry/incidents/endpoints/serializers/workflow_engine_action.py`

---

## Fix 2: SENTRY-5QVD — `KeyError: 'description'` in MNPlusOne DB span detector (medium severity)

**Issue:** [`SENTRY-5QVD`](https://sentry.sentry.io/issues/SENTRY-5QVD) — 213k+ events, ongoing since Jun 25

**Root cause:** `ContinuingMNPlusOne._maybe_performance_problem()` accesses `db_span["description"]` directly. New span schema (spans emitting `downsampled_retention_days` rather than the standard span fields) causes some spans to arrive without a `description` key. The `KeyError` is caught by the outer `detect_performance_problems` exception handler and logged as "Failed to detect performance problems", meaning N+1 detection silently fails for these segments.

**Fix:** Use `db_span.get("description", "")` — consistent with how `transaction_name` is accessed via `.get()` two lines below in the same function.

**Files changed:**
- `src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py`

---

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SibgpfAgzvJRtry63iYB3c)_