### PR TITLE
fix(flags): loosen StatsigEventSerializer to accept real Statsig payloads

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -387,11 +387,14 @@ class StatsigEventSerializer(serializers.Serializer):
     timestamp = serializers.CharField(required=True)
     metadata = serializers.DictField(required=True)
 
-    user = serializers.DictField(required=False, child=serializers.CharField())
+    # Statsig sends nested objects in user (e.g. custom, statsigEnvironment), so we
+    # can't restrict child values to strings.
+    user = serializers.DictField(required=False)
     userID = serializers.CharField(required=False)
-    value = serializers.CharField(required=False)
+    value = serializers.CharField(required=False, allow_blank=True)
     statsigMetadata = serializers.DictField(required=False)
-    timeUUID = serializers.UUIDField(required=False)
+    # timeUUID is not used but must accept non-UUID strings sent by Statsig.
+    timeUUID = serializers.CharField(required=False, allow_blank=True)
     unitID = serializers.CharField(required=False)
 
 

--- a/tests/sentry/flags/providers/test_statsig.py
+++ b/tests/sentry/flags/providers/test_statsig.py
@@ -258,6 +258,36 @@ def test_handle_created_by_name() -> None:
     assert logs[0]["created_by_type"] == 2
 
 
+def test_handle_nested_user_fields_and_non_uuid_timeuuid() -> None:
+    """Statsig sends nested objects in user.custom and user.statsigEnvironment, a blank
+    value, and a non-UUID timeUUID. These are valid payloads that must not raise."""
+    logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
+        {
+            "data": [
+                {
+                    "user": {
+                        "userID": "user-1",
+                        "custom": {"role": "admin"},
+                        "statsigEnvironment": {"tier": "production"},
+                        "customIDs": {"companyID": "42"},
+                    },
+                    "timestamp": 1739400185198,
+                    "eventName": "statsig::config_change",
+                    "metadata": {
+                        "type": "Gate",
+                        "name": "gate1",
+                        "action": "updated",
+                    },
+                    "value": "",
+                    "timeUUID": "not-a-uuid",
+                }
+            ]
+        }
+    )
+    assert len(logs) == 1
+    assert logs[0]["flag"] == "gate1"
+
+
 def test_handle_unsupported_events() -> None:
     logs = StatsigProvider(123, "abcdefgh", request_timestamp="1739400185400").handle(
         {


### PR DESCRIPTION
Fixes SENTRY-5J6Z (2.7M events, 4836 users affected)

## Problem

The `StatsigEventSerializer` was rejecting valid Statsig webhook payloads with a `DeserializationError`, causing flag change events to be silently dropped from the audit log. Three fields were too strict:

1. **`user`**: `child=serializers.CharField()` rejected nested objects that Statsig sends in `user.custom`, `user.statsigEnvironment`, and `user.customIDs`
2. **`value`**: `CharField` without `allow_blank=True` rejected empty strings that Statsig sends
3. **`timeUUID`**: `UUIDField` rejected non-UUID strings sent by Statsig (this field is never used in `handle()`)

The error surfaced in prod as:
```
DeserializationError: {'data': {'user': {'custom': ['Not a valid string.'], 'statsigEnvironment': ['Not a valid string.']}, 'value': ['This field may not be blank.'], 'timeUUID': ['Must be a valid UUID.']}}
```

## Fix

- Remove `child=serializers.CharField()` from `user` DictField so nested objects are accepted
- Add `allow_blank=True` to `value` CharField
- Change `timeUUID` from `UUIDField` to `CharField(allow_blank=True)` since it is never consumed by `handle()`

## Evidence / Reasoning

The `handle()` method only reads `user.email`, `user.userID`, `user.name` from the user dict — it never touches `custom`, `statsigEnvironment`, or `customIDs`. The `value` and `timeUUID` fields are validated but never used after passing validation. Relaxing these constraints has no downstream effect on the audit log output.

The issue has been firing continuously since Feb 2026 (2.7M occurrences) across all orgs using the Statsig integration.

Session: https://claude.ai/code/session_01M7qCaesB7YHMdkqnEj5XBP

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7qCaesB7YHMdkqnEj5XBP)_