### PR TITLE
build(ui): Reduce dev-ui memory usage

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -575,7 +575,7 @@ const appConfig: Configuration = {
       new rspack.SwcJsMinimizerRspackPlugin(),
     ],
   },
-  devtool: IS_PRODUCTION ? 'source-map' : 'eval-cheap-module-source-map',
+  devtool: IS_PRODUCTION ? 'source-map' : 'cheap-module-source-map',
 };
 
 /**


### PR DESCRIPTION
Switch development source maps from `eval-cheap-module-source-map` to [`cheap-module-source-map`](https://rspack.rs/config/devtool), Rspack's default and recommended development configuration.

Measured in the same Brave tab on the same 25-row issue stream, forcing garbage collection immediately before each heap snapshot:

| Metric | `eval-cheap-module-source-map` | `cheap-module-source-map` | Change |
|---|---:|---:|---:|
| Heap snapshot | 749 MB | 431 MB | -318 MB (-42.5%) |
| Live heap after forced GC | 653 MB | 349 MB | -304 MB (-46.6%) |

Moving source maps out of `eval()` avoids retaining the inline maps and compiled module strings while preserving line-level loader mappings.
