### PR TITLE
chore(scm-project-creation-flow): Clearing alert channel on refetch

### DIFF
--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -20,7 +20,7 @@ const pythonPlatform: OnboardingSelectedSDK = {
 };
 
 describe('getSubmitTooltipText', () => {
-  const none_missing = {
+  const none = {
     platform: false,
     projectName: false,
     team: false,
@@ -28,35 +28,33 @@ describe('getSubmitTooltipText', () => {
   };
 
   it('returns undefined when nothing is missing', () => {
-    expect(getSubmitTooltipText(none_missing)).toBeUndefined();
+    expect(getSubmitTooltipText(none)).toBeUndefined();
   });
 
   it('returns a summary when multiple fields are missing', () => {
-    expect(
-      getSubmitTooltipText({...none_missing, platform: true, projectName: true})
-    ).toBe('Please fill out all the required fields');
+    expect(getSubmitTooltipText({...none, platform: true, projectName: true})).toBe(
+      'Please fill out all the required fields'
+    );
   });
 
   it('names the platform when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, platform: true})).toBe(
+    expect(getSubmitTooltipText({...none, platform: true})).toBe(
       'Please select a platform'
     );
   });
 
   it('names the project name when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, projectName: true})).toBe(
+    expect(getSubmitTooltipText({...none, projectName: true})).toBe(
       'Please provide a project name'
     );
   });
 
   it('names the team when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, team: true})).toBe(
-      'Please select a team'
-    );
+    expect(getSubmitTooltipText({...none, team: true})).toBe('Please select a team');
   });
 
   it('names the notification channel when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, notificationChannel: true})).toBe(
+    expect(getSubmitTooltipText({...none, notificationChannel: true})).toBe(
       'Please provide an integration channel for alert notifications'
     );
   });

--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -20,7 +20,7 @@ const pythonPlatform: OnboardingSelectedSDK = {
 };
 
 describe('getSubmitTooltipText', () => {
-  const none = {
+  const none_missing = {
     platform: false,
     projectName: false,
     team: false,
@@ -28,33 +28,35 @@ describe('getSubmitTooltipText', () => {
   };
 
   it('returns undefined when nothing is missing', () => {
-    expect(getSubmitTooltipText(none)).toBeUndefined();
+    expect(getSubmitTooltipText(none_missing)).toBeUndefined();
   });
 
   it('returns a summary when multiple fields are missing', () => {
-    expect(getSubmitTooltipText({...none, platform: true, projectName: true})).toBe(
-      'Please fill out all the required fields'
-    );
+    expect(
+      getSubmitTooltipText({...none_missing, platform: true, projectName: true})
+    ).toBe('Please fill out all the required fields');
   });
 
   it('names the platform when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, platform: true})).toBe(
+    expect(getSubmitTooltipText({...none_missing, platform: true})).toBe(
       'Please select a platform'
     );
   });
 
   it('names the project name when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, projectName: true})).toBe(
+    expect(getSubmitTooltipText({...none_missing, projectName: true})).toBe(
       'Please provide a project name'
     );
   });
 
   it('names the team when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, team: true})).toBe('Please select a team');
+    expect(getSubmitTooltipText({...none_missing, team: true})).toBe(
+      'Please select a team'
+    );
   });
 
   it('names the notification channel when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, notificationChannel: true})).toBe(
+    expect(getSubmitTooltipText({...none_missing, notificationChannel: true})).toBe(
       'Please provide an integration channel for alert notifications'
     );
   });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -2,12 +2,21 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
+import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
+  MultipleCheckboxOptions,
+  useCreateNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 describe('MessagingIntegrationAlertRule', () => {
@@ -92,5 +101,119 @@ describe('MessagingIntegrationAlertRule', () => {
     await screen.findByText(/notify via integration/i);
     await userEvent.click(screen.getByText(/notify via integration/i));
     expect(mockSetAction).toHaveBeenCalled();
+  });
+});
+
+describe('useCreateNotificationAction', () => {
+  const organization = OrganizationFixture();
+
+  const slackIntegration = OrganizationIntegrationsFixture({
+    id: '1',
+    name: 'my-workspace',
+    status: 'active',
+    provider: {
+      key: 'slack',
+      slug: 'slack',
+      name: 'Slack',
+      canAdd: true,
+      canDisable: false,
+      features: [],
+      aspects: {},
+    },
+  });
+
+  function addIntegrationsResponse(body: OrganizationIntegration[]) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body,
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+  }
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('defaults provider and integration from the first result on load', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(() => useCreateNotificationAction(), {
+      organization,
+    });
+
+    // Initially unset while the query is pending.
+    expect(result.current.notificationProps.provider).toBeUndefined();
+
+    // After the query resolves, defaults to the first provider/integration.
+    await act(async () => {});
+    expect(result.current.notificationProps.provider).toBe('slack');
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.channel).toBeUndefined();
+  });
+
+  it('does not clobber a user-selected channel when the integrations list refetches', async () => {
+    const secondIntegration = OrganizationIntegrationsFixture({
+      id: '2',
+      name: 'another-workspace',
+      status: 'active',
+      provider: slackIntegration.provider,
+    });
+
+    // Initial load returns one integration.
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result, rerender} = renderHookWithProviders(
+      () => useCreateNotificationAction(),
+      {organization}
+    );
+
+    await act(async () => {});
+    expect(result.current.notificationProps.provider).toBe('slack');
+
+    // User picks a channel.
+    act(() => {
+      result.current.notificationProps.setChannel({label: '#alerts', value: '#alerts'});
+    });
+    expect(result.current.notificationProps.channel?.value).toBe('#alerts');
+
+    // A refetch comes in with an updated list. Simulate by providing a new mock response
+    // with two integrations and re-rendering so the deps change.
+    MockApiClient.clearMockResponses();
+    addIntegrationsResponse([slackIntegration, secondIntegration]);
+    await act(async () => {
+      rerender();
+    });
+
+    // The run-once guard holds: provider/integration/channel are not reset.
+    expect(result.current.notificationProps.provider).toBe('slack');
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.channel?.value).toBe('#alerts');
+  });
+
+  it('resolves provider, integration, and actions from defaultActions on mount', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useCreateNotificationAction({
+          actions: [
+            {
+              id: IssueAlertActionType.SLACK,
+              workspace: slackIntegration.id,
+              channel: '#eng',
+            },
+          ],
+        }),
+      {organization}
+    );
+
+    await act(async () => {});
+
+    // Autofill effect from defaultActions sets provider, integration, and channel.
+    expect(result.current.notificationProps.provider).toBe('slack');
+    expect(result.current.notificationProps.actions).toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+    expect(result.current.notificationProps.channel?.value).toBe('#eng');
   });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -8,6 +8,7 @@ import {
   renderHookWithProviders,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import {IssueAlertActionType} from 'sentry/types/alerts';
@@ -145,8 +146,7 @@ describe('useCreateNotificationAction', () => {
     expect(result.current.notificationProps.provider).toBeUndefined();
 
     // After the query resolves, defaults to the first provider/integration.
-    await act(async () => {});
-    expect(result.current.notificationProps.provider).toBe('slack');
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
     expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
     expect(result.current.notificationProps.channel).toBeUndefined();
   });
@@ -167,8 +167,7 @@ describe('useCreateNotificationAction', () => {
       {organization}
     );
 
-    await act(async () => {});
-    expect(result.current.notificationProps.provider).toBe('slack');
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
 
     // User picks a channel.
     act(() => {
@@ -180,7 +179,7 @@ describe('useCreateNotificationAction', () => {
     // with two integrations and re-rendering so the deps change.
     MockApiClient.clearMockResponses();
     addIntegrationsResponse([slackIntegration, secondIntegration]);
-    await act(async () => {
+    act(() => {
       rerender();
     });
 
@@ -193,17 +192,18 @@ describe('useCreateNotificationAction', () => {
   it('resolves provider, integration, and actions from defaultActions on mount', async () => {
     addIntegrationsResponse([slackIntegration]);
 
+    // Stable reference: the autofill effect depends on `defaultActions`, so an
+    // inline array (new ref each render) would loop render -> setState -> render.
+    const defaultActions = [
+      {
+        id: IssueAlertActionType.SLACK,
+        workspace: slackIntegration.id,
+        channel: '#eng',
+      },
+    ];
+
     const {result} = renderHookWithProviders(
-      () =>
-        useCreateNotificationAction({
-          actions: [
-            {
-              id: IssueAlertActionType.SLACK,
-              workspace: slackIntegration.id,
-              channel: '#eng',
-            },
-          ],
-        }),
+      () => useCreateNotificationAction({actions: defaultActions}),
       {organization}
     );
 

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -1,4 +1,12 @@
-import {Fragment, useCallback, useEffect, useMemo, useState, type ReactNode} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -124,6 +132,10 @@ export function useCreateNotificationAction({
   );
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(undefined);
   const [shouldRenderSetupButton, setShouldRenderSetupButton] = useState(false);
+  // Ensures the init effect runs exactly once (first successful load). Later
+  // refetches updating providersToIntegrations must not override a selection
+  // the user already made.
+  const hasInitializedSelection = useRef(false);
 
   useEffect(() => {
     // Initializes form state based on the first default action and available integrations.
@@ -164,14 +176,17 @@ export function useCreateNotificationAction({
   }, [defaultActions, providersToIntegrations]);
 
   useEffect(() => {
-    if (messagingIntegrationsQuery.isSuccess) {
-      const providerKeys = Object.keys(providersToIntegrations);
-      const firstProvider = providerKeys[0];
-      const firstIntegration = providersToIntegrations[String(firstProvider)]?.[0];
-      setProvider(firstProvider);
-      setIntegration(firstIntegration);
-      setShouldRenderSetupButton(!firstProvider);
+    if (!messagingIntegrationsQuery.isSuccess || hasInitializedSelection.current) {
+      return;
     }
+    hasInitializedSelection.current = true;
+    const providerKeys = Object.keys(providersToIntegrations);
+    const firstProvider = providerKeys[0];
+    const firstIntegration = providersToIntegrations[String(firstProvider)]?.[0];
+    setProvider(firstProvider);
+    setIntegration(firstIntegration);
+    setChannel(undefined);
+    setShouldRenderSetupButton(!firstProvider);
   }, [messagingIntegrationsQuery.isSuccess, providersToIntegrations]);
 
   const createNotificationAction = useCallback(

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -182,9 +182,17 @@ export function useCreateNotificationAction({
     if (!messagingIntegrationsQuery.isSuccess || hasInitializedSelection.current) {
       return;
     }
-    hasInitializedSelection.current = true;
     const providerKeys = Object.keys(providersToIntegrations);
     const firstProvider = providerKeys[0];
+
+    // If the first fetch returned no integrations, don't mark as initialized yet.
+    // A subsequent refetch (e.g. after connecting via SetupMessagingIntegrationButton)
+    // may deliver integrations and must be allowed to auto-select provider/integration.
+    if (!firstProvider) {
+      return;
+    }
+
+    hasInitializedSelection.current = true;
     const firstIntegration = providersToIntegrations[String(firstProvider)]?.[0];
     setProvider(firstProvider);
     setIntegration(firstIntegration);

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -131,9 +131,16 @@ export function useCreateNotificationAction({
     undefined
   );
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(undefined);
-  const [shouldRenderSetupButton, setShouldRenderSetupButton] = useState(false);
 
   const hasInitializedSelection = useRef(false);
+
+  // Derived rather than state so it stays in sync with the query instead of
+  // freezing at its first-success value: if the first fetch has no
+  // integrations, connecting one via SetupMessagingIntegrationButton
+  // refetches this query and should reveal the integration checkbox.
+  const shouldRenderSetupButton =
+    messagingIntegrationsQuery.isSuccess &&
+    Object.keys(providersToIntegrations).length === 0;
 
   useEffect(() => {
     // Initializes form state based on the first default action and available integrations.
@@ -154,8 +161,6 @@ export function useCreateNotificationAction({
 
     setProvider(matchedProviderKey);
     setIntegration(matchedIntegration);
-
-    setShouldRenderSetupButton(!matchedIntegration);
 
     const newActions =
       firstAction.id === IssueAlertActionType.NOTIFY_EMAIL
@@ -184,7 +189,6 @@ export function useCreateNotificationAction({
     setProvider(firstProvider);
     setIntegration(firstIntegration);
     setChannel(undefined);
-    setShouldRenderSetupButton(!firstProvider);
   }, [messagingIntegrationsQuery.isSuccess, providersToIntegrations]);
 
   const createNotificationAction = useCallback(

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -132,9 +132,7 @@ export function useCreateNotificationAction({
   );
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(undefined);
   const [shouldRenderSetupButton, setShouldRenderSetupButton] = useState(false);
-  // Ensures the init effect runs exactly once (first successful load). Later
-  // refetches updating providersToIntegrations must not override a selection
-  // the user already made.
+
   const hasInitializedSelection = useRef(false);
 
   useEffect(() => {

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -88,6 +88,21 @@ describe('MessagingIntegrationAlertRule', () => {
     expect(screen.getAllByRole('textbox')).toHaveLength(3);
   });
 
+  it('clears the channel select when channel prop becomes undefined', () => {
+    const {rerender} = render(getComponent(), {organization});
+
+    // The initial channel value label is visible.
+    expect(screen.getByText('channel')).toBeInTheDocument();
+
+    // Parent state clears channel (e.g. after provider or integration change).
+    rerender(
+      <MessagingIntegrationAlertRule {...notificationProps} channel={undefined} />
+    );
+
+    // The stale channel label must no longer be shown; the select is empty.
+    expect(screen.queryByText('channel')).not.toBeInTheDocument();
+  });
+
   it('calls setter when new integration is selected', async () => {
     render(getComponent());
     await selectEvent.select(

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -171,7 +171,7 @@ export function ChannelSelect({
       options={options}
       isLoading={isLoading}
       disabled={disabled}
-      value={value ? {label: value.label, value: value.value} : undefined}
+      value={value ? {label: value.label, value: value.value} : null}
       onChange={onChange}
       onCreateOption={onCreateOption}
       clearable


### PR DESCRIPTION
Fixes: [LINEAR TICKET](https://linear.app/getsentry/issue/VDY-130/messaging-integration-refetch-resets-providerintegration-without)

The notification picker's auto-select effect was keyed on `providersToIntegrations`, which gets a fresh reference on every refetch (stale time zero + refetch-on-focus), so refetches re-ran it and reset the user's provider/integration and could strand a chosen channel. This guards the init with a ref so it runs once after the query first succeeds and clears the channel there; later refetches no longer rewrite a user-selected provider, integration, or channel.

Covered by new `issueAlertNotificationOptions.spec.tsx` tests simulating a refetch and asserting the user's selection persists, with existing specs updated.