### PR TITLE
feat(producer): start rolling out rdkafka poll metrics

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3863,6 +3863,24 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# List of producer names to roll out poll metrics to. Enables everywhere if
+# list contains "all".
+register(
+    "arroyo.producer.record_poll_metrics",
+    type=Sequence,
+    default=None,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+
+# Arroyo producer poll metrics should be logged every X poll iterations.
+register(
+    "arroyo.producer.poll_metric_frequency",
+    type=Int,
+    default=10,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "github-enterprise.disallow-domain-mismatch",
     type=Bool,

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -9,6 +9,7 @@ from arroyo.backends.kafka import KafkaPayload, KafkaProducer, build_kafka_produ
 from arroyo.types import BrokerValue, Partition
 from arroyo.types import Topic as ArroyoTopic
 
+from sentry import options
 from sentry.conf.types.kafka_definition import Topic
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_topic_definition
 
@@ -100,6 +101,13 @@ def get_arroyo_producer(
 
     producer_config = get_kafka_producer_cluster_options(topic_definition["cluster"])
 
+    # temp(benmckerry): roll out poll metrics to our producers
+    poll_metrics_map = options.get("arroyo.producer.record_poll_metrics")
+    record_poll_metrics = False
+    if name in poll_metrics_map or "all" in poll_metrics_map:
+        record_poll_metrics = True
+    poll_metric_frequency = options.get("arroyo.producer.poll_metric_frequency")
+
     # Remove any excluded config keys
     if exclude_config_keys:
         for key in exclude_config_keys:
@@ -112,5 +120,8 @@ def get_arroyo_producer(
     producer_config["client.id"] = name
 
     return KafkaProducer(
-        build_kafka_producer_configuration(default_config=producer_config), **kafka_producer_kwargs
+        build_kafka_producer_configuration(default_config=producer_config),
+        record_poll_metrics=record_poll_metrics,
+        poll_metric_frequency=poll_metric_frequency,
+        **kafka_producer_kwargs,
     )

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -102,7 +102,7 @@ def get_arroyo_producer(
     producer_config = get_kafka_producer_cluster_options(topic_definition["cluster"])
 
     # temp(benmckerry): roll out poll metrics to our producers
-    poll_metrics_map = options.get("arroyo.producer.record_poll_metrics")
+    poll_metrics_map = options.get("arroyo.producer.record_poll_metrics") or []
     record_poll_metrics = False
     if name in poll_metrics_map or "all" in poll_metrics_map:
         record_poll_metrics = True

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -22,7 +22,13 @@ from sentry.replays.usecases.ingest.event_parser import (
     ParsedEventMeta,
     TapEvent,
 )
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
+
+_ARROYO_PRODUCER_OPTIONS = {
+    "arroyo.producer.record_poll_metrics": [],
+    "arroyo.producer.poll_metric_frequency": 10,
+}
 
 
 def test_gen_rage_clicks() -> None:
@@ -51,6 +57,7 @@ def test_gen_rage_clicks() -> None:
     assert len(list(gen_rage_clicks(meta, 1, "1", None))) == 0
 
 
+@override_options(_ARROYO_PRODUCER_OPTIONS)
 @thread_leak_allowlist(reason="replays", issue=97033)
 def test_emit_click_events_environment_handling() -> None:
     click_events = [
@@ -89,6 +96,7 @@ def test_emit_click_events_environment_handling() -> None:
         assert producer.call_args.args[1].value is not None
 
 
+@override_options(_ARROYO_PRODUCER_OPTIONS)
 @thread_leak_allowlist(reason="replays", issue=97033)
 def test_emit_tap_events_environment_handling() -> None:
     tap_events = [
@@ -115,6 +123,7 @@ def test_emit_tap_events_environment_handling() -> None:
         assert producer.call_args.args[1].value is not None
 
 
+@override_options(_ARROYO_PRODUCER_OPTIONS)
 @thread_leak_allowlist(reason="replays", issue=97033)
 @mock.patch("arroyo.backends.kafka.consumer.KafkaProducer.produce")
 def test_emit_trace_items_to_eap(producer: mock.MagicMock) -> None:

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -33,6 +33,8 @@ def build_mock_message(data, topic=None):
     {
         "spans.process-segments.dedupe-ttl": 0,
         "spans.process-segments.dedupe-filter-enable": False,
+        "arroyo.producer.record_poll_metrics": [],
+        "arroyo.producer.poll_metric_frequency": 10,
     }
 )
 @mock.patch(

--- a/tests/sentry/utils/test_arroyo_producer.py
+++ b/tests/sentry/utils/test_arroyo_producer.py
@@ -2,7 +2,9 @@ from unittest.mock import Mock, patch
 
 from arroyo.backends.kafka import KafkaProducer
 
-from sentry.utils.arroyo_producer import SingletonProducer
+from sentry.testutils.asserts import assert_mock_called_once_with_partial
+from sentry.testutils.helpers.options import override_options
+from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 
 
 def test_registers_shutdown_at_construction() -> None:
@@ -43,3 +45,33 @@ def test_track_futures() -> None:
     producer._track_futures(second_future_mock)
     first_future_mock.result.assert_called_once_with()
     second_future_mock.assert_not_called()
+
+
+@override_options(
+    {
+        "arroyo.producer.record_poll_metrics": ["producer.fake"],
+        "arroyo.producer.poll_metric_frequency": 1,
+    }
+)
+@patch("sentry.utils.arroyo_producer.KafkaProducer")
+@patch("sentry.utils.arroyo_producer.build_kafka_producer_configuration")
+def test_poll_metrics(mock_build_config: Mock, mock_producer: Mock) -> None:
+    get_arroyo_producer("producer.fake", "fake-topic")
+    assert_mock_called_once_with_partial(
+        mock_producer, record_poll_metrics=True, poll_metric_frequency=1
+    )
+
+
+@override_options(
+    {
+        "arroyo.producer.record_poll_metrics": [],
+        "arroyo.producer.poll_metric_frequency": 1,
+    }
+)
+@patch("sentry.utils.arroyo_producer.KafkaProducer")
+@patch("sentry.utils.arroyo_producer.build_kafka_producer_configuration")
+def test_poll_metrics_not_enabled(mock_build_config: Mock, mock_producer: Mock) -> None:
+    get_arroyo_producer("producer.fake", "fake-topic")
+    assert_mock_called_once_with_partial(
+        mock_producer, record_poll_metrics=False, poll_metric_frequency=1
+    )


### PR DESCRIPTION
Ref STREAM-1605

https://github.com/getsentry/arroyo/pull/551 added the ability to enable poll frequency metrics to `KafkaProducer`. This PR:
- adds an option to allow rolling out poll metrics to specific producers (or all of them)
- adds an option to configure how frequently the poll metric increments
- adds tests for this