### PR TITLE
chore(control): remove control callees for Team replication

### DIFF
--- a/src/sentry/hybridcloud/services/replica/impl.py
+++ b/src/sentry/hybridcloud/services/replica/impl.py
@@ -31,9 +31,7 @@ from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.models.projectkeymapping import ProjectKeyMapping
-from sentry.models.team import Team
-from sentry.models.teamreplica import TeamReplica
-from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
+from sentry.organizations.services.organization import RpcOrganizationMemberTeam
 from sentry.users.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -295,17 +293,6 @@ class DatabaseBackedControlReplicaService(ControlReplicaService):
         )
 
         handle_replication(OrganizationMemberTeam, destination, fk="organizationmemberteam_id")
-
-    def upsert_replicated_team(self, *, team: RpcTeam) -> None:
-        destination = TeamReplica(
-            team_id=team.id,
-            organization_id=team.organization_id,
-            slug=team.slug,
-            name=team.name,
-            status=team.status,
-        )
-
-        handle_replication(Team, destination)
 
     def upsert_project_key_mapping(self, *, project_key: RpcProjectKeyMapping) -> bool:
         try:

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -5,18 +5,13 @@ from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
 from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, cell_rpc_method, rpc_method
 from sentry.hybridcloud.services.project_key_mapping import RpcProjectKeyMapping
-from sentry.organizations.services.organization import RpcOrganizationMemberTeam, RpcTeam
+from sentry.organizations.services.organization import RpcOrganizationMemberTeam
 from sentry.silo.base import SiloMode
 
 
 class ControlReplicaService(RpcService):
     key = "control_replica"
     local_mode = SiloMode.CONTROL
-
-    @rpc_method
-    @abc.abstractmethod
-    def upsert_replicated_team(self, *, team: RpcTeam) -> None:
-        pass
 
     @rpc_method
     @abc.abstractmethod


### PR DESCRIPTION
Step 3 of tearing out the dead `TeamReplica` table. Now that the regions have stopped calling the replication RPC, we can remove the control-side endpoint and the rest of the Team -> TeamReplica wiring

Refs INFRENG-368