### PR TITLE
chore(control): remove control callees for ExternalActor replication

### DIFF
--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -52,7 +52,7 @@ class OutboxCategory(IntEnum):
     API_TOKEN_UPDATE = 32
     ORG_AUTH_TOKEN_UPDATE = 33
     ISSUE_COMMENT_UPDATE = 34
-    EXTERNAL_ACTOR_UPDATE = 35
+    UNUSED_SEVEN = 35  # was EXTERNAL_ACTOR_UPDATE, no longer in use
 
     UNUSED_FIVE = 36
     UNUSED_SIX = 37
@@ -315,7 +315,7 @@ class OutboxScope(IntEnum):
     )
     INTEGRATION_SCOPE = scope_categories(
         5,
-        {OutboxCategory.INTEGRATION_UPDATE, OutboxCategory.EXTERNAL_ACTOR_UPDATE},
+        {OutboxCategory.INTEGRATION_UPDATE, OutboxCategory.UNUSED_SEVEN},
     )
     APP_SCOPE = scope_categories(
         6,

--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -12,14 +12,12 @@ from sentry.db.postgres.transactions import enforce_constraints
 from sentry.hybridcloud.models import (
     ApiKeyReplica,
     ApiTokenReplica,
-    ExternalActorReplica,
     OrgAuthTokenReplica,
 )
 from sentry.hybridcloud.outbox.base import ReplicatedCellModel, ReplicatedControlModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
 from sentry.hybridcloud.services.replica.service import CellReplicaService, ControlReplicaService
-from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.models.integration import Integration
 from sentry.models.apikey import ApiKey
 from sentry.models.apitoken import ApiToken
@@ -35,7 +33,6 @@ from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.models.projectkeymapping import ProjectKeyMapping
 from sentry.models.team import Team
 from sentry.models.teamreplica import TeamReplica
-from sentry.notifications.services import RpcExternalActor
 from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
 from sentry.users.models.user import User
 
@@ -280,27 +277,6 @@ class DatabaseBackedCellReplicaService(CellReplicaService):
 
 
 class DatabaseBackedControlReplicaService(ControlReplicaService):
-    def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:
-        try:
-            if external_actor.user_id is not None:
-                # Validating existence of user
-                User.objects.get(id=external_actor.user_id)
-            integration = Integration.objects.get(id=external_actor.integration_id)
-        except (User.DoesNotExist, Integration.DoesNotExist):
-            return
-
-        destination = ExternalActorReplica(
-            externalactor_id=external_actor.id,
-            external_id=external_actor.external_id,
-            external_name=external_actor.external_name,
-            organization_id=external_actor.organization_id,
-            user_id=external_actor.user_id,
-            provider=external_actor.provider,
-            team_id=external_actor.team_id,
-            integration_id=integration.id,
-        )
-        handle_replication(ExternalActor, destination, "externalactor_id")
-
     def remove_replicated_organization_member_team(
         self, *, organization_id: int, organization_member_team_id: int
     ) -> None:

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -5,7 +5,6 @@ from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
 from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, cell_rpc_method, rpc_method
 from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
-from sentry.notifications.services import RpcExternalActor
 from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
 from sentry.silo.base import SiloMode
 
@@ -29,11 +28,6 @@ class ControlReplicaService(RpcService):
     def remove_replicated_organization_member_team(
         self, *, organization_id: int, organization_member_team_id: int
     ) -> None:
-        pass
-
-    @rpc_method
-    @abc.abstractmethod
-    def upsert_external_actor_replica(self, *, external_actor: RpcExternalActor) -> None:
         pass
 
     @rpc_method

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -7,10 +7,8 @@ from django.utils import timezone
 
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import ObjectStatus
-from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, cell_silo_model
+from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, cell_silo_model
 from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
-from sentry.hybridcloud.outbox.base import ReplicatedCellModel
-from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.integrations.types import (
     ExternalActorSource,
     ExternalProviders,
@@ -22,10 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 @cell_silo_model
-class ExternalActor(ReplicatedCellModel):
+class ExternalActor(Model):
     __relocation_scope__ = RelocationScope.Excluded
-
-    category = OutboxCategory.EXTERNAL_ACTOR_UPDATE
 
     date_updated = models.DateTimeField(default=timezone.now)
     date_added = models.DateTimeField(default=timezone.now, null=True)

--- a/src/sentry/notifications/services/model.py
+++ b/src/sentry/notifications/services/model.py
@@ -5,21 +5,6 @@
 
 
 from sentry.hybridcloud.rpc import RpcModel
-from sentry.integrations.types import ExternalProviders
-
-
-class RpcExternalActor(RpcModel):
-    id: int = -1
-    team_id: int | None = None
-    user_id: int | None = None
-    organization_id: int = -1
-    integration_id: int = -1
-
-    provider: int = int(ExternalProviders.UNUSED_GH.value)
-    # The display name i.e. username, team name, channel name.
-    external_name: str = ""
-    # The unique identifier i.e user ID, channel ID.
-    external_id: str | None = None
 
 
 class RpcSubscriptionStatus(RpcModel):


### PR DESCRIPTION
Step 3/4 of tearing out the dead ExternalActorReplica from control.

Deletes the callees from control. Blocked on [Step 2](https://github.com/getsentry/sentry/pull/119525) being merged + deployed everywhere.
