### PR TITLE
perf(dynamic-sampling): Reduce scheduler tick interval to 10s

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1155,7 +1155,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "dynamic-sampling-schedule-per-org-calculations": {
         "task": "telemetry-experience:sentry.dynamic_sampling.per_org.schedule_per_org_calculations",
-        "schedule": timedelta(minutes=1),
+        "schedule": timedelta(seconds=10),
     },
     "weekly-escalating-forecast": {
         "task": "issues:sentry.tasks.weekly_escalating_forecast.run_escalating_forecast",


### PR DESCRIPTION
Reduces the CursoredScheduler tick interval from 1 minute to 10 seconds. This produces 60 ticks per 10-minute cycle instead of 10, dispatching ~6x smaller batches per tick and smoothing out task dispatch over time.

At 10% rollout (~192k orgs): ~3.2k tasks per tick instead of ~19.2k.

Closes TET-2274