### PR TITLE
fix(profiling): Detect android trace chunks by version and structure

### DIFF
--- a/static/app/utils/profiling/guards/profile.spec.tsx
+++ b/static/app/utils/profiling/guards/profile.spec.tsx
@@ -2,6 +2,7 @@ import {
   isEventedProfile,
   isJSProfile,
   isSampledProfile,
+  isSentryAndroidContinuousProfileChunk,
   isSentryContinuousProfileChunk,
 } from 'sentry/utils/profiling/guards/profile';
 
@@ -56,4 +57,39 @@ describe('profile', () => {
   it('is js self profile', () => expect(isJSProfile(jsProfile)).toBe(true));
   it('is continuous profile chunk', () =>
     expect(isSentryContinuousProfileChunk(sentryContinuousProfileChunk)).toBe(true));
+
+  describe('isSentryAndroidContinuousProfileChunk', () => {
+    it('matches the explicit android trace version', () =>
+      expect(
+        isSentryAndroidContinuousProfileChunk({
+          platform: 'android',
+          version: '2.android-trace',
+        })
+      ).toBe(true));
+
+    it('matches an android chunk with a missing version', () =>
+      expect(
+        isSentryAndroidContinuousProfileChunk({
+          platform: 'android',
+          profile: {methods: []},
+        })
+      ).toBe(true));
+
+    it('matches an android chunk that stores frames in methods', () =>
+      expect(
+        isSentryAndroidContinuousProfileChunk({
+          platform: 'android',
+          version: '2',
+          profile: {methods: []},
+        })
+      ).toBe(true));
+
+    it('does not match a version="2" sampled android chunk', () =>
+      expect(
+        isSentryAndroidContinuousProfileChunk({
+          ...sentryContinuousProfileChunk,
+          platform: 'android',
+        })
+      ).toBe(false));
+  });
 });

--- a/static/app/utils/profiling/guards/profile.tsx
+++ b/static/app/utils/profiling/guards/profile.tsx
@@ -52,10 +52,32 @@ export function isSentryContinuousProfileChunk(
   return 'chunk_id' in profile || 'profiler_id' in profile;
 }
 
+// Mirrors PROFILE_FORMAT_V2_ANDROID_TRACE in src/sentry/profiles/utils.py
+const PROFILE_FORMAT_V2_ANDROID_TRACE = '2.android-trace';
+
 export function isSentryAndroidContinuousProfileChunk(
   profile: any
 ): profile is Profiling.SentryAndroidContinuousProfileChunk {
-  return 'platform' in profile && profile.platform === 'android';
+  const version = profile.version;
+
+  if (version === PROFILE_FORMAT_V2_ANDROID_TRACE) {
+    return true;
+  }
+
+  // A faulty version can't be trusted: it may be missing or wrongly set on
+  // android trace profiles, so probe the structure instead — only the android
+  // trace format stores its frames in "methods". A version="2" chunk on the
+  // android platform is the sampled continuous format and must not match here.
+  if (profile.platform === 'android') {
+    if (!version) {
+      return true;
+    }
+    if ('methods' in (profile.profile ?? {})) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function isContinuousProfileReference(


### PR DESCRIPTION
Update the isSentryAndroidContinuousProfileChunk check to recognize the
newly introduced "2.android-trace" trace version, with fallback handling
that probes the chunk structure — mirroring the backend detection in
https://github.com/getsentry/sentry/blob/848a79710cb297fb64e59f8aec56dae99b1e4614/src/sentry/profiles/utils.py#L201-L216

Previously any platform="android" chunk was treated as the legacy trace
format, so sampled v2 chunks were misrouted. While `/insights/summary/profiles/`
already rendered correctly, this fixes an empty page on the profile details
route (`/explore/profiles/profile/sentry-android/flamegraph`).