### PR TITLE
feat(seer): smart-assignment ground truth, scoring, and delivery

### DIFF
--- a/src/sentry/seer/agent/feature_delivery.py
+++ b/src/sentry/seer/agent/feature_delivery.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.night_shift.delivery import deliver_night_shift_result
+from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
 
 __all__ = ["DELIVERY_HANDLERS", "FeatureDeliveryFn", "FeatureRunStatus"]
 
@@ -23,4 +24,5 @@ class FeatureDeliveryFn(Protocol):
 
 DELIVERY_HANDLERS: dict[str, FeatureDeliveryFn] = {
     "night_shift": deliver_night_shift_result,
+    "smart_assignment": deliver_smart_assignment_result,
 }

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -97,7 +97,7 @@ def deliver_smart_assignment_result(
     if status == "error" or result is None:
         row.update(
             status=SmartAssignmentStatus.ERROR,
-            extras={**(row.extras or {}), "error": error or "no_artifact"},
+            error_message=error or "no_artifact",
         )
         metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
         logger.warning("smart_assignment.delivery.no_result", extra={**log_extra, "status": status})
@@ -108,7 +108,7 @@ def deliver_smart_assignment_result(
     except Exception:
         row.update(
             status=SmartAssignmentStatus.ERROR,
-            extras={**(row.extras or {}), "error": "invalid_artifact"},
+            error_message="invalid_artifact",
         )
         metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
         logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -1,0 +1,145 @@
+"""Delivery handler for smart_assignment feature results from Seer.
+
+Seer pushes the `AssigneeVerdict` artifact back via the `deliver_feature_result`
+RPC, routed here by feature_id (see `sentry.seer.agent.feature_delivery`). We
+locate the pending `SeerSmartAssignmentResult` row by the run uuid and record the
+verdict for offline evaluation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sentry.models.organization import Organization
+from sentry.organizations.services.organization import organization_service
+from sentry.seer.agent.types import FeatureRunStatus
+from sentry.seer.models.smart_assignment import SeerSmartAssignmentResult, SmartAssignmentStatus
+from sentry.seer.smart_assignment.models import AssigneeVerdict
+from sentry.seer.smart_assignment.scoring import score_prediction
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_identifier_to_user_id(
+    organization: Organization, identifier: str | None, kind: str | None
+) -> int | None:
+    """Map an agent-produced `identifier` to a Sentry user id in the org.
+
+    The agent tags each pick with `identifier_kind` (see the `RankedCandidate`
+    contract on the Seer side) so we resolve deterministically instead of inferring
+    the type from the string:
+      - "email":    verified org email (the RPC already scopes to the org).
+      - "username": unique username, confirmed to be an org member so a global match
+                    can't attribute a prediction to someone outside the org.
+    `kind` is a validated Literal by the time it gets here, so this doesn't guess.
+    Returns None when the agent named no one or the identifier maps to no org user.
+    """
+    if not identifier:
+        return None
+
+    value = identifier.strip()
+    if not value:
+        return None
+
+    if kind == "email":
+        users = user_service.get_many_by_email(
+            emails=[value], organization_id=organization.id, is_verified=True
+        )
+        return users[0].id if users else None
+
+    if kind == "username":
+        users = user_service.get_by_username(username=value)
+        if not users:
+            return None
+        user_id = users[0].id
+        member = organization_service.check_membership_by_id(
+            organization_id=organization.id, user_id=user_id
+        )
+        return user_id if member is not None else None
+
+    return None
+
+
+def deliver_smart_assignment_result(
+    organization_id: int,
+    run_uuid: str,
+    status: FeatureRunStatus,
+    result: dict[str, Any] | None,
+    error: str | None,
+) -> None:
+    """Record a smart_assignment verdict delivered from Seer onto its result row.
+
+    Emits a single `smart_assignment.delivery` counter tagged with the outcome so
+    we can track success vs failure, how often the agent abstains, and how often it
+    names someone we can't link to a Sentry user in the org:
+      - `missing_row`  -- delivery arrived with no matching row (orphaned run)
+      - `error`        -- Seer run failed or returned no artifact
+      - `abstain`      -- completed, but the agent named no one
+      - `unlinked`     -- named someone we couldn't map to an org user
+      - `resolved`     -- named someone we mapped to a Sentry user
+    """
+    row = SeerSmartAssignmentResult.objects.filter(
+        result_seer_run__uuid=run_uuid, organization_id=organization_id
+    ).first()
+    if row is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_row"})
+        logger.warning(
+            "smart_assignment.delivery.missing_row",
+            extra={"organization_id": organization_id, "run_uuid": run_uuid},
+        )
+        return
+
+    log_extra = {"organization_id": organization_id, "group_id": row.group_id, "row_id": row.id}
+
+    if status == "error" or result is None:
+        row.update(
+            status=SmartAssignmentStatus.ERROR,
+            extras={**(row.extras or {}), "error": error or "no_artifact"},
+        )
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
+        logger.warning("smart_assignment.delivery.no_result", extra={**log_extra, "status": status})
+        return
+
+    try:
+        verdict = AssigneeVerdict.parse_obj(result)
+    except Exception:
+        row.update(
+            status=SmartAssignmentStatus.ERROR,
+            extras={**(row.extras or {}), "error": "invalid_artifact"},
+        )
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
+        logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)
+        return
+
+    top_pick = verdict.candidates[0] if verdict.candidates else None
+    predicted_identifier = top_pick.identifier if top_pick is not None else None
+    predicted_kind = top_pick.identifier_kind if top_pick is not None else None
+
+    # Resolve the top pick to a Sentry user so evaluation can compare it directly
+    # against the recorded ground-truth assignee. Left null if the agent named no
+    # one or the identifier doesn't map to a user in the org; the raw string is
+    # still preserved in `verdict`.
+    predicted_assignee_user_id = _resolve_identifier_to_user_id(
+        row.organization, predicted_identifier, predicted_kind
+    )
+
+    row.update(
+        status=SmartAssignmentStatus.COMPLETED,
+        verdict=result,
+        predicted_assignee_user_id=predicted_assignee_user_id,
+    )
+
+    if not predicted_identifier:
+        outcome = "abstain"
+    elif predicted_assignee_user_id is None:
+        outcome = "unlinked"
+    else:
+        outcome = "resolved"
+    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome})
+
+    # Ground truth may already be recorded (assignment landed before Seer finished);
+    # if so this completes the pair and scores correctness now.
+    score_prediction(row)

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -1,0 +1,158 @@
+"""Capture ground truth for a prediction and score it.
+
+This is the evaluation side of the feature: `record_ground_truth` labels a result
+row with who the issue actually belonged to, and `score_prediction` grades the
+prediction against that label. Both the trigger path (on assignment/resolution)
+and the delivery handler (when Seer's answer lands) drive these.
+
+Correctness can't be scored at delivery: the ground-truth assignee usually lands
+later (and occasionally earlier, if someone assigns before Seer finishes). So both
+`record_ground_truth` and the delivery handler call `score_prediction` after they
+write, and whichever completes the (prediction, ground truth) pair second emits
+the metric. The chosen outcome is also stored on the row (in `extras`), which
+doubles as a one-shot marker so we emit exactly once.
+
+Outcomes give partial credit for landing on the right team:
+  - `exact` -- predicted user is the actual assignee
+  - `team`  -- predicted user isn't the assignee but is on the correct team
+  - `miss`  -- neither
+
+The "correct team" is the team the issue was assigned to, or (for a user
+assignment) any team the actual assignee belongs to. This is a coarse live signal;
+authoritative accuracy is best computed offline from the table.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.utils import timezone
+
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.seer.models.smart_assignment import SeerSmartAssignmentResult, SmartAssignmentTrigger
+from sentry.utils import metrics
+
+_SCORE_KEY = "score"
+
+# Marker the acting code stamps into the ASSIGNED activity's data (via the assign()
+# `extra` dict) when it auto-assigns based on a prediction. Lets ground-truth
+# capture skip our own assignment -- recording it would just score us against
+# ourselves.
+AUTO_ASSIGN_SOURCE = "seer_smart_assignment"
+
+
+def record_ground_truth(
+    group: Group,
+    trigger: SmartAssignmentTrigger,
+    activity: Activity | None = None,
+) -> None:
+    """Annotate an existing prediction row with ground truth for the given outcome.
+
+    No-op if no prediction was made for the group, or the outcome carries no useful
+    signal: `PR_CREATED`, an automatic resolution with no acting user, or our own
+    auto-assignment (tagged with `AUTO_ASSIGN_SOURCE`, which would just score us
+    against ourselves). For an assignment we mirror the current assignee (user
+    and/or team). For a user-driven resolution we record the resolver as the assumed
+    assignee only when no explicit assignee is set -- an assignment is better ground
+    truth than the resolver.
+    """
+    row = SeerSmartAssignmentResult.objects.filter(group_id=group.id).first()
+    if row is None:
+        return
+
+    updates: dict[str, Any] = {}
+    if trigger == SmartAssignmentTrigger.ASSIGNMENT:
+        if activity is not None and (activity.data or {}).get("source") == AUTO_ASSIGN_SOURCE:
+            # Our own auto-assignment from a prediction isn't independent ground
+            # truth -- recording it would just score us against ourselves.
+            return
+        assignee = GroupAssignee.objects.filter(group=group).first()
+        if assignee is None:
+            return
+        # Current assignment is authoritative: set whichever of user/team it is and
+        # clear the other so the row reflects the latest assignee.
+        updates["actual_assignee_user_id"] = assignee.user_id
+        updates["actual_assignee_team_id"] = assignee.team_id
+    elif trigger == SmartAssignmentTrigger.RESOLUTION:
+        if activity is None or activity.user_id is None:
+            return
+        if row.actual_assignee_user_id is not None:
+            # An explicit assignee is better ground truth than the resolver; don't
+            # overwrite it with whoever happened to resolve the issue.
+            return
+        # No assignee yet: treat the resolving user as the assumed assignee. Keep any
+        # existing team assignee (a user resolving a team-assigned issue is extra
+        # signal that they're on that team, not a correction).
+        updates["actual_assignee_user_id"] = activity.user_id
+    else:
+        return
+
+    updates["ground_truth_source"] = trigger
+    updates["ground_truth_at"] = timezone.now()
+    row.update(**updates)
+    metrics.incr("smart_assignment.ground_truth.recorded", tags={"trigger": trigger})
+
+    # If the prediction was already delivered, this completes the pair and scores
+    # whether our guess matched the actual assignee.
+    score_prediction(row)
+
+
+def _user_team_ids(organization_id: int, user_id: int) -> set[int]:
+    return set(
+        OrganizationMemberTeam.objects.filter(
+            is_active=True,
+            organizationmember__organization_id=organization_id,
+            organizationmember__user_id=user_id,
+        ).values_list("team_id", flat=True)
+    )
+
+
+def _correct_team_ids(row: SeerSmartAssignmentResult) -> set[int]:
+    """The team(s) a correct prediction could belong to for this row's ground truth."""
+    if row.actual_assignee_team_id is not None:
+        return {row.actual_assignee_team_id}
+    if row.actual_assignee_user_id is not None:
+        return _user_team_ids(row.organization_id, row.actual_assignee_user_id)
+    return set()
+
+
+def _is_team_match(row: SeerSmartAssignmentResult) -> bool:
+    """Whether the predicted user is on a team the ground truth points at."""
+    predicted_user_id = row.predicted_assignee_user_id
+    if predicted_user_id is None:
+        return False
+    correct_team_ids = _correct_team_ids(row)
+    if not correct_team_ids:
+        return False
+    predicted_team_ids = _user_team_ids(row.organization_id, predicted_user_id)
+    return bool(predicted_team_ids & correct_team_ids)
+
+
+def score_prediction(row: SeerSmartAssignmentResult) -> None:
+    """Emit `smart_assignment.scored` (exact/team/miss) once per row.
+
+    No-op until the row has both a resolved predicted user and some ground truth (a
+    user and/or team assignee), and only fires once (guarded by the stored outcome
+    in `extras`).
+    """
+    predicted_user_id = row.predicted_assignee_user_id
+    has_ground_truth = (
+        row.actual_assignee_user_id is not None or row.actual_assignee_team_id is not None
+    )
+    if predicted_user_id is None or not has_ground_truth:
+        return
+    if (row.extras or {}).get(_SCORE_KEY) is not None:
+        return
+
+    if predicted_user_id == row.actual_assignee_user_id:
+        outcome = "exact"
+    elif _is_team_match(row):
+        outcome = "team"
+    else:
+        outcome = "miss"
+
+    metrics.incr("smart_assignment.scored", tags={"result": outcome, "trigger": row.trigger})
+    row.update(extras={**(row.extras or {}), _SCORE_KEY: outcome})

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -9,8 +9,8 @@ Correctness can't be scored at delivery: the ground-truth assignee usually lands
 later (and occasionally earlier, if someone assigns before Seer finishes). So both
 `record_ground_truth` and the delivery handler call `score_prediction` after they
 write, and whichever completes the (prediction, ground truth) pair second emits
-the metric. The chosen outcome is also stored on the row (in `extras`), which
-doubles as a one-shot marker so we emit exactly once.
+the metric. The chosen outcome is also stored on the row (in the `score` column),
+which doubles as a one-shot marker so we emit exactly once.
 
 Outcomes give partial credit for landing on the right team:
   - `exact` -- predicted user is the actual assignee
@@ -32,10 +32,12 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.seer.models.smart_assignment import SeerSmartAssignmentResult, SmartAssignmentTrigger
+from sentry.seer.models.smart_assignment import (
+    SeerSmartAssignmentResult,
+    SmartAssignmentScore,
+    SmartAssignmentTrigger,
+)
 from sentry.utils import metrics
-
-_SCORE_KEY = "score"
 
 # Marker the acting code stamps into the ASSIGNED activity's data (via the assign()
 # `extra` dict) when it auto-assigns based on a prediction. Lets ground-truth
@@ -135,8 +137,7 @@ def score_prediction(row: SeerSmartAssignmentResult) -> None:
     """Emit `smart_assignment.scored` (exact/team/miss) once per row.
 
     No-op until the row has both a resolved predicted user and some ground truth (a
-    user and/or team assignee), and only fires once (guarded by the stored outcome
-    in `extras`).
+    user and/or team assignee), and only fires once (guarded by the stored `score`).
     """
     predicted_user_id = row.predicted_assignee_user_id
     has_ground_truth = (
@@ -144,15 +145,15 @@ def score_prediction(row: SeerSmartAssignmentResult) -> None:
     )
     if predicted_user_id is None or not has_ground_truth:
         return
-    if (row.extras or {}).get(_SCORE_KEY) is not None:
+    if row.score is not None:
         return
 
     if predicted_user_id == row.actual_assignee_user_id:
-        outcome = "exact"
+        outcome = SmartAssignmentScore.EXACT
     elif _is_team_match(row):
-        outcome = "team"
+        outcome = SmartAssignmentScore.TEAM
     else:
-        outcome = "miss"
+        outcome = SmartAssignmentScore.MISS
 
     metrics.incr("smart_assignment.scored", tags={"result": outcome, "trigger": row.trigger})
-    row.update(extras={**(row.extras or {}), _SCORE_KEY: outcome})
+    row.update(score=outcome)

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -2,9 +2,10 @@
 
 `maybe_trigger_smart_assignment` is the single gated entrypoint: it checks the
 feature flag, dedups to one prediction per issue (so a run is only dispatched the
-first time), and enforces per-org and global daily dispatch caps. It takes a
-`SmartAssignmentTrigger` (not an `ActivityType`) so callers that aren't driven by
-an activity can trigger too.
+first time), enforces per-org and global daily dispatch caps, and records the
+observed ground truth (via `scoring.record_ground_truth`) whether or not a new run
+was dispatched. It takes a `SmartAssignmentTrigger` (not an `ActivityType`) so
+callers that aren't driven by an activity can trigger too.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from sentry.seer.models.smart_assignment import (
     SmartAssignmentTrigger,
 )
 from sentry.seer.smart_assignment.models import SmartAssignmentPayload
+from sentry.seer.smart_assignment.scoring import record_ground_truth
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -43,14 +45,17 @@ def maybe_trigger_smart_assignment(
     trigger: SmartAssignmentTrigger,
     activity: Activity | None = None,
 ) -> None:
-    """Gate + dispatch a prediction for `group`.
+    """Gate + dispatch a prediction for `group`, and record ground truth.
 
     Dispatches a Seer run the first time (deduped to one row per group, and subject
-    to per-org / global daily caps). `activity` is only used to tell whether a
-    `RESOLUTION` had an acting user. No-op unless the org is flagged. Automatic
-    resolutions (no acting user, e.g. resolved by age) are skipped entirely -- we
-    only treat a resolution as signal when a human resolved the issue, since then
-    they probably should have been the assignee.
+    to per-org / global daily caps); records the observed ground truth for
+    `ASSIGNMENT` / `RESOLUTION` triggers either way. Note the caps only gate new
+    dispatches -- ground truth is still recorded for already-predicted issues.
+    `activity` is only needed to capture the resolving user for a `RESOLUTION`.
+    No-op unless the org is flagged. Automatic resolutions (no acting user, e.g.
+    resolved by age) are skipped entirely -- we only treat a resolution as signal
+    when a human resolved the issue, since then they probably should have been the
+    assignee.
     """
     organization = group.organization
 
@@ -72,6 +77,8 @@ def maybe_trigger_smart_assignment(
     if not SeerSmartAssignmentResult.objects.filter(group_id=group.id).exists():
         if not _dispatch_rate_limited(organization):
             _dispatch(group, trigger)
+
+    record_ground_truth(group, trigger, activity)
 
 
 def _dispatch_rate_limited(organization: Organization) -> bool:

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -133,7 +133,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
         )
         self.row.refresh_from_db()
         assert self.row.status == SmartAssignmentStatus.ERROR
-        assert self.row.extras.get("error") == "boom"
+        assert self.row.error_message == "boom"
         self._assert_outcome(mock_metrics, "error")
 
     @patch("sentry.seer.smart_assignment.scoring.metrics")

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -1,0 +1,178 @@
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from sentry.seer.models.run import SeerRun, SeerRunType
+from sentry.seer.models.smart_assignment import (
+    SeerSmartAssignmentResult,
+    SmartAssignmentStatus,
+    SmartAssignmentTrigger,
+)
+from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
+from sentry.testutils.cases import TestCase
+
+METRICS_PATH = "sentry.seer.smart_assignment.delivery.metrics"
+
+
+class DeliverSmartAssignmentResultTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        self.row = SeerSmartAssignmentResult.objects.create(
+            organization=self.organization,
+            group=self.group,
+            result_seer_run=self.seer_run,
+            trigger=SmartAssignmentTrigger.PR_CREATED,
+            status=SmartAssignmentStatus.PENDING,
+        )
+
+    def _assert_outcome(self, mock_metrics: MagicMock, expected: str) -> None:
+        mock_metrics.incr.assert_called_once_with(
+            "smart_assignment.delivery", tags={"outcome": expected}
+        )
+
+    @patch(METRICS_PATH)
+    def test_records_verdict_resolving_top_pick_to_user(self, mock_metrics: MagicMock) -> None:
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "suspect commit",
+                    "confidence": "high",
+                },
+                {
+                    "identifier": "bob",
+                    "identifier_kind": "username",
+                    "reason": "code owner",
+                    "confidence": "low",
+                },
+            ]
+        }
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), "completed", result, None
+        )
+
+        self.row.refresh_from_db()
+        assert self.row.status == SmartAssignmentStatus.COMPLETED
+        # Top pick resolved to a real user; raw string still lives in the verdict.
+        assert self.row.predicted_assignee_user_id == alice.id
+        assert self.row.verdict == result
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_email_kind_resolves_by_verified_email(self, mock_metrics: MagicMock) -> None:
+        # An email-kind pick (unlinked commit author) resolves by verified org email,
+        # even when the address happens to also be someone's username-shaped handle.
+        carol = self.create_user(email="carol@example.com")
+        self.create_member(user=carol, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "carol@example.com",
+                    "identifier_kind": "email",
+                    "reason": "unlinked commit author",
+                    "confidence": "low",
+                },
+            ]
+        }
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), "completed", result, None
+        )
+
+        self.row.refresh_from_db()
+        assert self.row.predicted_assignee_user_id == carol.id
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_unresolvable_identifier_completes_with_no_user(self, mock_metrics: MagicMock) -> None:
+        result = {
+            "candidates": [
+                {
+                    "identifier": "nobody-here",
+                    "identifier_kind": "username",
+                    "reason": "guess",
+                    "confidence": "low",
+                },
+            ]
+        }
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), "completed", result, None
+        )
+
+        self.row.refresh_from_db()
+        assert self.row.status == SmartAssignmentStatus.COMPLETED
+        assert self.row.predicted_assignee_user_id is None
+        # The raw identifier is still recoverable from the stored verdict.
+        assert self.row.verdict == result
+        self._assert_outcome(mock_metrics, "unlinked")
+
+    @patch(METRICS_PATH)
+    def test_empty_candidates_is_completed_with_no_prediction(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), "completed", {"candidates": []}, None
+        )
+        self.row.refresh_from_db()
+        assert self.row.status == SmartAssignmentStatus.COMPLETED
+        assert self.row.predicted_assignee_user_id is None
+        self._assert_outcome(mock_metrics, "abstain")
+
+    @patch(METRICS_PATH)
+    def test_error_status_marks_row_error(self, mock_metrics: MagicMock) -> None:
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), "error", None, "boom"
+        )
+        self.row.refresh_from_db()
+        assert self.row.status == SmartAssignmentStatus.ERROR
+        assert self.row.extras.get("error") == "boom"
+        self._assert_outcome(mock_metrics, "error")
+
+    @patch("sentry.seer.smart_assignment.scoring.metrics")
+    def test_scores_when_ground_truth_already_present(
+        self, mock_scoring_metrics: MagicMock
+    ) -> None:
+        # Assignment landed before Seer finished: ground truth is already on the row,
+        # so delivering the prediction should complete the pair and score it.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self.row.update(actual_assignee_user_id=alice.id)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "x",
+                    "confidence": "high",
+                }
+            ]
+        }
+
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), "completed", result, None
+        )
+
+        mock_scoring_metrics.incr.assert_called_once_with(
+            "smart_assignment.scored",
+            tags={"result": "exact", "trigger": SmartAssignmentTrigger.PR_CREATED},
+        )
+
+    @patch(METRICS_PATH)
+    def test_missing_row_is_noop(self, mock_metrics: MagicMock) -> None:
+        # Unknown run uuid: should not raise.
+        deliver_smart_assignment_result(
+            self.organization.id,
+            "00000000-0000-0000-0000-000000000000",
+            "completed",
+            {"candidates": []},
+            None,
+        )
+        self._assert_outcome(mock_metrics, "missing_row")

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -1,0 +1,225 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.models.groupassignee import GroupAssignee
+from sentry.seer.models.smart_assignment import (
+    SeerSmartAssignmentResult,
+    SmartAssignmentStatus,
+    SmartAssignmentTrigger,
+)
+from sentry.seer.smart_assignment.scoring import (
+    AUTO_ASSIGN_SOURCE,
+    record_ground_truth,
+    score_prediction,
+)
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+METRICS_PATH = "sentry.seer.smart_assignment.scoring.metrics"
+
+
+class ScorePredictionTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+
+    def _row(self, group: Group | None = None, **kwargs: object) -> SeerSmartAssignmentResult:
+        return SeerSmartAssignmentResult.objects.create(
+            organization=self.organization,
+            group=group or self.group,
+            trigger=SmartAssignmentTrigger.ASSIGNMENT,
+            status=SmartAssignmentStatus.COMPLETED,
+            **kwargs,
+        )
+
+    def _assert_result(self, mock_metrics: MagicMock, expected: str) -> None:
+        mock_metrics.incr.assert_called_once_with(
+            "smart_assignment.scored",
+            tags={"result": expected, "trigger": SmartAssignmentTrigger.ASSIGNMENT},
+        )
+
+    @patch(METRICS_PATH)
+    def test_exact_when_prediction_matches_user(self, mock_metrics: MagicMock) -> None:
+        user = self.create_user()
+        row = self._row(predicted_assignee_user_id=user.id, actual_assignee_user_id=user.id)
+        score_prediction(row)
+
+        self._assert_result(mock_metrics, "exact")
+        row.refresh_from_db()
+        assert row.extras.get("score") == "exact"
+
+    @patch(METRICS_PATH)
+    def test_team_when_predicted_user_on_assigned_team(self, mock_metrics: MagicMock) -> None:
+        team = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team])
+        row = self._row(predicted_assignee_user_id=alice.id, actual_assignee_team_id=team.id)
+        score_prediction(row)
+
+        self._assert_result(mock_metrics, "team")
+
+    @patch(METRICS_PATH)
+    def test_team_when_predicted_shares_team_with_actual_user(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        team = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        bob = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team])
+        self.create_member(user=bob, organization=self.organization, teams=[team])
+        row = self._row(predicted_assignee_user_id=alice.id, actual_assignee_user_id=bob.id)
+        score_prediction(row)
+
+        self._assert_result(mock_metrics, "team")
+
+    @patch(METRICS_PATH)
+    def test_miss_when_no_team_overlap(self, mock_metrics: MagicMock) -> None:
+        team_a = self.create_team(organization=self.organization)
+        team_b = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        bob = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team_a])
+        self.create_member(user=bob, organization=self.organization, teams=[team_b])
+        row = self._row(predicted_assignee_user_id=alice.id, actual_assignee_user_id=bob.id)
+        score_prediction(row)
+
+        self._assert_result(mock_metrics, "miss")
+
+    @patch(METRICS_PATH)
+    def test_noop_without_both_sides(self, mock_metrics: MagicMock) -> None:
+        # Prediction but no ground truth yet.
+        score_prediction(self._row(predicted_assignee_user_id=7))
+        # Ground truth but no (resolvable) prediction (separate group -- one row per group).
+        score_prediction(self._row(group=self.create_group(), actual_assignee_user_id=9))
+        mock_metrics.incr.assert_not_called()
+
+    @patch(METRICS_PATH)
+    def test_scores_only_once(self, mock_metrics: MagicMock) -> None:
+        user = self.create_user()
+        row = self._row(predicted_assignee_user_id=user.id, actual_assignee_user_id=user.id)
+        score_prediction(row)
+        score_prediction(row)
+        assert mock_metrics.incr.call_count == 1
+
+
+class RecordGroundTruthTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+
+    def _row(self) -> SeerSmartAssignmentResult:
+        return SeerSmartAssignmentResult.objects.create(
+            organization=self.organization,
+            group=self.group,
+            trigger=SmartAssignmentTrigger.PR_CREATED,
+            status=SmartAssignmentStatus.PENDING,
+        )
+
+    def _resolved_activity(self, user_id: int | None = None) -> Activity:
+        return self.create_group_activity(
+            group=self.group, type=ActivityType.SET_RESOLVED.value, user_id=user_id
+        )
+
+    def test_noop_without_row(self) -> None:
+        record_ground_truth(
+            self.group, SmartAssignmentTrigger.RESOLUTION, self._resolved_activity(self.user.id)
+        )
+        assert not SeerSmartAssignmentResult.objects.filter(group=self.group).exists()
+
+    def test_records_assignee_user(self) -> None:
+        row = self._row()
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        record_ground_truth(self.group, SmartAssignmentTrigger.ASSIGNMENT)
+
+        row.refresh_from_db()
+        assert row.actual_assignee_user_id == assignee.id
+        assert row.ground_truth_source == SmartAssignmentTrigger.ASSIGNMENT
+
+    def test_resolution_keeps_existing_team_and_adds_resolver(self) -> None:
+        team = self.create_team(organization=self.organization)
+        row = self._row()
+        row.update(actual_assignee_team=team)
+        resolver = self.create_user()
+        record_ground_truth(
+            self.group, SmartAssignmentTrigger.RESOLUTION, self._resolved_activity(resolver.id)
+        )
+
+        row.refresh_from_db()
+        assert row.actual_assignee_user_id == resolver.id
+        # A user-driven resolution shouldn't wipe a prior team assignee.
+        assert row.actual_assignee_team_id == team.id
+
+    def test_automatic_resolution_is_noop(self) -> None:
+        row = self._row()
+        record_ground_truth(
+            self.group, SmartAssignmentTrigger.RESOLUTION, self._resolved_activity(None)
+        )
+
+        row.refresh_from_db()
+        assert row.actual_assignee_user_id is None
+        assert row.ground_truth_source is None
+
+    def test_pr_created_is_noop(self) -> None:
+        row = self._row()
+        record_ground_truth(self.group, SmartAssignmentTrigger.PR_CREATED)
+
+        row.refresh_from_db()
+        assert row.ground_truth_source is None
+
+    def test_our_auto_assignment_is_not_recorded(self) -> None:
+        row = self._row()
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={
+                "assignee": str(assignee.id),
+                "assigneeType": "user",
+                "source": AUTO_ASSIGN_SOURCE,
+            },
+        )
+        record_ground_truth(self.group, SmartAssignmentTrigger.ASSIGNMENT, activity)
+
+        row.refresh_from_db()
+        assert row.actual_assignee_user_id is None
+        assert row.ground_truth_source is None
+
+    @patch(METRICS_PATH)
+    def test_records_ground_truth_scores_existing_prediction(self, mock_metrics: MagicMock) -> None:
+        # Prediction already delivered; recording the matching assignment as ground
+        # truth should complete the pair and score it exact.
+        assignee = self.create_user()
+        row = self._row()
+        row.update(predicted_assignee_user_id=assignee.id)
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        record_ground_truth(self.group, SmartAssignmentTrigger.ASSIGNMENT)
+
+        mock_metrics.incr.assert_any_call(
+            "smart_assignment.scored",
+            tags={"result": "exact", "trigger": SmartAssignmentTrigger.PR_CREATED},
+        )
+
+    def test_resolution_does_not_overwrite_existing_assignee(self) -> None:
+        assignee = self.create_user()
+        row = self._row()
+        row.update(
+            actual_assignee_user_id=assignee.id,
+            ground_truth_source=SmartAssignmentTrigger.ASSIGNMENT,
+        )
+        resolver = self.create_user()
+        record_ground_truth(
+            self.group, SmartAssignmentTrigger.RESOLUTION, self._resolved_activity(resolver.id)
+        )
+
+        row.refresh_from_db()
+        assert row.actual_assignee_user_id == assignee.id
+        assert row.ground_truth_source == SmartAssignmentTrigger.ASSIGNMENT

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -47,7 +47,7 @@ class ScorePredictionTest(TestCase):
 
         self._assert_result(mock_metrics, "exact")
         row.refresh_from_db()
-        assert row.extras.get("score") == "exact"
+        assert row.score == "exact"
 
     @patch(METRICS_PATH)
     def test_team_when_predicted_user_on_assigned_team(self, mock_metrics: MagicMock) -> None:

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.models.activity import Activity
+from sentry.models.groupassignee import GroupAssignee
 from sentry.seer.models.run import SeerRun, SeerRunType
 from sentry.seer.models.smart_assignment import (
     SeerSmartAssignmentResult,
@@ -76,6 +77,49 @@ class MaybeTriggerSmartAssignmentTest(TestCase):
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)
+    def test_assignment_dispatches_and_records_user(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with self.feature("organizations:seer-smart-assignment-run"):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.ASSIGNMENT)
+
+        row = SeerSmartAssignmentResult.objects.get(group=self.group)
+        assert row.trigger == SmartAssignmentTrigger.ASSIGNMENT
+        assert row.actual_assignee_user_id == assignee.id
+        assert row.actual_assignee_team_id is None
+        assert row.ground_truth_source == SmartAssignmentTrigger.ASSIGNMENT
+        assert row.ground_truth_at is not None
+
+    @patch(CLIENT_PATH)
+    def test_assignment_records_team(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        team = self.create_team(organization=self.organization)
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.ASSIGNMENT)
+
+        row = SeerSmartAssignmentResult.objects.get(group=self.group)
+        assert row.actual_assignee_team_id == team.id
+        assert row.actual_assignee_user_id is None
+
+    @patch(CLIENT_PATH)
+    def test_user_resolution_records_resolver_as_assignee(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        resolver = self.create_user()
+        with self.feature("organizations:seer-smart-assignment-run"):
+            maybe_trigger_smart_assignment(
+                self.group, SmartAssignmentTrigger.RESOLUTION, self._resolved_activity(resolver.id)
+            )
+
+        row = SeerSmartAssignmentResult.objects.get(group=self.group)
+        assert row.trigger == SmartAssignmentTrigger.RESOLUTION
+        assert row.actual_assignee_user_id == resolver.id
+        assert row.ground_truth_source == SmartAssignmentTrigger.RESOLUTION
+
+    @patch(CLIENT_PATH)
     def test_org_rate_limit_skips_dispatch(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         with (
@@ -98,6 +142,36 @@ class MaybeTriggerSmartAssignmentTest(TestCase):
             maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.PR_CREATED)
 
         assert not SeerSmartAssignmentResult.objects.filter(group=self.group).exists()
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_rate_limit_still_records_ground_truth(self, mock_client_cls: MagicMock) -> None:
+        # An issue predicted earlier still gets ground truth even once caps are
+        # exhausted -- the caps only gate new dispatches.
+        SeerSmartAssignmentResult.objects.create(
+            organization=self.organization,
+            group=self.group,
+            trigger=SmartAssignmentTrigger.PR_CREATED,
+            status=SmartAssignmentStatus.PENDING,
+        )
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options(
+                {
+                    "seer.smart_assignment.max_dispatches_per_org_per_day": 0,
+                    "seer.smart_assignment.max_dispatches_per_day": 0,
+                }
+            ),
+        ):
+            maybe_trigger_smart_assignment(self.group, SmartAssignmentTrigger.ASSIGNMENT)
+
+        row = SeerSmartAssignmentResult.objects.get(group=self.group)
+        assert row.actual_assignee_user_id == assignee.id
+        assert row.ground_truth_source == SmartAssignmentTrigger.ASSIGNMENT
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)


### PR DESCRIPTION
## Summary
The **outbound** side of Seer smart assignment (PR 3 of 3) — capture ground truth, score predictions, and handle Seer's async result. Stacked on #119592.

- `scoring`: `record_ground_truth` labels a result row with the actual assignee (on assignment/resolution); `score_prediction` grades the prediction (exact/team/miss). Wires `record_ground_truth` into the trigger so ground truth is captured whether or not a new run was dispatched.
- `delivery`: `deliver_smart_assignment_result` records the returned `AssigneeVerdict` on the pending row and scores it; registered in `feature_delivery` so Seer's `deliver_feature_result` RPC routes `smart_assignment` results here.
- `models`: adds the result artifact types (`AssigneeVerdict` / `RankedCandidate`).
- Scoring, delivery, and ground-truth trigger tests.

## Stack
1. #119591 — data model + migration
2. #119592 — dispatch + workflow wiring (stuff in)
3. **This PR** — ground truth, scoring, delivery (stuff out)

> Review after #119592; base retargets as the stack merges.

## Test plan
- [ ] `pytest tests/sentry/seer/smart_assignment/test_scoring.py test_delivery.py test_trigger.py`
- [ ] CI