### PR TITLE
fix(perf): skip spans with non-numeric encoded_body_size in LargeHTTPPayloadDetector

### DIFF
--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -56,7 +56,10 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         payload_size_threshold = self.settings["payload_size_threshold"]
 
         if isinstance(encoded_body_size, str):
-            encoded_body_size = int(encoded_body_size)
+            try:
+                encoded_body_size = int(encoded_body_size)
+            except ValueError:
+                return
 
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -330,6 +330,21 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
+    def test_skips_span_with_nan_encoded_body_size(self) -> None:
+        spans = [
+            create_span(
+                "http.client",
+                1000,
+                "GET /api/0/organizations/endpoint1",
+                "hash1",
+                data={
+                    "http.response_content_length": "[NaN]",
+                },
+            ),
+        ]
+        event = create_event(spans)
+        assert self.find_problems(event) == []
+
     def test_does_not_trigger_detection_for_filtered_paths_without_trailing_slash(self) -> None:
         project = self.create_project()
         ProjectOption.objects.set_value(


### PR DESCRIPTION
## Summary

Fixes **SENTRY-5R9R** — `ValueError: invalid literal for int() with base 10: '[NaN]'` in `LargeHTTPPayloadDetector`.

**Root cause:** In `large_http_payload_detector.py:59`, `http.response_content_length` span data can arrive as the string `'[NaN]'` (from scrubbed or filtered browser payloads). The bare `int(encoded_body_size)` call raises `ValueError`, which propagates through `detect_performance_problems → _run_legacy_detectors → run_detector_on_data` and gets caught by the `logging.exception("Failed to detect performance problems")` path — generating a Sentry error on every affected span.

**Evidence from Sentry issue:**
- 1,349 occurrences over 5 days (first seen 2026-07-07)
- `encoded_body_size = "'[NaN]'"` visible in local variables
- File: `sentry/issue_detection/detectors/large_http_payload_detector.py`, line 59

**Fix:** Wrap the `int()` conversion in a `try/except ValueError` and return early, skipping spans with unparseable body sizes.

```python
# Before
if isinstance(encoded_body_size, str):
    encoded_body_size = int(encoded_body_size)

# After
if isinstance(encoded_body_size, str):
    try:
        encoded_body_size = int(encoded_body_size)
    except ValueError:
        return
```

A test `test_skips_span_with_nan_encoded_body_size` is added to confirm the behavior.

Claude session: https://claude.ai/code/session_015pwRdeFeVj3ZSak5yEbtaY

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_015pwRdeFeVj3ZSak5yEbtaY)_