### PR TITLE
fix(alerts): raise ValidationError for deprecated sessions dataset

### DIFF
--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -167,6 +167,10 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
     def validate_dataset(self, value: str) -> Dataset:
         try:
             dataset_value = Dataset(value)
+            if dataset_value == Dataset.Sessions:
+                raise serializers.ValidationError(
+                    "The sessions dataset is deprecated. Use the metrics dataset for crash rate alerts."
+                )
             if dataset_value in [Dataset.PerformanceMetrics, Dataset.Transactions]:
                 return self._validate_performance_dataset(dataset_value)
 

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -76,6 +76,20 @@ class SnubaQueryValidatorTest(TestCase):
             ErrorDetail(string=f"Invalid query type {invalid_query_type}", code="invalid")
         ]
 
+    def test_sessions_dataset_deprecated(self) -> None:
+        data = {
+            **self.valid_data,
+            "dataset": Dataset.Sessions.value,
+        }
+        validator = SnubaQueryValidator(data=data, context=self.context)
+        assert not validator.is_valid()
+        assert validator.errors.get("dataset") == [
+            ErrorDetail(
+                string="The sessions dataset is deprecated. Use the metrics dataset for crash rate alerts.",
+                code="invalid",
+            )
+        ]
+
     def test_validated_create_source_limits(self) -> None:
         with self.settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=2):
             validator = SnubaQueryValidator(data=self.valid_data, context=self.context)


### PR DESCRIPTION
## Summary

Fixes an unhandled `KeyError` ([SENTRY-5PEF](https://sentry.sentry.io/issues/SENTRY-5PEF)) in the alert rule creation endpoint that surfaces as a 500 error for users attempting to create crash rate alerts with the legacy `sessions` dataset.

**Root cause:** `validate_dataset` in `SnubaQueryValidator` accepts any valid `Dataset` enum value — including the deprecated `Dataset.Sessions` — and passes it along. In `_validate_query`, line 321 does a dict lookup:
```python
query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
```
`Dataset.Sessions` is not in `query_datasets_to_type` (which maps to alert types), so this raises an unhandled `KeyError` instead of a user-friendly validation error.

**Fix:** Add an explicit check for `Dataset.Sessions` in `validate_dataset` that raises a clear `ValidationError` directing users to the `metrics` dataset for crash rate alerts. This is the correct dataset per the current `QUERY_TYPE_VALID_DATASETS` mapping (only `Dataset.Metrics` is valid for `CRASH_RATE` type).

**Evidence from Sentry:**
```
POST /api/0/organizations/{slug}/alert-rules/
aggregate: "percentage(sessions_crashed, sessions)"
dataset: Dataset.Sessions

KeyError: <Dataset.Sessions: 'sessions'>
  File "sentry/snuba/snuba_query_validator.py", line 321
    query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
```

**Session:** https://claude.ai/code/session_01J4LcBkJp5FmPYfxmFcq6ZV

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4LcBkJp5FmPYfxmFcq6ZV)_