### PR TITLE
fix(GAL): Allow null values in SetEscalatingAction expired_snooze

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -591,7 +591,7 @@ class AutoSetOngoingAction(GroupAction):
 class SetEscalatingAction(GroupAction):
     event_id: Optional[str] = None
     forecast: Optional[int] = None
-    expired_snooze: Optional[dict[str, int | str]] = None
+    expired_snooze: Optional[dict[str, int | str | None]] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:


### PR DESCRIPTION
## Summary
- `SetEscalatingAction.expired_snooze` was typed as `dict[str, int | str]` but the source data (`InboxReasonDetails`) allows `None` for all fields (`until`, `count`, `window`, `user_count`, `user_window`)
- Issues that escalate from an "ignore until escalating" snooze have all snooze fields set to `None`, which caused a `ValidationError` during Activity backfill
- Fix: `dict[str, int | str]` -> `dict[str, int | str | None]`

## Test plan
- [x] Existing tests pass (no behavior change for valid data)
- Validated against production data that previously caused validation errors