### PR TITLE
fix: guard against None actions in get_filtered_actions

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1995,7 +1995,9 @@ def get_filtered_actions(
     alert_rule_data: Mapping[str, Any],
     action_type: ActionService,
 ) -> list[dict[str, Any]]:
-    def is_included(action: Mapping[str, Any]) -> bool:
+    def is_included(action: Mapping[str, Any] | None) -> bool:
+        if action is None:
+            return False
         type_slug = action.get("type")
         if type_slug is None or not isinstance(type_slug, str):
             return False

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -46,6 +46,7 @@ from sentry.incidents.logic import (
     get_actions_for_trigger,
     get_alert_resolution,
     get_available_action_integrations_for_org,
+    get_filtered_actions,
     get_metric_issue_aggregates,
     get_triggers_for_alert_rule,
     snapshot_alert_rule,
@@ -3707,3 +3708,39 @@ class TestGetAlertResolution(TestCase):
         time_window = -5
         result = get_alert_resolution(time_window, self.organization)
         assert result == timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION)
+
+
+class TestGetFilteredActions(TestCase):
+    def test_none_action_in_trigger_actions(self) -> None:
+        # Regression test: None entries in trigger actions must not raise AttributeError
+        alert_rule_data: dict = {
+            "triggers": [
+                {
+                    "actions": [
+                        None,
+                        {"type": "sentry_app"},
+                    ]
+                }
+            ]
+        }
+        from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+
+        result = get_filtered_actions(
+            alert_rule_data, AlertRuleTriggerAction.Type.SENTRY_APP
+        )
+        assert isinstance(result, list)
+
+    def test_empty_actions(self) -> None:
+        alert_rule_data: dict = {"triggers": [{"actions": []}]}
+        from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+
+        result = get_filtered_actions(
+            alert_rule_data, AlertRuleTriggerAction.Type.SENTRY_APP
+        )
+        assert result == []
+
+    def test_no_triggers(self) -> None:
+        from sentry.incidents.models.alert_rule import AlertRuleTriggerAction
+
+        result = get_filtered_actions({}, AlertRuleTriggerAction.Type.SENTRY_APP)
+        assert result == []


### PR DESCRIPTION
## Summary

Fixes a production `AttributeError` ([SENTRY-5RDY](https://sentry.sentry.io/issues/SENTRY-5RDY)) in the alert-rules PUT endpoint (`/api/0/organizations/{org}/alert-rules/{id}/`).

### Root cause

`AlertRuleSerializer.triggers` is declared as a bare `ListField` with no `child` serializer (line 77):

```python
triggers = serializers.ListField(required=True)
```

This means DRF passes list elements through as raw Python objects with no element-level coercion. If a client sends `actions: [null, {...}]` in a trigger, the only validation that runs is:

```python
if not trigger.get("actions", []):   # line 208
    raise ValidationError(...)
```

A list like `[None, {...}]` is truthy, so it passes. The `None` flows into `validated_data`, into `get_filtered_actions`, where `is_included()` then calls `action.get("type")` and crashes:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "sentry/incidents/logic.py", line 1999, in is_included
      type_slug = action.get("type")
  Local Variables:
    action = None
```

### Fix

Adds a `None` guard at the top of `is_included()` so `None` entries are skipped rather than crashing. Also adds regression tests covering the `None`-entry case, empty actions, and missing triggers.

A follow-up should add stricter validation in `AlertRuleSerializer.validate()` to reject `null` entries inside `actions` with a 400 at the boundary rather than silently passing them through.

**Sentry issue:** https://sentry.sentry.io/issues/SENTRY-5RDY  
**Claude session:** https://claude.ai/code/session_01RCczjnRYDg9wEnRAyF1B9k

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.