### PR TITLE
fix(service-worker): skip Sentry capture for AbortErrors from update checks

### DIFF
--- a/static/app/serviceWorker/client/serviceWorkerContext.tsx
+++ b/static/app/serviceWorker/client/serviceWorkerContext.tsx
@@ -83,7 +83,7 @@ function useRegisterServiceWorker() {
       .catch(error => {
         // AbortErrors from registration are expected (e.g. user navigates away
         // during the initial register call) and produce no stack trace.
-        if (error.name === 'AbortError') {
+        if (error instanceof Error && error.name === 'AbortError') {
           return;
         }
         log('error');
@@ -114,7 +114,7 @@ function useServiceWorkerUpdateCheck() {
         .catch(error => {
           // AbortErrors are expected when the user navigates away during an
           // update check — they are not actionable and produce no stack trace.
-          if (error.name === 'AbortError') {
+          if (error instanceof Error && error.name === 'AbortError') {
             return;
           }
           Sentry.captureException(error);

--- a/static/app/serviceWorker/client/serviceWorkerContext.tsx
+++ b/static/app/serviceWorker/client/serviceWorkerContext.tsx
@@ -107,6 +107,11 @@ function useServiceWorkerUpdateCheck() {
       navigator.serviceWorker.ready
         .then(registration => registration.update())
         .catch(error => {
+          // AbortErrors are expected when the user navigates away during an
+          // update check — they are not actionable and produce no stack trace.
+          if (error.name === 'AbortError') {
+            return;
+          }
           Sentry.captureException(error);
         });
     };

--- a/static/app/serviceWorker/client/serviceWorkerContext.tsx
+++ b/static/app/serviceWorker/client/serviceWorkerContext.tsx
@@ -81,6 +81,11 @@ function useRegisterServiceWorker() {
         });
       })
       .catch(error => {
+        // AbortErrors from registration are expected (e.g. user navigates away
+        // during the initial register call) and produce no stack trace.
+        if (error.name === 'AbortError') {
+          return;
+        }
         log('error');
         Sentry.captureException(error);
       });


### PR DESCRIPTION
## Summary

This PR fixes noisy, non-actionable Sentry events caused by `AbortError` being captured from service worker operations in `serviceWorkerContext.tsx`.

**Root cause (from a live Sentry alert):**

Two `.catch()` handlers in `serviceWorkerContext.tsx` call `captureException` unconditionally:

1. **`useRegisterServiceWorker`** — `navigator.serviceWorker.register()` aborted:
   ```
   AbortError: Failed to register a ServiceWorker for scope ('https://<org>.sentry.io/') with script ('https://<org>.sentry.io/service-worker.js'): Operation has been aborted
   ```

2. **`useServiceWorkerUpdateCheck`** — `registration.update()` aborted:
   ```
   AbortError: Failed to update a ServiceWorker for scope ('https://<org>.sentry.io/') with script ('https://<org>.sentry.io/service-worker.js'): Operation has been aborted
   ```

Both arrive in Sentry as:
- `handled: yes` (caught exceptions)
- **Zero stack frames** (no debugging value)
- `DOMException.code: 20` = `ABORT_ERR` — transient, browser-driven abort when users navigate away

**Why the existing `ignoreErrors` patterns don't catch them:**

`initializeSdk.tsx` already ignores several `AbortError` variants (e.g. `AbortError: The operation was aborted`, Safari fetch-abort errors). The service-worker messages `"Failed to update/register a ServiceWorker…Operation has been aborted"` don't match any of those patterns, so these events leak through as Sentry noise.

**Fix:**

Add `error.name === 'AbortError'` guards to both `.catch()` blocks, silently discarding these expected browser-level aborts. This is consistent with `api.tsx`, which already skips `captureException` for `AbortError` from fetch/request paths.

## Evidence

- Triggered by Sentry alert event ID `c1533dbfe16d46bea35b5853e0a0d018`
- Breadcrumb in that event shows companion registration abort event `aafec53a4f9743a6b57c69b0c2ab5071`
- `DOMException.code: 20` confirms `ABORT_ERR` in both cases

Claude session: https://claude.ai/code/session_0195fxt7YcRVs51RoLXyfBiY

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.