### PR TITLE
fix(action_log): Make progress gate project-level

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -328,7 +328,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable the "progress" sort option (by issue fix-cycle progress) in the issue stream
     manager.add("organizations:issue-stream-progress-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use GroupDerivedData as the source for issue progress instead of activity-based heuristics
-    manager.add("organizations:issue-stream-derived-progress", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("projects:issue-stream-derived-progress", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Lets organizations manage grouping configs
     manager.add("organizations:set-grouping-config", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)

--- a/src/sentry/issues/endpoints/organization_group_index_progress.py
+++ b/src/sentry/issues/endpoints/organization_group_index_progress.py
@@ -99,8 +99,10 @@ class OrganizationGroupIndexProgressEndpoint(OrganizationEndpoint):
 
         found_group_ids = [g.id for g in groups]
 
-        if features.has(
-            "organizations:issue-stream-derived-progress", organization, actor=request.user
+        unique_projects = {g.project for g in groups}
+        if all(
+            features.has("projects:issue-stream-derived-progress", project, actor=request.user)
+            for project in unique_projects
         ):
             progress_by_group = _get_derived_progress(found_group_ids)
         else:

--- a/src/sentry/issues/endpoints/organization_group_index_progress.py
+++ b/src/sentry/issues/endpoints/organization_group_index_progress.py
@@ -99,6 +99,8 @@ class OrganizationGroupIndexProgressEndpoint(OrganizationEndpoint):
 
         found_group_ids = [g.id for g in groups]
 
+        # This is a multi-project endpoint that supports filtering;
+        # only enable if all selected projects have the feature
         unique_projects = {g.project for g in groups}
         if all(
             features.has("projects:issue-stream-derived-progress", project, actor=request.user)

--- a/tests/sentry/issues/endpoints/test_organization_group_index_progress.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index_progress.py
@@ -88,9 +88,7 @@ class OrganizationGroupIndexProgressTest(APITestCase):
             )
 
 
-@with_feature(
-    ["organizations:issue-stream-progress-ui", "organizations:issue-stream-derived-progress"]
-)
+@with_feature(["organizations:issue-stream-progress-ui", "projects:issue-stream-derived-progress"])
 class OrganizationGroupIndexProgressDerivedDataTest(APITestCase):
     endpoint = "sentry-api-0-organization-group-index-progress"
 
@@ -112,7 +110,7 @@ class OrganizationGroupIndexProgressDerivedDataTest(APITestCase):
         group = self.create_group(project=self.project)
         GroupDerivedData.objects.create(group=group, progress=IssueProgressState.DIAGNOSED)
 
-        with self.feature({"organizations:issue-stream-derived-progress": False}):
+        with self.feature({"projects:issue-stream-derived-progress": False}):
             response = self.get_success_response(
                 self.organization.slug,
                 groups=[group.id],


### PR DESCRIPTION
We're rolling out derived data at the project-level, so while org-level can work, it is inconsistent.

Note that this is much less interesting logic in the likely future cases in which we'll be enabling it based on whether a project is part of a set of orgs.
