### PR TITLE
fix(replays): Make links in timeline breadcrumb tooltips clickable

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -15,6 +15,7 @@ import {useCrumbHandlers} from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {ReplayFrame} from 'sentry/utils/replays/types';
 import {isWebVitalFrame} from 'sentry/utils/replays/types';
 import type {GraphicsVariant} from 'sentry/utils/theme';
+import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 
 const NODE_SIZES = [8, 12, 16];
 
@@ -101,10 +102,16 @@ function Event({
       onShowSnippet={() => {}}
     />
   ));
+  // Scope the card's nested hoverable tooltips (e.g. the selector link's own
+  // tooltip in a User Click crumb) to their own hover-overlay delay group.
+  // Otherwise a nested tooltip opening snap-closes this card and unmounts the
+  // link out from under the cursor.
   const title = (
-    <Container maxHeight="80vh" overflow="auto">
-      {buttons}
-    </Container>
+    <HoverOverlayGroupProvider>
+      <Container maxHeight="80vh" overflow="auto">
+        {buttons}
+      </Container>
+    </HoverOverlayGroupProvider>
   );
 
   // Web vital frames render an expandable JSON block that needs more room than


### PR DESCRIPTION
Links inside the "User Click" timeline breadcrumb tooltip over the replay player were impossible to click: the card's selector link has its own nested hoverable tooltip, and both shared a single hover-overlay delay group. When the inner tooltip opened, the group's snap-close logic instantly closed the outer card and unmounted the link before it could be clicked. Wrapping the card's content in `HoverOverlayGroupProvider` gives it its own delay-group scope, so a nested tooltip opening can no longer snap-close its container.

**Before**


https://github.com/user-attachments/assets/24492c9c-4419-47a8-ab9d-4aff76e12571



**After**

https://github.com/user-attachments/assets/dbf21894-c99b-4f06-9cec-a200373113e1


fixes DE-1359