### PR TITLE
fix(overlay): Recalculate controlled overlay position on open

### DIFF
--- a/static/app/utils/useOverlay.spec.tsx
+++ b/static/app/utils/useOverlay.spec.tsx
@@ -1,0 +1,37 @@
+import {usePopper} from 'react-popper';
+
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useOverlay} from 'sentry/utils/useOverlay';
+
+jest.mock('react-popper', () => ({
+  usePopper: jest.fn(),
+}));
+
+const mockUsePopper = jest.mocked(usePopper);
+const mockPopperUpdate = jest.fn();
+
+describe('useOverlay', () => {
+  beforeEach(() => {
+    mockPopperUpdate.mockReset();
+    mockUsePopper.mockReturnValue({
+      attributes: {},
+      forceUpdate: null,
+      state: null,
+      styles: {arrow: {}, popper: {}},
+      update: mockPopperUpdate,
+    });
+  });
+
+  it('updates Popper when a controlled overlay opens', () => {
+    const {rerender} = renderHook(({isOpen}) => useOverlay({isOpen}), {
+      initialProps: {isOpen: false},
+    });
+
+    expect(mockPopperUpdate).not.toHaveBeenCalled();
+
+    rerender({isOpen: true});
+
+    expect(mockPopperUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useRef, useState} from 'react';
+import {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {PopperProps} from 'react-popper';
 import {usePopper} from 'react-popper';
 import type {Modifier} from '@popperjs/core';
@@ -257,6 +257,15 @@ export function useOverlay({
     placement: position,
     strategy,
   });
+
+  useLayoutEffect(() => {
+    // Controlled overlays, such as submenus, can open without calling
+    // useOverlayTriggerState's onOpenChange callback. Update after the overlay
+    // has been mounted so Popper accounts for its measured size on first open.
+    if (openState.isOpen) {
+      popperUpdate?.();
+    }
+  }, [openState.isOpen, popperUpdate]);
 
   // Get props for trigger button
   const {triggerProps, overlayProps: overlayTriggerAriaProps} = useOverlayTriggerAria(


### PR DESCRIPTION
Controlled dropdown submenus now recalculate their Popper position after mounting on the first open.

The submenu can be controlled by parent menu selection state, so its open transition may bypass useOverlay's onOpenChange callback. A layout effect refreshes Popper once open, and a hook test covers the controlled transition.