### PR TITLE
fix(sdk): ignore 'Failed to resolve module specifier' errors from third-party code

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -155,6 +155,13 @@ export function initializeSdk(config: Config) {
        */
       "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
       "NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      /**
+       * Native ESM module specifier resolution failures are always from third-party
+       * code (browser extensions, injected scripts, e.g. Microsoft Teams web client).
+       * Sentry's own bundled code never emits this error because webpack/rspack
+       * resolves all imports at build time.
+       */
+      /Failed to resolve module specifier/i,
     ],
 
     beforeBreadcrumb(crumb) {

--- a/static/app/serviceWorker/worker/initializeSentry.ts
+++ b/static/app/serviceWorker/worker/initializeSentry.ts
@@ -91,6 +91,13 @@ export function initializeSentry({
       /AbortError: The operation was aborted/i,
       /AbortError: signal is aborted without reason/i,
       /AbortError: The user aborted a request/i,
+      /**
+       * Native ESM module specifier resolution failures are always from third-party
+       * code (browser extensions, injected scripts, e.g. Microsoft Teams web client).
+       * Sentry's own bundled code never emits this error because webpack/rspack
+       * resolves all imports at build time.
+       */
+      /Failed to resolve module specifier/i,
     ],
     ignoreSpans: IGNORED_SPAN_NAMES,
 


### PR DESCRIPTION
## Summary

Adds `Failed to resolve module specifier` to the `ignoreErrors` list in both the main SDK init and the service worker SDK init.

## Evidence & Reasoning

This PR was created in response to a Sentry alert triggered on issue [#7607760442](https://sentry.io/organizations/sentry/issues/7607760442/) — `TypeError: Failed to resolve module specifier 'badpath'`.

**Why this alert is not actionable:**
- The event has a single stack frame at `<anonymous>:1` with no source information (`js_no_source` error in symbolication)
- The event is already tagged `third_party_code=True` by the `ThirdPartyErrorsFilter` integration
- The `Referer` header is `https://teams.public.onecdn.static.microsoft/` — Microsoft Teams CDN code running in the user's browser
- The error mechanism is `auto.browser.global_handlers.onunhandledrejection` — a global catch of an unhandled browser-level rejection

**Why `Failed to resolve module specifier` is always third-party:**

Native ESM module resolution errors (`Failed to resolve module specifier 'X'`) can only be emitted by the browser when it encounters a bare specifier in a native `import` statement (e.g. `import 'badpath'`). Sentry's own code is bundled by webpack/rspack, which resolves all import specifiers at build time and replaces them with numeric chunk IDs — so Sentry's runtime bundle never triggers this browser API. The only sources are browser extensions, injected scripts, or web clients embedded in the page (like Microsoft Teams).

**Why the current instrumentation is insufficient:**

The `ThirdPartyErrorsFilter` is configured with `behaviour: 'apply-tag-if-contains-third-party-frames'` — it correctly tags these events (`third_party_code=True`) but still sends them to Sentry, generating noise. Adding the pattern to `ignoreErrors` drops them before they are ever sent, following the same approach already used for other browser-extension DOM errors (`removeChild`/`insertBefore` `NotFoundError`s).

## Changes

- `static/app/bootstrap/initializeSdk.tsx`: Add `/Failed to resolve module specifier/i` to `ignoreErrors`
- `static/app/serviceWorker/worker/initializeSentry.ts`: Same addition for consistency

## Claude Session

https://claude.ai/code/session_01Lj97Y1PFDR9hSqTNbXKiBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj97Y1PFDR9hSqTNbXKiBJ)_