### PR TITLE
ref(nav): Remove navigation tour from More menu

### DIFF
--- a/static/app/views/navigation/navigationTour.tsx
+++ b/static/app/views/navigation/navigationTour.tsx
@@ -1,22 +1,12 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {createContext, useCallback, useContext, useEffect, useMemo, useRef} from 'react';
 
 import NavigationTourSvg from 'sentry-images/spot/stacked-nav-tour.svg';
 
 import {useModal} from '@sentry/scraps/modal';
 
 import {
-  TourAction,
   TourContextProvider,
   TourElement,
-  TourGuide,
   type TourElementProps,
 } from 'sentry/components/tours/components';
 import {StartTourModal, startTourModalCss} from 'sentry/components/tours/startTour';
@@ -132,7 +122,6 @@ function useNavigationTourCompleted() {
 }
 
 export function NavigationTourProvider({children}: {children: React.ReactNode}) {
-  const {setShowTourReminder} = useNavigationTourReminderContext();
   const organization = useOrganization();
   const isNavigationTourCompleted = useNavigationTourCompleted();
   const initialUrlRef = useRef<string | null>(null);
@@ -150,8 +139,6 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
   }, [location.hash, location.pathname, location.search]);
 
   const onEndTour = useCallback(() => {
-    setShowTourReminder(true);
-
     // Restore the initial URL when the tour ends.
     if (initialUrlRef.current) {
       navigate(initialUrlRef.current, {replace: true});
@@ -160,7 +147,7 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
 
     // Unlock scrolling when the tour ends.
     document.documentElement.style.overflow = '';
-  }, [navigate, setShowTourReminder]);
+  }, [navigate]);
 
   const onStepChange = useCallback(
     (stepId: NavigationTour) => {
@@ -241,74 +228,6 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
     >
       {children}
     </TourContextProvider>
-  );
-}
-
-interface NavigationTourReminderContext {
-  setShowTourReminder: (value: boolean) => void;
-  showTourReminder: boolean;
-}
-
-const NavigationTourReminderContext = createContext<NavigationTourReminderContext>({
-  showTourReminder: false,
-  setShowTourReminder: () => {},
-});
-
-function useNavigationTourReminderContext(): NavigationTourReminderContext {
-  const context = useContext(NavigationTourReminderContext);
-  if (!context) {
-    throw new Error('Must be used within a NavigationTourReminderContextProvider');
-  }
-  return context;
-}
-
-interface NavigationTourReminderContextProviderProps {
-  children: React.ReactNode;
-}
-
-export function NavigationTourReminderContextProvider(
-  props: NavigationTourReminderContextProviderProps
-) {
-  const [showTourReminder, setShowTourReminder] = useState(false);
-
-  const contextValue = useMemo(
-    () => ({showTourReminder, setShowTourReminder}),
-    [showTourReminder, setShowTourReminder]
-  );
-
-  return (
-    <NavigationTourReminderContext.Provider value={contextValue}>
-      {props.children}
-    </NavigationTourReminderContext.Provider>
-  );
-}
-
-interface NavigationTourReminderProps {
-  children: React.ReactNode;
-}
-
-export function NavigationTourReminder(props: NavigationTourReminderProps) {
-  const {showTourReminder, setShowTourReminder} = useNavigationTourReminderContext();
-
-  if (!showTourReminder) {
-    return props.children;
-  }
-
-  return (
-    <TourGuide
-      title={t('Come back anytime')}
-      description={t(
-        'You can always use the help menu to take this tour again or share feedback with the team.'
-      )}
-      actions={
-        <TourAction size="xs" onClick={() => setShowTourReminder(false)}>
-          {t('Got it')}
-        </TourAction>
-      }
-      isOpen={showTourReminder}
-    >
-      {tourProps => <div {...tourProps}>{props.children}</div>}
-    </TourGuide>
   );
 }
 

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -291,11 +291,9 @@ interface PrimaryNavigationMenuProps extends PrimaryNavigationItemBaseProps {
   icon?: React.ReactNode;
   indicator?: 'accent' | 'danger' | 'warning';
   onOpen?: MouseEventHandler<HTMLButtonElement>;
-  triggerWrap?: React.ComponentType<{children: React.ReactNode}>;
 }
 
 function PrimaryNavigationMenu(props: PrimaryNavigationMenuProps) {
-  const TriggerWrap = props.triggerWrap ?? Fragment;
   const theme = useTheme();
   const organization = useOrganization({allowNull: true});
   const {layout} = usePrimaryNavigation();
@@ -320,42 +318,40 @@ function PrimaryNavigationMenu(props: PrimaryNavigationMenuProps) {
       minMenuWidth={200}
       trigger={triggerProps => {
         return (
-          <TriggerWrap>
-            <Tooltip
-              title={props.label}
-              disabled={layout === 'mobile'}
-              position="right"
-              skipWrapper
-            >
-              <NavigationButton
-                {...triggerProps}
-                aria-label={layout === 'mobile' ? undefined : props.label}
-                onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-                  if (organization) {
-                    trackAnalytics('navigation.primary_item_clicked', {
-                      item: props.analyticsKey,
-                      organization,
-                      ...props.analyticsParams,
-                    });
-                  }
-                  triggerProps.onClick?.(event);
-                  props.onOpen?.(event);
-                }}
-                icon={
-                  props.indicator ? (
-                    <Fragment>
-                      {props.icon}
-                      <PrimaryNavigationUnreadIndicator variant={props.indicator} />
-                    </Fragment>
-                  ) : (
-                    props.icon
-                  )
+          <Tooltip
+            title={props.label}
+            disabled={layout === 'mobile'}
+            position="right"
+            skipWrapper
+          >
+            <NavigationButton
+              {...triggerProps}
+              aria-label={layout === 'mobile' ? undefined : props.label}
+              onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                if (organization) {
+                  trackAnalytics('navigation.primary_item_clicked', {
+                    item: props.analyticsKey,
+                    organization,
+                    ...props.analyticsParams,
+                  });
                 }
-              >
-                {layout === 'mobile' ? null : props.children}
-              </NavigationButton>
-            </Tooltip>
-          </TriggerWrap>
+                triggerProps.onClick?.(event);
+                props.onOpen?.(event);
+              }}
+              icon={
+                props.indicator ? (
+                  <Fragment>
+                    {props.icon}
+                    <PrimaryNavigationUnreadIndicator variant={props.indicator} />
+                  </Fragment>
+                ) : (
+                  props.icon
+                )
+              }
+            >
+              {layout === 'mobile' ? null : props.children}
+            </NavigationButton>
+          </Tooltip>
         );
       }}
       items={props.items}

--- a/static/app/views/navigation/primary/helpMenu.spec.tsx
+++ b/static/app/views/navigation/primary/helpMenu.spec.tsx
@@ -6,15 +6,6 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import * as intercom from 'sentry/utils/intercom';
 import {PrimaryNavigationHelpMenu} from 'sentry/views/navigation/primary/helpMenu';
 
-jest.mock('sentry/views/navigation/navigationTour', () => ({
-  useNavigationTour: jest.fn(() => ({
-    startTour: jest.fn(),
-  })),
-  NavigationTourReminder: ({children}: {children: React.ReactNode}) => (
-    <div>{children}</div>
-  ),
-}));
-
 jest.mock('sentry/utils/intercom', () => ({
   showIntercom: jest.fn(),
 }));

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -9,7 +9,6 @@ import {
   IconDocs,
   IconEllipsis,
   IconGithub,
-  IconGlobe,
   IconGroup,
   IconMegaphone,
   IconOpen,
@@ -26,10 +25,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {showIntercom} from 'sentry/utils/intercom';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {
-  NavigationTourReminder,
-  useNavigationTour,
-} from 'sentry/views/navigation/navigationTour';
 import {PrimaryNavigation} from 'sentry/views/navigation/primary/components';
 
 export function PrimaryNavigationHelpMenu() {
@@ -37,7 +32,6 @@ export function PrimaryNavigationHelpMenu() {
   const contactSupportItem = getContactSupportItem(organization);
   const openForm = useFeedbackForm();
   const {privacyUrl, termsUrl} = useLegacyStore(ConfigStore);
-  const {startTour} = useNavigationTour();
 
   useEffect(() => {
     trackAnalytics('intercom_link.viewed', {organization, source: 'sidebar'});
@@ -195,25 +189,12 @@ export function PrimaryNavigationHelpMenu() {
           },
           hidden: !openForm,
         },
-        {
-          key: 'tour',
-          label: t('Tour the new navigation'),
-          leadingItems: (
-            <MenuIcon>
-              <IconGlobe />
-            </MenuIcon>
-          ),
-          onAction() {
-            startTour();
-          },
-        },
       ],
     },
   ];
 
   return (
     <PrimaryNavigation.Menu
-      triggerWrap={NavigationTourReminder}
       items={items}
       analyticsKey="help"
       label={t('Help')}

--- a/static/app/views/navigation/primaryNavigationContext.tsx
+++ b/static/app/views/navigation/primaryNavigationContext.tsx
@@ -5,7 +5,6 @@ import * as Sentry from '@sentry/react';
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMedia} from 'sentry/utils/useMedia';
-import {NavigationTourReminderContextProvider} from 'sentry/views/navigation/navigationTour';
 import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
 
 const PRIMARY_NAVIGATION_GROUP_CONFIG = {
@@ -70,13 +69,11 @@ export function PrimaryNavigationContextProvider(
   );
 
   return (
-    <NavigationTourReminderContextProvider>
-      <SecondaryNavigationContextProvider>
-        <PrimaryNavigationContext.Provider value={value}>
-          {props.children}
-        </PrimaryNavigationContext.Provider>
-      </SecondaryNavigationContextProvider>
-    </NavigationTourReminderContextProvider>
+    <SecondaryNavigationContextProvider>
+      <PrimaryNavigationContext.Provider value={value}>
+        {props.children}
+      </PrimaryNavigationContext.Provider>
+    </SecondaryNavigationContextProvider>
   );
 }
 


### PR DESCRIPTION
Removes the "Tour the new navigation" entry from the sidebar's More menu, since the tour content is outdated and most users dismiss it immediately. Also drops the now-orphaned post-tour reminder whose copy pointed users back to this menu entry.

Fixes [DE-1335](https://linear.app/getsentry/issue/DE-1335/remove-navigation-tour-from-more-menu)
