### PR TITLE
fix(frontend): suppress AbortError from service worker registration

### DIFF
--- a/static/app/serviceWorker/client/serviceWorkerContext.tsx
+++ b/static/app/serviceWorker/client/serviceWorkerContext.tsx
@@ -82,6 +82,12 @@ function useRegisterServiceWorker() {
       })
       .catch(error => {
         log('error');
+        // AbortError means the browser shut down the SW system (tab closed or
+        // navigated away during registration) — this is expected browser
+        // lifecycle behavior and not actionable.
+        if (error?.name === 'AbortError') {
+          return;
+        }
         Sentry.captureException(error);
       });
   }, []);
@@ -107,6 +113,9 @@ function useServiceWorkerUpdateCheck() {
       navigator.serviceWorker.ready
         .then(registration => registration.update())
         .catch(error => {
+          if (error?.name === 'AbortError') {
+            return;
+          }
           Sentry.captureException(error);
         });
     };


### PR DESCRIPTION
## Problem

`serviceWorkerContext.tsx` calls `Sentry.captureException(error)` for all errors from `navigator.serviceWorker.register()` and the periodic `.update()` call. When a user closes or navigates away from a tab while registration is in progress, Chrome throws:

> `AbortError: Failed to register a ServiceWorker for scope (...): The Service Worker system has shutdown.`

This is normal browser lifecycle behavior (`DOMException.code: 20`), not a bug in Sentry's code. Capturing it creates low-value noise — it's already `handled: yes` and has no user impact (the app works fine without the SW).

## Fix

Filter out `AbortError`s before calling `captureException` in both:
1. `useRegisterServiceWorker` — the initial registration `.catch()`
2. `useServiceWorkerUpdateCheck` — the periodic update check `.catch()`

## Evidence

- **JAVASCRIPT-3AT6**: Single occurrence, 1 user affected, Seer actionability: `super_low`, no stacktrace, `handled: yes`
- Error message: "The Service Worker system has shutdown." — this is a browser-emitted message, not from Sentry code
- `DOMException.code: 20` is the standard code for `AbortError`

Session: https://claude.ai/code/session_014nHHCFa15GuZSXmrie1JtV

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_014nHHCFa15GuZSXmrie1JtV)_