### PR TITLE
chore(hybridcloud): stop regions from replicating Team

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -149,12 +149,6 @@ class Team(ReplicatedCellModel):
     def __str__(self) -> str:
         return f"{self.name} ({self.slug})"
 
-    def handle_async_replication(self, shard_identifier: int) -> None:
-        from sentry.hybridcloud.services.replica import control_replica_service
-        from sentry.organizations.services.organization.serial import serialize_rpc_team
-
-        control_replica_service.upsert_replicated_team(team=serialize_rpc_team(self))
-
     def save(self, *args, **kwargs):
         if not self.slug:
             lock = locks.get(f"slug:team:{self.organization_id}", duration=5, name="team_slug")


### PR DESCRIPTION
Step 2 of tearing out the dead `TeamReplica` table.

Removes the region-side hook that called the RPC to push Team updates into the `TeamReplica` control table. This is a precondition for removing the RPC endpoint itself in Step 3.

Refs INFRENG-368