### PR TITLE
fix(release-bubbles): guard against disposed ECharts instance in mouse handlers

### DIFF
--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -512,6 +512,9 @@ export function useReleaseBubbles({
         if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
           return;
         }
+        if (echartsInstance.isDisposed()) {
+          return;
+        }
 
         const data = params.data as unknown as Bucket;
 
@@ -540,23 +543,34 @@ export function useReleaseBubbles({
             ],
           },
         };
-        echartsInstance.setOption({series: [customSeries]}, {lazyUpdate: true});
+        try {
+          echartsInstance.setOption({series: [customSeries]}, {lazyUpdate: true});
+        } catch {
+          // Chart may be disposed during a state transition
+        }
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
         if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
           return;
         }
+        if (echartsInstance.isDisposed()) {
+          return;
+        }
 
         // Clear the `markArea` that was drawn during mouse over
-        echartsInstance.setOption(
-          {
-            series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
-          },
-          {
-            lazyUpdate: true,
-          }
-        );
+        try {
+          echartsInstance.setOption(
+            {
+              series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
+            },
+            {
+              lazyUpdate: true,
+            }
+          );
+        } catch {
+          // Chart may be disposed during a state transition
+        }
       };
 
       // This fixes a bug where if you hover over a bubble and mouseout via xaxis
@@ -597,10 +611,17 @@ export function useReleaseBubbles({
         // Callback for when Releases legend status changes -- we want to
         // adjust the xAxis/grid accordingly when Releases are visible or
         // not
-        echartsInstance.setOption({
-          xAxis: selected ? releaseBubbleXAxis : defaultBubbleXAxis,
-          grid: selected ? releaseBubbleGrid : defaultBubbleGrid,
-        });
+        if (echartsInstance.isDisposed()) {
+          return;
+        }
+        try {
+          echartsInstance.setOption({
+            xAxis: selected ? releaseBubbleXAxis : defaultBubbleXAxis,
+            grid: selected ? releaseBubbleGrid : defaultBubbleGrid,
+          });
+        } catch {
+          // Chart may be disposed during a state transition
+        }
 
         trackLegend(params);
       };


### PR DESCRIPTION
## Summary

Fixes a crash ([JAVASCRIPT-3AP8](https://sentry.sentry.io/issues/JAVASCRIPT-3AP8)) affecting **192 users** on the `/issues/:groupId/events/` page where hovering over a release bubble then mousing out causes a `TypeError: Cannot read properties of undefined (reading 'get')`.

**Root cause:** When `handleMouseOut` (and `handleMouseOver`, `handleLegendSelectChanged`) call `echartsInstance.setOption()`, ECharts internally iterates over its series models. If the chart is being destroyed or re-rendered during the mouse event (a timing race), the model referenced by `MarkerModel.mergeOption` → `ecModel.eachSeries` can be undefined, causing the crash.

**Fix:**
- Add `isDisposed()` guard before each `setOption` call — ECharts' public API for checking if the instance has been destroyed
- Wrap each `setOption` in a try/catch to handle any transitional state that `isDisposed()` might miss

**Evidence from Sentry:**
```
handleMouseOut → echartsInstance.setOption() →
  MarkerModel.prototype.mergeOption →
  ecModel.eachSeries → seriesModel.get(this.mainType, true)
  // seriesModel is undefined → TypeError
```
Seer analysis confirmed: "Wrap setOption calls in mouse handlers with a try/catch and add an isDisposed guard to prevent crashes during chart state transitions."

**Session:** https://claude.ai/code/session_01J4LcBkJp5FmPYfxmFcq6ZV

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4LcBkJp5FmPYfxmFcq6ZV)_