### PR TITLE
fix(pr-metrics): Keep activity open during emit cooldown

### DIFF
--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -20,6 +20,7 @@ from sentry.models.pullrequest import (
     PullRequestAttribution,
     PullRequestLifecycleState,
     PullRequestMetrics,
+    PullRequestVerdict,
 )
 
 _PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=30)
@@ -41,9 +42,10 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
        already-terminal PR may also be recorded until the verdict is claimed —
        an accepted cost for capturing the closer.
 
-    2. A verdict check runs next: if ``PullRequestMetrics`` exists with a
-       non-null verdict (terminal emit or ``JUDGE_IN_PROGRESS`` claim), no
-       further activity is needed.
+    2. A verdict check runs next: activity remains enabled while the verdict is
+       null or ``WAITING_EVENT_COOLDOWN`` so late check events can be captured.
+       All other non-null verdicts (including terminal verdicts and
+       ``JUDGE_IN_PROGRESS``) stop further activity.
 
     3. A time-based buffer gate applies last:
        - Within ``_PR_ACTIVITY_ATTRIBUTION_BUFFER`` (30 h) of ``pr.date_added``,
@@ -57,11 +59,12 @@ def is_activity_tracking_enabled(organization: Organization, pr: PullRequest | N
     if pr is not None:
         if pr.state == PullRequestLifecycleState.SUPERSEDED:
             return False
-        verdict_claimed = PullRequestMetrics.objects.filter(
-            pull_request=pr,
-            verdict__isnull=False,
-        ).exists()
-        if verdict_claimed:
+        verdict = (
+            PullRequestMetrics.objects.filter(pull_request=pr)
+            .values_list("verdict", flat=True)
+            .first()
+        )
+        if verdict is not None and verdict != PullRequestVerdict.WAITING_EVENT_COOLDOWN:
             return False
         if timezone.now() - pr.date_added <= _PR_ACTIVITY_ATTRIBUTION_BUFFER:
             return True

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1861,10 +1861,40 @@ class HandleCheckEventsForPrMetricsTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 
+    def test_check_suite_cooldown_verdict_allows_late_check(self) -> None:
+        PullRequestMetrics.objects.create(
+            pull_request=self.pr,
+            verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN,
+        )
+
+        self._call_suite()
+
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
     def test_check_run_verdict_claimed_skips(self) -> None:
         PullRequestMetrics.objects.create(pull_request=self.pr, verdict="closed_unmerged")
 
         self._call_run()
+
+        assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_run_cooldown_verdict_allows_late_check(self) -> None:
+        PullRequestMetrics.objects.create(
+            pull_request=self.pr,
+            verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN,
+        )
+
+        self._call_run()
+
+        assert PullRequestActivity.objects.filter(pull_request=self.pr).exists()
+
+    def test_check_suite_judge_in_progress_skips(self) -> None:
+        PullRequestMetrics.objects.create(
+            pull_request=self.pr,
+            verdict=PullRequestVerdict.JUDGE_IN_PROGRESS,
+        )
+
+        self._call_suite()
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pr).exists()
 


### PR DESCRIPTION
## Summary
- Allow PR activity collection while `PullRequestMetrics.verdict` is `WAITING_EVENT_COOLDOWN`, so late check suite/run webhooks during the emit cooldown are stored.
- Continue blocking activity for final verdicts and `JUDGE_IN_PROGRESS`.
- Add webhook coverage for cooldown allow + judge-in-progress skip.

cc @giovanni-guidini

## Test plan
- [x] `HandleCheckEventsForPrMetricsTest` cooldown / verdict / judge-in-progress cases
- [ ] Confirm a check event after close still lands during the cooldown window in staging/dev