### PR TITLE
fix(release-bubbles): guard against disposed echartsInstance in mouse handlers

### DIFF
--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -451,7 +451,7 @@ export function useReleaseBubbles({
       const highlightedBuckets = new Set();
 
       const handleMouseMove = (params: ElementEvent) => {
-        if (!echartsInstance) {
+        if (!echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -509,7 +509,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOver = (params: Parameters<EChartMouseOverHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -544,7 +544,7 @@ export function useReleaseBubbles({
       };
 
       const handleMouseOut = (params: Parameters<EChartMouseOutHandler>[0]) => {
-        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance) {
+        if (params.seriesId !== BUBBLE_SERIES_ID || !echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 
@@ -563,7 +563,7 @@ export function useReleaseBubbles({
       // (i.e. bottom of chart), the bubble will remain highlighted. This makes it
       // look buggy and can be misleading especially for bubbles w/ 0 releases.
       const handleGlobalOut = () => {
-        if (!echartsInstance) {
+        if (!echartsInstance || echartsInstance.isDisposed()) {
           return;
         }
 


### PR DESCRIPTION
## Summary

Fixes **JAVASCRIPT-3AP8** — `TypeError: Cannot read properties of undefined (reading 'get')` in `useReleaseBubbles.tsx`, escalating with 195 users impacted.

**Root cause:** ECharts instances can be disposed during React component unmount/re-render while mouse events (`mouseover`, `mouseout`, `globalout`, `mousemove`) are still in-flight. When `setOption`, `getOption`, or `dispatchAction` are called on a disposed instance, ECharts' internal `GlobalModel._mergeOption` tries to call `.get()` on a series model that no longer exists, throwing the uncaught TypeError.

**Evidence from Sentry issue JAVASCRIPT-3AP8:**
- Stack trace points to `handleMouseOut` → `echartsInstance.setOption(...)` at line 552 of `useReleaseBubbles.tsx`
- The error originates inside `echarts/lib/component/marker/MarkerModel.js:98` — `seriesModel.get(this.mainType, true)` where `seriesModel` is undefined
- All occurrences are triggered by `mousemove` events on the `EventGraph-Grid > ChartContainer > BaseChart > ReactEchartsCore` element
- The existing `!echartsInstance` null check is insufficient — a disposed instance is still truthy

**Fix:** Add `echartsInstance.isDisposed()` guard to all four mouse event handlers (`handleMouseMove`, `handleMouseOver`, `handleMouseOut`, `handleGlobalOut`). The ECharts API exposes `isDisposed(): boolean` exactly for this purpose.

## Analysis Session

https://claude.ai/code/session_01KEXsNpah4hsB8C56Uzb3RJ

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEXsNpah4hsB8C56Uzb3RJ)_