### PR TITLE
fix(alerts): return 400 instead of 500 when creating alert with unsupported dataset

### DIFF
--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -318,6 +318,11 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
                     "You cannot use an MRI on alerts as the performance metrics dataset is being deprecated."
                 )
 
+        if dataset not in query_datasets_to_type:
+            raise serializers.ValidationError(
+                "Invalid dataset for alerts. Valid datasets are: %s"
+                % ", ".join(sorted(d.name.lower() for d in query_datasets_to_type))
+            )
         query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
 
         valid_datasets = QUERY_TYPE_VALID_DATASETS[query_type]

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -321,7 +321,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         if dataset not in query_datasets_to_type:
             raise serializers.ValidationError(
                 "Invalid dataset for alerts. Valid datasets are: %s"
-                % ", ".join(sorted(d.name.lower() for d in query_datasets_to_type))
+                % ", ".join(sorted(d.value for d in query_datasets_to_type))
             )
         query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
 

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -80,7 +80,7 @@ class SnubaQueryValidatorTest(TestCase):
         self.valid_data["dataset"] = Dataset.Sessions.value
         validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
         assert not validator.is_valid()
-        non_field_errors = validator.errors.get("non_field_errors", [])
+        non_field_errors = validator.errors.get("nonFieldErrors", [])
         assert any("Invalid dataset for alerts" in str(e) for e in non_field_errors)
 
     def test_validated_create_source_limits(self) -> None:

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -76,6 +76,13 @@ class SnubaQueryValidatorTest(TestCase):
             ErrorDetail(string=f"Invalid query type {invalid_query_type}", code="invalid")
         ]
 
+    def test_invalid_dataset_sessions_returns_validation_error(self) -> None:
+        self.valid_data["dataset"] = Dataset.Sessions.value
+        validator = SnubaQueryValidator(data=self.valid_data, context=self.context)
+        assert not validator.is_valid()
+        non_field_errors = validator.errors.get("non_field_errors", [])
+        assert any("Invalid dataset for alerts" in str(e) for e in non_field_errors)
+
     def test_validated_create_source_limits(self) -> None:
         with self.settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=2):
             validator = SnubaQueryValidator(data=self.valid_data, context=self.context)

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -82,6 +82,11 @@ class SnubaQueryValidatorTest(TestCase):
         assert not validator.is_valid()
         non_field_errors = validator.errors.get("nonFieldErrors", [])
         assert any("Invalid dataset for alerts" in str(e) for e in non_field_errors)
+        # The advertised datasets must be the submittable `.value` strings (e.g.
+        # "generic_metrics"), not the enum member names (e.g. "performancemetrics").
+        message = " ".join(str(e) for e in non_field_errors)
+        assert Dataset.PerformanceMetrics.value in message
+        assert Dataset.PerformanceMetrics.name.lower() not in message
 
     def test_validated_create_source_limits(self) -> None:
         with self.settings(MAX_QUERY_SUBSCRIPTIONS_PER_ORG=2):


### PR DESCRIPTION
## Summary

Fixes SENTRY-5PEF — `KeyError: <Dataset.Sessions: 'sessions'>` in `snuba_query_validator.py`

**Root cause:** When a user POSTs to `/api/0/organizations/{org}/alert-rules/` with `dataset=sessions` (or any dataset absent from `query_datasets_to_type`), the dict lookup on line 321 raises an unhandled `KeyError` that propagates as a 500.

`Dataset.Sessions` was removed from `query_datasets_to_type` (which now only contains `Events`, `Transactions`, `PerformanceMetrics`, `Metrics`, and `EventsAnalyticsPlatform`), but external API clients still send `dataset=sessions`. This has been happening since at least 2026-05-06 with 8 unique users affected.

**Fix:** Add an explicit `dataset not in query_datasets_to_type` check that raises a `serializers.ValidationError` (→ HTTP 400) with a message listing the valid datasets, before the dict lookup that was previously crashing.

**Evidence:**
- Sentry issue: https://sentry.sentry.io/issues/SENTRY-5PEF
- Stacktrace: `sentry/snuba/snuba_query_validator.py:321` in `_validate_query` — `query_datasets_to_type[dataset]` raises `KeyError` when dataset is `Dataset.Sessions`
- The fix converts a 500 (unhandled exception) to a 400 (proper validation error)

## Test plan

- Added `test_invalid_dataset_sessions_returns_validation_error` to `tests/sentry/snuba/test_validators.py` covering the exact failing case
- Existing `SnubaQueryValidatorTest` tests continue to pass

Claude session: https://claude.ai/code/session_01LjN9gb92hUE6jTqQ9dkjAm

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjN9gb92hUE6jTqQ9dkjAm)_