### PR TITLE
fix(conversations): Fix blank detail view on mobile breakpoint

### DIFF
--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -95,7 +95,15 @@ export function ConversationViewContainer({children}: {children: React.ReactNode
       background="primary"
       display="flex"
     >
-      <Flex flex={1} minWidth="0" minHeight="0" height="100%">
+      {/*
+       * No explicit `height: 100%` here: the parent Container is a flex row
+       * with the default `align-items: stretch`, so this pane already fills the
+       * available height. A `height: 100%` would resolve against the parent's
+       * height, which is indefinite when the app is in its mobile (column)
+       * layout — every browser then collapses this subtree to zero height,
+       * leaving the conversation detail view blank. (TET-2690)
+       */}
+      <Flex flex={1} minWidth="0" minHeight="0">
         {children}
       </Flex>
     </Container>


### PR DESCRIPTION
Fixes the conversation detail view rendering as a blank white box on mobile-width viewports (reported on iOS Safari, but reproduces in every browser).

The detail pane wrapped its content in a `Flex` with an explicit `height: 100%`. That percentage resolves against the parent `Container`'s height — which is indefinite once the app switches to its mobile (column) layout as the nav collapses. With an indefinite containing block, the subtree collapses to zero height, and the nested `SplitPanel` then hides itself (it renders `visibility: hidden` when it measures a height of 0), leaving the whole view blank.

The parent `Container` is a flex row and never overrides `align-items`, so it keeps the CSS default `stretch` — the `flex: 1` pane already fills the available height without `height: 100%`. Dropping the redundant `height: 100%` keeps the desktop layout unchanged (definite height there, so stretch fills it) while fixing the mobile collapse.

`ConversationViewContainer` is shared by both the redesigned and legacy detail pages, so this one change fixes both.

Fixes TET-2690