### PR TITLE
fix(explore): Prettify validated aggregate labels

### DIFF
--- a/static/app/views/explore/tables/aggregatesTable.spec.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.spec.tsx
@@ -77,9 +77,11 @@ function createAggregatesTableResult({
 
 function AggregatesTableWithParamsProvider({
   aggregatesTableResult,
+  aggregateNumberTags = numberTags,
   validatedFieldTypes = {},
 }: {
   aggregatesTableResult: AggregatesTableResult;
+  aggregateNumberTags?: TagCollection;
   validatedFieldTypes?: Partial<Record<string, FieldValueType>>;
 }) {
   return (
@@ -87,7 +89,7 @@ function AggregatesTableWithParamsProvider({
       <AggregatesTable
         aggregatesTableResult={aggregatesTableResult}
         stringTags={stringTags}
-        numberTags={numberTags}
+        numberTags={aggregateNumberTags}
         booleanTags={booleanTags}
         validatedFieldTypes={validatedFieldTypes}
       />
@@ -262,5 +264,54 @@ describe('AggregatesTable', () => {
     expect(
       screen.queryByRole('menuitemradio', {name: 'Add to filter'})
     ).not.toBeInTheDocument();
+  });
+
+  it('prettifies validated aggregate field names', () => {
+    const aggregate = 'count(span.duration)';
+    const eventView = EventView.fromLocation(
+      LocationFixture({query: {field: ['span.op', aggregate]}})
+    );
+
+    render(
+      <AggregatesTableWithParamsProvider
+        aggregateNumberTags={{
+          ...numberTags,
+          [aggregate]: {
+            key: aggregate,
+            name: aggregate,
+            kind: FieldKind.MEASUREMENT,
+          },
+        }}
+        aggregatesTableResult={createAggregatesTableResult({
+          eventView,
+          result: {
+            meta: {
+              fields: {
+                'span.op': FieldValueType.STRING,
+                [aggregate]: FieldValueType.NUMBER,
+              },
+              units: {},
+            },
+          },
+        })}
+      />,
+      {
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              visualize: JSON.stringify({yAxes: [aggregate]}),
+              aggregateSort: `-${aggregate}`,
+            },
+          },
+        },
+        organization,
+      }
+    );
+
+    expect(screen.getByText('count(spans)')).toBeInTheDocument();
+    expect(screen.queryByText(aggregate)).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -323,12 +323,17 @@ function prettifyField(
   numberTags: TagCollection,
   booleanTags: TagCollection
 ): string {
+  const prettifiedAggregation = prettifyAggregation(field);
+  if (prettifiedAggregation) {
+    return prettifiedAggregation;
+  }
+
   const tag = stringTags[field] ?? numberTags[field] ?? booleanTags[field] ?? null;
   if (tag) {
     return tag.name;
   }
 
-  return prettifyAggregation(field) ?? prettifyTagKey(field);
+  return prettifyTagKey(field);
 }
 
 const TopResultsIndicator = styled('div')<{color: string}>`


### PR DESCRIPTION
Validated aggregate expressions now retain their user-facing labels in grouped spans tables. Span validation adds expressions such as `count(span.duration)` to the typed attribute maps, and the table previously preferred those raw attribute names over aggregate formatting. Aggregate formatting now takes precedence, with regression coverage confirming that the canonical expression renders as `count(spans)`.