### PR TITLE
fix(release-bubbles): guard handleMouseOut against ECharts state transition crash

### DIFF
--- a/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
+++ b/static/app/views/explore/releases/releaseBubbles/useReleaseBubbles.tsx
@@ -548,15 +548,26 @@ export function useReleaseBubbles({
           return;
         }
 
-        // Clear the `markArea` that was drawn during mouse over
-        echartsInstance.setOption(
-          {
-            series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
-          },
-          {
-            lazyUpdate: true,
-          }
-        );
+        if (echartsInstance.isDisposed()) {
+          return;
+        }
+
+        // Clear the `markArea` that was drawn during mouse over.
+        // Wrapped in try/catch because ECharts can crash internally when iterating
+        // series models during a chart state transition (e.g. a concurrent lazyUpdate).
+        try {
+          echartsInstance.setOption(
+            {
+              series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}],
+            },
+            {
+              lazyUpdate: true,
+            }
+          );
+        } catch (_e) {
+          // Swallow errors from chart state transitions; the markArea will be
+          // cleared on the next mouse interaction.
+        }
       };
 
       // This fixes a bug where if you hover over a bubble and mouseout via xaxis


### PR DESCRIPTION
## Problem

**Sentry issue:** [JAVASCRIPT-3AP8](https://sentry.sentry.io/issues/JAVASCRIPT-3AP8) — escalating, 296 events, 196 users affected.

Users hovering over release bubbles in the Explore → Releases view encounter an unhandled crash:

```
TypeError: Cannot read properties of undefined (reading 'get')
```

The crash originates deep in ECharts (`MarkerModel._mergeOption → ecModel.eachSeries → seriesModel.get`) and bubbles up through our `handleMouseOut` handler at `useReleaseBubbles.tsx:552`.

## Root Cause

`handleMouseOut` calls `echartsInstance.setOption({series: [{id: BUBBLE_AREA_SERIES_ID, markArea: {data: []}}]}, {lazyUpdate: true})` to clear the highlighted mark area when the mouse leaves a bubble.

During this merge, ECharts iterates all series models and applies marker options. If a concurrent `lazyUpdate` from `handleMouseOver` is still being processed, the chart's internal series model list can contain `undefined` entries, causing the crash.

The stack trace confirms the path:
```
handleMouseOut (useReleaseBubbles.tsx:552)
  → echartsInstance.setOption
  → GlobalModel._mergeOption
  → MarkerModel.mergeOption
  → ecModel.eachSeries
  → seriesModel.get(this.mainType, true)  ← crashes: seriesModel is undefined
```

## Fix

1. Add an `isDisposed()` guard before calling `setOption`, to handle the case where the chart instance has been torn down.
2. Wrap the `setOption` call in a try/catch to swallow transient state transition errors. If the clear fails, the mark area will be cleaned up on the next mouse interaction.

## Evidence

- Issue escalating since 2026-07-06, 196 unique users impacted
- Seer analysis: "Wrap setOption calls in mouse handlers with a try/catch and add an isDisposed guard to prevent crashes during chart state transitions"
- Session replays confirm reproducibility on mousemove across the releases chart

## Session

Claude session: https://claude.ai/code/session_014Ti4xAam9aMA4vPse1BLQu

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ti4xAam9aMA4vPse1BLQu)_