### PR TITLE
fix(analytics): strip leading colon from route params in Reload Analytics event keys

### DIFF
--- a/static/gsApp/overrides/useButtonTracking.spec.tsx
+++ b/static/gsApp/overrides/useButtonTracking.spec.tsx
@@ -67,9 +67,9 @@ describe('buttonTracking', () => {
 
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith({
       eventName: null,
-      eventKey: 'button_click.settings.:org_id.projects.:project_id',
+      eventKey: 'button_click.settings.org_id.projects.project_id',
       organization: expect.objectContaining(organization),
-      parameterized_path: 'settings.:org_id.projects.:project_id',
+      parameterized_path: 'settings.org_id.projects.project_id',
       text: 'Create Alert',
     });
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledTimes(1);
@@ -91,7 +91,7 @@ describe('buttonTracking', () => {
       eventName: 'Settings: Create Alert',
       eventKey: 'settings.create_alert',
       organization: expect.objectContaining(organization),
-      parameterized_path: 'settings.:org_id.projects.:project_id',
+      parameterized_path: 'settings.org_id.projects.project_id',
       text: 'Create Alert',
       priority: 'primary',
       href: 'sentry.io/settings/create_alert',
@@ -114,7 +114,7 @@ describe('buttonTracking', () => {
       eventName: 'Settings: Create Alert',
       eventKey: 'settings.create_alert',
       organization: expect.objectContaining(organization),
-      parameterized_path: 'settings.:org_id.projects.:project_id',
+      parameterized_path: 'settings.org_id.projects.project_id',
       text: 'Create Alert',
     });
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledTimes(1);

--- a/static/gsApp/overrides/useRouteActivatedHook.spec.tsx
+++ b/static/gsApp/overrides/useRouteActivatedHook.spec.tsx
@@ -24,6 +24,8 @@ function makeMatch(path: string): UIMatch {
 
 const SETTINGS_MATCHES = [makeMatch('/settings/:orgId/projects/:projectId/')];
 const RELEASES_MATCHES = [makeMatch('/organizations/:orgId/releases/:release/')];
+// Customer-domain issue detail route (no org prefix)
+const ISSUES_MATCHES = [makeMatch('/issues/'), makeMatch(':groupId/')];
 
 describe('useRouteActivatedHook', () => {
   const organization = OrganizationFixture();
@@ -68,8 +70,8 @@ describe('useRouteActivatedHook', () => {
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith(
       {
         eventName: 'Page View: Settings :OrgId Projects :ProjectId',
-        eventKey: 'page_view.settings.:org_id.projects.:project_id',
-        parameterized_path: 'settings.:org_id.projects.:project_id',
+        eventKey: 'page_view.settings.org_id.projects.project_id',
+        parameterized_path: 'settings.org_id.projects.project_id',
         organization: expect.objectContaining(organization),
         subscription: expect.objectContaining(subscription),
         url: `http://localhost/settings/${organization.slug}/${project.slug}/`,
@@ -101,8 +103,8 @@ describe('useRouteActivatedHook', () => {
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith(
       {
         eventName: 'Page View: Settings :OrgId Projects :ProjectId',
-        eventKey: 'page_view.settings.:org_id.projects.:project_id',
-        parameterized_path: 'settings.:org_id.projects.:project_id',
+        eventKey: 'page_view.settings.org_id.projects.project_id',
+        parameterized_path: 'settings.org_id.projects.project_id',
         organization: expect.objectContaining(organization),
         subscription: expect.objectContaining(subscription),
         url: `http://localhost/settings/${organization.slug}/${project.slug}/`,
@@ -183,8 +185,8 @@ describe('useRouteActivatedHook', () => {
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith(
       {
         eventName: 'Page View: Organizations :OrgId Releases :Release',
-        eventKey: 'page_view.organizations.:org_id.releases.:release',
-        parameterized_path: 'organizations.:org_id.releases.:release',
+        eventKey: 'page_view.organizations.org_id.releases.release',
+        parameterized_path: 'organizations.org_id.releases.release',
         organization: expect.objectContaining(organization),
         subscription: expect.objectContaining(subscription),
         url: `http://localhost/organizations/${organization.slug}/releases/some-release/`,
@@ -207,11 +209,32 @@ describe('useRouteActivatedHook', () => {
       {
         eventName: 'Test Event',
         eventKey: 'test.event',
-        parameterized_path: 'settings.:org_id.projects.:project_id',
+        parameterized_path: 'settings.org_id.projects.project_id',
         organization: expect.objectContaining(organization),
         subscription: expect.objectContaining(subscription),
         url: `http://localhost/settings/${organization.slug}/${project.slug}/`,
       },
+      {time: loadTime}
+    );
+    expect(rawTrackAnalyticsEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends valid eventKey without colons for issue detail route (regression for JAVASCRIPT-39C7)', () => {
+    jest.useFakeTimers();
+    const {result} = renderHook(useRouteActivatedHook, {
+      initialProps: genProps({
+        location: LocationFixture({pathname: '/issues/123/'}),
+        matches: ISSUES_MATCHES,
+      }),
+    });
+    act(() => result.current.setOrganization(organization));
+    const loadTime = Date.now();
+    act(() => jest.advanceTimersByTime(DEFAULT_ADVANCE_PERIOD));
+    expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventKey: 'page_view.issues.group_id',
+        parameterized_path: 'issues.group_id',
+      }),
       {time: loadTime}
     );
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledTimes(1);
@@ -240,8 +263,8 @@ describe('useRouteActivatedHook', () => {
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith(
       {
         eventName: 'Page View: Settings :OrgId Projects :ProjectId',
-        eventKey: 'page_view.settings.:org_id.projects.:project_id',
-        parameterized_path: 'settings.:org_id.projects.:project_id',
+        eventKey: 'page_view.settings.org_id.projects.project_id',
+        parameterized_path: 'settings.org_id.projects.project_id',
         organization: expect.objectContaining(organization),
         subscription: expect.objectContaining(subscription),
         url: `http://localhost/settings/${organization.slug}/${project.slug}/`,
@@ -256,8 +279,8 @@ describe('useRouteActivatedHook', () => {
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith(
       {
         eventName: 'Page View: Organizations :OrgId Releases :Release',
-        eventKey: 'page_view.organizations.:org_id.releases.:release',
-        parameterized_path: 'organizations.:org_id.releases.:release',
+        eventKey: 'page_view.organizations.org_id.releases.release',
+        parameterized_path: 'organizations.org_id.releases.release',
         organization: expect.objectContaining(organization),
         subscription: expect.objectContaining(subscription),
         url: `http://localhost/organizations/${organization.slug}/releases/some-release/`,

--- a/static/gsApp/utils/routeAnalytics.tsx
+++ b/static/gsApp/utils/routeAnalytics.tsx
@@ -51,11 +51,11 @@ export function getUrlFromLocation(location: Location) {
  * @param string representing the route path in Amplitude format
  * @return Reload representation of the route path
  * Ex: Organizations :OrgId Alerts New :AlertType ->
- * organizations.:org_id.alerts.new.:alert_type
+ * organizations.org_id.alerts.new.alert_type
  */
 export function convertToReloadPath(routeString: string) {
   return routeString
     .split(' ')
-    .map(tok => tok.replace(/[\w ]+/g, snakeCase))
+    .map(tok => tok.replace(/^:/, '').replace(/[\w ]+/g, snakeCase))
     .join('.');
 }


### PR DESCRIPTION
## Problem

Sentry issue **JAVASCRIPT-39C7** (`SyntaxError: Invalid or unexpected token: /issues/:groupId/`) was thrown from `useRouteActivatedHook.tsx:60` on the issue detail page in customer-domain mode.

**Root cause:** `convertToReloadPath` in `static/gsApp/utils/routeAnalytics.tsx` preserved the leading `:` from route parameter segments. For the issue detail route `/issues/:groupId/`, the resulting Reload Analytics eventKey was `page_view.issues.:group_id`. The Reload Analytics library (`window.ra.event()`) throws a `SyntaxError` when it encounters `.:` because `:identifier` is not a valid JavaScript property name in dot-notation.

**Why it surfaces on the issues route:** `groupDetails.tsx` overrides the eventKey to `issue_details.viewed` via `useRouteAnalyticsEventNames`. However, the component is **lazily loaded** — if the user navigates away before the component mounts, `_eventKey` is still `undefined` and the fallback `page_view.issues.:group_id` is sent to Reload. Other routes that use the fallback pattern appear to not produce this error in practice.

## Fix

Strip the leading `:` from each route parameter token in `convertToReloadPath`:

```diff
- .map(tok => tok.replace(/[\w ]+/g, snakeCase))
+ .map(tok => tok.replace(/^:/, '').replace(/[\w ]+/g, snakeCase))
```

This changes the output format from `issues.:group_id` → `issues.group_id`, producing a valid dot-notation path that the Reload library can process without throwing.

## Evidence

- Sentry issue JAVASCRIPT-39C7: 2 occurrences, 2 users, status: regressed, `handled: yes`
- Transaction: `/issues/:groupId/` (customer domain)
- Frame: `useRouteActivatedHook.tsx:60:9 (callback)` → `rawTrackAnalyticsEvent(`
- The error was caught by `rawTrackAnalyticsEvent`'s try/catch but reported to Sentry via instrumented `console.error`

## Changes

- `static/gsApp/utils/routeAnalytics.tsx` — strip `:` prefix from parameter tokens in `convertToReloadPath`, update JSDoc example
- `static/gsApp/overrides/useRouteActivatedHook.spec.tsx` — update expected eventKey/parameterized_path format; add regression test for issue detail route
- `static/gsApp/overrides/useButtonTracking.spec.tsx` — update expected eventKey/parameterized_path format

**Frontend-only change** (backend fixes for other issues in PR #119482).

Session: https://claude.ai/code/session_0152iRwgLj2pwmC8VKUsxoKL

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_0152iRwgLj2pwmC8VKUsxoKL)_