### PR TITLE
feat(dashboards): add ability to sync prebuilt favorited dashboards

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -96,6 +96,7 @@ class PrebuiltDashboard(TypedDict, total=False):
     prebuilt_id: Required[PrebuiltDashboardId]
     title: Required[str]
     hidden: bool
+    pre_favorited: bool
 
 
 # Prebuilt dashboards store minimal fields in the database. The actual dashboard and widget settings are
@@ -131,6 +132,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.WEB_VITALS,
         "title": "Web Vitals",
+        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.WEB_VITALS_SUMMARY,
@@ -159,6 +161,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_OVERVIEW,
         "title": "Backend Overview",
+        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_SESSION_HEALTH,
@@ -195,6 +198,7 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.AI_AGENTS_OVERVIEW,
         "title": "AI Agents Overview",
+        "pre_favorited": True,
     },
     {
         "prebuilt_id": PrebuiltDashboardId.MCP_OVERVIEW,
@@ -301,6 +305,41 @@ def sync_prebuilt_dashboards(organization: Organization) -> None:
         ).exclude(prebuilt_id__in=prebuilt_ids).delete()
 
 
+def sync_prebuilt_dashboards_favorited(organization: Organization, user_id: int) -> None:
+    """
+    Checks if pre-favorited prebuilt dashboards have a DashboardFavoriteUser record for the
+    user, and creates them if they don't. This ensures that certain prebuilt dashboards are
+    favorited by default for all users, preserving any existing stared ones.
+    """
+    enabled_prebuilt_dashboards = get_enabled_prebuilt_dashboards(organization)
+    pre_favorited_ids = [
+        d["prebuilt_id"] for d in enabled_prebuilt_dashboards if d.get("pre_favorited")
+    ]
+    if not pre_favorited_ids:
+        return
+
+    with transaction.atomic(router.db_for_write(DashboardFavoriteUser)):
+        prebuilt_dashboards_without_favorite = (
+            Dashboard.objects.filter(
+                organization=organization,
+                prebuilt_id__in=pre_favorited_ids,
+            )
+            .exclude(
+                id__in=DashboardFavoriteUser.objects.filter(
+                    organization=organization,
+                    user_id=user_id,
+                ).values_list("dashboard_id", flat=True)
+            )
+            .order_by("prebuilt_id")
+        )
+        for dashboard in prebuilt_dashboards_without_favorite:
+            DashboardFavoriteUser.objects.insert_favorite_dashboard(
+                organization=organization,
+                user_id=user_id,
+                dashboard=dashboard,
+            )
+
+
 class OrganizationDashboardsPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
@@ -392,6 +431,20 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 pass
             except Exception as err:
                 sentry_sdk.capture_exception(err)
+
+            if features.has("organizations:dashboards-starred", organization, actor=request.user):
+                try:
+                    favorite_lock = locks.get(
+                        f"dashboards:sync_prebuilt_dashboards_favorited:{organization.id}:{request.user.id}",
+                        duration=10,
+                        name="sync_prebuilt_dashboards_favorited",
+                    )
+                    with favorite_lock.acquire():
+                        sync_prebuilt_dashboards_favorited(organization, request.user.id)
+                except UnableToAcquireLock:
+                    pass
+                except Exception as err:
+                    sentry_sdk.capture_exception(err)
 
         filters = request.query_params.getlist("filter")
 

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -319,6 +319,8 @@ def sync_prebuilt_dashboards_favorited(organization: Organization, user_id: int)
         return
 
     with transaction.atomic(router.db_for_write(DashboardFavoriteUser)):
+        # Exclude any dashboard the user has already starred or that has unfavorited. We don't
+        # exclude by favorited=False so we never re-star something the user chose to unstar.
         prebuilt_dashboards_without_favorite = (
             Dashboard.objects.filter(
                 organization=organization,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -79,6 +79,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-powered dashboard editing via Seer
     manager.add("organizations:dashboards-ai-generate-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables starred dashboards functionality
+    manager.add("organizations:dashboards-starred", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy v2 (with Break the Glass feature)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2125,6 +2125,134 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         ]
         assert len(prebuilt_in_response) == 1
 
+    def test_endpoint_creates_pre_favorited_prebuilt_dashboards(self) -> None:
+        assert (
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            ).count()
+            == 0
+        )
+
+        pre_favorited_prebuilt_ids = {
+            d["prebuilt_id"] for d in PREBUILT_DASHBOARDS if d.get("pre_favorited")
+        }
+
+        with self.feature(
+            [
+                "organizations:dashboards-prebuilt-insights-dashboards",
+                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
+                "organizations:dashboards-starred",
+            ]
+        ):
+            response = self.do_request("get", self.url)
+        assert response.status_code == 200
+
+        favorites = DashboardFavoriteUser.objects.filter(
+            organization=self.organization, user_id=self.user.id
+        )
+        favorited_prebuilt_ids = set(
+            Dashboard.objects.filter(
+                id__in=favorites.values_list("dashboard_id", flat=True)
+            ).values_list("prebuilt_id", flat=True)
+        )
+        assert favorited_prebuilt_ids == pre_favorited_prebuilt_ids
+
+    def test_endpoint_does_not_create_favorites_without_starred_flag(self) -> None:
+        with self.feature(
+            [
+                "organizations:dashboards-prebuilt-insights-dashboards",
+                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
+            ]
+        ):
+            response = self.do_request("get", self.url)
+        assert response.status_code == 200
+
+        assert (
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            ).count()
+            == 0
+        )
+
+    def test_endpoint_does_not_re_favorite_unstarred_prebuilt_dashboards(self) -> None:
+        pre_favorited_prebuilt_ids = {
+            d["prebuilt_id"] for d in PREBUILT_DASHBOARDS if d.get("pre_favorited")
+        }
+
+        with self.feature(
+            [
+                "organizations:dashboards-prebuilt-insights-dashboards",
+                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
+                "organizations:dashboards-starred",
+            ]
+        ):
+            response = self.do_request("get", self.url)
+            assert response.status_code == 200
+
+            # The user deliberately unstars one of the pre-favorited prebuilt dashboards.
+            unstarred_prebuilt_id = next(iter(pre_favorited_prebuilt_ids))
+            unstarred_dashboard = Dashboard.objects.get(
+                organization=self.organization, prebuilt_id=unstarred_prebuilt_id
+            )
+            DashboardFavoriteUser.objects.unfavorite_dashboard(
+                organization=self.organization,
+                user_id=self.user.id,
+                dashboard=unstarred_dashboard,
+            )
+
+            # A subsequent load must not silently re-star it.
+            response = self.do_request("get", self.url)
+            assert response.status_code == 200
+
+        favorites = DashboardFavoriteUser.objects.filter(
+            organization=self.organization, user_id=self.user.id, favorited=True
+        )
+        favorited_prebuilt_ids = set(
+            Dashboard.objects.filter(
+                id__in=favorites.values_list("dashboard_id", flat=True)
+            ).values_list("prebuilt_id", flat=True)
+        )
+        assert favorited_prebuilt_ids == pre_favorited_prebuilt_ids - {unstarred_prebuilt_id}
+
+    def test_endpoint_preserves_existing_stars_and_appends_prebuilts(self) -> None:
+        # User already has a starred (non-prebuilt) dashboard before rollout.
+        DashboardFavoriteUser.objects.insert_favorite_dashboard(
+            organization=self.organization,
+            user_id=self.user.id,
+            dashboard=self.dashboard_2,
+        )
+
+        pre_favorited_prebuilt_ids = {
+            d["prebuilt_id"] for d in PREBUILT_DASHBOARDS if d.get("pre_favorited")
+        }
+
+        with self.feature(
+            [
+                "organizations:dashboards-prebuilt-insights-dashboards",
+                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
+                "organizations:dashboards-starred",
+            ]
+        ):
+            response = self.do_request("get", self.url)
+        assert response.status_code == 200
+
+        favorites = list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id, favorited=True
+            ).order_by("position")
+        )
+        # Existing star is retained and kept at the front; prebuilts appended after.
+        assert favorites[0].dashboard_id == self.dashboard_2.id
+        assert favorites[0].position == 0
+
+        favorited_prebuilt_ids = set(
+            Dashboard.objects.filter(
+                id__in=[f.dashboard_id for f in favorites],
+                prebuilt_id__isnull=False,
+            ).values_list("prebuilt_id", flat=True)
+        )
+        assert favorited_prebuilt_ids == pre_favorited_prebuilt_ids
+
     def test_post_with_text_widget(self) -> None:
         data = {
             "title": "Dashboard from Post",


### PR DESCRIPTION
This PR adds the ability to add specific prebuilt dashboards, namely `AI Agents Overview`, `Backend Overview` and `Web Vitals`. These will respect the existing list of favorite dashboards by the user and just be appended to that list. Also added some tests. This is currently feature flagged. 

Closes BROWSE-610.