### PR TITLE
ref(span-buffer): Reduce Lua memory allocation pressure and function call overhead

### DIFF
--- a/bin/benchmark-span-buffer
+++ b/bin/benchmark-span-buffer
@@ -17,7 +17,6 @@ import math
 import random
 import statistics
 import subprocess
-import sys
 import time
 from collections import defaultdict
 from collections.abc import Callable, Sequence
@@ -275,8 +274,7 @@ def parse_args() -> argparse.Namespace:
         default=1,
         type=int,
         help=(
-            "sample metrics and per-call latency on one call in N; "
-            "default: 1 to measure every call"
+            "sample metrics and per-call latency on one call in N; default: 1 to measure every call"
         ),
     )
     return parser.parse_args()
@@ -292,9 +290,7 @@ def main() -> int:
     client = redis.Redis(host=args.host, port=args.port, db=args.db)
     client.ping()
     if client.dbsize() != 0:
-        logger.critical(
-            f"Redis database {args.db} is not empty; refusing to flush it.", file=sys.stderr
-        )
+        logger.critical(f"Redis database {args.db} is not empty; refusing to flush it.")
         return 2
 
     variants = load_scripts(client, args.script, args.git_ref)

--- a/bin/benchmark-span-buffer
+++ b/bin/benchmark-span-buffer
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Benchmark one or more versions of the span-buffer Lua script.
+
+Examples:
+
+  .venv/bin/python bin/benchmark-span-buffer \
+    --git-ref baseline=cmanallen/span-buffer-optimization \
+    --git-ref candidate=codex/span-buffer-07-packed-metadata-writer
+
+  .venv/bin/python bin/benchmark-span-buffer \
+    --script baseline=/tmp/add-buffer-before.lua \
+    --script candidate=src/sentry/scripts/spans/add-buffer.lua
+
+The benchmark measures the Redis server's `cmdstat_evalsha` usec/call delta.
+It includes Lua execution, nested Redis commands, and reply creation, but not
+network or client-side RESP parsing. It runs only against an initially empty
+Redis database and flushes that database between variants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import random
+import statistics
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import redis
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LUA_SCRIPT_PATH = "src/sentry/scripts/spans/add-buffer.lua"
+TIMEOUT = 3600
+MAX_SEGMENT_BYTES = 10 * 1024 * 1024
+
+type Call = tuple[str, list[str | int]]
+type Workload = Callable[[random.Random], list[Call]]
+
+
+def random_hex(rng: random.Random, length: int) -> str:
+    return f"{rng.getrandbits(length * 4):0{length}x}"
+
+
+def fresh_calls(rng: random.Random, count: int, num_spans: int) -> list[Call]:
+    calls: list[Call] = []
+    for _ in range(count):
+        trace = f"1:{random_hex(rng, 32)}"
+        parent = random_hex(rng, 16)
+        span_ids = [random_hex(rng, 16) for _ in range(num_spans)]
+        calls.append(
+            (
+                trace,
+                [
+                    num_spans,
+                    parent,
+                    "false",
+                    TIMEOUT,
+                    500 * num_spans,
+                    MAX_SEGMENT_BYTES,
+                    random_hex(rng, 32),
+                    "false",
+                ]
+                + span_ids,
+            )
+        )
+    return calls
+
+
+def trace_calls(rng: random.Random, num_traces: int, num_spans: int) -> list[Call]:
+    """Ten subsegments per trace, with the first carrying the root span."""
+    calls: list[Call] = []
+    for _ in range(num_traces):
+        trace = f"1:{random_hex(rng, 32)}"
+        root = random_hex(rng, 16)
+        for index in range(10):
+            if index == 0:
+                span_ids = [root] + [random_hex(rng, 16) for _ in range(num_spans - 1)]
+                has_root = "true"
+            else:
+                span_ids = [random_hex(rng, 16) for _ in range(num_spans)]
+                has_root = "false"
+            calls.append(
+                (
+                    trace,
+                    [
+                        num_spans,
+                        root,
+                        has_root,
+                        TIMEOUT,
+                        500 * num_spans,
+                        MAX_SEGMENT_BYTES,
+                        random_hex(rng, 32),
+                        "false",
+                    ]
+                    + span_ids,
+                )
+            )
+    return calls
+
+
+def merge_calls(rng: random.Random, num_traces: int) -> list[Call]:
+    """Three child segments followed by a parent subsegment that merges them."""
+    calls: list[Call] = []
+    for _ in range(num_traces):
+        trace = f"1:{random_hex(rng, 32)}"
+        children = [random_hex(rng, 16) for _ in range(3)]
+        for child in children:
+            calls.append(
+                (
+                    trace,
+                    [
+                        2,
+                        child,
+                        "false",
+                        TIMEOUT,
+                        1000,
+                        MAX_SEGMENT_BYTES,
+                        random_hex(rng, 32),
+                        "false",
+                    ]
+                    + [random_hex(rng, 16), random_hex(rng, 16)],
+                )
+            )
+        calls.append(
+            (
+                trace,
+                [
+                    5,
+                    random_hex(rng, 16),
+                    "false",
+                    TIMEOUT,
+                    2500,
+                    MAX_SEGMENT_BYTES,
+                    random_hex(rng, 32),
+                    "false",
+                ]
+                + children
+                + [random_hex(rng, 16), random_hex(rng, 16)],
+            )
+        )
+    return calls
+
+
+WORKLOADS: dict[str, Workload] = {
+    "fresh_n1": lambda rng: fresh_calls(rng, 20_000, 1),
+    "fresh_n5": lambda rng: fresh_calls(rng, 20_000, 5),
+    "fresh_n20": lambda rng: fresh_calls(rng, 10_000, 20),
+    "fresh_n100": lambda rng: fresh_calls(rng, 3_000, 100),
+    "fresh_n200": lambda rng: fresh_calls(rng, 3_000, 200),
+    "trace10_n5": lambda rng: trace_calls(rng, 2_000, 5),
+    "merge3": lambda rng: merge_calls(rng, 5_000),
+}
+
+
+def parse_variant(value: str) -> tuple[str, str]:
+    name, separator, source = value.partition("=")
+    if not separator or not name or not source:
+        raise argparse.ArgumentTypeError("variants must be written as NAME=PATH_OR_REF")
+    return name, source
+
+
+def load_scripts(
+    client: redis.Redis[bytes],
+    script_variants: Sequence[tuple[str, str]],
+    git_ref_variants: Sequence[tuple[str, str]],
+) -> dict[str, str]:
+    scripts: dict[str, str] = {}
+    for name, path in script_variants:
+        scripts[name] = Path(path).read_text()
+    for name, ref in git_ref_variants:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{LUA_SCRIPT_PATH}"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        scripts[name] = result.stdout
+
+    if len(scripts) < 2:
+        raise ValueError("supply at least two --script and/or --git-ref variants")
+    return {name: client.script_load(script) for name, script in scripts.items()}
+
+
+def evalsha_stats(client: redis.Redis[bytes]) -> tuple[int, int]:
+    commandstats = client.info("commandstats")
+    stats = commandstats.get("cmdstat_evalsha", {"calls": 0, "usec": 0})
+    return int(stats["calls"]), int(stats["usec"])
+
+
+def run_calls(
+    client: redis.Redis[bytes],
+    sha: str,
+    calls: Sequence[Call],
+    metrics_sample_rate: int,
+) -> tuple[float, float]:
+    calls_before, usec_before = evalsha_stats(client)
+    wall_start = time.perf_counter()
+    call_iter = iter(calls)
+    while block := list(itertools.islice(call_iter, 500)):
+        with client.pipeline(transaction=False) as pipeline:
+            for trace, args in block:
+                full_args = args[:8] + [metrics_sample_rate] + args[8:]
+                pipeline.execute_command("EVALSHA", sha, 1, trace, *full_args)
+            pipeline.execute()
+    wall_seconds = time.perf_counter() - wall_start
+    calls_after, usec_after = evalsha_stats(client)
+    if calls_after - calls_before != len(calls):
+        raise RuntimeError(f"expected {len(calls)} EVALSHA calls, got {calls_after - calls_before}")
+    return (usec_after - usec_before) / len(calls), wall_seconds
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--script",
+        action="append",
+        type=parse_variant,
+        default=[],
+        metavar="NAME=PATH",
+        help="load a Lua script from a filesystem path; repeat for each variant",
+    )
+    parser.add_argument(
+        "--git-ref",
+        action="append",
+        type=parse_variant,
+        default=[],
+        metavar="NAME=REVISION",
+        help=f"load {LUA_SCRIPT_PATH} from a Git revision; repeat for each variant",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=6379, type=int)
+    parser.add_argument("--db", default=13, type=int)
+    parser.add_argument("--trials", default=3, type=int)
+    parser.add_argument(
+        "--metrics-sample-rate",
+        default=1,
+        type=int,
+        help="sample metrics on one call in N; default: 1 to include instrumentation cost",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.trials < 1:
+        raise ValueError("--trials must be at least 1")
+    if args.metrics_sample_rate < 1:
+        raise ValueError("--metrics-sample-rate must be at least 1")
+
+    client = redis.Redis(host=args.host, port=args.port, db=args.db)
+    client.ping()
+    if client.dbsize() != 0:
+        print(f"Redis database {args.db} is not empty; refusing to flush it.", file=sys.stderr)
+        return 2
+
+    variants = load_scripts(client, args.script, args.git_ref)
+    results: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    names = list(variants)
+    try:
+        for trial in range(args.trials):
+            for workload_name, workload in WORKLOADS.items():
+                calls = workload(random.Random(f"{workload_name}:{trial}"))
+                order = names[trial % len(names) :] + names[: trial % len(names)]
+                for name in order:
+                    client.flushdb()
+                    usec, wall_seconds = run_calls(
+                        client,
+                        variants[name],
+                        calls,
+                        args.metrics_sample_rate,
+                    )
+                    results[workload_name][name].append(usec)
+                    print(
+                        f"trial={trial} workload={workload_name} variant={name} "
+                        f"server_usec_per_call={usec:.2f} wall_seconds={wall_seconds:.2f}"
+                    )
+    finally:
+        client.flushdb()
+
+    baseline = names[0]
+    print(f"\nMedians (server usec/call; delta versus {baseline})")
+    for workload_name in WORKLOADS:
+        baseline_value = statistics.median(results[workload_name][baseline])
+        print(workload_name)
+        for name in names:
+            median = statistics.median(results[workload_name][name])
+            delta = (median - baseline_value) / baseline_value * 100
+            print(f"  {name:24} {median:8.2f}  {delta:+6.1f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/benchmark-span-buffer
+++ b/bin/benchmark-span-buffer
@@ -4,23 +4,15 @@
 Examples:
 
   .venv/bin/python bin/benchmark-span-buffer \
-    --git-ref baseline=cmanallen/span-buffer-optimization \
-    --git-ref candidate=codex/span-buffer-07-packed-metadata-writer
-
-  .venv/bin/python bin/benchmark-span-buffer \
-    --script baseline=/tmp/add-buffer-before.lua \
-    --script candidate=src/sentry/scripts/spans/add-buffer.lua
-
-The benchmark measures the Redis server's `cmdstat_evalsha` usec/call delta.
-It includes Lua execution, nested Redis commands, and reply creation, but not
-network or client-side RESP parsing. It runs only against an initially empty
-Redis database and flushes that database between variants.
+    --git-ref baseline=master \
+    --git-ref candidate=HEAD
 """
 
 from __future__ import annotations
 
 import argparse
 import itertools
+import logging
 import random
 import statistics
 import subprocess
@@ -32,11 +24,12 @@ from pathlib import Path
 
 import redis
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LUA_SCRIPT_PATH = "src/sentry/scripts/spans/add-buffer.lua"
 TIMEOUT = 3600
 MAX_SEGMENT_BYTES = 10 * 1024 * 1024
+
+logger = logging.getLogger()
 
 type Call = tuple[str, list[str | int]]
 type Workload = Callable[[random.Random], list[Call]]
@@ -256,7 +249,9 @@ def main() -> int:
     client = redis.Redis(host=args.host, port=args.port, db=args.db)
     client.ping()
     if client.dbsize() != 0:
-        print(f"Redis database {args.db} is not empty; refusing to flush it.", file=sys.stderr)
+        logger.critical(
+            f"Redis database {args.db} is not empty; refusing to flush it.", file=sys.stderr
+        )
         return 2
 
     variants = load_scripts(client, args.script, args.git_ref)
@@ -276,7 +271,7 @@ def main() -> int:
                         args.metrics_sample_rate,
                     )
                     results[workload_name][name].append(usec)
-                    print(
+                    logger.critical(
                         f"trial={trial} workload={workload_name} variant={name} "
                         f"server_usec_per_call={usec:.2f} wall_seconds={wall_seconds:.2f}"
                     )
@@ -284,14 +279,14 @@ def main() -> int:
         client.flushdb()
 
     baseline = names[0]
-    print(f"\nMedians (server usec/call; delta versus {baseline})")
+    logger.critical(f"\nMedians (server usec/call; delta versus {baseline})")
     for workload_name in WORKLOADS:
         baseline_value = statistics.median(results[workload_name][baseline])
-        print(workload_name)
+        logger.critical(workload_name)
         for name in names:
             median = statistics.median(results[workload_name][name])
             delta = (median - baseline_value) / baseline_value * 100
-            print(f"  {name:24} {median:8.2f}  {delta:+6.1f}%")
+            logger.critical(f"  {name:24} {median:8.2f}  {delta:+6.1f}%")
     return 0
 
 

--- a/bin/benchmark-span-buffer
+++ b/bin/benchmark-span-buffer
@@ -40,6 +40,14 @@ def random_hex(rng: random.Random, length: int) -> str:
 
 
 def fresh_calls(rng: random.Random, count: int, num_spans: int) -> list[Call]:
+    """Generate isolated subsegment calls, each for a new trace.
+
+    This measures the base ingestion path and how its cost scales with the number of
+    spans in one call. Every call starts without redirect, counter, or member-key
+    state, and does not exercise segment merging, size detachment, or flush locks.
+    Results are relevant to first-seen subsegments and to comparing per-span overhead
+    across batch sizes.
+    """
     calls: list[Call] = []
     for _ in range(count):
         trace = f"1:{random_hex(rng, 32)}"
@@ -65,7 +73,14 @@ def fresh_calls(rng: random.Random, count: int, num_spans: int) -> list[Call]:
 
 
 def trace_calls(rng: random.Random, num_traces: int, num_spans: int) -> list[Call]:
-    """Ten subsegments per trace, with the first carrying the root span."""
+    """Generate ten subsegment calls that accumulate into each trace's root segment.
+
+    The first call contains the root span and the following nine calls target that
+    same root, exercising repeated updates to existing redirect, counter, and
+    member-key state without merging independently buffered child segments. Results
+    are relevant when traces arrive in several small, ordered batches whose common
+    segment is already known.
+    """
     calls: list[Call] = []
     for _ in range(num_traces):
         trace = f"1:{random_hex(rng, 32)}"
@@ -97,7 +112,14 @@ def trace_calls(rng: random.Random, num_traces: int, num_spans: int) -> list[Cal
 
 
 def merge_calls(rng: random.Random, num_traces: int) -> list[Call]:
-    """Three child segments followed by a parent subsegment that merges them."""
+    """Generate three buffered child segments and a call that merges them into a parent.
+
+    Each child is ingested as a separate two-span segment before a five-span parent
+    subsegment references all three child roots. This exercises child counter reads,
+    member-set merging, redirect updates, and cleanup of superseded child metadata.
+    Results are relevant to out-of-order traces where child subtrees arrive before
+    the subsegment that connects them.
+    """
     calls: list[Call] = []
     for _ in range(num_traces):
         trace = f"1:{random_hex(rng, 32)}"
@@ -146,6 +168,9 @@ WORKLOADS: dict[str, Workload] = {
     "fresh_n100": lambda rng: fresh_calls(rng, 3_000, 100),
     "fresh_n200": lambda rng: fresh_calls(rng, 3_000, 200),
     "trace10_n5": lambda rng: trace_calls(rng, 2_000, 5),
+    "trace10_n20": lambda rng: trace_calls(rng, 1_000, 20),
+    "trace10_n100": lambda rng: trace_calls(rng, 300, 100),
+    "trace10_n200": lambda rng: trace_calls(rng, 300, 200),
     "merge3": lambda rng: merge_calls(rng, 5_000),
 }
 

--- a/bin/benchmark-span-buffer
+++ b/bin/benchmark-span-buffer
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import itertools
 import logging
+import math
 import random
 import statistics
 import subprocess
@@ -216,21 +217,35 @@ def run_calls(
     sha: str,
     calls: Sequence[Call],
     metrics_sample_rate: int,
-) -> tuple[float, float]:
+) -> tuple[float, float, list[int]]:
     calls_before, usec_before = evalsha_stats(client)
     wall_start = time.perf_counter()
+    latencies_us: list[int] = []
     call_iter = iter(calls)
     while block := list(itertools.islice(call_iter, 500)):
         with client.pipeline(transaction=False) as pipeline:
             for trace, args in block:
                 full_args = args[:8] + [metrics_sample_rate] + args[8:]
                 pipeline.execute_command("EVALSHA", sha, 1, trace, *full_args)
-            pipeline.execute()
+            responses = pipeline.execute()
+        for response in responses:
+            if not isinstance(response, list) or len(response) < 3:
+                raise RuntimeError(f"unexpected EVALSHA response: {response!r}")
+            latency_us = response[2]
+            if not isinstance(latency_us, int):
+                raise RuntimeError(f"unexpected latency value: {latency_us!r}")
+            if latency_us >= 0:
+                latencies_us.append(latency_us)
     wall_seconds = time.perf_counter() - wall_start
     calls_after, usec_after = evalsha_stats(client)
     if calls_after - calls_before != len(calls):
         raise RuntimeError(f"expected {len(calls)} EVALSHA calls, got {calls_after - calls_before}")
-    return (usec_after - usec_before) / len(calls), wall_seconds
+    return (usec_after - usec_before) / len(calls), wall_seconds, latencies_us
+
+
+def nearest_rank(sorted_values: Sequence[int], percentile: float) -> int:
+    """Return a percentile from non-empty sorted values using the nearest-rank method."""
+    return sorted_values[math.ceil(percentile * len(sorted_values)) - 1]
 
 
 def parse_args() -> argparse.Namespace:
@@ -259,7 +274,10 @@ def parse_args() -> argparse.Namespace:
         "--metrics-sample-rate",
         default=1,
         type=int,
-        help="sample metrics on one call in N; default: 1 to include instrumentation cost",
+        help=(
+            "sample metrics and per-call latency on one call in N; "
+            "default: 1 to measure every call"
+        ),
     )
     return parser.parse_args()
 
@@ -280,7 +298,8 @@ def main() -> int:
         return 2
 
     variants = load_scripts(client, args.script, args.git_ref)
-    results: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    batch_results: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    latency_results: dict[str, dict[str, list[int]]] = defaultdict(lambda: defaultdict(list))
     names = list(variants)
     try:
         for trial in range(args.trials):
@@ -289,13 +308,14 @@ def main() -> int:
                 order = names[trial % len(names) :] + names[: trial % len(names)]
                 for name in order:
                     client.flushdb()
-                    usec, wall_seconds = run_calls(
+                    usec, wall_seconds, latencies_us = run_calls(
                         client,
                         variants[name],
                         calls,
                         args.metrics_sample_rate,
                     )
-                    results[workload_name][name].append(usec)
+                    batch_results[workload_name][name].append(usec)
+                    latency_results[workload_name][name].extend(latencies_us)
                     logger.critical(
                         f"trial={trial} workload={workload_name} variant={name} "
                         f"server_usec_per_call={usec:.2f} wall_seconds={wall_seconds:.2f}"
@@ -304,14 +324,33 @@ def main() -> int:
         client.flushdb()
 
     baseline = names[0]
-    logger.critical(f"\nMedians (server usec/call; delta versus {baseline})")
+    logger.critical(f"\nBatch-average medians (server usec/call; delta versus {baseline})")
     for workload_name in WORKLOADS:
-        baseline_value = statistics.median(results[workload_name][baseline])
+        baseline_value = statistics.median(batch_results[workload_name][baseline])
         logger.critical(workload_name)
         for name in names:
-            median = statistics.median(results[workload_name][name])
+            median = statistics.median(batch_results[workload_name][name])
             delta = (median - baseline_value) / baseline_value * 100
             logger.critical(f"  {name:24} {median:8.2f}  {delta:+6.1f}%")
+
+    logger.critical("\nPer-call Lua latency (usec; sampled calls across all trials)")
+    logger.critical(
+        f"{'workload':16} {'variant':24} {'avg':>10} {'p95':>10} "
+        f"{'p99':>10} {'max':>10} {'samples':>10}"
+    )
+    for workload_name in WORKLOADS:
+        for name in names:
+            latencies_us = sorted(latency_results[workload_name][name])
+            if not latencies_us:
+                logger.critical(f"{workload_name:16} {name:24} {'no samples':>54}")
+                continue
+            logger.critical(
+                f"{workload_name:16} {name:24} "
+                f"{statistics.fmean(latencies_us):10.2f} "
+                f"{nearest_rank(latencies_us, 0.95):10d} "
+                f"{nearest_rank(latencies_us, 0.99):10d} "
+                f"{latencies_us[-1]:10d} {len(latencies_us):10d}"
+            )
     return 0
 
 

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -80,7 +80,7 @@ local function merge_set(source_key, dest_key)
     until cursor == "0"
 end
 
-local num_spans = ARGV[1]
+local num_spans = tonumber(ARGV[1])
 local parent_span_id = ARGV[2]
 local has_root_span = ARGV[3] == "true"
 local set_timeout = tonumber(ARGV[4])
@@ -110,7 +110,7 @@ end
 local set_span_id = parent_span_id
 local redirect_depth = 0
 
-local main_redirect_key = string.format("span-buf:ssr:{%s}", project_and_trace)
+local main_redirect_key = "span-buf:ssr:{" .. project_and_trace .. "}"
 
 -- Navigates the tree up to the highest level parent span we can find. Such
 -- span is needed to know the segment we need to merge the subsegment into.
@@ -125,8 +125,8 @@ for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
 end
 
 local function insert_metric(t, key, value)
-    table.insert(t, key)
-    table.insert(t, value)
+    t[#t + 1] = key
+    t[#t + 1] = value
 end
 
 -- latency_table and metrics_table are flattened lists of [key1, value1, key2, value2, ...]
@@ -140,22 +140,31 @@ if sample_metrics then
     insert_metric(metrics_table, "redirect_depth", redirect_depth)
 end
 
-local set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, set_span_id)
+-- Precompute prefixes once per invocation. These key builders are used in the
+-- span loops below, where concatenation is cheaper than repeated string.format.
+local span_prefix = "span-buf:s:{" .. project_and_trace .. "}:"
+local ic_prefix = "span-buf:ic:" .. span_prefix
+local ibc_prefix = "span-buf:ibc:" .. span_prefix
+local mk_prefix = "span-buf:mk:{" .. project_and_trace .. "}:"
+
+local set_key = span_prefix .. set_span_id
 
 -- Reset the set expiry as we saw a new subsegment for this set
-local has_root_span_key = string.format("span-buf:hrs:%s", set_key)
+local has_root_span_key = "span-buf:hrs:" .. set_key
 has_root_span = has_root_span or redis.call("get", has_root_span_key) == "1"
 if has_root_span then
     redis.call("setex", has_root_span_key, set_timeout, "1")
 end
 
 local hset_args = {}
+local num_hset_args = 0
 
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
 
-    table.insert(hset_args, span_id)
-    table.insert(hset_args, set_span_id)
+    hset_args[num_hset_args + 1] = span_id
+    hset_args[num_hset_args + 2] = set_span_id
+    num_hset_args = num_hset_args + 2
 end
 
 redis.call("hset", main_redirect_key, unpack(hset_args))
@@ -167,7 +176,7 @@ if sample_metrics then
     insert_metric(latency_table, "redirect_step_latency_us", redirect_end_time_us - start_time_us)
 end
 
-local ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
+local ingested_byte_count_key = ibc_prefix .. set_span_id
 local ingested_byte_count = tonumber(redis.call("get", ingested_byte_count_key) or 0)
 
 -- Pre-processing loop runs first to collect all the keys.
@@ -176,9 +185,8 @@ local child_ibc_keys = {}
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
-        local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
-        table.insert(child_ic_keys, string.format("span-buf:ic:%s", child_set_key))
-        table.insert(child_ibc_keys, string.format("span-buf:ibc:%s", child_set_key))
+        child_ic_keys[#child_ic_keys + 1] = ic_prefix .. span_id
+        child_ibc_keys[#child_ibc_keys + 1] = ibc_prefix .. span_id
     end
 end
 
@@ -206,23 +214,24 @@ end
 local segment_too_large = max_segment_bytes > 0 and tonumber(ingested_byte_count) + byte_count > max_segment_bytes
 local segment_locked = false
 if check_flush_lock then
-    local flush_lock_key = string.format("span-buf:fl:%s", set_key)
+    local flush_lock_key = "span-buf:fl:" .. set_key
     segment_locked = redis.call("exists", flush_lock_key) == 1
 end
 if segment_too_large or segment_locked then
     set_span_id = salt
-    set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, salt)
-    ingested_byte_count_key = string.format("span-buf:ibc:%s", set_key)
+    set_key = span_prefix .. salt
+    ingested_byte_count_key = ibc_prefix .. salt
 end
 if sample_metrics then
     insert_metric(metrics_table, "detached_segment_too_large", segment_too_large and 1 or 0)
     insert_metric(metrics_table, "detached_segment_locked", segment_locked and 1 or 0)
 end
 
-local ingested_count_key = string.format("span-buf:ic:%s", set_key)
-local members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, set_span_id)
+local ingested_count_key = ic_prefix .. set_span_id
+local members_key = mk_prefix .. set_span_id
 
 local merged_segment_span_ids = {}
+local num_merged_segment_span_ids = 0
 
 -- NOTE: This loop is assumed to match the iteration semantics of the child_ibc cache key
 --       lookup loop. If it doesn't then this will breakerino.
@@ -230,30 +239,28 @@ local child_idx = 0
 for i = NUM_ARGS + 1, NUM_ARGS + num_spans do
     local span_id = ARGV[i]
     if span_id ~= parent_span_id then
-        local child_set_key = string.format("span-buf:s:{%s}:%s", project_and_trace, span_id)
         child_idx = child_idx + 1
 
         local child_ic = child_ics[child_idx]
         if child_ic then
-            local child_ic_key = string.format("span-buf:ic:%s", child_set_key)
             redis.call("incrby", ingested_count_key, child_ic)
-            redis.call("del", child_ic_key)
+            redis.call("del", child_ic_keys[child_idx])
         end
 
         local child_ibc = child_ibcs[child_idx]
         if child_ibc then
-            local child_ibc_key = string.format("span-buf:ibc:%s", child_set_key)
             -- byte_count already holds the child's byte count, so we don't need to add again
-            redis.call("del", child_ibc_key)
+            redis.call("del", child_ibc_keys[child_idx])
         end
 
         -- Presence of child_ic implies that this span is a root span. Only root spans have these associations.
         -- We can skip all the child spans (which will be no-ops) and save some Redis calls.
         if child_ic then
-            local child_members_key = string.format("span-buf:mk:{%s}:%s", project_and_trace, span_id)
+            local child_members_key = mk_prefix .. span_id
             merge_set(child_members_key, members_key)
             redis.call("del", child_members_key)
-            table.insert(merged_segment_span_ids, span_id)
+            num_merged_segment_span_ids = num_merged_segment_span_ids + 1
+            merged_segment_span_ids[num_merged_segment_span_ids] = span_id
         end
     end
 end

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -125,6 +125,8 @@ for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
 end
 
 local function insert_metric(t, key, value)
+    -- This is only reliable for dense tables. If the table is sparse this behavior is undefined
+    -- (varies by Lua version).
     t[#t + 1] = key
     t[#t + 1] = value
 end
@@ -140,8 +142,8 @@ if sample_metrics then
     insert_metric(metrics_table, "redirect_depth", redirect_depth)
 end
 
--- Precompute prefixes once per invocation. These key builders are used in the
--- span loops below, where concatenation is cheaper than repeated string.format.
+-- Precompute prefixes once per invocation. These key builders are used in the span loops below,
+-- where concatenation is cheaper than repeated string.format.
 local span_prefix = "span-buf:s:{" .. project_and_trace .. "}:"
 local ic_prefix = "span-buf:ic:" .. span_prefix
 local ibc_prefix = "span-buf:ibc:" .. span_prefix

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -125,8 +125,7 @@ for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
 end
 
 local function insert_metric(t, key, value)
-    -- This is only reliable for dense tables. If the table is sparse this behavior is undefined
-    -- (varies by Lua version).
+    -- This is only reliable for dense tables. If the table is sparse this behavior is undefined.
     t[#t + 1] = key
     t[#t + 1] = value
 end

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -124,21 +124,28 @@ for i = 0, 100 do -- Theoretic maximum depth of redirects is 100
     set_span_id = new_set_span
 end
 
-local function insert_metric(t, key, value)
-    -- This is only reliable for dense tables. If the table is sparse this behavior is undefined.
-    t[#t + 1] = key
-    t[#t + 1] = value
-end
-
 -- latency_table and metrics_table are flattened lists of [key1, value1, key2, value2, ...]
 -- so that the result is a flat array that is trivial to parse in Python, rather than a list
 -- of nested {key, value} pair tables.
 local latency_table = {}
+local latency_table_len = 0
+local function insert_latency(key, value)
+    latency_table[latency_table_len + 1] = key
+    latency_table[latency_table_len + 2] = value
+    latency_table_len = latency_table_len + 2
+end
+
 local metrics_table = {}
+local metrics_table_len = 0
+local function insert_metrics(key, value)
+    metrics_table[metrics_table_len + 1] = key
+    metrics_table[metrics_table_len + 2] = value
+    metrics_table_len = metrics_table_len + 2
+end
 
 if sample_metrics then
-    insert_metric(metrics_table, "redirect_table_size", redis.call("hlen", main_redirect_key))
-    insert_metric(metrics_table, "redirect_depth", redirect_depth)
+    insert_metrics("redirect_table_size", redis.call("hlen", main_redirect_key))
+    insert_metrics("redirect_depth", redirect_depth)
 end
 
 -- Precompute prefixes once per invocation. These key builders are used in the span loops below,
@@ -174,7 +181,7 @@ redis.call("expire", main_redirect_key, set_timeout)
 local redirect_end_time_us = 0
 if sample_metrics then
     redirect_end_time_us = get_time_us()
-    insert_metric(latency_table, "redirect_step_latency_us", redirect_end_time_us - start_time_us)
+    insert_latency("redirect_step_latency_us", redirect_end_time_us - start_time_us)
 end
 
 local ingested_byte_count_key = ibc_prefix .. set_span_id
@@ -224,8 +231,8 @@ if segment_too_large or segment_locked then
     ingested_byte_count_key = ibc_prefix .. salt
 end
 if sample_metrics then
-    insert_metric(metrics_table, "detached_segment_too_large", segment_too_large and 1 or 0)
-    insert_metric(metrics_table, "detached_segment_locked", segment_locked and 1 or 0)
+    insert_metrics("detached_segment_too_large", segment_too_large and 1 or 0)
+    insert_metrics("detached_segment_locked", segment_locked and 1 or 0)
 end
 
 local ingested_count_key = ic_prefix .. set_span_id
@@ -269,7 +276,7 @@ end
 local merge_payload_keys_end_time_us = 0
 if sample_metrics then
     merge_payload_keys_end_time_us = get_time_us()
-    insert_metric(latency_table, "merge_payload_keys_step_latency_us",
+    insert_latency("merge_payload_keys_step_latency_us",
         merge_payload_keys_end_time_us - redirect_end_time_us)
 end
 
@@ -287,10 +294,10 @@ redis.call("expire", ingested_byte_count_key, set_timeout)
 local latency_us = -1
 if sample_metrics then
     local counter_merge_end_time_us = get_time_us()
-    insert_metric(latency_table, "counter_merge_step_latency_us",
+    insert_latency("counter_merge_step_latency_us",
         counter_merge_end_time_us - merge_payload_keys_end_time_us)
     latency_us = counter_merge_end_time_us - start_time_us
-    insert_metric(latency_table, "total_step_latency_us", latency_us)
+    insert_latency("total_step_latency_us", latency_us)
 end
 
 return { set_key, has_root_span, latency_us, latency_table, metrics_table, merged_segment_span_ids }


### PR DESCRIPTION
Performance optimizations for the `EVALSHA` Redis function. A couple things happening here:

1. All calls to `string.format` have been replaced with simple string concatenation. Its faster and we don't need the overhead of string format.
2. Many of the former calls to `string.format` are pre-computed outside their loops to reduce allocation pressure and the number of operations performed in hot paths.
3. We're reusing strings across loops where possible rather than reallocating a new one.
4. Calls to `table.insert` were removed in favor of the faster index assignment `t[key] = value`.
5. Some other things like explicit, one-time type coercion to a number.

The benchmark is tastefully curated AI slop. I found it helpful so I'm committing it. The results of the benchmark is positive. Broad improvements across a variety of workloads. Potentially a +40% improvement in latency. Nearly halving the already halved evalsha times.

```
Medians (server usec/call; delta versus baseline)
fresh_n1
  baseline                    21.90    +0.0%
  candidate                   19.03   -13.1%
fresh_n5
  baseline                    32.80    +0.0%
  candidate                   25.70   -21.7%
fresh_n20
  baseline                    61.92    +0.0%
  candidate                   41.47   -33.0%
fresh_n100
  baseline                   238.50    +0.0%
  candidate                  136.47   -42.8%
fresh_n200
  baseline                   483.51    +0.0%
  candidate                  288.52   -40.3%
trace10_n5
  baseline                    32.08    +0.0%
  candidate                   25.86   -19.4%
trace10_n20
  baseline                    67.37    +0.0%
  candidate                   49.68   -26.3%
trace10_n100
  baseline                   261.53    +0.0%
  candidate                  168.91   -35.4%
trace10_n200
  baseline                   455.30    +0.0%
  candidate                  263.86   -42.0%
merge3
  baseline                    29.06    +0.0%
  candidate                   23.61   -18.8%

Per-call Lua latency (usec; sampled calls across all trials)
workload         variant                         avg        p95        p99        max    samples
fresh_n1         baseline                      16.84         26         38        393      60000
fresh_n1         candidate                     13.77         21         31        155      60000
fresh_n5         baseline                      26.15         43         62       1114      60000
fresh_n5         candidate                     19.53         35         53        326      60000
fresh_n20        baseline                      57.35         89        114       1207      30000
fresh_n20        candidate                     33.53         62         88        567      30000
fresh_n100       baseline                     222.33        304        347       1015       9000
fresh_n100       candidate                    127.53        202        242        415       9000
fresh_n200       baseline                     459.97        569        649       1640       9000
fresh_n200       candidate                    269.05        368        433        868       9000
trace10_n5       baseline                      24.93         35         52        610      60000
trace10_n5       candidate                     18.66         27         40        202      60000
trace10_n20      baseline                      61.11         99        147        324      30000
trace10_n20      candidate                     40.79         72        102       1027      30000
trace10_n100     baseline                     253.64        391        444        569       9000
trace10_n100     candidate                    156.85        268        316        498       9000
trace10_n200     baseline                     435.25        660        738       2080       9000
trace10_n200     candidate                    242.10        451        527       3324       9000
merge3           baseline                      22.26         41         53        332      60000
merge3           candidate                     17.83         33         49        420      60000
```