### PR TITLE
feat(seer): smart-assignment dispatch and workflow wiring

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -245,6 +245,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-index", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Night Shift nightly autofix cron
     manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Run the Seer smart assignment feature (predictions + ground truth) on issues
+    manager.add("organizations:seer-smart-assignment-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Send notifications for Seer smart assignment predictions
+    manager.add("organizations:seer-smart-assignment-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display nightshift settings
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Roll out structured LLM page context on STRUCTURED_CONTEXT_ROUTES to all orgs

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1213,6 +1213,22 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Safety ceilings on how many smart-assignment Seer runs we dispatch, on top of
+# the feature flag and per-issue dedup. Rolling 24h windows; set to 0 to pause
+# dispatching entirely. See sentry.seer.smart_assignment.trigger.
+register(
+    "seer.smart_assignment.max_dispatches_per_org_per_day",
+    type=Int,
+    default=500,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "seer.smart_assignment.max_dispatches_per_day",
+    type=Int,
+    default=1500,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "issues.backfill_group_action_log.killswitch",
     type=Bool,

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -1,0 +1,153 @@
+"""Gating and dispatch for the smart assignment feature.
+
+`maybe_trigger_smart_assignment` is the single gated entrypoint: it checks the
+feature flag, dedups to one prediction per issue (so a run is only dispatched the
+first time), and enforces per-org and global daily dispatch caps. It takes a
+`SmartAssignmentTrigger` (not an `ActivityType`) so callers that aren't driven by
+an activity can trigger too.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import IntegrityError
+
+from sentry import features, options
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.ratelimits import backend as ratelimiter
+from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.models import SeerApiError, SeerPermissionError
+from sentry.seer.models.run import SeerRun
+from sentry.seer.models.smart_assignment import (
+    SeerSmartAssignmentResult,
+    SmartAssignmentStatus,
+    SmartAssignmentTrigger,
+)
+from sentry.seer.smart_assignment.models import SmartAssignmentPayload
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+FEATURE_FLAG = "organizations:seer-smart-assignment-run"
+FEATURE_ID = "smart_assignment"
+
+# Rolling window (seconds) for the per-org and global dispatch caps below.
+_RATE_LIMIT_WINDOW = 86400
+
+
+def maybe_trigger_smart_assignment(
+    group: Group,
+    trigger: SmartAssignmentTrigger,
+    activity: Activity | None = None,
+) -> None:
+    """Gate + dispatch a prediction for `group`.
+
+    Dispatches a Seer run the first time (deduped to one row per group, and subject
+    to per-org / global daily caps). `activity` is only used to tell whether a
+    `RESOLUTION` had an acting user. No-op unless the org is flagged. Automatic
+    resolutions (no acting user, e.g. resolved by age) are skipped entirely -- we
+    only treat a resolution as signal when a human resolved the issue, since then
+    they probably should have been the assignee.
+    """
+    organization = group.organization
+
+    if not features.has(FEATURE_FLAG, organization):
+        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "flag_disabled"})
+        return
+
+    if trigger == SmartAssignmentTrigger.RESOLUTION and (
+        activity is None or activity.user_id is None
+    ):
+        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "automatic_resolution"})
+        return
+
+    # Policy gate: today we predict at most once per issue, ever. This lives in app
+    # code (not the DB constraint, which only prevents concurrent in-flight runs) so
+    # re-runs are cheap to enable later -- e.g. swap this for a `status=PENDING`
+    # check to allow a fresh run once the previous one finished, or gate on a
+    # cooldown/new-signal check against the latest row. No migration required.
+    if not SeerSmartAssignmentResult.objects.filter(group_id=group.id).exists():
+        if not _dispatch_rate_limited(organization):
+            _dispatch(group, trigger)
+
+
+def _dispatch_rate_limited(organization: Organization) -> bool:
+    """True if we've hit the per-org or global daily dispatch cap.
+
+    A safety ceiling on Seer spend, layered on top of the flag and per-issue
+    dedup. Both caps are rolling 24h windows backed by the Redis ratelimiter. We
+    check the per-org bucket first so a single noisy org rejects without eating
+    into the global budget.
+    """
+    if ratelimiter.is_limited(
+        f"smart_assignment:dispatch:org:{organization.id}",
+        limit=options.get("seer.smart_assignment.max_dispatches_per_org_per_day"),
+        window=_RATE_LIMIT_WINDOW,
+    ):
+        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "org_rate_limited"})
+        return True
+
+    if ratelimiter.is_limited(
+        "smart_assignment:dispatch:global",
+        limit=options.get("seer.smart_assignment.max_dispatches_per_day"),
+        window=_RATE_LIMIT_WINDOW,
+    ):
+        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "global_rate_limited"})
+        return True
+
+    return False
+
+
+def _dispatch(group: Group, trigger: SmartAssignmentTrigger) -> None:
+    """Dispatch a Seer smart-assignment run and create the pending result row."""
+    organization = group.organization
+
+    try:
+        client = SeerAgentClient(
+            organization,
+            project=group.project,
+            group=group,
+            category_key=FEATURE_ID,
+            category_value=str(group.id),
+        )
+    except SeerPermissionError:
+        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "no_seer_access"})
+        return
+
+    def _create_row(run: SeerRun) -> None:
+        SeerSmartAssignmentResult.objects.create(
+            organization_id=organization.id,
+            group_id=group.id,
+            result_seer_run=run,
+            trigger=trigger,
+            status=SmartAssignmentStatus.PENDING,
+        )
+
+    payload = SmartAssignmentPayload(group_id=group.id, project_slug=group.project.slug)
+    title = f"Smart assignment for {group.qualified_short_id or group.id}"
+    try:
+        client.start_feature_run(
+            feature_id=FEATURE_ID,
+            payload=payload.dict(),
+            title=title,
+            flush=False,
+            on_run_created=_create_row,
+        )
+    except IntegrityError:
+        # A concurrent trigger already created an in-flight row for this group (the
+        # partial unique index allows only one PENDING row per group); its run
+        # dispatch is rolled back with it. Treat as a dedup no-op.
+        metrics.incr("smart_assignment.trigger.skipped", tags={"reason": "already_predicted_race"})
+        return
+    except SeerApiError:
+        logger.exception("smart_assignment.trigger.dispatch_failed", extra={"group_id": group.id})
+        return
+
+    metrics.incr("smart_assignment.trigger.dispatched", tags={"trigger": trigger})
+    logger.info(
+        "smart_assignment.trigger.dispatched",
+        extra={"group_id": group.id, "organization_id": organization.id, "trigger": trigger},
+    )

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,6 +1,11 @@
-from .workflow_activity_handlers import activity_handler, seer_activity_handler
+from .workflow_activity_handlers import (
+    activity_handler,
+    seer_activity_handler,
+    smart_assignment_activity_handler,
+)
 
 __all__ = [
     "activity_handler",
     "seer_activity_handler",
+    "smart_assignment_activity_handler",
 ]

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -34,6 +34,22 @@ SUPPORTED_ACTIVITIES = [
     # When it fires, it means the issue was referenced in a pull request, not resolved.
 ]
 
+# Activities the smart assignment feature reacts to: Seer opening a PR, an
+# assignment, or a resolution. Each triggers a prediction (deduped to one per
+# group) and records ground truth; gating lives in maybe_trigger_smart_assignment.
+# SET_RESOLVED_BY_AGE is intentionally excluded: it's always the auto-resolve cron
+# (no acting user), so it carries no signal and would only ever be filtered out.
+_SMART_ASSIGNMENT_ACTIVITIES = frozenset(
+    {
+        ActivityType.SEER_PR_CREATED,
+        ActivityType.ASSIGNED,
+        ActivityType.SET_RESOLVED,
+        ActivityType.SET_RESOLVED_IN_RELEASE,
+        ActivityType.SET_RESOLVED_IN_COMMIT,
+        ActivityType.SET_RESOLVED_IN_PULL_REQUEST,
+    }
+)
+
 
 @workflow_activity_registry.register("seer_activity")
 def seer_activity_handler(
@@ -85,6 +101,40 @@ def seer_activity_handler(
         tags={"activity_name": activity_type.name},
     )
     logger.info("workflow_engine.seer_activity_handler.complete", extra=logging_ctx)
+
+
+@workflow_activity_registry.register("smart_assignment")
+def smart_assignment_activity_handler(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId | None = None,
+) -> None:
+    """Trigger the smart assignment feature off Seer PRs, assignment, and resolution.
+
+    Invoked unconditionally for every group activity (via
+    invoke_workflow_activity_handlers), so it self-filters to the activities we care
+    about and delegates gating, dispatch (deduped to one run per group), and
+    ground-truth capture to maybe_trigger_smart_assignment.
+    """
+    try:
+        activity_type = ActivityType(activity.type)
+    except ValueError:
+        return
+
+    if activity_type not in _SMART_ASSIGNMENT_ACTIVITIES:
+        return
+
+    from sentry.seer.models.smart_assignment import SmartAssignmentTrigger
+    from sentry.seer.smart_assignment.trigger import maybe_trigger_smart_assignment
+
+    if activity_type == ActivityType.SEER_PR_CREATED:
+        trigger = SmartAssignmentTrigger.PR_CREATED
+    elif activity_type == ActivityType.ASSIGNED:
+        trigger = SmartAssignmentTrigger.ASSIGNMENT
+    else:
+        trigger = SmartAssignmentTrigger.RESOLUTION
+
+    maybe_trigger_smart_assignment(group, trigger, activity)
 
 
 @workflow_activity_registry.register("generic_activity")

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -1,0 +1,113 @@
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from sentry.models.activity import Activity
+from sentry.seer.models.run import SeerRun, SeerRunType
+from sentry.seer.models.smart_assignment import (
+    SeerSmartAssignmentResult,
+    SmartAssignmentStatus,
+    SmartAssignmentTrigger,
+)
+from sentry.seer.smart_assignment.trigger import maybe_trigger_smart_assignment
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+CLIENT_PATH = "sentry.seer.smart_assignment.trigger.SeerAgentClient"
+
+
+class MaybeTriggerSmartAssignmentTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+
+    def _wire_client(self, mock_client_cls: MagicMock) -> SeerRun:
+        """Make start_feature_run invoke on_run_created with a real SeerRun."""
+        seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+
+        def fake_start(**kwargs: object) -> SeerRun:
+            on_run_created = kwargs["on_run_created"]
+            assert callable(on_run_created)
+            on_run_created(seer_run)
+            return seer_run
+
+        mock_client_cls.return_value.start_feature_run.side_effect = fake_start
+        return seer_run
+
+    def _resolved_activity(self, user_id: int | None = None) -> Activity:
+        return self.create_group_activity(
+            group=self.group, type=ActivityType.SET_RESOLVED.value, user_id=user_id
+        )
+
+    @patch(CLIENT_PATH)
+    def test_dispatch_creates_pending_row(self, mock_client_cls: MagicMock) -> None:
+        seer_run = self._wire_client(mock_client_cls)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.PR_CREATED)
+
+        row = SeerSmartAssignmentResult.objects.get(group=self.group)
+        assert row.trigger == SmartAssignmentTrigger.PR_CREATED
+        assert row.status == SmartAssignmentStatus.PENDING
+        assert row.result_seer_run_id == seer_run.id
+        # PR creation carries no ground truth.
+        assert row.actual_assignee_user_id is None
+        assert row.ground_truth_source is None
+
+    @patch(CLIENT_PATH)
+    def test_flag_disabled_is_noop(self, mock_client_cls: MagicMock) -> None:
+        maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.PR_CREATED)
+        assert not SeerSmartAssignmentResult.objects.filter(group=self.group).exists()
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_dedup_skips_second_dispatch(self, mock_client_cls: MagicMock) -> None:
+        SeerSmartAssignmentResult.objects.create(
+            organization=self.organization,
+            group=self.group,
+            trigger=SmartAssignmentTrigger.PR_CREATED,
+            status=SmartAssignmentStatus.PENDING,
+        )
+        with self.feature("organizations:seer-smart-assignment-run"):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.PR_CREATED)
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_org_rate_limit_skips_dispatch(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.max_dispatches_per_org_per_day": 0}),
+        ):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.PR_CREATED)
+
+        assert not SeerSmartAssignmentResult.objects.filter(group=self.group).exists()
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_global_rate_limit_skips_dispatch(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        # Org cap is generous; the global cap is what trips here.
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options({"seer.smart_assignment.max_dispatches_per_day": 0}),
+        ):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.PR_CREATED)
+
+        assert not SeerSmartAssignmentResult.objects.filter(group=self.group).exists()
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_automatic_resolution_is_skipped(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            maybe_trigger_smart_assignment(
+                self.group, SmartAssignmentTrigger.RESOLUTION, self._resolved_activity(None)
+            )
+
+        # No acting user -> not a signal, so we don't even dispatch a prediction.
+        assert not SeerSmartAssignmentResult.objects.filter(group=self.group).exists()
+        mock_client_cls.return_value.start_feature_run.assert_not_called()

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -10,6 +10,7 @@ from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import 
     SUPPORTED_ACTIVITIES,
     activity_handler,
     seer_activity_handler,
+    smart_assignment_activity_handler,
 )
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.registry import workflow_activity_registry
@@ -20,7 +21,48 @@ class WorkflowActivityRegistryTest(TestCase):
     def test_registrants(self) -> None:
         assert "seer_activity" in workflow_activity_registry.registrations
         assert "generic_activity" in workflow_activity_registry.registrations
-        assert len(workflow_activity_registry.registrations) == 2
+        assert "smart_assignment" in workflow_activity_registry.registrations
+        assert len(workflow_activity_registry.registrations) == 3
+
+
+class SmartAssignmentActivityHandlerTest(TestCase):
+    TRIGGER = "sentry.seer.smart_assignment.trigger.maybe_trigger_smart_assignment"
+
+    def setUp(self) -> None:
+        self.group = self.create_group()
+
+    @mock.patch(TRIGGER)
+    def test_delegates_for_relevant_activities(self, mock_trigger: MagicMock) -> None:
+        from sentry.seer.models.smart_assignment import SmartAssignmentTrigger
+
+        cases = [
+            (ActivityType.SEER_PR_CREATED, SmartAssignmentTrigger.PR_CREATED, None),
+            (
+                ActivityType.ASSIGNED,
+                SmartAssignmentTrigger.ASSIGNMENT,
+                {"assignee": "1", "assigneeType": "user"},
+            ),
+            (ActivityType.SET_RESOLVED, SmartAssignmentTrigger.RESOLUTION, None),
+            (ActivityType.SET_RESOLVED_IN_COMMIT, SmartAssignmentTrigger.RESOLUTION, None),
+        ]
+        for activity_type, expected_trigger, data in cases:
+            mock_trigger.reset_mock()
+            activity = self.create_group_activity(
+                group=self.group, type=activity_type.value, data=data
+            )
+            smart_assignment_activity_handler(self.group, activity, None)
+            mock_trigger.assert_called_once_with(self.group, expected_trigger, activity)
+
+    @mock.patch(TRIGGER)
+    def test_skips_unrelated_activities(self, mock_trigger: MagicMock) -> None:
+        for activity_type in (
+            ActivityType.SEER_SOLUTION_COMPLETED,
+            ActivityType.SET_RESOLVED_BY_AGE,
+            ActivityType.NOTE,
+        ):
+            activity = self.create_group_activity(group=self.group, type=activity_type.value)
+            smart_assignment_activity_handler(self.group, activity, None)
+        mock_trigger.assert_not_called()
 
 
 class SeerActivityHandlerTest(TestCase):


### PR DESCRIPTION
## Summary
The **inbound** side of Seer smart assignment (PR 2 of 3) — everything that reacts to Sentry-side events and dispatches a prediction. Stacked on #119591.

- Feature flags `seer-smart-assignment-run` / `seer-smart-assignment-notifications` and per-org/global daily dispatch safety limits.
- Seer request payload model (`SmartAssignmentPayload`).
- `maybe_trigger_smart_assignment` — flag gate, one-prediction-per-issue dedup, per-org/global rate limits, dispatch.
- Workflow-engine wiring: `smart_assignment_activity_handler` routes Seer-PR-created, assignment, and resolution activities into the trigger (`SET_RESOLVED_BY_AGE` intentionally excluded).
- Dispatch/gating and workflow-handler tests.

Ground-truth capture, scoring, and delivery of Seer's async result land in PR 3.

## Stack
1. #119591 — data model + migration
2. **This PR** — dispatch + workflow wiring (stuff in)
3. #119593 — ground truth, scoring, delivery (stuff out)

> Review after #119591; base retargets to `master` once it merges.

## Test plan
- [ ] `pytest tests/sentry/seer/smart_assignment/test_trigger.py`
- [ ] `pytest tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py`
- [ ] CI