### PR TITLE
fix: guard against invalid span data in performance detectors

### DIFF
--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -56,7 +56,10 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         payload_size_threshold = self.settings["payload_size_threshold"]
 
         if isinstance(encoded_body_size, str):
-            encoded_body_size = int(encoded_body_size)
+            try:
+                encoded_body_size = int(encoded_body_size)
+            except ValueError:
+                return
 
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -330,6 +330,24 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
+    def test_does_not_trigger_detection_for_non_numeric_string_payload_size(self) -> None:
+        # Relay data scrubbing can replace numeric values with '[NaN]' strings
+        spans = [
+            create_span(
+                "http.client",
+                1000,
+                "GET /api/0/organizations/endpoint1",
+                "hash1",
+                data={
+                    "http.response_transfer_size": "[NaN]",
+                    "http.response_content_length": "[NaN]",
+                    "http.decoded_response_content_length": "[NaN]",
+                },
+            ),
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == []
+
     def test_does_not_trigger_detection_for_filtered_paths_without_trailing_slash(self) -> None:
         project = self.create_project()
         ProjectOption.objects.set_value(

--- a/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
@@ -179,6 +179,17 @@ class MNPlusOneDBDetectorTest(TestCase):
         event = get_event("m-n-plus-one-db/m-n-plus-one-graphql-truncated")
         assert self.find_problems(event) == []
 
+    def test_handles_db_spans_missing_description(self) -> None:
+        # Some spans arrive without a description key (e.g. after data scrubbing);
+        # the detector should not raise a KeyError.
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
+        for span in event["spans"]:
+            if span.get("op", "").startswith("db"):
+                span.pop("description", None)
+        problems = self.find_problems(event)
+        assert len(problems) == 1
+        assert problems[0].desc == ""
+
     def test_does_not_detect_n_plus_one(self) -> None:
         event = get_event("n-plus-one-db/n-plus-one-in-django-index-view")
         assert self.find_problems(event) == []


### PR DESCRIPTION
Fix two high-actionability production errors in the spans performance-problem detection pipeline, both triggered by missing or scrubbed span data.

## Problem 1: `KeyError: 'description'` — SENTRY-5QVD (285k events, high actionability)

**File:** `src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py:258`

The MN+1 DB detector accessed `db_span["description"]` directly. Relay data scrubbing can strip this key entirely, causing a `KeyError` that is caught by the outer `detect_performance_problems` exception handler and logged as "Failed to detect performance problems". With 285k events, this was the most impactful of the two bugs.

**Fix:** Use `.get("description", "")` instead.

## Problem 2: `ValueError: invalid literal for int() with base 10: '[NaN]'` — SENTRY-5R9R (1.3k events, high actionability)

**File:** `src/sentry/issue_detection/detectors/large_http_payload_detector.py:59`

The large HTTP payload detector converts `http.response_content_length` from a string to an int when it arrives as a string. However, Relay data scrubbing can replace numeric values with the sentinel string `'[NaN]'`, which is not a valid integer literal.

**Fix:** Wrap the `int()` conversion in a `try/except ValueError` and skip the span if conversion fails.

## Evidence

Both errors share the same culprit (`spans.consumers.process_segments.process_segment`) and the same outer error message ("Failed to detect performance problems"), confirming they originate from the same exception-handling wrapper in `performance_detection.py`.

Session: https://claude.ai/code/session_014nHHCFa15GuZSXmrie1JtV

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_014nHHCFa15GuZSXmrie1JtV)_