### PR TITLE
fix(autofix): don't treat queued PR feedback as iterating

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -801,7 +801,7 @@ describe('ArtifactCard', () => {
       ]);
     });
 
-    it('shows the iterating loader without replaying the previous step when feedback is queued', () => {
+    it('shows the code changes, not the loader, when feedback is only queued', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
@@ -821,20 +821,15 @@ describe('ArtifactCard', () => {
             'code_changes',
             'completed',
             [[makePatch('org/repo', 'src/app.py')]],
-            [
-              makePrIterationBlock(0, {text: 'first pass'}),
-              makeAssistantBlock('Previous step output that should not replay'),
-            ]
+            [makePrIterationBlock(0, {text: 'first pass'})]
           )}
         />,
         {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText('Iterating on PR…')).toBeInTheDocument();
-      expect(
-        screen.queryByText('Previous step output that should not replay')
-      ).not.toBeInTheDocument();
-      expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
+      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
+      expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
+      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
     });
 
     it('renders queued feedback as a feedback item', () => {
@@ -864,7 +859,7 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('Make the button blue')).toBeInTheDocument();
     });
 
-    it('shows generic processing copy for queued feedback without the feature flag', () => {
+    it('shows the code changes for queued feedback without the feature flag', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
@@ -886,7 +881,8 @@ describe('ArtifactCard', () => {
         />
       );
 
-      expect(screen.getByText('Implementing changes…')).toBeInTheDocument();
+      expect(screen.getByText('1 file changed in 1 repo')).toBeInTheDocument();
+      expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
       expect(screen.queryByText('Iterating on PR…')).not.toBeInTheDocument();
     });
 

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -125,12 +125,10 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   const organization = useOrganization();
   const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
 
-  const hasQueuedFeedback = (autofix.runState?.queued_feedback ?? []).length > 0;
-
   const isIterating =
     hasPrIterationFeature &&
-    (hasQueuedFeedback ||
-      (section.status === 'processing' && section.blocks.some(isPrIterationBlock)));
+    section.status === 'processing' &&
+    section.blocks.some(isPrIterationBlock);
 
   const currentStepStart = useMemo(
     () => section.blocks.findLastIndex(block => defined(block.message.metadata?.step)),
@@ -274,7 +272,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
-  const isProcessing = section.status === 'processing' || hasQueuedFeedback;
+  const isProcessing = section.status === 'processing';
 
   const showPrIterationForm = hasPRs && prIterationEnabled;
   const prIterationForm = (


### PR DESCRIPTION
we don't want to treat queued PR feedback as iterating otherwise we'll be hiding the current code changes when we have check suites waiting in the queue when we add check suite feedback