### PR TITLE
feat(seer): include low-value-span issues in night shift triage

### DIFF
--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -8,8 +8,10 @@ import sentry_sdk
 
 from sentry import search
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.issues.search import group_types_from
 from sentry.models.group import GroupStatus
 from sentry.models.project import Project
+from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
 from sentry.seer.autofix.utils import is_issue_category_eligible
 from sentry.snuba.referrer import Referrer
@@ -69,6 +71,8 @@ def _fetch_and_score(
     fixability), then backfilled with unscored issues in their original recommended
     sort order.
     """
+    # Default types + LowValueSpan
+    type_ids = sorted(group_types_from([]) | {LowValueSpanConfigurationType.type_id})
     result = search.backend.query(
         projects=projects,
         sort_by="recommended",
@@ -76,6 +80,7 @@ def _fetch_and_score(
         search_filters=[
             SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
             SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
+            SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
         ],
         referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
     )

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -2,8 +2,10 @@ from unittest.mock import Mock, patch
 
 from sentry.hybridcloud.models.outbox import CellOutbox
 from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.issues.search import group_types_from
 from sentry.models.group import Group
 from sentry.models.organization import OrganizationStatus
+from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models.night_shift import (
@@ -966,6 +968,31 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         assert null.id in result_ids
         # Low-scored issue (below threshold) is excluded entirely
         assert len(result) == 3
+
+    def test_includes_low_value_span_issues_in_search(self) -> None:
+        project = self.create_project()
+        error_group = self.create_group(project=project)
+        lvs_group = self.create_group(project=project, type=LowValueSpanConfigurationType.type_id)
+
+        with patch(
+            "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
+        ) as mock_query:
+            mock_query.return_value = Mock(results=[error_group, lvs_group])
+            result = fixability_score_strategy([project], max_candidates=10)
+
+        assert {c.group.id for c in result} == {error_group.id, lvs_group.id}
+
+        mock_query.assert_called_once()
+        type_filters = [
+            sf
+            for sf in mock_query.call_args.kwargs["search_filters"]
+            if sf.key.name == "issue.type"
+        ]
+        assert len(type_filters) == 1
+        # The default type set is widened to include low-value-span, not replaced by it.
+        assert set(type_filters[0].value.raw_value) == group_types_from([]) | {
+            LowValueSpanConfigurationType.type_id
+        }
 
     def test_per_project_fetch_limit_scales_with_max_candidates(self) -> None:
         project = self.create_project()


### PR DESCRIPTION
Night Shift didn't triaged low-value-span configuration issues, even though the `CONFIGURATION` category is eligible for Seer autofix (`is_issue_category_eligible`).

The cause is upstream of that eligibility check: Night Shift's candidate search (`_fetch_and_score`) passed no `issue.type` / `issue.category` filter, so the search backend applied its default visibility, which drops these issues in two independent places:

- Type visibility — `LowValueSpanConfigurationType` sets `in_default_search = False`, so `group_types_from` excludes its `type_id` from the default set.
- Category fan-out — `group_categories_from_search_filters` explicitly discards `GroupCategory.CONFIGURATION` from the default fan-out.

So the issues were filtered out before ever reaching the eligibility check.

- `_fetch_and_score` now passes an explicit `issue.type` filter equal to the default type set + low-value-spans.
This keeps every issue type the default search already surfaced and adds low-value-span, in a single query with a
unified `recommended` ranking.
- Low-value-span issues typically have no `seer_fixability_score`, so they land in the unscored backfill bucket after fixability-scored error issues, capped by `max_candidates`.