### PR TITLE
feat(conversations): Return tool call result on conversation spans

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -57,6 +57,8 @@ AI_CONVERSATION_ATTRIBUTES = [
     "gen_ai.tool.name",
     "gen_ai.tool.call.arguments",
     "gen_ai.tool.input",
+    "gen_ai.tool.call.result",
+    "gen_ai.tool.output",
     "gen_ai.usage.total_tokens",
     "gen_ai.request.model",
     "gen_ai.response.model",

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -341,6 +341,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             operation_type="tool",
             trace_id=trace_id,
             tool_name="search_database",
+            tool_result="found 3 rows",
+            tool_output="tool output payload",
         )
 
         query = {
@@ -357,6 +359,8 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["span.op"] == "gen_ai.execute_tool"
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
+        assert span["gen_ai.tool.call.result"] == "found 3 rows"
+        assert span["gen_ai.tool.output"] == "tool output payload"
 
     def test_stats_period_is_tried_first_then_widened(self) -> None:
         timestamp_15d = before_now(days=15).replace(microsecond=0)

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -34,6 +34,8 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         messages=None,
         response_text=None,
         tool_name=None,
+        tool_result=None,
+        tool_output=None,
         user_id=None,
         user_email=None,
         user_username=None,
@@ -62,6 +64,8 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             messages: The gen_ai.request.messages (will be JSON serialized)
             response_text: The gen_ai.response.text attribute
             tool_name: The gen_ai.tool.name attribute
+            tool_result: The gen_ai.tool.call.result attribute
+            tool_output: The gen_ai.tool.output attribute
             user_id: User ID (sentry.user.id)
             user_email: User email (sentry.user.email)
             user_username: User username (sentry.user.username)
@@ -94,6 +98,10 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             span_data["gen_ai.response.text"] = response_text
         if tool_name is not None:
             span_data["gen_ai.tool.name"] = tool_name
+        if tool_result is not None:
+            span_data["gen_ai.tool.call.result"] = tool_result
+        if tool_output is not None:
+            span_data["gen_ai.tool.output"] = tool_output
         # New format attributes
         if input_messages is not None:
             span_data["gen_ai.input.messages"] = json.dumps(input_messages)


### PR DESCRIPTION
The AI conversation details endpoint now selects `gen_ai.tool.call.result` and `gen_ai.tool.output` for each span, alongside the tool input attributes it already returns.

This closes a gap where the frontend had to make a per-span `trace-items` request for every tool call on page load just to read the tool output (e.g. to render its output size).

Refs TET-2677