### PR TITLE
ref(conversations): Avoid empty wrapper around the span detail issue list

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -165,15 +165,12 @@ export function ConversationSpanDetail({
         )}
       </Stack>
 
-      {/* IssueList renders nothing when the span has no linked issues. */}
-      <IssueListWrapper>
-        <IssueList
-          node={node}
-          issues={node.uniqueIssues}
-          organization={organization}
-          traceSlug={traceId}
-        />
-      </IssueListWrapper>
+      <StyledIssueList
+        node={node}
+        issues={node.uniqueIssues}
+        organization={organization}
+        traceSlug={traceId}
+      />
 
       {/*
        * The per-span fetch backs both the metadata and the tab content, and it
@@ -408,7 +405,7 @@ function AttributesTab({
 // IssueList colors its severity icons from the trace grid CSS variables, which
 // the trace waterfall normally provides via an ancestor. This panel isn't nested
 // under the waterfall, so scope those variables here.
-const IssueListWrapper = styled('div')`
+const StyledIssueList = styled(IssueList)`
   ${traceGridCssVariables}
   flex-shrink: 0;
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/issues/issues.tsx
@@ -172,6 +172,7 @@ type IssueListProps = {
   issues: TraceTree.TraceIssue[];
   node: BaseNode;
   organization: Organization;
+  className?: string;
   /**
    * Overrides the trace slug used for the "Open N more in Issues" link. Pass
    * this when rendering outside the trace waterfall route (e.g. the
@@ -180,7 +181,13 @@ type IssueListProps = {
   traceSlug?: string;
 };
 
-export function IssueList({issues, node, organization, traceSlug}: IssueListProps) {
+export function IssueList({
+  issues,
+  node,
+  organization,
+  traceSlug,
+  className,
+}: IssueListProps) {
   const uniqueIssues = [
     ...node.uniqueErrorIssues.sort(sortIssuesByLevel),
     ...node.uniqueOccurrenceIssues,
@@ -191,7 +198,7 @@ export function IssueList({issues, node, organization, traceSlug}: IssueListProp
   }
 
   return (
-    <IssuesWrapper>
+    <IssuesWrapper className={className}>
       <StyledPanel>
         {uniqueIssues.slice(0, MAX_DISPLAYED_ISSUES_COUNT).map((issue, index) => (
           <Issue key={index} issue={issue} organization={organization} />


### PR DESCRIPTION
Follow-up to review feedback on #119601.

The span detail scoped the trace grid CSS variables on a wrapper `div` around `IssueList`. But `IssueList` returns `null` when the span has no linked issues, so that wrapper rendered an empty `<div>` in the DOM for every span without errors — the common case.

`IssueList` now accepts an optional `className` applied to its root element (which only renders when there are issues), so the conversation span detail can style it directly via `styled(IssueList)` instead of wrapping it. When the list is empty, nothing hits the DOM.

No behavior change for the existing trace waterfall callers — `className` is optional.

Refs TET-2662