### PR TITLE
feat: minimal update to logs empty-state

### DIFF
--- a/static/app/gettingStartedDocs/apple-ios/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/logs.tsx
@@ -97,7 +97,9 @@ SentrySDK.start { options in
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/apple-macos/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/logs.tsx
@@ -97,7 +97,9 @@ SentrySDK.start { options in
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/dotnet/logs.tsx
+++ b/static/app/gettingStartedDocs/dotnet/logs.tsx
@@ -18,7 +18,9 @@ export const logsVerify = (params: DocsParams): ContentBlock => ({
   content: [
     {
       type: 'text',
-      text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+      text: t(
+        'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+      ),
     },
     {
       type: 'code',

--- a/static/app/gettingStartedDocs/go/logs.tsx
+++ b/static/app/gettingStartedDocs/go/logs.tsx
@@ -92,7 +92,9 @@ func main() {
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/java-spring/logs.tsx
+++ b/static/app/gettingStartedDocs/java-spring/logs.tsx
@@ -71,7 +71,9 @@ Sentry.init { options ->
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/java/logs.tsx
+++ b/static/app/gettingStartedDocs/java/logs.tsx
@@ -71,7 +71,9 @@ Sentry.init { options ->
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/javascript/logs.tsx
+++ b/static/app/gettingStartedDocs/javascript/logs.tsx
@@ -96,7 +96,9 @@ Sentry.init({
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',
@@ -104,6 +106,28 @@ Sentry.init({
           code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          text:
+            docsPlatform === 'nextjs'
+              ? tct(
+                  'Already using console.log, Pino, Winston, or Consola? See our [link:integrations].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/logs/#integrations" />
+                    ),
+                  }
+                )
+              : tct(
+                  'Already using console.log? Capture console calls as Sentry Logs with the [link:consoleLoggingIntegration].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/logs/#console-integration" />
+                    ),
+                  }
+                ),
         },
       ],
     },
@@ -221,7 +245,7 @@ Sentry.init({
         {
           type: 'text',
           text: t(
-            'To confirm that logs are working correctly, run your application and check the Sentry logs page for the collected logs.'
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
           ),
         },
         {
@@ -230,6 +254,28 @@ Sentry.init({
           code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          text:
+            docsPlatform === 'nextjs'
+              ? tct(
+                  'Already using console.log, Pino, Winston, or Consola? See our [link:integrations].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/logs/#integrations" />
+                    ),
+                  }
+                )
+              : tct(
+                  'Already using console.log? Capture console calls as Sentry Logs with the [link:consoleLoggingIntegration].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/logs/#console-integration" />
+                    ),
+                  }
+                ),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -562,7 +562,7 @@ export const getNodeLogsOnboarding = <
           {
             type: 'text',
             text: t(
-              'Send a test log from your app to verify logs are arriving in Sentry.'
+              'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
             ),
           },
           {

--- a/static/app/gettingStartedDocs/react-native/logs.tsx
+++ b/static/app/gettingStartedDocs/react-native/logs.tsx
@@ -59,7 +59,9 @@ Sentry.init({
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/rust/logs.tsx
+++ b/static/app/gettingStartedDocs/rust/logs.tsx
@@ -89,7 +89,9 @@ export const logs: OnboardingConfig = {
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/unreal/logs.tsx
+++ b/static/app/gettingStartedDocs/unreal/logs.tsx
@@ -14,7 +14,9 @@ export const logsVerify = (params: DocsParams): ContentBlock => ({
   content: [
     {
       type: 'text',
-      text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+      text: t(
+        'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+      ),
     },
     {
       type: 'code',

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -181,7 +181,7 @@ describe('LogsPage', () => {
     expect(sdkMock).toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(screen.getByText('Your Source for Log-ical Data')).toBeInTheDocument();
+      expect(screen.getByText('Logs in Sentry')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -40,6 +40,7 @@ import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {pulsingIndicatorStyles} from 'sentry/styles/pulsingIndicator';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -127,19 +128,13 @@ function OnboardingPanel({
             <div>
               <HeaderWrapper>
                 <HeaderText>
-                  <Title>{t('Your Source for Log-ical Data')}</Title>
+                  <Title>{t('Logs in Sentry')}</Title>
                   <SubTitle>
-                    {t(
-                      "It's about time we offered something a bit more robust than breadcrumbs. With logs, you'll be able to have a lot more control and context over all your data."
-                    )}
+                    {t('Search and visualize application logs at scale.')}
                   </SubTitle>
                   <BulletList>
-                    <li>
-                      {t('Access logs in real time and query them by any attribute')}
-                    </li>
-                    <li>
-                      {t('Correlate your logs with errors and traces for full context')}
-                    </li>
+                    <li>{t('View logs in context with errors and traces')}</li>
+                    <li>{t('Query, filter, and group logs by any attribute')}</li>
                     <li>
                       {t('Build alerts and dashboard widgets based on log queries')}
                     </li>
@@ -358,6 +353,7 @@ function Onboarding({organization, project}: OnboardingProps) {
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />
+                  <EventWaitingIndicator />
                 </GuidedSteps.ButtonWrapper>
               ) : (
                 <GuidedSteps.ButtonWrapper>
@@ -372,6 +368,29 @@ function Onboarding({organization, project}: OnboardingProps) {
     </OnboardingPanel>
   );
 }
+
+const PulsingIndicator = styled('div')`
+  ${pulsingIndicatorStyles};
+  flex-shrink: 0;
+`;
+
+const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...p}>
+    {t("Waiting for this project's first log")}
+    <PulsingIndicator />
+  </div>
+))`
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 0 ${p => p.theme.space.md};
+  z-index: 10;
+  gap: ${p => p.theme.space.md};
+  flex-grow: 1;
+  font-size: ${p => p.theme.font.size.md};
+  color: ${p => p.theme.colors.pink500};
+  padding-right: ${p => p.theme.space['3xl']};
+`;
 
 const SubTitle = styled('div')`
   margin-bottom: ${p => p.theme.space.md};


### PR DESCRIPTION
**Changes:**

* Updated copy in top section.
* small copy change in verify section, asking that users refresh the page.
* Link to integrations -- _this has to be done 1 by one for each platform, I added a couple to start. I don't think we need to go overboard here, because suggesting using a skill is better.*
* Added the "waiting for projects first log" blurb.


**Browser JavaScript:**

<img width="1039" height="620" alt="Screenshot 2026-07-14 at 12 31 29 PM" src="https://github.com/user-attachments/assets/27801146-3b8e-40d7-b3fc-4fcf4b0317a8" />

**Next.js:**

<img width="1007" height="538" alt="Screenshot 2026-07-14 at 12 29 28 PM" src="https://github.com/user-attachments/assets/76960406-78cc-4dd3-bcf6-e7233d0f317d" />
