### PR TITLE
chore(event formatter): add llmFormat to endpoint

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -41,6 +41,7 @@ from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.endpoints.project_event_details import wrap_event_response
+from sentry.issues.formatting.mixin import FormattableResponseMixin, format_event_response
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -129,10 +130,11 @@ def issue_search_query_to_conditions(
 
 @extend_schema(tags=["Events"])
 @cell_silo_endpoint
-class GroupEventDetailsEndpoint(GroupEndpoint):
+class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
     }
+    formatter_adapter = staticmethod(format_event_response)
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
         limit_overrides={
@@ -153,6 +155,17 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             IssueParams.ISSUE_ID,
             GlobalParams.ENVIRONMENT,
             EventParams.EVENT_ID_EXTENDED,
+            OpenApiParameter(
+                name="llmFormat",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=str,
+                enum=["markdown", "xml"],
+                description=(
+                    "If set, adds a `formatted` field to the response with the event rendered "
+                    "as the requested format for LLM consumption."
+                ),
+            ),
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
-from typing import Any, TypedDict, cast
+from typing import Any, NotRequired, cast
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -42,7 +42,11 @@ from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.endpoints.project_event_details import wrap_event_response
 from sentry.issues.formatting.formatter import FormattedResponse
-from sentry.issues.formatting.mixin import FormattableResponseMixin, format_event_response
+from sentry.issues.formatting.mixin import (
+    VALID_FORMATS,
+    FormattableResponseMixin,
+    format_event_response,
+)
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.group import Group
@@ -129,15 +133,9 @@ def issue_search_query_to_conditions(
     return snql_conditions, resolved_legacy_conditions
 
 
-class _GroupEventDetailsFormattedResponseOptional(TypedDict, total=False):
-    # present only when ``?llmFormat`` is requested and the formatter option is on
-    formatted: FormattedResponse
-
-
-class GroupEventDetailsFormattedResponse(
-    GroupEventDetailsResponse, _GroupEventDetailsFormattedResponseOptional
-):
-    pass
+class GroupEventDetailsFormattedResponse(GroupEventDetailsResponse):
+    # present only when ``?llmFormat`` is requested and the formatter feature is on
+    formatted: NotRequired[FormattedResponse]
 
 
 @extend_schema(tags=["Events"])
@@ -172,7 +170,7 @@ class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
                 location=OpenApiParameter.QUERY,
                 required=False,
                 type=str,
-                enum=["markdown", "xml"],
+                enum=list(VALID_FORMATS),
                 description=(
                     "If set, adds a `formatted` field to the response with the event rendered "
                     "as the requested format for LLM consumption."

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
-from typing import Any, NotRequired
+from typing import Any, TypedDict, cast
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -129,9 +129,15 @@ def issue_search_query_to_conditions(
     return snql_conditions, resolved_legacy_conditions
 
 
-class GroupEventDetailsFormattedResponse(GroupEventDetailsResponse):
+class _GroupEventDetailsFormattedResponseOptional(TypedDict, total=False):
     # present only when ``?llmFormat`` is requested and the formatter option is on
-    formatted: NotRequired[FormattedResponse]
+    formatted: FormattedResponse
+
+
+class GroupEventDetailsFormattedResponse(
+    GroupEventDetailsResponse, _GroupEventDetailsFormattedResponseOptional
+):
+    pass
 
 
 @extend_schema(tags=["Events"])
@@ -306,4 +312,4 @@ class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
         )
         if data is None:
             return Response({"detail": "Failed to load event"}, status=500)
-        return Response(data)
+        return Response(cast(GroupEventDetailsFormattedResponse, data))

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
-from typing import Any, NotRequired, cast
+from typing import Any, cast
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -133,9 +133,12 @@ def issue_search_query_to_conditions(
     return snql_conditions, resolved_legacy_conditions
 
 
-class GroupEventDetailsFormattedResponse(GroupEventDetailsResponse):
+# total=False rather than NotRequired: this module uses `from __future__ import annotations`, so
+# NotRequired arrives as a string, TypedDict marks the key required, and the openapi schema then
+# fails the api-docs example validator. Inherited keys keep their own totality.
+class GroupEventDetailsFormattedResponse(GroupEventDetailsResponse, total=False):
     # present only when ``?llmFormat`` is requested and the formatter feature is on
-    formatted: NotRequired[FormattedResponse]
+    formatted: FormattedResponse
 
 
 @extend_schema(tags=["Events"])

--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, NotRequired
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -41,6 +41,7 @@ from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.endpoints.project_event_details import wrap_event_response
+from sentry.issues.formatting.formatter import FormattedResponse
 from sentry.issues.formatting.mixin import FormattableResponseMixin, format_event_response
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
@@ -128,6 +129,11 @@ def issue_search_query_to_conditions(
     return snql_conditions, resolved_legacy_conditions
 
 
+class GroupEventDetailsFormattedResponse(GroupEventDetailsResponse):
+    # present only when ``?llmFormat`` is requested and the formatter option is on
+    formatted: NotRequired[FormattedResponse]
+
+
 @extend_schema(tags=["Events"])
 @cell_silo_endpoint
 class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
@@ -169,7 +175,7 @@ class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
         ],
         responses={
             200: inline_sentry_response_serializer(
-                "IssueEventDetailsResponse", GroupEventDetailsResponse
+                "IssueEventDetailsResponse", GroupEventDetailsFormattedResponse
             ),
             400: RESPONSE_BAD_REQUEST,
             401: RESPONSE_UNAUTHORIZED,
@@ -186,7 +192,7 @@ class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
     def get(
         self, request: Request, group: Group, event_id: str
     ) -> (
-        Response[GroupEventDetailsResponse]
+        Response[GroupEventDetailsFormattedResponse]
         | Response[EventSerializerResponse]
         | Response[DetailResponse]
     ):

--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -1,0 +1,78 @@
+"""Renders a serialized autofix (Seer Issue Fix) state response into text, reusing the shared
+formatter primitives. Delivered over REST via ``FormattableResponseMixin`` on the autofix
+endpoint; mirrors the root-cause / solution / pull-request output that the MCP server and the
+issue-details UI each build today, so those consumers can share one implementation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from sentry.issues.formatting.formatter import Format, Formatter, get_formatter
+
+
+def _artifacts(autofix: Mapping[str, Any]) -> dict[str, Any]:
+    """Latest data per artifact key across the run's blocks (later wins), mirroring
+    ``SeerRunState.get_artifacts()``. Keys we render: ``root_cause``, ``solution``.
+    """
+    result: dict[str, Any] = {}
+    for block in autofix.get("blocks") or []:
+        for artifact in block.get("artifacts") or []:  # not every block has artifacts
+            if artifact.get("data") is not None:
+                result[artifact["key"]] = artifact["data"]
+    return result
+
+
+def _root_cause(data: Any, fmt: Formatter) -> str:
+    if not data:
+        return ""
+    parts: list[str] = []
+    if data.get("one_line_description"):
+        parts.append(data["one_line_description"])
+    whys = data.get("five_whys") or []
+    if whys:
+        parts.append("\n".join(f"{i}. {why}" for i, why in enumerate(whys, 1)))
+    steps = data.get("reproduction_steps") or []
+    if steps:
+        parts.append("\n".join(f"- {step}" for step in steps))
+    return fmt.block("Root Cause", "\n\n".join(parts)) if parts else ""
+
+
+def _solution(data: Any, fmt: Formatter) -> str:
+    if not data:
+        return ""
+    parts: list[str] = []
+    if data.get("one_line_summary"):
+        parts.append(data["one_line_summary"])
+    steps = [
+        f"- **{step.get('title', '')}**: {step.get('description', '')}"
+        for step in data.get("steps") or []
+    ]
+    if steps:
+        parts.append("\n".join(steps))
+    return fmt.block("Solution", "\n\n".join(parts)) if parts else ""
+
+
+def _pull_requests(autofix: Mapping[str, Any], fmt: Formatter) -> str:
+    lines = [
+        f"- {repo}: {pr['pr_url']}"
+        for repo, pr in (autofix.get("repo_pr_states") or {}).items()
+        if pr.get("pr_url")
+    ]
+    return fmt.block("Pull Requests", "\n".join(lines)) if lines else ""
+
+
+def format_autofix(data: Mapping[str, Any], format: Format = "markdown") -> str:
+    """Render a serialized autofix state response (``{"autofix": {...}}``) into text."""
+    autofix = data.get("autofix")
+    if not autofix:  # no autofix run on this issue yet
+        return ""
+    fmt = get_formatter(format)
+    artifacts = _artifacts(autofix)
+    parts = [
+        _root_cause(artifacts.get("root_cause"), fmt),
+        _solution(artifacts.get("solution"), fmt),
+        _pull_requests(autofix, fmt),
+    ]
+    return "\n\n".join(part for part in parts if part)

--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -1,7 +1,5 @@
 """Renders a serialized autofix (Seer Issue Fix) state response into text, reusing the shared
-formatter primitives. Delivered over REST via ``FormattableResponseMixin`` on the autofix
-endpoint; mirrors the root-cause / solution / pull-request output that the MCP server and the
-issue-details UI each build today, so those consumers can share one implementation.
+formatter primitives. Delivered over REST via ``FormattableResponseMixin`` on the autofix endpoint.
 """
 
 from __future__ import annotations
@@ -18,9 +16,8 @@ def _artifacts(autofix: Mapping[str, Any]) -> dict[str, Any]:
     """
     result: dict[str, Any] = {}
     for block in autofix.get("blocks") or []:
-        for artifact in block.get("artifacts") or []:  # not every block has artifacts
-            if artifact.get("data") is not None:
-                result[artifact["key"]] = artifact["data"]
+        for artifact in block.get("artifacts") or []:
+            result[artifact["key"]] = artifact.get("data")
     return result
 
 

--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -43,7 +43,7 @@ def _solution(data: Any, fmt: Formatter) -> str:
     if data.get("one_line_summary"):
         parts.append(data["one_line_summary"])
     steps = [
-        f"- **{step.get('title', '')}**: {step.get('description', '')}"
+        fmt.field(step.get("title") or "Step", step.get("description") or "")
         for step in data.get("steps") or []
     ]
     if steps:

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -9,6 +9,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
+from typing import Literal
 
 from sentry.issues.formatting.limits import Limits
 from sentry.issues.formatting.models import EventObject
@@ -83,3 +84,18 @@ class XmlFormatter(Formatter):
 
     def code_block(self, text: str) -> str:
         return f"<code>{text}</code>"
+
+
+Format = Literal["markdown", "xml"]
+
+_FORMATTERS: dict[Format, type[Formatter]] = {
+    "markdown": MarkdownFormatter,
+    "xml": XmlFormatter,
+}
+
+
+def get_formatter(format: Format) -> Formatter:
+    try:
+        return _FORMATTERS[format]()
+    except KeyError:
+        raise ValueError(f"unsupported format: {format!r}") from None

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -9,7 +9,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Literal
+from typing import Literal, TypedDict
 
 from sentry.issues.formatting.limits import Limits
 from sentry.issues.formatting.models import EventObject
@@ -87,6 +87,14 @@ class XmlFormatter(Formatter):
 
 
 Format = Literal["markdown", "xml"]
+
+
+class FormattedResponse(TypedDict):
+    """The ``formatted`` field the mixin adds to a response when ``?llmFormat`` is requested."""
+
+    format: Format
+    content: str
+
 
 _FORMATTERS: dict[Format, type[Formatter]] = {
     "markdown": MarkdownFormatter,

--- a/src/sentry/issues/formatting/limits.py
+++ b/src/sentry/issues/formatting/limits.py
@@ -26,3 +26,13 @@ LIMITS_DEFAULT = Limits(
     max_stacktrace_chars=20_000,
     max_spans_chars=5_000,
 )
+
+# tighter caps for token-constrained callers; mirrors Seer's EVENT_FORMAT_LIMITS_LOW
+LIMITS_LOW = Limits(
+    max_exceptions_chars=50_000,
+    max_stacktrace_chars=10_000,
+    max_breadcrumbs_chars=5_000,
+    max_single_breadcrumb_chars=500,
+    max_request_chars=2_000,
+    max_spans_chars=5_000,
+)

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -1,0 +1,77 @@
+"""REST delivery for the formatter.
+
+A mixin that adds a ``formatted`` field to an endpoint's JSON response when ``?format`` is
+requested. Endpoints opt in by setting ``formatter_adapter`` (serialized response -> text).
+Gated by the ``issues.standardized-markdown-for-llm`` option: when it's off the mixin is inert
+and the response is untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
+
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import options
+from sentry.issues.formatting.sections import Format, format_issue
+
+if TYPE_CHECKING:
+    # for typing, treat the super() chain as an Endpoint; runtime uses the real base via MRO
+    from sentry.api.base import Endpoint
+
+    _Base = Endpoint
+else:
+    _Base = object
+
+logger = logging.getLogger(__name__)
+
+FORMATTER_OPTION = "issues.standardized-markdown-for-llm"
+# not "format": DRF reserves that query param for renderer content-negotiation
+QUERY_PARAM = "llmFormat"
+_VALID_FORMATS: tuple[Format, ...] = ("markdown", "xml")
+
+
+class FormattableResponseMixin(_Base):
+    # maps this endpoint's serialized response dict + format into rendered text
+    formatter_adapter: Callable[[Mapping[str, Any], Format], str] | None = None
+
+    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
+        super().initial(request, *args, **kwargs)
+        if not options.get(FORMATTER_OPTION):
+            return
+        fmt = request.GET.get(QUERY_PARAM)
+        if fmt is not None and fmt not in _VALID_FORMATS:
+            raise ParseError(
+                f"Unsupported {QUERY_PARAM}: {fmt!r}. Expected one of {list(_VALID_FORMATS)}."
+            )
+
+    def finalize_response(
+        self, request: Request, response: Response, *args: Any, **kwargs: Any
+    ) -> Response:
+        response = super().finalize_response(request, response, *args, **kwargs)
+
+        adapter = self.formatter_adapter
+        fmt = request.GET.get(QUERY_PARAM)
+        if adapter is None or fmt not in _VALID_FORMATS or not options.get(FORMATTER_OPTION):
+            return response
+        if response.status_code != 200 or not isinstance(response.data, dict):
+            return response
+
+        try:
+            content = adapter(response.data, fmt)
+        except Exception:
+            # never let formatting turn a good response into a 5xx
+            logger.warning("formatter.render_failed", extra={"endpoint": type(self).__name__})
+            return response
+
+        response.data = {**response.data, "formatted": {"format": fmt, "content": content}}
+        return response
+
+
+def format_event_response(data: Mapping[str, Any], fmt: Format) -> str:
+    """Adapter for event endpoints: the serialized event is what ``format_issue`` consumes."""
+    return format_issue(data, format=fmt)

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -1,6 +1,6 @@
 """REST delivery for the formatter.
 
-A mixin that adds a ``formatted`` field to an endpoint's JSON response when ``?format`` is
+A mixin that adds a ``formatted`` field to an endpoint's JSON response when ``?llmFormat`` is
 requested. Endpoints opt in by setting ``formatter_adapter`` (serialized response -> text).
 Gated by the ``issues.standardized-markdown-for-llm`` option: when it's off the mixin is inert
 and the response is untouched.
@@ -12,7 +12,6 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any
 
-from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -38,16 +37,6 @@ _VALID_FORMATS: tuple[Format, ...] = ("markdown", "xml")
 class FormattableResponseMixin(_Base):
     # maps this endpoint's serialized response dict + format into rendered text
     formatter_adapter: Callable[[Mapping[str, Any], Format], str] | None = None
-
-    def initial(self, request: Request, *args: Any, **kwargs: Any) -> None:
-        super().initial(request, *args, **kwargs)
-        if not options.get(FORMATTER_OPTION):
-            return
-        fmt = request.GET.get(QUERY_PARAM)
-        if fmt is not None and fmt not in _VALID_FORMATS:
-            raise ParseError(
-                f"Unsupported {QUERY_PARAM}: {fmt!r}. Expected one of {list(_VALID_FORMATS)}."
-            )
 
     def finalize_response(
         self, request: Request, response: Response, *args: Any, **kwargs: Any

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -16,7 +16,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
-from sentry.issues.formatting.sections import Format, format_issue
+from sentry.issues.formatting.formatter import Format
+from sentry.issues.formatting.sections import format_issue
 
 if TYPE_CHECKING:
     # for typing, treat the super() chain as an Endpoint; runtime uses the real base via MRO

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -2,8 +2,8 @@
 
 A mixin that adds a ``formatted`` field to an endpoint's JSON response when ``?llmFormat`` is
 requested. Endpoints opt in by setting ``formatter_adapter`` (serialized response -> text).
-Gated by the ``issues.standardized-markdown-for-llm`` option: when it's off the mixin is inert
-and the response is untouched.
+Gated by the ``organizations:issue-standardized-markdown-for-llm`` feature: when it's off the
+mixin is inert and the response is untouched.
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
+from sentry import features
 from sentry.issues.formatting.formatter import Format
 from sentry.issues.formatting.sections import format_issue
 
@@ -29,7 +29,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
-FORMATTER_OPTION = "issues.standardized-markdown-for-llm"
+FORMATTER_FEATURE = "organizations:issue-standardized-markdown-for-llm"
 # not "format": DRF reserves that query param for renderer content-negotiation
 QUERY_PARAM = "llmFormat"
 _VALID_FORMATS: tuple[Format, ...] = ("markdown", "xml")
@@ -46,7 +46,13 @@ class FormattableResponseMixin(_Base):
 
         adapter = self.formatter_adapter
         fmt = request.GET.get(QUERY_PARAM)
-        if adapter is None or fmt not in _VALID_FORMATS or not options.get(FORMATTER_OPTION):
+        organization = getattr(request, "organization", None)
+        if (
+            adapter is None
+            or fmt not in _VALID_FORMATS
+            or organization is None
+            or not features.has(FORMATTER_FEATURE, organization, actor=request.user)
+        ):
             return response
         if response.status_code != 200 or not isinstance(response.data, dict):
             return response

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_args
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 FORMATTER_FEATURE = "organizations:issue-standardized-markdown-for-llm"
 # not "format": DRF reserves that query param for renderer content-negotiation
 QUERY_PARAM = "llmFormat"
-_VALID_FORMATS: tuple[Format, ...] = ("markdown", "xml")
+VALID_FORMATS: tuple[Format, ...] = get_args(Format)
 
 
 class FormattableResponseMixin(_Base):
@@ -50,7 +50,7 @@ class FormattableResponseMixin(_Base):
         organization = getattr(request, "organization", None)
         if (
             adapter is None
-            or fmt not in _VALID_FORMATS
+            or fmt not in VALID_FORMATS
             or organization is None
             or not features.has(FORMATTER_FEATURE, organization, actor=request.user)
         ):

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.issues.formatting.formatter import Format
 from sentry.issues.formatting.limits import LIMITS_LOW
-from sentry.issues.formatting.sections import format_issue
+from sentry.issues.formatting.sections import EVENT_SECTIONS_WITH_USER, format_issue
 
 if TYPE_CHECKING:
     # for typing, treat the super() chain as an Endpoint; runtime uses the real base via MRO
@@ -77,5 +77,8 @@ def format_event_response(data: Mapping[str, Any], fmt: Format) -> str:
     context (Copy to Markdown, the MCP), and these caps are what the copy-markdown builder
     already applies client-side. Callers that want the default profile use ``format_issue``
     directly, as the Seer RPC does.
+
+    Opts into the user identifiers the default section list holds back: this response already
+    carries ``user`` in full, so rendering it adds nothing the caller can't already read.
     """
-    return format_issue(data, format=fmt, limits=LIMITS_LOW)
+    return format_issue(data, format=fmt, sections=EVENT_SECTIONS_WITH_USER, limits=LIMITS_LOW)

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -61,8 +61,9 @@ class FormattableResponseMixin(_Base):
         try:
             content = adapter(response.data, fmt)
         except Exception:
-            # never let formatting turn a good response into a 5xx
-            logger.warning("formatter.render_failed", extra={"endpoint": type(self).__name__})
+            # never let formatting turn a good response into a 5xx, but keep the traceback:
+            # this path degrades silently, so without it a formatter bug is undiagnosable
+            logger.exception("formatter.render_failed", extra={"endpoint": type(self).__name__})
             return response
 
         response.data = {**response.data, "formatted": {"format": fmt, "content": content}}

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.issues.formatting.formatter import Format
+from sentry.issues.formatting.limits import LIMITS_LOW
 from sentry.issues.formatting.sections import format_issue
 
 if TYPE_CHECKING:
@@ -69,5 +70,11 @@ class FormattableResponseMixin(_Base):
 
 
 def format_event_response(data: Mapping[str, Any], fmt: Format) -> str:
-    """Adapter for event endpoints: the serialized event is what ``format_issue`` consumes."""
-    return format_issue(data, format=fmt)
+    """Adapter for event endpoints: the serialized event is what ``format_issue`` consumes.
+
+    Renders with the low limits because every ``?llmFormat`` consumer pastes into a model's
+    context (Copy to Markdown, the MCP), and these caps are what the copy-markdown builder
+    already applies client-side. Callers that want the default profile use ``format_issue``
+    directly, as the Seer RPC does.
+    """
+    return format_issue(data, format=fmt, limits=LIMITS_LOW)

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from datetime import UTC
-from typing import Any, Literal
+from typing import Any
 
 from sentry.issues.formatting.adapter import event_response_to_model
-from sentry.issues.formatting.formatter import Formatter, MarkdownFormatter, SectionFn, XmlFormatter
+from sentry.issues.formatting.formatter import Format, Formatter, SectionFn, get_formatter
 from sentry.issues.formatting.limits import LIMITS_DEFAULT, Limits
 from sentry.issues.formatting.models import EventObject, Frame, Stacktrace, contains_filtered
 
@@ -278,13 +278,6 @@ def spans_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
     return fmt.block("Span Evidence", _truncate("\n".join(lines), limits.max_spans_chars))
 
 
-Format = Literal["markdown", "xml"]
-
-_FORMATTERS: dict[Format, type[Formatter]] = {
-    "markdown": MarkdownFormatter,
-    "xml": XmlFormatter,
-}
-
 # every section in render order, including the user identifiers that ``EVENT_SECTIONS`` holds
 # back. Pass this only from a surface that already exposes those fields to its caller.
 EVENT_SECTIONS_WITH_USER: list[SectionFn] = [
@@ -319,14 +312,10 @@ def format_issue(
     Returns "" when the payload can't be adapted, matching how ``Formatter.render`` absorbs
     per-section failures, so a malformed event never takes down the caller.
     """
-    try:
-        formatter_cls = _FORMATTERS[format]
-    except KeyError:
-        raise ValueError(f"unsupported format: {format!r}") from None
-
+    formatter = get_formatter(format)
     try:
         model = event_response_to_model(data)
     except Exception:
         logger.exception("formatter.adapter_failed")
         return ""
-    return formatter_cls().render(model, sections, limits)
+    return formatter.render(model, sections, limits)

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, NotRequired, TypedDict, Union
+from typing import Annotated, Any, Literal, TypedDict, Union
 
 from pydantic import BaseModel, Field
 
@@ -38,9 +38,12 @@ class AutofixHandoffResponse(TypedDict):
     failures: list[dict[str, Any]]
 
 
-class AutofixStateResponse(TypedDict):
+class _AutofixStateResponseOptional(TypedDict, total=False):
+    # present only when ``?llmFormat`` is requested and the formatter option is on
+    formatted: FormattedResponse
+
+
+class AutofixStateResponse(_AutofixStateResponseOptional):
     """Response type for the GET endpoint"""
 
     autofix: dict[str, Any] | None
-    # present only when ``?llmFormat`` is requested and the formatter option is on
-    formatted: NotRequired[FormattedResponse]

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, TypedDict, Union
+from typing import Annotated, Any, Literal, NotRequired, TypedDict, Union
 
 from pydantic import BaseModel, Field
+
+from sentry.issues.formatting.formatter import FormattedResponse
 
 
 class GithubAppPermissionsWarning(BaseModel):
@@ -40,3 +42,5 @@ class AutofixStateResponse(TypedDict):
     """Response type for the GET endpoint"""
 
     autofix: dict[str, Any] | None
+    # present only when ``?llmFormat`` is requested and the formatter option is on
+    formatted: NotRequired[FormattedResponse]

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, TypedDict, Union
+from typing import Annotated, Any, Literal, NotRequired, TypedDict, Union
 
 from pydantic import BaseModel, Field
 
@@ -38,12 +38,9 @@ class AutofixHandoffResponse(TypedDict):
     failures: list[dict[str, Any]]
 
 
-class _AutofixStateResponseOptional(TypedDict, total=False):
-    # present only when ``?llmFormat`` is requested and the formatter option is on
-    formatted: FormattedResponse
-
-
-class AutofixStateResponse(_AutofixStateResponseOptional):
+class AutofixStateResponse(TypedDict):
     """Response type for the GET endpoint"""
 
     autofix: dict[str, Any] | None
+    # present only when ``?llmFormat`` is requested and the formatter feature is on
+    formatted: NotRequired[FormattedResponse]

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, NotRequired, TypedDict, Union
+from typing import Annotated, Any, Literal, TypedDict, Union
 
 from pydantic import BaseModel, Field
 
@@ -38,9 +38,17 @@ class AutofixHandoffResponse(TypedDict):
     failures: list[dict[str, Any]]
 
 
-class AutofixStateResponse(TypedDict):
+class _AutofixStateResponseOptional(TypedDict, total=False):
+    # present only when ``?llmFormat`` is requested and the formatter feature is on.
+    # total=False rather than NotRequired: this module uses `from __future__ import annotations`,
+    # so NotRequired arrives as a string, TypedDict marks the key required, and the openapi
+    # schema then fails the api-docs example validator.
+    formatted: FormattedResponse
+
+
+class AutofixStateResponse(_AutofixStateResponseOptional):
     """Response type for the GET endpoint"""
 
+    # can't fold into one `total=False` class the way GroupEventDetailsFormattedResponse does:
+    # `autofix` is declared here, so it would go optional too
     autofix: dict[str, Any] | None
-    # present only when ``?llmFormat`` is requested and the formatter feature is on
-    formatted: NotRequired[FormattedResponse]

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -39,7 +39,7 @@ from sentry.issues.action_log import (
 from sentry.issues.action_log.types import GroupActorType
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.issues.formatting.autofix import format_autofix
-from sentry.issues.formatting.mixin import FormattableResponseMixin
+from sentry.issues.formatting.mixin import VALID_FORMATS, FormattableResponseMixin
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
@@ -500,7 +500,7 @@ class GroupAutofixEndpoint(FormattableResponseMixin, GroupAiEndpoint):
                 location=OpenApiParameter.QUERY,
                 required=False,
                 type=str,
-                enum=["markdown", "xml"],
+                enum=list(VALID_FORMATS),
                 description=(
                     "If set, adds a `formatted` field to the response with the autofix rendered "
                     "as the requested format for LLM consumption."

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from typing import Any
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -39,6 +39,8 @@ from sentry.issues.action_log import (
 from sentry.issues.action_log.types import GroupActorType
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.activity import Activity
+from sentry.issues.formatting.autofix import format_autofix
+from sentry.issues.formatting.mixin import FormattableResponseMixin
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix_agent import (
@@ -184,11 +186,12 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
 
 @cell_silo_endpoint
 @extend_schema(tags=["Seer"])
-class GroupAutofixEndpoint(GroupAiEndpoint):
+class GroupAutofixEndpoint(FormattableResponseMixin, GroupAiEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
         "GET": ApiPublishStatus.PUBLIC,
     }
+    formatter_adapter = staticmethod(format_autofix)
     owner = ApiOwner.ML_AI
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
@@ -492,6 +495,17 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             IssueParams.ISSUES_OR_GROUPS,
             IssueParams.ISSUE_ID,
+            OpenApiParameter(
+                name="llmFormat",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=str,
+                enum=["markdown", "xml"],
+                description=(
+                    "If set, adds a `formatted` field to the response with the autofix rendered "
+                    "as the requested format for LLM consumption."
+                ),
+            ),
         ],
         responses={
             200: inline_sentry_response_serializer("AutofixStateResponse", AutofixStateResponse),

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -38,9 +38,9 @@ from sentry.issues.action_log import (
 )
 from sentry.issues.action_log.types import GroupActorType
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
-from sentry.models.activity import Activity
 from sentry.issues.formatting.autofix import format_autofix
 from sentry.issues.formatting.mixin import FormattableResponseMixin
+from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix_agent import (

--- a/tests/sentry/issues/formatting/test_autofix.py
+++ b/tests/sentry/issues/formatting/test_autofix.py
@@ -49,9 +49,18 @@ def test_markdown_renders_root_cause_solution_and_prs() -> None:
     assert "1. parse fails" in out
     assert "- call crash()" in out
     assert "## Solution" in out
-    assert "- **Update regex**: Allow alphanumerics" in out
+    assert "**Update regex:** Allow alphanumerics" in out
     assert "## Pull Requests" in out
     assert "- getsentry/sentry: https://github.com/getsentry/sentry/pull/1" in out
+
+
+def test_xml_renders_solution_steps_with_field_tags() -> None:
+    out = format_autofix(_autofix_response(), format="xml")
+    assert "<root_cause>" in out
+    assert "<solution>" in out
+    assert "<update_regex>Allow alphanumerics</update_regex>" in out
+    assert "**" not in out
+    assert "<pull_requests>" in out
 
 
 def test_no_autofix_run_returns_empty() -> None:

--- a/tests/sentry/issues/formatting/test_autofix.py
+++ b/tests/sentry/issues/formatting/test_autofix.py
@@ -46,19 +46,12 @@ def test_markdown_renders_root_cause_solution_and_prs() -> None:
     out = format_autofix(_autofix_response())
     assert "## Root Cause" in out
     assert "The device id is parsed with the wrong regex." in out
-    assert "1. parse fails" in out  # numbered five whys
-    assert "- call crash()" in out  # bulleted reproduction steps
+    assert "1. parse fails" in out
+    assert "- call crash()" in out
     assert "## Solution" in out
     assert "- **Update regex**: Allow alphanumerics" in out
     assert "## Pull Requests" in out
     assert "- getsentry/sentry: https://github.com/getsentry/sentry/pull/1" in out
-
-
-def test_xml_format() -> None:
-    out = format_autofix(_autofix_response(), "xml")
-    assert "<root_cause>" in out
-    assert "<solution>" in out
-    assert "<pull_requests>" in out
 
 
 def test_no_autofix_run_returns_empty() -> None:

--- a/tests/sentry/issues/formatting/test_autofix.py
+++ b/tests/sentry/issues/formatting/test_autofix.py
@@ -1,0 +1,94 @@
+from typing import Any
+
+from sentry.issues.formatting.autofix import format_autofix
+
+
+def _autofix_response(**overrides: Any) -> dict[str, Any]:
+    autofix: dict[str, Any] = {
+        "run_id": 1,
+        "status": "COMPLETED",
+        "blocks": [
+            {
+                "artifacts": [
+                    {
+                        "key": "root_cause",
+                        "data": {
+                            "one_line_description": "The device id is parsed with the wrong regex.",
+                            "five_whys": ["parse fails", "regex too strict"],
+                            "reproduction_steps": ["call crash()", "observe RuntimeError"],
+                        },
+                    }
+                ]
+            },
+            {
+                "artifacts": [
+                    {
+                        "key": "solution",
+                        "data": {
+                            "one_line_summary": "Loosen the device id regex.",
+                            "steps": [
+                                {"title": "Update regex", "description": "Allow alphanumerics"},
+                            ],
+                        },
+                    }
+                ]
+            },
+        ],
+        "repo_pr_states": {
+            "getsentry/sentry": {"pr_url": "https://github.com/getsentry/sentry/pull/1"}
+        },
+    }
+    autofix.update(overrides)
+    return {"autofix": autofix}
+
+
+def test_markdown_renders_root_cause_solution_and_prs() -> None:
+    out = format_autofix(_autofix_response())
+    assert "## Root Cause" in out
+    assert "The device id is parsed with the wrong regex." in out
+    assert "1. parse fails" in out  # numbered five whys
+    assert "- call crash()" in out  # bulleted reproduction steps
+    assert "## Solution" in out
+    assert "- **Update regex**: Allow alphanumerics" in out
+    assert "## Pull Requests" in out
+    assert "- getsentry/sentry: https://github.com/getsentry/sentry/pull/1" in out
+
+
+def test_xml_format() -> None:
+    out = format_autofix(_autofix_response(), "xml")
+    assert "<root_cause>" in out
+    assert "<solution>" in out
+    assert "<pull_requests>" in out
+
+
+def test_no_autofix_run_returns_empty() -> None:
+    assert format_autofix({"autofix": None}) == ""
+    assert format_autofix({}) == ""
+
+
+def test_only_present_sections_render() -> None:
+    # a run with a root cause but no solution / PRs yet
+    data = _autofix_response(
+        blocks=[
+            {"artifacts": [{"key": "root_cause", "data": {"one_line_description": "boom"}}]},
+        ],
+        repo_pr_states={},
+    )
+    out = format_autofix(data)
+    assert "## Root Cause" in out
+    assert "## Solution" not in out
+    assert "## Pull Requests" not in out
+
+
+def test_latest_artifact_per_key_wins() -> None:
+    # two root_cause artifacts across blocks; the later one should win
+    data = _autofix_response(
+        blocks=[
+            {"artifacts": [{"key": "root_cause", "data": {"one_line_description": "old"}}]},
+            {"artifacts": [{"key": "root_cause", "data": {"one_line_description": "new"}}]},
+        ],
+        repo_pr_states={},
+    )
+    out = format_autofix(data)
+    assert "new" in out
+    assert "old" not in out

--- a/tests/sentry/issues/formatting/test_mixin.py
+++ b/tests/sentry/issues/formatting/test_mixin.py
@@ -21,3 +21,12 @@ def test_rest_output_uses_the_low_limits() -> None:
     out = format_event_response(_event_with_request_body(5_000), "markdown")
     assert "... (truncated)" in out
     assert len(out) < 3_000  # max_request_chars=2_000, plus the surrounding section
+
+
+def test_rest_output_opts_into_user_identifiers() -> None:
+    # the ?llmFormat response already carries `user` in full, so rendering those fields adds
+    # nothing the caller can't read -- unlike the default list, which holds them back
+    data = {"title": "t", "user": {"email": "someone@example.com", "ipAddress": "203.0.113.7"}}
+    out = format_event_response(data, "markdown")
+    assert "someone@example.com" in out
+    assert "203.0.113.7" in out

--- a/tests/sentry/issues/formatting/test_mixin.py
+++ b/tests/sentry/issues/formatting/test_mixin.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from sentry.issues.formatting.mixin import format_event_response
+
+
+def _event_with_request_body(body_chars: int) -> dict[str, Any]:
+    return {
+        "title": "t",
+        "entries": [
+            {
+                "type": "request",
+                "data": {"method": "POST", "url": "https://x.com", "data": "x" * body_chars},
+            }
+        ],
+    }
+
+
+def test_rest_output_uses_the_low_limits() -> None:
+    # the ?llmFormat response is pasted into a model's context, so it renders with the tighter
+    # profile rather than the default one the Seer RPC gets
+    out = format_event_response(_event_with_request_body(5_000), "markdown")
+    assert "... (truncated)" in out
+    assert len(out) < 3_000  # max_request_chars=2_000, plus the surrounding section

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -158,19 +158,6 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert "## Solution" in content
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
-    def test_get_llm_format_ignored_when_option_off(self, mock_get_explorer_state):
-        group = self.create_group()
-        mock_get_explorer_state.return_value = SeerRunState(
-            run_id=888, blocks=[], status="completed", updated_at="2023-07-18T12:00:00Z"
-        )
-
-        self.login_as(user=self.user)
-        response = self.client.get(self._get_url(group.id) + "?llmFormat=markdown", format="json")
-
-        assert response.status_code == 200, response.data
-        assert "formatted" not in response.data
-
-    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
     def test_get_handles_block_with_null_metadata(self, mock_get_explorer_state):
         group = self.create_group()
         mock_get_explorer_state.return_value = SeerRunState(

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -6,6 +6,7 @@ from sentry.integrations.types import ExternalProviders
 from sentry.issues.action_log.types import GroupActionActor, TriggerAutofixAction
 from sentry.models.activity import Activity
 from sentry.seer.agent.client_models import (
+    Artifact,
     CodingAgentState,
     MemoryBlock,
     Message,
@@ -19,6 +20,7 @@ from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.action_log import capture_action_log
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -106,6 +108,67 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             ]
         ):
             assert get_flags() == (True, True)
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_llm_format_adds_formatted_field(self, mock_get_explorer_state):
+        group = self.create_group()
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888,
+            blocks=[
+                MemoryBlock(
+                    id="block-1",
+                    message=Message(role="assistant", content="", metadata=None),
+                    timestamp="2023-07-18T12:00:00Z",
+                    artifacts=[
+                        Artifact(
+                            key="root_cause",
+                            reason="",
+                            data={
+                                "one_line_description": "regex too strict",
+                                "five_whys": ["parse fails"],
+                                "reproduction_steps": ["call crash()"],
+                            },
+                        ),
+                        Artifact(
+                            key="solution",
+                            reason="",
+                            data={
+                                "one_line_summary": "loosen regex",
+                                "steps": [{"title": "Update regex", "description": "allow alnum"}],
+                            },
+                        ),
+                    ],
+                )
+            ],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+        )
+
+        self.login_as(user=self.user)
+        with override_options({"issues.standardized-markdown-for-llm": True}):
+            response = self.client.get(
+                self._get_url(group.id) + "?llmFormat=markdown", format="json"
+            )
+
+        assert response.status_code == 200, response.data
+        assert response.data["formatted"]["format"] == "markdown"
+        content = response.data["formatted"]["content"]
+        assert "## Root Cause" in content
+        assert "regex too strict" in content
+        assert "## Solution" in content
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_llm_format_ignored_when_option_off(self, mock_get_explorer_state):
+        group = self.create_group()
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888, blocks=[], status="completed", updated_at="2023-07-18T12:00:00Z"
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.get(self._get_url(group.id) + "?llmFormat=markdown", format="json")
+
+        assert response.status_code == 200, response.data
+        assert "formatted" not in response.data
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
     def test_get_handles_block_with_null_metadata(self, mock_get_explorer_state):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -20,7 +20,6 @@ from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.action_log import capture_action_log
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -145,7 +144,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        with override_options({"issues.standardized-markdown-for-llm": True}):
+        with self.feature("organizations:issue-standardized-markdown-for-llm"):
             response = self.client.get(
                 self._get_url(group.id) + "?llmFormat=markdown", format="json"
             )

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -165,14 +165,16 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         assert "formatted" not in response.data
 
     def test_format_ignored_when_option_off(self) -> None:
-        # option defaults off -> ?format is inert, response unchanged
+        # option defaults off -> ?llmFormat is inert, response unchanged
         response = self.client.get(self._latest_url("?llmFormat=markdown"))
 
         assert response.status_code == 200
         assert "formatted" not in response.data
 
-    def test_invalid_format_returns_400(self) -> None:
+    def test_invalid_format_is_ignored(self) -> None:
+        # an unrecognized value is inert, not a 400 -> response is unchanged
         with override_options(FORMATTER_ON):
             response = self.client.get(self._latest_url("?llmFormat=banana"))
 
-        assert response.status_code == 400
+        assert response.status_code == 200
+        assert "formatted" not in response.data

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -1,6 +1,9 @@
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
+
+FORMATTER_ON = {"issues.standardized-markdown-for-llm": True}
 
 
 class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
@@ -129,4 +132,47 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         assert event.group is not None
         url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/{event.event_id}/"
         response = self.client.get(url, format="json", data={"query": "release.version:foobar"})
+        assert response.status_code == 400
+
+    def _latest_url(self, query: str = "") -> str:
+        base = (
+            f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/events/latest/"
+        )
+        return base + query
+
+    def test_format_markdown_adds_formatted_field(self) -> None:
+        with override_options(FORMATTER_ON):
+            response = self.client.get(self._latest_url("?llmFormat=markdown"))
+
+        assert response.status_code == 200
+        assert response.data["id"] == str(self.event2.event_id)  # normal response intact
+        assert response.data["formatted"]["format"] == "markdown"
+        assert "## Title" in response.data["formatted"]["content"]
+
+    def test_format_xml(self) -> None:
+        with override_options(FORMATTER_ON):
+            response = self.client.get(self._latest_url("?llmFormat=xml"))
+
+        assert response.status_code == 200
+        assert response.data["formatted"]["format"] == "xml"
+        assert "<title>" in response.data["formatted"]["content"]
+
+    def test_no_format_param_has_no_formatted_field(self) -> None:
+        with override_options(FORMATTER_ON):
+            response = self.client.get(self._latest_url())
+
+        assert response.status_code == 200
+        assert "formatted" not in response.data
+
+    def test_format_ignored_when_option_off(self) -> None:
+        # option defaults off -> ?format is inert, response unchanged
+        response = self.client.get(self._latest_url("?llmFormat=markdown"))
+
+        assert response.status_code == 200
+        assert "formatted" not in response.data
+
+    def test_invalid_format_returns_400(self) -> None:
+        with override_options(FORMATTER_ON):
+            response = self.client.get(self._latest_url("?llmFormat=banana"))
+
         assert response.status_code == 400

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -145,17 +145,9 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
             response = self.client.get(self._latest_url("?llmFormat=markdown"))
 
         assert response.status_code == 200
-        assert response.data["id"] == str(self.event2.event_id)  # normal response intact
+        assert response.data["id"] == str(self.event2.event_id)
         assert response.data["formatted"]["format"] == "markdown"
         assert "## Title" in response.data["formatted"]["content"]
-
-    def test_format_xml(self) -> None:
-        with override_options(FORMATTER_ON):
-            response = self.client.get(self._latest_url("?llmFormat=xml"))
-
-        assert response.status_code == 200
-        assert response.data["formatted"]["format"] == "xml"
-        assert "<title>" in response.data["formatted"]["content"]
 
     def test_no_format_param_has_no_formatted_field(self) -> None:
         with override_options(FORMATTER_ON):

--- a/tests/snuba/api/endpoints/test_group_event_details.py
+++ b/tests/snuba/api/endpoints/test_group_event_details.py
@@ -1,9 +1,8 @@
 from sentry.models.group import Group
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
 
-FORMATTER_ON = {"issues.standardized-markdown-for-llm": True}
+FORMATTER_FEATURE = "organizations:issue-standardized-markdown-for-llm"
 
 
 class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase):
@@ -141,7 +140,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         return base + query
 
     def test_format_markdown_adds_formatted_field(self) -> None:
-        with override_options(FORMATTER_ON):
+        with self.feature(FORMATTER_FEATURE):
             response = self.client.get(self._latest_url("?llmFormat=markdown"))
 
         assert response.status_code == 200
@@ -150,14 +149,14 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
         assert "## Title" in response.data["formatted"]["content"]
 
     def test_no_format_param_has_no_formatted_field(self) -> None:
-        with override_options(FORMATTER_ON):
+        with self.feature(FORMATTER_FEATURE):
             response = self.client.get(self._latest_url())
 
         assert response.status_code == 200
         assert "formatted" not in response.data
 
-    def test_format_ignored_when_option_off(self) -> None:
-        # option defaults off -> ?llmFormat is inert, response unchanged
+    def test_format_ignored_when_feature_off(self) -> None:
+        # feature defaults off -> ?llmFormat is inert, response unchanged
         response = self.client.get(self._latest_url("?llmFormat=markdown"))
 
         assert response.status_code == 200
@@ -165,7 +164,7 @@ class GroupEventDetailsTest(APITestCase, SnubaTestCase, PerformanceIssueTestCase
 
     def test_invalid_format_is_ignored(self) -> None:
         # an unrecognized value is inert, not a 400 -> response is unchanged
-        with override_options(FORMATTER_ON):
+        with self.feature(FORMATTER_FEATURE):
             response = self.client.get(self._latest_url("?llmFormat=banana"))
 
         assert response.status_code == 200


### PR DESCRIPTION
to be merged after #119250

 Adds a reusable `FormattableResponseMixin` that lets an endpoint return LLM-ready formatted output. When a request passes `?llmFormat=markdown` (or xml), the endpoint includes a new formatted: `{format, content}` field in its JSON response, rendered by the shared formatter. Existing response fields are unchanged. Wires this into the group event details endpoint and the autofix endpoint (group_ai_autofix).

No behavioral change on merge. behind the `issues.standardized-markdown-for-llm` option. Rollout will happen gradually via feature flag.