### PR TITLE
build(ui): Silence `data-sentry-component` passed to fragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "scroll-to-element": "^2.0.0",
     "sprintf-js": "1.0.3",
     "style-loader": "4.0.0",
-    "swc-plugin-component-annotate": "1.17.0",
+    "swc-plugin-component-annotate": "1.17.1",
     "ts-checker-rspack-plugin": "1.5.2",
     "tslib": "^2.8.1",
     "type-fest": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,8 +527,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0(webpack@5.108.4(@swc/core@1.15.43)(esbuild@0.28.1)(postcss@8.5.3))
       swc-plugin-component-annotate:
-        specifier: 1.17.0
-        version: 1.17.0
+        specifier: 1.17.1
+        version: 1.17.1
       ts-checker-rspack-plugin:
         specifier: 1.5.2
         version: 1.5.2(@rspack/core@2.1.3)(@typescript/typescript6@6.0.2)(tslib@2.8.1)
@@ -8559,8 +8559,8 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
-  swc-plugin-component-annotate@1.17.0:
-    resolution: {integrity: sha512-hKu5oOx3w+VivrOaJvGPD2LbxErCNr1pRNHG1dXNPH5g9YzE4gX3bo04Fi1P+X9E2VtdZzvW8QeAIp7rtHDJFA==}
+  swc-plugin-component-annotate@1.17.1:
+    resolution: {integrity: sha512-ielxTb7QFGG/Qz43nrBAL8//5RZPSNTgEA0s3LJZEnFrHhCEle2RO5aRgNG3b5taKrTOFJzAPCKVEc/fACXWJA==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -18481,7 +18481,7 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  swc-plugin-component-annotate@1.17.0: {}
+  swc-plugin-component-annotate@1.17.1: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
Silences a dev warning caused by react compiler + our annotations. https://github.com/scttcper/swc-plugin-component-annotate/commit/14c9916db89dae1f436909e4e12f53e889f6ead0
