### PR TITLE
fix(perf): Use span with description to prevent `KeyError`

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -292,6 +292,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
         for span in self.spans:
             if (
                 span["op"].startswith("db")
+                and "description" in span
                 and get_span_evidence_value(span, include_op=False) != "prisma:engine:connection"
             ):
                 return span


### PR DESCRIPTION
Prevent `KeyError` due to missing `description` key.
There is at least one span with a description due to validation in `_is_valid_pattern()`.
Span streaming payloads produce segments including both database spans with and without descriptions. If the database span without a description is encountered first, a `KeyError` was raised. 