### PR TITLE
feat(scm): Surface installation and repository ids on webhook events

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -124,6 +124,17 @@ def get_github_external_id(event: Mapping[str, Any], host: str | None = None) ->
     return f"{host}:{external_id}" if host else external_id
 
 
+def get_scm_stream_extra(
+    event: Mapping[str, Any],
+) -> dict[str, str | None | bool | int | float]:
+    """Identifiers an SCM-stream listener needs to resolve org/integration/repo context,
+    surfaced so listeners don't have to re-parse the raw event body."""
+    return {
+        "installation_id": event.get("installation", {}).get("id"),
+        "repository_id": event.get("repository", {}).get("id"),
+    }
+
+
 def get_file_language(filename: str) -> str | None:
     extension = filename.split(".")[-1]
     language = None
@@ -1465,7 +1476,7 @@ class GitHubIntegrationsWebhookEndpoint(Endpoint):
             {
                 "event_type_hint": request.headers.get(GITHUB_WEBHOOK_TYPE_HEADER_KEY),
                 "event": request.body.decode("utf-8"),
-                "extra": {},
+                "extra": get_scm_stream_extra(event),
                 "received_at": int(time.time()),
                 "sentry_meta": None,
                 "type": IntegrationProviderSlug.GITHUB.value,

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -34,6 +34,7 @@ from sentry.integrations.github.webhook import (
     PullRequestReviewThreadEventWebhook,
     PushEventWebhook,
     get_github_external_id,
+    get_scm_stream_extra,
 )
 from sentry.integrations.github.webhook_types import GithubWebhookType
 from sentry.integrations.github_enterprise.client import GitHubEnterpriseApiClient
@@ -407,6 +408,7 @@ class GitHubEnterpriseWebhookBase(Endpoint):
                 "event_type_hint": request.headers.get("X-GitHub-Event"),
                 "event": request.body.decode("utf-8"),
                 "extra": {
+                    **get_scm_stream_extra(event),
                     "host": host,
                     "skipped-authentication": skipped_authentication,
                     "enterprise-version": request.headers.get("x-github-enterprise-version"),


### PR DESCRIPTION
SCM-platform listeners registered via `scm_event_stream.listen_for(...)` receive a normalized event whose `sentry_meta` is unset for GitHub, which means a listener has no organization, integration, or repository context to work with — unlike the legacy webhook handlers, where the endpoint resolves all of that upfront and passes it into each processor. Without it, every listener would have to re-parse the raw event body to recover the installation id (the integration's `external_id`) and repository id (the repository's `external_id`) needed to look that context up. This change populates those two identifiers on the subscription event's `extra` field at ingest time, via a shared `get_scm_stream_extra` helper wired into both the GitHub and GitHub Enterprise webhook endpoints. Because `extra` round-trips unchanged through the taskbroker hop and is event-type-agnostic, every current and future listener gets the identifiers for free — with a cheap dict lookup on the webhook path and no changes to the typed event dataclasses.