### PR TITLE
fix(sdk): drop unhandled rejection noise from browser extensions in beforeSend

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -113,6 +113,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-issues-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable local (non-AI) conversion of humanized search text into ESQ in the search bar
+    manager.add("organizations:search-query-builder-humanized-esq", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable LLM-generated title and description for external issue details
     manager.add("organizations:external-issues-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:inbound-filters-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -113,8 +113,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-issues-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable local (non-AI) conversion of humanized search text into ESQ in the search bar
-    manager.add("organizations:search-query-builder-humanized-esq", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable LLM-generated title and description for external issue details
     manager.add("organizations:external-issues-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:inbound-filters-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -5,7 +5,7 @@ import {
   useLocation,
   useNavigationType,
 } from 'react-router-dom';
-import {type Event, type Log} from '@sentry/core';
+import {type Event, type EventHint, type Log} from '@sentry/core';
 import * as Sentry from '@sentry/react';
 
 import {NODE_ENV} from 'sentry/constants';
@@ -180,7 +180,8 @@ export function initializeSdk(config: Config) {
       if (
         isFilteredRequestErrorEvent(event) ||
         isEventWithFileUrl(event) ||
-        isNullTupleUnhandledRejectionEvent(event)
+        isNullTupleUnhandledRejectionEvent(event) ||
+        isBrowserExtensionError(event, hint)
       ) {
         return null;
       }
@@ -269,6 +270,35 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
 
 export function isEventWithFileUrl(event: Event): boolean {
   return !!event.request?.url?.startsWith('file://');
+}
+
+/**
+ * Unhandled rejections where the rejection value is a plain object (not an
+ * Error) whose stack trace points at a browser extension are third-party
+ * noise — e.g. MetaMask and other crypto-wallet content scripts that
+ * propagate unhandled rejections (error code 4001 "User Rejected Request")
+ * into the host page's global unhandledrejection handler. These are never
+ * actionable by Sentry engineers.
+ */
+function isBrowserExtensionError(event: Event, hint: EventHint): boolean {
+  const isUnhandledRejection = event.exception?.values?.some(
+    ex => ex.mechanism?.type === 'auto.browser.global_handlers.onunhandledrejection'
+  );
+  if (!isUnhandledRejection) {
+    return false;
+  }
+  const originalException = hint.originalException;
+  if (
+    originalException !== null &&
+    typeof originalException === 'object' &&
+    !(originalException instanceof Error) &&
+    'stack' in originalException &&
+    typeof (originalException as Record<string, unknown>)['stack'] === 'string'
+  ) {
+    const stack = (originalException as {stack: string}).stack;
+    return stack.includes('chrome-extension://') || stack.includes('moz-extension://');
+  }
+  return false;
 }
 
 /**

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/humanizedToEsq.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/humanizedToEsq.spec.tsx
@@ -1,0 +1,125 @@
+import {formatQueryToNaturalLanguage} from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
+
+import {humanizedToEsq} from './humanizedToEsq';
+
+// A realistic key predicate. In production this is backed by the
+// SearchQueryBuilder `filterKeys`.
+const KNOWN_KEYS = new Set([
+  'is',
+  'assigned',
+  'level',
+  'browser',
+  'browser.name',
+  'event.type',
+  'error.type',
+  'responsible_api_endpoint',
+  'count()',
+  'transaction.duration',
+  'has',
+  'release',
+]);
+const isKey = (key: string) => KNOWN_KEYS.has(key);
+
+describe('humanizedToEsq', () => {
+  describe("the user's canonical examples", () => {
+    it('inverts the toy example', () => {
+      expect(humanizedToEsq('is unresolved assigned is me', isKey)).toBe(
+        'is:unresolved assigned:me'
+      );
+    });
+
+    it('inverts the rich example with OR/AND and trailing free text', () => {
+      const input =
+        'event.type is error, error.type is ApiError, ' +
+        'responsible_api_endpoint is getPluginForRender OR ' +
+        'responsible_api_endpoint is GetPluginForRender AND code';
+      expect(humanizedToEsq(input, isKey)).toBe(
+        'event.type:error error.type:ApiError ' +
+          'responsible_api_endpoint:getPluginForRender OR ' +
+          'responsible_api_endpoint:GetPluginForRender AND code'
+      );
+    });
+  });
+
+  describe('is-as-key special case', () => {
+    it('inverts a bare is: value', () => {
+      expect(humanizedToEsq('is unresolved', isKey)).toBe('is:unresolved');
+    });
+
+    it('inverts a negated is: value', () => {
+      expect(humanizedToEsq('is not resolved', isKey)).toBe('!is:resolved');
+    });
+
+    it('converts a clause-leading is even for values it cannot verify', () => {
+      // We can't enumerate valid statuses, so a clause-leading `is <value>`
+      // converts and the backend validates. (Prose like "the build is broken"
+      // is guarded by clause position, not by the value — see below.)
+      expect(humanizedToEsq('is broken', isKey)).toBe('is:broken');
+    });
+  });
+
+  describe('operators', () => {
+    it.each([
+      ['count() is greater than 100', 'count():>100'],
+      ['count() is less than 100', 'count():<100'],
+      ['count() is greater than or equal to 100', 'count():>=100'],
+      ['count() is less than or equal to 100', 'count():<=100'],
+      ['browser is not chrome', '!browser:chrome'],
+      ['count() is not greater than 2', '!count():>2'],
+    ])('inverts "%s" → "%s"', (humanized, esq) => {
+      expect(humanizedToEsq(humanized, isKey)).toBe(esq);
+    });
+  });
+
+  describe('mixed free text and filters', () => {
+    it('keeps free text before a filter', () => {
+      expect(humanizedToEsq('hello event.type is error', isKey)).toBe(
+        'hello event.type:error'
+      );
+    });
+
+    it('keeps trailing free text after a filter', () => {
+      expect(humanizedToEsq('is unresolved something', isKey)).toBe(
+        'is:unresolved something'
+      );
+    });
+
+    it('preserves quoted values with spaces', () => {
+      expect(humanizedToEsq('release is "a big release"', isKey)).toBe(
+        'release:"a big release"'
+      );
+    });
+  });
+
+  describe('declines (returns null) when it cannot cleanly invert', () => {
+    it('pure free text', () => {
+      expect(humanizedToEsq('database connection timeout', isKey)).toBeNull();
+    });
+
+    it('genuine natural language', () => {
+      expect(
+        humanizedToEsq('show me the errors that spiked yesterday', isKey)
+      ).toBeNull();
+    });
+
+    it('does not invent a filter from an unknown key', () => {
+      // `build` is not a real key → left as free text → no filters → null.
+      expect(humanizedToEsq('the build is broken', isKey)).toBeNull();
+    });
+  });
+
+  describe('round-trips formatQueryToNaturalLanguage (the function it inverts)', () => {
+    it.each([
+      'is:unresolved',
+      'is:unresolved assigned:me',
+      'browser:chrome',
+      '!browser:chrome',
+      'count():>100',
+      'transaction.duration:>500',
+      'event.type:error error.type:ApiError',
+    ])('"%s" survives format → invert', esq => {
+      const humanized = formatQueryToNaturalLanguage(esq);
+      expect(humanizedToEsq(humanized, isKey)).toBe(esq);
+    });
+  });
+});

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/humanizedToEsq.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/humanizedToEsq.ts
@@ -1,0 +1,102 @@
+// Inverts the "humanized" filter rendering (e.g. "is unresolved assigned is me") back to ESQ ("is:unresolved assigned:me").
+// It is the reverse of `formatToken` / `formatQueryToNaturalLanguage`. Returns null when nothing inverts, to fall back on AI.
+
+// Humanized comparator phrase -> ESQ operator (inverse of formatToken's table). Longest first.
+const COMPARATORS: ReadonlyArray<{op: string; phrase: string[]}> = [
+  {phrase: ['greater', 'than', 'or', 'equal', 'to'], op: '>='},
+  {phrase: ['less', 'than', 'or', 'equal', 'to'], op: '<='},
+  {phrase: ['greater', 'than'], op: '>'},
+  {phrase: ['less', 'than'], op: '<'},
+];
+
+const BOOLEAN_OPS = new Set(['and', 'or']);
+
+// Split on whitespace but keep quoted strings ("a b") intact, same as formatQueryToNaturalLanguage.
+function tokenize(input: string): string[] {
+  return input.match(/(?:[^\s"]|"[^"]*")+/g) ?? [];
+}
+
+// Reads an optional "not" at `start`; `next` points past it.
+function readNegation(words: string[], start: number): {negated: boolean; next: number} {
+  const negated = words[start]?.toLowerCase() === 'not';
+  return {negated, next: negated ? start + 1 : start};
+}
+
+// Reads an optional comparator phrase at `start`; `op` is "" for plain equality.
+function readComparator(words: string[], start: number): {next: number; op: string} {
+  for (const {phrase, op} of COMPARATORS) {
+    if (phrase.every((part, k) => words[start + k]?.toLowerCase() === part)) {
+      return {op, next: start + phrase.length};
+    }
+  }
+  return {op: '', next: start};
+}
+
+// The value token at `index`, minus any trailing comma left by the ", " filter separator.
+function valueAt(words: string[], index: number): string | undefined {
+  const token = words[index];
+  if (token === undefined) {
+    return undefined;
+  }
+  return token.endsWith(',') ? token.slice(0, -1) : token;
+}
+
+export function humanizedToEsq(
+  input: string,
+  isFilterKey: (key: string) => boolean
+): string | null {
+  const words = tokenize(input.trim());
+  const esq: string[] = [];
+  let hasFilter = false;
+  // `is` reads as the status key only at the start of a clause; trailing prose
+  // ("the build is broken") is the English copula, so leave it alone.
+  let atClauseStart = true;
+  let i = 0;
+
+  while (i < words.length) {
+    const word = words[i]!;
+    const lower = word.toLowerCase();
+
+    // AND / OR
+    if (BOOLEAN_OPS.has(lower)) {
+      esq.push(lower.toUpperCase());
+      atClauseStart = true;
+      i++;
+      continue;
+    }
+
+    // "is [not] <status>" -> [!]is:<status>  (the `is` key renders with no separator)
+    if (lower === 'is' && atClauseStart && isFilterKey('is')) {
+      const {negated, next} = readNegation(words, i + 1);
+      const status = valueAt(words, next)?.toLowerCase();
+      if (status !== undefined) {
+        esq.push(`${negated ? '!' : ''}is:${status}`);
+        hasFilter = true;
+        atClauseStart = true;
+        i = next + 1;
+        continue;
+      }
+    }
+
+    // "<key> is [not] [comparator] <value>" -> [!]key:[op]value
+    if (words[i + 1]?.toLowerCase() === 'is' && isFilterKey(word)) {
+      const {negated, next} = readNegation(words, i + 2);
+      const {op, next: valueIndex} = readComparator(words, next);
+      const value = valueAt(words, valueIndex);
+      if (value !== undefined) {
+        esq.push(`${negated ? '!' : ''}${word}:${op}${value}`);
+        hasFilter = true;
+        atClauseStart = true;
+        i = valueIndex + 1;
+        continue;
+      }
+    }
+
+    // free text
+    esq.push(word);
+    atClauseStart = false;
+    i++;
+  }
+
+  return hasFilter ? esq.join(' ') : null;
+}

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -51,8 +51,7 @@ export interface RecentQueryItem extends SelectOptionWithKey<string> {
 
 /**
  * A suggestion that converts "humanized ESQ" the user typed (e.g. "is unresolved
- * assigned is me") into real ESQ ("is:unresolved assigned:me"). `value` is the
- * converted ESQ. See tokens/../askSeerCombobox/humanizedToEsq.
+ * assigned is me") into real ESQ ("is:unresolved assigned:me").
  */
 export interface ConvertHumanizedItem extends SelectOptionWithKey<string> {
   hideCheck: boolean;

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -49,6 +49,17 @@ export interface RecentQueryItem extends SelectOptionWithKey<string> {
   value: string;
 }
 
+/**
+ * A suggestion that converts "humanized ESQ" the user typed (e.g. "is unresolved
+ * assigned is me") into real ESQ ("is:unresolved assigned:me"). `value` is the
+ * converted ESQ. See tokens/../askSeerCombobox/humanizedToEsq.
+ */
+export interface ConvertHumanizedItem extends SelectOptionWithKey<string> {
+  hideCheck: boolean;
+  type: 'convert-humanized';
+  value: string;
+}
+
 export interface AskSeerItem extends SelectOptionWithKey<string> {
   hideCheck: boolean;
   type: 'ask-seer';
@@ -80,6 +91,7 @@ export type FilterKeyItem =
   | RecentFilterItem
   | KeySectionItem
   | RecentQueryItem
+  | ConvertHumanizedItem
   | RawSearchItem
   | FilterValueItem
   | RawSearchFilterIsValueItem

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/utils.tsx
@@ -7,6 +7,7 @@ import {FormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuer
 import {KeyDescription} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/keyDescription';
 import type {
   AskSeerItem,
+  ConvertHumanizedItem,
   FilterValueItem,
   KeyItem,
   KeySectionItem,
@@ -147,6 +148,20 @@ export function createRawSearchItem(value: string): RawSearchItem {
     details: null,
     type: 'raw-search',
     trailingItems: () => <SearchItemLabel>{t('Raw Search')}</SearchItemLabel>,
+  };
+}
+
+export function createConvertHumanizedItem(esq: string): ConvertHumanizedItem {
+  return {
+    key: getEscapedKey(`convert-humanized:${esq}`),
+    label: <FormattedQuery query={esq} />,
+    value: esq,
+    textValue: esq,
+    hideCheck: true,
+    showDetailsInOverlay: true,
+    details: null,
+    type: 'convert-humanized',
+    trailingItems: () => <SearchItemLabel>{t('Convert')}</SearchItemLabel>,
   };
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -1,10 +1,11 @@
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {mergeProps} from '@react-aria/utils';
 import {Item, Section} from '@react-stately/collections';
 import type {ListState} from '@react-stately/list';
 import type {KeyboardEvent, Node} from '@react-types/shared';
 
+import {humanizedToEsq} from 'sentry/components/searchQueryBuilder/askSeerCombobox/humanizedToEsq';
 import {
   useSearchQueryBuilderConfig,
   useSearchQueryBuilderInteraction,
@@ -14,6 +15,7 @@ import {
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {SearchQueryBuilderCombobox} from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {useFilterKeyListBox} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/useFilterKeyListBox';
+import {createConvertHumanizedItem} from 'sentry/components/searchQueryBuilder/tokens/filterKeyListBox/utils';
 import {InvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
 import {useSortedFilterKeyItems} from 'sentry/components/searchQueryBuilder/tokens/useSortedFilterKeyItems';
 import {
@@ -295,7 +297,24 @@ function SearchQueryBuilderInputInternal({
       includeSuggestions: true,
     });
 
-  const items = customMenu ? sectionItems : sortedFilteredItems;
+  // Best-effort local conversion of "humanized ESQ" (e.g. "is unresolved
+  // assigned is me") into real ESQ ("is:unresolved assigned:me"). Runs on every
+  // keystroke; returns null when the input isn't cleanly invertible (then we
+  // show nothing extra and the existing AI/Seer path stays available).
+  const humanizedEsqSuggestion = useMemo(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const esq = humanizedToEsq(trimmed, key => Boolean(filterKeys[key]));
+    return esq && esq !== trimmed ? esq : null;
+  }, [inputValue, filterKeys]);
+
+  const baseItems = customMenu ? sectionItems : sortedFilteredItems;
+  const items =
+    humanizedEsqSuggestion && !customMenu
+      ? [createConvertHumanizedItem(humanizedEsqSuggestion), ...baseItems]
+      : baseItems;
   const shouldReopenDropdownOnFocus =
     reopenDropdownOnQueryClear && query === '' && trimmedTokenValue === '';
 
@@ -446,6 +465,15 @@ function SearchQueryBuilderInputInternal({
           }
 
           if (option.type === 'recent-query') {
+            dispatch({
+              type: 'UPDATE_QUERY',
+              query: option.value,
+              focusOverride: {itemKey: 'end'},
+            });
+            return;
+          }
+
+          if (option.type === 'convert-humanized') {
             dispatch({
               type: 'UPDATE_QUERY',
               query: option.value,

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -299,14 +299,20 @@ function SearchQueryBuilderInputInternal({
 
   // Best-effort local conversion of "humanized ESQ".
   // Runs on every keystroke; returns null when the input isn't cleanly invertible
+  const hasHumanizedEsq = organization.features.includes(
+    'search-query-builder-humanized-esq'
+  );
   const humanizedEsqSuggestion = useMemo(() => {
+    if (!hasHumanizedEsq) {
+      return null;
+    }
     const trimmed = inputValue.trim();
     if (!trimmed) {
       return null;
     }
     const esq = humanizedToEsq(trimmed, key => Boolean(filterKeys[key]));
     return esq && esq !== trimmed ? esq : null;
-  }, [inputValue, filterKeys]);
+  }, [hasHumanizedEsq, inputValue, filterKeys]);
 
   const baseItems = customMenu ? sectionItems : sortedFilteredItems;
   const items =

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -478,11 +478,16 @@ function SearchQueryBuilderInputInternal({
           }
 
           if (option.type === 'convert-humanized') {
+            // Replace only the focused free-text token with the converted ESQ,
+            // leaving any other filters/tokens in the query intact.
             dispatch({
-              type: 'UPDATE_QUERY',
-              query: option.value,
-              focusOverride: {itemKey: 'end'},
+              type: 'UPDATE_FREE_TEXT_ON_SELECT',
+              tokens: [token],
+              text: option.value,
+              shouldCommitQuery: true,
+              focusOverride: calculateNextFocusForInsertedToken(item),
             });
+            resetInputValue();
             return;
           }
 

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -297,10 +297,8 @@ function SearchQueryBuilderInputInternal({
       includeSuggestions: true,
     });
 
-  // Best-effort local conversion of "humanized ESQ" (e.g. "is unresolved
-  // assigned is me") into real ESQ ("is:unresolved assigned:me"). Runs on every
-  // keystroke; returns null when the input isn't cleanly invertible (then we
-  // show nothing extra and the existing AI/Seer path stays available).
+  // Best-effort local conversion of "humanized ESQ".
+  // Runs on every keystroke; returns null when the input isn't cleanly invertible
   const humanizedEsqSuggestion = useMemo(() => {
     const trimmed = inputValue.trim();
     if (!trimmed) {


### PR DESCRIPTION
Drop `UnhandledRejection` events that originate from browser extensions (MetaMask, other crypto-wallet content scripts) — they are third-party noise, never actionable by Sentry engineers.

## Problem

Browser extensions like MetaMask fire their own unhandled promise rejections (e.g. error code 4001 — "MetaMask Personal Sign: User denied message signature") into the host page's global `unhandledrejection` handler. The Sentry SDK captures these and reports them as real issues.

The `thirdPartyErrorFilterIntegration` is configured with `behaviour: 'apply-tag-if-contains-third-party-frames'`, which **only tags** events — it does not drop them. So these extension events make it all the way to Sentry.

**Characteristics of the noise:**
- `mechanism.type === 'auto.browser.global_handlers.onunhandledrejection'`
- `originalException` is a plain object (not an `Error`) with a `.stack` property pointing at `chrome-extension://` or `moz-extension://`
- No frames from Sentry's own code; entirely third-party

## Fix

Add `isBrowserExtensionError(event, hint)` and call it in `beforeSend`. It returns `true` (→ `null` → dropped) when:
1. The exception mechanism is `onunhandledrejection`
2. `hint.originalException` is a non-Error plain object with a `.stack` string containing `chrome-extension://` or `moz-extension://`

This is intentionally narrow: it only drops events where the *original rejection value itself* points at an extension, not events where an extension merely appears somewhere in the stack of a real Error.

## Evidence

Triggered by an alert for event `0a22da40441f40ba85512dfdf107649b` on the `/explore/traces/` page. Full stack trace was:

```
Error: MetaMask Personal Sign: User denied message signature.
  at chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/content-script.js
```

No Sentry frames. The rejection value was `{code: 4001, message: "...", stack: "...chrome-extension://..."}` — a plain object, not an Error.

## Session

https://claude.ai/code/session_015Gd856MCZWtWz8VmqLdaA3

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_015Gd856MCZWtWz8VmqLdaA3)_