### PR TITLE
fix(eap): deduplicate TimeSeriesRequest expressions to prevent SnubaRPCError on duplicate yAxis

### DIFF
--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -796,8 +796,11 @@ class RPCBase:
                 filter=query,
                 expressions=[
                     cls.categorize_aggregate(fn)
-                    for fn in (functions + equations)
-                    if fn.is_aggregate
+                    for fn in {
+                        fn.public_alias: fn
+                        for fn in (functions + equations)
+                        if fn.is_aggregate
+                    }.values()
                 ],
                 group_by=[
                     groupby.proto_definition

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -797,9 +797,7 @@ class RPCBase:
                 expressions=[
                     cls.categorize_aggregate(fn)
                     for fn in {
-                        fn.public_alias: fn
-                        for fn in (functions + equations)
-                        if fn.is_aggregate
+                        fn.public_alias: fn for fn in (functions + equations) if fn.is_aggregate
                     }.values()
                 ],
                 group_by=[

--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -790,16 +790,18 @@ class RPCBase:
             else:
                 query = timeseries_filter
 
+        # Deduplicate aggregate expressions by public_alias. Snuba rejects a
+        # TimeSeriesRequest with two expressions sharing the same label, which can
+        # happen when the same y-axis function is requested more than once.
+        aggregates = [fn for fn in (functions + equations) if fn.is_aggregate]
+        deduped = {fn.public_alias: fn for fn in aggregates}.values()
+        expressions = [cls.categorize_aggregate(fn) for fn in deduped]
+
         return (
             TimeSeriesRequest(
                 meta=meta,
                 filter=query,
-                expressions=[
-                    cls.categorize_aggregate(fn)
-                    for fn in {
-                        fn.public_alias: fn for fn in (functions + equations) if fn.is_aggregate
-                    }.values()
-                ],
+                expressions=expressions,
                 group_by=[
                     groupby.proto_definition
                     for groupby in groupbys

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -347,6 +347,29 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
         )
         assert response.status_code == 200, response.content
 
+    def test_duplicate_y_axis_does_not_error(self) -> None:
+        """Sending the same yAxis value twice must not cause a 'Duplicate expression label' RPC error."""
+        self.store_eap_items(
+            [
+                self.create_ourlog(
+                    {"body": "hello"},
+                    timestamp=self.start + timedelta(minutes=1),
+                )
+            ]
+        )
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count(message)", "count(message)"],
+                "project": self.project.id,
+                "dataset": "logs",
+            },
+        )
+        assert response.status_code == 200, response.content
+
     def test_count_with_latest_release_filter(self) -> None:
         self.create_release(version="0.8")
         self.create_release(version="0.9")


### PR DESCRIPTION
## Summary

Fixes **SENTRY-5RBD** (https://sentry.sentry.io/issues/7601703740/?project=1&query=message%3A%EF%80%8DContains%EF%80%8D%22Duplicate%20expression%20label%22&referrer=issue-list&statsPeriod=14d) — `SnubaRPCError: Duplicate expression label: count(message)` — which was impacting ~1,485 users across 15,736 events and escalating.

### Root cause

`get_timeseries_query` in `src/sentry/snuba/rpc_dataset_common.py` builds the `TimeSeriesRequest.expressions` list by iterating `functions + equations`. When the same y-axis function (e.g. `count(message)`) appears more than once in the request's `yAxis` parameter, the resolver's `_resolved_function_cache` returns the same object for each duplicate entry, resulting in two `Expression` proto objects with identical `label` values in the request. Snuba enforces uniqueness of expression labels and rejects the request with a 400 that surfaces as a 500 to end users.

The duplicate entries can originate in at least two ways:
- The frontend sends `?yAxis=count(message)&yAxis=count(message)` (duplicate query param)
- Both a plain function and an equation-prefixed entry resolve to the same alias

### Fix

Deduplicate aggregate expressions by `public_alias` using a dict comprehension before passing them to `TimeSeriesRequest`. The returned `(functions + equations)` tuple is unchanged, so downstream callers (e.g. `run_top_events_timeseries_query`) are unaffected.

```python
# Before
expressions=[
    cls.categorize_aggregate(fn)
    for fn in (functions + equations)
    if fn.is_aggregate
],

# After — deduplicate by public_alias
expressions=[
    cls.categorize_aggregate(fn)
    for fn in {
        fn.public_alias: fn
        for fn in (functions + equations)
        if fn.is_aggregate
    }.values()
],
```

### Test coverage

Added `test_duplicate_y_axis_does_not_error` in `tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py` to assert that sending the same `yAxis` value twice returns HTTP 200 rather than a Snuba RPC error.

---

Generated by Claude Code session: https://claude.ai/code/session_01716tJbLSAfHJaanYeWkoqu

---
_Generated by [Claude Code](https://claude.ai/code/session_01716tJbLSAfHJaanYeWkoqu)_