### PR TITLE
fix(nav): Highlight Explore for preprod pages

### DIFF
--- a/static/app/views/navigation/primaryNavigationContext.tsx
+++ b/static/app/views/navigation/primaryNavigationContext.tsx
@@ -10,7 +10,7 @@ import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/second
 
 const PRIMARY_NAVIGATION_GROUP_CONFIG = {
   issues: ['issues'],
-  explore: ['explore'],
+  explore: ['explore', 'preprod'],
   dashboards: ['dashboards', 'dashboard'],
   insights: ['insights'],
   projects: ['projects'], // No primary nav button — accessed via logo nav. Needed for secondary nav routing.

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -248,9 +248,10 @@ interface SecondaryNavigationItemProps extends Omit<LinkProps, 'ref' | 'to'> {
   children: ReactNode;
   to: To;
   /**
-   * Will display the link as active under the given path.
+   * Will display the link as active under the given path. Pass a list of paths
+   * to display the link as active when any of them match.
    */
-  activeTo?: To;
+  activeTo?: To | To[];
   analyticsItemName?: string;
   /**
    * When passed, will not show the link as active for descendant paths.
@@ -440,8 +441,12 @@ function SecondaryNavigationLink({
 }: SecondaryNavigationItemProps) {
   const organization = useOrganization();
   const location = useLocation();
+  const activeToList = Array.isArray(activeTo) ? activeTo : [activeTo];
   const isActive =
-    incomingIsActive ?? isPrimaryNavigationLinkActive(activeTo, location.pathname, {end});
+    incomingIsActive ??
+    activeToList.some(path =>
+      isPrimaryNavigationLinkActive(path, location.pathname, {end})
+    );
 
   const {layout, features} = usePrimaryNavigation();
   const {reset: closeCollapsedNavigationHovercard} = useHovercardContext();
@@ -801,8 +806,12 @@ function SecondaryNavigationReorderableLink({
 }: SecondaryNavigationReorderableLinkProps) {
   const organization = useOrganization();
   const location = useLocation();
+  const activeToList = Array.isArray(activeTo) ? activeTo : [activeTo];
   const isActive =
-    incomingIsActive ?? isPrimaryNavigationLinkActive(activeTo, location.pathname, {end});
+    incomingIsActive ??
+    activeToList.some(path =>
+      isPrimaryNavigationLinkActive(path, location.pathname, {end})
+    );
   const {layout, features} = usePrimaryNavigation();
   const {reset: closeCollapsedNavigationHovercard} = useHovercardContext();
   const {setView} = useSecondaryNavigation();

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -58,6 +58,30 @@ describe('ExploreSecondaryNavigation', () => {
     expect(screen.getByText('Traces')).toBeInTheDocument();
   });
 
+  it('marks Releases as active on preprod pages', () => {
+    render(
+      <PrimaryNavigationContextProvider>
+        <SecondaryNavigationContextProvider>
+          <Navigation />
+          <div id="main" />
+        </SecondaryNavigationContextProvider>
+      </PrimaryNavigationContextProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/preprod/snapshots/123/',
+          },
+        },
+      }
+    );
+
+    expect(screen.getByRole('link', {name: 'Releases'})).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
   it('links Discover to homepage when discover-query is enabled', () => {
     const {organization: orgWithQuery} = initializeOrg({
       organization: {

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -70,7 +70,7 @@ describe('ExploreSecondaryNavigation', () => {
         organization,
         initialRouterConfig: {
           location: {
-            pathname: '/preprod/snapshots/123/',
+            pathname: '/organizations/org-slug/preprod/snapshots/123/',
           },
         },
       }

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -4,7 +4,6 @@ import {FeatureBadge} from '@sentry/scraps/badge';
 
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import {
@@ -16,13 +15,8 @@ import {ExploreSavedQueryNavigationItems} from 'sentry/views/navigation/secondar
 
 export function ExploreSecondaryNavigation() {
   const organization = useOrganization();
-  const location = useLocation();
 
   const baseUrl = `/organizations/${organization.slug}/explore`;
-
-  const isReleasesActive =
-    location.pathname.includes('/explore/releases/') ||
-    location.pathname.includes('/preprod/');
 
   const {data: starredQueries} = useGetSavedQueries({
     starred: true,
@@ -123,7 +117,7 @@ export function ExploreSecondaryNavigation() {
             <SecondaryNavigation.ListItem>
               <SecondaryNavigation.Link
                 to={`${baseUrl}/releases/`}
-                isActive={isReleasesActive}
+                activeTo={[`${baseUrl}/releases/`, '/preprod/']}
                 analyticsItemName="explore_releases"
               >
                 {t('Releases')}

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -4,6 +4,7 @@ import {FeatureBadge} from '@sentry/scraps/badge';
 
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import {
@@ -15,8 +16,13 @@ import {ExploreSavedQueryNavigationItems} from 'sentry/views/navigation/secondar
 
 export function ExploreSecondaryNavigation() {
   const organization = useOrganization();
+  const location = useLocation();
 
   const baseUrl = `/organizations/${organization.slug}/explore`;
+
+  const isReleasesActive =
+    location.pathname.includes('/explore/releases/') ||
+    location.pathname.includes('/preprod/');
 
   const {data: starredQueries} = useGetSavedQueries({
     starred: true,
@@ -117,6 +123,7 @@ export function ExploreSecondaryNavigation() {
             <SecondaryNavigation.ListItem>
               <SecondaryNavigation.Link
                 to={`${baseUrl}/releases/`}
+                isActive={isReleasesActive}
                 analyticsItemName="explore_releases"
               >
                 {t('Releases')}

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -117,7 +117,10 @@ export function ExploreSecondaryNavigation() {
             <SecondaryNavigation.ListItem>
               <SecondaryNavigation.Link
                 to={`${baseUrl}/releases/`}
-                activeTo={[`${baseUrl}/releases/`, '/preprod/']}
+                activeTo={[
+                  `${baseUrl}/releases/`,
+                  `/organizations/${organization.slug}/preprod/`,
+                ]}
                 analyticsItemName="explore_releases"
               >
                 {t('Releases')}


### PR DESCRIPTION
Preprod pages such as `/preprod/snapshots/:id/` highlighted **Issues** in the left nav instead of Explore.

The active primary-nav group is derived from the first URL path segment via `PRIMARY_NAVIGATION_GROUP_CONFIG`. `preprod` was mapped to no group, so it fell through to the `issues` default. This adds `preprod` to the `explore` group, and forces the Explore > Releases secondary item to stay active on `/preprod/` paths — matching the existing `/snapshots/` → `/explore/releases/?tab=snapshots` redirect, since the secondary item's default `startsWith` matching can't bridge the two different URL prefixes.

This scopes all `/preprod/*` routes (size, install, comparison, snapshots) to Explore, which is correct — none belonged under Issues.