### PR TITLE
fix(pr-metrics): Add retry to the PR-close cooldown task

### DIFF
--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import logging
 
+from django.conf import settings
+from django.db import Error as DjangoDBError
 from taskbroker_client.retry import Retry
 from urllib3.exceptions import HTTPError
 
 from sentry.models.organization import Organization
-from sentry.models.pullrequest import PullRequest, PullRequestActivity
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestActivity,
+    PullRequestMetrics,
+    PullRequestVerdict,
+)
 from sentry.models.repository import Repository
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge
 from sentry.silo.base import SiloMode
@@ -21,6 +28,12 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = 5
 DELAY_BETWEEN_RETRIES = 60  # seconds
 
+# forward_pr_to_seer_task's Seer call blocks for up to settings.SEER_DEFAULT_TIMEOUT.
+# Give the task headroom past that instead of the taskbroker client's 10s default —
+# otherwise the broker can decide the worker is dead (and redeliver the task to
+# another worker) while the call is still legitimately in flight.
+FORWARD_PROCESSING_DEADLINE = settings.SEER_DEFAULT_TIMEOUT + 15
+
 
 @instrumented_task(
     name="sentry.pr_metrics.tasks.forward_pr_to_seer",
@@ -28,6 +41,7 @@ DELAY_BETWEEN_RETRIES = 60  # seconds
     # introducing an unrouted one; both forward PR events to the same Seer host.
     namespace=seer_code_review_tasks,
     retry=Retry(times=MAX_RETRIES, delay=DELAY_BETWEEN_RETRIES, on=(HTTPError,)),
+    processing_deadline_duration=FORWARD_PROCESSING_DEADLINE,
     silo_mode=SiloMode.CELL,
 )
 def forward_pr_to_seer_task(
@@ -74,6 +88,7 @@ def forward_pr_to_seer_task(
 @instrumented_task(
     name="sentry.pr_metrics.tasks.emit_pr_metrics_cooldown",
     namespace=seer_code_review_tasks,
+    retry=Retry(times=MAX_RETRIES, delay=DELAY_BETWEEN_RETRIES, on=(DjangoDBError, HTTPError)),
     silo_mode=SiloMode.CELL,
 )
 def emit_pr_metrics_cooldown_task(
@@ -87,14 +102,14 @@ def emit_pr_metrics_cooldown_task(
     Scheduled by ``handle_emission`` when a close/merge webhook claims the
     ``WAITING_EVENT_COOLDOWN`` sentinel. Deferring emission by the cooldown lets
     late attribution and activity settle before the verdict is chosen and the row
-    read (see ``run_deferred_emission``). A PR or org that vanished between enqueue
-    and run is permanent and dropped.
+    read (see ``run_deferred_emission``).
     """
     log_extra = {
         "pull_request_id": pull_request_id,
         "organization_id": organization_id,
         "repository_id": repository_id,
     }
+
     # Scope to the claimed org+repo, matching the rest of the pipeline.
     try:
         pull_request = PullRequest.objects.get(
@@ -103,14 +118,18 @@ def emit_pr_metrics_cooldown_task(
             repository_id=repository_id,
         )
     except PullRequest.DoesNotExist:
-        logger.warning("pr_metrics.cooldown.pull_request_not_found", extra=log_extra)
+        logger.exception("pr_metrics.cooldown.pull_request_not_found", extra=log_extra)
         metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "pr_gone"})
         return
+
+    PullRequestMetrics.objects.filter(
+        pull_request=pull_request, verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
+    ).update(verdict=None)
 
     try:
         organization = Organization.objects.get(id=organization_id)
     except Organization.DoesNotExist:
-        logger.warning("pr_metrics.cooldown.organization_not_found", extra=log_extra)
+        logger.exception("pr_metrics.cooldown.organization_not_found", extra=log_extra)
         metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "org_gone"})
         return
 

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -407,11 +407,10 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
     final state.
 
     Reopen handling: if the PR is no longer terminal (reopened during the window),
-    release the sentinel and stop — a later re-close reschedules. Otherwise release
-    the cooldown claim back to NULL and run the standard verdict -> emit/forward
-    path, whose own NULL-based guards settle the row exactly once (a late redelivery
-    that races the brief NULL window still emits once: whichever of the two claims
-    the verdict wins, the other no-ops).
+    release the sentinel and stop — a later re-close reschedules. Otherwise run the
+    standard verdict -> emit/forward path, whose own NULL-based guards settle the
+    row exactly once (a late redelivery that races the brief NULL window still
+    emits once: whichever of the two claims the verdict wins, the other no-ops).
     """
     log_extra = {
         "organization_id": organization.id,
@@ -419,8 +418,6 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
         "pull_request_id": pull_request.id,
     }
 
-    # Release our cooldown claim so the deterministic/judge guards below — which
-    # compare-and-set against a NULL verdict — can settle the row.
     PullRequestMetrics.objects.filter(
         pull_request=pull_request, verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN
     ).update(verdict=None)

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -670,12 +670,40 @@ class HandleWebhookForPrMetricsCooldownTest(TestCase):
 
     @patch("sentry.analytics.record")
     def test_task_drops_when_pull_request_gone(self, mock_record: MagicMock) -> None:
+        # The lookup is scoped by (id, organization_id, repository_id) together, so
+        # a real PR whose repository_id no longer matches (e.g. re-parented between
+        # enqueue and run) is indistinguishable from one that vanished outright —
+        # both raise PullRequest.DoesNotExist on this compound filter. No PR, no
+        # PullRequestMetrics row to release: the sentinel is left untouched rather
+        # than guessed at from pull_request_id alone.
+        self.pull_request.metrics.update(verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN)
+
         emit_pr_metrics_cooldown_task(
-            pull_request_id=self.pull_request.id + 999,
+            pull_request_id=self.pull_request.id,
             organization_id=self.organization.id,
+            repository_id=self.repo.id + 999,
+        )
+
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+        assert self._verdict() == "waiting_event_cooldown"
+
+    @patch("sentry.analytics.record")
+    def test_task_drops_when_organization_gone(self, mock_record: MagicMock) -> None:
+        # The PR lookup is itself scoped by organization_id, so to reach the
+        # Organization lookup (rather than failing the PR lookup first), the PR's
+        # own organization_id must point at the now-missing org.
+        missing_organization_id = self.organization.id + 999
+        self.pull_request.update(organization_id=missing_organization_id)
+        self.pull_request.metrics.update(verdict=PullRequestVerdict.WAITING_EVENT_COOLDOWN)
+
+        emit_pr_metrics_cooldown_task(
+            pull_request_id=self.pull_request.id,
+            organization_id=missing_organization_id,
             repository_id=self.repo.id,
         )
+
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
+        assert self._verdict() is None
 
 
 @with_feature("organizations:pr-metrics-emit")


### PR DESCRIPTION
Adds explicit timeouts to the pr-metrics tasks (that are slightly larger than the default SEER_DEFAULT_TIMEOUT)

Adds retry to the `emit_pr_metrics_cooldown_task` (because it didn't exist before)

Fail loud (with exception, not warning) if we asked to emit pr metrics for either a PR that doesn't exist or an org that doesn't exist.

