### PR TITLE
fix: handle missing description key in MN+1 DB span detector

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -255,7 +255,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span.get("description", ""),
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,
@@ -280,7 +280,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
                     name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
-                        db_span["description"],
+                        db_span.get("description", ""),
                     ),
                     # Has to be marked important to be displayed in the notifications
                     important=True,

--- a/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
+++ b/tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py
@@ -306,3 +306,13 @@ class MNPlusOneDBDetectorTest(TestCase):
         event = get_event("m-n-plus-one-db/m-n-plus-one-prisma-client")
         assert self.find_problems(event, settings) == []
         metrics_mock.incr.assert_called_with("mn_plus_one_db_span_detector.no_parent_span")
+
+    def test_does_not_raise_when_db_span_missing_description(self) -> None:
+        event = get_event("m-n-plus-one-db/m-n-plus-one-graphql")
+        for span in event["spans"]:
+            if span.get("op", "").startswith("db"):
+                span.pop("description", None)
+
+        problems = self.find_problems(event)
+        assert len(problems) == 1
+        assert problems[0].desc == ""


### PR DESCRIPTION
## Summary

Fixes a `KeyError: 'description'` crash in the MN+1 DB span detector that has been firing 333K+ times since 2026-06-25, affecting the `process-segments` consumer in production.

**Root cause:** `ContinuingMNPlusOne._maybe_performance_problem()` accessed `db_span["description"]` directly. Spans processed by the standalone segment pipeline (`spans.consumers.process_segments`) may not include a `description` field, causing an unhandled `KeyError` that swallowed the entire performance detection step via a broad `except` in `detect_performance_problems`.

**Fix:** Replace `db_span["description"]` with `db_span.get("description", "")` in both places in `_maybe_performance_problem()` — once for the `PerformanceProblem.desc` field and once for the `evidence_display` notification body.

## Evidence

- Sentry issue: [SENTRY-5QVD](https://sentry.sentry.io/issues/SENTRY-5QVD) — 333,450 occurrences, first seen 2026-06-25, ongoing
- Seer actionability: **high**
- Stack trace confirms the crash is at `mn_plus_one_db_span_detector.py:258` in `_maybe_performance_problem`
- Seer analysis: "Use `.get('description', '')` to safely access the db span description"

## Changes

- `src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py`: Use `.get("description", "")` instead of direct key access in two places
- `tests/sentry/issue_detection/test_m_n_plus_one_db_detector.py`: Add `test_does_not_raise_when_db_span_missing_description` — verifies the detector returns a problem with `desc=""` instead of crashing

## Claude Session

https://claude.ai/code/session_01KBB4d6THmfZynYkkcPNxTh

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBB4d6THmfZynYkkcPNxTh)_