### PR TITLE
feat(snuba): add response logging to RPC calls

### DIFF
--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -201,6 +201,7 @@ def _make_rpc_requests(
                 "rpc_rows": rpc_rows,
                 "referrer": request.meta.referrer,
                 "organization_id": request.meta.organization_id,
+                "trace_item_type": request.meta.trace_item_type,
                 "page_token": table_response.page_token,
                 "meta": table_response.meta,
                 "debug": debug is not False,
@@ -225,6 +226,7 @@ def _make_rpc_requests(
                 "rpc_rows": rpc_rows,
                 "referrer": request.meta.referrer,
                 "organization_id": request.meta.organization_id,
+                "trace_item_type": request.meta.trace_item_type,
                 "meta": timeseries_response.meta,
                 "debug": debug is not False,
             }
@@ -494,4 +496,5 @@ def create_subscription(req: CreateSubscriptionRequest) -> CreateSubscriptionRes
     http_resp = _make_rpc_request(endpoint_name, class_version, None, req)
     resp = CreateSubscriptionResponse()
     resp.ParseFromString(http_resp.data)
+    _log_rpc_response(endpoint_name, req.time_series_request, None)
     return resp

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -123,6 +123,11 @@ def get_trace_rpc(request: GetTraceRequest) -> GetTraceResponse:
     resp = _make_rpc_request("EndpointGetTrace", "v1", referrer=request.meta.referrer, req=request)
     response = GetTraceResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response(
+        "EndpointGetTrace",
+        request,
+        sum(len(group.items) for group in response.item_groups),
+    )
     return response
 
 
@@ -194,6 +199,7 @@ def _make_rpc_requests(
                 rpc_rows = 0
             logger_extra = {
                 "rpc_rows": rpc_rows,
+                "referrer": request.meta.referrer,
                 "organization_id": request.meta.organization_id,
                 "page_token": table_response.page_token,
                 "meta": table_response.meta,
@@ -217,6 +223,7 @@ def _make_rpc_requests(
                 rpc_rows = 0
             logger_extra = {
                 "rpc_rows": rpc_rows,
+                "referrer": request.meta.referrer,
                 "organization_id": request.meta.organization_id,
                 "meta": timeseries_response.meta,
                 "debug": debug is not False,
@@ -231,6 +238,32 @@ def _make_rpc_requests(
     return MultiRpcResponse(table_results, timeseries_results)
 
 
+def _log_rpc_response(
+    endpoint_name: str,
+    req: SnubaRPCRequest,
+    rpc_rows: int | None,
+    debug: str | bool = False,
+) -> None:
+    logger_extra: dict[str, object] = {
+        "rpc_rows": rpc_rows,
+        "referrer": req.meta.referrer,
+        "organization_id": req.meta.organization_id,
+        "trace_item_type": req.meta.trace_item_type,
+        "debug": debug is not False,
+    }
+    if isinstance(debug, str):
+        logger_extra["debug_msg"] = debug
+    logger.info(
+        "%s RPC query response",
+        endpoint_name,
+        extra=logger_extra,
+    )
+    if rpc_rows is not None:
+        metrics.distribution(
+            "snuba_rpc.response.length", rpc_rows, tags={"endpoint": endpoint_name}
+        )
+
+
 def attribute_names_rpc(
     req: TraceItemAttributeNamesRequest, debug: str | bool = False
 ) -> TraceItemAttributeNamesResponse:
@@ -243,6 +276,7 @@ def attribute_names_rpc(
     )
     response = TraceItemAttributeNamesResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("EndpointTraceItemAttributeNames", req, len(response.attributes), debug=debug)
     return response
 
 
@@ -258,6 +292,7 @@ def attribute_values_rpc(req: TraceItemAttributeValuesRequest) -> TraceItemAttri
     resp = _make_rpc_request("AttributeValuesRequest", "v1", req.meta.referrer, req)
     response = TraceItemAttributeValuesResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("AttributeValuesRequest", req, len(response.values))
     return response
 
 
@@ -269,6 +304,7 @@ def get_traces_rpc(req: GetTracesRequest) -> GetTracesResponse:
     resp = _make_rpc_request("EndpointGetTraces", "v1", req.meta.referrer, req)
     response = GetTracesResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("EndpointGetTraces", req, len(response.traces))
     return response
 
 
@@ -276,6 +312,7 @@ def trace_item_stats_rpc(req: TraceItemStatsRequest) -> TraceItemStatsResponse:
     resp = _make_rpc_request("EndpointTraceItemStats", "v1", req.meta.referrer, req)
     response = TraceItemStatsResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("EndpointTraceItemStats", req, len(response.results))
     return response
 
 
@@ -290,6 +327,7 @@ def trace_item_details_rpc(
     resp = _make_rpc_request("EndpointTraceItemDetails", "v1", req.meta.referrer, req, debug=debug)
     response = TraceItemDetailsResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("EndpointTraceItemDetails", req, len(response.attributes), debug=debug)
     return response
 
 
@@ -301,6 +339,7 @@ def delete_trace_items_rpc(req: DeleteTraceItemsRequest) -> DeleteTraceItemsResp
     resp = _make_rpc_request("EndpointDeleteTraceItems", "v1", req.meta.referrer, req)
     response = DeleteTraceItemsResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("EndpointDeleteTraceItems", req, response.matching_items_count)
     return response
 
 
@@ -346,6 +385,7 @@ def rpc(
     http_resp = _make_rpc_request(endpoint_name, class_version, req.meta.referrer, req)
     resp = resp_type()
     resp.ParseFromString(http_resp.data)
+    _log_rpc_response(endpoint_name, req, None)
     return resp
 
 
@@ -353,6 +393,7 @@ def export_logs_rpc(req: ExportTraceItemsRequest) -> ExportTraceItemsResponse:
     resp = _make_rpc_request("EndpointExportTraceItems", "v1", req.meta.referrer, req)
     response = ExportTraceItemsResponse()
     response.ParseFromString(resp.data)
+    _log_rpc_response("EndpointExportTraceItems", req, len(response.trace_items))
     return response
 
 

--- a/tests/sentry/utils/test_snuba_rpc.py
+++ b/tests/sentry/utils/test_snuba_rpc.py
@@ -2,12 +2,17 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
+    CreateSubscriptionRequest,
+    CreateSubscriptionResponse,
+)
 from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import (
     DeleteTraceItemsRequest,
     DeleteTraceItemsResponse,
 )
 from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest, GetTraceResponse
 from sentry_protos.snuba.v1.endpoint_get_traces_pb2 import GetTracesRequest, GetTracesResponse
+from sentry_protos.snuba.v1.endpoint_time_series_pb2 import TimeSeriesRequest, TimeSeriesResponse
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
     TraceItemAttributeNamesRequest,
     TraceItemAttributeNamesResponse,
@@ -22,7 +27,10 @@ from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
     TraceItemStatsRequest,
     TraceItemStatsResponse,
 )
-from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    TraceItemTableRequest,
+    TraceItemTableResponse,
+)
 from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsRequest,
     ExportTraceItemsResponse,
@@ -226,3 +234,75 @@ def test_single_request_helper_logs_response_row_count(
     assert mock_distribution.call_args == mock.call(
         "snuba_rpc.response.length", expected_rows, tags={"endpoint": expected_endpoint}
     )
+
+
+def _table_response() -> TraceItemTableResponse:
+    response = TraceItemTableResponse()
+    column = response.column_values.add()
+    column.results.add()
+    column.results.add()
+    return response
+
+
+def _timeseries_response() -> TimeSeriesResponse:
+    response = TimeSeriesResponse()
+    response.result_timeseries.add().data_points.add()
+    return response
+
+
+def test_table_rpc_logs_trace_item_type_and_row_count() -> None:
+    http_response = mock.Mock()
+    http_response.data = _table_response().SerializeToString()
+
+    with (
+        mock.patch.object(snuba_rpc, "_make_rpc_request", return_value=http_response),
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution") as mock_distribution,
+    ):
+        snuba_rpc.table_rpc([TraceItemTableRequest(meta=_meta())])
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert mock_info.call_args.args[0] == "Table RPC query response"
+    assert extra["rpc_rows"] == 2
+    assert extra["trace_item_type"] == TraceItemType.TRACE_ITEM_TYPE_LOG
+    assert mock_distribution.call_args == mock.call("snuba_rpc.table_response.length", 2)
+
+
+def test_timeseries_rpc_logs_trace_item_type_and_row_count() -> None:
+    http_response = mock.Mock()
+    http_response.data = _timeseries_response().SerializeToString()
+
+    with (
+        mock.patch.object(snuba_rpc, "_make_rpc_request", return_value=http_response),
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution") as mock_distribution,
+    ):
+        snuba_rpc.timeseries_rpc([TimeSeriesRequest(meta=_meta())])
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert mock_info.call_args.args[0] == "Timeseries RPC query response"
+    assert extra["rpc_rows"] == 1
+    assert extra["trace_item_type"] == TraceItemType.TRACE_ITEM_TYPE_LOG
+    assert mock_distribution.call_args == mock.call("snuba_rpc.timeseries_response.length", 1)
+
+
+def test_create_subscription_logs_response() -> None:
+    http_response = mock.Mock()
+    http_response.data = CreateSubscriptionResponse(subscription_id="sub-1").SerializeToString()
+    request = CreateSubscriptionRequest(time_series_request=TimeSeriesRequest(meta=_meta()))
+
+    with (
+        mock.patch.object(snuba_rpc, "_make_rpc_request", return_value=http_response),
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution") as mock_distribution,
+    ):
+        snuba_rpc.create_subscription(request)
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert mock_info.call_args.args[1] == "CreateSubscriptionRequest"
+    assert extra["rpc_rows"] is None
+    assert extra["referrer"] == "test.referrer"
+    assert mock_distribution.call_count == 0

--- a/tests/sentry/utils/test_snuba_rpc.py
+++ b/tests/sentry/utils/test_snuba_rpc.py
@@ -1,0 +1,228 @@
+from typing import Any
+from unittest import mock
+
+import pytest
+from sentry_protos.snuba.v1.endpoint_delete_trace_items_pb2 import (
+    DeleteTraceItemsRequest,
+    DeleteTraceItemsResponse,
+)
+from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest, GetTraceResponse
+from sentry_protos.snuba.v1.endpoint_get_traces_pb2 import GetTracesRequest, GetTracesResponse
+from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import (
+    TraceItemAttributeNamesRequest,
+    TraceItemAttributeNamesResponse,
+    TraceItemAttributeValuesRequest,
+    TraceItemAttributeValuesResponse,
+)
+from sentry_protos.snuba.v1.endpoint_trace_item_details_pb2 import (
+    TraceItemDetailsRequest,
+    TraceItemDetailsResponse,
+)
+from sentry_protos.snuba.v1.endpoint_trace_item_stats_pb2 import (
+    TraceItemStatsRequest,
+    TraceItemStatsResponse,
+)
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import TraceItemTableRequest
+from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
+    ExportTraceItemsRequest,
+    ExportTraceItemsResponse,
+)
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+
+from sentry.utils import snuba_rpc
+
+
+def _meta() -> RequestMeta:
+    return RequestMeta(
+        organization_id=123,
+        referrer="test.referrer",
+        trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
+    )
+
+
+def _request() -> TraceItemTableRequest:
+    return TraceItemTableRequest(meta=_meta())
+
+
+def test_logs_referrer_and_row_count_when_rows_provided() -> None:
+    with (
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution") as mock_distribution,
+    ):
+        snuba_rpc._log_rpc_response("EndpointTraceItemDetails", _request(), 5)
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert extra["rpc_rows"] == 5
+    assert extra["referrer"] == "test.referrer"
+    assert extra["organization_id"] == 123
+    assert mock_distribution.call_args == mock.call(
+        "snuba_rpc.response.length", 5, tags={"endpoint": "EndpointTraceItemDetails"}
+    )
+
+
+def test_skips_metric_when_row_count_is_none() -> None:
+    with (
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution") as mock_distribution,
+    ):
+        snuba_rpc._log_rpc_response("EndpointGetTrace", _request(), None)
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert extra["rpc_rows"] is None
+    assert mock_distribution.call_count == 0
+
+
+def test_includes_debug_message_when_debug_is_a_string() -> None:
+    with (
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution"),
+    ):
+        snuba_rpc._log_rpc_response("EndpointGetTrace", _request(), 0, debug="why")
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert extra["debug"] is True
+    assert extra["debug_msg"] == "why"
+
+
+def _get_trace_response() -> GetTraceResponse:
+    response = GetTraceResponse()
+    first_group = response.item_groups.add()
+    first_group.items.add()
+    first_group.items.add()
+    second_group = response.item_groups.add()
+    second_group.items.add()
+    return response
+
+
+def _attribute_names_response() -> TraceItemAttributeNamesResponse:
+    response = TraceItemAttributeNamesResponse()
+    response.attributes.add()
+    response.attributes.add()
+    return response
+
+
+def _attribute_values_response() -> TraceItemAttributeValuesResponse:
+    response = TraceItemAttributeValuesResponse()
+    response.values.extend(["a", "b", "c"])
+    return response
+
+
+def _get_traces_response() -> GetTracesResponse:
+    response = GetTracesResponse()
+    response.traces.add()
+    response.traces.add()
+    return response
+
+
+def _trace_item_stats_response() -> TraceItemStatsResponse:
+    response = TraceItemStatsResponse()
+    response.results.add()
+    return response
+
+
+def _trace_item_details_response() -> TraceItemDetailsResponse:
+    response = TraceItemDetailsResponse()
+    for _ in range(4):
+        response.attributes.add()
+    return response
+
+
+def _delete_trace_items_response() -> DeleteTraceItemsResponse:
+    return DeleteTraceItemsResponse(matching_items_count=7)
+
+
+def _export_logs_response() -> ExportTraceItemsResponse:
+    response = ExportTraceItemsResponse()
+    response.trace_items.add()
+    response.trace_items.add()
+    return response
+
+
+@pytest.mark.parametrize(
+    "helper, request_obj, response_obj, expected_endpoint, expected_rows",
+    [
+        (
+            snuba_rpc.get_trace_rpc,
+            GetTraceRequest(meta=_meta()),
+            _get_trace_response(),
+            "EndpointGetTrace",
+            3,
+        ),
+        (
+            snuba_rpc.attribute_names_rpc,
+            TraceItemAttributeNamesRequest(meta=_meta()),
+            _attribute_names_response(),
+            "EndpointTraceItemAttributeNames",
+            2,
+        ),
+        (
+            snuba_rpc.attribute_values_rpc,
+            TraceItemAttributeValuesRequest(meta=_meta()),
+            _attribute_values_response(),
+            "AttributeValuesRequest",
+            3,
+        ),
+        (
+            snuba_rpc.get_traces_rpc,
+            GetTracesRequest(meta=_meta()),
+            _get_traces_response(),
+            "EndpointGetTraces",
+            2,
+        ),
+        (
+            snuba_rpc.trace_item_stats_rpc,
+            TraceItemStatsRequest(meta=_meta()),
+            _trace_item_stats_response(),
+            "EndpointTraceItemStats",
+            1,
+        ),
+        (
+            snuba_rpc.trace_item_details_rpc,
+            TraceItemDetailsRequest(meta=_meta()),
+            _trace_item_details_response(),
+            "EndpointTraceItemDetails",
+            4,
+        ),
+        (
+            snuba_rpc.delete_trace_items_rpc,
+            DeleteTraceItemsRequest(meta=_meta()),
+            _delete_trace_items_response(),
+            "EndpointDeleteTraceItems",
+            7,
+        ),
+        (
+            snuba_rpc.export_logs_rpc,
+            ExportTraceItemsRequest(meta=_meta()),
+            _export_logs_response(),
+            "EndpointExportTraceItems",
+            2,
+        ),
+    ],
+)
+def test_single_request_helper_logs_response_row_count(
+    helper: Any,
+    request_obj: Any,
+    response_obj: Any,
+    expected_endpoint: str,
+    expected_rows: int,
+) -> None:
+    http_response = mock.Mock()
+    http_response.data = response_obj.SerializeToString()
+
+    with (
+        mock.patch.object(snuba_rpc, "_make_rpc_request", return_value=http_response),
+        mock.patch.object(snuba_rpc.logger, "info") as mock_info,
+        mock.patch("sentry.utils.snuba_rpc.metrics.distribution") as mock_distribution,
+    ):
+        helper(request_obj)
+
+    extra = mock_info.call_args.kwargs["extra"]
+
+    assert mock_info.call_args.args[1] == expected_endpoint
+    assert extra["rpc_rows"] == expected_rows
+    assert mock_distribution.call_args == mock.call(
+        "snuba_rpc.response.length", expected_rows, tags={"endpoint": expected_endpoint}
+    )


### PR DESCRIPTION
Adds a unified `_log_rpc_response` that logs basic attributes from an RPC request and response count.

Closes LOGS-525.