### PR TITLE
fix: Forward query string verbatim in Objectstore proxy and API gateways

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -174,7 +174,8 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
     header_dict[PROXY_APIGATEWAY_HEADER] = "true"
 
     assert request.method is not None
-    query_params = request.GET
+    query_string = request.META.get("QUERY_STRING")
+    request_url = f"{target_url}?{query_string}" if query_string else target_url
 
     # This option has a default of None, which is cast to 0
     timeout = options.get("apigateway.proxy.timeout")
@@ -205,9 +206,8 @@ def proxy_cell_request(request: HttpRequest, cell: Cell, url_name: str) -> HttpR
         with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
             resp = requester(
                 request.method,
-                url=target_url,
+                url=request_url,
                 headers=header_dict,
-                params=dict(query_params) if query_params is not None else None,
                 data=data,
                 stream=True,
                 timeout=timeout,

--- a/src/sentry/hybridcloud/apigateway_async/proxy.py
+++ b/src/sentry/hybridcloud/apigateway_async/proxy.py
@@ -135,7 +135,8 @@ async def proxy_cell_request(
     header_dict[PROXY_APIGATEWAY_HEADER] = "true"
 
     assert request.method is not None
-    query_params = request.GET
+    query_string = request.META.get("QUERY_STRING")
+    request_url = f"{target_url}?{query_string}" if query_string else target_url
 
     timeout = ENDPOINT_TIMEOUT_OVERRIDE.get(url_name, settings.GATEWAY_PROXY_TIMEOUT)
 
@@ -163,9 +164,8 @@ async def proxy_cell_request(
                 with metrics.timer("apigateway.proxy_request.duration", tags=metric_tags):
                     req = proxy_client.build_request(
                         request.method,
-                        target_url,
+                        request_url,
                         headers=header_dict,
-                        params=dict(query_params) if query_params is not None else None,
                         content=_stream_request(data) if data else None,  # type: ignore[arg-type]
                         timeout=timeout or httpx.USE_CLIENT_DEFAULT,
                     )

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -88,7 +88,7 @@ class ObjectstoreEndpoint(Endpoint):
             url=target_url,
             headers=headers,
             data=get_raw_body(request._request),
-            params=dict(request.GET) if request.GET else None,
+            params=request.META.get("QUERY_STRING") or None,
             stream=True,
             allow_redirects=False,
         )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -690,8 +690,7 @@ class APITestCaseMixin:
                     ret += chunk
                 return ret
 
-            def build_request(self, method, url, headers, params, content, timeout):
-                assert not params
+            def build_request(self, method, url, *, headers, content, timeout, **kwargs):
                 target = getattr(self.client, method.lower())
                 content_type = headers.pop("Content-Type", "application/octet-stream")
                 extra: Mapping[str, Any] = {

--- a/tests/sentry/hybridcloud/apigateway/test_proxy.py
+++ b/tests/sentry/hybridcloud/apigateway/test_proxy.py
@@ -151,6 +151,52 @@ class ProxyTestCase(ApiGatewayTestCase):
         assert query_param_dict["foo"] == resp_json["foo"][0]
         assert query_param_dict["numlist"] == resp_json["numlist"]
 
+    def test_async_query_string_forwarded_verbatim(self) -> None:
+        captured: dict[str, str] = {}
+
+        def capture(request: httpx.Request) -> tuple[int, dict[str, str], bytes]:
+            captured["raw_query"] = str(request.url).split("?", 1)[1]
+            return (200, {}, b"{}")
+
+        self.httpx_router.add_callback("GET", f"{self.CELL.address}/echo-verbatim", capture)
+
+        # The ``:`` and ``+`` would be percent-encoded by ``dict(request.GET)``.
+        query = (
+            "os_kid=sentry&os_timestamp=2026-07-13T13:19:24+00:00&os_duration=300&os_sig=ab_c-D9z"
+        )
+        request = RequestFactory().get(f"http://sentry.io/echo-verbatim?{query}")
+
+        resp = proxy_request(request, self.organization.slug, url_name)
+        close_streaming_response(resp)
+
+        assert captured["raw_query"] == query
+
+    @responses.activate
+    def test_sync_query_string_forwarded_verbatim(self) -> None:
+        captured: dict[str, str] = {}
+
+        def request_callback(request: PreparedRequest) -> tuple[int, dict[str, str], str]:
+            assert request.url is not None
+            captured["url"] = request.url
+            return 200, {"Content-Type": "application/json"}, json.dumps({"proxy": True})
+
+        responses.add_callback(
+            responses.GET,
+            "http://us.internal.sentry.io/echo-verbatim",
+            callback=request_callback,
+        )
+
+        # The ``:`` and ``+`` would be percent-encoded by ``dict(request.GET)``.
+        query = (
+            "os_kid=sentry&os_timestamp=2026-07-13T13:19:24+00:00&os_duration=300&os_sig=ab_c-D9z"
+        )
+        request = RequestFactory().get(f"http://sentry.io/echo-verbatim?{query}")
+
+        resp = sync_proxy.proxy_request(request, self.organization.slug, url_name)
+        close_streaming_response(resp)
+
+        assert captured["url"].split("?", 1)[1] == query
+
     def test_bad_org(self) -> None:
         request = RequestFactory().get("http://sentry.io/get")
         resp = proxy_request(request, "doesnotexist", url_name)

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import asdict
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -344,3 +344,29 @@ class ObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
                 )
                 assert_status_code(response, 200)
                 assert response.content == data
+
+
+class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
+    def test_query_string_forwarded_verbatim(self) -> None:
+        from rest_framework.request import Request
+        from rest_framework.test import APIRequestFactory
+
+        from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
+
+        # The ``:`` and ``+`` would be percent-encoded by ``dict(request.GET)``.
+        query = (
+            "os_kid=sentry&os_timestamp=2026-07-13T13:19:24+00:00&os_duration=300&os_sig=ab_c-D9z"
+        )
+        request = APIRequestFactory().get(f"/v1/objects/test/org=1/key?{query}")
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.headers = requests.structures.CaseInsensitiveDict()
+
+        with patch(
+            "sentry.objectstore.endpoints.organization.requests.request",
+            return_value=fake_response,
+        ) as mock_request:
+            ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
+
+        assert mock_request.call_args.kwargs["params"] == query

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import asdict
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -344,3 +344,63 @@ class ObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
                 )
                 assert_status_code(response, 200)
                 assert response.content == data
+
+
+class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
+    """The proxy must forward the raw query string verbatim.
+
+    Pre-signed URLs carry an Ed25519 signature computed over the exact query bytes,
+    so any re-encoding by the proxy breaks verification on the Objectstore side.
+    Round-tripping the query through ``dict(request.GET)`` (the previous behaviour)
+    let ``requests`` re-encode it, e.g. percent-encoding the ``:`` in ``os_timestamp``.
+    """
+
+    def test_query_string_forwarded_verbatim(self) -> None:
+        from rest_framework.request import Request
+        from rest_framework.test import APIRequestFactory
+
+        from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
+
+        # Contains characters that ``dict(request.GET)`` + ``requests`` would re-encode:
+        # the ``:`` in the timestamp becomes ``%3A``, and the ``+`` would be mangled too.
+        query = (
+            "os_kid=sentry&os_timestamp=2026-07-13T13:19:24+00:00&os_duration=300&os_sig=ab_c-D9z"
+        )
+        request = APIRequestFactory().get(f"/v1/objects/test/org=1/key?{query}")
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.headers = requests.structures.CaseInsensitiveDict()
+
+        with patch(
+            "sentry.objectstore.endpoints.organization.requests.request",
+            return_value=fake_response,
+        ) as mock_request:
+            ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
+
+        # A string is forwarded by ``requests`` untouched, unlike a dict.
+        params = mock_request.call_args.kwargs["params"]
+        assert params == query
+        # Guard against the specific regression: the timestamp is preserved as-is.
+        assert "2026-07-13T13:19:24+00:00" in params
+        assert "%3A" not in params
+
+    def test_empty_query_string_forwarded_as_none(self) -> None:
+        from rest_framework.request import Request
+        from rest_framework.test import APIRequestFactory
+
+        from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
+
+        request = APIRequestFactory().get("/v1/objects/test/org=1/key")
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.headers = requests.structures.CaseInsensitiveDict()
+
+        with patch(
+            "sentry.objectstore.endpoints.organization.requests.request",
+            return_value=fake_response,
+        ) as mock_request:
+            ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
+
+        assert mock_request.call_args.kwargs["params"] is None

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import asdict
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -344,63 +344,3 @@ class ObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
                 )
                 assert_status_code(response, 200)
                 assert response.content == data
-
-
-class ObjectstoreProxyQueryForwardingTest(TransactionTestCase):
-    """The proxy must forward the raw query string verbatim.
-
-    Pre-signed URLs carry an Ed25519 signature computed over the exact query bytes,
-    so any re-encoding by the proxy breaks verification on the Objectstore side.
-    Round-tripping the query through ``dict(request.GET)`` (the previous behaviour)
-    let ``requests`` re-encode it, e.g. percent-encoding the ``:`` in ``os_timestamp``.
-    """
-
-    def test_query_string_forwarded_verbatim(self) -> None:
-        from rest_framework.request import Request
-        from rest_framework.test import APIRequestFactory
-
-        from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
-
-        # Contains characters that ``dict(request.GET)`` + ``requests`` would re-encode:
-        # the ``:`` in the timestamp becomes ``%3A``, and the ``+`` would be mangled too.
-        query = (
-            "os_kid=sentry&os_timestamp=2026-07-13T13:19:24+00:00&os_duration=300&os_sig=ab_c-D9z"
-        )
-        request = APIRequestFactory().get(f"/v1/objects/test/org=1/key?{query}")
-
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.headers = requests.structures.CaseInsensitiveDict()
-
-        with patch(
-            "sentry.objectstore.endpoints.organization.requests.request",
-            return_value=fake_response,
-        ) as mock_request:
-            ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
-
-        # A string is forwarded by ``requests`` untouched, unlike a dict.
-        params = mock_request.call_args.kwargs["params"]
-        assert params == query
-        # Guard against the specific regression: the timestamp is preserved as-is.
-        assert "2026-07-13T13:19:24+00:00" in params
-        assert "%3A" not in params
-
-    def test_empty_query_string_forwarded_as_none(self) -> None:
-        from rest_framework.request import Request
-        from rest_framework.test import APIRequestFactory
-
-        from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
-
-        request = APIRequestFactory().get("/v1/objects/test/org=1/key")
-
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.headers = requests.structures.CaseInsensitiveDict()
-
-        with patch(
-            "sentry.objectstore.endpoints.organization.requests.request",
-            return_value=fake_response,
-        ) as mock_request:
-            ObjectstoreEndpoint()._proxy(Request(request), "v1/objects/test/org=1/key")
-
-        assert mock_request.call_args.kwargs["params"] is None


### PR DESCRIPTION
## Summary

Fixes pre-signed Objectstore URLs failing with `auth error: failed to verify token` when accessed through a Sentry proxy (e.g. DIF download redirects).

Three proxies forwarded the query string via `params=dict(request.GET)`, which lets the HTTP client re-encode it (e.g. percent-encoding the `:` in a pre-signed URL's `os_timestamp` to `%3A`, and mangling other reserved chars):

- the Objectstore endpoint proxy (`src/sentry/objectstore/endpoints/organization.py`)
- the sync API gateway (`src/sentry/hybridcloud/apigateway/proxy.py`)
- the async API gateway (`src/sentry/hybridcloud/apigateway_async/proxy.py`)

Pre-signed URLs carry an Ed25519 signature computed over the **exact query bytes**, so any re-encoding changes those bytes and verification fails on the Objectstore side. Internal callers (Symbolicator) are redirected straight to Objectstore and were unaffected; external callers go through these proxies and hit the failure. Objectstore requests also transit the API gateways, so the gateways needed the same fix.

## Fix

Forward the raw `QUERY_STRING` verbatim instead of a re-encoded dict:

- Objectstore endpoint (uses `requests`): pass the raw `QUERY_STRING` as string `params` — `requests` forwards a string untouched.
- API gateways: `requests` honors a string `params`, but `httpx` (async gateway) re-encodes reserved chars even for a string. The approach that preserves the bytes for **both** clients is appending the raw `QUERY_STRING` to the request URL, so both gateways do that (keeping the base `target_url` clean for logging/metrics).
