### PR TITLE
fix(explore): Respect span field definitions in tables

### DIFF
--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -26,6 +26,15 @@ describe('addValidatedFieldTypesToMeta', () => {
     });
   });
 
+  it('uses span field definitions over validated field types', () => {
+    const meta = addValidatedFieldTypesToMeta({
+      meta: {fields: {'span.duration': FieldValueType.NUMBER}},
+      validatedFieldTypes: {'span.duration': FieldValueType.NUMBER},
+    });
+
+    expect(meta.fields?.['span.duration']).toBe(FieldValueType.DURATION);
+  });
+
   it('passes validated field types to table column metadata', () => {
     const eventView = EventView.fromLocation(
       LocationFixture({query: {field: ['sentry.duration']}})

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -13,7 +13,7 @@ import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils/defined';
 import type {MetaType} from 'sentry/utils/discover/eventView';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
-import {FieldValueType, prettifyTagKey} from 'sentry/utils/fields';
+import {FieldValueType, getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
 import {
   Table,
   TableBody,
@@ -195,5 +195,11 @@ export function addValidatedFieldTypesToMeta({
   meta: MetaType;
   validatedFieldTypes: Partial<Record<string, FieldValueType>>;
 }): MetaType {
-  return {...meta, fields: {...meta?.fields, ...validatedFieldTypes}};
+  const fields = {...meta?.fields};
+
+  for (const [field, validatedType] of Object.entries(validatedFieldTypes)) {
+    fields[field] = getFieldDefinition(field, 'span')?.valueType ?? validatedType;
+  }
+
+  return {...meta, fields};
 }


### PR DESCRIPTION
Explore span tables now preserve built-in span field definitions when validation returns a less-specific primitive type. Previously, the validated `number` type replaced the `duration` definition for `span.duration`, causing cells to render as plain numbers. Known span fields now retain their definitions, while custom attributes continue to use validated types.

A regression test covers the `span.duration` precedence behavior.