### PR TITLE
fix: guard against None actions in incidents and add deliver_feature_result to org seer rpc

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1995,7 +1995,9 @@ def get_filtered_actions(
     alert_rule_data: Mapping[str, Any],
     action_type: ActionService,
 ) -> list[dict[str, Any]]:
-    def is_included(action: Mapping[str, Any]) -> bool:
+    def is_included(action: Mapping[str, Any] | None) -> bool:
+        if action is None:
+            return False
         type_slug = action.get("type")
         if type_slug is None or not isinstance(type_slug, str):
             return False

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -65,6 +65,7 @@ from sentry.seer.assisted_query.traces_tools import (
 from sentry.seer.autofix.autofix_tools import get_error_event_details, get_profile_details
 from sentry.seer.endpoints.registry import SeerRpcMethod, seer_rpc
 from sentry.seer.endpoints.seer_rpc import (
+    deliver_feature_result,
     get_attributes_and_values,
     get_attributes_for_span,
     get_github_enterprise_integration_config,
@@ -158,6 +159,9 @@ public_org_seer_method_registry: dict[str, SeerRpcMethod] = {
     #
     # Agent eval tooling
     "export_explorer_indexes": seer_rpc(map_org_id_param(export_agent_indexes)),
+    #
+    # Feature result delivery (explorer push-back)
+    "deliver_feature_result": seer_rpc(deliver_feature_result),
 }
 
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -28,6 +28,7 @@ from sentry.incidents.logic import (
     WARNING_TRIGGER_LABEL,
     WINDOWED_STATS_DATA_POINTS,
     AlertRuleTriggerLabelAlreadyUsedError,
+    get_filtered_actions,
     AlertTarget,
     ChannelLookupTimeoutError,
     GetMetricIssueAggregatesParams,
@@ -3707,3 +3708,30 @@ class TestGetAlertResolution(TestCase):
         time_window = -5
         result = get_alert_resolution(time_window, self.organization)
         assert result == timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION)
+
+
+class TestGetFilteredActions(TestCase):
+    def test_none_action_does_not_raise(self) -> None:
+        """None entries in the actions list must be silently skipped (SENTRY-5RDY)."""
+        from sentry.notifications.models.notificationaction import ActionService
+
+        alert_rule_data = {
+            "triggers": [
+                {"actions": [None]},
+            ]
+        }
+        # Should not raise AttributeError even though action is None
+        result = get_filtered_actions(alert_rule_data, ActionService.SENTRY_APP)
+        assert result == []
+
+    def test_valid_actions_are_filtered(self) -> None:
+        from sentry.notifications.models.notificationaction import ActionService
+
+        alert_rule_data = {
+            "triggers": [
+                {"actions": [{"type": "sentry_notification"}, None, {"type": "unknown_type"}]},
+            ]
+        }
+        # Neither type matches SENTRY_APP so the result is empty, but no crash on None
+        result = get_filtered_actions(alert_rule_data, ActionService.SENTRY_APP)
+        assert result == []

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -382,6 +382,23 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         )
 
     @with_feature("organizations:seer-public-rpc")
+    def test_deliver_feature_result_unknown_feature_returns_200(self) -> None:
+        """deliver_feature_result is now in the org registry; unknown feature_id is a no-op."""
+        path = self._get_path("deliver_feature_result")
+        response = self.client.post(
+            path,
+            data={
+                "args": {
+                    "feature_id": "nonexistent_feature",
+                    "run_uuid": "some-uuid",
+                    "status": "completed",
+                }
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+
+    @with_feature("organizations:seer-public-rpc")
     def test_has_repo_code_mappings(self) -> None:
         """Test that has_repo_code_mappings works through the public endpoint"""
         path = self._get_path("has_repo_code_mappings")


### PR DESCRIPTION
Fixes two production errors caught by automated monitoring.

## Bug 1: SENTRY-5RDY — AttributeError in `is_included` when action is `None`

**Severity:** Medium (production error on alert rule update path)
**Evidence:** `AttributeError: 'NoneType' object has no attribute 'get'` at `sentry/incidents/logic.py:1999` with local variable `action: "None"`. Triggered by PUT `/api/0/organizations/{org}/alert-rules/{id}/` when a trigger's `actions` list contains a `None` entry.

**Fix:** Guard `is_included` against `None` entries before calling `.get()`. A `None` action is excluded (returns `False`) rather than crashing. Also corrects the type annotation to `Mapping[str, Any] | None`.

## Bug 2: SENTRY-5RDJ — `RpcResolutionException: Unknown method deliver_feature_result`

**Severity:** Medium (breaks Seer explorer feature result push-back to Sentry)
**Evidence:** `RpcResolutionException` raised in `organization_seer_rpc.py:332` with `rpc.referrer: explorer`. Seer's explorer calls `deliver_feature_result` via `ProductionProxyRpcClient` which routes to `/api/0/organizations/{org}/seer-rpc/` (the org-scoped endpoint), but the method was only registered in the internal `seer_method_registry`, not in `public_org_seer_method_registry`.

**Seer Autofix root cause:** "deliver_feature_result is registered in the global seer RPC registry but missing from the organization-scoped endpoint's registry."

**Fix:** Add `deliver_feature_result` to `public_org_seer_method_registry`. The method is safe here — it is already gated by the `organizations:seer-public-rpc` feature flag and `org:read` permission, and unknown `feature_id` values are silently ignored.

## Session

https://claude.ai/code/session_01AMHSVfELZygxVFppMefZzm

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMHSVfELZygxVFppMefZzm)_