### PR TITLE
fix(split-panel): Restore horizontal divider hit area

### DIFF
--- a/static/app/components/core/splitPanel/splitPanel.tsx
+++ b/static/app/components/core/splitPanel/splitPanel.tsx
@@ -363,7 +363,8 @@ const DividerLine = styled('div')<{$cursor: React.CSSProperties['cursor']}>`
 
   &[data-orientation='horizontal'] {
     width: 0;
-    height: 100%;
+    height: auto;
+    align-self: stretch;
     border-left: 1px solid ${p => p.theme.tokens.border.primary};
 
     &::before {


### PR DESCRIPTION
Let the horizontal divider stretch with its row flex container instead of resolving its height against an indefinite containing block. This restores pointer dragging for right-docked Seer sidebars below the md breakpoint.

closes [DE-1358](https://linear.app/getsentry/issue/DE-1358/fix-detached-command-box-and-mobile-breakpoint-issues)