### PR TITLE
fix(consumers): propagate tags to all threads

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -602,6 +602,7 @@ def basic_consumer(
         logging.getLogger("arroyo").setLevel(log_level.upper())
 
     add_global_tags(
+        all_threads=True,
         set_sentry_tags=True,
         tags={
             "kafka_topic": topic,


### PR DESCRIPTION
Currently, our Arroyo producer metrics are only tagged by `consumer_group` for multiprocessing consumers. Non-multiprocessing consumers show `consumer_group:N/A`, indicating the tag isn't being sent: https://app.datadoghq.com/s/FH6-Y3/hcs-z9c-bph

Multiprocessing consumers run their own instance of `add_global_tags(all_threads=True)` here: https://github.com/getsentry/sentry/blob/master/src/sentry/utils/arroyo.py#L141

I believe `all_threads` is necessary for producer metrics to get tagged properly, since the Arroyo `KafkaProducer` polls rdkafka (and so runs the metric callback) in a separate thread: https://github.com/getsentry/arroyo/blob/main/arroyo/backends/kafka/consumer.py#L779

I'm not sure if the multiprocessing instance of `add_global_tags()` is still needed after this change, since it only propagates existing tags as global tags: https://github.com/getsentry/sentry/blob/master/src/sentry/utils/arroyo.py#L119
But IMO it can't hurt to keep them both.