### PR TITLE
feat(action_log): Ensure we have GroupActions for all type enums

### DIFF
--- a/tests/sentry/issues/action_log/test_types.py
+++ b/tests/sentry/issues/action_log/test_types.py
@@ -1,0 +1,11 @@
+from sentry.issues.action_log.types import GroupAction, GroupActionType
+from sentry.testutils.cases import TestCase
+
+
+class GroupActionRegistrationTest(TestCase):
+    def test_all_types_are_registered(self):
+        missing = [member for member in GroupActionType if GroupAction.by_type(member) is None]
+        assert missing == [], (
+            f"GroupActionType members without a registered GroupAction subclass: "
+            f"{[m.name for m in missing]}"
+        )

--- a/tests/sentry/issues/action_log/test_types.py
+++ b/tests/sentry/issues/action_log/test_types.py
@@ -3,7 +3,7 @@ from sentry.testutils.cases import TestCase
 
 
 class GroupActionRegistrationTest(TestCase):
-    def test_all_types_are_registered(self):
+    def test_all_types_are_registered(self) -> None:
         missing = [member for member in GroupActionType if GroupAction.by_type(member) is None]
         assert missing == [], (
             f"GroupActionType members without a registered GroupAction subclass: "


### PR DESCRIPTION
Type enums should have matching GroupActions. We already have validation that GroupActions have types and they aren't shared, this just finishes the coverage.