### PR TITLE
fix(msteams): treat ApiUnauthorized (401) as a configuration halt, not a failure

### DIFF
--- a/src/sentry/integrations/msteams/metrics.py
+++ b/src/sentry/integrations/msteams/metrics.py
@@ -2,6 +2,7 @@ from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiRateLimitedError,
+    ApiUnauthorized,
     IntegrationConfigurationError,
     IntegrationError,
 )
@@ -27,8 +28,9 @@ def record_lifecycle_termination_level(lifecycle: EventLifecycle, error: ApiErro
 
 
 def translate_msteams_api_error(error: ApiError) -> None:
-    if isinstance(error, ApiRateLimitedError):
-        # TODO(ecosystem): We should batch this on a per-organization basis
+    if isinstance(error, (ApiUnauthorized, ApiRateLimitedError)):
+        # 401 Unauthorized means expired/invalid credentials — a configuration issue, not a failure.
+        # TODO(ecosystem): We should batch rate-limiting on a per-organization basis
         raise IntegrationConfigurationError(error.text) from error
     elif error.json:
         if error.json.get("error", {}).get("code") in MSTEAMS_HALT_ERROR_CODES:


### PR DESCRIPTION
<!-- Describe your PR here. -->

## Problem

`translate_msteams_api_error` in `src/sentry/integrations/msteams/metrics.py` doesn't handle `ApiUnauthorized` (HTTP 401) as a distinct case. When an MS Teams integration returns 401 (e.g. expired Azure app secret), the error has no JSON body, so it falls through to the `else` branch and raises `IntegrationError`. This causes `record_lifecycle_termination_level` to call `lifecycle.record_failure()`, which internally calls `sentry_sdk.capture_exception()` — generating a Sentry event for every notification attempt.

A 401 Unauthorized means the integration credentials are invalid or expired. That is a **configuration problem** (a "halt"), not an application failure.

**Evidence:** SENTRY-49E4 — `IntegrationError` in `sentry.workflow_engine.tasks.trigger_action` — 244k+ events all traced to `sentry/integrations/msteams/metrics.py:39` firing `IntegrationError` from an `ApiUnauthorized` root cause. Related to expired Azure app secret (see SENTRY-2FWK).

## Fix

Add `ApiUnauthorized` alongside `ApiRateLimitedError` in the first `isinstance` check so both raise `IntegrationConfigurationError`. This makes `record_lifecycle_termination_level` call `lifecycle.record_halt()` instead of `lifecycle.record_failure()`, stopping the Sentry event capture.

**Precedent:** OpsGenie's equivalent function (`src/sentry/integrations/opsgenie/metrics.py`) already does this:
```python
if isinstance(error, (ApiUnauthorized, ApiRateLimitedError)):
    lifecycle.record_halt(halt_reason=error)
```

## Changes

- `src/sentry/integrations/msteams/metrics.py`: Add `ApiUnauthorized` to imports; group it with `ApiRateLimitedError` in the first `isinstance` check in `translate_msteams_api_error`.

## Session

https://claude.ai/code/session_01DjQvjPC8WnAiZEUe6zLwVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjQvjPC8WnAiZEUe6zLwVs)_