### PR TITLE
feat(conversations): Add direct-hit redirect header for conversation ID search

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, TypedDict
@@ -33,6 +34,15 @@ from sentry.utils.ai_message_normalizer import (
 from sentry.utils.tracing import set_span_data, start_span, trace
 
 logger = logging.getLogger("sentry.api.endpoints.organization_ai_conversations")
+
+
+# Matches a query that is exactly a single gen_ai.conversation.id filter, e.g.
+# `gen_ai.conversation.id:abc` or `gen_ai.conversation.id:"slack:1234"`.
+_CONVERSATION_ID_LOOKUP_RE = re.compile(r'^gen_ai\.conversation\.id:(?:"[^"]+"|\S+)$')
+
+
+def _is_conversation_id_lookup(user_query: str) -> bool:
+    return bool(_CONVERSATION_ID_LOOKUP_RE.match(user_query.strip()))
 
 
 def _build_conversation_query(base_query: str, user_query: str) -> str:
@@ -220,13 +230,23 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             )
 
         with handle_query_errors():
-            return self.paginate(
+            response = self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
                 on_results=lambda results: results,
                 default_per_page=10,
                 max_per_page=100,
             )
+
+        # A search for a single conversation ID that resolves to exactly one
+        # conversation signals the client to redirect straight to the detail view.
+        if (
+            _is_conversation_id_lookup(validated_data.get("query") or "")
+            and len(response.data) == 1
+        ):
+            response["X-Sentry-Direct-Hit"] = "1"
+
+        return response
 
     @trace
     def _get_conversations(

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -255,6 +255,73 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["firstInput"] == "Hello, I need help"
         assert conversation["lastOutput"] == last_response_text
 
+    def _store_minimal_conversation(self, conversation_id: str, timestamp) -> None:
+        self.store_ai_span(
+            conversation_id=conversation_id,
+            timestamp=timestamp,
+            op="gen_ai.chat",
+            operation_type="ai_client",
+            tokens=LLM_TOKENS,
+            cost=LLM_COST,
+            messages=[{"role": "user", "content": "Hello"}],
+            response_text="Hi",
+        )
+
+    def test_direct_hit_header_set_for_single_id_lookup(self) -> None:
+        """A conversation-ID search resolving to exactly one conversation sets the header."""
+        now = before_now(days=15).replace(microsecond=0)
+        conversation_id_1 = uuid4().hex
+        conversation_id_2 = uuid4().hex
+        self._store_minimal_conversation(conversation_id_1, now)
+        self._store_minimal_conversation(conversation_id_2, now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+            "query": f"gen_ai.conversation.id:{conversation_id_1}",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["conversationId"] == conversation_id_1
+        assert response.has_header("X-Sentry-Direct-Hit")
+        assert response["X-Sentry-Direct-Hit"] == "1"
+
+    def test_direct_hit_header_not_set_for_non_id_query(self) -> None:
+        """A non-ID query resolving to a single conversation does not set the header."""
+        now = before_now(days=16).replace(microsecond=0)
+        self._store_minimal_conversation(uuid4().hex, now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert not response.has_header("X-Sentry-Direct-Hit")
+
+    def test_direct_hit_header_not_set_when_id_lookup_matches_nothing(self) -> None:
+        """A conversation-ID search that resolves to no conversation does not set the header."""
+        now = before_now(days=17).replace(microsecond=0)
+        self._store_minimal_conversation(uuid4().hex, now)
+
+        query = {
+            "project": [self.project.id],
+            "start": (now - timedelta(hours=1)).isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+            "query": f"gen_ai.conversation.id:{uuid4().hex}",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert len(response.data) == 0
+        assert not response.has_header("X-Sentry-Direct-Hit")
+
     def test_conversation_spanning_multiple_traces(self) -> None:
         """Test a conversation with spans across multiple traces"""
         now = before_now(days=30).replace(microsecond=0)


### PR DESCRIPTION
Searching AI conversations for a single conversation ID now returns the `X-Sentry-Direct-Hit: 1` header when the query resolves to exactly one conversation. The client uses this to redirect straight to the conversation detail view instead of showing a one-row list — the same pattern the issue stream uses for event-ID and short-ID searches.

Detection is entirely server-side: the header is set only when the query is a lone `gen_ai.conversation.id:…` filter (matching the issue stream's event-ID direct hit). A normal text search that happens to return one conversation does not trigger a redirect. If the query is combined with other filters (e.g. an agent selection), the header is intentionally not set.

The frontend change that consumes this header is a follow-up PR and depends on this one landing first.

Refs TET-2657