### PR TITLE
fix(explore): Preserve compact span count rendering

### DIFF
--- a/static/app/views/explore/tables/aggregatesTable.spec.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.spec.tsx
@@ -210,7 +210,7 @@ describe('AggregatesTable', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('uses validated field types for aggregate table actions', async () => {
+  it('uses validated field types when aggregate metadata is missing', async () => {
     const eventView = EventView.fromLocation(
       LocationFixture({
         query: {
@@ -233,7 +233,6 @@ describe('AggregatesTable', () => {
             ],
             meta: {
               fields: {
-                'sentry.duration': FieldValueType.STRING,
                 'count()': FieldValueType.INTEGER,
               },
               units: {},
@@ -313,5 +312,46 @@ describe('AggregatesTable', () => {
 
     expect(screen.getByText('count(spans)')).toBeInTheDocument();
     expect(screen.queryByText(aggregate)).not.toBeInTheDocument();
+  });
+
+  it('abbreviates span counts when validation returns a less specific type', () => {
+    const aggregate = 'count(span.duration)';
+    const eventView = EventView.fromLocation(
+      LocationFixture({query: {field: ['span.op', aggregate]}})
+    );
+
+    render(
+      <AggregatesTableWithParamsProvider
+        validatedFieldTypes={{[aggregate]: FieldValueType.NUMBER}}
+        aggregatesTableResult={createAggregatesTableResult({
+          eventView,
+          result: {
+            data: [{'span.op': 'http', [aggregate]: 7_800_800}],
+            meta: {
+              fields: {
+                'span.op': FieldValueType.STRING,
+                [aggregate]: FieldValueType.INTEGER,
+              },
+              units: {},
+            },
+          },
+        })}
+      />,
+      {
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              visualize: JSON.stringify({yAxes: [aggregate]}),
+            },
+          },
+        },
+        organization,
+      }
+    );
+
+    expect(screen.getByText('7.8M')).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -5,7 +5,7 @@ import {FieldValueType} from 'sentry/utils/fields';
 import {addValidatedFieldTypesToMeta} from 'sentry/views/explore/tables/spansTable';
 
 describe('addValidatedFieldTypesToMeta', () => {
-  it('uses validated field types over table meta field types', () => {
+  it('preserves table meta field types over validated field types', () => {
     const meta = addValidatedFieldTypesToMeta({
       meta: {
         fields: {
@@ -20,7 +20,7 @@ describe('addValidatedFieldTypesToMeta', () => {
     });
 
     expect(meta.fields).toEqual({
-      'custom.duration': FieldValueType.NUMBER,
+      'custom.duration': FieldValueType.STRING,
       id: FieldValueType.STRING,
       'span.op': FieldValueType.STRING,
     });
@@ -40,7 +40,7 @@ describe('addValidatedFieldTypesToMeta', () => {
       LocationFixture({query: {field: ['sentry.duration']}})
     );
     const meta = addValidatedFieldTypesToMeta({
-      meta: {fields: {'sentry.duration': FieldValueType.STRING}},
+      meta: {fields: {}},
       validatedFieldTypes: {'sentry.duration': FieldValueType.NUMBER},
     });
 

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -198,7 +198,8 @@ export function addValidatedFieldTypesToMeta({
   const fields = {...meta?.fields};
 
   for (const [field, validatedType] of Object.entries(validatedFieldTypes)) {
-    fields[field] = getFieldDefinition(field, 'span')?.valueType ?? validatedType;
+    fields[field] =
+      getFieldDefinition(field, 'span')?.valueType ?? fields[field] ?? validatedType;
   }
 
   return {...meta, fields};


### PR DESCRIPTION
Span aggregate tables now preserve known field definitions and query response metadata before falling back to validation types. This keeps count aggregates typed as integers and restores compact values such as 7.8M instead of 7,800,800.

The validation endpoint intentionally returns the broader number type for numeric fields, so it remains useful when response metadata is missing without replacing more precise local information. Regression coverage verifies both the fallback behavior and compact count rendering.