### PR TITLE
fix(flags): relax StatsigEventSerializer to accept nested user fields and blank values

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -387,11 +387,11 @@ class StatsigEventSerializer(serializers.Serializer):
     timestamp = serializers.CharField(required=True)
     metadata = serializers.DictField(required=True)
 
-    user = serializers.DictField(required=False, child=serializers.CharField())
+    user = serializers.DictField(required=False)
     userID = serializers.CharField(required=False)
-    value = serializers.CharField(required=False)
+    value = serializers.CharField(required=False, allow_blank=True)
     statsigMetadata = serializers.DictField(required=False)
-    timeUUID = serializers.UUIDField(required=False)
+    timeUUID = serializers.CharField(required=False, allow_blank=True)
     unitID = serializers.CharField(required=False)
 
 

--- a/tests/sentry/flags/providers/test_statsig.py
+++ b/tests/sentry/flags/providers/test_statsig.py
@@ -191,6 +191,41 @@ def test_handle_additional_fields() -> None:
     assert logs[0]["organization_id"] == org_id
 
 
+def test_handle_nested_user_fields() -> None:
+    """Statsig sends nested objects (customIDs, custom, statsigEnvironment) in the user
+    field. These should not cause a DeserializationError."""
+    org_id = 123
+    logs = StatsigProvider(org_id, "abcdefgh", request_timestamp="1739400185400").handle(
+        {
+            "data": [
+                {
+                    "user": {
+                        "userID": "abc123",
+                        "email": "user@example.com",
+                        "customIDs": {"companyID": "acme"},
+                        "custom": {"role": "admin"},
+                        "statsigEnvironment": {"tier": "production"},
+                    },
+                    "timestamp": 1739400185198,
+                    "eventName": "statsig::config_change",
+                    "metadata": {
+                        "type": "Gate",
+                        "name": "gate1",
+                        "action": "updated",
+                    },
+                    "value": "",
+                    "timeUUID": "not-a-uuid",
+                }
+            ]
+        }
+    )
+
+    assert len(logs) == 1
+    assert logs[0]["flag"] == "gate1"
+    assert logs[0]["created_by"] == "user@example.com"
+    assert logs[0]["created_by_type"] == 0
+
+
 def test_handle_created_by_id() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {


### PR DESCRIPTION
## Summary

Fixes a production `DeserializationError` in the Statsig webhook handler (SENTRY-5J6Z) that has been generating ~2.75M errors affecting 4,825 users since 2026-02-07.

## Root Cause

`StatsigEventSerializer` was too strict about the shape of optional fields that are never actually used in the audit log business logic:

1. **`user` DictField with `child=serializers.CharField()`**: Statsig sends nested objects (e.g. `customIDs: {"companyID": "acme"}`, `custom: {"role": "admin"}`, `statsigEnvironment: {"tier": "production"}`) as values within the `user` dict. The `child=serializers.CharField()` constraint rejects any value that isn't a plain string.

2. **`value = serializers.CharField(required=False)`**: Statsig sends `value=""` (empty string) which fails the default `allow_blank=False` on CharField.

3. **`timeUUID = serializers.UUIDField(required=False)`**: Statsig sends arbitrary string values that aren't valid UUIDs.

## Fix

- Remove `child=serializers.CharField()` from `user` DictField — the field accepts any dict structure now
- Add `allow_blank=True` to `value` CharField
- Change `timeUUID` from `UUIDField` to `CharField(allow_blank=True)` — we never validate or use this field

None of these fields are used in the audit log rows produced by `StatsigProvider.handle()`. The business logic only reads `user.email`, `user.userID`, `user.name`, `userID`, `eventName`, `timestamp`, and `metadata` from each event.

## Evidence

Sentry issue: https://sentry.sentry.io/issues/SENTRY-5J6Z
- 2,753,422 events, 4,825 users affected
- Seer root cause: "Overly strict validation in `StatsigEventSerializer` for unused fields causes `DeserializationError` when processing Statsig webhooks containing unexpected formats like nested objects or empty strings."

Example failing payload fragment:
```json
{
  "user": {
    "userID": "...",
    "customIDs": {"companyID": "acme"},
    "custom": {"role": "admin"},
    "statsigEnvironment": {"tier": "production"}
  },
  "value": "",
  "timeUUID": "not-a-uuid"
}
```

## Test Plan

Added `test_handle_nested_user_fields` which covers the exact pattern from the failing production events (nested user dict values, blank `value`, non-UUID `timeUUID`).

Session: https://claude.ai/code/session_0184E4PYCz4ekKHjv3cZkUJT

---
_Generated by [Claude Code](https://claude.ai/code/session_0184E4PYCz4ekKHjv3cZkUJT)_