### PR TITLE
feat(conversations): Redirect to detail on single conversation ID search

### DIFF
--- a/static/app/utils/api/apiFetch.tsx
+++ b/static/app/utils/api/apiFetch.tsx
@@ -10,6 +10,7 @@ export type ApiResponse<TResponseData = unknown> = {
     Link?: string;
     'X-Hits'?: number;
     'X-Max-Hits'?: number;
+    'X-Sentry-Direct-Hit'?: string;
   };
   json: TResponseData;
 };
@@ -36,6 +37,8 @@ export async function apiFetch<TQueryFnData = unknown>(
       Link: response?.getResponseHeader('Link') ?? undefined,
       'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
       'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
+      'X-Sentry-Direct-Hit':
+        response?.getResponseHeader('X-Sentry-Direct-Hit') ?? undefined,
     },
     json: json as TQueryFnData,
   };
@@ -66,6 +69,8 @@ export async function apiFetchInfinite<TQueryFnData = unknown>(
       Link: response?.getResponseHeader('Link') ?? undefined,
       'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
       'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
+      'X-Sentry-Direct-Hit':
+        response?.getResponseHeader('X-Sentry-Direct-Hit') ?? undefined,
     },
     json: json as TQueryFnData,
   };

--- a/static/app/utils/api/apiOptions.spec.tsx
+++ b/static/app/utils/api/apiOptions.spec.tsx
@@ -164,6 +164,7 @@ describe('apiOptions', () => {
       Link?: string;
       'X-Hits'?: number;
       'X-Max-Hits'?: number;
+      'X-Sentry-Direct-Hit'?: string;
     }>();
   });
 

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -24,50 +24,23 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {isUUID} from 'sentry/utils/string/isUUID';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ConversationMissingMessagesAlert} from 'sentry/views/explore/conversations/components/conversationMissingMessagesAlert';
 import {ToolTags} from 'sentry/views/explore/conversations/components/toolTags';
+import {useConversationDirectHitRedirect} from 'sentry/views/explore/conversations/hooks/useConversationDirectHitRedirect';
 import {
   useConversations,
   type Conversation,
   type ConversationUser,
 } from 'sentry/views/explore/conversations/hooks/useConversations';
-import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
 import {getConversationsListLocationState} from 'sentry/views/explore/conversations/utils/listNavigation';
+import {getConversationDetailUrl} from 'sentry/views/explore/conversations/utils/urlParams';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {AIContentRenderer} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer';
-
-const ONE_HOUR_MS = 60 * 60 * 1000;
-
-export function getConversationDetailUrl(
-  orgSlug: string,
-  conversation: Conversation,
-  projects: number[],
-  referrer = 'conversations-table'
-): string {
-  const basePath = `/organizations/${orgSlug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${encodeURIComponent(conversation.conversationId)}/`;
-  const params = new URLSearchParams();
-  if (conversation.startTimestamp) {
-    params.set(
-      'start',
-      new Date(conversation.startTimestamp - ONE_HOUR_MS).toISOString()
-    );
-  }
-  if (conversation.endTimestamp) {
-    params.set('end', new Date(conversation.endTimestamp + ONE_HOUR_MS).toISOString());
-  }
-  for (const project of projects) {
-    params.append('project', String(project));
-  }
-  params.set('referrer', referrer);
-  const qs = params.toString();
-  return normalizeUrl(qs ? `${basePath}?${qs}` : basePath);
-}
 
 export function ConversationsTable() {
   const organization = useOrganization();
@@ -99,7 +72,8 @@ function ConversationsTableInner() {
     columns: defaultColumnOrder,
   });
 
-  const {data, isFetching, error, pageLinks, setCursor} = useConversations();
+  const {data, isFetching, error, pageLinks, setCursor, isDirectHit} = useConversations();
+  useConversationDirectHitRedirect({isDirectHit, conversations: data});
 
   const showMissingMessagesAlert =
     !isFetching &&

--- a/static/app/views/explore/conversations/components/conversationsTableNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTableNew.tsx
@@ -31,12 +31,12 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {ConversationMissingMessagesAlert} from 'sentry/views/explore/conversations/components/conversationMissingMessagesAlert';
 import {
   CellContent,
-  getConversationDetailUrl,
   getUserDisplayName,
   UserNotInstrumentedTooltip,
 } from 'sentry/views/explore/conversations/components/conversationsTable';
 import {ConversationsTableEditModal} from 'sentry/views/explore/conversations/components/conversationsTableEditModal';
 import {ConversationToolCallsBreakdown} from 'sentry/views/explore/conversations/components/conversationToolCallsBreakdown';
+import {useConversationDirectHitRedirect} from 'sentry/views/explore/conversations/hooks/useConversationDirectHitRedirect';
 import {
   useConversations,
   type Conversation,
@@ -49,6 +49,7 @@ import {
   CONVERSATION_COLUMNS,
   RIGHT_ALIGNED_CONVERSATION_COLUMNS,
 } from 'sentry/views/explore/conversations/utils/tableColumns';
+import {getConversationDetailUrl} from 'sentry/views/explore/conversations/utils/urlParams';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 
@@ -59,7 +60,8 @@ export function ConversationsTableNew() {
   const {selection} = usePageFilters();
   const {openModal} = useModal();
   const {columns, setColumns} = useConversationsTableColumns();
-  const {data, isFetching, error, pageLinks, setCursor} = useConversations();
+  const {data, isFetching, error, pageLinks, setCursor, isDirectHit} = useConversations();
+  useConversationDirectHitRedirect({isDirectHit, conversations: data});
   const [highlightedRowKey, setHighlightedRowKey] = useState<number | undefined>();
 
   const columnOrder = useMemo<Array<GridColumnOrder<ConversationColumnKey>>>(

--- a/static/app/views/explore/conversations/hooks/useConversationDirectHitRedirect.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationDirectHitRedirect.spec.tsx
@@ -1,0 +1,68 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {Conversation} from 'sentry/views/explore/conversations/hooks/useConversations';
+
+import {useConversationDirectHitRedirect} from './useConversationDirectHitRedirect';
+
+const CONVERSATION: Conversation = {
+  conversationId: 'conv-1',
+  duration: 1000,
+  endTimestamp: 2000,
+  errors: 0,
+  firstInput: null,
+  inputTokens: 0,
+  lastOutput: null,
+  llmCalls: 1,
+  outputTokens: 0,
+  startTimestamp: 1000,
+  toolCalls: 0,
+  toolErrors: 0,
+  toolNames: [],
+  totalCost: null,
+  totalTokens: 100,
+  traceCount: 1,
+  traceIds: ['trace-1'],
+  user: null,
+};
+
+describe('useConversationDirectHitRedirect', () => {
+  const organization = OrganizationFixture();
+
+  it('redirects to the conversation detail on a single direct hit', async () => {
+    const {router} = renderHookWithProviders(useConversationDirectHitRedirect, {
+      organization,
+      initialProps: {isDirectHit: true, conversations: [CONVERSATION]},
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        `/organizations/${organization.slug}/explore/conversations/conv-1/`
+      );
+    });
+  });
+
+  it('does not redirect when it is not a direct hit', () => {
+    const {router} = renderHookWithProviders(useConversationDirectHitRedirect, {
+      organization,
+      initialRouterConfig: {location: {pathname: '/conversations-list/'}},
+      initialProps: {isDirectHit: false, conversations: [CONVERSATION]},
+    });
+
+    expect(router.location.pathname).toBe('/conversations-list/');
+  });
+
+  it('does not redirect when more than one conversation is returned', () => {
+    const {router} = renderHookWithProviders(useConversationDirectHitRedirect, {
+      organization,
+      initialRouterConfig: {location: {pathname: '/conversations-list/'}},
+      initialProps: {
+        isDirectHit: true,
+        conversations: [CONVERSATION, {...CONVERSATION, conversationId: 'conv-2'}],
+      },
+    });
+
+    expect(router.location.pathname).toBe('/conversations-list/');
+  });
+});

--- a/static/app/views/explore/conversations/hooks/useConversationDirectHitRedirect.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversationDirectHitRedirect.tsx
@@ -1,0 +1,42 @@
+import {useEffect, useRef} from 'react';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {Conversation} from 'sentry/views/explore/conversations/hooks/useConversations';
+import {getConversationDetailUrl} from 'sentry/views/explore/conversations/utils/urlParams';
+
+interface UseConversationDirectHitRedirectOptions {
+  conversations: Conversation[];
+  isDirectHit: boolean;
+}
+
+/**
+ * Redirects to the conversation detail view when a conversation-ID search
+ * resolves to a single direct hit, instead of showing a one-row list.
+ */
+export function useConversationDirectHitRedirect({
+  conversations,
+  isDirectHit,
+}: UseConversationDirectHitRedirectOptions) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const {selection} = usePageFilters();
+  const hasRedirectedRef = useRef(false);
+
+  useEffect(() => {
+    const conversation = conversations[0];
+    if (
+      isDirectHit &&
+      conversations.length === 1 &&
+      conversation &&
+      !hasRedirectedRef.current
+    ) {
+      hasRedirectedRef.current = true;
+      navigate(
+        getConversationDetailUrl(organization.slug, conversation, selection.projects),
+        {replace: true}
+      );
+    }
+  }, [isDirectHit, conversations, navigate, organization.slug, selection.projects]);
+}

--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -182,4 +182,31 @@ describe('useConversations', () => {
     expect(result.current.data[0]?.conversationId).toBe('newer');
     expect(result.current.data[1]?.conversationId).toBe('older');
   });
+
+  it('reports a direct hit when the header is present', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/`,
+      body: [{...BASE_CONVERSATION, firstInput: null, lastOutput: null}],
+      headers: {'X-Sentry-Direct-Hit': '1'},
+    });
+
+    const {result} = renderHookWithProviders(() => useConversations(), {organization});
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.isDirectHit).toBe(true);
+  });
+
+  it('does not report a direct hit when the header is absent', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/ai-conversations/`,
+      body: [{...BASE_CONVERSATION, firstInput: null, lastOutput: null}],
+    });
+
+    const {result} = renderHookWithProviders(() => useConversations(), {organization});
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(result.current.isDirectHit).toBe(false);
+  });
 });

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -76,6 +76,7 @@ export function useConversations() {
   });
 
   const pageLinks = response?.headers.Link;
+  const isDirectHit = response?.headers['X-Sentry-Direct-Hit'] === '1';
 
   const data = useMemo(() => {
     return (response?.json ?? [])
@@ -105,5 +106,6 @@ export function useConversations() {
     error,
     pageLinks,
     setCursor,
+    isDirectHit,
   };
 }

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -14,6 +14,7 @@ import {
   type UseSpanSearchQueryBuilderProps,
 } from 'sentry/components/performance/spanSearchQueryBuilder';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -119,7 +120,10 @@ function ConversationsOverviewPage() {
               </Flex>
               {!showOnboarding && !isOnboardingLoading && (
                 <Flex flex={1} minWidth="300px">
-                  <TraceItemSearchQueryBuilder {...spanSearchQueryBuilderProps} />
+                  <TraceItemSearchQueryBuilder
+                    {...spanSearchQueryBuilderProps}
+                    placeholder={t('Search or paste a conversation ID')}
+                  />
                 </Flex>
               )}
               {!showOnboarding && !isOnboardingLoading && <SaveConversationQueryButton />}

--- a/static/app/views/explore/conversations/utils/urlParams.tsx
+++ b/static/app/views/explore/conversations/utils/urlParams.tsx
@@ -1,10 +1,43 @@
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import type {Conversation} from 'sentry/views/explore/conversations/hooks/useConversations';
 import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/explore/conversations/settings';
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
 interface ConversationsUrlOptions {
   end?: string;
   project?: number | string;
   referrer?: string;
   start?: string;
+}
+
+/**
+ * Returns the in-app path to a conversation's detail view, scoped to a time
+ * window around the conversation and the given projects.
+ */
+export function getConversationDetailUrl(
+  orgSlug: string,
+  conversation: Conversation,
+  projects: number[],
+  referrer = 'conversations-table'
+): string {
+  const basePath = `/organizations/${orgSlug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${encodeURIComponent(conversation.conversationId)}/`;
+  const params = new URLSearchParams();
+  if (conversation.startTimestamp) {
+    params.set(
+      'start',
+      new Date(conversation.startTimestamp - ONE_HOUR_MS).toISOString()
+    );
+  }
+  if (conversation.endTimestamp) {
+    params.set('end', new Date(conversation.endTimestamp + ONE_HOUR_MS).toISOString());
+  }
+  for (const project of projects) {
+    params.append('project', String(project));
+  }
+  params.set('referrer', referrer);
+  const qs = params.toString();
+  return normalizeUrl(qs ? `${basePath}?${qs}` : basePath);
 }
 
 /**


### PR DESCRIPTION
Searching AI conversations for a single conversation ID now takes you straight to that conversation's detail view instead of showing a one-row list. The search bar also gains a placeholder guiding users to search or paste a conversation ID.

The backend signals this via the `X-Sentry-Direct-Hit` header (see the required backend PR below). On the client:

- `apiFetch` now surfaces `X-Sentry-Direct-Hit` in the typed `ApiResponse` headers, alongside the existing `Link`/`X-Hits`/`X-Max-Hits`.
- `useConversations` exposes it as `isDirectHit` and stays a pure data hook.
- A dedicated `useConversationDirectHitRedirect` hook performs the `navigate(..., {replace: true})` to the detail view when there's a single direct hit. Both table variants call it.
- `getConversationDetailUrl` moved from `conversationsTable.tsx` to `utils/urlParams.tsx` so the redirect hook can build the URL without a circular import.

Requires #119613 (backend). That PR must land first, since the redirect depends on the `X-Sentry-Direct-Hit` header it introduces.

Fixes TET-2657