### PR TITLE
feat(auth): Add analytics events for signup email verification

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -99,6 +99,7 @@ from .sentry_app_token_exchanged import *  # noqa: F401,F403
 from .sentry_app_uninstalled import *  # noqa: F401,F403
 from .sentry_app_updated import *  # noqa: F401,F403
 from .sentryapp_issue_webhooks import *  # noqa: F401,F403
+from .signup_email_verification import *  # noqa: F401,F403
 from .sso_enabled import *  # noqa: F401,F403
 from .suspectcommit_assignment import *  # noqa: F401,F403
 from .team_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/signup_email_verification.py
+++ b/src/sentry/analytics/events/signup_email_verification.py
@@ -1,0 +1,10 @@
+from sentry import analytics
+
+
+@analytics.eventclass("signup_email_verification.clicked")
+class SignupEmailVerificationClickedEvent(analytics.Event):
+    email_hash: str
+    outcome: str  # "success", "expired", "tampered", "session_mismatch"
+
+
+analytics.register(SignupEmailVerificationClickedEvent)

--- a/src/sentry/auth/email_verification.py
+++ b/src/sentry/auth/email_verification.py
@@ -18,6 +18,18 @@ from sentry.utils.signing import sign, unsign
 
 logger = logging.getLogger("sentry.auth.email_verification")
 
+
+class SignupLinkExpired(SignatureExpired):
+    def __init__(self, message: str, email: str) -> None:
+        super().__init__(message)
+        self.email = email
+
+
+def hash_email(email: str) -> str:
+    """One-way hash for logging and analytics. Not the same hash used for rollout group assignment."""
+    return sha256_text(email.lower()).hexdigest()
+
+
 DEFAULT_MAX_AGE_MINUTES = 120
 
 
@@ -62,7 +74,7 @@ def send_signup_verification_email(
 
     logger.info(
         "signup_verification.sent",
-        extra={"email_hash": sha256_text(email.lower()).hexdigest()},
+        extra={"email_hash": hash_email(email)},
     )
 
 
@@ -79,12 +91,13 @@ def verify_signup_link(signed_data: str) -> dict[str, Any]:
     Session binding is the caller's responsibility — compare
     payload["email"] against request.session[PENDING_VERIFICATION_SESSION_KEY].
 
-    Raises BadSignature if tampered, SignatureExpired if past expires_at.
+    Raises BadSignature if tampered, SignupLinkExpired (a SignatureExpired
+    subclass) if past expires_at.
     """
     try:
         payload = unsign(signed_data, salt=settings.SIGNUP_VERIFICATION_EMAIL_SALT, max_age=None)
     except binascii.Error as e:
         raise BadSignature("Malformed verification link") from e
     if time.time() > payload["expires_at"]:
-        raise SignatureExpired("Verification link expired")
+        raise SignupLinkExpired("Verification link expired", email=payload["email"])
     return payload

--- a/src/sentry/web/frontend/signup_email_verification.py
+++ b/src/sentry/web/frontend/signup_email_verification.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import logging
 
 from django.conf import settings
-from django.core.signing import BadSignature, SignatureExpired
+from django.core.signing import BadSignature
 from django.http import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 
+from sentry import analytics
 from sentry import ratelimits as ratelimiter
-from sentry.auth.email_verification import verify_signup_link
-from sentry.utils.hashlib import sha256_text
+from sentry.analytics.events.signup_email_verification import (
+    SignupEmailVerificationClickedEvent,
+)
+from sentry.auth.email_verification import SignupLinkExpired, hash_email, verify_signup_link
 from sentry.web.frontend.base import BaseView
 
 PENDING_VERIFICATION_SESSION_KEY = "pending_signup_verification_email"
@@ -34,6 +37,18 @@ class BaseSignupVerificationView(BaseView):
     """
 
     auth_required = False
+
+    @staticmethod
+    def _record_clicked(request: HttpRequest, outcome: str, email: str | None = None) -> None:
+        if email is None:
+            email = request.session.get(PENDING_VERIFICATION_SESSION_KEY, "")
+        email_hash = hash_email(email) if email else ""
+        analytics.record(
+            SignupEmailVerificationClickedEvent(
+                email_hash=email_hash,
+                outcome=outcome,
+            )
+        )
 
     def _render_error(self, title: str, message: str) -> HttpResponseBase:
         context = {
@@ -62,12 +77,14 @@ class BaseSignupVerificationView(BaseView):
 
         try:
             payload = verify_signup_link(signed_data)
-        except SignatureExpired:
+        except SignupLinkExpired as e:
+            self._record_clicked(request, "expired", email=e.email)
             return self._render_error(
                 title="Link expired",
                 message="This verification link has expired. Please restart the signup process.",
             )
         except (BadSignature, ValueError):
+            self._record_clicked(request, "tampered")
             return self._render_error(
                 title="Verification error",
                 message="Something went wrong. Please restart the signup process.",
@@ -77,6 +94,7 @@ class BaseSignupVerificationView(BaseView):
         email = payload["email"].lower()
         email_in_session = request.session.get(PENDING_VERIFICATION_SESSION_KEY)
         if not email_in_session or email_in_session.lower() != email:
+            self._record_clicked(request, "session_mismatch", email=email)
             return self._render_error(
                 title="Verification error",
                 message="Please open this link in the same browser where you started signing up, or restart the signup process.",
@@ -86,8 +104,9 @@ class BaseSignupVerificationView(BaseView):
 
         logger.info(
             "signup_verification.verified",
-            extra={"email_hash": sha256_text(email.lower()).hexdigest()},
+            extra={"email_hash": hash_email(email)},
         )
+        self._record_clicked(request, "success", email=email)
 
         return self.handle_verified_email(request, email)
 


### PR DESCRIPTION
Add BigQuery analytics tracking and Amplitude experiment exposure tagging for the `email-verification-at-signup` experiment.

- Add `signup_email_verification.clicked` event recording outcome (`success` / `expired` / `tampered` / `session_mismatch`) in `BaseSignupVerificationView`
- Add `hash_email()` helper in `auth.email_verification` to deduplicate the email hashing pattern across logging and analytics call sites