### PR TITLE
fix(sdk): drop handled third-party errors in beforeSend to reduce alert noise

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -7,6 +7,7 @@ import {
   initializeSdk,
   isEventWithFileUrl,
   isFilteredRequestErrorEvent,
+  isHandledThirdPartyError,
 } from './initializeSdk';
 
 const ERROR_MAP: Record<number, string | undefined> = {
@@ -204,6 +205,65 @@ describe('isEventWithFileUrl', () => {
     const event = {};
 
     expect(isEventWithFileUrl(event)).toBeFalsy();
+  });
+});
+
+describe('isHandledThirdPartyError', () => {
+  it('drops handled errors tagged as third-party', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: 'Converting circular structure to JSON',
+            mechanism: {handled: true, type: 'generic'},
+          },
+        ],
+      },
+      tags: {third_party_code: 'True'},
+    };
+
+    expect(isHandledThirdPartyError(event)).toBeTruthy();
+  });
+
+  it('keeps unhandled errors even if tagged third-party', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: 'Something exploded',
+            mechanism: {handled: false, type: 'onerror'},
+          },
+        ],
+      },
+      tags: {third_party_code: 'True'},
+    };
+
+    expect(isHandledThirdPartyError(event)).toBeFalsy();
+  });
+
+  it('keeps handled errors not tagged as third-party', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: 'Something exploded',
+            mechanism: {handled: true, type: 'generic'},
+          },
+        ],
+      },
+      tags: {},
+    };
+
+    expect(isHandledThirdPartyError(event)).toBeFalsy();
+  });
+
+  it('keeps events with no exception', () => {
+    const event = {tags: {third_party_code: 'True'}};
+
+    expect(isHandledThirdPartyError(event)).toBeFalsy();
   });
 });
 

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -180,7 +180,8 @@ export function initializeSdk(config: Config) {
       if (
         isFilteredRequestErrorEvent(event) ||
         isEventWithFileUrl(event) ||
-        isNullTupleUnhandledRejectionEvent(event)
+        isNullTupleUnhandledRejectionEvent(event) ||
+        isHandledThirdPartyError(event)
       ) {
         return null;
       }
@@ -269,6 +270,20 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
 
 export function isEventWithFileUrl(event: Event): boolean {
   return !!event.request?.url?.startsWith('file://');
+}
+
+/**
+ * Drop handled errors that originated entirely from third-party code (e.g. browser
+ * extensions). These are tagged by `thirdPartyErrorFilterIntegration` with
+ * `third_party_code: True` and are not actionable — they represent noise from
+ * injected scripts outside our control. Unhandled third-party errors are kept
+ * because they may still crash the page.
+ */
+export function isHandledThirdPartyError(event: Event): boolean {
+  const allHandled = event.exception?.values?.every(
+    exc => exc.mechanism?.handled !== false
+  );
+  return !!(allHandled && event.tags?.['third_party_code'] === 'True');
 }
 
 /**


### PR DESCRIPTION
## Context

This PR was created in response to a Sentry webhook alert received by the Claude automated session: https://claude.ai/code/session_01DoEYiubDpVgZv6GepfzYtd

## Problem

A Sentry alert fired for event `b37780c91da546a9a209ccf4f14d43f5` — a `TypeError: Converting circular structure to JSON` on the `/unsubscribe/issue/:id/` transaction.

**Evidence this is browser extension noise, not a Sentry bug:**
- Tagged `third_party_code: True` by `thirdPartyErrorFilterIntegration`
- Tagged `handled: yes` — caught by React's ErrorBoundary before surfacing
- Stack trace originates from `<anonymous>` code (classic browser extension injection pattern), not Sentry's own source files
- The anonymous code was calling `JSON.stringify` on an `HTMLAnchorElement` that had React fiber nodes attached (`__reactFiber$...`), a circular-reference pattern exclusively caused by external scripts trying to serialize DOM elements that React has hydrated
- The Sentry CDN frames in the stack (`s1.sentry-cdn.com/...`) are React's reconciler responding to the DOM mutation, not the root cause

## Root Cause

`thirdPartyErrorFilterIntegration` is configured with `behaviour: 'apply-tag-if-contains-third-party-frames'`, which **tags** events as `third_party_code: True` but does not **drop** them. Handled third-party errors are therefore sent to Sentry and can trigger alerts, even though they provide no actionable signal.

## Fix

Add `isHandledThirdPartyError` predicate to `beforeSend` that returns `null` (drops the event) when:
1. All exception values have `mechanism.handled !== false` (the error was caught), AND
2. The event is tagged `third_party_code: True`

Unhandled third-party errors are intentionally preserved — they can still crash the page and may be worth investigating.

This is consistent with existing `beforeSend` filters (`isFilteredRequestErrorEvent`, `isEventWithFileUrl`, `isNullTupleUnhandledRejectionEvent`) that drop other categories of unactionable noise.

## Changes

- `static/app/bootstrap/initializeSdk.tsx`: Add `isHandledThirdPartyError` filter and wire into `beforeSend`
- `static/app/bootstrap/initializeSdk.spec.tsx`: Add unit tests covering all four cases (handled+third-party, unhandled+third-party, handled+first-party, no exception)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DoEYiubDpVgZv6GepfzYtd)_