### PR TITLE
feat(metrics): Add metrics.set for unique-value set metrics

### DIFF
--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -79,6 +79,17 @@ class MetricsBackend(local):
     ) -> None:
         raise NotImplementedError
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        raise NotImplementedError
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -112,6 +112,27 @@ class DatadogMetricsBackend(MetricsBackend):
         # We keep the same implementation for Datadog.
         return self.timing(key, value, instance, tags, sample_rate)
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        tags = dict(tags or ())
+
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+
+        tags_list = [f"{k}:{v}" for k, v in tags.items()]
+        self.stats.set(
+            self._get_key(key), value, sample_rate=sample_rate, tags=tags_list, host=self.host
+        )
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -114,6 +114,25 @@ class DogStatsdMetricsBackend(MetricsBackend):
         # We keep the same implementation for Datadog.
         return self.timing(key, value, instance, tags, sample_rate)
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        tags = dict(tags or ())
+
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+
+        tags_list = [f"{k}:{v}" for k, v in tags.items()]
+        statsd.set(self._get_key(key), value, tags=tags_list, sample_rate=sample_rate)
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/dualwrite.py
+++ b/src/sentry/metrics/dualwrite.py
@@ -159,6 +159,22 @@ class DualWriteMetricsBackend(MetricsBackend):
             key, value, instance, tags, sample_rate, unit, stacklevel + 1
         )
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        use_primary, use_secondary = self._other_choice(key)
+        if use_primary:
+            self._primary_backend.set(key, value, instance, tags, sample_rate, stacklevel + 1)
+        if use_secondary:
+            self._secondary_backend.set(key, value, instance, tags, sample_rate, stacklevel + 1)
+        self._experimental_backend.set(key, value, instance, tags, sample_rate, stacklevel + 1)
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -51,6 +51,17 @@ class DummyMetricsBackend(MetricsBackend):
     ) -> None:
         pass
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        pass
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -55,6 +55,17 @@ class LoggingBackend(MetricsBackend):
     ) -> None:
         logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        logger.debug("%r: %r", key, value, extra={"instance": instance, "tags": tags or {}})
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -210,6 +210,22 @@ class MiddlewareWrapper(MetricsBackend):
             key, value, instance, current_tags, sample_rate, unit, stacklevel + 1
         )
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        current_tags = get_current_global_tags()
+        if tags is not None:
+            current_tags.update(tags)
+        current_tags = _filter_tags(key, current_tags)
+
+        return self.inner.set(key, value, instance, current_tags, sample_rate, stacklevel + 1)
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/precise_dogstatsd.py
+++ b/src/sentry/metrics/precise_dogstatsd.py
@@ -117,6 +117,25 @@ class PreciseDogStatsdMetricsBackend(MetricsBackend):
         tags_list = [f"{k}:{v}" for k, v in tags.items()]
         self.statsd.distribution(self._get_key(key), value, sample_rate=sample_rate, tags=tags_list)
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        tags = dict(tags or ())
+
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+
+        tags_list = [f"{k}:{v}" for k, v in tags.items()]
+        self.statsd.set(self._get_key(key), value, tags=tags_list, sample_rate=sample_rate)
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -155,6 +155,18 @@ class SentrySDKMetricsBackend(MetricsBackend):
             attributes=metric_attributes,
         )
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        # Sentry SDK metrics have no set type.
+        pass
+
     def event(
         self,
         title: str,

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -65,6 +65,17 @@ class StatsdMetricsBackend(MetricsBackend):
         # NOTE: the statsd client does not have a `distribution` method
         self.timing(key, value, instance, tags, sample_rate)
 
+    def set(
+        self,
+        key: str,
+        value: str | int,
+        instance: str | None = None,
+        tags: Tags | None = None,
+        sample_rate: float = 1,
+        stacklevel: int = 0,
+    ) -> None:
+        self.client.set(self._full_key(self._get_key(key)), value, sample_rate)
+
     def event(
         self,
         title: str,

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -31,6 +31,7 @@ __all__ = [
     "timing",
     "gauge",
     "distribution",
+    "set",
     "backend",
     "MutableTags",
     "ensure_crash_rate_in_bounds",
@@ -181,6 +182,21 @@ def distribution(
 ) -> None:
     try:
         backend.distribution(key, value, instance, tags, sample_rate, unit, stacklevel + 1)
+    except Exception:
+        logger = logging.getLogger("sentry.errors")
+        logger.exception("Unable to record backend metric")
+
+
+def set(
+    key: str,
+    value: str | int,
+    instance: str | None = None,
+    tags: Tags | None = None,
+    sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
+    stacklevel: int = 0,
+) -> None:
+    try:
+        backend.set(key, value, instance, tags, sample_rate, stacklevel + 1)
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")

--- a/tests/sentry/metrics/test_datadog.py
+++ b/tests/sentry/metrics/test_datadog.py
@@ -45,6 +45,17 @@ class DatadogMetricsBackendTest(TestCase):
             host=get_hostname(hostname_from_config=True),
         )
 
+    @patch("datadog.threadstats.base.ThreadStats.set")
+    def test_set(self, mock_set: MagicMock) -> None:
+        self.backend.set("foo", 4242, instance="bar")
+        mock_set.assert_called_once_with(
+            "sentrytest.foo",
+            4242,
+            sample_rate=1,
+            tags=["instance:bar"],
+            host=get_hostname(hostname_from_config=True),
+        )
+
     @patch("datadog.threadstats.base.ThreadStats.event")
     def test_event(self, mock_event: MagicMock) -> None:
         self.backend.event("foo", "bar", instance="baz")

--- a/tests/sentry/metrics/test_dualwrite.py
+++ b/tests/sentry/metrics/test_dualwrite.py
@@ -70,3 +70,34 @@ def test_dualwrite_experimental_backend_rollout_disabled(dogstatsd_gauge, sentry
     backend.gauge("metric", 42, tags={"test": "tag"}, unit="none")
     dogstatsd_gauge.assert_called_once()
     sentry_sdk_gauge.assert_not_called()
+
+
+@mock.patch("datadog.dogstatsd.base.DogStatsd.set")
+@thread_leak_allowlist(reason="datadog dualwrite metrics", issue=98803)
+def test_dualwrite_set(dogstatsd_set):
+    backend = DualWriteMetricsBackend(
+        primary_backend="sentry.metrics.dogstatsd.DogStatsdMetricsBackend",
+        secondary_backend="sentry.metrics.precise_dogstatsd.PreciseDogStatsdMetricsBackend",
+        secondary_prefixes=["secondary"],
+    )
+
+    backend.set("foo", 4242, tags={"some": "stuff"})
+    dogstatsd_set.assert_called_once()
+
+    dogstatsd_set.reset_mock()
+
+    backend.set("secondary.foo", 4242, tags={"some": "stuff"})
+    dogstatsd_set.assert_called_once()
+
+
+@mock.patch("datadog.dogstatsd.base.DogStatsd.set")
+@thread_leak_allowlist(reason="datadog dualwrite metrics", issue=98803)
+def test_dualwrite_set_experimental_backend(dogstatsd_set):
+    backend = DualWriteMetricsBackend(
+        primary_backend="sentry.metrics.dogstatsd.DogStatsdMetricsBackend",
+        experimental_backend="sentry.metrics.sentry_sdk.SentrySDKMetricsBackend",
+        experimental_args={"deny_list": [], "experimental_sample_rate": 1.0},
+    )
+
+    backend.set("allowed", 4242, tags={"test": "tag"})
+    dogstatsd_set.assert_called_once()

--- a/tests/sentry/metrics/test_dualwrite.py
+++ b/tests/sentry/metrics/test_dualwrite.py
@@ -73,8 +73,12 @@ def test_dualwrite_experimental_backend_rollout_disabled(dogstatsd_gauge, sentry
 
 
 @mock.patch("datadog.dogstatsd.base.DogStatsd.set")
+@mock.patch("datadog.dogstatsd.base.statsd.set")
 @thread_leak_allowlist(reason="datadog dualwrite metrics", issue=98803)
-def test_dualwrite_set(dogstatsd_set):
+def test_dualwrite_set(primary_set, secondary_set):
+    # Primary DogStatsdMetricsBackend uses the module-level statsd client;
+    # PreciseDogStatsdMetricsBackend uses its own DogStatsd instance. Patch them
+    # separately so routing to primary vs secondary is actually observable.
     backend = DualWriteMetricsBackend(
         primary_backend="sentry.metrics.dogstatsd.DogStatsdMetricsBackend",
         secondary_backend="sentry.metrics.precise_dogstatsd.PreciseDogStatsdMetricsBackend",
@@ -82,17 +86,23 @@ def test_dualwrite_set(dogstatsd_set):
     )
 
     backend.set("foo", 4242, tags={"some": "stuff"})
-    dogstatsd_set.assert_called_once()
+    primary_set.assert_called_once()
+    secondary_set.assert_not_called()
 
-    dogstatsd_set.reset_mock()
+    primary_set.reset_mock()
+    secondary_set.reset_mock()
 
     backend.set("secondary.foo", 4242, tags={"some": "stuff"})
-    dogstatsd_set.assert_called_once()
+    primary_set.assert_not_called()
+    secondary_set.assert_called_once()
 
 
-@mock.patch("datadog.dogstatsd.base.DogStatsd.set")
+@mock.patch("sentry.metrics.sentry_sdk.SentrySDKMetricsBackend.set")
+@mock.patch("datadog.dogstatsd.base.statsd.set")
 @thread_leak_allowlist(reason="datadog dualwrite metrics", issue=98803)
-def test_dualwrite_set_experimental_backend(dogstatsd_set):
+def test_dualwrite_set_experimental_backend(primary_set, experimental_set):
+    # The experimental backend's set is patched directly (SentrySDK's set is a
+    # no-op otherwise) so forwarding to the experimental backend is observable.
     backend = DualWriteMetricsBackend(
         primary_backend="sentry.metrics.dogstatsd.DogStatsdMetricsBackend",
         experimental_backend="sentry.metrics.sentry_sdk.SentrySDKMetricsBackend",
@@ -100,4 +110,5 @@ def test_dualwrite_set_experimental_backend(dogstatsd_set):
     )
 
     backend.set("allowed", 4242, tags={"test": "tag"})
-    dogstatsd_set.assert_called_once()
+    primary_set.assert_called_once()
+    experimental_set.assert_called_once()

--- a/tests/sentry/metrics/test_middleware.py
+++ b/tests/sentry/metrics/test_middleware.py
@@ -1,8 +1,12 @@
+from unittest import mock
+
 import pytest
 from django.test import override_settings
 
+from sentry.metrics.dummy import DummyMetricsBackend
 from sentry.metrics.middleware import (
     BadMetricTags,
+    MiddlewareWrapper,
     _filter_tags,
     add_global_tags,
     get_current_global_tags,
@@ -38,3 +42,16 @@ def test_global() -> None:
         assert get_current_global_tags() == {"tag_a": 123, "tag_b": 123}
 
     assert get_current_global_tags() == {}
+
+
+def test_middleware_set_forwards_global_tags_and_filters_bad_tags() -> None:
+    inner = mock.Mock(spec=DummyMetricsBackend)
+    wrapper = MiddlewareWrapper(inner)
+
+    with global_tags(tags={"global_tag": "value"}):
+        with override_settings(SENTRY_METRICS_DISALLOW_BAD_TAGS=False):
+            wrapper.set("metric", 42, tags={"good": "tag", "org_id": 99})
+
+    inner.set.assert_called_once_with(
+        "metric", 42, None, {"global_tag": "value", "good": "tag"}, 1, 1
+    )

--- a/tests/sentry/metrics/test_precise.py
+++ b/tests/sentry/metrics/test_precise.py
@@ -15,3 +15,12 @@ def test_precise_distribution(distribution):
 
     backend.timing("bar", 100, tags={"some": "stuff"})
     distribution.assert_called_once()
+
+
+@thread_leak_allowlist(reason="datadog precise metrics", issue=98805)
+@mock.patch("datadog.dogstatsd.base.DogStatsd.set")
+def test_precise_set(mock_set):
+    backend = PreciseDogStatsdMetricsBackend(prefix="sentrytest.")
+
+    backend.set("foo", 4242, tags={"some": "stuff"})
+    mock_set.assert_called_once_with("sentrytest.foo", 4242, tags=["some:stuff"], sample_rate=1)

--- a/tests/sentry/metrics/test_sentry_sdk.py
+++ b/tests/sentry/metrics/test_sentry_sdk.py
@@ -85,6 +85,9 @@ class TestSentrySDKMetricsBackend:
     def test_event_noop(self, backend):
         backend.event("title", "message")
 
+    def test_set_noop(self, backend):
+        backend.set("foo", 4242, tags={"x": "y"})
+
     @mock.patch("sentry_sdk.metrics.count")
     def test_incr_sampling(self, mock_count):
         backend = SentrySDKMetricsBackend(prefix="test.", experimental_sample_rate=0.0)

--- a/tests/sentry/metrics/test_statsd.py
+++ b/tests/sentry/metrics/test_statsd.py
@@ -31,3 +31,9 @@ def test_timing(mock_timing, statsd_backend) -> None:
 def test_gauge(mock_gauge, statsd_backend) -> None:
     statsd_backend.gauge("foo", 5)
     mock_gauge.assert_called_once_with("sentrytest.foo", 5, 1)
+
+
+@patch("statsd.StatsClient.set")
+def test_set(mock_set, statsd_backend) -> None:
+    statsd_backend.set("foo", 4242)
+    mock_set.assert_called_once_with("sentrytest.foo", 4242, 1)


### PR DESCRIPTION
This supports this work: https://github.com/getsentry/getsentry/pull/21041

Callers can emit DogStatsD/statsd set metrics through `sentry.utils.metrics.set`, so unique members (for example org IDs) can be counted per flush window without inflating a counter on every evaluation.

The helper mirrors the existing `incr`/`gauge`/`timing` shape: tags and `instance` are applied the same way, middleware still filters bad tags, and dual-write forwards to primary/secondary/experimental backends. The Sentry SDK metrics backend is a no-op because that pipeline has no set type.

```python
metrics.set("some.unique.orgs", organization_id)
```