### PR TITLE
feat(issue-progress): Update progress on new PR lifecycle actions

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -2,6 +2,9 @@ from sentry.issues.action_log.types import (
     ArchiveAction,
     AssignAction,
     PullRequestClosedAction,
+    PullRequestMergedAction,
+    PullRequestReopenedAction,
+    PullRequestUnlinkedAction,
     ReconcileStatusAction,
     ResolveAction,
     ResolvedInPullRequestAction,
@@ -125,20 +128,26 @@ def track_root_cause(state: StateView, entry: GroupActionLogEntry) -> Aggregator
     scope=(
         ResolvedInPullRequestAction,
         PullRequestClosedAction,
+        PullRequestReopenedAction,
+        PullRequestMergedAction,
+        PullRequestUnlinkedAction,
     ),
 )
 def track_open_fix_prs(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     """Track whether an issue has an open fix PR.
-    When an issue has a fix PR created, the flag should be True.
-    When the last open PR closes, the flag should be False.
+    When an issue has a fix PR created or reopened, the flag should be True.
+    When the last open PR closes, merges, or is unlinked, the flag should be False.
     """
     current_has_open_fix_pr = state[HAS_OPEN_FIX_PR]
 
-    # TODO(malwilley): Merging or unlinking a PR should also clear the flag.
     match entry.action:
-        case ResolvedInPullRequestAction() if not current_has_open_fix_pr:
+        case ResolvedInPullRequestAction() | PullRequestReopenedAction() if not current_has_open_fix_pr:
             return emit(HAS_OPEN_FIX_PR.value(True))
-        case PullRequestClosedAction(has_other_open_prs=False) if current_has_open_fix_pr:
+        case (
+            PullRequestClosedAction(has_other_open_prs=False)
+            | PullRequestMergedAction(has_other_open_prs=False)
+            | PullRequestUnlinkedAction(has_other_open_prs=False)
+        ) if current_has_open_fix_pr:
             return emit(HAS_OPEN_FIX_PR.value(False))
 
     return None

--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -141,7 +141,9 @@ def track_open_fix_prs(state: StateView, entry: GroupActionLogEntry) -> Aggregat
     current_has_open_fix_pr = state[HAS_OPEN_FIX_PR]
 
     match entry.action:
-        case ResolvedInPullRequestAction() | PullRequestReopenedAction() if not current_has_open_fix_pr:
+        case ResolvedInPullRequestAction() | PullRequestReopenedAction() if (
+            not current_has_open_fix_pr
+        ):
             return emit(HAS_OPEN_FIX_PR.value(True))
         case (
             PullRequestClosedAction(has_other_open_prs=False)

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -681,6 +681,79 @@ def test_pr_close_with_remaining_keeps_fix_proposed() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "action_type",
+    [
+        GroupActionType.PULL_REQUEST_MERGED,
+        GroupActionType.PULL_REQUEST_UNLINKED,
+    ],
+)
+def test_pr_merged_or_unlinked_demotes_when_no_open_prs_remain(action_type: int) -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(type=GroupActionType.ROOT_CAUSE_IDENTIFIED),
+                FakeEntry(
+                    type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+                    data=_resolved_pr_data(101),
+                ),
+                FakeEntry(
+                    type=action_type,
+                    data={"pull_request": 101, "has_other_open_prs": False},
+                ),
+            ],
+        )
+        == IssueProgressState.DIAGNOSED
+    )
+
+
+@pytest.mark.parametrize(
+    "action_type",
+    [
+        GroupActionType.PULL_REQUEST_MERGED,
+        GroupActionType.PULL_REQUEST_UNLINKED,
+    ],
+)
+def test_pr_merged_or_unlinked_with_remaining_keeps_fix_proposed(action_type: int) -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(
+                    type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+                    data=_resolved_pr_data(101),
+                ),
+                FakeEntry(
+                    type=action_type,
+                    data={"pull_request": 101, "has_other_open_prs": True},
+                ),
+            ],
+        )
+        == IssueProgressState.FIX_PROPOSED
+    )
+
+
+def test_pr_reopened_restores_fix_proposed() -> None:
+    assert (
+        _run_for_feature(
+            PROGRESS,
+            [
+                FakeEntry(
+                    type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+                    data=_resolved_pr_data(101),
+                ),
+                _pr_closed(has_other=False),
+                FakeEntry(
+                    type=GroupActionType.PULL_REQUEST_REOPENED,
+                    data={"pull_request": 101},
+                ),
+            ],
+        )
+        == IssueProgressState.FIX_PROPOSED
+    )
+
+
 def test_pr_close_last_remaining_then_zero_demotes() -> None:
     assert (
         _run_for_feature(


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/119523

Now that we are creating logs for PRs being reopened, merged, or unlinked, this PR updates the progress logic to react to those new logs.