### PR TITLE
fix(perf-detection): skip spans with PII-redacted http.response_content_length

### DIFF
--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -56,7 +56,11 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         payload_size_threshold = self.settings["payload_size_threshold"]
 
         if isinstance(encoded_body_size, str):
-            encoded_body_size = int(encoded_body_size)
+            try:
+                encoded_body_size = int(encoded_body_size)
+            except ValueError:
+                # Scrubbed/redacted values (e.g. '[Filtered]') can't be evaluated
+                return
 
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -330,6 +330,24 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
+    def test_does_not_raise_on_redacted_payload_size(self) -> None:
+        # PII scrubbing can replace numeric span data with '[Filtered]' or '[REDACTED]',
+        # which must be skipped gracefully rather than raising ValueError from int()
+        for redacted_value in ("[Filtered]", "[REDACTED]", "***"):
+            spans = [
+                create_span(
+                    "http.client",
+                    1000,
+                    "GET /api/0/organizations/endpoint1",
+                    "hash1",
+                    data={
+                        "http.response_content_length": redacted_value,
+                    },
+                ),
+            ]
+            event = create_event(spans)
+            assert self.find_problems(event) == [], f"Expected no problems for redacted value {redacted_value!r}"
+
     def test_does_not_trigger_detection_for_filtered_paths_without_trailing_slash(self) -> None:
         project = self.create_project()
         ProjectOption.objects.set_value(


### PR DESCRIPTION
## Summary

Fixes **SENTRY-5R9R** (`ValueError: invalid literal for int() with base 10: '[Filtered]'`)

In `LargeHTTPPayloadDetector.visit_span`, the code converts `http.response_content_length` from `str` to `int` when the value arrives as a string. When PII scrubbing is active, that value can be replaced with a non-numeric sentinel like `'[Filtered]'` or `'[REDACTED]'`, causing `int()` to raise `ValueError`. This bubbles up as `"Failed to detect performance problems"` logged from the spans process-segments consumer.

**Root cause**: `large_http_payload_detector.py:59` — unconditional `int(encoded_body_size)` when the value is a scrubbed string.

**Fix**: Wrap the conversion in `try/except ValueError` and `return` early (skip the span) when the value is non-numeric. The span can't be evaluated anyway.

**Evidence from Sentry:**
- 1,432+ occurrences since 2026-07-07 (Seer actionability: **high**)
- Culprit: `spans.consumers.process_segments.process_segment`
- Local variable at crash: `encoded_body_size: "'[REDACTED]'"`
- Environment: DE region, `process-segments` consumer pods

## Changes

- `src/sentry/issue_detection/detectors/large_http_payload_detector.py`: wrap `int()` cast in `try/except ValueError`, returning early for non-parseable values
- `tests/sentry/issue_detection/test_large_http_payload_detector.py`: add `test_does_not_raise_on_redacted_payload_size` covering `'[Filtered]'`, `'[REDACTED]'`, and `'***'`

## Claude Session

https://claude.ai/code/session_01AQUEoDMYw8jPUTwTHHHLt6

<!-- Describe your PR here. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQUEoDMYw8jPUTwTHHHLt6)_