### PR TITLE
fix(conversations): Remember last selected project

### DIFF
--- a/static/app/views/explore/conversations/layout.tsx
+++ b/static/app/views/explore/conversations/layout.tsx
@@ -64,7 +64,6 @@ function ConversationsLayoutContent() {
           <NoProjectMessage organization={organization}>
             <PageFiltersContainer
               maxPickableDays={MAX_PICKABLE_DAYS}
-              storageNamespace="conversations"
               skipLoadLastUsed={isDetailPage}
             >
               <Outlet />


### PR DESCRIPTION
Selecting a project on the conversations page is now remembered when you leave and come back, matching the behavior of every other explore view.

The conversations layout set `storageNamespace="conversations"` on its `PageFiltersContainer` but left it off the project/environment/date dropdowns. Initialization and the container's URL-sync read from the isolated `conversations:` localStorage bucket, while dropdown changes were persisted to the global bucket. The two buckets drifted, so on returning to the page the stale namespaced value won and an old project was restored instead of the last one you picked.

No other explore view (spans, logs, metrics, profiling, releases, replays, errors) namespaces its page filters. Removing the namespace lets conversations share the global bucket like its siblings, so the selection persists across visits.

If you want a conversations view pinned to a specific project regardless of the global filter, you can always save the query — the saved query captures the project selection.

Fixes TET-2660