### PR TITLE
feat(ourlogs): show timestamps in detail view

### DIFF
--- a/static/app/utils/array/toSplicedSorted.spec.tsx
+++ b/static/app/utils/array/toSplicedSorted.spec.tsx
@@ -1,0 +1,30 @@
+import {toSplicedSorted} from 'sentry/utils/array/toSplicedSorted';
+
+const comparator = (a: string, b: string) => a.localeCompare(b);
+
+describe('toSplicedSorted', () => {
+  it('returns just the item when original items is empty', () => {
+    const actual = toSplicedSorted([], 'a', comparator);
+    expect(actual).toEqual(['a']);
+  });
+
+  it('adds the item to the end when an insertion index is not found', () => {
+    const actual = toSplicedSorted(['a', 'b'], 'c', comparator);
+    expect(actual).toEqual(['a', 'b', 'c']);
+  });
+
+  it('adds the item to the beginning when the insertion index is the first element', () => {
+    const actual = toSplicedSorted(['b', 'c'], 'a', comparator);
+    expect(actual).toEqual(['a', 'b', 'c']);
+  });
+
+  it('adds the item between elements when the insertion index is inside the array', () => {
+    const actual = toSplicedSorted(['a', 'c'], 'b', comparator);
+    expect(actual).toEqual(['a', 'b', 'c']);
+  });
+
+  it('adds the item to the end when the insertion index is the last element', () => {
+    const actual = toSplicedSorted(['a', 'b'], 'c', comparator);
+    expect(actual).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/static/app/utils/array/toSplicedSorted.ts
+++ b/static/app/utils/array/toSplicedSorted.ts
@@ -1,0 +1,11 @@
+export function toSplicedSorted<T>(
+  items: readonly T[],
+  item: T,
+  comparator: (a: T, b: T) => number
+) {
+  const insertionIndex = items.findIndex(original => comparator(original, item) > 0);
+
+  return insertionIndex === -1
+    ? [...items, item]
+    : [...items.slice(0, insertionIndex), item, ...items.slice(insertionIndex)];
+}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -29,6 +29,7 @@ import type {Organization} from 'sentry/types/organization';
 import {escapeDoubleQuotes} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {toSplicedSorted} from 'sentry/utils/array/toSplicedSorted';
 import {normalizeTimestampToSeconds} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
@@ -738,16 +739,17 @@ function LogRowDetails({
               </DetailsBody>
               <LogAttributeTreeWrapper>
                 <AttributesTree<RendererExtra>
-                  attributes={[
-                    ...data.attributes.filter(
+                  attributes={toSplicedSorted(
+                    data.attributes.filter(
                       attribute => !HiddenLogDetailFields.includes(attribute.name)
                     ),
                     {
                       name: OurLogKnownFieldKey.TIMESTAMP,
                       type: 'str',
                       value: dataRow[OurLogKnownFieldKey.TIMESTAMP],
-                    } as const,
-                  ].sort((a, b) => a.name.localeCompare(b.name))}
+                    },
+                    (a, b) => a.name.localeCompare(b.name)
+                  )}
                   getCustomActions={getActions}
                   getAdjustedAttributeKey={adjustAliases}
                   renderers={LogAttributesRendererMap}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -738,9 +738,16 @@ function LogRowDetails({
               </DetailsBody>
               <LogAttributeTreeWrapper>
                 <AttributesTree<RendererExtra>
-                  attributes={data.attributes.filter(
-                    attribute => !HiddenLogDetailFields.includes(attribute.name)
-                  )}
+                  attributes={[
+                    ...data.attributes.filter(
+                      attribute => !HiddenLogDetailFields.includes(attribute.name)
+                    ),
+                    {
+                      name: OurLogKnownFieldKey.TIMESTAMP,
+                      type: 'str',
+                      value: dataRow[OurLogKnownFieldKey.TIMESTAMP],
+                    } as const,
+                  ].sort((a, b) => a.name.localeCompare(b.name))}
                   getCustomActions={getActions}
                   getAdjustedAttributeKey={adjustAliases}
                   renderers={LogAttributesRendererMap}


### PR DESCRIPTION
Timestamp isn't an _attribute_ on the log, it's just a piece of data associated with it. This manually adds timestamp to the list of attributes to be rendered in the `AttributesTree` within a `LogsTableRow`.

Log attributes don't come in sorted order, so I made a `toSplicedSorted` helper used to add timestamp in the first place it would alphabetically fit. 

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1629" height="716" alt="Screenshot 2026-07-13 at 11 04 54 AM" src="https://github.com/user-attachments/assets/e824b79a-29d1-4cf7-9a5b-e0c5b7e4470a" />
</td>
<td>
<img width="1629" height="716" alt="Screenshot 2026-07-13 at 11 05 02 AM" src="https://github.com/user-attachments/assets/fa0f289b-2036-4fac-9d3c-8238db76bd1f" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-561.