### PR TITLE
docs(scraps): Point Flex column direction to Stack

### DIFF
--- a/static/app/components/core/layout/flex.mdx
+++ b/static/app/components/core/layout/flex.mdx
@@ -106,6 +106,10 @@ Simialarly to `Container`, `Flex` inherits all spacing props like `m`, `p`, `mt`
 
 #### Column direction
 
+> [!NOTE]
+> While `Flex` supports `direction="column"`, prefer [`Stack`](/stories/core/stack/)
+> for vertical layouts. It's a `Flex` that defaults to column direction with a focused API.
+
 <Storybook.Demo>
   <Flex direction="column" gap="md" justify="between" align="center">
     <Container padding="md" border="primary" radius="md" background="primary">


### PR DESCRIPTION
Adds an info callout in the `Flex` docs steering authors toward [`Stack`](/stories/layout/stack/) for vertical layouts, and links to the Stack page.

Follow-up to review feedback on #119397 (now merged): readers — and the bots adding these cases — landing on the Flex docs should discover that `direction="column"` has a preferred primitive. Complements the `@sentry/scraps/prefer-stack-for-column-flex` lint rule.

The note renders as an **info** `Alert` via the stories admonition renderer:

\`\`\`md
> [!NOTE]
> While \`Flex\` supports \`direction="column"\`, prefer [\`Stack\`](/stories/layout/stack/)
> for vertical layouts — it's a \`Flex\` that defaults to column direction with a focused API.
\`\`\`

Refs #119397