### PR TITLE
chore(scm-project-creation-flow): Channel fallback  and label reconci…

### DIFF
--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -20,7 +20,7 @@ const pythonPlatform: OnboardingSelectedSDK = {
 };
 
 describe('getSubmitTooltipText', () => {
-  const none_missing = {
+  const none = {
     platform: false,
     projectName: false,
     team: false,
@@ -28,35 +28,33 @@ describe('getSubmitTooltipText', () => {
   };
 
   it('returns undefined when nothing is missing', () => {
-    expect(getSubmitTooltipText(none_missing)).toBeUndefined();
+    expect(getSubmitTooltipText(none)).toBeUndefined();
   });
 
   it('returns a summary when multiple fields are missing', () => {
-    expect(
-      getSubmitTooltipText({...none_missing, platform: true, projectName: true})
-    ).toBe('Please fill out all the required fields');
+    expect(getSubmitTooltipText({...none, platform: true, projectName: true})).toBe(
+      'Please fill out all the required fields'
+    );
   });
 
   it('names the platform when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, platform: true})).toBe(
+    expect(getSubmitTooltipText({...none, platform: true})).toBe(
       'Please select a platform'
     );
   });
 
   it('names the project name when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, projectName: true})).toBe(
+    expect(getSubmitTooltipText({...none, projectName: true})).toBe(
       'Please provide a project name'
     );
   });
 
   it('names the team when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, team: true})).toBe(
-      'Please select a team'
-    );
+    expect(getSubmitTooltipText({...none, team: true})).toBe('Please select a team');
   });
 
   it('names the notification channel when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none_missing, notificationChannel: true})).toBe(
+    expect(getSubmitTooltipText({...none, notificationChannel: true})).toBe(
       'Please provide an integration channel for alert notifications'
     );
   });

--- a/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/components/useScmProjectDetails.spec.tsx
@@ -20,7 +20,7 @@ const pythonPlatform: OnboardingSelectedSDK = {
 };
 
 describe('getSubmitTooltipText', () => {
-  const none = {
+  const none_missing = {
     platform: false,
     projectName: false,
     team: false,
@@ -28,33 +28,35 @@ describe('getSubmitTooltipText', () => {
   };
 
   it('returns undefined when nothing is missing', () => {
-    expect(getSubmitTooltipText(none)).toBeUndefined();
+    expect(getSubmitTooltipText(none_missing)).toBeUndefined();
   });
 
   it('returns a summary when multiple fields are missing', () => {
-    expect(getSubmitTooltipText({...none, platform: true, projectName: true})).toBe(
-      'Please fill out all the required fields'
-    );
+    expect(
+      getSubmitTooltipText({...none_missing, platform: true, projectName: true})
+    ).toBe('Please fill out all the required fields');
   });
 
   it('names the platform when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, platform: true})).toBe(
+    expect(getSubmitTooltipText({...none_missing, platform: true})).toBe(
       'Please select a platform'
     );
   });
 
   it('names the project name when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, projectName: true})).toBe(
+    expect(getSubmitTooltipText({...none_missing, projectName: true})).toBe(
       'Please provide a project name'
     );
   });
 
   it('names the team when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, team: true})).toBe('Please select a team');
+    expect(getSubmitTooltipText({...none_missing, team: true})).toBe(
+      'Please select a team'
+    );
   });
 
   it('names the notification channel when it is the only missing field', () => {
-    expect(getSubmitTooltipText({...none, notificationChannel: true})).toBe(
+    expect(getSubmitTooltipText({...none_missing, notificationChannel: true})).toBe(
       'Please provide an integration channel for alert notifications'
     );
   });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -2,12 +2,21 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
+import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
+  MultipleCheckboxOptions,
+  useCreateNotificationAction,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 describe('MessagingIntegrationAlertRule', () => {
@@ -92,5 +101,119 @@ describe('MessagingIntegrationAlertRule', () => {
     await screen.findByText(/notify via integration/i);
     await userEvent.click(screen.getByText(/notify via integration/i));
     expect(mockSetAction).toHaveBeenCalled();
+  });
+});
+
+describe('useCreateNotificationAction', () => {
+  const organization = OrganizationFixture();
+
+  const slackIntegration = OrganizationIntegrationsFixture({
+    id: '1',
+    name: 'my-workspace',
+    status: 'active',
+    provider: {
+      key: 'slack',
+      slug: 'slack',
+      name: 'Slack',
+      canAdd: true,
+      canDisable: false,
+      features: [],
+      aspects: {},
+    },
+  });
+
+  function addIntegrationsResponse(body: OrganizationIntegration[]) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body,
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+  }
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('defaults provider and integration from the first result on load', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(() => useCreateNotificationAction(), {
+      organization,
+    });
+
+    // Initially unset while the query is pending.
+    expect(result.current.notificationProps.provider).toBeUndefined();
+
+    // After the query resolves, defaults to the first provider/integration.
+    await act(async () => {});
+    expect(result.current.notificationProps.provider).toBe('slack');
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.channel).toBeUndefined();
+  });
+
+  it('does not clobber a user-selected channel when the integrations list refetches', async () => {
+    const secondIntegration = OrganizationIntegrationsFixture({
+      id: '2',
+      name: 'another-workspace',
+      status: 'active',
+      provider: slackIntegration.provider,
+    });
+
+    // Initial load returns one integration.
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result, rerender} = renderHookWithProviders(
+      () => useCreateNotificationAction(),
+      {organization}
+    );
+
+    await act(async () => {});
+    expect(result.current.notificationProps.provider).toBe('slack');
+
+    // User picks a channel.
+    act(() => {
+      result.current.notificationProps.setChannel({label: '#alerts', value: '#alerts'});
+    });
+    expect(result.current.notificationProps.channel?.value).toBe('#alerts');
+
+    // A refetch comes in with an updated list. Simulate by providing a new mock response
+    // with two integrations and re-rendering so the deps change.
+    MockApiClient.clearMockResponses();
+    addIntegrationsResponse([slackIntegration, secondIntegration]);
+    await act(async () => {
+      rerender();
+    });
+
+    // The run-once guard holds: provider/integration/channel are not reset.
+    expect(result.current.notificationProps.provider).toBe('slack');
+    expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
+    expect(result.current.notificationProps.channel?.value).toBe('#alerts');
+  });
+
+  it('resolves provider, integration, and actions from defaultActions on mount', async () => {
+    addIntegrationsResponse([slackIntegration]);
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useCreateNotificationAction({
+          actions: [
+            {
+              id: IssueAlertActionType.SLACK,
+              workspace: slackIntegration.id,
+              channel: '#eng',
+            },
+          ],
+        }),
+      {organization}
+    );
+
+    await act(async () => {});
+
+    // Autofill effect from defaultActions sets provider, integration, and channel.
+    expect(result.current.notificationProps.provider).toBe('slack');
+    expect(result.current.notificationProps.actions).toContain(
+      MultipleCheckboxOptions.INTEGRATION
+    );
+    expect(result.current.notificationProps.channel?.value).toBe('#eng');
   });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -216,4 +216,42 @@ describe('useCreateNotificationAction', () => {
     );
     expect(result.current.notificationProps.channel?.value).toBe('#eng');
   });
+
+  it('restores the channel from channel_id for a Discord defaultAction', async () => {
+    const discordIntegration = OrganizationIntegrationsFixture({
+      id: '3',
+      name: 'my-server',
+      status: 'active',
+      provider: {
+        key: 'discord',
+        slug: 'discord',
+        name: 'Discord',
+        canAdd: true,
+        canDisable: false,
+        features: [],
+        aspects: {},
+      },
+    });
+    addIntegrationsResponse([discordIntegration]);
+
+    // Stable reference; see comment in the preceding test.
+    const defaultActions = [
+      {
+        id: IssueAlertActionType.DISCORD,
+        server: discordIntegration.id,
+        channel_id: '2',
+      },
+    ];
+
+    const {result} = renderHookWithProviders(
+      () => useCreateNotificationAction({actions: defaultActions}),
+      {organization}
+    );
+
+    await act(async () => {});
+
+    // Discord actions store the channel under `channel_id`, not `channel`.
+    expect(result.current.notificationProps.provider).toBe('discord');
+    expect(result.current.notificationProps.channel?.value).toBe('2');
+  });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -8,6 +8,7 @@ import {
   renderHookWithProviders,
   screen,
   userEvent,
+  waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
 import {IssueAlertActionType} from 'sentry/types/alerts';
@@ -145,8 +146,7 @@ describe('useCreateNotificationAction', () => {
     expect(result.current.notificationProps.provider).toBeUndefined();
 
     // After the query resolves, defaults to the first provider/integration.
-    await act(async () => {});
-    expect(result.current.notificationProps.provider).toBe('slack');
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
     expect(result.current.notificationProps.integration?.id).toBe(slackIntegration.id);
     expect(result.current.notificationProps.channel).toBeUndefined();
   });
@@ -167,8 +167,7 @@ describe('useCreateNotificationAction', () => {
       {organization}
     );
 
-    await act(async () => {});
-    expect(result.current.notificationProps.provider).toBe('slack');
+    await waitFor(() => expect(result.current.notificationProps.provider).toBe('slack'));
 
     // User picks a channel.
     act(() => {
@@ -180,7 +179,7 @@ describe('useCreateNotificationAction', () => {
     // with two integrations and re-rendering so the deps change.
     MockApiClient.clearMockResponses();
     addIntegrationsResponse([slackIntegration, secondIntegration]);
-    await act(async () => {
+    act(() => {
       rerender();
     });
 
@@ -193,17 +192,18 @@ describe('useCreateNotificationAction', () => {
   it('resolves provider, integration, and actions from defaultActions on mount', async () => {
     addIntegrationsResponse([slackIntegration]);
 
+    // Stable reference: the autofill effect depends on `defaultActions`, so an
+    // inline array (new ref each render) would loop render -> setState -> render.
+    const defaultActions = [
+      {
+        id: IssueAlertActionType.SLACK,
+        workspace: slackIntegration.id,
+        channel: '#eng',
+      },
+    ];
+
     const {result} = renderHookWithProviders(
-      () =>
-        useCreateNotificationAction({
-          actions: [
-            {
-              id: IssueAlertActionType.SLACK,
-              workspace: slackIntegration.id,
-              channel: '#eng',
-            },
-          ],
-        }),
+      () => useCreateNotificationAction({actions: defaultActions}),
       {organization}
     );
 

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -1,4 +1,12 @@
-import {Fragment, useCallback, useEffect, useMemo, useState, type ReactNode} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -124,6 +132,10 @@ export function useCreateNotificationAction({
   );
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(undefined);
   const [shouldRenderSetupButton, setShouldRenderSetupButton] = useState(false);
+  // Ensures the init effect runs exactly once (first successful load). Later
+  // refetches updating providersToIntegrations must not override a selection
+  // the user already made.
+  const hasInitializedSelection = useRef(false);
 
   useEffect(() => {
     // Initializes form state based on the first default action and available integrations.
@@ -164,14 +176,17 @@ export function useCreateNotificationAction({
   }, [defaultActions, providersToIntegrations]);
 
   useEffect(() => {
-    if (messagingIntegrationsQuery.isSuccess) {
-      const providerKeys = Object.keys(providersToIntegrations);
-      const firstProvider = providerKeys[0];
-      const firstIntegration = providersToIntegrations[String(firstProvider)]?.[0];
-      setProvider(firstProvider);
-      setIntegration(firstIntegration);
-      setShouldRenderSetupButton(!firstProvider);
+    if (!messagingIntegrationsQuery.isSuccess || hasInitializedSelection.current) {
+      return;
     }
+    hasInitializedSelection.current = true;
+    const providerKeys = Object.keys(providersToIntegrations);
+    const firstProvider = providerKeys[0];
+    const firstIntegration = providersToIntegrations[String(firstProvider)]?.[0];
+    setProvider(firstProvider);
+    setIntegration(firstIntegration);
+    setChannel(undefined);
+    setShouldRenderSetupButton(!firstProvider);
   }, [messagingIntegrationsQuery.isSuccess, providersToIntegrations]);
 
   const createNotificationAction = useCallback(

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -164,11 +164,13 @@ export function useCreateNotificationAction({
 
     setActions(newActions);
 
-    if (firstAction.channel) {
+    // Discord stores the channel under `channel_id` rather than `channel`.
+    const restoredChannel = firstAction.channel ?? firstAction.channel_id;
+    if (restoredChannel) {
       // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
       setChannel({
-        label: firstAction.channel,
-        value: firstAction.channel,
+        label: restoredChannel,
+        value: restoredChannel,
       });
     }
   }, [defaultActions, providersToIntegrations]);

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -132,9 +132,7 @@ export function useCreateNotificationAction({
   );
   const [channel, setChannel] = useState<IntegrationChannel | undefined>(undefined);
   const [shouldRenderSetupButton, setShouldRenderSetupButton] = useState(false);
-  // Ensures the init effect runs exactly once (first successful load). Later
-  // refetches updating providersToIntegrations must not override a selection
-  // the user already made.
+
   const hasInitializedSelection = useRef(false);
 
   useEffect(() => {

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -1,11 +1,20 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import type {IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
-import {MessagingIntegrationAlertRule} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
+import {
+  MessagingIntegrationAlertRule,
+  useMessagingIntegrationAlertRule,
+} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
 import * as useValidateChannelModule from 'sentry/views/projectInstall/useValidateChannel';
 
 function setupValidateChannelSpy() {
@@ -387,5 +396,92 @@ describe('MessagingIntegrationAlertRule', () => {
       value: '2',
       new: false,
     });
+  });
+});
+
+describe('useMessagingIntegrationAlertRule channel label reconciliation', () => {
+  const organization = OrganizationFixture();
+  const discordIntegration = OrganizationIntegrationsFixture({
+    name: "Moo Deng's Server",
+  });
+  const slackIntegration = OrganizationIntegrationsFixture({
+    name: "Moo Deng's Workspace",
+  });
+
+  function renderRule(
+    props: Partial<IssueAlertNotificationProps>,
+    setChannel: jest.Mock
+  ) {
+    return renderHookWithProviders(
+      () =>
+        useMessagingIntegrationAlertRule({
+          actions: [],
+          integration: undefined,
+          provider: undefined,
+          providersToIntegrations: {},
+          querySuccess: true,
+          shouldRenderSetupButton: false,
+          setActions: jest.fn(),
+          setChannel,
+          setIntegration: jest.fn(),
+          setProvider: jest.fn(),
+          ...props,
+        }),
+      {organization}
+    );
+  }
+
+  it('upgrades a restored Discord channel label once the channel list loads', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${discordIntegration.id}/channels/`,
+      body: {
+        results: [{id: '2', name: 'alerts', display: '#alerts', type: 'text'}],
+      },
+    });
+
+    const mockSetChannel = jest.fn();
+    renderRule(
+      {
+        integration: discordIntegration,
+        provider: 'discord',
+        providersToIntegrations: {discord: [discordIntegration]},
+        // Restored from a persisted/default action: raw id used as a
+        // placeholder label until the channel list resolves it.
+        channel: {label: '2', value: '2'},
+      },
+      mockSetChannel
+    );
+
+    await waitFor(() => {
+      expect(mockSetChannel).toHaveBeenCalledWith({
+        label: '#alerts (2)',
+        value: '2',
+        new: false,
+      });
+    });
+  });
+
+  it('does not re-set an already-resolved Slack channel (legacy flow unaffected)', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${slackIntegration.id}/channels/`,
+      body: {
+        results: [{id: '1', name: 'general', display: '#general', type: 'text'}],
+      },
+    });
+
+    const mockSetChannel = jest.fn();
+    const {result} = renderRule(
+      {
+        integration: slackIntegration,
+        provider: 'slack',
+        providersToIntegrations: {slack: [slackIntegration]},
+        // Slack channel labels/values are already identical once resolved.
+        channel: {label: '#general', value: '#general', new: false},
+      },
+      mockSetChannel
+    );
+
+    await waitFor(() => expect(result.current.channelOptions).toBeDefined());
+    expect(mockSetChannel).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -461,7 +461,7 @@ describe('useMessagingIntegrationAlertRule channel label reconciliation', () => 
     });
   });
 
-  it('does not re-set an already-resolved Slack channel (legacy flow unaffected)', async () => {
+  it('does not re-set an already-resolved Slack channel', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${slackIntegration.id}/channels/`,
       body: {

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -110,7 +110,6 @@ export function useMessagingIntegrationAlertRule({
     }
     const match = channelOptions.find(option => option.value === channel.value);
     if (match && match.label !== channel.label) {
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
       setChannel({value: channel.value, label: match.label, new: false});
     }
   }, [channel, channelOptions, setChannel]);

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Select, SelectOption} from '@sentry/scraps/select';
@@ -99,6 +99,21 @@ export function useMessagingIntegrationAlertRule({
       ),
     [channels, provider]
   );
+
+  useEffect(() => {
+    // A restored channel (e.g. from persisted/default actions) only has a raw
+    // id as its label until the channel list loads. Upgrade it to the
+    // human-readable label once we can resolve it. Skips user-created
+    // channels, which intentionally keep their typed-in label.
+    if (!channel || channel.new || !channelOptions) {
+      return;
+    }
+    const match = channelOptions.find(option => option.value === channel.value);
+    if (match && match.label !== channel.label) {
+      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
+      setChannel({value: channel.value, label: match.label, new: false});
+    }
+  }, [channel, channelOptions, setChannel]);
 
   return {
     provider,


### PR DESCRIPTION
Fixes: [LINEAR TICKET](https://linear.app/getsentry/issue/VDY-125/notification-channel-restore-checks-channel-but-discord-stores-channel)

When restoring a saved notification action, Discord stores its `channel` under `channel_id`, not channel, so the restore missed it and left Discord without a `channel`. This adds a `channel ?? channel_id` fallback. Since that only yields the raw id, it's used as a placeholder label too.

A small effect in `useMessagingIntegrationAlertRule` then reconciles the label once the channel list loads, upgrading the placeholder to the human-readable name (2 → #alerts (2)) while keeping the value. It skips user-created channels and only fires when the label actually differs, so the Slack flow is untouched. Covered by new tests for the Discord restore, the label upgrade, and the Slack no-op.