### PR TITLE
ref(waterfall): Improve streamed span detection logic

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -513,10 +513,13 @@ function EAPSpanNodeDetailsContent({
   }, [genAiOperationType, organization, hideNodeActions]);
 
   const isSdkSentStreamedSpan =
+    // Sent by span-streaming-configured SDKs to explicitly indicate a streamed span:
     attributesMap.trace_lifecycle === 'stream' ||
-    // The presence of this attribute indicates that the EAP span was sent as a v2 span
-    // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
-    (attributesMap.observed_timestamp_nanos &&
+    // If the attribute is not set, we fall back to infer the original span type from other attributes:
+    (!attributesMap.trace_lifecycle &&
+      // The presence of this attribute indicates that the EAP span was sent as a v2 span
+      // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
+      attributesMap.observed_timestamp_nanos &&
       // Furthermore, to distinguish between v2 and v1 web vital spans, we can check that the old
       // report_event only sent on v1 spans attribute is undefined
       !attributesMap.report_event);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -512,13 +512,14 @@ function EAPSpanNodeDetailsContent({
     }
   }, [genAiOperationType, organization, hideNodeActions]);
 
-  const isSdkSentV2Span =
+  const isSdkSentStreamedSpan =
+    attributesMap.trace_lifecycle === 'stream' ||
     // The presence of this attribute indicates that the EAP span was sent as a v2 span
     // from SDKs rather than an SDK-sent transaction converted to EAP spans during ingestion.
-    attributesMap.observed_timestamp_nanos &&
-    // Furthermore, to distinguish between v2 and v1 web vital spans, we can check that the old
-    // report_event only sent on v1 spans attribute is undefined
-    !attributesMap.report_event;
+    (attributesMap.observed_timestamp_nanos &&
+      // Furthermore, to distinguish between v2 and v1 web vital spans, we can check that the old
+      // report_event only sent on v1 spans attribute is undefined
+      !attributesMap.report_event);
 
   return (
     <TraceDrawerComponents.DetailContainer>
@@ -527,7 +528,7 @@ function EAPSpanNodeDetailsContent({
           <TraceDrawerComponents.LegacyTitleText>
             <TraceDrawerComponents.TitleText>
               {t('Span')}
-              {isSdkSentV2Span && (
+              {isSdkSentStreamedSpan && (
                 <Fragment>
                   {' '}
                   <Tooltip title={t('Streamed Span')}>


### PR DESCRIPTION
SDKs now send `sentry.trace_lifecycle: 'stream'` to indicate that a span was sent as a streamed (v2) span in the UI. This PR adjusts our previous check that relied on more brittle logic to determine streamed spans (introduced in https://github.com/getsentry/sentry/pull/116386). Decided to leave the old logic in place for backwards compat but if reviewers prefer, I'm happy to rip it out