### PR TITLE
fix: handle PII-scrubbed span values and unknown GitHub PR actions gracefully

### DIFF
--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -56,7 +56,11 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         payload_size_threshold = self.settings["payload_size_threshold"]
 
         if isinstance(encoded_body_size, str):
-            encoded_body_size = int(encoded_body_size)
+            try:
+                encoded_body_size = int(encoded_body_size)
+            except ValueError:
+                # Value may be scrubbed by PII filters (e.g. '[Filtered]')
+                return
 
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)

--- a/src/sentry/scm/private/webhooks/github.py
+++ b/src/sentry/scm/private/webhooks/github.py
@@ -1,3 +1,5 @@
+import logging
+import typing
 from typing import Optional
 
 import msgspec
@@ -14,6 +16,15 @@ from sentry.scm.types import (
     EventType,
     PullRequestEvent,
     SubscriptionEvent,
+)
+
+logger = logging.getLogger(__name__)
+
+# Valid pull request action strings, derived from the PullRequestAction type alias.
+# Used to gracefully skip events with action values not yet in our type definition
+# (e.g. new GitHub features like "stacked") instead of crashing on decode.
+_KNOWN_PR_ACTIONS: frozenset[str] = frozenset(
+    typing.get_args(getattr(PullRequestAction, "__value__", PullRequestAction))
 )
 
 # Remaining types in use:
@@ -63,7 +74,7 @@ class GitHubIssue(msgspec.Struct, gc=False):
 
 
 class GitHubPullRequestEvent(msgspec.Struct, gc=False):
-    action: PullRequestAction
+    action: str  # str so unknown future GitHub action types don't fail validation
     number: int
     pull_request: "GitHubPullRequest"
 
@@ -136,13 +147,20 @@ def deserialize_github_comment_event(event: SubscriptionEvent) -> CommentEvent:
     )
 
 
-def deserialize_github_pull_request_event(event: SubscriptionEvent) -> PullRequestEvent:
+def deserialize_github_pull_request_event(event: SubscriptionEvent) -> PullRequestEvent | None:
     e = pull_request_decoder.decode(event["event"])
 
+    # GitHub adds new pull_request action types over time (e.g. "stacked").
+    # Skip events whose action we don't recognise rather than crashing.
+    if e.action not in _KNOWN_PR_ACTIONS:
+        logger.info("github.webhook.pull_request.unknown_action", extra={"action": e.action})
+        return None
+
+    action: PullRequestAction = e.action  # type: ignore[assignment]
     repo = e.pull_request.head.repo or e.pull_request.base.repo
 
     return PullRequestEvent(
-        action=e.action,
+        action=action,
         pull_request={
             "author": {"id": str(e.pull_request.user.id), "username": e.pull_request.user.login},
             "base": {"ref": e.pull_request.base.ref, "sha": e.pull_request.base.sha},


### PR DESCRIPTION
Fixes two escalating Sentry alerts surfaced by automated monitoring.

## SENTRY-5R9R — `ValueError` in `LargeHTTPPayloadDetector` (HIGH actionability, 1256 occurrences)

**Root cause:** `large_http_payload_detector.py:59` calls `int(encoded_body_size)` where `encoded_body_size` is a string. When Sentry's PII data scrubber replaces the value with `'[Filtered]'`, the `int()` conversion throws `ValueError`, which is caught upstream as "Failed to detect performance problems" — silently skipping performance issue detection for that span.

**Fix:** Wrap the `int()` call in `try/except ValueError` and return early, so scrubbed spans are skipped cleanly.

**Evidence:** Stacktrace shows `encoded_body_size = "'[Filtered]'"` as a local variable at the crash point. Issue link: https://sentry.sentry.io/issues/SENTRY-5R9R

---

## SENTRY-5R97 — `ValidationError: Invalid enum value 'stacked'` in GitHub webhook (MEDIUM actionability, 177 occurrences, 93 users)

**Root cause:** GitHub introduced a new pull request action type `"stacked"` (stacked PRs feature). Our `GitHubPullRequestEvent` msgspec struct used `PullRequestAction` (a strict `Literal[...]` type) for the `action` field, so msgspec's decoder throws `ValidationError` on any action not in the enum. This generates a Sentry error for every `stacked` PR event from any customer's GitHub integration.

**Fix:**
- Widen `GitHubPullRequestEvent.action` from `PullRequestAction` to `str` so msgspec accepts any string without failing validation.
- Compute `_KNOWN_PR_ACTIONS` at import time from `typing.get_args` on the `PullRequestAction` type alias (so it stays in sync when `sentry-scm` is bumped).
- In `deserialize_github_pull_request_event`, return `None` for unrecognised action types with an `info`-level log instead of crashing. The caller (`deserialize_github_event`) already returns `EventType | None`, so `None` events are silently dropped.

**Note:** `sentry-scm==0.32.1` (released 2026-07-10) already adds `"stacked"` to `PullRequestAction`, but it hasn't been published to the internal PyPI yet. This sentry-side fix provides immediate relief and future-proofs us against any other new GitHub action types.

**Evidence:** Error tags show `github_event_action: stacked`. Issue link: https://sentry.sentry.io/issues/SENTRY-5R97

---

## Changes

- `src/sentry/issue_detection/detectors/large_http_payload_detector.py`: try/except ValueError around `int(encoded_body_size)`
- `src/sentry/scm/private/webhooks/github.py`: widen action field to `str`, validate against `_KNOWN_PR_ACTIONS`, return `None` for unknown actions

---

Claude session: https://claude.ai/code/session_015Gd856MCZWtWz8VmqLdaA3

---
_Generated by [Claude Code](https://claude.ai/code/session_015Gd856MCZWtWz8VmqLdaA3)_