### PR TITLE
fix(slack): Improve "channel not found" error with /invite hint

### DIFF
--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -181,7 +181,10 @@ def validate_channel_id(name: str, integration_id: int, input_channel_id: str) -
         )
 
         if unpack_slack_api_error(e) == CHANNEL_NOT_FOUND:
-            raise ValidationError("Channel not found. Invalid ID provided.") from e
+            raise ValidationError(
+                "Channel not found. Invalid ID provided. "
+                "Ensure the channel exists and that you’ve invited Sentry to it by running /invite @Sentry"
+            ) from e
         elif unpack_slack_api_error(e) == RATE_LIMITED:
             raise ValidationError("Rate limited") from e
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -2230,7 +2230,13 @@ class AlertRuleDetailsSlackPutEndpointTest(AlertRuleDetailsBase):
             assert resp.status_code == 400
             assert resp.data == {
                 "nonFieldErrors": [
-                    ErrorDetail(string="Channel not found. Invalid ID provided.", code="invalid")
+                    ErrorDetail(
+                        string=(
+                            "Channel not found. Invalid ID provided. "
+                            "Ensure the channel exists and that you’ve invited Sentry to it by running /invite @Sentry"
+                        ),
+                        code="invalid",
+                    )
                 ]
             }
 


### PR DESCRIPTION
If channel is private and `@sentry` not in the channel the error will be 404 - the same as the channel does not really exist. The fix will help to understand the root case "Channel not found"