### PR TITLE
fix: loosen StatsigEventSerializer validation and downgrade DetectorGroup.DoesNotExist noise

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -387,11 +387,11 @@ class StatsigEventSerializer(serializers.Serializer):
     timestamp = serializers.CharField(required=True)
     metadata = serializers.DictField(required=True)
 
-    user = serializers.DictField(required=False, child=serializers.CharField())
+    user = serializers.DictField(required=False)
     userID = serializers.CharField(required=False)
-    value = serializers.CharField(required=False)
+    value = serializers.CharField(required=False, allow_blank=True)
     statsigMetadata = serializers.DictField(required=False)
-    timeUUID = serializers.UUIDField(required=False)
+    timeUUID = serializers.CharField(required=False, allow_blank=True)
     unitID = serializers.CharField(required=False)
 
 

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -152,7 +152,7 @@ def _get_detector_for_group(group: Group) -> Detector:
         if detector is not None:
             return detector
     except DetectorGroup.DoesNotExist:
-        logger.exception(
+        logger.warning(
             "DetectorGroup not found for group",
             extra={"group_id": group.id},
         )

--- a/tests/sentry/flags/providers/test_statsig.py
+++ b/tests/sentry/flags/providers/test_statsig.py
@@ -356,6 +356,39 @@ def test_handle_empty_message() -> None:
     assert errors["data"][0].code == "required"
 
 
+def test_handle_nested_user_fields() -> None:
+    """Statsig server SDKs send user.customIDs, user.custom, and user.statsigEnvironment
+    as nested objects rather than strings. The serializer must not reject these payloads."""
+    org_id = 123
+    logs = StatsigProvider(org_id, "abcdefgh", request_timestamp="1739400185400").handle(
+        {
+            "data": [
+                {
+                    "user": {
+                        "userID": "user_abc",
+                        "email": "alice@example.com",
+                        "customIDs": {"organizationId": "org_xyz"},
+                        "custom": {"organizationId": "org_xyz", "organization_id": "org_xyz"},
+                        "statsigEnvironment": {"tier": "production"},
+                    },
+                    "timestamp": 1739400185198,
+                    "eventName": "statsig::config_change",
+                    "metadata": {
+                        "type": "Gate",
+                        "name": "my-gate",
+                        "action": "updated",
+                    },
+                }
+            ]
+        }
+    )
+
+    assert len(logs) == 1
+    assert logs[0]["flag"] == "my-gate"
+    assert logs[0]["created_by"] == "alice@example.com"
+    assert logs[0]["created_by_type"] == 0
+
+
 def test_handle_empty_event() -> None:
     with pytest.raises(DeserializationError) as exc_info:
         StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle({"data": [{}]})


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Summary

Fixes two production Sentry alerts surfaced by automated monitoring.

---

### Fix 1 — SENTRY-5J6Z: Statsig webhook `DeserializationError` (medium severity, ~17k events/day, 4826 users impacted)

**Root cause:** `StatsigEventSerializer.user` was declared as `DictField(child=CharField())`, which requires every value in the dict to be a plain string. Statsig server-SDK payloads (e.g. `statsig-server-core-node`) send nested objects for `user.customIDs`, `user.custom`, and `user.statsigEnvironment`. This caused every such webhook to fail with a `DeserializationError` before flag audit logs could be written.

Two additional fields also caused spurious failures:
- `value` — Statsig sends an empty string for exposure events; `CharField` without `allow_blank=True` rejects it.
- `timeUUID` — Sent in formats that don't satisfy DRF's `UUIDField`; changed to `CharField` since this field is unused by the handler.

**Fix:** Remove the `child=CharField()` constraint from `user`, add `allow_blank=True` to `value`, and relax `timeUUID` to `CharField`. None of these fields are used downstream in the audit-log construction path.

**Files changed:**
- `src/sentry/flags/providers.py` — relax `StatsigEventSerializer` field constraints
- `tests/sentry/flags/providers/test_statsig.py` — add regression test with nested user fields

---

### Fix 2 — SENTRY-5R4N: `DetectorGroup.DoesNotExist` logged as exception (medium severity, ~27k events, 4800 users triggering noisy errors)

**Root cause:** `_get_detector_for_group` in `sentry/workflow_engine/processors/detector.py` used `logger.exception()` inside the `DetectorGroup.DoesNotExist` handler. `logger.exception()` attaches the exception traceback and triggers a Sentry capture, but this `DoesNotExist` is an **expected condition** for legacy groups that were created before the workflow engine's `DetectorGroup` table existed. The function already falls through correctly to two further lookup strategies; the exception capture was pure instrumentation noise.

**Fix:** Downgrade `logger.exception()` → `logger.warning()` so the condition is noted in logs without generating a Sentry event.

**Files changed:**
- `src/sentry/workflow_engine/processors/detector.py` — downgrade log level

---

## Evidence / Reasoning

- SENTRY-5J6Z: https://sentry.sentry.io/issues/SENTRY-5J6Z/ — Seer root cause: "Overly strict validation in StatsigEventSerializer for unused fields." The actual webhook payload in the event shows `user.customIDs: {"organizationId": "org_..."}` (a dict) being rejected by `child=CharField()`.
- SENTRY-5R4N: https://sentry.sentry.io/issues/SENTRY-5R4N/ — Seer root cause: "Legacy groups without DetectorGroup associations trigger a logged exception." Stack trace shows `logger.exception` directly after catching `DetectorGroup.DoesNotExist`; the surrounding code falls back to other lookups successfully.
- Claude session: https://claude.ai/code/session_0152iRwgLj2pwmC8VKUsxoKL

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_0152iRwgLj2pwmC8VKUsxoKL)_