### PR TITLE
feat(autofix): Add header to autofix slack response sections

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -193,11 +193,17 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         if data.summary:
             blocks.append(SectionBlock(text=MarkdownTextObject(text=data.summary)))
         if data.reasoning:
+            if data.reasoning_header:
+                blocks.append(
+                    SectionBlock(text=MarkdownTextObject(text=f"*{data.reasoning_header}*"))
+                )
             parts = [RichTextElementParts.Text(text=item) for item in data.reasoning[:MAX_STEPS]]
             sections = [RichTextSectionElement(elements=[part]) for part in parts]
             list_element = RichTextListElement(style="ordered", indent=0, elements=sections)
             blocks.append(RichTextBlock(elements=[list_element]))
         if data.steps:
+            if data.steps_header:
+                blocks.append(SectionBlock(text=MarkdownTextObject(text=f"*{data.steps_header}*")))
             parts = [RichTextElementParts.Text(text=step) for step in data.steps[:MAX_STEPS]]
             sections = [RichTextSectionElement(elements=[part]) for part in parts]
             list_element = RichTextListElement(style="ordered", indent=0, elements=sections)

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -74,6 +74,8 @@ class SeerAutofixUpdate(NotificationData):
     group_link: str
     steps: list[str] = Field(default_factory=list)
     reasoning: list[str] = Field(default_factory=list)
+    reasoning_header: str | None = None
+    steps_header: str | None = None
     changes: list[SeerAutofixCodeChange] = Field(default_factory=list)
     pull_requests: list[SeerAutofixPullRequest] = Field(default_factory=list)
     summary: str | None = None

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -367,6 +367,8 @@ class SlackAutofixEntrypoint(
                         "summary": summary,
                         "steps": steps,
                         "reasoning": root_cause.get("five_whys", []),
+                        "reasoning_header": "Why did this happen?",
+                        "steps_header": "Reproduction Steps",
                         "handoff_target": cache_payload.get("handoff_target"),
                     }
                 )
@@ -387,6 +389,7 @@ class SlackAutofixEntrypoint(
                         "current_point": AutofixStoppingPoint.SOLUTION,
                         "summary": summary,
                         "steps": steps,
+                        "steps_header": "Steps to Resolve",
                     }
                 )
             case SentryAppEventType.SEER_CODING_COMPLETED:

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -37,6 +37,8 @@ class SeerSlackRendererTest(TestCase):
         changes: list[SeerAutofixCodeChange] | None = None,
         pull_requests: list[SeerAutofixPullRequest] | None = None,
         handoff_target: str | None = None,
+        reasoning_header: str | None = None,
+        steps_header: str | None = None,
     ) -> SeerAutofixUpdate:
         return SeerAutofixUpdate(
             run_id=MOCK_RUN_ID,
@@ -51,6 +53,8 @@ class SeerSlackRendererTest(TestCase):
             changes=changes or [],
             pull_requests=pull_requests or [],
             handoff_target=handoff_target,
+            reasoning_header=reasoning_header,
+            steps_header=steps_header,
         )
 
     def test_render_footer_blocks_with_has_complete_stage(self) -> None:


### PR DESCRIPTION
This adds headers to the sections in the autofix slack response sections so it's clear where one section starts/ends.