### PR TITLE
feat(pr-metrics): Close SENTRY_APP attribution gaps for autofix PRs

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -157,7 +157,7 @@ def _handle_pr_webhook_for_autofix_processor(
     if organization and action and user:
         # Because we require that the sentry github integration be installed for autofix, we can piggyback
         # on this webhook for autofix for now. We may move to a separate autofix github integration in the future
-        handle_github_pr_webhook_for_autofix(organization, action, pull_request, user)
+        handle_github_pr_webhook_for_autofix(organization, action, pull_request, user, repo.id)
 
 
 def _track_contributor_action_processor(

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -88,6 +88,34 @@ def is_seer_attribution(attribution: PullRequestAttribution) -> bool:
     )
 
 
+def _merge_signal_details(
+    existing: Mapping[str, Any] | None, incoming: Mapping[str, Any] | None
+) -> dict[str, Any] | None:
+    """Combine two ``signal_details`` payloads for the same attribution row.
+
+    Schema-agnostic, since ``signal_details`` shapes differ by signal type: list
+    values are unioned (e.g. ``group_ids``), dict values are merged with the
+    incoming side winning on key conflicts (e.g. MCP's group_id -> client_family
+    map), and every other value keeps the incoming value when truthy, else falls
+    back to the existing one.
+    """
+    if existing is None:
+        return dict(incoming) if incoming is not None else None
+    if incoming is None:
+        return dict(existing)
+
+    merged = dict(existing)
+    for key, new_value in incoming.items():
+        old_value = merged.get(key)
+        if isinstance(old_value, list) and isinstance(new_value, list):
+            merged[key] = sorted({*old_value, *new_value})
+        elif isinstance(old_value, Mapping) and isinstance(new_value, Mapping):
+            merged[key] = {**old_value, **new_value}
+        elif new_value:
+            merged[key] = new_value
+    return merged
+
+
 def record_attribution_signal(
     *,
     pull_request: PullRequest,
@@ -98,8 +126,13 @@ def record_attribution_signal(
     """Idempotently record one detected attribution signal for a PR.
 
     Keyed on ``(pull_request, signal_type, source)`` — matching the model's
-    unique constraint — so webhook/event redelivery updates the existing row's
-    ``signal_details`` rather than inserting a duplicate.
+    unique constraint. A still-valid existing row is merged with the incoming
+    details via ``_merge_signal_details`` rather than replaced outright, so two
+    independent producers of the same signal/source (e.g. Seer's
+    ``pr_created`` callback and the live-RPC autofix lookup) accumulate onto the
+    same row instead of clobbering each other on redelivery/race. A previously
+    invalidated row is replaced outright and revived, since the source is
+    reporting it as present again.
     """
     details = dict(signal_details) if signal_details is not None else None
 
@@ -110,10 +143,16 @@ def record_attribution_signal(
         defaults={"signal_details": details, "is_valid": True},
     )
 
-    # Refresh details on redelivery — and revive a previously-invalidated signal,
-    # since the source is reporting it as present again.
-    if not created and (attribution.signal_details != details or not attribution.is_valid):
-        attribution.signal_details = details
+    if created:
+        return attribution
+
+    new_details = (
+        details
+        if not attribution.is_valid
+        else _merge_signal_details(attribution.signal_details, details)
+    )
+    if new_details != attribution.signal_details or not attribution.is_valid:
+        attribution.signal_details = new_details
         attribution.is_valid = True
         attribution.save(update_fields=["signal_details", "is_valid", "date_updated"])
 

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -13,6 +13,7 @@ import logging
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from django.db import router, transaction
 from pydantic import BaseModel
 
 from sentry import features
@@ -130,33 +131,38 @@ def record_attribution_signal(
     details via ``_merge_signal_details`` rather than replaced outright, so two
     independent producers of the same signal/source (e.g. Seer's
     ``pr_created`` callback and the live-RPC autofix lookup) accumulate onto the
-    same row instead of clobbering each other on redelivery/race. A previously
+    same row instead of clobbering each other on redelivery/race. Reading the
+    existing row with ``select_for_update`` inside the transaction is what
+    makes that merge race-safe: it blocks a concurrent writer until this one
+    commits, so the concurrent writer's merge starts from an up-to-date
+    snapshot instead of a stale one it would otherwise clobber. A previously
     invalidated row is replaced outright and revived, since the source is
     reporting it as present again.
     """
     details = dict(signal_details) if signal_details is not None else None
 
-    attribution, created = PullRequestAttribution.objects.get_or_create(
-        pull_request=pull_request,
-        signal_type=signal_type,
-        source=source,
-        defaults={"signal_details": details, "is_valid": True},
-    )
+    with transaction.atomic(using=router.db_for_write(PullRequestAttribution)):
+        attribution, created = PullRequestAttribution.objects.select_for_update().get_or_create(
+            pull_request=pull_request,
+            signal_type=signal_type,
+            source=source,
+            defaults={"signal_details": details, "is_valid": True},
+        )
 
-    if created:
+        if created:
+            return attribution
+
+        new_details = (
+            details
+            if not attribution.is_valid
+            else _merge_signal_details(attribution.signal_details, details)
+        )
+        if new_details != attribution.signal_details or not attribution.is_valid:
+            attribution.signal_details = new_details
+            attribution.is_valid = True
+            attribution.save(update_fields=["signal_details", "is_valid", "date_updated"])
+
         return attribution
-
-    new_details = (
-        details
-        if not attribution.is_valid
-        else _merge_signal_details(attribution.signal_details, details)
-    )
-    if new_details != attribution.signal_details or not attribution.is_valid:
-        attribution.signal_details = new_details
-        attribution.is_valid = True
-        attribution.save(update_fields=["signal_details", "is_valid", "date_updated"])
-
-    return attribution
 
 
 def recompute_pull_request_attribution(pull_request: PullRequest) -> str | None:

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -22,6 +22,7 @@ from sentry.models.pullrequest import (
     PullRequestMetrics,
     PullRequestVerdict,
 )
+from sentry.seer.models import SeerAgentRun, SeerRunPullRequest
 
 _PR_ACTIVITY_ATTRIBUTION_BUFFER = timedelta(hours=30)
 
@@ -199,3 +200,29 @@ def resolved_group_ids(pull_request: PullRequest) -> list[int]:
         combined = pr_filter
 
     return sorted(GroupLink.objects.filter(combined).values_list("group_id", flat=True).distinct())
+
+
+def seer_run_link_for_pull_request(pull_request: PullRequest) -> tuple[list[int], int | None]:
+    """Group id and run id for the Seer run that opened this PR, via the local
+    ``SeerRunPullRequest`` link.
+
+    That link is written by the on_completion_hook-driven ``seer.pr_created`` flow
+    (``process_autofix_updates`` -> ``link_seer_run_pull_requests``). It may not
+    exist yet at the "opened" webhook if that flow hasn't landed; the "closed"
+    re-check in ``handle_attribution`` covers that case.
+    """
+    link = (
+        SeerRunPullRequest.objects.select_related("seer_run__agent")
+        .filter(pull_request=pull_request)
+        .first()
+    )
+    if link is None:
+        return [], None
+
+    run_id = link.seer_run.seer_run_state_id
+    try:
+        group_id = link.seer_run.agent.group_id
+    except SeerAgentRun.DoesNotExist:
+        group_id = None
+
+    return ([group_id] if group_id is not None else []), run_id

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -89,6 +89,7 @@ from sentry.pr_metrics.utils import (
     is_activity_tracking_enabled,
     org_has_coding_agent_for_provider,
     resolved_group_ids,
+    seer_run_link_for_pull_request,
 )
 from sentry.seer.autofix.utils import (
     DelegatedAgentMatch,
@@ -176,7 +177,11 @@ def handle_attribution(
     # where the PR open and closes super fast and the webhooks might be out of order
     if action in ("opened", "closed"):
         pr_url = (pull_request or {}).get("html_url") or None
-        _write_author_attribution(pr, github_user, pr_url=pr_url, group_ids=resolved_group_ids(pr))
+        seer_group_ids, seer_run_id = seer_run_link_for_pull_request(pr)
+        group_ids = sorted(set(resolved_group_ids(pr)) | set(seer_group_ids))
+        _write_author_attribution(
+            pr, github_user, pr_url=pr_url, group_ids=group_ids, run_id=seer_run_id
+        )
     if features.has("organizations:mcp-issue-view-attribution", organization):
         _write_mcp_attribution(pr)
     # Checked on open and re-checked on close, mirroring the SENTRY_APP author
@@ -1068,6 +1073,7 @@ def _write_author_attribution(
     github_user: dict[str, Any],
     pr_url: str | None = None,
     group_ids: list[int] | None = None,
+    run_id: int | None = None,
 ) -> None:
     user_id = github_user.get("id")
     if user_id is None:
@@ -1080,6 +1086,7 @@ def _write_author_attribution(
         signal_details = SentryAppSignalDetails(
             pr_url=pr_url,
             group_ids=group_ids or [],
+            run_id=run_id,
         )
     record_attribution_signal(
         pull_request=pr,

--- a/src/sentry/seer/autofix/webhooks.py
+++ b/src/sentry/seer/autofix/webhooks.py
@@ -1,10 +1,11 @@
+import logging
 from datetime import datetime
 from typing import Any, Literal
 
 import sentry_sdk
 from django.conf import settings
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.analytics.events.ai_autofix_pr_events import (
     AiAutofixPrClosedEvent,
     AiAutofixPrEvent,
@@ -14,8 +15,16 @@ from sentry.analytics.events.ai_autofix_pr_events import (
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
+from sentry.pr_metrics.attribution import SentryAppSignalDetails, record_attribution_signal
 from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
 from sentry.utils import metrics
+
+logger = logging.getLogger("sentry.webhooks")
 
 AnalyticAction = Literal["opened", "closed", "merged"]
 
@@ -33,7 +42,11 @@ ACTION_TO_TIMESTAMP_FIELD: dict[AnalyticAction, str] = {
 
 
 def handle_github_pr_webhook_for_autofix(
-    org: Organization, action: str, pull_request: dict[str, Any], github_user: dict[str, Any]
+    org: Organization,
+    action: str,
+    pull_request: dict[str, Any],
+    github_user: dict[str, Any],
+    repo_id: int,
 ) -> None:
     seer_app_id = getattr(settings, "SEER_AUTOFIX_GITHUB_APP_USER_ID", None)
     sentry_app_id = getattr(settings, "SENTRY_GITHUB_APP_USER_ID", None)
@@ -52,13 +65,13 @@ def handle_github_pr_webhook_for_autofix(
         return None
 
     try:
-        record_pr_action_analytic(org, action, pull_request, github_app)
+        record_pr_action_analytic(org, action, pull_request, github_app, repo_id)
     except Exception as e:
         sentry_sdk.capture_exception(e)
 
 
 def record_pr_action_analytic(
-    org: Organization, action: str, pull_request: dict[str, Any], github_app: str
+    org: Organization, action: str, pull_request: dict[str, Any], github_app: str, repo_id: int
 ) -> None:
     analytic_action: AnalyticAction = "opened" if action == "opened" else "closed"
     if pull_request["merged"]:
@@ -87,7 +100,69 @@ def record_pr_action_analytic(
         )
 
         metrics.incr(f"ai.autofix.pr.{analytic_action}", tags={"mode": "explorer"})
+
+        try:
+            _record_pr_attribution(
+                org=org,
+                repo_id=repo_id,
+                pull_request=pull_request,
+                group_id=group.id,
+                run_id=agent_state.run_id,
+            )
+        except Exception:
+            logger.exception(
+                "seer.autofix.pr_attribution.failed",
+                extra={
+                    "organization_id": org.id,
+                    "group_id": group.id,
+                    "run_id": agent_state.run_id,
+                },
+            )
+
         return
+
+
+def _record_pr_attribution(
+    *,
+    org: Organization,
+    repo_id: int,
+    pull_request: dict[str, Any],
+    group_id: int,
+    run_id: int,
+) -> None:
+    """Write a SEER_DATA attribution signal from the same live Seer lookup that
+    powers the ai.autofix.pr.opened/closed/merged analytics, so a PR is attributed
+    as soon as any of those events fire — a backstop for (and independent of) the
+    ``seer.pr_created`` callback that normally attributes it, which can race the
+    GitHub webhook or be missed entirely.
+
+    Shares the ``SEER_DATA``/``SENTRY_APP`` row with
+    ``attribute_seer_created_pull_requests``; ``record_attribution_signal`` merges
+    the two writes rather than one clobbering the other.
+    """
+    if not features.has("organizations:pr-metrics-attribution", org):
+        return
+
+    number = pull_request.get("number")
+    if number is None:
+        return
+
+    pr, _ = PullRequest.objects.get_or_create(
+        organization_id=org.id,
+        repository_id=repo_id,
+        key=str(number),
+    )
+
+    record_attribution_signal(
+        pull_request=pr,
+        signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+        source=PullRequestAttributionSource.SEER_DATA,
+        signal_details=SentryAppSignalDetails(
+            pr_url=pull_request.get("html_url") or "",
+            group_ids=[group_id],
+            run_id=run_id,
+        ).dict(),
+    )
 
 
 def _get_pr_timestamp_ms(pull_request: dict[str, Any], action: AnalyticAction) -> int:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -149,7 +149,7 @@ from sentry.preprod.models import (
     PreprodSnapshotMetrics,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
-from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunPullRequest, SeerRunType
 from sentry.sentry_apps.installations import (
     SentryAppInstallationCreator,
     SentryAppInstallationTokenCreator,
@@ -2991,3 +2991,8 @@ class Factories:
         run: SeerRun, title: str = "Test run", source: str = "chat", **kwargs
     ) -> SeerAgentRun:
         return SeerAgentRun.objects.create(run=run, title=title, source=source, **kwargs)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_seer_run_pull_request(run: SeerRun, pull_request, **kwargs) -> SeerRunPullRequest:
+        return SeerRunPullRequest.objects.create(seer_run=run, pull_request=pull_request, **kwargs)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1240,6 +1240,9 @@ class Fixtures:
     def create_seer_agent_run(self, run, **kwargs):
         return Factories.create_seer_agent_run(run=run, **kwargs)
 
+    def create_seer_run_pull_request(self, run, pull_request, **kwargs):
+        return Factories.create_seer_run_pull_request(run=run, pull_request=pull_request, **kwargs)
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot: InstaSnapshotter) -> None:
         self.insta_snapshot = insta_snapshot

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -8,6 +8,12 @@ from sentry.analytics.events.ai_autofix_pr_events import (
     AiAutofixPrMergedEvent,
     AiAutofixPrOpenedEvent,
 )
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttribution,
+    PullRequestAttributionSignalType,
+    PullRequestAttributionSource,
+)
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.webhooks import handle_github_pr_webhook_for_autofix
 from sentry.testutils.cases import APITestCase
@@ -16,8 +22,13 @@ from sentry.testutils.helpers.analytics import (
     assert_not_analytics_event,
 )
 
+PR_URL = "https://github.com/getsentry/sentry/pull/42"
+
 
 class AutofixPrWebhookTest(APITestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(self.project, provider="integrations:github")
+
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
@@ -34,19 +45,23 @@ class AutofixPrWebhookTest(APITestCase):
             metadata={"group_id": group.id},
         )
 
-        handle_github_pr_webhook_for_autofix(
-            self.organization,
-            "opened",
-            {
-                "id": 1,
-                "merged": False,
-                "created_at": "2025-01-15T10:30:00Z",
-                "updated_at": "2025-01-15T10:30:00Z",
-            },
-            {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
-        )
+        with self.feature("organizations:pr-metrics-attribution"):
+            handle_github_pr_webhook_for_autofix(
+                self.organization,
+                "opened",
+                {
+                    "id": 1,
+                    "number": 42,
+                    "html_url": PR_URL,
+                    "merged": False,
+                    "created_at": "2025-01-15T10:30:00Z",
+                    "updated_at": "2025-01-15T10:30:00Z",
+                },
+                {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                self.repo.id,
+            )
 
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.opened", tags={"mode": "explorer"})
+        mock_metrics_incr.assert_any_call("ai.autofix.pr.opened", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrOpenedEvent(
@@ -59,6 +74,16 @@ class AutofixPrWebhookTest(APITestCase):
                 sent_at=1736937000000,
             ),
         )
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
+        attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
+        assert attribution.signal_type == PullRequestAttributionSignalType.SENTRY_APP
+        assert attribution.source == PullRequestAttributionSource.SEER_DATA
+        assert attribution.signal_details == {
+            "pr_url": PR_URL,
+            "group_ids": [group.id],
+            "run_id": 1,
+        }
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345", SENTRY_GITHUB_APP_USER_ID="67890")
     @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
@@ -81,14 +106,17 @@ class AutofixPrWebhookTest(APITestCase):
             "opened",
             {
                 "id": 1,
+                "number": 42,
+                "html_url": PR_URL,
                 "merged": False,
                 "created_at": "2025-01-15T10:30:00Z",
                 "updated_at": "2025-01-15T10:30:00Z",
             },
             {"id": settings.SENTRY_GITHUB_APP_USER_ID},
+            self.repo.id,
         )
 
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.opened", tags={"mode": "explorer"})
+        mock_metrics_incr.assert_any_call("ai.autofix.pr.opened", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrOpenedEvent(
@@ -101,6 +129,9 @@ class AutofixPrWebhookTest(APITestCase):
                 sent_at=1736937000000,
             ),
         )
+
+        # Feature flag defaults off — no attribution row without it.
+        assert not PullRequestAttribution.objects.exists()
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
@@ -118,19 +149,23 @@ class AutofixPrWebhookTest(APITestCase):
             metadata={"group_id": group.id},
         )
 
-        handle_github_pr_webhook_for_autofix(
-            self.organization,
-            "closed",
-            {
-                "id": 1,
-                "merged": False,
-                "closed_at": "2025-01-15T12:00:00Z",
-                "updated_at": "2025-01-15T12:00:00Z",
-            },
-            {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
-        )
+        with self.feature("organizations:pr-metrics-attribution"):
+            handle_github_pr_webhook_for_autofix(
+                self.organization,
+                "closed",
+                {
+                    "id": 1,
+                    "number": 42,
+                    "html_url": PR_URL,
+                    "merged": False,
+                    "closed_at": "2025-01-15T12:00:00Z",
+                    "updated_at": "2025-01-15T12:00:00Z",
+                },
+                {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                self.repo.id,
+            )
 
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.closed", tags={"mode": "explorer"})
+        mock_metrics_incr.assert_any_call("ai.autofix.pr.closed", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrClosedEvent(
@@ -143,6 +178,15 @@ class AutofixPrWebhookTest(APITestCase):
                 sent_at=1736942400000,
             ),
         )
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
+        attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
+        assert attribution.source == PullRequestAttributionSource.SEER_DATA
+        assert attribution.signal_details == {
+            "pr_url": PR_URL,
+            "group_ids": [group.id],
+            "run_id": 1,
+        }
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
     @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
@@ -160,18 +204,22 @@ class AutofixPrWebhookTest(APITestCase):
             metadata={"group_id": group.id},
         )
 
-        handle_github_pr_webhook_for_autofix(
-            self.organization,
-            "closed",
-            {
-                "id": 1,
-                "merged": True,
-                "merged_at": "2025-01-15T14:00:00Z",
-                "updated_at": "2025-01-15T14:00:00Z",
-            },
-            {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
-        )
-        mock_metrics_incr.assert_called_with("ai.autofix.pr.merged", tags={"mode": "explorer"})
+        with self.feature("organizations:pr-metrics-attribution"):
+            handle_github_pr_webhook_for_autofix(
+                self.organization,
+                "closed",
+                {
+                    "id": 1,
+                    "number": 42,
+                    "html_url": PR_URL,
+                    "merged": True,
+                    "merged_at": "2025-01-15T14:00:00Z",
+                    "updated_at": "2025-01-15T14:00:00Z",
+                },
+                {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                self.repo.id,
+            )
+        mock_metrics_incr.assert_any_call("ai.autofix.pr.merged", tags={"mode": "explorer"})
         assert_last_analytics_event(
             mock_analytics_record,
             AiAutofixPrMergedEvent(
@@ -185,26 +233,93 @@ class AutofixPrWebhookTest(APITestCase):
             ),
         )
 
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="42")
+        assert PullRequestAttribution.objects.filter(pull_request=pull_request).exists()
+
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
-    @patch(
-        "sentry.seer.autofix.webhooks.get_agent_state_from_pr_id",
-        return_value=None,
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
+    @patch("sentry.seer.autofix.webhooks.analytics.record")
+    @patch("sentry.seer.autofix.webhooks.metrics.incr")
+    def test_merges_with_existing_seer_created_attribution(
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
+    ):
+        """The seer.pr_created flow may have already written a SEER_DATA/SENTRY_APP
+        row (via ``attribute_seer_created_pull_requests``) for a different group_id
+        than what the live RPC lookup resolves here — the two writes must merge
+        rather than one clobbering the other.
+        """
+        group = self.create_group(project=self.project)
+        other_group = self.create_group(project=self.project)
+        pull_request = self.create_pull_request(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key="42",
+        )
+        PullRequestAttribution.objects.create(
+            pull_request=pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=True,
+            signal_details={
+                "pr_url": PR_URL,
+                "group_ids": [other_group.id],
+                "run_id": 1,
+            },
+        )
+
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T12:00:00Z",
+            metadata={"group_id": group.id},
+        )
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            handle_github_pr_webhook_for_autofix(
+                self.organization,
+                "closed",
+                {
+                    "id": 1,
+                    "number": 42,
+                    "html_url": PR_URL,
+                    "merged": False,
+                    "closed_at": "2025-01-15T12:00:00Z",
+                    "updated_at": "2025-01-15T12:00:00Z",
+                },
+                {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                self.repo.id,
+            )
+
+        assert PullRequestAttribution.objects.filter(pull_request=pull_request).count() == 1
+        attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
+        assert attribution.signal_details == {
+            "pr_url": PR_URL,
+            "group_ids": sorted([group.id, other_group.id]),
+            "run_id": 1,
+        }
+
+    @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_run(
         self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        mock_get_agent_state_from_pr_id.return_value = None
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
             {
                 "id": 1,
+                "number": 42,
+                "html_url": PR_URL,
                 "merged": True,
                 "merged_at": "2025-01-15T14:00:00Z",
                 "updated_at": "2025-01-15T14:00:00Z",
             },
             {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+            self.repo.id,
         )
 
         for key in ["ai.autofix.pr.merged", "ai.autofix.pr.closed", "ai.autofix.pr.opened"]:
@@ -213,27 +328,29 @@ class AutofixPrWebhookTest(APITestCase):
         assert_not_analytics_event(mock_analytics_record, AiAutofixPrClosedEvent)
         assert_not_analytics_event(mock_analytics_record, AiAutofixPrMergedEvent)
         assert_not_analytics_event(mock_analytics_record, AiAutofixPrOpenedEvent)
+        assert not PullRequestAttribution.objects.exists()
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID=None)
-    @patch(
-        "sentry.seer.autofix.webhooks.get_agent_state_from_pr_id",
-        return_value=None,
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_settings_github_app_id_set(
         self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        mock_get_agent_state_from_pr_id.return_value = None
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
             {
                 "id": 1,
+                "number": 42,
+                "html_url": PR_URL,
                 "merged": True,
                 "merged_at": "2025-01-15T14:00:00Z",
                 "updated_at": "2025-01-15T14:00:00Z",
             },
             {"id": "5655"},
+            self.repo.id,
         )
 
         for key in ["ai.autofix.pr.merged", "ai.autofix.pr.closed", "ai.autofix.pr.opened"]:
@@ -241,25 +358,26 @@ class AutofixPrWebhookTest(APITestCase):
             assert call(key) not in mock_analytics_record.call_args_list
 
     @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
-    @patch(
-        "sentry.seer.autofix.webhooks.get_agent_state_from_pr_id",
-        return_value=None,
-    )
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_different_github_app(
         self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):
+        mock_get_agent_state_from_pr_id.return_value = None
         handle_github_pr_webhook_for_autofix(
             self.organization,
             "closed",
             {
                 "id": 1,
+                "number": 42,
+                "html_url": PR_URL,
                 "merged": True,
                 "merged_at": "2025-01-15T14:00:00Z",
                 "updated_at": "2025-01-15T14:00:00Z",
             },
             {"id": "321"},
+            self.repo.id,
         )
 
         for key in ["ai.autofix.pr.merged", "ai.autofix.pr.closed", "ai.autofix.pr.opened"]:

--- a/tests/sentry/autofix/test_webhooks.py
+++ b/tests/sentry/autofix/test_webhooks.py
@@ -303,6 +303,107 @@ class AutofixPrWebhookTest(APITestCase):
     @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
     @patch("sentry.seer.autofix.webhooks.analytics.record")
     @patch("sentry.seer.autofix.webhooks.metrics.incr")
+    def test_skips_attribution_when_pr_number_missing(
+        self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
+    ):
+        group = self.create_group(project=self.project)
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T10:30:00Z",
+            metadata={"group_id": group.id},
+        )
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            handle_github_pr_webhook_for_autofix(
+                self.organization,
+                "opened",
+                {
+                    "id": 1,
+                    "html_url": PR_URL,
+                    "merged": False,
+                    "created_at": "2025-01-15T10:30:00Z",
+                    "updated_at": "2025-01-15T10:30:00Z",
+                },
+                {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                self.repo.id,
+            )
+
+        # Analytics still fire even though there's no PR number to attribute against.
+        mock_metrics_incr.assert_any_call("ai.autofix.pr.opened", tags={"mode": "explorer"})
+        assert_last_analytics_event(
+            mock_analytics_record,
+            AiAutofixPrOpenedEvent(
+                organization_id=self.organization.id,
+                integration="github",
+                project_id=group.project.id,
+                group_id=group.id,
+                run_id=1,
+                github_app="seer",
+                sent_at=1736937000000,
+            ),
+        )
+        assert not PullRequestAttribution.objects.exists()
+
+    @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
+    @patch("sentry.seer.autofix.webhooks.record_attribution_signal")
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
+    @patch("sentry.seer.autofix.webhooks.analytics.record")
+    @patch("sentry.seer.autofix.webhooks.metrics.incr")
+    def test_attribution_failure_does_not_block_analytics(
+        self,
+        mock_metrics_incr,
+        mock_analytics_record,
+        mock_get_agent_state_from_pr_id,
+        mock_record_attribution_signal,
+    ):
+        group = self.create_group(project=self.project)
+        mock_get_agent_state_from_pr_id.return_value = SeerRunState(
+            run_id=1,
+            blocks=[],
+            status="processing",
+            updated_at="2025-01-15T10:30:00Z",
+            metadata={"group_id": group.id},
+        )
+        mock_record_attribution_signal.side_effect = RuntimeError("boom")
+
+        with self.feature("organizations:pr-metrics-attribution"):
+            handle_github_pr_webhook_for_autofix(
+                self.organization,
+                "opened",
+                {
+                    "id": 1,
+                    "number": 42,
+                    "html_url": PR_URL,
+                    "merged": False,
+                    "created_at": "2025-01-15T10:30:00Z",
+                    "updated_at": "2025-01-15T10:30:00Z",
+                },
+                {"id": settings.SEER_AUTOFIX_GITHUB_APP_USER_ID},
+                self.repo.id,
+            )
+
+        # The analytics event already fired before the attribution write raised.
+        mock_metrics_incr.assert_any_call("ai.autofix.pr.opened", tags={"mode": "explorer"})
+        assert_last_analytics_event(
+            mock_analytics_record,
+            AiAutofixPrOpenedEvent(
+                organization_id=self.organization.id,
+                integration="github",
+                project_id=group.project.id,
+                group_id=group.id,
+                run_id=1,
+                github_app="seer",
+                sent_at=1736937000000,
+            ),
+        )
+        assert not PullRequestAttribution.objects.exists()
+
+    @override_settings(SEER_AUTOFIX_GITHUB_APP_USER_ID="12345")
+    @patch("sentry.seer.autofix.webhooks.get_agent_state_from_pr_id")
+    @patch("sentry.seer.autofix.webhooks.analytics.record")
+    @patch("sentry.seer.autofix.webhooks.metrics.incr")
     def test_no_run(
         self, mock_metrics_incr, mock_analytics_record, mock_get_agent_state_from_pr_id
     ):

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -345,6 +345,63 @@ class RecordAttributionSignalTest(TestCase):
         attribution.refresh_from_db()
         assert attribution.is_valid is True
 
+    def test_merges_list_values_across_producers(self) -> None:
+        self._record_seer_signal(
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+        )
+        second = self._record_seer_signal(
+            signal_details={"run_id": 1, "group_ids": [3], "pr_url": "https://x/1"}
+        )
+
+        second.refresh_from_db()
+        assert second.signal_details is not None
+        assert second.signal_details["group_ids"] == [2, 3]
+
+    def test_merges_dict_values_across_producers(self) -> None:
+        first = record_attribution_signal(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.MCP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            signal_details={"group_ids": {"1": "cursor"}},
+        )
+        second = record_attribution_signal(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.MCP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            signal_details={"group_ids": {"2": "claude_code"}},
+        )
+
+        assert first.id == second.id
+        second.refresh_from_db()
+        assert second.signal_details is not None
+        assert second.signal_details["group_ids"] == {"1": "cursor", "2": "claude_code"}
+
+    def test_scalar_merge_keeps_existing_when_incoming_is_falsy(self) -> None:
+        self._record_seer_signal(
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+        )
+        second = self._record_seer_signal(
+            signal_details={"run_id": None, "group_ids": [], "pr_url": "https://x/1"}
+        )
+
+        second.refresh_from_db()
+        assert second.signal_details is not None
+        assert second.signal_details["run_id"] == 1
+
+    def test_replaces_outright_when_existing_signal_invalid(self) -> None:
+        attribution = self._record_seer_signal(
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+        )
+        attribution.update(is_valid=False)
+
+        second = self._record_seer_signal(
+            signal_details={"run_id": 9, "group_ids": [3], "pr_url": "https://x/2"}
+        )
+
+        second.refresh_from_db()
+        assert second.signal_details == {"run_id": 9, "group_ids": [3], "pr_url": "https://x/2"}
+        assert second.is_valid is True
+
 
 class RecomputePullRequestAttributionTest(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -388,6 +388,24 @@ class RecordAttributionSignalTest(TestCase):
         assert second.signal_details is not None
         assert second.signal_details["run_id"] == 1
 
+    def test_merge_treats_none_existing_details_as_incoming(self) -> None:
+        self._record_seer_signal(signal_details=None)
+        second = self._record_seer_signal(
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+        )
+
+        second.refresh_from_db()
+        assert second.signal_details == {"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+
+    def test_merge_keeps_existing_details_when_incoming_is_none(self) -> None:
+        self._record_seer_signal(
+            signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+        )
+        second = self._record_seer_signal(signal_details=None)
+
+        second.refresh_from_db()
+        assert second.signal_details == {"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}
+
     def test_replaces_outright_when_existing_signal_invalid(self) -> None:
         attribution = self._record_seer_signal(
             signal_details={"run_id": 1, "group_ids": [2], "pr_url": "https://x/1"}

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -68,9 +68,12 @@ class HandleWebhookForPrMetricsTest(TestCase):
         action: str = "opened",
         user_id: int = 999,
         changes: dict[str, Any] | None = None,
+        html_url: str | None = None,
     ) -> None:
         payload = dict(self.base_pr_payload)
         payload["user"] = {"id": user_id, "login": "testbot"}
+        if html_url is not None:
+            payload["html_url"] = html_url
         event: dict[str, Any] = {"action": action, "pull_request": payload}
         if changes is not None:
             event["changes"] = changes
@@ -166,6 +169,81 @@ class HandleWebhookForPrMetricsTest(TestCase):
 
         attr = PullRequestAttribution.objects.get(pull_request=self.pr)
         assert attr.is_valid is True
+
+    # --- Local Seer run lookup (supplements the regex-based GroupLink match) ---
+
+    def test_app_attribution_includes_seer_run_group_id(self) -> None:
+        group = self.create_group(project=self.project)
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        self.create_seer_agent_run(run=run, group=group)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pr)
+
+        self._call(
+            user_id=settings.SEER_AUTOFIX_GITHUB_APP_USER_ID,
+            html_url="https://github.com/org/repo/pull/42",
+        )
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details == {
+            "pr_url": "https://github.com/org/repo/pull/42",
+            "group_ids": [group.id],
+            "run_id": 555,
+        }
+
+    def test_app_attribution_unions_regex_and_seer_run_group_ids(self) -> None:
+        regex_group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group_id=regex_group.id,
+            project_id=regex_group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=self.pr.id,
+        )
+        seer_group = self.create_group(project=self.project)
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=777)
+        self.create_seer_agent_run(run=run, group=seer_group)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pr)
+
+        self._call(
+            user_id=settings.SENTRY_GITHUB_APP_USER_ID,
+            html_url="https://github.com/org/repo/pull/42",
+        )
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details["group_ids"] == sorted([regex_group.id, seer_group.id])
+        assert attr.signal_details["run_id"] == 777
+
+    def test_app_attribution_without_seer_run_link_falls_back_to_regex(self) -> None:
+        regex_group = self.create_group(project=self.project)
+        GroupLink.objects.create(
+            group_id=regex_group.id,
+            project_id=regex_group.project_id,
+            linked_type=GroupLink.LinkedType.pull_request,
+            relationship=GroupLink.Relationship.resolves,
+            linked_id=self.pr.id,
+        )
+
+        self._call(
+            user_id=settings.SENTRY_GITHUB_APP_USER_ID,
+            html_url="https://github.com/org/repo/pull/42",
+        )
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details["group_ids"] == [regex_group.id]
+        assert attr.signal_details["run_id"] is None
+
+    def test_app_attribution_seer_run_without_agent_row_yields_no_group_id(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=888)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pr)
+
+        self._call(
+            user_id=settings.SENTRY_GITHUB_APP_USER_ID,
+            html_url="https://github.com/org/repo/pull/42",
+        )
+
+        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details["group_ids"] == []
+        assert attr.signal_details["run_id"] == 888
 
     # --- MCP attribution ---
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -210,6 +210,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
         )
 
         attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details is not None
         assert attr.signal_details["group_ids"] == sorted([regex_group.id, seer_group.id])
         assert attr.signal_details["run_id"] == 777
 
@@ -229,6 +230,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
         )
 
         attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details is not None
         assert attr.signal_details["group_ids"] == [regex_group.id]
         assert attr.signal_details["run_id"] is None
 
@@ -242,6 +244,7 @@ class HandleWebhookForPrMetricsTest(TestCase):
         )
 
         attr = PullRequestAttribution.objects.get(pull_request=self.pr)
+        assert attr.signal_details is not None
         assert attr.signal_details["group_ids"] == []
         assert attr.signal_details["run_id"] == 888
 


### PR DESCRIPTION
After reviewing some attribution gaps for the Seer-created repos these changes aim to close the gap by:

* On the webhook attribution source we try to enhance the signal_details but looking in the `SeerRun` table to find run_ids and group_ids for the PR (using the pr number + org, repo). This is similar to the autofix webhook that eventually fires ai.autofix.pr.created
* On the path that fires the ai.autofix.pr.merge|closed we added a new attribution write for the SEER_DATA source. 
