### PR TITLE
fix: safely access description field in MN+1 DB span detector

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,
@@ -280,7 +280,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
                     name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
-                        db_span["description"],
+                        db_span.get("description", ""),
                     ),
                     # Has to be marked important to be displayed in the notifications
                     important=True,


### PR DESCRIPTION
## Summary

Fixes a `KeyError: 'description'` that crashes performance problem detection for segments containing spans without a `description` field. Spans from downsampled data (with `downsampled_retention_days` set) may omit the `description` key, causing `_maybe_performance_problem` in `ContinuingMNPlusOne` to raise and silently swallow the exception, losing all performance detection for that segment.

**Root cause:** Two direct dict key accesses `db_span["description"]` in `mn_plus_one_db_span_detector.py` lines 258 and 283 — one for the `PerformanceProblem.desc` field and one for the `IssueEvidence` display value.

**Fix:** Changed both to `db_span.get("description", "")`.

## Evidence

**Sentry issue:** [SENTRY-5QVD](https://sentry.sentry.io/issues/SENTRY-5QVD) — `KeyError: 'description'` in `mn_plus_one_db_span_detector.py:258`
- **297,442 events** since 2026-06-25
- Seer actionability: **high**
- Culprit: `spans.consumers.process_segments.process_segment`

Stack trace confirms the span's local variables show `{"downsampled_retention_days":"30", ...}` without a `description` field.

Seer analysis: _"Use .get('description', '') to safely access the db span description."_

## Session

This fix was identified and created by Claude Code: https://claude.ai/code/session_01JhWfwrF5pc1GH772kWC27t

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhWfwrF5pc1GH772kWC27t)_