### PR TITLE
fix(autofix): Add word boundary check for @sentry mention parsing

### DIFF
--- a/src/sentry/seer/webhooks.py
+++ b/src/sentry/seer/webhooks.py
@@ -21,11 +21,21 @@ def sentry_command(comment_body: str | None) -> SentryCommand | None:
         return None
 
     lowered = comment_body.lower()
-    if REVIEW_COMMAND in lowered:
-        return SentryReviewCommand()
 
-    if MARKER not in lowered:
+    # Check for @sentry with word boundaries to avoid matching @sentry-cursor-agent, etc.
+    # Pattern explanation:
+    # (?:^|\s) - either start of string or whitespace (non-capturing group)
+    # @sentry - literal match
+    # (?=\s|$) - followed by whitespace or end of string (positive lookahead, doesn't consume)
+    marker_pattern = r"(?:^|\s)@sentry(?=\s|$)"
+
+    if not re.search(marker_pattern, lowered):
         return None
+
+    # Check for "review" command with the same boundary requirements
+    review_pattern = r"(?:^|\s)@sentry\s+review"
+    if re.search(review_pattern, lowered):
+        return SentryReviewCommand()
 
     removed_marker = re.split(re.escape(MARKER), comment_body, flags=re.IGNORECASE)
     stripped_parts = [part.strip() for part in removed_marker if part.strip()]

--- a/src/sentry/seer/webhooks.py
+++ b/src/sentry/seer/webhooks.py
@@ -4,6 +4,10 @@ from dataclasses import dataclass
 MARKER = "@sentry"
 REVIEW_COMMAND = f"{MARKER} review"
 
+# Shared patterns for bounded @sentry mentions (whitespace or string edges only).
+MARKER_PATTERN = re.compile(r"(?:^|\s)@sentry(?=\s|$)", re.IGNORECASE)
+REVIEW_PATTERN = re.compile(r"(?:^|\s)@sentry review(?=\s|$)", re.IGNORECASE)
+
 
 class SentryCommand: ...
 
@@ -16,31 +20,26 @@ class SentryIterateCommand(SentryCommand):
     feedback: str
 
 
+def _remove_bounded_sentry_mentions(comment_body: str) -> str:
+    def replacer(match: re.Match[str]) -> str:
+        # Preserve whitespace that preceded the mention so surrounding words stay separated.
+        return " " if match.group(0)[0].isspace() else ""
+
+    return MARKER_PATTERN.sub(replacer, comment_body)
+
+
 def sentry_command(comment_body: str | None) -> SentryCommand | None:
     if comment_body is None:
         return None
 
-    lowered = comment_body.lower()
-
-    # Check for @sentry with word boundaries to avoid matching @sentry-cursor-agent, etc.
-    # Pattern explanation:
-    # (?:^|\s) - either start of string or whitespace (non-capturing group)
-    # @sentry - literal match
-    # (?=\s|$) - followed by whitespace or end of string (positive lookahead, doesn't consume)
-    marker_pattern = r"(?:^|\s)@sentry(?=\s|$)"
-
-    if not re.search(marker_pattern, lowered):
+    if not MARKER_PATTERN.search(comment_body):
         return None
 
-    # Check for "review" command with the same boundary requirements
-    review_pattern = r"(?:^|\s)@sentry\s+review"
-    if re.search(review_pattern, lowered):
+    if REVIEW_PATTERN.search(comment_body):
         return SentryReviewCommand()
 
-    removed_marker = re.split(re.escape(MARKER), comment_body, flags=re.IGNORECASE)
-    stripped_parts = [part.strip() for part in removed_marker if part.strip()]
-    joined = " ".join(stripped_parts)
-    if not joined:
+    feedback = " ".join(_remove_bounded_sentry_mentions(comment_body).split())
+    if not feedback:
         return None
 
-    return SentryIterateCommand(feedback=joined)
+    return SentryIterateCommand(feedback=feedback)

--- a/tests/sentry/seer/autofix/pr_iteration/test_mention.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_mention.py
@@ -92,3 +92,24 @@ class HandleIssueCommentForAutofixIterationTest(TestCase):
         with self.feature("organizations:autofix-pr-iteration"):
             self._call(event)
         mock_delay.assert_not_called()
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    def test_skips_when_mention_has_hyphen_suffix(self, mock_delay: MagicMock) -> None:
+        """Test that @sentry-cursor-agent doesn't trigger the command."""
+        with self.feature("organizations:autofix-pr-iteration"):
+            self._call(self._event(body="@sentry-cursor-agent please help"))
+        mock_delay.assert_not_called()
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    def test_skips_when_mention_has_underscore_suffix(self, mock_delay: MagicMock) -> None:
+        """Test that @sentry_bot doesn't trigger the command."""
+        with self.feature("organizations:autofix-pr-iteration"):
+            self._call(self._event(body="@sentry_bot do something"))
+        mock_delay.assert_not_called()
+
+    @patch(f"{MENTION_PATH}.trigger_pr_iteration_from_comment.delay")
+    def test_skips_when_mention_in_email(self, mock_delay: MagicMock) -> None:
+        """Test that email@sentry.io doesn't trigger the command."""
+        with self.feature("organizations:autofix-pr-iteration"):
+            self._call(self._event(body="contact email@sentry.io for help"))
+        mock_delay.assert_not_called()

--- a/tests/sentry/seer/test_webhooks.py
+++ b/tests/sentry/seer/test_webhooks.py
@@ -47,6 +47,11 @@ class TestSentryCommand:
             "review",
             "@sentry",
             "@sentry    ",
+            "@sentry-cursor-agent please help",
+            "@sentry-bot do something",
+            "email@sentry.io",
+            "@sentry_bot",
+            "check@sentrycode",
         ],
     )
     def test_returns_none(self, body: str | None) -> None:

--- a/tests/sentry/seer/test_webhooks.py
+++ b/tests/sentry/seer/test_webhooks.py
@@ -23,6 +23,17 @@ class TestSentryCommand:
         assert isinstance(sentry_command(body), SentryReviewCommand)
 
     @pytest.mark.parametrize(
+        "body",
+        [
+            "@sentry reviewed this",
+            "@sentry  review",
+            "@sentry\nreviewed",
+        ],
+    )
+    def test_review_command_not_matched(self, body: str) -> None:
+        assert not isinstance(sentry_command(body), SentryReviewCommand)
+
+    @pytest.mark.parametrize(
         "body, expected_feedback",
         [
             ("@sentry fix the typo", "fix the typo"),
@@ -31,6 +42,10 @@ class TestSentryCommand:
             ("hey @sentry do the thing", "hey do the thing"),
             ("@sentry a @sentry b", "a b"),
             ("@Sentry fix this", "fix this"),
+            ("@sentry reviewed this", "reviewed this"),
+            ("@sentry  review", "review"),
+            ("@sentry fix docs@sentry.io", "fix docs@sentry.io"),
+            ("@sentry fix @sentry-cursor-agent", "fix @sentry-cursor-agent"),
         ],
     )
     def test_iterate_command(self, body: str, expected_feedback: str) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `@sentry` mention parsing in GitHub PR comments was matching any string containing `@sentry`, including:
- `@sentry-cursor-agent` (other bot mentions with hyphens)
- `@sentry_bot` (other bot mentions with underscores)  
- `email@sentry.io` (email addresses)

This caused incorrect command parsing when users mentioned other bots or included the word in different contexts, leading to unintended autofix iterations being triggered.

## Solution

Added word-boundary checking so `@sentry` is only recognized when surrounded by whitespace or string start/end. Shared `MARKER_PATTERN` / `REVIEW_PATTERN` keep detection and feedback extraction in sync:

1. **Detection** — only bounded `@sentry` mentions count
2. **Review command** — exact `@sentry review` with trailing boundary (rejects `@sentry reviewed`, extra spaces)
3. **Feedback extraction** — strips only bounded mentions so emails / suffixed bots stay intact

Punctuation-adjacent mentions (e.g. `@sentry,`) are intentionally **not** accepted — we keep the stricter whitespace boundary.

[Slack Thread](https://sentry.slack.com/archives/C0B3BC328DU/p1783966154650939?thread_ts=1783966154.650939&cid=C0B3BC328DU)