### PR TITLE
fix(logs): add auto_fields=True to OurLogs SearchResolverConfig

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -562,6 +562,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                     )
                 elif scoped_dataset == OurLogs:
                     return SearchResolverConfig(
+                        auto_fields=True,
                         use_aggregate_conditions=use_aggregate_conditions,
                         disable_aggregate_extrapolation=disable_aggregate_extrapolation,
                         extrapolation_mode=extrapolation_mode,

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -1108,3 +1108,28 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
 
         mock_table_rpc.assert_called_once()
         assert mock_table_rpc.call_args.args[0][0].meta.project_ids == [project1.id]
+
+    @pytest.mark.querybuilder
+    def test_no_fields_returns_auto_fields(self) -> None:
+        """Regression test: a request with no field params should not 500 via SnubaRPCError.
+
+        Previously, OurLogs was missing auto_fields=True in its SearchResolverConfig, causing
+        resolve_columns([]) to return an empty list. Snuba RPC then rejected the request with
+        "At least one column must be specified in the request".
+        """
+        log = self.create_ourlog(
+            {"body": "hello"},
+            timestamp=self.ten_mins_ago,
+        )
+        self.store_eap_items([log])
+        response = self.do_request(
+            {
+                "query": "",
+                "project": self.project.id,
+                "dataset": self.dataset,
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) >= 1
+        assert "id" in data[0]


### PR DESCRIPTION
## Summary

Fixes SENTRY-5RBD — escalating error affecting ~1500 users: `SnubaRPCError: code: 400 "At least one column must be specified in the request"` on the `/api/0/organizations/{org}/events/` endpoint when called with `dataset=ourlogs` and no `field` parameters.

**Root cause:** `OurLogs` was missing `auto_fields=True` in its `SearchResolverConfig` in `organization_events.py`. Every other RPC-backed dataset (`Spans`, `TraceMetrics`, `ProfileFunctions`, `UptimeResults`, `ProcessingErrors`) already sets `auto_fields=True`. Without it, `resolve_columns([])` returns an empty list, and Snuba RPC rejects the request outright.

**Execution path:**
1. Request arrives at `/api/0/organizations/{org}/events/?dataset=ourlogs` with no `field=` params
2. `get_field_list()` returns `[]`
3. `SearchResolverConfig(auto_fields=False)` causes `resolve_columns([])` to return `([], [])`
4. `TraceItemTableRequest(columns=[])` is sent to Snuba RPC
5. Snuba rejects with `400 "At least one column must be specified in the request"` → `SnubaRPCError`

**Fix:** Add `auto_fields=True` to the `OurLogs` config block so that `resolve_columns` automatically injects the `id` column (mapped to `sentry.item_id`) when no fields are specified, consistent with all other RPC datasets.

**Evidence:** [Sentry issue SENTRY-5RBD](https://sentry.sentry.io/issues/SENTRY-5RBD/) — 16K events, 1496 users impacted, escalating at time of detection.

**Claude session:** https://claude.ai/code/session_01LzmoeZyxeQmHXpCfKUNzXr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzmoeZyxeQmHXpCfKUNzXr)_