### PR TITLE
fix(flags): relax StatsigEventSerializer to accept heterogeneous user fields

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -387,11 +387,14 @@ class StatsigEventSerializer(serializers.Serializer):
     timestamp = serializers.CharField(required=True)
     metadata = serializers.DictField(required=True)
 
-    user = serializers.DictField(required=False, child=serializers.CharField())
+    # Statsig sends heterogeneous values in the user dict (nested objects, not just strings).
+    user = serializers.DictField(required=False)
     userID = serializers.CharField(required=False)
-    value = serializers.CharField(required=False)
+    # Statsig sometimes sends an empty string for value.
+    value = serializers.CharField(required=False, allow_blank=True)
     statsigMetadata = serializers.DictField(required=False)
-    timeUUID = serializers.UUIDField(required=False)
+    # Statsig sometimes sends non-UUID values; accept as a plain string.
+    timeUUID = serializers.CharField(required=False)
     unitID = serializers.CharField(required=False)
 
 

--- a/tests/sentry/flags/endpoints/test_hooks.py
+++ b/tests/sentry/flags/endpoints/test_hooks.py
@@ -158,6 +158,59 @@ class OrganizationFlagsHooksEndpointTestCase(APITestCase):
             )
             assert FlagAuditLogModel.objects.count() == 1
 
+    def test_statsig_post_create_with_nested_user_fields(self, mock_incr: MagicMock) -> None:
+        """Statsig sends heterogeneous user fields (nested objects, blank value, non-UUID timeUUID).
+
+        Previously StatsigEventSerializer rejected these with DeserializationError because
+        user was DictField(child=CharField()), value didn't allow blank, and timeUUID was
+        a UUIDField. These fields are not used in processing, so the validation is too strict.
+        """
+        request_data = {
+            "data": [
+                {
+                    "eventName": "statsig::gate_exposure",
+                    "timestamp": "1739400185198",
+                    "metadata": {
+                        "type": "Gate",
+                        "name": "gate1",
+                        "action": "updated",
+                    },
+                    "user": {
+                        "name": "johndoe",
+                        "email": "john@sentry.io",
+                        # Non-string values that Statsig sends in the wild
+                        "custom": {"role": "admin"},
+                        "statsigEnvironment": {"tier": "production"},
+                    },
+                    "value": "",
+                    "timeUUID": "not-a-uuid",
+                },
+            ]
+        }
+
+        secret = "webhook-Xk9pL8NQaR5Ym2cx7vHnWtBj4M3f6qyZdC12mnspk8"
+        FlagWebHookSigningSecretModel.objects.create(
+            organization=self.organization,
+            provider="statsig",
+            secret=secret,
+        )
+
+        request_timestamp = "1739400185400"
+        signature_basestring = f"v0:{request_timestamp}:{json.dumps(request_data)}".encode()
+        signature = "v0=" + hmac_sha256_hex_digest(key=secret, message=signature_basestring)
+        headers = {
+            "X-Statsig-Signature": signature,
+            "X-Statsig-Request-Timestamp": request_timestamp,
+        }
+
+        with self.feature(self.features):
+            response = self.client.post(
+                reverse(self.endpoint, args=(self.organization.slug, "statsig")),
+                request_data,
+                headers=headers,
+            )
+            assert response.status_code == 200, response.content
+
     def test_statsig_post_unauthorized(self, mock_incr: MagicMock) -> None:
         request_data = {
             "data": [


### PR DESCRIPTION
## Summary

Fixes [SENTRY-5J6Z](https://sentry.sentry.io/issues/SENTRY-5J6Z) — 2.7M spurious `DeserializationError` captures affecting 4,836 users.

**Root cause:** `StatsigEventSerializer` was too strict for fields that are never used in the processing logic:

| Field | Old validation | Problem | Fix |
|-------|----------------|---------|-----|
| `user` | `DictField(child=CharField())` | Statsig sends `custom` and `statsigEnvironment` as nested objects, not strings | `DictField()` (no child constraint) |
| `value` | `CharField(required=False)` | Statsig sends `value=""` (empty string) | `CharField(required=False, allow_blank=True)` |
| `timeUUID` | `UUIDField(required=False)` | Statsig sends non-UUID values | `CharField(required=False)` |

None of these three fields are read or used in `StatsigProvider.handle()` — they exist only to pass schema validation. Seer's analysis confirmed: *"Overly strict validation in `StatsigEventSerializer` for unused fields causes `DeserializationError` when processing Statsig webhooks containing unexpected formats like nested objects or empty strings."*

## Evidence

- Sentry issue: [SENTRY-5J6Z](https://sentry.sentry.io/issues/SENTRY-5J6Z)
- 2,775,374 events since 2026-02-07, affecting 4,836 users
- Triggered by this automated alert-triage session: https://claude.ai/code/session_012nLw6h7MkgYvacLmtPpFe6
- Stacktrace confirms the error always originates at `providers.py:424` (`raise DeserializationError(serializer.errors)`) with error details pointing to user sub-fields, blank value, and invalid UUID

## Test plan

- [x] Added `test_statsig_post_create_with_nested_user_fields` reproducing the exact payload shape from the wild (nested `custom`/`statsigEnvironment` objects, blank `value`, non-UUID `timeUUID`)
- [ ] Run `pytest tests/sentry/flags/endpoints/test_hooks.py -k statsig` — all tests green


---
_Generated by [Claude Code](https://claude.ai/code/session_012nLw6h7MkgYvacLmtPpFe6)_