### PR TITLE
fix(releases): guard echarts handlers against disposed instances in useReleaseBubbles

### DIFF
--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -451,7 +451,7 @@ export function useReleaseBubbles({
       const highlightedBuckets = new Set();
 
       const handleMouseMove = (params: ElementEvent) => {
-        if (!echartsInstance) {
+        if (!echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -509,7 +509,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOver = (params: Parameters<EChartMouseOverHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -544,7 +544,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -563,7 +563,7 @@ export function useReleaseBubbles({
       // (i.e. bottom of chart), the bubble will remain highlighted. This makes it
       // look buggy and can be misleading especially for bubbles w/ 0 releases.
       const handleGlobalOut = () => {
-        if (!echartsInstance) {
+        if (!echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 


### PR DESCRIPTION
## Summary

Fixes JAVASCRIPT-3AP8 — `TypeError: Cannot read properties of undefined (reading 'get')` escalating on `/dashboard/:dashboardId/`.

**Root cause:** Mouse event handlers (`mousemove`, `mouseover`, `mouseout`, `globalout`) in `useReleaseBubbles.tsx` were calling `echartsInstance.setOption()` / `getOption()` / `dispatchAction()` on an echarts instance that had already been disposed during chart state transitions (e.g. component unmount/remount racing with an in-flight mousemove event). The existing `!echartsInstance` null guard didn't cover the disposed case.

**Fix:** Added `echartsInstance.isDisposed()` checks to all four handlers alongside the existing null guards. This matches the established pattern in `useChartBoxZoom.tsx` (line 123) which has the same comment and guard.

**Evidence from Sentry:**
- Issue: https://sentry.sentry.io/issues/JAVASCRIPT-3AP8
- 292 events, 194 users impacted, status: escalating
- Stacktrace clearly points to `useReleaseBubbles.tsx:552` → `handleMouseOut` → `echartsInstance.setOption()`
- Seer analysis: "Wrap setOption calls in mouse handlers with a try/catch and add an isDisposed guard to prevent crashes during chart state transitions"

**Session:** https://claude.ai/code/session_01Vi9sPcdPUAQFGdtxcNjJ5R


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vi9sPcdPUAQFGdtxcNjJ5R)_