### PR TITLE
fix(conversations): Show "no cost recorded" instead of a misleading amount

### DIFF
--- a/static/app/views/explore/conversations/components/conversationSummary.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummary.tsx
@@ -27,13 +27,13 @@ import {normalizeUserField} from 'sentry/views/explore/conversations/components/
 import type {ConversationUser} from 'sentry/views/explore/conversations/hooks/useConversations';
 import {getTimeBoundsFromNodes} from 'sentry/views/explore/conversations/utils/timeBounds';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
 import {
   getNumberAttr,
   getStringAttr,
   hasError,
 } from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
-import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {
   getIsAiGenerationSpan,
   getIsExecuteToolSpan,
@@ -189,7 +189,7 @@ export function ConversationAggregatesBar({
           aggregates.totalCost < 0 ? (
             <NegativeCostInfo cost={aggregates.totalCost} />
           ) : (
-            formatLLMCosts(aggregates.totalCost)
+            <LLMCosts cost={aggregates.totalCost} />
           )
         }
         isLoading={isLoading}

--- a/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationSummaryNew.tsx
@@ -27,8 +27,8 @@ import {
 } from 'sentry/views/explore/conversations/components/conversationSummary';
 import {ToolTag} from 'sentry/views/explore/conversations/components/toolTag';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {NegativeCostInfo} from 'sentry/views/insights/pages/agents/components/negativeCostWarning';
-import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 
 interface ConversationSummaryNewProps {
@@ -222,7 +222,7 @@ export function ConversationSummaryNew({
             aggregates.totalCost < 0 ? (
               <NegativeCostInfo cost={aggregates.totalCost} />
             ) : (
-              formatLLMCosts(aggregates.totalCost)
+              <LLMCosts cost={aggregates.totalCost} />
             )
           }
           isLoading={isLoading}

--- a/static/app/views/insights/pages/agents/components/llmCosts.spec.tsx
+++ b/static/app/views/insights/pages/agents/components/llmCosts.spec.tsx
@@ -1,0 +1,36 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
+
+describe('LLMCosts', () => {
+  it('renders a regular cost as a dollar amount', () => {
+    render(<LLMCosts cost={1.23} />);
+    expect(screen.getByText('$1.23')).toBeInTheDocument();
+  });
+
+  it('renders a near-zero cost as the sub-cent placeholder', () => {
+    render(<LLMCosts cost={0.004} />);
+    expect(screen.getByText('<$0.01')).toBeInTheDocument();
+  });
+
+  it('renders a dash with an explanatory tooltip when the cost is zero', async () => {
+    render(<LLMCosts cost={0} />);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('—'));
+
+    expect(await screen.findByText(/No cost recorded/)).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Learn more'})).toBeInTheDocument();
+  });
+
+  it('renders a dash with an explanatory tooltip when there is no cost', async () => {
+    render(<LLMCosts cost={null} />);
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+
+    await userEvent.hover(screen.getByText('—'));
+
+    expect(await screen.findByText(/No cost recorded/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/insights/pages/agents/components/llmCosts.tsx
+++ b/static/app/views/insights/pages/agents/components/llmCosts.tsx
@@ -1,11 +1,38 @@
+import {InfoText} from '@sentry/scraps/info';
+
+import {ExternalLink} from 'sentry/components/links/externalLink';
+import {tct} from 'sentry/locale';
 import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
+
+const COST_DOCS_URL = 'https://docs.sentry.io/ai/monitoring/agents/costs/';
 
 interface LLMCostsProps {
   cost: number | string | null;
   className?: string;
 }
 
+/**
+ * Renders an LLM cost via `formatLLMCosts`. A missing (null) or exactly-zero
+ * cost both mean "no cost recorded" and render as a `—` wrapped in a tooltip
+ * explaining how cost is calculated, so it reads as "no data" rather than a
+ * free ($0) call.
+ */
 export function LLMCosts({cost, className}: LLMCostsProps) {
+  if (cost === null || Number(cost) === 0) {
+    return (
+      <InfoText
+        className={className}
+        variant="inherit"
+        title={tct(
+          'No cost recorded. Cost is calculated from token usage and model pricing on your AI spans. [link:Learn more].',
+          {link: <ExternalLink href={COST_DOCS_URL} />}
+        )}
+      >
+        {'—'}
+      </InfoText>
+    );
+  }
+
   return (
     <span
       className={className}
@@ -15,7 +42,7 @@ export function LLMCosts({cost, className}: LLMCostsProps) {
         maximumFractionDigits: 8,
       })}
     >
-      {cost ? formatLLMCosts(cost) : '—'}
+      {formatLLMCosts(cost)}
     </span>
   );
 }

--- a/static/app/views/insights/pages/agents/utils/formatLLMCosts.tsx
+++ b/static/app/views/insights/pages/agents/utils/formatLLMCosts.tsx
@@ -6,6 +6,13 @@ export function formatLLMCosts(cost: string | number | null) {
   }
   const number = Number(cost);
 
+  // Treat an exact 0 the same as null. Summed aggregations report 0 when every
+  // value was null, and a genuine 0 cost is very unlikely (most often an
+  // instrumentation bug), so render "no cost recorded" rather than $0.
+  if (number === 0) {
+    return '—';
+  }
+  // Negative costs signal bad token reporting and render as a precise amount.
   if (number < 0) {
     return formatDollars(number);
   }


### PR DESCRIPTION
The conversation summary showed `<$0.01` for conversations that have no cost data. A missing cost aggregated to `0` and then formatted as a near-zero amount, which reads as "this was almost free" when the truth is that cost couldn't be calculated at all.

A `0` cost now renders as a dash with a tooltip explaining how cost is derived, so it reads as "no data" rather than a free call. Costs of exactly `0` are treated the same as `null`: summed aggregations report `0` when every value was null, and a genuine `0` cost is very unlikely (most often an instrumentation bug).

The null/zero handling and the tooltip are merged into the shared `LLMCosts` component rather than living only in the summary, so the conversation tables, timeline, and span list stay consistent. A visible consequence: no-cost rows in the conversations list table now show the dash with the explanatory tooltip instead of a bare dash.

| `cost` | Renders |
|---|---|
| `null` / `0` | `—` + "No cost recorded" tooltip |
| `0 < x < 0.01` | `<$0.01` |
| `x ≥ 0.01` | `$1.23` |
| `< 0` | negative-cost warning (unchanged) |

Fixes TET-2663