### PR TITLE
fix: handle missing span description and empty webhook URL

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -69,6 +69,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     GOT_CLIENT_ERROR = "got_client_error"
     INTEGRATOR_ERROR = "integrator_error"
     MISSING_INSTALLATION = "missing_installation"
+    MISSING_URL = "missing_url"
     RESTRICTED_IP = "restricted_ip"
     CONNECTION_RESET = "connection_reset"
     HARD_TIMEOUT = "hard_timeout"

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -264,7 +264,11 @@ def send_and_save_webhook_request(
             }
         )
 
-        assert url is not None
+        if not url:
+            lifecycle.record_halt(
+                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.MISSING_URL}"
+            )
+            return Response()
         custom_headers_enabled = False
         try:
             owner_context = organization_service.get_organization_by_id(


### PR DESCRIPTION
Fixes two high/medium severity production errors surfaced by Sentry alerts.

## SENTRY-5QVD — `KeyError: 'description'` in MN+1 DB span detector (219k+ events, **high** actionability)

**Root cause:** `mn_plus_one_db_span_detector.py` line 258 accessed `db_span["description"]` directly. Certain span payloads (observed in the `de` region) lack a `description` key, causing a `KeyError` that bubbles up as `Failed to detect performance problems` and silently skips performance problem detection for those segments.

**Fix:** `db_span.get("description", "")` — consistent with how other span fields (e.g. `transaction_name`) are read defensively throughout the same file.

**Evidence:**
- 219,795 events over the past ~16 days
- Culprit: `spans.consumers.process_segments.process_segment`
- Seer actionability: **high**
- Sentry issue: https://sentry.sentry.io/issues/SENTRY-5QVD

---

## SENTRY-5HAE — `MissingSchema: Invalid URL ''` in sentry app webhook sender (178k+ events, **medium** actionability)

**Root cause:** `send_and_save_webhook_request` falls back to `sentry_app.webhook_url` when no URL override is provided (line 256: `url = url or sentry_app.webhook_url`). When a sentry app has an empty string webhook URL, the `assert url is not None` guard on line 267 passes (empty string is not None), and `safe_urlopen("")` raises `requests.exceptions.MissingSchema` rather than halting cleanly.

**Fix:** After resolving `url`, check `if not url:` and halt the lifecycle with the new `SentryAppWebhookHaltReason.MISSING_URL` reason. This surfaces the configuration problem as a structured halt instead of an unhandled exception, and avoids polluting error tracking with noise from misconfigured apps.

**Evidence:**
- 178,895 events since January 2026
- Culprit: `sentry.sentry_apps.tasks.sentry_apps.send_alert_webhook_v2`
- Seer actionability: **medium**
- Sentry issue: https://sentry.sentry.io/issues/SENTRY-5HAE

---

## Changes

| File | Change |
|---|---|
| `src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py` | `db_span.get("description", "")` instead of `db_span["description"]` |
| `src/sentry/utils/sentry_apps/webhooks.py` | Guard `if not url:` → halt with `MISSING_URL` |
| `src/sentry/sentry_apps/metrics.py` | Add `MISSING_URL = "missing_url"` to `SentryAppWebhookHaltReason` enum |

---

**Session:** https://claude.ai/code/session_015nUsqCoG5gXgQM8FLTigMk

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nUsqCoG5gXgQM8FLTigMk)_