### PR TITLE
ref(stories): Use Rspack globs for story modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "@types/react-select": "4.0.18",
     "@types/reflux": "0.4.1",
     "@types/scroll-to-element": "^2.0.2",
-    "@types/webpack-env": "1.18.8",
     "ansi-to-react": "^6.1.6",
     "base64-arraybuffer": "^1.0.1",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,9 +313,6 @@ importers:
       '@types/scroll-to-element':
         specifier: ^2.0.2
         version: 2.0.2
-      '@types/webpack-env':
-        specifier: 1.18.8
-        version: 1.18.8
       ansi-to-react:
         specifier: ^6.1.6
         version: 6.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3993,9 +3990,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/webpack-env@1.18.8':
-    resolution: {integrity: sha512-G9eAoJRMLjcvN4I08wB5I7YofOb/kaJNd5uoCMX+LbKXTPCF+ZIHuqTnFaK9Jz1rgs035f9JUPUhNFtqgucy/A==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -12854,8 +12848,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/webpack-env@1.18.8': {}
 
   '@types/ws@8.18.1':
     dependencies:

--- a/static/app/components/core/inspector.tsx
+++ b/static/app/components/core/inspector.tsx
@@ -21,11 +21,8 @@ import {
 import {NODE_ENV} from 'sentry/constants';
 import {IconChevron, IconCopy, IconDocs, IconLink, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {
-  isMDXStory,
-  useStoriesLoader,
-  useStoryBookFiles,
-} from 'sentry/stories/view/useStoriesLoader';
+import {isMDXStory} from 'sentry/stories/view/storyDescriptor';
+import {useStoriesLoader, useStoryBookFiles} from 'sentry/stories/view/useStoriesLoader';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 import {useOrganization} from 'sentry/utils/useOrganization';

--- a/static/app/stories/frontmatter.ts
+++ b/static/app/stories/frontmatter.ts
@@ -11,7 +11,7 @@ type ComponentCategory =
   | 'utilities'
   | 'shared';
 
-export interface StoryResources {
+interface StoryResources {
   a11y?: Record<string, string>;
   figma?: string;
   js?: string;

--- a/static/app/stories/frontmatter.ts
+++ b/static/app/stories/frontmatter.ts
@@ -1,5 +1,3 @@
-import type {StoryResources} from './view/useStoriesLoader';
-
 type ComponentCategory =
   | 'typography'
   | 'layout'
@@ -12,6 +10,14 @@ type ComponentCategory =
   | 'overlays'
   | 'utilities'
   | 'shared';
+
+export interface StoryResources {
+  a11y?: Record<string, string>;
+  figma?: string;
+  js?: string;
+  reference?: Record<string, string>;
+}
+
 /**
  * Frontmatter schema for MDX story files.
  * Validated at type-check time via Volar + @mdx-js/language-service.

--- a/static/app/stories/view/storyDescriptor.ts
+++ b/static/app/stories/view/storyDescriptor.ts
@@ -1,0 +1,32 @@
+import type {ElementType} from 'react';
+
+import type {MDXFrontmatter} from 'sentry/stories/frontmatter';
+
+export type StoryDocumentation = Promise<
+  TypeLoader.TypeLoaderResult | {default: TypeLoader.TypeLoaderResult}
+>;
+
+export interface MDXStoryExports {
+  default: ElementType;
+  documentation?: StoryDocumentation;
+  frontmatter?: MDXFrontmatter;
+}
+
+export interface TSStoryExports {
+  [exportName: string]: unknown;
+  default?: ElementType;
+  documentation?: StoryDocumentation;
+}
+
+interface LoadedStory<TExports> {
+  exports: TExports;
+  filename: string;
+}
+
+export type MDXStoryDescriptor = LoadedStory<MDXStoryExports>;
+type TSStoryDescriptor = LoadedStory<TSStoryExports>;
+export type StoryDescriptor = MDXStoryDescriptor | TSStoryDescriptor;
+
+export function isMDXStory(story: StoryDescriptor): story is MDXStoryDescriptor {
+  return story.filename.endsWith('.mdx');
+}

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -16,6 +16,12 @@ import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
 import {APIReference} from 'sentry/stories/apiReference';
 
+import {
+  isMDXStory,
+  type MDXStoryDescriptor,
+  type StoryDescriptor,
+  type StoryDocumentation,
+} from './storyDescriptor';
 import {StoryFooter} from './storyFooter';
 import {storyMdxComponents} from './storyMdxComponent';
 import {StoryResources} from './storyResources';
@@ -24,12 +30,6 @@ import {
   StoryTableOfContents,
   StoryTableOfContentsPlaceholder,
 } from './storyTableOfContents';
-import {
-  isMDXStory,
-  type MDXStoryDescriptor,
-  type StoryDescriptor,
-  type StoryDocumentation,
-} from './useStoriesLoader';
 import type {StoryExports as StoryExportValues} from './useStory';
 import {StoryContextProvider, useStory} from './useStory';
 
@@ -48,9 +48,7 @@ function StoryLayout() {
     parseAsString.withOptions({history: 'push'}).withDefault('usage')
   );
   const documentation = useStoryDocumentation(
-    (isMDXStory(story) ? story.exports.documentation : story.exports.documentation) as
-      | StoryDocumentation
-      | undefined,
+    story.exports.documentation,
     story.filename
   );
 

--- a/static/app/stories/view/storyFooter.tsx
+++ b/static/app/stories/view/storyFooter.tsx
@@ -8,9 +8,9 @@ import {IconArrow} from 'sentry/icons';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import type {StoryDescriptor} from './storyDescriptor';
 import type {StoryTreeNode} from './storyTree';
 import {useFlatStoryList} from './storyTree';
-import {type StoryDescriptor} from './useStoriesLoader';
 import {useStory} from './useStory';
 
 export function StoryFooter() {

--- a/static/app/stories/view/storyModules.ts
+++ b/static/app/stories/view/storyModules.ts
@@ -1,0 +1,9 @@
+import type {MDXStoryExports, TSStoryExports} from './storyDescriptor';
+
+export const tsStoryModules = import.meta.glob<TSStoryExports>('./**/*.stories.tsx', {
+  base: '../../',
+});
+
+export const mdxStoryModules = import.meta.glob<MDXStoryExports>('./**/*.mdx', {
+  base: '../../',
+});

--- a/static/app/stories/view/storyResources.tsx
+++ b/static/app/stories/view/storyResources.tsx
@@ -5,7 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 
 import {IconGithub} from 'sentry/icons';
 import * as Stories from 'sentry/stories';
-import {isMDXStory} from 'sentry/stories/view/useStoriesLoader';
+import {isMDXStory} from 'sentry/stories/view/storyDescriptor';
 import {useStory} from 'sentry/stories/view/useStory';
 
 export function StoryResources() {

--- a/static/app/stories/view/useStoriesLoader.tsx
+++ b/static/app/stories/view/useStoriesLoader.tsx
@@ -1,117 +1,47 @@
-import type React from 'react';
-import {useMemo, useSyncExternalStore} from 'react';
+import {useSyncExternalStore} from 'react';
 import {useQuery} from '@tanstack/react-query';
 import type {UseQueryResult} from '@tanstack/react-query';
 
-import type {MDXFrontmatter} from 'sentry/stories/frontmatter';
-let context = import.meta.webpackContext('sentry', {
-  recursive: true,
-  regExp: /\.stories.tsx$/,
-  mode: 'lazy',
-});
-let mdxContext = import.meta.webpackContext('sentry', {
-  recursive: true,
-  regExp: /\.mdx$/,
-  mode: 'lazy',
-});
+import type {StoryDescriptor} from './storyDescriptor';
+import {mdxStoryModules, tsStoryModules} from './storyModules';
 
-// External store that increments whenever HMR replaces a story or mdx file.
-// Accepting context module IDs creates proper HMR boundaries — without this,
-// updates are silently dropped or cause "unexpected require from disposed module".
-let _storiesHmrVersion = 0;
-const _storiesHmrListeners = new Set<() => void>();
+const listeners = new Set<() => void>();
+let storyFiles = listStoryFiles();
+let storyRevision = 0;
 
-if (process.env.NODE_ENV === 'development' && import.meta.webpackHot) {
-  const onUpdate = () => {
-    // Re-capture and re-register after each replacement — the old context
-    // reference is stale and its replacement won't have accept handlers.
-    context = import.meta.webpackContext('sentry', {
-      recursive: true,
-      regExp: /\.stories.tsx$/,
-      mode: 'lazy',
-    });
-    mdxContext = import.meta.webpackContext('sentry', {
-      recursive: true,
-      regExp: /\.mdx$/,
-      mode: 'lazy',
-    });
-    import.meta.webpackHot!.accept(context.id as string, onUpdate);
-    import.meta.webpackHot!.accept(mdxContext.id as string, onUpdate);
-    _storiesHmrVersion++;
-    _storiesHmrListeners.forEach(l => l());
-  };
-  import.meta.webpackHot.accept(context.id as string, onUpdate);
-  import.meta.webpackHot.accept(mdxContext.id as string, onUpdate);
+// Keep this module stable while Rspack replaces the glob module. ESM bindings
+// are updated before the callback, including added or removed glob matches.
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept('./storyModules', () => {
+    storyFiles = listStoryFiles();
+    storyRevision++;
+    listeners.forEach(listener => listener());
+  });
 }
 
-function subscribeToStoriesHmr(listener: () => void) {
-  _storiesHmrListeners.add(listener);
-  return () => _storiesHmrListeners.delete(listener);
-}
-
-function getStoriesHmrVersion() {
-  return _storiesHmrVersion;
-}
-
-export interface StoryResources {
-  a11y?: Record<string, string>;
-  figma?: string;
-  js?: string;
-  reference?: Record<string, string>;
-}
-
-export type StoryDocumentation = Promise<
-  TypeLoader.TypeLoaderResult | {default: TypeLoader.TypeLoaderResult}
->;
-
-export interface MDXStoryDescriptor {
-  exports: {
-    default: React.ComponentType | any;
-    documentation?: StoryDocumentation;
-    frontmatter?: MDXFrontmatter;
-  };
-  filename: string;
-}
-
-interface TSStoryDescriptor {
-  exports: Record<string, React.ComponentType | unknown>;
-  filename: string;
-}
-
-export type StoryDescriptor = MDXStoryDescriptor | TSStoryDescriptor;
-
-export function isMDXStory(story: StoryDescriptor): story is MDXStoryDescriptor {
-  return story.filename.endsWith('.mdx');
-}
-
-export function useStoryBookFiles() {
-  return useMemo(
-    () =>
-      [...context.keys(), ...mdxContext.keys()].map(file =>
-        file.replace(/^\.\//, 'app/')
-      ),
-    []
+function listStoryFiles(): string[] {
+  return [...Object.keys(tsStoryModules), ...Object.keys(mdxStoryModules)].map(
+    moduleKey => `app/${moduleKey.slice('./'.length)}`
   );
 }
 
-async function importStory(filename: string): Promise<StoryDescriptor> {
-  if (!filename) {
-    throw new Error(`Filename is required, got ${filename}`);
-  }
-
-  if (filename.endsWith('.mdx')) {
-    const story = await mdxContext(filename.replace(/^app\//, './'));
-    return {
-      exports: story,
-      filename,
-    };
-  }
-
-  const story = await context(filename.replace(/^app\//, './'));
-  return {
-    exports: story,
-    filename,
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
   };
+}
+
+function getStoryFiles(): string[] {
+  return storyFiles;
+}
+
+function getStoryRevision(): number {
+  return storyRevision;
+}
+
+export function useStoryBookFiles(): string[] {
+  return useSyncExternalStore(subscribe, getStoryFiles, getStoryFiles);
 }
 
 interface UseStoriesLoaderOptions {
@@ -121,12 +51,39 @@ interface UseStoriesLoaderOptions {
 export function useStoriesLoader(
   options: UseStoriesLoaderOptions
 ): UseQueryResult<StoryDescriptor[]> {
-  const hmrVersion = useSyncExternalStore(subscribeToStoriesHmr, getStoriesHmrVersion);
+  const revision = useSyncExternalStore(subscribe, getStoryRevision, getStoryRevision);
+
   return useQuery({
-    queryKey: [options.files, hmrVersion],
-    queryFn: (): Promise<StoryDescriptor[]> => {
-      return Promise.all(options.files.map(importStory));
-    },
+    queryKey: ['stories', options.files, revision],
+    queryFn: () => Promise.all(options.files.map(loadStory)),
     enabled: options.files.length > 0,
   });
+}
+
+async function loadStory(filename: string): Promise<StoryDescriptor> {
+  if (filename.endsWith('.mdx')) {
+    return {
+      exports: await loadStoryModule(mdxStoryModules, filename),
+      filename,
+    };
+  }
+
+  return {
+    exports: await loadStoryModule(tsStoryModules, filename),
+    filename,
+  };
+}
+
+async function loadStoryModule<T>(
+  modules: Record<string, () => Promise<T>>,
+  filename: string
+): Promise<T> {
+  const moduleKey = `./${filename.replace(/^app\//, '')}`;
+  const loadModule = modules[moduleKey];
+
+  if (!loadModule) {
+    throw new Error(`Story module not found: ${filename}`);
+  }
+
+  return loadModule();
 }

--- a/static/app/stories/view/useStory.tsx
+++ b/static/app/stories/view/useStory.tsx
@@ -1,6 +1,6 @@
 import {createContext, useContext} from 'react';
 
-import type {StoryDescriptor} from './useStoriesLoader';
+import type {StoryDescriptor} from './storyDescriptor';
 
 interface StoryContextValue {
   story?: StoryDescriptor;

--- a/static/app/styles/images.stories.tsx
+++ b/static/app/styles/images.stories.tsx
@@ -6,24 +6,17 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import * as Storybook from 'sentry/stories';
 
-interface ImageEntry {
-  file: string;
-  src: string;
-}
-
-const imageContext = require.context('sentry-images', true, /\.(svg|gif|png)$/, 'sync');
-const images: ImageEntry[] = imageContext.keys().map(file => ({
-  file: file.replace(/^\.\//, 'sentry-images/'),
-  src: loadImage(file),
+const images = Object.entries(
+  import.meta.glob<string>('../../images/**/*.{svg,gif,png}', {
+    eager: true,
+    import: 'default',
+  })
+).map(([file, src]) => ({
+  file: file.replace('../../images/', 'sentry-images/'),
+  src,
 }));
 
-function loadImage(file: string): string {
-  const image = imageContext(file);
-  if (typeof image !== 'string') {
-    throw new TypeError(`Expected ${file} to resolve to an image URL`);
-  }
-  return image;
-}
+type ImageEntry = (typeof images)[number];
 
 const toCamelCase = function camalize(str: string) {
   return str

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     // Skip type checking of all declaration files
     "skipLibCheck": true,
 
-    // Explicitly list which @types/* packages to include as global types
-    "types": ["gtag.js", "jest", "node", "webpack-env"],
+    // Explicitly list which packages provide global types
+    "types": ["gtag.js", "jest", "node", "@rspack/core/module"],
 
     // We do not actually use tsc to output any JavaScript anywhere
     "noEmit": true,


### PR DESCRIPTION
The story loader's webpack contexts expose unknown modules under Rspack's actual types, and the HMR handler had to cast internal context IDs then re-register stale contexts after every update.

Use lazy import.meta.glob maps in a small dependency module and accept that dependency from the stable loader. This also refreshes the file list when stories are added or removed.

Swap @types/webpack-env for @rspack/core/module so the runtime APIs come from the bundler we use.

Stacked on #119632.