### PR TITLE
ref(billing): bump sentry-protos to 0.43.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.43.2",
+  "sentry-protos>=0.43.3",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.32.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.40" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.43.2" },
+    { name = "sentry-protos", specifier = ">=0.43.3" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.32.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.43.2"
+version = "0.43.3"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.43.2-py3-none-any.whl", hash = "sha256:0bd1edfa2fdea80461f3dd36ddff7a467b44e3da5cae5fe385c710ac476954ee" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.43.3-py3-none-any.whl", hash = "sha256:40bf35881568a997a05873113eeaf94bc6793348d02ab5270ec773a2fc878c70" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `sentry-protos` pin to `>=0.43.3` — the release with [sentry-protos#347](https://github.com/getsentry/sentry-protos/pull/347)'s `ClaimChargeLock` / `ReleaseChargeLock` proto rename (and deprecation shims for the previous `StartManualPayment` / `ReleaseManualPaymentLock` messages).

Unblocks [getsentry/getsentry#20960](https://github.com/getsentry/getsentry/pull/20960) — the atomic-claim PR is currently prototyping the new request/response types as inline dataclasses; the follow-up commit swapping back to the protos depends on this pin landing.

## Test plan

- [ ] `uv lock --refresh` resolves cleanly against `pypi.devinfra.sentry.io`.
- [ ] CI passes.