### PR TITLE
fix(feedback): don't orphan feedback payloads in the processing store

### DIFF
--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -190,8 +190,14 @@ def process_event(
         if attachment_objects:
             store_attachments_for_event(project, data, attachment_objects, timeout=CACHE_TIMEOUT)
 
-        with metrics.timer("ingest_consumer._store_event"):
-            cache_key = processing_store.store(data)
+        # Feedback events pass their payload inline to `save_event_feedback` and
+        # never read it back from the processing store, so skip the Redis write
+        # for them. Storing would orphan the payload in Redis until its TTL
+        # expires, since nothing on the feedback path deletes it.
+        cache_key = None
+        if data.get("type") != "feedback":
+            with metrics.timer("ingest_consumer._store_event"):
+                cache_key = processing_store.store(data)
         if consumer_type == ConsumerType.Transactions:
             track_sampled_event(
                 data["event_id"], ConsumerType.Transactions, TransactionStageStatus.REDIS_PUT
@@ -249,7 +255,7 @@ def process_event(
         elif data.get("type") == "feedback":
             if not is_in_feedback_denylist(project.organization):
                 save_event_feedback.delay(
-                    cache_key=None,  # no need to cache as volume is low
+                    cache_key=None,  # data is passed inline; not stored in Redis
                     data=data,
                     start_time=start_time,
                     event_id=event_id,

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -37,6 +37,7 @@ from sentry.models.eventattachment import EventAttachment
 from sentry.models.userreport import UserReport
 from sentry.objectstore import get_attachments_session
 from sentry.services import eventstore
+from sentry.services.eventstore.processing import event_processing_store
 from sentry.testutils.factories import get_fixture_path
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
@@ -437,11 +438,17 @@ def test_feedbacks_spawn_save_event_feedback(
         )
     assert not len(preprocess_event)
     assert save_event_feedback.delay.call_args[0] == ()
+    # Feedback data is passed inline; nothing is stored in the processing store,
+    # so no cache_key is threaded through.
+    assert save_event_feedback.delay.call_args[1]["cache_key"] is None
     assert (
         save_event_feedback.delay.call_args[1]["data"]["contexts"]["feedback"]
         == event["contexts"]["feedback"]
     )
     assert save_event_feedback.delay.call_args[1]["data"]["type"] == "feedback"
+
+    # The feedback payload must not be left orphaned in the processing store.
+    assert event_processing_store.get(f"e:{event_id}:{project_id}") is None
 
 
 @django_db_all


### PR DESCRIPTION
## Summary

Feedback events were leaking their full payload into the `event_processing_store` (Redis).

In `process_event()` (`src/sentry/ingest/consumer/processors.py`), `processing_store.store(data)` ran unconditionally for **every** event, including feedback. The feedback branch then dispatched `save_event_feedback.delay(cache_key=None, ...)` with the comment *"no need to cache as volume is low"* — but the payload had **already** been written to Redis, and passing `cache_key=None` discarded the key so nothing downstream ever deleted it.

Unlike errors (deleted in post-process / on `HashDiscarded`) and transactions (deleted in the `_do_save_event` `finally` block), the feedback path calls none of those, so each feedback payload sat in the default Redis cluster for its full **24h TTL** doing nothing. Bounded (TTL-capped), but a real standing-memory cost at scale.

## Fix

Feedback data is already passed inline to `save_event_feedback`, so it never needs the processing store. Skip the Redis write entirely for `type == "feedback"` rather than writing-then-deleting. This honors the original "no need to cache" intent.

- The transaction path (needs the real `cache_key`, asserts it's not `None`) and the error/preprocess path (`cache_key or ""`) are unaffected — only feedback is skipped.

## Test plan

- Extended `test_feedbacks_spawn_save_event_feedback` to assert `cache_key is None` **and** that `event_processing_store.get("e:{event_id}:{project_id}")` returns `None` (regression guard proving no orphaned payload).
- Ran feedback + transaction/error store + dedup + accountant tests: **4 passed**.
- `ruff` and `mypy` clean.

## Notes

This only prevents *new* leaks. Existing orphaned entries in production age out on their own within 24h via the TTL — no backfill cleanup needed.