### PR TITLE
feat(pr_metrics): Include autofix referrers in scm.pr.closed

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import field
 from typing import Literal
 
 from sentry import analytics
@@ -76,6 +77,12 @@ class PrCloseMetricsEvent(analytics.Event):
     # the active (is_valid=True) attributions, each {signal_type, source,
     # signal_details}, ordered by attribution priority (highest-confidence first).
     attributions: str = "[]"
+    # Distinct ``AutofixReferrer`` values (e.g. "slack", "night_shift") behind the
+    # Seer runs that produced this PR's attributions, resolved via ``SeerRun`` at
+    # emit time rather than stored on ``attributions`` itself — see
+    # ``resolve_autofix_referrers``. Empty when no attribution carries a
+    # resolvable Seer run id.
+    autofix_referrers: list[str] = field(default_factory=list)
     # The terminal verdict, one of ``PullRequestVerdict``: the deterministic
     # outcome (``merged_unchanged`` / ``closed_unmerged``) on the no-judge path, or
     # the Seer judge's verdict on the judge path. Claimed before emit on both paths

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -31,6 +31,7 @@ from sentry.pr_metrics.contracts import (
     PrConversationAnalysis,
 )
 from sentry.pr_metrics.utils import is_activity_tracking_enabled, iso_or_none, resolved_group_ids
+from sentry.seer.models.run import SeerRun
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -121,6 +122,41 @@ def active_attributions(pull_request: PullRequest) -> list[dict[str, Any]]:
         {"signal_type": a.signal_type, "source": a.source, "signal_details": a.signal_details}
         for a in ordered
     ]
+
+
+def resolve_autofix_referrers(
+    pull_request: PullRequest, attributions: list[dict[str, Any]]
+) -> list[str]:
+    """The distinct ``SeerRun.referrer`` values behind this PR's attributions.
+
+    Order is not meaningful — attributions aren't recorded in any guaranteed
+    order — so this returns a plain deduplicated set.
+
+    Both the ``SENTRY_APP`` and ``SEER_DELEGATED_*`` signal paths stamp a Seer
+    ``run_id`` onto their ``signal_details`` (see ``SentryAppSignalDetails`` /
+    ``DelegatedAgentSignalDetails``). Resolves each distinct run id to its
+    mirrored ``SeerRun`` row rather than duplicating the referrer onto
+    ``signal_details`` at write time, so this reads correctly even for PRs
+    attributed before this field existed. Run ids with no matching (or
+    referrer-less) ``SeerRun`` row are skipped — not every run id resolves,
+    e.g. Cursor's delegated-agent path doesn't record one today.
+    """
+    run_ids = {
+        details["run_id"]
+        for attribution in attributions
+        if (details := attribution.get("signal_details")) and details.get("run_id") is not None
+    }
+    if not run_ids:
+        return []
+
+    referrers = (
+        SeerRun.objects.filter(
+            organization_id=pull_request.organization_id, seer_run_state_id__in=run_ids
+        )
+        .values_list("referrer", flat=True)
+        .distinct()
+    )
+    return list(filter(None, referrers))
 
 
 def _merge_commit_id(pull_request: PullRequest) -> int | None:
@@ -232,6 +268,7 @@ def build_pr_metrics_row(
         closed_by_bot=metrics.closed_by_bot,
         opened_and_closed_by_same_actor=metrics.opened_and_closed_by_same_actor,
         attributions=json.dumps(attributions),
+        autofix_referrers=resolve_autofix_referrers(pull_request, attributions),
         verdict=metrics.verdict,
         diagnosis_labels=list(diagnosis_labels) if diagnosis_labels is not None else None,
         **_conversation_analysis_fields(conversation_analysis),

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -22,6 +22,7 @@ from sentry.pr_metrics.emit import (
     build_pr_metrics_row,
     emit_pr_metrics_row,
     is_pr_tracked,
+    resolve_autofix_referrers,
     select_verdict,
 )
 from sentry.pr_metrics.utils import _commit_shas_from_activity, resolved_group_ids
@@ -368,6 +369,75 @@ class PrMetricsEmissionTest(TestCase):
                 "signal_details": {"group_ids": [7]},
             },
         ]
+
+    def test_resolve_autofix_referrers_empty_without_run_id(self) -> None:
+        assert resolve_autofix_referrers(self.pull_request, [SENTRY_APP_ATTRIBUTION]) == []
+
+    def test_resolve_autofix_referrers_resolves_seer_run(self) -> None:
+        seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=555, referrer="slack"
+        )
+        attributions = [
+            {
+                "signal_type": "sentry_app",
+                "source": "seer_data",
+                "signal_details": {"run_id": seer_run.seer_run_state_id},
+            }
+        ]
+        assert resolve_autofix_referrers(self.pull_request, attributions) == ["slack"]
+
+    def test_resolve_autofix_referrers_dedupes_repeated_run_ids(self) -> None:
+        seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=556, referrer="night_shift"
+        )
+        details = {"run_id": seer_run.seer_run_state_id}
+        attributions = [
+            {"signal_type": "sentry_app", "source": "seer_data", "signal_details": details},
+            {
+                "signal_type": "seer_delegated:claude_code",
+                "source": "seer_data",
+                "signal_details": details,
+            },
+        ]
+        assert resolve_autofix_referrers(self.pull_request, attributions) == ["night_shift"]
+
+    def test_resolve_autofix_referrers_skips_run_ids_with_no_matching_seer_run(self) -> None:
+        attributions = [
+            {
+                "signal_type": "seer_delegated:cursor",
+                "source": "seer_data",
+                # Cursor's delegated-agent path doesn't record a run_id today.
+                "signal_details": {"run_id": None},
+            }
+        ]
+        assert resolve_autofix_referrers(self.pull_request, attributions) == []
+
+    def test_build_row_carries_autofix_referrers(self) -> None:
+        seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=557, referrer="night_shift"
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[
+                {
+                    "signal_type": "sentry_app",
+                    "source": "seer_data",
+                    "signal_details": {"run_id": seer_run.seer_run_state_id},
+                }
+            ],
+            group_ids=[],
+        )
+        assert row.autofix_referrers == ["night_shift"]
+
+    def test_build_row_autofix_referrers_empty_by_default(self) -> None:
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.autofix_referrers == []
 
     def test_resolved_group_ids_returns_sorted_resolving_links(self) -> None:
         ids = sorted([self._link_group(), self._link_group()])


### PR DESCRIPTION
Adds `autofix_referrers` to the `scm.pr.closed` analytics row: the distinct
Seer referrer values (e.g. `slack`, `night_shift`) behind the PR's recorded
attributions, so it's possible to see which referrers are most likely to
lead to a merged/self-healing PR.

The attribution `signal_details` on `SENTRY_APP` and `SEER_DELEGATED_*` rows
already carries a Seer `run_id`, and `SeerRun.referrer` already stores what
triggered that run. Rather than duplicating the referrer onto
`signal_details` at write time, `resolve_autofix_referrers` resolves it via
`SeerRun` at emit time — this also means it works retroactively for PRs
attributed before this field existed, with no backfill needed.

Refs CW-1592