### PR TITLE
fix(backpressure): Remove unhealthy service log

### DIFF
--- a/src/sentry/processing/backpressure/health.py
+++ b/src/sentry/processing/backpressure/health.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Mapping
+from dataclasses import asdict
 from typing import Any
 
 import sentry_sdk
@@ -124,12 +125,7 @@ def record_consumer_health(unhealthy_services: Mapping[str, UnhealthyReasons]) -
                 if isinstance(unhealthy_reasons, Exception):
                     extra = {"exception": unhealthy_reasons}
                 else:
-                    for memory in unhealthy_reasons:
-                        extra[memory.name] = {
-                            "used": memory.used,
-                            "available": memory.available,
-                            "percentage": memory.percentage,
-                        }
+                    extra = {"memory": [asdict(memory) for memory in unhealthy_reasons]}
 
                 metrics.incr("backpressure.monitor.service.unhealthy", tags={"service": name})
                 metrics.event(

--- a/src/sentry/processing/backpressure/health.py
+++ b/src/sentry/processing/backpressure/health.py
@@ -1,7 +1,5 @@
 import logging
 from collections.abc import Mapping
-from dataclasses import asdict
-from typing import Any
 
 import sentry_sdk
 from django.conf import settings
@@ -120,13 +118,7 @@ def record_consumer_health(unhealthy_services: Mapping[str, UnhealthyReasons]) -
         for name, unhealthy_reasons in unhealthy_services.items():
             pipeline.set(_service_key(name), "false" if unhealthy_reasons else "true", ex=key_ttl)
 
-            extra: dict[str, Any] = {}
             if unhealthy_reasons:
-                if isinstance(unhealthy_reasons, Exception):
-                    extra = {"exception": unhealthy_reasons}
-                else:
-                    extra = {"memory": [asdict(memory) for memory in unhealthy_reasons]}
-
                 metrics.incr("backpressure.monitor.service.unhealthy", tags={"service": name})
                 metrics.event(
                     "backpressure.monitor.service.unhealthy",
@@ -137,7 +129,6 @@ def record_consumer_health(unhealthy_services: Mapping[str, UnhealthyReasons]) -
                 with sentry_sdk.isolation_scope():
                     sentry_sdk.set_tag("service", name)
                     sentry_sdk.set_attribute("service", name)
-                    logger.error("Service `%s` marked as unhealthy", name, extra=extra)
 
         for name, dependencies in CONSUMERS.items():
             unhealthy_dependencies = []

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -1,4 +1,6 @@
+import logging
 from collections.abc import MutableMapping
+from unittest.mock import patch
 
 import pytest
 from django.test.utils import override_settings
@@ -8,6 +10,7 @@ from sentry.processing.backpressure.health import (
     is_consumer_healthy,
     record_consumer_health,
 )
+from sentry.processing.backpressure.memory import ServiceMemory
 from sentry.processing.backpressure.monitor import (
     Redis,
     assert_all_services_defined,
@@ -91,3 +94,40 @@ def test_record_consumer_health() -> None:
                 "post-process-locks": [],
             }
         )
+
+
+@override_options({"backpressure.status_ttl": 60})
+def test_record_consumer_health_logs_memory_details(caplog: pytest.LogCaptureFixture) -> None:
+    memory = ServiceMemory("127.0.0.1:6379", 75, 100)
+    memory.host = "127.0.0.1"
+    memory.port = 6379
+
+    with (
+        patch("sentry.processing.backpressure.health.service_monitoring_cluster"),
+        caplog.at_level(logging.ERROR, logger="sentry.processing.backpressure.health"),
+    ):
+        record_consumer_health(
+            {
+                "attachments-store": [memory],
+                "processing-store": [],
+                "processing-store-transactions": [],
+                "processing-locks": [],
+                "post-process-locks": [],
+            }
+        )
+
+    service_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Service `attachments-store` marked as unhealthy"
+    )
+    assert service_record.__dict__["memory"] == [
+        {
+            "name": "127.0.0.1:6379",
+            "used": 75,
+            "available": 100,
+            "percentage": 0.75,
+            "host": "127.0.0.1",
+            "port": 6379,
+        }
+    ]

--- a/tests/sentry/processing/backpressure/test_monitoring.py
+++ b/tests/sentry/processing/backpressure/test_monitoring.py
@@ -1,6 +1,4 @@
-import logging
 from collections.abc import MutableMapping
-from unittest.mock import patch
 
 import pytest
 from django.test.utils import override_settings
@@ -10,7 +8,6 @@ from sentry.processing.backpressure.health import (
     is_consumer_healthy,
     record_consumer_health,
 )
-from sentry.processing.backpressure.memory import ServiceMemory
 from sentry.processing.backpressure.monitor import (
     Redis,
     assert_all_services_defined,
@@ -94,40 +91,3 @@ def test_record_consumer_health() -> None:
                 "post-process-locks": [],
             }
         )
-
-
-@override_options({"backpressure.status_ttl": 60})
-def test_record_consumer_health_logs_memory_details(caplog: pytest.LogCaptureFixture) -> None:
-    memory = ServiceMemory("127.0.0.1:6379", 75, 100)
-    memory.host = "127.0.0.1"
-    memory.port = 6379
-
-    with (
-        patch("sentry.processing.backpressure.health.service_monitoring_cluster"),
-        caplog.at_level(logging.ERROR, logger="sentry.processing.backpressure.health"),
-    ):
-        record_consumer_health(
-            {
-                "attachments-store": [memory],
-                "processing-store": [],
-                "processing-store-transactions": [],
-                "processing-locks": [],
-                "post-process-locks": [],
-            }
-        )
-
-    service_record = next(
-        record
-        for record in caplog.records
-        if record.getMessage() == "Service `attachments-store` marked as unhealthy"
-    )
-    assert service_record.__dict__["memory"] == [
-        {
-            "name": "127.0.0.1:6379",
-            "used": 75,
-            "available": 100,
-            "percentage": 0.75,
-            "host": "127.0.0.1",
-            "port": 6379,
-        }
-    ]


### PR DESCRIPTION
Remove the unhealthy-service error log and its structured payload construction. The existing backpressure metric and metric event continue to report the unhealthy state without emitting a duplicate log event.