### PR TITLE
feat(slack): log channel id on successful message sends

### DIFF
--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -504,6 +504,7 @@ class SlackService:
         """Execution of send_notification_as_slack."""
 
         client = SlackSdkClient(integration_id=integration_id)
+        channel = str(payload.get("channel", ""))
         with MessagingInteractionEvent(
             interaction_type=MessagingInteractionType.SEND_GENERIC_NOTIFICATION,
             spec=SlackMessagingSpec(),
@@ -513,10 +514,14 @@ class SlackService:
                 client.chat_postMessage(
                     blocks=str(payload.get("blocks", "")),
                     text=str(payload.get("text", "")),
-                    channel=str(payload.get("channel", "")),
+                    channel=channel,
                     unfurl_links=False,
                     unfurl_media=False,
                     callback_id=str(payload.get("callback_id", "")),
+                )
+                _default_logger.info(
+                    "slack.send_message_to_slack_channel.success",
+                    extra={"integration_id": integration_id, "channel_id": channel},
                 )
             except SlackApiError as e:
                 lifecycle.add_extras(


### PR DESCRIPTION
let's log what channel we send the message to in order to gain more insight on what the alert usage pattern is

We would like to know the usage patterns for users, especially how many alerts a Slack channel gets, since we are trying to get the users to update their Slack app via the nudges (https://github.com/getsentry/sentry/pull/118288). After we analyze the usage pattern, we will modify the throttling logic so there is more exposure on nudges.

Using metrics here would cause high cardinality since channel IDs are unique