### PR TITLE
fix(textAreaAutoSize): turn off the react compiler

### DIFF
--- a/static/app/components/core/textarea/textarea.tsx
+++ b/static/app/components/core/textarea/textarea.tsx
@@ -52,6 +52,9 @@ interface AutosizeTextAreaProps extends Omit<TextAreaProps, 'autosize' | 'size'>
 // container-driven resizes leave the height stale. Force a recompute on
 // border-box width changes (border box ignores internal-scrollbar jitter).
 function AutosizeTextArea({ref, rows, maxRows, ...p}: AutosizeTextAreaProps) {
+  // we need to turn off the compiler here because we need to force text-area-auto-size
+  // to recompute on width changes, even though we don't use the state variable.
+  'use no memo';
   // Storing width in state re-renders on change so react-textarea-autosize recomputes
   const [, setWidth] = useState<number>();
 


### PR DESCRIPTION
because we need to force textAreaAutosize to re-render when the width changes (we observe its own size) so that we can re-size the textArea when it gets smaller or larger (e.g. in a resizable SplitPanel). The react compiler however sees that we don't use the width variable and therefore correctly opts out of re-rendering.

This restores the behavior introduced in:

- https://github.com/getsentry/sentry/pull/118855
