### PR TITLE
fix(releaseBubbles): guard echarts mouse handlers against disposed instance

### DIFF
--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -451,7 +451,7 @@ export function useReleaseBubbles({
       const highlightedBuckets = new Set();
 
       const handleMouseMove = (params: ElementEvent) => {
-        if (!echartsInstance) {
+        if (!echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -509,7 +509,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOver = (params: Parameters<EChartMouseOverHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -544,7 +544,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -563,7 +563,7 @@ export function useReleaseBubbles({
       // (i.e. bottom of chart), the bubble will remain highlighted. This makes it
       // look buggy and can be misleading especially for bubbles w/ 0 releases.
       const handleGlobalOut = () => {
-        if (!echartsInstance) {
+        if (!echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -581,7 +581,8 @@ export function useReleaseBubbles({
         if (
           params.name !== 'Releases' ||
           !('Releases' in params.selected) ||
-          !echartsInstance
+          !echartsInstance ||
+          echartsInstance.isDisposed()
         ) {
           return;
         }


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot read properties of undefined (reading 'get')` crash in `useReleaseBubbles.tsx` that is escalating in production (Sentry issue [JAVASCRIPT-3AP8](https://sentry.sentry.io/issues/JAVASCRIPT-3AP8), 290 events, 193 users affected).

## Root cause

All five echarts event handlers in `handleChartRef` (`handleMouseMove`, `handleMouseOver`, `handleMouseOut`, `handleGlobalOut`, `handleLegendSelectChanged`) checked `!echartsInstance` but did not check `echartsInstance.isDisposed()`.

The crash path is:

1. User moves mouse over the release bubbles chart
2. zrender's native `mousemove` DOM handler fires and internally dispatches a `mouseout` event via `Handler.prototype.dispatchToElement`
3. This reaches our registered `handleMouseOut` callback
4. `handleMouseOut` calls `echartsInstance.setOption(...)` — but at this point the chart is mid-teardown (deps changed, triggering cleanup + re-registration, or component is unmounting)
5. ECharts' `GlobalModel._mergeOption` iterates `_seriesIndices` and hits a stale/undefined `seriesModel`, throwing `TypeError: Cannot read properties of undefined (reading 'get')`

## Fix

Add `echartsInstance.isDisposed()` to the guard condition in all five handlers. ECharts sets this flag synchronously when `dispose()` is called, so the check is reliable.

```
if (!echartsInstance || echartsInstance.isDisposed()) return;
```

This is the approach recommended by Seer analysis on the issue.

## Evidence

- Sentry issue: https://sentry.sentry.io/issues/JAVASCRIPT-3AP8
- 290 occurrences, 193 users, escalating since 2026-07-06
- Stack trace confirms crash at `useReleaseBubbles.tsx:552` inside `handleMouseOut → setOption → GlobalModel._mergeOption → eachSeries → seriesModel.get`
- Seer actionability: medium

## Claude session

https://claude.ai/code/session_01RgKuwi8ia6932f3JRJau9x

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgKuwi8ia6932f3JRJau9x)_