### PR TITLE
fix(conversations): Show connected issues in the span detail panel

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -167,7 +167,12 @@ export function ConversationSpanDetail({
 
       {/* IssueList renders nothing when the span has no linked issues. */}
       <IssueListWrapper>
-        <IssueList node={node} issues={node.uniqueIssues} organization={organization} />
+        <IssueList
+          node={node}
+          issues={node.uniqueIssues}
+          organization={organization}
+          traceSlug={traceId}
+        />
       </IssueListWrapper>
 
       {/*

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useEffect, useRef} from 'react';
 import {css, useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
@@ -28,6 +29,7 @@ import {
   MIN_PCT_DURATION_DIFFERENCE,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/durationComparison';
 import {getHighlightedSpanAttributes} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes';
+import {IssueList} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/issues/issues';
 import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
 import {
   getAIInputMessages,
@@ -40,6 +42,7 @@ import {
 import {AttributesContent} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {isEAPSpanNode} from 'sentry/views/performance/newTraceDetails/traceGuards';
+import {traceGridCssVariables} from 'sentry/views/performance/newTraceDetails/traceWaterfallStyles';
 
 export type DetailTab = 'input' | 'output' | 'attributes';
 
@@ -88,6 +91,7 @@ export function ConversationSpanDetail({
   scrollResetKey,
 }: ConversationSpanDetailProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const organization = useOrganization();
 
   useEffect(() => {
     scrollContainerRef.current?.scrollTo({top: 0});
@@ -160,6 +164,11 @@ export function ConversationSpanDetail({
           <SpanMetadata node={node} attributes={attributes} />
         )}
       </Stack>
+
+      {/* IssueList renders nothing when the span has no linked issues. */}
+      <IssueListWrapper>
+        <IssueList node={node} issues={node.uniqueIssues} organization={organization} />
+      </IssueListWrapper>
 
       {/*
        * The per-span fetch backs both the metadata and the tab content, and it
@@ -390,6 +399,14 @@ function AttributesTab({
     />
   );
 }
+
+// IssueList colors its severity icons from the trace grid CSS variables, which
+// the trace waterfall normally provides via an ancestor. This panel isn't nested
+// under the waterfall, so scope those variables here.
+const IssueListWrapper = styled('div')`
+  ${traceGridCssVariables}
+  flex-shrink: 0;
+`;
 
 function EmptyTab({message}: {message: string}) {
   return (

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -172,9 +172,15 @@ type IssueListProps = {
   issues: TraceTree.TraceIssue[];
   node: BaseNode;
   organization: Organization;
+  /**
+   * Overrides the trace slug used for the "Open N more in Issues" link. Pass
+   * this when rendering outside the trace waterfall route (e.g. the
+   * conversations span detail), where the `traceSlug` route param is absent.
+   */
+  traceSlug?: string;
 };
 
-export function IssueList({issues, node, organization}: IssueListProps) {
+export function IssueList({issues, node, organization, traceSlug}: IssueListProps) {
   const uniqueIssues = [
     ...node.uniqueErrorIssues.sort(sortIssuesByLevel),
     ...node.uniqueOccurrenceIssues,
@@ -192,7 +198,7 @@ export function IssueList({issues, node, organization}: IssueListProps) {
         ))}
       </StyledPanel>
       {uniqueIssues.length > MAX_DISPLAYED_ISSUES_COUNT ? (
-        <TraceDrawerComponents.IssuesLink node={node}>
+        <TraceDrawerComponents.IssuesLink node={node} traceSlug={traceSlug}>
           <Flex align="center" marginLeft="2xs" gap="xs">
             <IconOpen />
             {t(

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -662,10 +662,24 @@ const HighlightsWrapper = styled('div')`
   margin: ${p => p.theme.space.md} 0;
 `;
 
-function IssuesLink({node, children}: {children: React.ReactNode; node: BaseNode}) {
+function IssuesLink({
+  node,
+  children,
+  traceSlug: traceSlugProp,
+}: {
+  children: React.ReactNode;
+  node: BaseNode;
+  /**
+   * Overrides the trace slug used to build the Issues link. The slug is
+   * normally read from the `traceSlug` route param, but surfaces that render
+   * this outside the trace waterfall route (e.g. the conversations span detail)
+   * have no such param and must pass the trace id explicitly.
+   */
+  traceSlug?: string;
+}) {
   const organization = useOrganization();
   const params = useParams<{traceSlug?: string}>();
-  const traceSlug = params.traceSlug?.trim() ?? '';
+  const traceSlug = (traceSlugProp || params.traceSlug || '').trim();
 
   // Adding a buffer of 15mins for errors only traces, where there is no concept of
   // trace duration and start equals end timestamps.


### PR DESCRIPTION
The conversation span detail panel showed a fire icon when a span had a linked error, but it never rendered the associated issue — so users saw that something went wrong without a way to reach it.

The node built in `useConversation` already carries the linked error/occurrence issues returned by the conversation endpoint (`node.uniqueIssues`), so this reuses the trace drawer's `IssueList` to fetch each issue's group details and render them, right below the span metadata.

`IssueList` colors its severity icons from the trace grid CSS variables (`--error`, `--warning`, `--occurrence`, …), which the trace waterfall normally injects on an ancestor. This panel isn't nested under the waterfall, so those variables are scoped on the wrapper — otherwise the severity icon renders with no color and is invisible.

The "Open N more in Issues" overflow link (shown when a span has more than 3 linked issues) previously read the trace slug from the `traceSlug` route param, which is absent in the conversations route. `IssueList`/`IssuesLink` now take an optional `traceSlug` override, and the panel passes the selected span's trace id; existing trace waterfall callers keep falling back to the route param.

Fixes TET-2662