### PR TITLE
fix(issue-stream): Dismiss the Recommended sort badge after a sort is chosen

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -8,9 +8,11 @@ import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {IconSort} from 'sentry/icons/iconSort';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,
+  getStoredIssueSort,
   IssueSortOptions,
 } from 'sentry/views/issueList/utils';
 
@@ -56,9 +58,13 @@ export function IssueListSortOptions({
   showIcon = true,
 }: Props) {
   const organization = useOrganization();
+  const {viewId} = useParams<{viewId?: string}>();
   const hasRecommendedSortDefault = organization.features.includes(
     'issue-stream-recommended-sort-default'
   );
+  // The trigger badge announces the Recommended default. A stored sort means
+  // the user has already made an explicit choice, so stop announcing.
+  const hasChosenSort = getStoredIssueSort(organization.slug) !== null;
   const hasProgressSort =
     organization.features.includes('issue-stream-progress-sort') ||
     sort === IssueSortOptions.PROGRESS;
@@ -108,7 +114,10 @@ export function IssueListSortOptions({
           size={triggerSize}
           icon={showIcon && <IconSort />}
         >
-          {hasRecommendedSortDefault && sortKey === IssueSortOptions.RECOMMENDED ? (
+          {hasRecommendedSortDefault &&
+          !hasChosenSort &&
+          !viewId &&
+          sortKey === IssueSortOptions.RECOMMENDED ? (
             <Flex as="span" gap="sm" align="center">
               {triggerProps.children}
               <FeatureBadge

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -434,6 +434,27 @@ describe('IssueList', () => {
       const recommendedOption = screen.getByRole('option', {name: /Recommended/});
       expect(within(recommendedOption).getByLabelText('new')).toBeInTheDocument();
     });
+
+    it('hides the trigger badge once the user has chosen a sort', async () => {
+      const featureOrg = OrganizationFixture({
+        ...organization,
+        features: ['issue-stream-recommended-sort-default'],
+      });
+      // An explicitly chosen sort (even Recommended itself) means the user has
+      // seen the dropdown, so the announcement badge no longer shows
+      setStoredIssueSort(featureOrg.slug, IssueSortOptions.RECOMMENDED);
+      render(<IssueListOverview />, {organization: featureOrg, initialRouterConfig});
+
+      expect(
+        await screen.findByRole('button', {name: /Recommended/})
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText('new')).not.toBeInTheDocument();
+
+      // The Recommended option inside the dropdown keeps its badge
+      await userEvent.click(screen.getByRole('button', {name: /Recommended/}));
+      const recommendedOption = screen.getByRole('option', {name: /Recommended/});
+      expect(within(recommendedOption).getByLabelText('new')).toBeInTheDocument();
+    });
   });
 
   describe('transitionTo', () => {


### PR DESCRIPTION
The new-feature badge on the sort dropdown trigger (shown behind `issue-stream-recommended-sort-default`) announcing the Recommended sort default showed whenever the current sort was Recommended, so a user who explicitly selected Recommended — or switched away and came back — kept seeing "Issues now default to the Recommended sort. Pick a different sort and we'll remember your choice." indefinitely.

The trigger badge now shows only while no stored sort exists, i.e. while the user is seeing Recommended because of the default rather than by choice. Any explicit sort selection, including re-selecting Recommended, writes the stored sort and permanently dismisses it — no new state needed. It is also hidden on view pages, where sort changes are no longer remembered (#119415), so the tooltip copy would be wrong.

The badge on the Recommended option inside the dropdown menu is unchanged and still always shows.