### PR TITLE
fix(idb): Handle IndexedDB errors in query cache persister gracefully

### DIFF
--- a/static/app/appQueryClient.tsx
+++ b/static/app/appQueryClient.tsx
@@ -1,7 +1,7 @@
 import {createAsyncStoragePersister} from '@tanstack/query-async-storage-persister';
 import {notifyManager, QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {PersistQueryClientProvider} from '@tanstack/react-query-persist-client';
-import {get as getItem, del as removeItem, set as setItem} from 'idb-keyval';
+import {del, get, set} from 'idb-keyval';
 
 import {SENTRY_RELEASE_VERSION} from 'sentry/constants/sdk';
 import {DEFAULT_QUERY_CLIENT_CONFIG} from 'sentry/utils/queryClient';
@@ -28,9 +28,49 @@ if (process.env.NODE_ENV !== 'test') {
   notifyManager.setScheduler(queueMicrotask);
 }
 
+// Track whether IndexedDB has failed so we can disable persistence for the session.
+// IndexedDB can throw DOMExceptions (e.g. ConstraintError, QuotaExceededError) in
+// certain browsers or when storage is corrupted. When that happens, we clear any
+// corrupted data and stop trying to persist for the rest of the session.
+let idbFailed = false;
+
+async function idbGetItem(key: string): Promise<string | null | undefined> {
+  if (idbFailed) return null;
+  try {
+    return (await get<string>(key)) ?? null;
+  } catch {
+    idbFailed = true;
+    return null;
+  }
+}
+
+async function idbSetItem(key: string, value: string): Promise<void> {
+  if (idbFailed) return;
+  try {
+    await set(key, value);
+  } catch {
+    // Clear potentially corrupted data and disable persistence for this session.
+    idbFailed = true;
+    try {
+      await del(cacheKey);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+async function idbRemoveItem(key: string): Promise<void> {
+  if (idbFailed) return;
+  try {
+    await del(key);
+  } catch {
+    idbFailed = true;
+  }
+}
+
 const indexedDbPersister = createAsyncStoragePersister({
   // We're using indexedDB as our storage provider because projects cache can be large
-  storage: {getItem, setItem, removeItem},
+  storage: {getItem: idbGetItem, setItem: idbSetItem, removeItem: idbRemoveItem},
   // Reduce the frequency of writes to indexedDB
   throttleTime: 10_000,
   // The cache is stored entirely on one key
@@ -84,6 +124,6 @@ export async function clearQueryCache() {
       queryKey: ['bootstrap-projects'],
       refetchType: 'none',
     });
-    await removeItem(cacheKey);
+    await idbRemoveItem(cacheKey);
   }
 }


### PR DESCRIPTION
## Summary

A Sentry alert fired for `ConstraintError: A mutation operation in the transaction failed because a constraint was not satisfied.` from the JavaScript platform in the `control` environment. The error originated in the browser's IndexedDB subsystem on the `/settings/:orgId/projects/` page, captured with `handled: true` and **no stack trace**.

The only IndexedDB-backed code in the Sentry frontend is `appQueryClient.tsx`, which uses `idb-keyval` to persist the React Query `bootstrap-projects` cache. IndexedDB can throw `DOMException`s (`ConstraintError`, `QuotaExceededError`, etc.) in certain browser conditions (Firefox, private browsing, corrupted storage). Previously these exceptions would bubble up unhandled through `PersistQueryClientProvider` and get captured by Sentry with no actionable information.

**Changes:**
- Wrap `idb-keyval` operations (`get`, `set`, `del`) in resilient adapters that catch storage exceptions
- On any write failure, clear the potentially-corrupted cache entry and disable IDB persistence for the rest of the session
- Read/remove failures also disable IDB so the app keeps working without storage

This prevents the error from reaching Sentry (it was noise: handled, no stack trace, single browser occurrence) and ensures the app degrades gracefully when IDB is unavailable.

**Evidence / Reasoning:**
- Sentry issue [#7607519198](https://sentry.io/organizations/sentry/issues/7607519198/): single occurrence, `handled: true`, no frames in stacktrace
- Triggered by one Firefox 152.0 / macOS user visiting settings/projects — browser-level IDB failure, not a product bug
- No test changes needed: the error is caught silently and the cache falls back to non-persistent mode, which is already tested behavior
- Session: https://claude.ai/code/session_015NbPDLwEwyAJfbeFe9cpua

---
_Generated by [Claude Code](https://claude.ai/code/session_015NbPDLwEwyAJfbeFe9cpua)_