### PR TITLE
fix: handle missing span description and non-dict MSTeams error JSON

### DIFF
--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -30,7 +30,7 @@ def translate_msteams_api_error(error: ApiError) -> None:
     if isinstance(error, ApiRateLimitedError):
         # TODO(ecosystem): We should batch this on a per-organization basis
         raise IntegrationConfigurationError(error.text) from error
-    elif error.json:
+    elif isinstance(error.json, dict):
         if error.json.get("error", {}).get("code") in MSTEAMS_HALT_ERROR_CODES:
             raise IntegrationConfigurationError(error.text) from error
         else:

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,


### PR DESCRIPTION
Fixes two bugs surfaced by Sentry alert monitoring.

---

## Fix 1: KeyError 'description' in N+1 DB span detector (SENTRY-5QVD — HIGH actionability)

**Issue:** [SENTRY-5QVD](https://sentry.sentry.io/issues/SENTRY-5QVD) — 291K+ occurrences since 2026-06-25.

**Root cause:** `mn_plus_one_db_span_detector.py:258` did a direct dict lookup `db_span["description"]`. Spans arriving from the `process-segments` consumer can omit the `"description"` field, causing a `KeyError`. This exception is caught by the outer `try/except` in `detect_performance_problems()` which logs `"Failed to detect performance problems"` and suppresses detection entirely for affected spans.

**Evidence from event stacktrace:**
```
File "sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py", line 258, in _maybe_performance_problem
    desc=db_span["description"],
KeyError: 'description'
```
Local variable `common_parent_span` showed `"downsampled_retention_days":"30"` and no `"description"` key.

**Fix:** Use `db_span.get("description", "")` — matches the pattern used in `evidence_data` throughout the same function.

---

## Fix 2: AttributeError on non-dict MSTeams error JSON (SENTRY-5PKQ — MEDIUM)

**Issue:** [SENTRY-5PKQ](https://sentry.sentry.io/issues/SENTRY-5PKQ) — 2573 occurrences, 240 users affected since 2026-05-11.

**Root cause:** `msteams/metrics.py:34` called `error.json.get(...)` without verifying `error.json` is a dict. When Microsoft's OAuth endpoint returns a 401 with certain error payloads (e.g. `AADSTS7000222` — expired client secret), `error.json` is a string, not a dict. `.get()` on a string raises `AttributeError`, which bubbles up as a noisy secondary exception obscuring the real `ApiUnauthorized` error.

**Evidence from event stacktrace:**
```
File "sentry/integrations/msteams/metrics.py", line 34, in translate_msteams_api_error
    if error.json.get("error", {}).get("code") in MSTEAMS_HALT_ERROR_CODES:
AttributeError: 'str' object has no attribute 'get'
```
The underlying cause was an expired Azure app client secret (the primary operator issue), but the secondary `AttributeError` was generating an additional 2500+ Sentry events.

**Fix:** Use `isinstance(error.json, dict)` instead of a truthiness check, so non-dict payloads fall through to the existing `IntegrationError` branch cleanly.

---

## Session

Generated by Claude Code: https://claude.ai/code/session_01KTwqnL4x74X2LSUoHg32sd

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTwqnL4x74X2LSUoHg32sd)_