### PR TITLE
feat(pr-metrics): Derive ci_failing_at_close on the no-judge close path

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -83,8 +83,11 @@ class PrCloseMetricsEvent(analytics.Event):
     # ``| None`` is only the column's unset default, not an expected emitted value.
     verdict: str | None = None
     # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
-    # "why", a vocabulary shared across judges, not specific to any one. Repeated
-    # free-string column; null off the judge path. BigQuery-only.
+    # "why", a vocabulary shared across judges, not specific to any one. Mostly
+    # judge-sourced, but Sentry's own deterministic CLOSED_UNMERGED path can also
+    # set "ci_failing_at_close" (see pr_metrics.emit.ci_failing_at_close) — so a
+    # non-null value doesn't by itself mean the row was judged. Repeated
+    # free-string column; null when nothing applies. BigQuery-only.
     diagnosis_labels: list[str] | None = None
 
     # --- Conversation judge (set only on a judged close/merge row) ---

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -93,6 +93,45 @@ def select_verdict(
     return PullRequestVerdict.CLOSED_UNMERGED
 
 
+# Diagnosis label Sentry can derive on its own (unlike the judge's free-string
+# vocabulary): the deterministic closed-unmerged path's "why", read straight off
+# the PR's own check-suite activity rather than a judge's opinion.
+CI_FAILING_AT_CLOSE = "ci_failing_at_close"
+
+# Conclusions that unambiguously mean the check errored out, as opposed to
+# cancelled/skipped/stale (never ran to completion, not a failure verdict),
+# neutral (a soft pass), or action_required (blocked on approval, not broken).
+_FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure"})
+
+
+def ci_failing_at_close(pull_request: PullRequest) -> bool:
+    """Whether any CI provider's check suite was failing when the PR closed.
+
+    Reads ``CHECK_SUITE_COMPLETED`` activity rows — the aggregate "was CI green
+    or red" signal per provider app (``app_slug``), per ``CheckSuiteCompletedPayload``
+    — keeping only the latest completion per app: a check suite can be rerun with
+    no new push (no ``SYNCHRONIZED`` row), so an earlier failure superseded by a
+    passing rerun shouldn't count.
+
+    Only meaningful for ``select_verdict``'s deterministic ``CLOSED_UNMERGED``
+    outcome: that path is reached only when there were no commits after open, so
+    every recorded check row necessarily belongs to the PR's one and only head
+    commit — there's no other commit's CI status to accidentally mix in.
+    """
+    rows = (
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request, event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED
+        )
+        .order_by("date_added", "id")
+        .values_list("payload__app_slug", "payload__conclusion")
+    )
+    # dict() keeps the last entry per key, i.e. each app's latest conclusion.
+    latest_conclusion_by_app: dict[str, str] = dict(rows)
+    return any(
+        conclusion in _FAILING_CHECK_CONCLUSIONS for conclusion in latest_conclusion_by_app.values()
+    )
+
+
 def is_pr_tracked(pull_request: PullRequest) -> bool:
     """Whether the PR has ≥1 valid attribution — the emission tracking gate.
 
@@ -183,10 +222,12 @@ def build_pr_metrics_row(
     emitted row read the same query. A missing metrics row (a PR Sentry never saw
     active) coalesces every counter to its default.
 
-    The judge enrichment is set on the judge path only: ``conversation_analysis``
-    is the conversation judge's result (semantic outputs become columns, its
-    ``metadata`` is JSON-encoded), and ``diagnosis_labels`` is the cross-judge
-    close-reason "why".
+    ``conversation_analysis`` is set on the judge path only: the conversation
+    judge's result (semantic outputs become columns, its ``metadata`` is
+    JSON-encoded). ``diagnosis_labels`` is the cross-judge close-reason "why" —
+    mostly judge-sourced, but ``select_verdict``'s deterministic
+    ``CLOSED_UNMERGED`` path can also populate it (see ``ci_failing_at_close``),
+    so its presence doesn't by itself mean the row was judged.
     """
     head_commit_sha = pull_request.head_commit_sha
     closed_at = pull_request.closed_at
@@ -342,8 +383,10 @@ def emit_pr_metrics_row(
     attributed to. Returns whether a row was emitted, for callers/tests.
 
     Takes only the canonical ``PullRequest`` — no webhook payload — so Seer's
-    judge can call it directly via RPC callback. ``conversation_analysis`` and
-    ``diagnosis_labels`` are set only on that judge path.
+    judge can call it directly via RPC callback. ``conversation_analysis`` is set
+    only on that judge path; ``diagnosis_labels`` is mostly judge-sourced but the
+    deterministic ``CLOSED_UNMERGED`` path can also pass one in (see
+    ``ci_failing_at_close``).
     """
     # Fetch the attribution snapshot once: it both gates emission (≥1 valid row)
     # and rides along on the emitted row, so the two can't diverge.

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -73,6 +73,8 @@ from sentry.pr_metrics.attribution import (
     record_attribution_signal,
 )
 from sentry.pr_metrics.emit import (
+    CI_FAILING_AT_CLOSE,
+    ci_failing_at_close,
     emit_pr_metrics_row,
     is_pr_tracked,
     select_verdict,
@@ -439,11 +441,21 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"})
         return
 
+    # Sentry can derive this one diagnosis label itself, without a judge: a plain
+    # close (no merge, no engagement) whose check suites were red at close. Scoped
+    # to CLOSED_UNMERGED specifically — the judge-needed and merged paths don't
+    # carry this deterministic signal.
+    diagnosis_labels = (
+        [CI_FAILING_AT_CLOSE]
+        if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request)
+        else None
+    )
+
     # Claim before emit so build_pr_metrics_row reads the verdict back onto the row.
     # analytics.record is best-effort, async-batched telemetry; if it raises the
     # claim still stands and the row is forgone — an acceptable loss for telemetry,
     # not worth a rollback that would reopen the redelivery race.
-    emit_pr_metrics_row(pull_request=pull_request)
+    emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
     metrics.incr("pr_metrics.cooldown.emitted")
 
 

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -20,6 +20,7 @@ from sentry.pr_metrics.emit import (
     _activity_derived_metrics,
     active_attributions,
     build_pr_metrics_row,
+    ci_failing_at_close,
     emit_pr_metrics_row,
     is_pr_tracked,
     select_verdict,
@@ -138,6 +139,16 @@ class PrMetricsEmissionTest(TestCase):
             payload={},
         )
 
+    def _add_check_suite(
+        self, *, app_slug: str = "github-actions", conclusion: str = "success", webhook_id: str
+    ) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
+            payload={"conclusion": conclusion, "app_slug": app_slug, "check_runs_count": 1},
+        )
+
     def test_select_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         # Merged with no SYNCHRONIZED activity: merge head == opened head.
         assert (
@@ -210,6 +221,50 @@ class PrMetricsEmissionTest(TestCase):
             with patch("sentry.pr_metrics.emit.metrics") as mock_metrics:
                 assert select_verdict(self.pull_request, self.organization) is None
         mock_metrics.incr.assert_called_once_with("pr_metrics.select_verdict.activity_disabled")
+
+    def test_ci_failing_at_close_no_check_activity_is_false(self) -> None:
+        assert ci_failing_at_close(self.pull_request) is False
+
+    def test_ci_failing_at_close_all_success_is_false(self) -> None:
+        self._add_check_suite(conclusion="success", webhook_id="check-1")
+        assert ci_failing_at_close(self.pull_request) is False
+
+    def test_ci_failing_at_close_failure_is_true(self) -> None:
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        assert ci_failing_at_close(self.pull_request) is True
+
+    def test_ci_failing_at_close_timed_out_is_true(self) -> None:
+        self._add_check_suite(conclusion="timed_out", webhook_id="check-1")
+        assert ci_failing_at_close(self.pull_request) is True
+
+    def test_ci_failing_at_close_startup_failure_is_true(self) -> None:
+        self._add_check_suite(conclusion="startup_failure", webhook_id="check-1")
+        assert ci_failing_at_close(self.pull_request) is True
+
+    def test_ci_failing_at_close_non_failure_conclusions_are_false(self) -> None:
+        # neutral/cancelled/skipped/stale/action_required never ran to a failure
+        # verdict, so none of them should trip the label.
+        for conclusion in ("neutral", "cancelled", "skipped", "stale", "action_required"):
+            PullRequestActivity.objects.filter(pull_request=self.pull_request).delete()
+            self._add_check_suite(conclusion=conclusion, webhook_id="check-1")
+            assert ci_failing_at_close(self.pull_request) is False, conclusion
+
+    def test_ci_failing_at_close_one_app_failing_among_others_is_true(self) -> None:
+        self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-1")
+        self._add_check_suite(app_slug="codecov", conclusion="failure", webhook_id="check-2")
+        assert ci_failing_at_close(self.pull_request) is True
+
+    def test_ci_failing_at_close_rerun_success_after_failure_is_false(self) -> None:
+        # A rerun with no new push (no SYNCHRONIZED row) still writes another
+        # CHECK_SUITE_COMPLETED row for the same app; the latest one wins.
+        self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-1")
+        self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-2")
+        assert ci_failing_at_close(self.pull_request) is False
+
+    def test_ci_failing_at_close_rerun_failure_after_success_is_true(self) -> None:
+        self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-1")
+        self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-2")
+        assert ci_failing_at_close(self.pull_request) is True
 
     def test_build_row_for_merge(self) -> None:
         row = build_pr_metrics_row(

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -368,6 +368,45 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         row = mock_record.call_args_list[-1].args[0]
         assert row.close_action == "closed"
         assert row.verdict == "closed_unmerged"
+        assert row.diagnosis_labels is None
+
+    def _add_check_suite(self, *, conclusion: str, webhook_id: str) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
+            payload={"conclusion": conclusion, "app_slug": "github-actions", "check_runs_count": 1},
+        )
+
+    @patch("sentry.analytics.record")
+    def test_closed_unmerged_with_failing_ci_sets_diagnosis_label(
+        self, mock_record: MagicMock
+    ) -> None:
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        self._call(merged=False)
+        row = mock_record.call_args_list[-1].args[0]
+        assert row.verdict == "closed_unmerged"
+        assert row.diagnosis_labels == ["ci_failing_at_close"]
+
+    @patch("sentry.analytics.record")
+    def test_closed_unmerged_with_passing_ci_has_no_diagnosis_label(
+        self, mock_record: MagicMock
+    ) -> None:
+        self._add_check_suite(conclusion="success", webhook_id="check-1")
+        self._call(merged=False)
+        row = mock_record.call_args_list[-1].args[0]
+        assert row.verdict == "closed_unmerged"
+        assert row.diagnosis_labels is None
+
+    @patch("sentry.analytics.record")
+    def test_merged_with_failing_ci_has_no_diagnosis_label(self, mock_record: MagicMock) -> None:
+        # The deterministic CI-failure label is scoped to CLOSED_UNMERGED; a clean
+        # merge never carries it even if a check suite failed along the way.
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        self._call(merged=True)
+        row = mock_record.call_args_list[-1].args[0]
+        assert row.verdict == "merged_unchanged"
+        assert row.diagnosis_labels is None
 
     def _add_synchronize(self) -> None:
         # A push to the PR branch after it opened — makes a merge non-deterministic.


### PR DESCRIPTION
The deterministic closed-unmerged path in pr_metrics (no engagement, no
commits after open) never reaches the Seer judge, so it never had a way to
carry a diagnosis label — even when the PR's CI was failing at close. Sentry
already records that as `CHECK_SUITE_COMPLETED` activity, so this derives the
`ci_failing_at_close` label locally instead of leaving it judge-only.

`ci_failing_at_close()` reads the PR's check-suite activity, keeps only the
latest completion per CI provider app (a suite can be rerun with no new push,
so an earlier failure superseded by a passing rerun shouldn't count), and
treats `failure` / `timed_out` / `startup_failure` as failing conclusions.
`run_deferred_emission` only applies it on the `CLOSED_UNMERGED` verdict —
never on a clean merge, even if some check suite happened to fail earlier.

`diagnosis_labels` was previously judge-only by convention (docstrings said
so); this makes it possible for the deterministic path to also populate it,
so those comments are updated accordingly — a non-null value no longer implies
the row was judged.