### PR TITLE
fix(seer): Anchor Explorer command menu to input

### DIFF
--- a/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
@@ -10,6 +10,7 @@ import {
   INPUT_STORAGE_KEY_PREFIX,
   SeerExplorerContent,
 } from 'sentry/views/seerExplorer/components/seerExplorerContent';
+import {SeerExplorerHeader} from 'sentry/views/seerExplorer/components/seerExplorerHeader';
 import * as useSeerExplorerModule from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
 import {SeerExplorerSessionsProvider} from 'sentry/views/seerExplorer/seerExplorerSessionContext';
 import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/types';
@@ -860,22 +861,30 @@ describe('SeerExplorerContent', () => {
 
     it('shows the context engine toggle in the debug menu when the flag is enabled', async () => {
       render(
-        <PictureInPictureProvider>
-          <SeerExplorerSessionsProvider>
-            <SeerExplorerContent
-              getPageReferrer={mockGetPageReferrer}
-              onClose={() => {}}
-            />
-          </SeerExplorerSessionsProvider>
-        </PictureInPictureProvider>,
+        <SeerExplorerSessionsProvider>
+          <SeerExplorerHeader
+            onNewChatClick={() => {}}
+            onChangeSession={() => {}}
+            onCopySessionClick={undefined}
+            onCopyLinkClick={undefined}
+            overrideCtxEngEnable
+            onOverrideCtxEngEnableToggle={() => {}}
+            showThinking={false}
+            onShowThinkingToggle={() => {}}
+            isPipSupported={false}
+            isPoppedOut={false}
+            onTogglePictureInPicture={() => {}}
+          />
+        </SeerExplorerSessionsProvider>,
         {
           organization: orgWithFlag,
         }
       );
 
+      await screen.findByText('Seer Agent');
       await userEvent.click(await screen.findByRole('button', {name: 'Debug'}));
       expect(
-        screen.getByRole('menuitemradio', {name: /Context Engine/})
+        await screen.findByRole('menuitemradio', {name: /Context Engine/})
       ).toBeInTheDocument();
     });
   });

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -543,6 +543,7 @@ export function SeerExplorerContent({
       data-seer-explorer-root=""
       width="100%"
       height="100%"
+      position="relative"
       background="primary"
       overflow="hidden"
       containerType="inline-size"


### PR DESCRIPTION
Make the shared Seer Explorer root the containing block for the floating command menu so its existing textarea-relative coordinates remain correct in both drawer and persistent-sidebar modes.

before:

<img width="1487" height="197" alt="Screenshot 2026-07-14 at 14 50 57" src="https://github.com/user-attachments/assets/958ef00d-4338-4864-ba7e-5321d3e93234" />

after:

<img width="511" height="190" alt="Screenshot 2026-07-14 at 14 49 51" src="https://github.com/user-attachments/assets/7f5eb074-79e5-47e6-9742-20f918f8266c" />
