### PR TITLE
feat(merge): Separate start task names for merge and unmerge chains

### DIFF
--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -33,7 +33,7 @@ from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.services import eventstore
-from sentry.tasks.unmerge import unmerge
+from sentry.tasks.unmerge import start_unmerge
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils import metrics
@@ -172,7 +172,7 @@ class GroupHashesEndpoint(GroupEndpoint):
             tags={"platform": group.platform or "unknown", "sdk": group.sdk or "unknown"},
         )
 
-        unmerge.delay(
+        start_unmerge.delay(
             group.project_id, group.id, None, grouphashes, request.user.id if request.user else None
         )
 

--- a/src/sentry/issues/merge.py
+++ b/src/sentry/issues/merge.py
@@ -12,7 +12,7 @@ from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
-from sentry.tasks.merge import merge_groups
+from sentry.tasks.merge import start_merge_groups
 from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -75,7 +75,7 @@ def handle_merge(
     )
 
     transaction_id = uuid4().hex
-    merge_groups.delay(
+    start_merge_groups.delay(
         from_object_ids=group_ids_to_merge,
         to_object_id=primary_group.id,
         transaction_id=transaction_id,

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -31,6 +31,44 @@ _TASK_KEY = "merge_groups"
 
 
 @instrumented_task(
+    name="sentry.tasks.merge.start_merge_groups",
+    namespace=issues_merge_tasks,
+    alias_namespace=issues_tasks,
+    retry=Retry(delay=60 * 5),
+    silo_mode=SiloMode.CELL,
+)
+@track_group_async_operation
+def start_merge_groups(
+    from_object_ids: list[int] | None = None,
+    to_object_id: int | str | None = None,
+    transaction_id: int | None = None,
+    eventstream_state: Mapping[str, Any] | None = None,
+) -> bool:
+    if not (from_object_ids and to_object_id):
+        logger.error("merge.start.missing_params", extra={"transaction_id": transaction_id})
+        return False
+
+    logger.info(
+        "merge.start",
+        extra={
+            "transaction_id": transaction_id,
+            "to_group_id": to_object_id,
+            "from_group_ids": from_object_ids,
+            "num_groups": len(from_object_ids),
+        },
+    )
+    metrics.incr("merge.started")
+
+    merge_groups.delay(
+        from_object_ids=from_object_ids,
+        to_object_id=to_object_id,
+        transaction_id=transaction_id,
+        eventstream_state=eventstream_state,
+    )
+    return True
+
+
+@instrumented_task(
     name="sentry.tasks.merge.merge_groups",
     namespace=issues_merge_tasks,
     alias_namespace=issues_tasks,
@@ -42,7 +80,6 @@ def merge_groups(
     from_object_ids: list[int] | None = None,
     to_object_id: int | str | None = None,
     transaction_id: int | None = None,
-    recursed: bool = False,
     eventstream_state: Mapping[str, Any] | None = None,
 ) -> bool:
     # TODO(mattrobenolt): Write tests for all of this
@@ -80,6 +117,16 @@ def merge_groups(
     # until each group has been merged.
     from_object_id = from_object_ids[0]
 
+    logger.info(
+        "merge.batch",
+        extra={
+            "transaction_id": transaction_id,
+            "from_object_id": from_object_id,
+            "remaining_groups": len(from_object_ids),
+            "to_group_id": to_object_id,
+        },
+    )
+
     try:
         new_group, _ = get_group_with_redirect(
             to_object_id,
@@ -102,21 +149,6 @@ def merge_groups(
         if eventstream_state:
             eventstream.backend.end_merge(eventstream_state)
         return False
-
-    if not recursed:
-        logger.info(
-            "merge.queued",
-            extra={
-                "transaction_id": transaction_id,
-                "new_group_id": new_group.id,
-                "old_group_ids": from_object_ids,
-                # TODO(jtcunning): figure out why these are full seq scans and/or alternative solution
-                # 'new_event_id': getattr(new_group.event_set.order_by('-id').first(), 'id', None),
-                # 'old_event_id': getattr(group.event_set.order_by('-id').first(), 'id', None),
-                # 'new_hash_id': getattr(new_group.grouphash_set.order_by('-id').first(), 'id', None),
-                # 'old_hash_id': getattr(group.grouphash_set.order_by('-id').first(), 'id', None),
-            },
-        )
 
     try:
         group = Group.objects.select_related("project").get(id=from_object_id)
@@ -239,7 +271,6 @@ def merge_groups(
             from_object_ids=from_object_ids,
             to_object_id=to_object_id,
             transaction_id=transaction_id,
-            recursed=True,
             eventstream_state=eventstream_state,
         )
         # Record that this activation has spawned its continuation. A subsequent re-pend of this

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -18,7 +18,7 @@ from sentry.models.group import Group
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 from sentry.tasks.post_process import fetch_buffered_group_stats
-from sentry.taskworker.namespaces import issues_merge_tasks, issues_tasks
+from sentry.taskworker.namespaces import issues_merge_tasks
 from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.tsdb.base import TSDBModel
 from sentry.utils import metrics
@@ -70,7 +70,6 @@ def start_merge_groups(
 @instrumented_task(
     name="sentry.tasks.merge.merge_groups",
     namespace=issues_merge_tasks,
-    alias_namespace=issues_tasks,
     retry=Retry(delay=60 * 5),
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -33,7 +33,7 @@ _TASK_KEY = "merge_groups"
 @instrumented_task(
     name="sentry.tasks.merge.start_merge_groups",
     namespace=issues_merge_tasks,
-    retry=Retry(delay=60 * 5),
+    at_most_once=True,
     silo_mode=SiloMode.CELL,
 )
 @track_group_async_operation

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -39,7 +39,7 @@ _TASK_KEY = "merge_groups"
 def start_merge_groups(
     from_object_ids: list[int] | None = None,
     to_object_id: int | str | None = None,
-    transaction_id: int | None = None,
+    transaction_id: str | None = None,
     eventstream_state: Mapping[str, Any] | None = None,
 ) -> bool:
     if not (from_object_ids and to_object_id):
@@ -76,7 +76,7 @@ def start_merge_groups(
 def merge_groups(
     from_object_ids: list[int] | None = None,
     to_object_id: int | str | None = None,
-    transaction_id: int | None = None,
+    transaction_id: str | None = None,
     eventstream_state: Mapping[str, Any] | None = None,
     recursed: bool = False,  # Deprecated: tolerated for in-flight tasks during rolling deploy
 ) -> bool:
@@ -296,7 +296,7 @@ def merge_objects(
     new_group: Group,
     limit: int = 1000,
     logger: logging.Logger | None = None,
-    transaction_id: int | None = None,
+    transaction_id: str | None = None,
 ) -> bool:
     has_more = False
     for model in models:

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -33,7 +33,6 @@ _TASK_KEY = "merge_groups"
 @instrumented_task(
     name="sentry.tasks.merge.start_merge_groups",
     namespace=issues_merge_tasks,
-    alias_namespace=issues_tasks,
     retry=Retry(delay=60 * 5),
     silo_mode=SiloMode.CELL,
 )
@@ -81,6 +80,7 @@ def merge_groups(
     to_object_id: int | str | None = None,
     transaction_id: int | None = None,
     eventstream_state: Mapping[str, Any] | None = None,
+    recursed: bool = False,  # Deprecated: tolerated for in-flight tasks during rolling deploy
 ) -> bool:
     # TODO(mattrobenolt): Write tests for all of this
     from sentry.models.activity import Activity

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -36,7 +36,6 @@ _TASK_KEY = "merge_groups"
     at_most_once=True,
     silo_mode=SiloMode.CELL,
 )
-@track_group_async_operation
 def start_merge_groups(
     from_object_ids: list[int] | None = None,
     to_object_id: int | str | None = None,

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -30,10 +30,13 @@ delete_logger = logging.getLogger("sentry.deletions.async")
 _TASK_KEY = "merge_groups"
 
 
+_START_TASK_KEY = "start_merge_groups"
+
+
 @instrumented_task(
     name="sentry.tasks.merge.start_merge_groups",
     namespace=issues_merge_tasks,
-    at_most_once=True,
+    retry=Retry(delay=60 * 5),
     silo_mode=SiloMode.CELL,
 )
 def start_merge_groups(
@@ -45,6 +48,16 @@ def start_merge_groups(
     if not (from_object_ids and to_object_id):
         logger.error("merge.start.missing_params", extra={"transaction_id": transaction_id})
         return False
+
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_START_TASK_KEY, activation_id):
+        logger.info(
+            "merge.start.duplicate_redelivery.skipped",
+            extra={"transaction_id": transaction_id, "activation_id": activation_id},
+        )
+        metrics.incr("taskworker.selfchain.duplicate_skipped", tags={"task": _START_TASK_KEY})
+        return True
 
     logger.info(
         "merge.start",
@@ -63,6 +76,8 @@ def start_merge_groups(
         transaction_id=transaction_id,
         eventstream_state=eventstream_state,
     )
+    if activation_id:
+        mark_spawned(_START_TASK_KEY, activation_id)
     return True
 
 

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -505,7 +505,7 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
 @instrumented_task(
     name="sentry.tasks.unmerge.start_unmerge",
     namespace=issues_merge_tasks,
-    processing_deadline_duration=300,
+    at_most_once=True,
     silo_mode=SiloMode.CELL,
 )
 def start_unmerge(

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -505,7 +505,6 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
 @instrumented_task(
     name="sentry.tasks.unmerge.start_unmerge",
     namespace=issues_merge_tasks,
-    alias_namespace=issues_tasks,
     processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -30,7 +30,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import GroupEvent
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import issues_merge_tasks, issues_tasks
+from sentry.taskworker.namespaces import issues_merge_tasks
 from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType
@@ -535,7 +535,6 @@ def start_unmerge(
 @instrumented_task(
     name="sentry.tasks.unmerge",
     namespace=issues_merge_tasks,
-    alias_namespace=issues_tasks,
     processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,
 )

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -503,6 +503,37 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
 
 
 @instrumented_task(
+    name="sentry.tasks.unmerge.start_unmerge",
+    namespace=issues_merge_tasks,
+    alias_namespace=issues_tasks,
+    processing_deadline_duration=300,
+    silo_mode=SiloMode.CELL,
+)
+def start_unmerge(
+    project_id: int,
+    source_id: int,
+    destination_id: int | None,
+    fingerprints: Sequence[str],
+    actor_id: int | None,
+    batch_size: int = 500,
+) -> None:
+    logger.info(
+        "unmerge.start",
+        extra={
+            "project_id": project_id,
+            "source_id": source_id,
+            "num_fingerprints": len(fingerprints),
+            "actor_id": actor_id,
+        },
+    )
+    metrics.incr("unmerge.started")
+
+    unmerge.delay(
+        project_id, source_id, destination_id, fingerprints, actor_id, batch_size=batch_size
+    )
+
+
+@instrumented_task(
     name="sentry.tasks.unmerge",
     namespace=issues_merge_tasks,
     alias_namespace=issues_tasks,

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -502,10 +502,13 @@ def unlock_hashes(project_id: int, locked_primary_hashes: Sequence[str]) -> None
     ).update(state=GroupHash.State.UNLOCKED)
 
 
+_START_TASK_KEY = "start_unmerge"
+
+
 @instrumented_task(
     name="sentry.tasks.unmerge.start_unmerge",
     namespace=issues_merge_tasks,
-    at_most_once=True,
+    processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,
 )
 def start_unmerge(
@@ -516,6 +519,20 @@ def start_unmerge(
     actor_id: int | None,
     batch_size: int = 500,
 ) -> None:
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_START_TASK_KEY, activation_id):
+        logger.info(
+            "unmerge.start.duplicate_redelivery.skipped",
+            extra={
+                "project_id": project_id,
+                "source_id": source_id,
+                "activation_id": activation_id,
+            },
+        )
+        metrics.incr("taskworker.selfchain.duplicate_skipped", tags={"task": _START_TASK_KEY})
+        return
+
     logger.info(
         "unmerge.start",
         extra={
@@ -530,6 +547,8 @@ def start_unmerge(
     unmerge.delay(
         project_id, source_id, destination_id, fingerprints, actor_id, batch_size=batch_size
     )
+    if activation_id:
+        mark_spawned(_START_TASK_KEY, activation_id)
 
 
 @instrumented_task(

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -4063,7 +4063,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not r4.exists()
 
     @patch("sentry.issues.merge.uuid4")
-    @patch("sentry.issues.merge.merge_groups")
+    @patch("sentry.issues.merge.start_merge_groups")
     @patch("sentry.eventstream.backend")
     def test_merge(
         self, mock_eventstream: MagicMock, merge_groups: MagicMock, mock_uuid4: MagicMock
@@ -4105,7 +4105,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
     @patch("sentry.issues.merge.uuid4")
-    @patch("sentry.issues.merge.merge_groups")
+    @patch("sentry.issues.merge.start_merge_groups")
     @patch("sentry.eventstream.backend")
     def test_merge_performance_issues(
         self, mock_eventstream: MagicMock, merge_groups: MagicMock, mock_uuid4: MagicMock

--- a/tests/sentry/issues/test_merge.py
+++ b/tests/sentry/issues/test_merge.py
@@ -28,7 +28,7 @@ class HandleIssueMergeTest(TestCase):
             add_group_to_inbox(group, GroupInboxReason.NEW)
             self.groups.append(group)
 
-    @patch("sentry.tasks.merge.merge_groups.delay")
+    @patch("sentry.tasks.merge.start_merge_groups.delay")
     def test_handle_merge(self, merge_groups: MagicMock) -> None:
         Activity.objects.all().delete()
         merge = handle_merge(self.groups, self.project_lookup, self.user)
@@ -50,7 +50,7 @@ class HandleIssueMergeTest(TestCase):
         assert primary_group.status == GroupStatus.UNRESOLVED
         assert primary_group.substatus == GroupSubStatus.ONGOING
 
-    @patch("sentry.tasks.merge.merge_groups.delay")
+    @patch("sentry.tasks.merge.start_merge_groups.delay")
     def test_handle_merge_rejects_large_groups(self, merge_groups: MagicMock) -> None:
         self.groups[0].update(times_seen=10001)
         self.groups[0].refresh_from_db()
@@ -62,7 +62,7 @@ class HandleIssueMergeTest(TestCase):
         assert "temporarily restricted" in str(exc_info.value.detail)
         assert not merge_groups.called
 
-    @patch("sentry.tasks.merge.merge_groups.delay")
+    @patch("sentry.tasks.merge.start_merge_groups.delay")
     def test_handle_merge_allows_groups_at_threshold(self, merge_groups: MagicMock) -> None:
         for group in self.groups:
             group.update(times_seen=10000)
@@ -72,7 +72,7 @@ class HandleIssueMergeTest(TestCase):
             handle_merge(self.groups, self.project_lookup, self.user)
         assert merge_groups.called
 
-    @patch("sentry.tasks.merge.merge_groups.delay")
+    @patch("sentry.tasks.merge.start_merge_groups.delay")
     def test_handle_merge_respects_custom_threshold(self, merge_groups: MagicMock) -> None:
         self.groups[0].update(times_seen=500)
         self.groups[0].refresh_from_db()
@@ -83,7 +83,7 @@ class HandleIssueMergeTest(TestCase):
 
         assert not merge_groups.called
 
-    @patch("sentry.tasks.merge.merge_groups.delay")
+    @patch("sentry.tasks.merge.start_merge_groups.delay")
     def test_handle_merge_disabled_with_zero_threshold(self, merge_groups: MagicMock) -> None:
         self.groups[0].update(times_seen=999999)
         self.groups[0].refresh_from_db()

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -11,7 +11,7 @@ from sentry.models.groupredirect import GroupRedirect
 from sentry.models.userreport import UserReport
 from sentry.services import eventstore
 from sentry.similarity import _make_index_backend, features
-from sentry.tasks.merge import merge_groups
+from sentry.tasks.merge import merge_groups, start_merge_groups
 from sentry.tasks.post_process import fetch_buffered_group_stats
 from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.testutils.cases import SnubaTestCase, TestCase
@@ -309,3 +309,31 @@ class MergeGroupTest(TestCase, SnubaTestCase):
         gale.refresh_from_db()
         assert gale.group_id == new_group.id
         assert gale.original_group_id == old_group.id
+
+
+class StartMergeGroupsTest(TestCase):
+    def test_delegates_to_merge_groups(self) -> None:
+        group1 = self.create_group(self.project)
+        group2 = self.create_group(self.project)
+        target = self.create_group(self.project)
+
+        with patch.object(merge_groups, "delay") as mock_delay:
+            result = start_merge_groups(
+                from_object_ids=[group1.id, group2.id],
+                to_object_id=target.id,
+                transaction_id="txn-123",
+                eventstream_state={"key": "value"},
+            )
+
+        assert result is True
+        mock_delay.assert_called_once_with(
+            from_object_ids=[group1.id, group2.id],
+            to_object_id=target.id,
+            transaction_id="txn-123",
+            eventstream_state={"key": "value"},
+        )
+
+    def test_validates_missing_params(self) -> None:
+        assert start_merge_groups(from_object_ids=None, to_object_id=1) is False
+        assert start_merge_groups(from_object_ids=[], to_object_id=1) is False
+        assert start_merge_groups(from_object_ids=[1], to_object_id=None) is False

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1327,7 +1327,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert "inbox" not in response.data
 
     @patch("sentry.issues.merge.uuid4")
-    @patch("sentry.issues.merge.merge_groups")
+    @patch("sentry.issues.merge.start_merge_groups")
     @patch("sentry.eventstream.backend")
     def test_merge(
         self, mock_eventstream: MagicMock, merge_groups: MagicMock, mock_uuid4: MagicMock
@@ -1369,7 +1369,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
     @patch("sentry.issues.merge.uuid4")
-    @patch("sentry.issues.merge.merge_groups")
+    @patch("sentry.issues.merge.start_merge_groups")
     @patch("sentry.eventstream.backend")
     def test_merge_performance_issues(
         self, mock_eventstream: MagicMock, merge_groups: MagicMock, mock_uuid4: MagicMock

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -30,6 +30,7 @@ from sentry.tasks.unmerge import (
     get_group_backfill_attributes,
     get_group_creation_attributes,
     repair_denormalizations,
+    start_unmerge,
     unmerge,
 )
 from sentry.taskworker.selfchain_idempotency import mark_spawned
@@ -657,3 +658,18 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         repair_denormalizations(get_caches(), project, [event])
 
         mock_similarity.record.assert_called_once_with(project, [event])
+
+
+class StartUnmergeTest(TestCase):
+    def test_delegates_to_unmerge(self) -> None:
+        with patch.object(unmerge, "delay") as mock_delay:
+            start_unmerge(
+                project_id=1,
+                source_id=2,
+                destination_id=None,
+                fingerprints=["abc", "def"],
+                actor_id=3,
+                batch_size=500,
+            )
+
+        mock_delay.assert_called_once_with(1, 2, None, ["abc", "def"], 3, batch_size=500)


### PR DESCRIPTION
## Summary
- Add `start_merge_groups` and `start_unmerge` wrapper tasks that log/emit metrics before delegating to the existing continuation tasks
- Removes the now-dead `recursed` parameter from `merge_groups`
- Adds per-batch `merge.batch` logging to `merge_groups` for better chain visibility

This lets monitoring distinguish new merge/unmerge initiations from ongoing chain iterations, and enables independent control of new merges vs in-progress chains at the taskbroker level.

Refs ID-1665, ID-1666

## Test plan
- [x] New tests for `start_merge_groups` delegation and input validation
- [x] New test for `start_unmerge` delegation
- [x] Updated mock targets in existing merge/unmerge endpoint tests
- [x] All existing `merge_groups` and `unmerge` continuation tests pass unchanged
- [x] `prek run -q` passes on all changed files