### PR TITLE
chore(tracemetrics): Remove equations in explore flagging code

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -638,7 +638,6 @@ describe('Incident Rules Form', () => {
         ...organization.features,
         'performance-view',
         'tracemetrics-enabled',
-        'tracemetrics-equations-in-explore',
       ];
       location = {
         ...location,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.spec.tsx
@@ -54,7 +54,7 @@ jest.mock('sentry/views/explore/metrics/hooks/useStableLabels', () => {
 
 const mockedUseNavigate = jest.mocked(useNavigate);
 
-const EQUATION_FEATURES = ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'];
+const EQUATION_FEATURES = ['tracemetrics-enabled'];
 
 const DASHBOARD_WIDGET_BUILDER_PATHNAME =
   '/organizations/org-slug/dashboards/new/widget/new/';

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/index.tsx
@@ -96,7 +96,7 @@ export function MetricsEquationVisualize({
   });
 
   return (
-    <LocalMultiMetricsQueryParamsProvider initialQueries={initialQueries} hasEquations>
+    <LocalMultiMetricsQueryParamsProvider initialQueries={initialQueries}>
       <MetricQueryRows
         selectedLabel={selectedLabel}
         setSelectedLabel={setSelectedLabel}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.spec.tsx
@@ -757,7 +757,7 @@ describe('WidgetBuilderSlideout', () => {
       />,
       {
         organization: OrganizationFixture({
-          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+          features: ['tracemetrics-enabled'],
         }),
         initialRouterConfig: {
           location: {
@@ -802,7 +802,7 @@ describe('WidgetBuilderSlideout', () => {
       />,
       {
         organization: OrganizationFixture({
-          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+          features: ['tracemetrics-enabled'],
         }),
         initialRouterConfig: {
           location: {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useTraceMetricsVisualizeModeState.spec.tsx
@@ -24,7 +24,7 @@ import {
 jest.mock('sentry/utils/useNavigate');
 const mockedUseNavigate = jest.mocked(useNavigate);
 
-const EQUATION_FEATURES = ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'];
+const EQUATION_FEATURES = ['tracemetrics-enabled'];
 
 const DASHBOARD_WIDGET_BUILDER_PATHNAME =
   '/organizations/org-slug/dashboards/new/widget/new/';

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -10,7 +10,6 @@ import {FormContext} from 'sentry/components/forms/formContext';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {METRIC_DETECTOR_FORM_FIELDS} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {ToolbarVisualizeAddChart} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
@@ -21,7 +20,6 @@ import {
 } from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {useMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
 import type {MetricQuery, TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsEquationsInAlerts} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   MetricsQueryParamsProvider,
   useMetricVisualize,
@@ -88,8 +86,6 @@ export function MetricsEquationVisualize({
   environments,
   onQueryChange,
 }: MetricsEquationVisualizeProps) {
-  const organization = useOrganization();
-  const hasEquations = canUseMetricsEquationsInAlerts(organization);
   const aggregateFunction = useFormField<string>(aggregateFieldName);
   const query = useFormField<string>(METRIC_DETECTOR_FORM_FIELDS.query);
 
@@ -105,10 +101,7 @@ export function MetricsEquationVisualize({
   }, []);
 
   return (
-    <LocalMultiMetricsQueryParamsProvider
-      initialQueries={initialQueries}
-      hasEquations={hasEquations}
-    >
+    <LocalMultiMetricsQueryParamsProvider initialQueries={initialQueries}>
       <MetricsEquationVisualizeContent
         aggregateFieldName={aggregateFieldName}
         projectIds={projectIds}

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -18,7 +18,6 @@ import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExploreBreadcrumb} from 'sentry/views/explore/components/breadcrumb';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
-import {canUseMetricsEquations} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricsTabOnboarding} from 'sentry/views/explore/metrics/metricsOnboarding';
 import {MetricsTabContent} from 'sentry/views/explore/metrics/metricsTab';
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
@@ -36,8 +35,6 @@ export default function MetricsContent() {
     dataCategories: [DataCategory.TRACE_METRICS],
   });
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
-  const hasEquations = canUseMetricsEquations(organization);
-
   return (
     <SentryDocumentTitle title={METRICS_TITLE} orgSlug={organization?.slug}>
       <PageFiltersContainer
@@ -57,7 +54,7 @@ export default function MetricsContent() {
       >
         <AnalyticsArea name="explore.metrics">
           <Stack flex={1}>
-            <MultiMetricsQueryParamsProvider hasEquations={hasEquations}>
+            <MultiMetricsQueryParamsProvider>
               <MetricsHeader />
               {defined(onboardingProject) ? (
                 <MetricsTabOnboarding

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -202,7 +202,7 @@ describe('MetricPanel', () => {
 
     const equationOrg = {
       ...organization,
-      features: [...organization.features, 'tracemetrics-equations-in-explore'],
+      features: [...organization.features],
     };
 
     render(
@@ -246,11 +246,7 @@ describe('MetricPanel', () => {
 
     const equationOrg = {
       ...organization,
-      features: [
-        ...organization.features,
-        'tracemetrics-equations-in-explore',
-        'data-browsing-heat-map-widget',
-      ],
+      features: [...organization.features, 'data-browsing-heat-map-widget'],
     };
 
     render(

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -78,7 +78,7 @@ describe('MetricToolbar', () => {
 
   it('renders group by selector for equation visualizations', async () => {
     const organization = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+      features: ['tracemetrics-enabled'],
     });
 
     const queryParams = new ReadableQueryParams({

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -29,13 +29,6 @@ export const canUseMetricsStatsBytesUI = (organization: Organization) => {
   );
 };
 
-export const canUseMetricsEquations = (organization: Organization) => {
-  return (
-    canUseMetricsUI(organization) &&
-    organization.features.includes('tracemetrics-equations-in-explore')
-  );
-};
-
 export const canUseMetricsEquationsInAlerts = (organization: Organization) => {
   return canUseMetricsAlertsUI(organization);
 };

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -2,9 +2,7 @@ import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useMemo} from 'react';
 
 import {defined} from 'sentry/utils/defined';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import {canUseMetricsEquations} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   MetricsFrozenContextProvider,
   type MetricsFrozenForTracesProviderProps,
@@ -130,13 +128,10 @@ function getUpdatedValue<T>(
 }
 
 export function useMetricVisualize(): Visualize {
-  const organization = useOrganization();
   const visualizes = useQueryParamsVisualizes();
-  const hasEquations = canUseMetricsEquations(organization);
   if (
     visualizes.length > 0 &&
-    (isVisualizeFunction(visualizes[0]!) ||
-      (isVisualizeEquation(visualizes[0]!) && hasEquations))
+    (isVisualizeFunction(visualizes[0]!) || isVisualizeEquation(visualizes[0]!))
   ) {
     return visualizes[0];
   }
@@ -144,14 +139,10 @@ export function useMetricVisualize(): Visualize {
 }
 
 export function useMetricVisualizes(): readonly Visualize[] {
-  const organization = useOrganization();
   const visualizes = useQueryParamsVisualizes();
-  const hasEquations = canUseMetricsEquations(organization);
   if (
     visualizes.length > 0 &&
-    visualizes.every(
-      v => isVisualizeFunction(v) || (isVisualizeEquation(v) && hasEquations)
-    )
+    visualizes.every(v => isVisualizeFunction(v) || isVisualizeEquation(v))
   ) {
     return visualizes;
   }

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -636,9 +636,9 @@ describe('MetricsTabContent', () => {
     expect(screen.queryByText('Add Equation')).not.toBeInTheDocument();
   });
 
-  it('shows the Add Equation button when the feature flag is enabled', async () => {
+  it('shows the Add Equation button', async () => {
     const orgWithFeature = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+      features: ['tracemetrics-enabled'],
     });
     render(
       <ProviderWrapper>
@@ -654,7 +654,7 @@ describe('MetricsTabContent', () => {
 
   it('renders aggregate and equation panels in separate sections', async () => {
     const orgWithFeatures = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+      features: ['tracemetrics-enabled'],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${orgWithFeatures.slug}/events/`,
@@ -719,7 +719,7 @@ describe('MetricsTabContent', () => {
       mode: 'aggregate',
     });
     const orgWithFeature = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+      features: ['tracemetrics-enabled'],
     });
     render(
       <ProviderWrapper>
@@ -768,7 +768,7 @@ describe('MetricsTabContent', () => {
 
   it('disables delete button for metrics referenced by an equation', async () => {
     const orgWithEquations = OrganizationFixture({
-      features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+      features: ['tracemetrics-enabled'],
     });
 
     const metricA = JSON.stringify({

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -623,29 +623,13 @@ describe('MetricsTabContent', () => {
     expect(parsedQuery.aggregateFields).toContainEqual({groupBy: 'test.region'});
   });
 
-  it('does not show the Add Equation button when the feature flag is disabled', async () => {
+  it('shows the Add Equation button', async () => {
     render(
       <ProviderWrapper>
         <MetricsTabContent datePageFilterProps={datePageFilterProps} />
       </ProviderWrapper>,
       {
         organization,
-      }
-    );
-    expect(await screen.findAllByText('Add Metric')).toHaveLength(1);
-    expect(screen.queryByText('Add Equation')).not.toBeInTheDocument();
-  });
-
-  it('shows the Add Equation button', async () => {
-    const orgWithFeature = OrganizationFixture({
-      features: ['tracemetrics-enabled'],
-    });
-    render(
-      <ProviderWrapper>
-        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
-      </ProviderWrapper>,
-      {
-        organization: orgWithFeature,
       }
     );
     expect(await screen.findAllByText('Add Metric')).toHaveLength(1);

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -14,7 +14,6 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {AiQueryProvider} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {t} from 'sentry/locale';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
 import {
   ExploreBodyContent,
@@ -29,7 +28,6 @@ import {useEquationReferencedLabels} from 'sentry/views/explore/metrics/hooks/us
 import {useMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
 import {useSortableMetricQueries} from 'sentry/views/explore/metrics/hooks/useSortableMetricQueries';
 import {SortableMetricPanel} from 'sentry/views/explore/metrics/metricPanel/sortableMetricPanel';
-import {canUseMetricsEquations} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
 import {
@@ -67,11 +65,9 @@ function MetricsTabContentInner({datePageFilterProps}: MetricsTabProps) {
 }
 
 function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
-  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const addMetricQuery = useAddMetricQuery();
   const addEquationQuery = useAddMetricQuery({type: 'equation'});
-  const hasEquations = canUseMetricsEquations(organization);
 
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
@@ -97,14 +93,12 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
               label={t('Add Metric')}
               display="button"
             />
-            {hasEquations && (
-              <ToolbarVisualizeAddChart
-                display="button"
-                add={addEquationQuery}
-                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-                label={t('Add Equation')}
-              />
-            )}
+            <ToolbarVisualizeAddChart
+              display="button"
+              add={addEquationQuery}
+              disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+              label={t('Add Equation')}
+            />
             <MetricSaveAs size="md" />
           </Flex>
         </FilterBarWithSaveAsContainer>

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -4,9 +4,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {act, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
 
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {canUseMetricsEquations} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   MultiMetricsQueryParamsProvider,
   useAddMetricQuery,
@@ -33,10 +31,8 @@ function TestableMetricComponent() {
 }
 
 function Wrapper({children}: {children: ReactNode}) {
-  const organization = useOrganization();
-  const hasEquations = canUseMetricsEquations(organization);
   return (
-    <MultiMetricsQueryParamsProvider hasEquations={hasEquations}>
+    <MultiMetricsQueryParamsProvider>
       <TestableMetricComponent />
       {children}
     </MultiMetricsQueryParamsProvider>
@@ -611,7 +607,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       const {result, router} = renderHookWithProviders(useAddMetricQuery, {
         additionalWrapper: Wrapper,
         organization: OrganizationFixture({
-          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+          features: ['tracemetrics-enabled'],
         }),
         initialRouterConfig: {
           location: {
@@ -678,7 +674,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       const {result, router} = renderHookWithProviders(useAddMetricQuery, {
         additionalWrapper: Wrapper,
         organization: OrganizationFixture({
-          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+          features: ['tracemetrics-enabled'],
         }),
         initialRouterConfig: {
           location: {
@@ -754,7 +750,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       const {result} = renderHookWithProviders(useAddMetricQuery, {
         additionalWrapper: Wrapper,
         organization: OrganizationFixture({
-          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+          features: ['tracemetrics-enabled'],
         }),
         initialRouterConfig: {
           location: {
@@ -795,7 +791,7 @@ describe('MultiMetricsQueryParamsProvider', () => {
       const {result} = renderHookWithProviders(useAddMetricQuery, {
         additionalWrapper: Wrapper,
         organization: OrganizationFixture({
-          features: ['tracemetrics-enabled', 'tracemetrics-equations-in-explore'],
+          features: ['tracemetrics-enabled'],
         }),
         initialRouterConfig: {
           location: {

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -50,13 +50,11 @@ function useMultiMetricsQueryParamsContext(): MetricQueriesControllerValue {
 interface MultiMetricsQueryParamsProviderProps {
   children: ReactNode;
   allowUpTo?: number;
-  hasEquations?: boolean;
 }
 
 export function MultiMetricsQueryParamsProvider({
   children,
   allowUpTo,
-  hasEquations,
 }: MultiMetricsQueryParamsProviderProps) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -75,7 +73,7 @@ export function MultiMetricsQueryParamsProvider({
     [location, navigate]
   );
 
-  const value = useMetricQueriesController({queries, setQueries, hasEquations});
+  const value = useMetricQueriesController({queries, setQueries});
 
   return (
     <MultiMetricsQueryParamsContext value={value}>
@@ -108,10 +106,6 @@ interface LocalMultiMetricsQueryParamsProviderProps {
    * provider's behavior on an empty URL).
    */
   initialQueries: BaseMetricQuery[];
-  /**
-   * Gates insert-before-equation behavior in `addMetricQuery`.
-   */
-  hasEquations?: boolean;
 }
 
 /**
@@ -130,13 +124,12 @@ interface LocalMultiMetricsQueryParamsProviderProps {
 export function LocalMultiMetricsQueryParamsProvider({
   children,
   initialQueries,
-  hasEquations,
 }: LocalMultiMetricsQueryParamsProviderProps) {
   const [queries, setQueries] = useState<BaseMetricQuery[]>(() =>
     initialQueries.length > 0 ? initialQueries : [defaultMetricQuery()]
   );
 
-  const value = useMetricQueriesController({queries, setQueries, hasEquations});
+  const value = useMetricQueriesController({queries, setQueries});
 
   return (
     <MultiMetricsQueryParamsContext value={value}>

--- a/static/app/views/explore/metrics/useMetricQueriesController.tsx
+++ b/static/app/views/explore/metrics/useMetricQueriesController.tsx
@@ -52,12 +52,6 @@ export interface MetricQueriesControllerValue {
 interface UseMetricQueriesControllerArgs {
   queries: BaseMetricQuery[];
   setQueries: (nextQueries: BaseMetricQuery[]) => void;
-  /**
-   * Whether equations are enabled. Gates the insert-before-equation behavior
-   * of `addMetricQuery` so new aggregates are inserted before any existing
-   * equation rather than appended after them.
-   */
-  hasEquations?: boolean;
 }
 
 /**
@@ -71,7 +65,6 @@ interface UseMetricQueriesControllerArgs {
 export function useMetricQueriesController({
   queries,
   setQueries,
-  hasEquations,
 }: UseMetricQueriesControllerArgs): MetricQueriesControllerValue {
   const labels = useStableLabels(queries);
 
@@ -176,7 +169,7 @@ export function useMetricQueriesController({
         isVisualizeEquation(metricQuery.queryParams.visualizes[0]!)
       );
       const insertAt =
-        hasEquations && equationStart !== -1 && type === 'aggregate'
+        equationStart !== -1 && type === 'aggregate'
           ? equationStart
           : labeledQueries.length;
       const lastAggregate = labeledQueries.at(insertAt - 1) ?? defaultMetricQuery();
@@ -210,5 +203,5 @@ export function useMetricQueriesController({
       addMetricQuery,
       reorderMetricQueries,
     };
-  }, [queries, setQueries, labels, hasEquations]);
+  }, [queries, setQueries, labels]);
 }


### PR DESCRIPTION
Flags for the equations in alerts and dashboards features have been removed prior to this PR, the `tracemetrics-equations-in-explore` flag can now be removed because those features built on top of this one.