### PR TITLE
feat(ai-spans): Adjust JSON expansion defaults

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -41,6 +41,10 @@ import {AttributesContent} from 'sentry/views/performance/newTraceDetails/traceD
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
 
+const AI_SPAN_INPUT_JSON_MAX_DEFAULT_DEPTH = 3;
+const AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH = 100;
+const AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT = 100_000;
+
 export type DetailTab = 'input' | 'output' | 'attributes';
 
 export const CONVERSATION_SPAN_DETAIL_TABS: readonly DetailTab[] = [
@@ -287,11 +291,20 @@ function InputTab({
             {capitalize(message.role)}
           </TraceDrawerComponents.MultilineTextLabel>
           {/* System prompts are usually long, repetitive, and sit on top, so keep them clipped */}
-          <MessageContent content={message.content} clip={message.role === 'system'} />
+          <InputMessageContent
+            key={`${node.id}:message:${index}`}
+            content={message.content}
+            clip={message.role === 'system'}
+          />
         </Fragment>
       ))}
       {toolArgs ? (
-        <TraceDrawerComponents.MultilineJSON value={toolArgs} maxDefaultDepth={1} />
+        <TraceDrawerComponents.MultilineJSON
+          key={`${node.id}:tool-input`}
+          value={toolArgs}
+          maxDefaultDepth={AI_SPAN_INPUT_JSON_MAX_DEFAULT_DEPTH}
+          autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+        />
       ) : null}
       {embeddingsInput ? (
         <TraceDrawerComponents.MultilineText clip={false}>
@@ -323,7 +336,13 @@ function OutputTab({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <AIContentRenderer text={responseText} clip={false} />
+          <AIContentRenderer
+            key={`${node.id}:response-text`}
+            text={responseText}
+            maxJsonDepth={AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH}
+            autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+            clip={false}
+          />
         </Fragment>
       ) : null}
       {responseObject ? (
@@ -331,7 +350,13 @@ function OutputTab({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Response Object')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <AIContentRenderer text={responseObject} clip={false} />
+          <AIContentRenderer
+            key={`${node.id}:response-object`}
+            text={responseObject}
+            maxJsonDepth={AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH}
+            autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+            clip={false}
+          />
         </Fragment>
       ) : null}
       {toolCalls ? (
@@ -339,23 +364,45 @@ function OutputTab({
           <TraceDrawerComponents.MultilineTextLabel>
             {t('Tool Calls')}
           </TraceDrawerComponents.MultilineTextLabel>
-          <TraceDrawerComponents.MultilineJSON value={toolCalls} maxDefaultDepth={2} />
+          <TraceDrawerComponents.MultilineJSON
+            key={`${node.id}:tool-calls`}
+            value={toolCalls}
+            maxDefaultDepth={AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH}
+            autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+          />
         </Fragment>
       ) : null}
       {toolOutput ? (
-        <TraceDrawerComponents.MultilineJSON value={toolOutput} maxDefaultDepth={1} />
+        <TraceDrawerComponents.MultilineJSON
+          key={`${node.id}:tool-output`}
+          value={toolOutput}
+          maxDefaultDepth={AI_SPAN_OUTPUT_JSON_MAX_DEFAULT_DEPTH}
+          autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+        />
       ) : null}
     </Fragment>
   );
 }
 
-function MessageContent({content, clip = false}: {content: unknown; clip?: boolean}) {
+function InputMessageContent({
+  content,
+  clip = false,
+}: {
+  content: unknown;
+  clip?: boolean;
+}) {
   return typeof content === 'string' ? (
-    <AIContentRenderer text={content} clip={clip} />
+    <AIContentRenderer
+      text={content}
+      maxJsonDepth={AI_SPAN_INPUT_JSON_MAX_DEFAULT_DEPTH}
+      autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
+      clip={clip}
+    />
   ) : (
     <TraceDrawerComponents.MultilineJSON
       value={content}
-      maxDefaultDepth={2}
+      maxDefaultDepth={AI_SPAN_INPUT_JSON_MAX_DEFAULT_DEPTH}
+      autoCollapseLimit={AI_SPAN_JSON_AUTO_COLLAPSE_LIMIT}
       clip={clip}
     />
   );


### PR DESCRIPTION
AI span details now use different JSON expansion defaults for the input and output tabs: input JSON expands three levels by default, while output JSON expands fully. This keeps request data from getting too large by default while making generated responses and tool results immediately inspectable.

The change is scoped to the AI span detail input/output view and leaves the attributes tab and shared JSON renderer defaults unchanged.

Closes TET-2646
