### PR TITLE
feat(pr iteration): Comment when @sentry iteration hits an ineligible PR

### DIFF
--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Any
 
 import sentry_sdk
@@ -10,6 +11,7 @@ from scm.types import (
     CreatePullRequestCommentReactionProtocol,
     CreateReviewCommentReactionProtocol,
     GetRepositoryUserPermissionProtocol,
+    Reaction,
 )
 from taskbroker_client.retry import Retry
 
@@ -45,6 +47,7 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils import metrics
+from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
@@ -57,6 +60,17 @@ INELIGIBLE_PR_ITERATION_COMMENT = (
     "PRs that the Autofix Agent didn't create aren't eligible. This includes PRs "
     "created by the Coding Agent handoff and unrelated human PRs."
 )
+
+# One explanatory comment per PR; further pings still get a :confused: reaction.
+_INELIGIBLE_COMMENT_CACHE_TTL = int(timedelta(days=7).total_seconds())
+
+
+def _ineligible_comment_cache_key(*, organization_id: int, repo_id: int, pr_number: int) -> str:
+    return f"autofix:pr_iteration:ineligible_comment:{organization_id}:{repo_id}:{pr_number}"
+
+
+def _ineligible_pr_iteration_comment_body(github_username: str) -> str:
+    return f"@{github_username}\n\n{INELIGIBLE_PR_ITERATION_COMMENT}"
 
 
 def _get_feedback_referrer(items: list[QueuedAutofixFeedback]) -> AutofixReferrer:
@@ -227,26 +241,29 @@ def _github_commenter_has_repo_write_access(
     return result["data"]["perms"] in ("write", "admin")
 
 
-def _add_comment_eyes_reaction(
+def _add_comment_reaction(
     scm: SourceCodeManager,
     *,
     source_type: GithubPrCommentFeedbackType,
     pr_number: int,
     comment_id: int,
+    reaction: Reaction,
 ) -> None:
-    """Acknowledge a PR comment with an :eyes: reaction via the SCM platform."""
+    """React to a PR comment via the SCM platform."""
     try:
         if source_type == "github-pr-review-comment":
             if not isinstance(scm, CreateReviewCommentReactionProtocol):
                 logger.warning("autofix.pr_iteration.comment_trigger.unsupported_provider")
                 return
-            scm_actions.create_review_comment_reaction(scm, str(pr_number), str(comment_id), "eyes")
+            scm_actions.create_review_comment_reaction(
+                scm, str(pr_number), str(comment_id), reaction
+            )
         else:
             if not isinstance(scm, CreatePullRequestCommentReactionProtocol):
                 logger.warning("autofix.pr_iteration.comment_trigger.unsupported_provider")
                 return
             scm_actions.create_pull_request_comment_reaction(
-                scm, str(pr_number), str(comment_id), "eyes"
+                scm, str(pr_number), str(comment_id), reaction
             )
     except Exception as e:
         sentry_sdk.capture_exception(e)
@@ -255,14 +272,57 @@ def _add_comment_eyes_reaction(
 def _comment_pr_iteration_ineligible(
     client: Any,
     *,
+    organization_id: int,
+    repo_id: int,
     repo_name: str,
     pr_number: int,
-    organization_id: int,
+    github_username: str,
+    source_type: GithubPrCommentFeedbackType,
+    comment_id: int | None,
 ) -> None:
-    """Explain on the PR why ``@sentry`` iteration didn't run."""
+    """React :confused: and, at most once per PR, explain why iteration didn't run."""
     try:
-        client.create_comment(repo_name, str(pr_number), {"body": INELIGIBLE_PR_ITERATION_COMMENT})
+        scm = make_scm(organization_id, repo_id, referrer="seer")
     except Exception:
+        logger.warning(
+            "autofix.pr_iteration.comment_trigger.ineligible_scm_init_failed",
+            extra={"organization_id": organization_id, "repo_id": repo_id},
+            exc_info=True,
+        )
+        scm = None
+
+    if scm is not None and comment_id is not None:
+        _add_comment_reaction(
+            scm,
+            source_type=source_type,
+            pr_number=pr_number,
+            comment_id=comment_id,
+            reaction="confused",
+        )
+
+    cache_key = _ineligible_comment_cache_key(
+        organization_id=organization_id, repo_id=repo_id, pr_number=pr_number
+    )
+    if not cache.add(cache_key, True, timeout=_INELIGIBLE_COMMENT_CACHE_TTL):
+        logger.info(
+            "autofix.pr_iteration.comment_trigger.ineligible_comment_skipped",
+            extra={
+                "organization_id": organization_id,
+                "repo_id": repo_id,
+                "pr_number": pr_number,
+            },
+        )
+        return
+
+    try:
+        client.create_comment(
+            repo_name,
+            str(pr_number),
+            {"body": _ineligible_pr_iteration_comment_body(github_username)},
+        )
+    except Exception:
+        # Allow a later ping to retry the explanatory comment.
+        cache.delete(cache_key)
         logger.warning(
             "autofix.pr_iteration.comment_trigger.ineligible_comment_failed",
             extra={"organization_id": organization_id, "pr_number": pr_number},
@@ -359,9 +419,13 @@ def trigger_pr_iteration_from_comment(
         )
         _comment_pr_iteration_ineligible(
             client,
+            organization_id=organization_id,
+            repo_id=repo.id,
             repo_name=repo.name,
             pr_number=pr_number,
-            organization_id=organization_id,
+            github_username=github_username,
+            source_type=source.type,
+            comment_id=comment.get("id"),
         )
         return None
 
@@ -411,8 +475,12 @@ def trigger_pr_iteration_from_comment(
     if comment_id is None:
         return None
 
-    _add_comment_eyes_reaction(
-        scm, source_type=source.type, pr_number=pr_number, comment_id=comment_id
+    _add_comment_reaction(
+        scm,
+        source_type=source.type,
+        pr_number=pr_number,
+        comment_id=comment_id,
+        reaction="eyes",
     )
 
     logger.info(

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -433,7 +433,7 @@ def trigger_pr_iteration_from_comment(
             pr_number=pr_number,
             github_username=github_username,
             source_type=source.type,
-            comment_id=comment.get("id"),
+            comment_id=comment.id,
         )
         return None
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -49,6 +49,15 @@ from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 
+# Posted when someone ``@sentry``-iterates a PR that isn't backed by an Autofix
+# explorer run with ``repo_pr_states`` — including coding-agent-handoff PRs and
+# unrelated human PRs. We can't reliably tell those apart at comment time.
+INELIGIBLE_PR_ITERATION_COMMENT = (
+    "PR iteration only works on pull requests created by Seer's Autofix agent. "
+    "PRs that the Autofix Agent didn't create aren't eligible. This includes PRs "
+    "created by the Coding Agent handoff and unrelated human PRs."
+)
+
 
 def _get_feedback_referrer(items: list[QueuedAutofixFeedback]) -> AutofixReferrer:
     referrers = {item.referrer for item in items}
@@ -243,6 +252,24 @@ def _add_comment_eyes_reaction(
         sentry_sdk.capture_exception(e)
 
 
+def _comment_pr_iteration_ineligible(
+    client: Any,
+    *,
+    repo_name: str,
+    pr_number: int,
+    organization_id: int,
+) -> None:
+    """Explain on the PR why ``@sentry`` iteration didn't run."""
+    try:
+        client.create_comment(repo_name, str(pr_number), {"body": INELIGIBLE_PR_ITERATION_COMMENT})
+    except Exception:
+        logger.warning(
+            "autofix.pr_iteration.comment_trigger.ineligible_comment_failed",
+            extra={"organization_id": organization_id, "pr_number": pr_number},
+            exc_info=True,
+        )
+
+
 @instrumented_task(
     name="sentry.tasks.autofix.trigger_pr_iteration_from_comment",
     namespace=seer_tasks,
@@ -329,6 +356,12 @@ def trigger_pr_iteration_from_comment(
         logger.info(
             "autofix.pr_iteration.comment_trigger.no_run",
             extra={"organization_id": organization_id, "pr_id": pr_id},
+        )
+        _comment_pr_iteration_ineligible(
+            client,
+            repo_name=repo.name,
+            pr_number=pr_number,
+            organization_id=organization_id,
         )
         return None
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -15,6 +15,7 @@ from scm.types import (
 )
 from taskbroker_client.retry import Retry
 
+from sentry.cache import default_cache
 from sentry.integrations.services.integration import integration_service
 from sentry.locks import locks
 from sentry.models.group import Group
@@ -47,7 +48,6 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils import metrics
-from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
@@ -281,12 +281,18 @@ def _comment_pr_iteration_ineligible(
     comment_id: int | None,
 ) -> None:
     """React :confused: and, at most once per PR, explain why iteration didn't run."""
+    log_extra = {
+        "organization_id": organization_id,
+        "repo_id": repo_id,
+        "pr_number": pr_number,
+    }
+
     try:
         scm = make_scm(organization_id, repo_id, referrer="seer")
     except Exception:
         logger.warning(
             "autofix.pr_iteration.comment_trigger.ineligible_scm_init_failed",
-            extra={"organization_id": organization_id, "repo_id": repo_id},
+            extra=log_extra,
             exc_info=True,
         )
         scm = None
@@ -303,31 +309,33 @@ def _comment_pr_iteration_ineligible(
     cache_key = _ineligible_comment_cache_key(
         organization_id=organization_id, repo_id=repo_id, pr_number=pr_number
     )
-    if not cache.add(cache_key, True, timeout=_INELIGIBLE_COMMENT_CACHE_TTL):
-        logger.info(
-            "autofix.pr_iteration.comment_trigger.ineligible_comment_skipped",
-            extra={
-                "organization_id": organization_id,
-                "repo_id": repo_id,
-                "pr_number": pr_number,
-            },
-        )
-        return
-
+    lock = locks.get(
+        f"autofix:pr_iteration:ineligible_comment:lock:{organization_id}:{repo_id}:{pr_number}",
+        duration=30,
+        name="autofix_pr_iteration_ineligible_comment",
+    )
     try:
-        client.create_comment(
-            repo_name,
-            str(pr_number),
-            {"body": _ineligible_pr_iteration_comment_body(github_username)},
-        )
-    except Exception:
-        # Allow a later ping to retry the explanatory comment.
-        cache.delete(cache_key)
-        logger.warning(
-            "autofix.pr_iteration.comment_trigger.ineligible_comment_failed",
-            extra={"organization_id": organization_id, "pr_number": pr_number},
-            exc_info=True,
-        )
+        with lock.acquire():
+            if default_cache.get(cache_key) is not None:
+                return
+
+            try:
+                client.create_comment(
+                    repo_name,
+                    str(pr_number),
+                    {"body": _ineligible_pr_iteration_comment_body(github_username)},
+                )
+            except Exception:
+                logger.warning(
+                    "autofix.pr_iteration.comment_trigger.ineligible_comment_failed",
+                    extra=log_extra,
+                    exc_info=True,
+                )
+                return
+
+            default_cache.set(cache_key, True, timeout=_INELIGIBLE_COMMENT_CACHE_TTL)
+    except UnableToAcquireLock:
+        pass
 
 
 @instrumented_task(

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -382,7 +382,11 @@ class AddCommentEyesReactionTest(TestCase):
     def test_review_comment_uses_review_comment_reaction(self, mock_actions: MagicMock) -> None:
         scm = MagicMock(spec=CreateReviewCommentReactionProtocol)
         _add_comment_reaction(
-            scm, source_type="github-pr-review-comment", pr_number=7, comment_id=999, reaction="eyes"
+            scm,
+            source_type="github-pr-review-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="eyes",
         )
 
         mock_actions.create_review_comment_reaction.assert_called_once_with(scm, "7", "999", "eyes")

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -369,9 +369,7 @@ class AddCommentEyesReactionTest(TestCase):
     @patch(f"{TASK_PATH}.scm_actions")
     def test_pr_comment_uses_pull_request_comment_reaction(self, mock_actions: MagicMock) -> None:
         scm = MagicMock(spec=CreatePullRequestCommentReactionProtocol)
-        _add_comment_reaction(
-            scm, source_type="github-pr-comment", pr_number=7, comment_id=999
-        )
+        _add_comment_reaction(scm, source_type="github-pr-comment", pr_number=7, comment_id=999)
 
         mock_actions.create_pull_request_comment_reaction.assert_called_once_with(
             scm, "7", "999", "eyes"

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -369,7 +369,9 @@ class AddCommentEyesReactionTest(TestCase):
     @patch(f"{TASK_PATH}.scm_actions")
     def test_pr_comment_uses_pull_request_comment_reaction(self, mock_actions: MagicMock) -> None:
         scm = MagicMock(spec=CreatePullRequestCommentReactionProtocol)
-        _add_comment_reaction(scm, source_type="github-pr-comment", pr_number=7, comment_id=999)
+        _add_comment_reaction(
+            scm, source_type="github-pr-comment", pr_number=7, comment_id=999, reaction="eyes"
+        )
 
         mock_actions.create_pull_request_comment_reaction.assert_called_once_with(
             scm, "7", "999", "eyes"
@@ -380,7 +382,7 @@ class AddCommentEyesReactionTest(TestCase):
     def test_review_comment_uses_review_comment_reaction(self, mock_actions: MagicMock) -> None:
         scm = MagicMock(spec=CreateReviewCommentReactionProtocol)
         _add_comment_reaction(
-            scm, source_type="github-pr-review-comment", pr_number=7, comment_id=999
+            scm, source_type="github-pr-review-comment", pr_number=7, comment_id=999, reaction="eyes"
         )
 
         mock_actions.create_review_comment_reaction.assert_called_once_with(scm, "7", "999", "eyes")
@@ -390,7 +392,11 @@ class AddCommentEyesReactionTest(TestCase):
     def test_noop_when_provider_unsupported(self, mock_actions: MagicMock) -> None:
         # A provider that doesn't implement the reaction protocol is skipped.
         _add_comment_reaction(
-            MagicMock(spec=object), source_type="github-pr-comment", pr_number=7, comment_id=999
+            MagicMock(spec=object),
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="eyes",
         )
 
         mock_actions.create_pull_request_comment_reaction.assert_not_called()
@@ -406,4 +412,5 @@ class AddCommentEyesReactionTest(TestCase):
             source_type="github-pr-comment",
             pr_number=7,
             comment_id=999,
+            reaction="eyes",
         )

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -18,7 +18,7 @@ from sentry.seer.autofix.pr_iteration.mention import (
     handle_pull_request_review_comment_for_autofix_iteration,
 )
 from sentry.tasks.seer.pr_iteration import (
-    _add_comment_eyes_reaction,
+    _add_comment_reaction,
     trigger_pr_iteration_from_comment,
 )
 from sentry.testutils.cases import TestCase
@@ -230,7 +230,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             feedback=Feedback(source=source).json(),
         )
 
-    @patch(f"{TASK_PATH}._add_comment_eyes_reaction")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
@@ -321,7 +321,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue.assert_not_called()
         mock_consume.assert_not_called()
 
-    @patch(f"{TASK_PATH}._add_comment_eyes_reaction")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
@@ -369,7 +369,7 @@ class AddCommentEyesReactionTest(TestCase):
     @patch(f"{TASK_PATH}.scm_actions")
     def test_pr_comment_uses_pull_request_comment_reaction(self, mock_actions: MagicMock) -> None:
         scm = MagicMock(spec=CreatePullRequestCommentReactionProtocol)
-        _add_comment_eyes_reaction(
+        _add_comment_reaction(
             scm, source_type="github-pr-comment", pr_number=7, comment_id=999
         )
 
@@ -381,7 +381,7 @@ class AddCommentEyesReactionTest(TestCase):
     @patch(f"{TASK_PATH}.scm_actions")
     def test_review_comment_uses_review_comment_reaction(self, mock_actions: MagicMock) -> None:
         scm = MagicMock(spec=CreateReviewCommentReactionProtocol)
-        _add_comment_eyes_reaction(
+        _add_comment_reaction(
             scm, source_type="github-pr-review-comment", pr_number=7, comment_id=999
         )
 
@@ -391,7 +391,7 @@ class AddCommentEyesReactionTest(TestCase):
     @patch(f"{TASK_PATH}.scm_actions")
     def test_noop_when_provider_unsupported(self, mock_actions: MagicMock) -> None:
         # A provider that doesn't implement the reaction protocol is skipped.
-        _add_comment_eyes_reaction(
+        _add_comment_reaction(
             MagicMock(spec=object), source_type="github-pr-comment", pr_number=7, comment_id=999
         )
 
@@ -403,7 +403,7 @@ class AddCommentEyesReactionTest(TestCase):
         mock_actions.create_pull_request_comment_reaction.side_effect = Exception("boom")
 
         # Should not raise.
-        _add_comment_eyes_reaction(
+        _add_comment_reaction(
             MagicMock(spec=CreatePullRequestCommentReactionProtocol),
             source_type="github-pr-comment",
             pr_number=7,

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -273,6 +273,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             source_type="github-pr-comment",
             pr_number=7,
             comment_id=999,
+            reaction="eyes",
         )
 
     @patch(f"{TASK_PATH}.make_scm")
@@ -362,6 +363,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             source_type="github-pr-review-comment",
             pr_number=7,
             comment_id=999,
+            reaction="eyes",
         )
 
 

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -152,7 +152,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
 
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
-    @patch(f"{TASK_PATH}.cache")
+    @patch(f"{TASK_PATH}.default_cache")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
@@ -172,7 +172,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_integration = self._mock_integration()
         mock_get_integration.return_value = mock_integration
         mock_get_state.return_value = None
-        mock_cache.add.return_value = True
+        mock_cache.get.return_value = None
 
         self._call()
 
@@ -191,10 +191,11 @@ class TriggerPrIterationFromCommentTest(TestCase):
             "7",
             {"body": _ineligible_pr_iteration_comment_body("octocat")},
         )
+        mock_cache.set.assert_called_once()
 
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
-    @patch(f"{TASK_PATH}.cache")
+    @patch(f"{TASK_PATH}.default_cache")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
@@ -214,7 +215,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_integration = self._mock_integration()
         mock_get_integration.return_value = mock_integration
         mock_get_state.return_value = None
-        mock_cache.add.return_value = False
+        mock_cache.get.return_value = True
 
         self._call()
 
@@ -226,6 +227,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             reaction="confused",
         )
         mock_integration.get_installation.return_value.get_client.return_value.create_comment.assert_not_called()
+        mock_cache.set.assert_not_called()
         mock_enqueue.assert_not_called()
         mock_trigger_consume.assert_not_called()
 

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -17,6 +17,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeed
 from sentry.seer.autofix.pr_iteration.queue import QueuedAutofixFeedback
 from sentry.seer.models import SeerApiError
 from sentry.tasks.seer.pr_iteration import (
+    INELIGIBLE_PR_ITERATION_COMMENT,
     consume_queued_autofix_feedback,
     trigger_consume_pr_iteration_feedback,
     trigger_pr_iteration_from_comment,
@@ -161,7 +162,8 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_trigger_consume: MagicMock,
         mock_has_access: MagicMock,
     ) -> None:
-        mock_get_integration.return_value = self._mock_integration()
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
         mock_get_state.return_value = None
 
         self._call()
@@ -169,6 +171,11 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_has_access.assert_not_called()
         mock_enqueue.assert_not_called()
         mock_trigger_consume.assert_not_called()
+        mock_integration.get_installation.return_value.get_client.return_value.create_comment.assert_called_once_with(
+            self.repo.name,
+            "7",
+            {"body": INELIGIBLE_PR_ITERATION_COMMENT},
+        )
 
     @patch(f"{TASK_PATH}._add_comment_eyes_reaction")
     @patch(f"{TASK_PATH}.make_scm")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -17,7 +17,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeed
 from sentry.seer.autofix.pr_iteration.queue import QueuedAutofixFeedback
 from sentry.seer.models import SeerApiError
 from sentry.tasks.seer.pr_iteration import (
-    INELIGIBLE_PR_ITERATION_COMMENT,
+    _ineligible_pr_iteration_comment_body,
     consume_queued_autofix_feedback,
     trigger_consume_pr_iteration_feedback,
     trigger_pr_iteration_from_comment,
@@ -70,7 +70,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             feedback=self.feedback.json(),
         )
 
-    @patch(f"{TASK_PATH}._add_comment_eyes_reaction")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
@@ -123,6 +123,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             source_type="github-pr-comment",
             pr_number=7,
             comment_id=999,
+            reaction="eyes",
         )
 
     @patch(f"{TASK_PATH}.make_scm")
@@ -149,6 +150,9 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue.assert_not_called()
         mock_trigger_consume.assert_not_called()
 
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm")
+    @patch(f"{TASK_PATH}.cache")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
@@ -161,23 +165,71 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
         mock_has_access: MagicMock,
+        mock_cache: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
     ) -> None:
         mock_integration = self._mock_integration()
         mock_get_integration.return_value = mock_integration
         mock_get_state.return_value = None
+        mock_cache.add.return_value = True
 
         self._call()
 
         mock_has_access.assert_not_called()
         mock_enqueue.assert_not_called()
         mock_trigger_consume.assert_not_called()
+        mock_reaction.assert_called_once_with(
+            mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="confused",
+        )
         mock_integration.get_installation.return_value.get_client.return_value.create_comment.assert_called_once_with(
             self.repo.name,
             "7",
-            {"body": INELIGIBLE_PR_ITERATION_COMMENT},
+            {"body": _ineligible_pr_iteration_comment_body("octocat")},
         )
 
-    @patch(f"{TASK_PATH}._add_comment_eyes_reaction")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm")
+    @patch(f"{TASK_PATH}.cache")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_skips_ineligible_comment_when_already_posted(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_cache: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
+    ) -> None:
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
+        mock_get_state.return_value = None
+        mock_cache.add.return_value = False
+
+        self._call()
+
+        mock_reaction.assert_called_once_with(
+            mock_make_scm.return_value,
+            source_type="github-pr-comment",
+            pr_number=7,
+            comment_id=999,
+            reaction="confused",
+        )
+        mock_integration.get_installation.return_value.get_client.return_value.create_comment.assert_not_called()
+        mock_enqueue.assert_not_called()
+        mock_trigger_consume.assert_not_called()
+
+    @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
     @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
@@ -206,6 +258,7 @@ class TriggerPrIterationFromCommentTest(TestCase):
             source_type="github-pr-comment",
             pr_number=7,
             comment_id=999,
+            reaction="eyes",
         )
 
 


### PR DESCRIPTION
When a PR has no Autofix run with repo_pr_states, reply explaining that iteration only works on Autofix-created PRs (handoff and unrelated PRs aren't eligible) instead of failing silently.