### PR TITLE
fix(ui): Pin GridEditable header height in Safari on back-nav

### DIFF
--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -95,6 +95,9 @@ export const Grid = styled('table')<{
       overflow-x: auto;
       overflow-y: scroll;
     `}
+  /* Pin the header to a definite track height in both layouts; a content-based
+     header track lets Safari mis-size the <thead> on back/forward navigation.
+     Body track: 1fr absorbs slack when a height is given, else auto. */
   ${p =>
     p.height
       ? css`
@@ -104,14 +107,22 @@ export const Grid = styled('table')<{
           min-height: 0;
 
           &:has(> thead + tbody) {
-            grid-template-rows: auto 1fr;
+            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px 1fr;
           }
 
           &:has(> thead + tbody + tbody) {
-            grid-template-rows: auto fit-content(100%) 1fr;
+            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px fit-content(100%) 1fr;
           }
         `
-      : ''}
+      : css`
+          &:has(> thead + tbody) {
+            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px auto;
+          }
+
+          &:has(> thead + tbody + tbody) {
+            grid-template-rows: ${GRID_HEAD_ROW_HEIGHT}px fit-content(100%) auto;
+          }
+        `}
 
   min-width: ${p => p.fit}
 `;

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -213,10 +213,7 @@ export function CellContent({text, ref, ...props}: CellContentProps) {
   const cleanedText = cleanMarkdownForCell(text);
   return (
     <SingleLineMarkdown ref={ref} {...props}>
-      {/* inline: no block <p>/<pre> children, so white-space:nowrap clamps to
-          one line without relying on `* {display:inline}` (Safari drops it on
-          MarkedText's async innerHTML swap, growing rows on back-nav). */}
-      <MarkedText inline text={ellipsize(cleanedText, CELL_MAX_CHARS)} />
+      <MarkedText text={ellipsize(cleanedText, CELL_MAX_CHARS)} />
     </SingleLineMarkdown>
   );
 }


### PR DESCRIPTION
Safari mis-sizes GridEditable's `<thead>` on back-navigation, making the header super tall until a reflow fixes it (it self-heals after a few seconds, or when you open devtools). Happens because the header row track is content-based (`auto`) on a real `<thead>`, which WebKit sizes wrong on the back-nav remount.

Fix: pin the header row to a fixed 45px track on the `<table>` in both layouts. Also reverts the earlier inline-markdown workaround (#119100) that was chasing the same bug.

Repro'd on macOS Tahoe 26.5.2 in conversation, and traces.