### PR TITLE
fix(seer): Log every disqualifying reason for skipped night shift projects

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -475,7 +475,9 @@ def _get_eligible_projects(
 
     eligible: list[EligibleProject] = []
     for pid, project in project_map.items():
-        pref = preferences[pid]
+        pref = preferences.get(pid)
+        if pref is None:
+            continue
         tweaks = get_night_shift_tweaks(project)
         stopping_point = AutofixStoppingPoint(
             pref.automated_run_stopping_point or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -481,9 +481,6 @@ def _get_eligible_projects(
             pref.automated_run_stopping_point or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
         )
 
-        # Collect every disqualifying condition instead of stopping at the
-        # first one, so a project stuck on multiple settings doesn't look
-        # newly-broken each time an earlier one gets fixed.
         reasons: list[str] = []
         if not pref.repositories:
             reasons.append("no_connected_repos")

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -473,48 +473,53 @@ def _get_eligible_projects(
 
     preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
-    with_automation = [
-        project_map[pid]
-        for pid, pref in preferences.items()
-        if pref.repositories
-        and pref.autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
-    ]
-    if not with_automation:
-        return []
-
-    eligible = [
-        EligibleProject(
-            project=p,
-            tweaks=get_night_shift_tweaks(p),
-            stopping_point=AutofixStoppingPoint(
-                preferences[p.id].automated_run_stopping_point
-                or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
-            ),
-            connected_repos=[
-                f"{repo.owner}/{repo.name}" for repo in preferences[p.id].repositories
-            ],
+    eligible: list[EligibleProject] = []
+    for pid, project in project_map.items():
+        pref = preferences[pid]
+        tweaks = get_night_shift_tweaks(project)
+        stopping_point = AutofixStoppingPoint(
+            pref.automated_run_stopping_point or SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
         )
-        for p in with_automation
-    ]
-    if source == "cron":
-        eligible = [ep for ep in eligible if ep.tweaks.enabled]
 
-    # Night shift's only output is a PR, so drop projects that don't stop at
-    # open_pr; log the stopping point to surface misconfigured UX.
-    pr_producing: list[EligibleProject] = []
-    for ep in eligible:
-        if ep.stopping_point == AutofixStoppingPoint.OPEN_PR:
-            pr_producing.append(ep)
+        # Collect every disqualifying condition instead of stopping at the
+        # first one, so a project stuck on multiple settings doesn't look
+        # newly-broken each time an earlier one gets fixed.
+        reasons: list[str] = []
+        if not pref.repositories:
+            reasons.append("no_connected_repos")
+        if pref.autofix_automation_tuning == AutofixAutomationTuningSettings.OFF:
+            reasons.append("automation_tuning_off")
+        if source == "cron" and not tweaks.enabled:
+            reasons.append("tweaks_disabled")
+        if stopping_point != AutofixStoppingPoint.OPEN_PR:
+            # Night shift's only output is a PR, so a project that stops
+            # short of open_pr can never produce a usable result.
+            reasons.append("not_pr_producing")
+
+        if reasons:
+            logger.info(
+                "night_shift.project_filtered",
+                extra={
+                    "organization_id": organization.id,
+                    "project_id": pid,
+                    "reasons": reasons,
+                    "automation_tuning": pref.autofix_automation_tuning.value,
+                    "tweaks_enabled": tweaks.enabled,
+                    "stopping_point": stopping_point.value,
+                },
+            )
             continue
-        logger.info(
-            "night_shift.project_filtered.not_pr_producing",
-            extra={
-                "organization_id": organization.id,
-                "project_id": ep.project.id,
-                "stopping_point": ep.stopping_point.value,
-            },
+
+        eligible.append(
+            EligibleProject(
+                project=project,
+                tweaks=tweaks,
+                stopping_point=stopping_point,
+                connected_repos=[f"{repo.owner}/{repo.name}" for repo in pref.repositories],
+            )
         )
-    return pr_producing
+
+    return eligible
 
 
 def _should_use_per_project_quotas(source: NightShiftRunSource, organization_id: int) -> bool:

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -281,7 +281,9 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         # Eligible on every gate.
         eligible = self._make_eligible(self.create_project(organization=org))
 
-        # Automation off (even with a connected repo).
+        # Automation off (even with a connected repo), and never given a
+        # stopping point (defaults to code_changes, not open_pr) — fails two
+        # gates at once, so the resulting log call should list both reasons.
         off = self.create_project(organization=org)
         off.update_option("sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF)
         off_repo = self.create_repo(project=off, provider="github", name="owner/off-repo")
@@ -290,10 +292,18 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         # No connected repo.
         self.create_project(organization=org)
 
-        result = _get_eligible_projects(org, "manual")
+        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
+            result = _get_eligible_projects(org, "manual")
 
         assert [ep.project for ep in result] == [eligible]
         assert result[0].tweaks.enabled is True
+
+        off_extra = next(
+            call.kwargs["extra"]
+            for call in mock_logger.info.call_args_list
+            if call.kwargs["extra"]["project_id"] == off.id
+        )
+        assert off_extra["reasons"] == ["automation_tuning_off", "not_pr_producing"]
 
     def test_carries_each_projects_connected_repos(self) -> None:
         org = self.create_organization()
@@ -360,38 +370,6 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
 
         assert [ep.project.slug for ep in cron_result] == ["keep"]
         assert sorted(ep.project.slug for ep in manual_result) == ["drop", "keep"]
-
-    def test_logs_every_disqualifying_reason_at_once(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
-        )
-        project.update_option(
-            "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.CODE_CHANGES.value
-        )
-        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": False})
-
-        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
-            result = _get_eligible_projects(org, "cron")
-
-        assert result == []
-        mock_logger.info.assert_called_once_with(
-            "night_shift.project_filtered",
-            extra={
-                "organization_id": org.id,
-                "project_id": project.id,
-                "reasons": [
-                    "no_connected_repos",
-                    "automation_tuning_off",
-                    "tweaks_disabled",
-                    "not_pr_producing",
-                ],
-                "automation_tuning": AutofixAutomationTuningSettings.OFF.value,
-                "tweaks_enabled": False,
-                "stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
-            },
-        )
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -361,6 +361,38 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         assert [ep.project.slug for ep in cron_result] == ["keep"]
         assert sorted(ep.project.slug for ep in manual_result) == ["drop", "keep"]
 
+    def test_logs_every_disqualifying_reason_at_once(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
+        )
+        project.update_option(
+            "sentry:seer_automated_run_stopping_point", AutofixStoppingPoint.CODE_CHANGES.value
+        )
+        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": False})
+
+        with patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger:
+            result = _get_eligible_projects(org, "cron")
+
+        assert result == []
+        mock_logger.info.assert_called_once_with(
+            "night_shift.project_filtered",
+            extra={
+                "organization_id": org.id,
+                "project_id": project.id,
+                "reasons": [
+                    "no_connected_repos",
+                    "automation_tuning_off",
+                    "tweaks_disabled",
+                    "not_pr_producing",
+                ],
+                "automation_tuning": AutofixAutomationTuningSettings.OFF.value,
+                "tweaks_enabled": False,
+                "stopping_point": AutofixStoppingPoint.CODE_CHANGES.value,
+            },
+        )
+
 
 @django_db_all
 class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -5,7 +5,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.models.group import Group
 from sentry.models.organization import OrganizationStatus
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
@@ -370,6 +370,27 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
 
         assert [ep.project.slug for ep in cron_result] == ["keep"]
         assert sorted(ep.project.slug for ep in manual_result) == ["drop", "keep"]
+
+    def test_skips_project_missing_from_preferences_lookup(self) -> None:
+        """project_map and preferences come from separate queries, so a
+        project absent from the preferences result (e.g. deleted in the gap
+        between the two queries) must be skipped, not raise a KeyError."""
+        org = self.create_organization()
+        present = self._make_eligible(self.create_project(organization=org))
+        missing = self._make_eligible(self.create_project(organization=org))
+
+        real_preferences = bulk_read_preferences_from_sentry_db(org.id, [present.id, missing.id])
+        stale_preferences = {
+            pid: pref for pid, pref in real_preferences.items() if pid != missing.id
+        }
+
+        with patch(
+            "sentry.tasks.seer.night_shift.cron.bulk_read_preferences_from_sentry_db",
+            return_value=stale_preferences,
+        ):
+            result = _get_eligible_projects(org, "manual")
+
+        assert [ep.project for ep in result] == [present]
 
 
 @django_db_all


### PR DESCRIPTION
## Summary
- `_get_eligible_projects` previously filtered out ineligible projects through a chain of list comprehensions, logging only the last-applied filter (`night_shift.project_filtered.not_pr_producing`). A project failing multiple gates only ever surfaced one reason, so fixing it looked like it "broke" again once the next gate was hit.
- Evaluate all four project-level gates per project (connected repos, automation tuning, night shift tweaks, stopping point) and log a single `night_shift.project_filtered` event with the full list of applicable `reasons`, so a project's complete eligibility state is visible in one log line.

## Test plan
- Added `test_logs_every_disqualifying_reason_at_once` covering a project failing all four gates at once.
- Existing `TestGetEligibleProjects` suite (7 tests) passes unchanged.