### PR TITLE
fix(data_export): Scope export detail lookup to the requesting user

### DIFF
--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -31,8 +31,12 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
         """
 
         try:
-            data_export = ExportedData.objects.get(id=data_export_id, organization=organization)
+            data_export = ExportedData.objects.get(
+                id=data_export_id, organization=organization, user_id=request.user.id
+            )
         except ExportedData.DoesNotExist:
+            if ExportedData.objects.filter(id=data_export_id, organization=organization).exists():
+                metrics.incr("dataexport.details.cross_user_access", sample_rate=1.0)
             return Response(status=404)
         # Check data export permissions
         if data_export.query_info.get("project"):

--- a/tests/sentry/data_export/endpoints/test_data_export_details.py
+++ b/tests/sentry/data_export/endpoints/test_data_export_details.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from hashlib import sha1
 from io import BytesIO
+from unittest.mock import patch
 
 from django.urls import reverse
 from django.utils import timezone
@@ -94,6 +95,32 @@ class DataExportDetailsTest(APITestCase):
             args=[invalid_organization.slug, self.data_export.id],
         )
         response = self.client.get(url)
+        assert response.status_code == 404
+
+    def test_cannot_access_another_members_export(self) -> None:
+        # A second member of the same organization must not be able to read
+        # another member's export by enumerating its id (IDOR).
+        other_user = self.create_user()
+        self.create_member(user=other_user, organization=self.organization, role="member")
+        self.login_as(user=other_user)
+        with patch("sentry.data_export.endpoints.data_export_details.metrics.incr") as mock_incr:
+            self.get_error_response(self.organization.slug, self.data_export.id, status_code=404)
+        mock_incr.assert_any_call("dataexport.details.cross_user_access", sample_rate=1.0)
+
+    def test_cannot_download_another_members_export(self) -> None:
+        contents = b"secret"
+        file = File.objects.create(
+            name="secret.csv", type="export.csv", headers={"Content-Type": "text/csv"}
+        )
+        file.putfile(BytesIO(contents))
+        self.data_export.update(file_id=file.id)
+
+        other_user = self.create_user()
+        self.create_member(user=other_user, organization=self.organization, role="member")
+        self.login_as(user=other_user)
+
+        url = reverse(self.endpoint, args=[self.organization.slug, self.data_export.id])
+        response = self.client.get(f"{url}?download")
         assert response.status_code == 404
 
     def test_content_errors(self) -> None:


### PR DESCRIPTION
The data export detail endpoint (`GET /api/0/organizations/{org}/data-export/{id}/`) looked up `ExportedData` scoped only by organization, so any org member could read the metadata and download the file of another member's export by enumerating the sequential integer id.

Exports belong to a single user — the create path already records `user_id`; but retrieval never enforced that ownership. The existing project-access check only guards exports that carry a project filter, and passes whenever the requester happens to share access to those projects, so it does not close the gap. The lookup now also filters by `user_id=request.user.id`, so a non-owner falls through to the existing `DoesNotExist` → 404. 

To keep visibility into probing, a `dataexport.details.cross_user_access` counter is emitted when the requested id exists in the org but is owned by another member. 

Regression tests cover a second org member being blocked from both reading and downloading another member's export.

Fixes EXP-958