### PR TITLE
feat(admin): gift recurring credits UI extras (dry-run)

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -44,6 +44,70 @@ describe('CustomerOverview', () => {
     expect(screen.getByText('Soft Cap By Category:')).toBeInTheDocument();
   });
 
+  it('renders recurring credit gifts with active and upcoming status', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      giftCredits: [
+        {
+          id: 1,
+          type: 'replay',
+          amount: 5000,
+          periodStart: moment().subtract(2, 'days').format('YYYY-MM-DD'),
+          periodEnd: moment().add(1, 'month').format('YYYY-MM-DD'),
+          totalAmountRemaining: null,
+        },
+        {
+          id: 2,
+          type: 'error',
+          amount: 1000,
+          periodStart: moment().add(1, 'month').format('YYYY-MM-DD'),
+          periodEnd: moment().add(4, 'months').format('YYYY-MM-DD'),
+          totalAmountRemaining: null,
+        },
+      ],
+    });
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    // Scope to the gifts section: category names also appear in Reserved Data.
+    const header = screen.getByText('Recurring Credit Gifts');
+    const giftListEl = header.nextElementSibling as HTMLElement;
+    const giftList = within(giftListEl);
+    expect(giftList.getByText('Replays:')).toBeInTheDocument();
+    expect(giftList.getByText('Errors:')).toBeInTheDocument();
+    // The in-progress gift reads Active; the future-dated one reads Upcoming.
+    expect(giftList.getByText('Active')).toBeInTheDocument();
+    expect(giftList.getByText('Upcoming')).toBeInTheDocument();
+    // Each gift shows its billing-period count and start date.
+    expect(giftListEl).toHaveTextContent('3 billing periods');
+    expect(giftListEl).toHaveTextContent(moment().add(1, 'month').format('ll'));
+  });
+
+  it('shows the recurring credit gifts section as None when there are none', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization});
+    render(
+      <CustomerOverview
+        customer={subscription}
+        onAction={jest.fn()}
+        organization={organization}
+      />
+    );
+
+    // The section is always present so an admin can tell "no gift" apart from
+    // a missing/broken section.
+    const header = screen.getByText('Recurring Credit Gifts');
+    expect(
+      within(header.nextElementSibling as HTMLElement).getByText('None')
+    ).toBeInTheDocument();
+  });
+
   it('renders soft cap type details', () => {
     const organization = OrganizationFixture();
     const subscription = SubscriptionFixture({

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -31,6 +31,7 @@ import {getLogQuery} from 'admin/utils';
 import {BILLED_DATA_CATEGORY_INFO, UNLIMITED} from 'getsentry/constants';
 import type {
   Plan,
+  RecurringCredit,
   ReservedBudget,
   ReservedBudgetMetricHistory,
   Subscription,
@@ -46,6 +47,7 @@ import {
   RETENTION_SETTINGS_CATEGORIES,
 } from 'getsentry/utils/billing';
 import {
+  getCreditDataCategory,
   getPlanCategoryName,
   getReservedBudgetDisplayName,
   sortCategories,
@@ -254,6 +256,61 @@ function ReservedBudgetsData({customer}: ReservedDataProps) {
           </Fragment>
         );
       })}
+    </Fragment>
+  );
+}
+
+function giftCreditIsUpcoming(credit: RecurringCredit) {
+  return moment(credit.periodStart).utc().startOf('day') > moment().utc().startOf('day');
+}
+
+function RecurringGiftCredits({customer}: ReservedDataProps) {
+  const giftCredits = customer.giftCredits ?? [];
+
+  // Always render the section — an explicit "None" tells an admin the org has
+  // no active or upcoming gift, which a disappearing section would not.
+  return (
+    <Fragment>
+      <h6>Recurring Credit Gifts</h6>
+      <DetailList>
+        {giftCredits.length === 0 && (
+          <DetailLabel title="Active or upcoming">None</DetailLabel>
+        )}
+        {giftCredits.map(credit => {
+          const category = getCreditDataCategory(credit);
+          const categoryName = category
+            ? getPlanCategoryName({
+                plan: customer.planDetails,
+                category,
+                capitalize: false,
+              })
+            : credit.type;
+          const amount = category
+            ? formatReservedWithUnits(credit.amount, category, {
+                isAbbreviated: true,
+                useUnitScaling: true,
+              })
+            : credit.amount;
+          const upcoming = giftCreditIsUpcoming(credit);
+          // The window spans exactly this many monthly billing periods
+          // (period_end = period_start + N months).
+          const billingPeriods = Math.round(
+            moment(credit.periodEnd).diff(moment(credit.periodStart), 'months', true)
+          );
+          return (
+            <DetailLabel key={credit.id} title={upperFirst(categoryName)}>
+              {`+${amount}/mo · ${billingPeriods} billing period${
+                billingPeriods === 1 ? '' : 's'
+              } · ${moment(credit.periodStart).format('ll')} → ${moment(
+                credit.periodEnd
+              ).format('ll')} `}
+              <Tag variant={upcoming ? 'info' : 'success'}>
+                {upcoming ? 'Upcoming' : 'Active'}
+              </Tag>
+            </DetailLabel>
+          );
+        })}
+      </DetailList>
     </Fragment>
   );
 }
@@ -678,6 +735,7 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
         <SubscriptionSummary customer={customer} onAction={onAction} />
         <ReservedData customer={customer} />
         <ReservedBudgetsData customer={customer} />
+        <RecurringGiftCredits customer={customer} />
         <h6>PCSS</h6>
         <DetailList>
           <DetailLabel title="Custom Price PCSS">

--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -16,6 +16,7 @@ import {DebuggingTools} from 'admin/views/debuggingTools';
 import {DocIntegrationDetails} from 'admin/views/docIntegrationDetails';
 import {DocIntegrations} from 'admin/views/docIntegrations';
 import {GenerateSpikeProjectionsForBatch} from 'admin/views/generateSpikeProjectionsForBatch';
+import {GiftRecurringCredits} from 'admin/views/giftRecurringCredits';
 import {HomePage as Home} from 'admin/views/home';
 import {InstanceLevelOAuth} from 'admin/views/instanceLevelOAuth/instanceLevelOAuth';
 import {InstanceLevelOAuthDetails} from 'admin/views/instanceLevelOAuth/instanceLevelOAuthDetails';
@@ -282,6 +283,15 @@ function buildRoutes() {
           {
             index: true,
             component: GenerateSpikeProjectionsForBatch,
+          },
+        ],
+      },
+      {
+        path: 'gift-recurring-credits/',
+        children: [
+          {
+            index: true,
+            component: GiftRecurringCredits,
           },
         ],
       },

--- a/static/gsAdmin/views/giftRecurringCredits.spec.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.spec.tsx
@@ -1,0 +1,536 @@
+import {UserFixture} from 'sentry-fixture/user';
+
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {ConfigStore} from 'sentry/stores/configStore';
+
+import {GiftRecurringCredits} from 'admin/views/giftRecurringCredits';
+
+jest.mock('sentry/actionCreators/indicator');
+
+describe('GiftRecurringCredits', () => {
+  beforeEach(() => {
+    ConfigStore.set(
+      'user',
+      UserFixture({isSuperuser: true, permissions: new Set(['billing.admin'])})
+    );
+    ConfigStore.set('cells', [
+      {name: 'us', locality_url: 'https://us.test/api/0/'},
+      {name: 'eu', locality_url: 'https://eu.test/api/0/'},
+    ]);
+    MockApiClient.addMockResponse({
+      url: '/billing-config/',
+      body: {
+        category_info: {
+          '1': {
+            api_name: 'errors',
+            billed_category: 1,
+            display_name: 'Errors',
+            name: 'errors',
+            name_singular: 'error',
+            order: 1,
+            product_name: 'Error Tracking',
+            singular: 'error',
+            tally_type: 1,
+          },
+          '7': {
+            api_name: 'replays',
+            billed_category: 7,
+            display_name: 'Replays',
+            name: 'replays',
+            name_singular: 'replay',
+            order: 7,
+            product_name: 'Session Replay',
+            singular: 'replay',
+            tally_type: 1,
+          },
+          '24': {
+            api_name: 'logBytes',
+            billed_category: 24,
+            display_name: 'Logs',
+            name: 'log_bytes',
+            name_singular: 'log_byte',
+            order: 24,
+            product_name: 'Logs',
+            singular: 'log byte',
+            tally_type: 1,
+          },
+          '13': {
+            api_name: 'monitorSeats',
+            billed_category: 13,
+            display_name: 'Cron Monitors',
+            name: 'monitor_seats',
+            name_singular: 'monitor_seat',
+            order: 13,
+            product_name: 'Cron Monitoring',
+            singular: 'monitor seat',
+            tally_type: 1,
+          },
+        },
+        outcomes: {},
+        reason_codes: {},
+      },
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  async function fillRequiredFields() {
+    await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5000');
+  }
+
+  it('submits the raw textarea tokens as multipart, without parsing them', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {
+        results: [
+          {
+            id: 12345,
+            slug: 'acme',
+            status: 'created',
+            code: null,
+            plan: 'am3_team',
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: null,
+          },
+          {
+            id: null,
+            slug: 'beta-org',
+            status: 'error',
+            code: 'unknown-org',
+            plan: null,
+            periodStart: null,
+            periodEnd: null,
+            creditId: null,
+          },
+        ],
+      },
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(
+      screen.getByLabelText(/Target organizations/),
+      '12345, beta-org'
+    );
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(postMock).toHaveBeenCalledWith(
+      '/_admin/cells/us/gift-recurring-credits/',
+      expect.objectContaining({
+        method: 'POST',
+        host: 'https://us.test/api/0/',
+        data: expect.any(FormData),
+      })
+    );
+
+    // The manual tokens ride along verbatim; nothing is parsed client-side.
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('orgsTokens')).toBe('12345, beta-org');
+    expect(formData.get('file')).toBeNull();
+    expect(formData.get('dataCategory')).toBe('replay');
+    expect(formData.get('amount')).toBe('5000');
+    expect(formData.get('billingPeriods')).toBe('3');
+
+    // The per-org results render, including the typed error code.
+    const results = await screen.findByTestId('results');
+    expect(results).toHaveTextContent('created');
+    expect(results).toHaveTextContent('unknown-org');
+    expect(results).toHaveTextContent('beta-org');
+
+    // The gift just created is summarized per org.
+    expect(results).toHaveTextContent('5,000/mo ×3');
+
+    // The org's plan shows, and its slug links to the admin customer page.
+    expect(results).toHaveTextContent('am3_team');
+    expect(screen.getByRole('link', {name: 'acme'})).toHaveAttribute(
+      'href',
+      '/_admin/customers/acme/'
+    );
+
+    // Orgs not found in the queried region are collected into a callout that
+    // names the region and lists them, so the operator can re-run elsewhere.
+    expect(screen.getByTestId('not-in-region-warning')).toHaveTextContent(
+      '1 of 2 orgs were not found in the us region'
+    );
+    expect(screen.getByTestId('not-in-region-warning')).toHaveTextContent('beta-org');
+  });
+
+  it('uploads a CSV file as multipart to the selected region', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {
+        results: [
+          {
+            id: 1,
+            slug: 'acme',
+            status: 'created',
+            code: null,
+            plan: 'am3_business',
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: 42,
+          },
+        ],
+      },
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+
+    const file = new File(['org_id\n987\n555'], 'ids.csv', {type: 'text/csv'});
+    await userEvent.upload(screen.getByLabelText('csv-upload'), file);
+
+    // The raw file is held; there is no client-side parse or org count.
+    expect(await screen.findByText(/ids\.csv/)).toBeInTheDocument();
+    expect(addErrorMessage).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(postMock).toHaveBeenCalledWith(
+      '/_admin/cells/us/gift-recurring-credits/',
+      expect.objectContaining({
+        method: 'POST',
+        host: 'https://us.test/api/0/',
+        data: expect.any(FormData),
+      })
+    );
+
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('file')).toBe(file);
+    expect(formData.get('orgsTokens')).toBeNull();
+
+    expect(await screen.findByTestId('results')).toHaveTextContent('created');
+  });
+
+  it('surfaces the backend error message when the request is rejected', async () => {
+    // The org cap now lives only on the backend; its rejection is shown verbatim.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      statusCode: 400,
+      body: {orgs: ['Ensure this field has no more than 10000 elements.']},
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() =>
+      expect(addErrorMessage).toHaveBeenCalledWith(
+        'Ensure this field has no more than 10000 elements.'
+      )
+    );
+  });
+
+  it('converts byte-category amounts from GB to bytes', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {results: []},
+    });
+
+    render(<GiftRecurringCredits />);
+    await userEvent.click(screen.getByRole('button', {name: /Data Category/}));
+    await userEvent.click(screen.getByRole('option', {name: 'Logs'}));
+
+    expect(screen.getByText('Amount per billing period (GB):')).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5');
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('dataCategory')).toBe('log_byte');
+    expect(formData.get('amount')).toBe('5000000000');
+  });
+
+  it('rejects a non-CSV file without attaching it', async () => {
+    render(<GiftRecurringCredits />);
+
+    const file = new File(['nope'], 'orgs.txt', {type: 'text/plain'});
+    await userEvent.upload(screen.getByLabelText('csv-upload'), file, {
+      applyAccept: false,
+    });
+
+    await waitFor(() =>
+      expect(addErrorMessage).toHaveBeenCalledWith('Please upload a .csv file.')
+    );
+    expect(screen.queryByText(/orgs\.txt/)).not.toBeInTheDocument();
+  });
+
+  it('keeps submission disabled until a file or tokens are provided', async () => {
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+
+    // Amount and periods are valid, but with no target the gift can't be sent.
+    expect(screen.getByTestId('gift-submit')).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+    expect(screen.getByTestId('gift-submit')).toBeEnabled();
+  });
+
+  it('disables submission without billing.admin', async () => {
+    ConfigStore.set('user', UserFixture({isSuperuser: true, permissions: new Set()}));
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    expect(screen.getByText('Requires billing admin permissions.')).toBeInTheDocument();
+    expect(screen.getByTestId('gift-submit')).toBeDisabled();
+  });
+
+  it('previews the billing period schedule, counting the current period', async () => {
+    render(<GiftRecurringCredits />);
+
+    // Default of 3 periods: the current period plus the next two, then a stop.
+    const preview = await screen.findByTestId('schedule-preview');
+    expect(preview).toHaveTextContent('This billing period');
+    expect(preview).toHaveTextContent('starts now, applied immediately');
+    expect(preview).toHaveTextContent('Next billing period');
+    expect(preview).toHaveTextContent('About 2 months from now');
+    expect(preview).toHaveTextContent('Every billing period after these 3 gets nothing');
+    // The current period is one of the three, not an extra on top.
+    expect(preview).not.toHaveTextContent('About 3 months from now');
+    // Use-it-or-lose-it is called out so it isn't read as a bankable pool.
+    expect(screen.getByTestId('no-rollover-note')).toHaveTextContent(
+      "Unused credits don't roll over"
+    );
+  });
+
+  it('lets the billing period field be cleared without inserting a leading zero', async () => {
+    render(<GiftRecurringCredits />);
+
+    const periodsInput = screen.getByLabelText<HTMLInputElement>(
+      'How many monthly billing periods?'
+    );
+    await userEvent.clear(periodsInput);
+
+    // Empty stays empty (not coerced to 0), and the preview hides until a value.
+    expect(periodsInput).toHaveValue(null);
+    expect(screen.queryByTestId('schedule-preview')).not.toBeInTheDocument();
+
+    await userEvent.type(periodsInput, '5');
+    expect(periodsInput).toHaveValue(5);
+    expect(screen.getByTestId('schedule-preview')).toHaveTextContent(
+      'for 5 monthly periods.'
+    );
+  });
+
+  it('blocks submission of a fractional billing period', async () => {
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    const periodsInput = screen.getByLabelText('How many monthly billing periods?');
+    await userEvent.clear(periodsInput);
+    await userEvent.type(periodsInput, '3.5');
+
+    // A non-integer count has no schedule and cannot be submitted; the backend
+    // only accepts whole periods, so we never let it be POSTed.
+    expect(screen.queryByTestId('schedule-preview')).not.toBeInTheDocument();
+    expect(screen.getByTestId('gift-submit')).toBeDisabled();
+  });
+
+  it('shows a single-period gift as just the current period', async () => {
+    render(<GiftRecurringCredits />);
+
+    const periodsInput = screen.getByLabelText('How many monthly billing periods?');
+    await userEvent.clear(periodsInput);
+    await userEvent.type(periodsInput, '1');
+
+    const preview = screen.getByTestId('schedule-preview');
+    expect(preview).toHaveTextContent('This billing period');
+    expect(preview).toHaveTextContent('for 1 monthly period.');
+    // No future periods when only the current one is gifted.
+    expect(preview).not.toHaveTextContent('Next billing period');
+    expect(preview).toHaveTextContent('Every billing period after these 1 gets nothing');
+  });
+
+  it('drops a previously staged CSV when a later file is rejected', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {results: []},
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    const goodFile = new File(['org_id\n1'], 'ids.csv', {type: 'text/csv'});
+    await userEvent.upload(screen.getByLabelText('csv-upload'), goodFile);
+    expect(await screen.findByText(/ids\.csv/)).toBeInTheDocument();
+
+    const badFile = new File(['nope'], 'orgs.txt', {type: 'text/plain'});
+    await userEvent.upload(screen.getByLabelText('csv-upload'), badFile, {
+      applyAccept: false,
+    });
+
+    // The rejected reselection clears the earlier file rather than leaving it
+    // staged for the request.
+    await waitFor(() =>
+      expect(addErrorMessage).toHaveBeenCalledWith('Please upload a .csv file.')
+    );
+    expect(screen.queryByText(/ids\.csv/)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('file')).toBeNull();
+    expect(formData.get('orgsTokens')).toBe('acme');
+  });
+
+  it('does not POST when a submit event fires on an invalid form', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {results: []},
+    });
+
+    render(<GiftRecurringCredits />);
+
+    // No amount and no target: the button is disabled, but a submit event that
+    // slips past it (e.g. a double-click race) must still be refused.
+    const form = screen.getByTestId('gift-submit').closest('form')!;
+    fireEvent.submit(form);
+
+    await waitFor(() => expect(addErrorMessage).not.toHaveBeenCalled());
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks submission of a fractional count amount', async () => {
+    render(<GiftRecurringCredits />);
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    const amountInput = screen.getByLabelText(/Amount per billing period/);
+    await userEvent.type(amountInput, '5000.5');
+
+    // The POST rounds the amount, so a fractional count would credit a value the
+    // preview never showed; the form refuses it.
+    expect(screen.getByTestId('gift-submit')).toBeDisabled();
+
+    await userEvent.clear(amountInput);
+    await userEvent.type(amountInput, '5000');
+    expect(screen.getByTestId('gift-submit')).toBeEnabled();
+  });
+
+  it('links only slugged orgs and shows the id as plain text otherwise', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {
+        results: [
+          {
+            id: 1,
+            slug: 'acme',
+            status: 'created',
+            code: null,
+            plan: 'am3_team',
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: null,
+          },
+          {
+            id: 999,
+            slug: null,
+            status: 'created',
+            code: null,
+            plan: 'am3_team',
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: null,
+          },
+          {
+            id: 888,
+            slug: '',
+            status: 'created',
+            code: null,
+            plan: 'am3_team',
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: null,
+          },
+        ],
+      },
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await screen.findByTestId('results');
+
+    // Only the slugged org is a link; a null or empty slug never produces a
+    // dash-link or a `/_admin/customers//` href.
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute('href', '/_admin/customers/acme/');
+    expect(screen.getByTestId('results')).toHaveTextContent('999');
+    expect(screen.getByTestId('results')).toHaveTextContent('888');
+  });
+
+  it('clears a prior results table when a later submit fails', async () => {
+    const successMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {
+        results: [
+          {
+            id: 1,
+            slug: 'acme',
+            status: 'created',
+            code: null,
+            plan: 'am3_team',
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: 7,
+          },
+        ],
+      },
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    expect(await screen.findByTestId('results')).toHaveTextContent('created');
+
+    // A second run that fails must not leave the previous run's table on screen.
+    successMock.mockClear();
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Something went wrong.'},
+    });
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() =>
+      expect(addErrorMessage).toHaveBeenCalledWith('Something went wrong.')
+    );
+    expect(screen.queryByTestId('results')).not.toBeInTheDocument();
+  });
+});

--- a/static/gsAdmin/views/giftRecurringCredits.spec.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.spec.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {ConfigStore} from 'sentry/stores/configStore';
 
 import {GiftRecurringCredits} from 'admin/views/giftRecurringCredits';
@@ -362,6 +362,68 @@ describe('GiftRecurringCredits', () => {
     // only accepts whole periods, so we never let it be POSTed.
     expect(screen.queryByTestId('schedule-preview')).not.toBeInTheDocument();
     expect(screen.getByTestId('gift-submit')).toBeDisabled();
+  });
+
+  it('defaults to a dry run and previews without creating credits', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {
+        results: [{id: 1, slug: 'acme', status: 'dry-run-ok', code: null, plan: null}],
+      },
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    // The checkbox defaults on, so the submit button offers a dry run.
+    expect(screen.getByTestId('gift-submit')).toHaveTextContent('Run Dry Run');
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('dryRun')).toBe('true');
+  });
+
+  it('reports the dry-run mode the request was sent with, not the live checkbox', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {
+        results: [
+          {
+            id: 1,
+            slug: 'acme',
+            status: 'dry-run-ok',
+            code: null,
+            plan: 'am3_business',
+            existingGift: null,
+            periodStart: '2025-07-01',
+            periodEnd: '2025-10-01',
+            creditId: null,
+          },
+        ],
+      },
+      // Hold the response so the checkbox can be toggled while it's in flight.
+      asyncDelay: 50,
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    // Submit as a dry run, then flip to a real gift before the response lands.
+    await userEvent.click(screen.getByTestId('gift-submit'));
+    await userEvent.click(screen.getByLabelText(/Dry run/));
+
+    // The toast reflects the dry run that was actually sent, not the new state.
+    await waitFor(() =>
+      expect(addSuccessMessage).toHaveBeenCalledWith('Dry run passed for 1 orgs.')
+    );
+    expect(addSuccessMessage).not.toHaveBeenCalledWith(
+      'Gifted recurring credits to 1 orgs.'
+    );
   });
 
   it('shows a single-period gift as just the current period', async () => {

--- a/static/gsAdmin/views/giftRecurringCredits.spec.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.spec.tsx
@@ -86,6 +86,7 @@ describe('GiftRecurringCredits', () => {
 
   async function fillRequiredFields() {
     await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5000');
+    await userEvent.type(screen.getByLabelText(/Ticket URL/), 'http://t/1');
     await userEvent.type(screen.getByLabelText('Notes:'), 'note');
   }
 
@@ -267,6 +268,7 @@ describe('GiftRecurringCredits', () => {
 
     expect(screen.getByText('Amount per billing period (GB):')).toBeInTheDocument();
     await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5');
+    await userEvent.type(screen.getByLabelText(/Ticket URL/), 'http://t/1');
     await userEvent.type(screen.getByLabelText('Notes:'), 'note');
     await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
 
@@ -301,6 +303,25 @@ describe('GiftRecurringCredits', () => {
 
     await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
     expect(screen.getByTestId('gift-submit')).toBeEnabled();
+  });
+
+  it('allows submitting without a ticket URL', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {results: []},
+    });
+
+    render(<GiftRecurringCredits />);
+    await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5000');
+    await userEvent.type(screen.getByLabelText('Notes:'), 'note');
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('ticketUrl')).toBe('');
   });
 
   it('disables submission without billing.admin', async () => {

--- a/static/gsAdmin/views/giftRecurringCredits.spec.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.spec.tsx
@@ -100,6 +100,11 @@ describe('GiftRecurringCredits', () => {
             status: 'created',
             code: null,
             plan: 'am3_team',
+            existingGift: {
+              amount: 2000,
+              periodStart: '2025-06-01',
+              periodEnd: '2025-08-01',
+            },
             periodStart: '2025-07-01',
             periodEnd: '2025-10-01',
             creditId: null,
@@ -110,6 +115,7 @@ describe('GiftRecurringCredits', () => {
             status: 'error',
             code: 'unknown-org',
             plan: null,
+            existingGift: null,
             periodStart: null,
             periodEnd: null,
             creditId: null,
@@ -151,7 +157,14 @@ describe('GiftRecurringCredits', () => {
     expect(results).toHaveTextContent('unknown-org');
     expect(results).toHaveTextContent('beta-org');
 
-    // The gift just created is summarized per org.
+    // The org with an existing gift is flagged, and a summary warns that
+    // gifting overwrites rather than stacks.
+    expect(screen.getByTestId('existing-gift-warning')).toHaveTextContent(
+      '1 of 2 orgs already have an active recurring gift'
+    );
+
+    // The override shows the current gift (before) next to the new one (after).
+    expect(results).toHaveTextContent('2,000/mo ×2');
     expect(results).toHaveTextContent('5,000/mo ×3');
 
     // The org's plan shows, and its slug links to the admin customer page.
@@ -181,6 +194,7 @@ describe('GiftRecurringCredits', () => {
             status: 'created',
             code: null,
             plan: 'am3_business',
+            existingGift: null,
             periodStart: '2025-07-01',
             periodEnd: '2025-10-01',
             creditId: 42,

--- a/static/gsAdmin/views/giftRecurringCredits.spec.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.spec.tsx
@@ -330,6 +330,42 @@ describe('GiftRecurringCredits', () => {
     );
   });
 
+  it('shifts the schedule to the next period when the current one is skipped', async () => {
+    render(<GiftRecurringCredits />);
+
+    await userEvent.click(screen.getByLabelText(/Skip the current billing period/));
+
+    const preview = screen.getByTestId('schedule-preview');
+    // The first gifted period is the next one, not the current in-progress one.
+    expect(preview).toHaveTextContent('Next billing period');
+    expect(preview).toHaveTextContent('the first gifted period');
+    expect(preview).toHaveTextContent('The current billing period is skipped');
+    // Nothing is applied to the current period.
+    expect(preview).not.toHaveTextContent('This billing period');
+    expect(preview).not.toHaveTextContent('starts now, applied immediately');
+    // 3 periods, shifted out one month each: next, +2, +3.
+    expect(preview).toHaveTextContent('About 3 months from now');
+  });
+
+  it('sends skipCurrentPeriod when the box is checked', async () => {
+    const postMock = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/gift-recurring-credits/',
+      method: 'POST',
+      body: {results: []},
+    });
+
+    render(<GiftRecurringCredits />);
+    await fillRequiredFields();
+    await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+    await userEvent.click(screen.getByLabelText(/Skip the current billing period/));
+
+    await userEvent.click(screen.getByTestId('gift-submit'));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const formData = postMock.mock.calls[0][1].data as FormData;
+    expect(formData.get('skipCurrentPeriod')).toBe('true');
+  });
+
   it('lets the billing period field be cleared without inserting a leading zero', async () => {
     render(<GiftRecurringCredits />);
 

--- a/static/gsAdmin/views/giftRecurringCredits.spec.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.spec.tsx
@@ -86,6 +86,7 @@ describe('GiftRecurringCredits', () => {
 
   async function fillRequiredFields() {
     await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5000');
+    await userEvent.type(screen.getByLabelText('Notes:'), 'note');
   }
 
   it('submits the raw textarea tokens as multipart, without parsing them', async () => {
@@ -266,6 +267,7 @@ describe('GiftRecurringCredits', () => {
 
     expect(screen.getByText('Amount per billing period (GB):')).toBeInTheDocument();
     await userEvent.type(screen.getByLabelText(/Amount per billing period/), '5');
+    await userEvent.type(screen.getByLabelText('Notes:'), 'note');
     await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
 
     await userEvent.click(screen.getByTestId('gift-submit'));
@@ -532,6 +534,7 @@ describe('GiftRecurringCredits', () => {
   it('blocks submission of a fractional count amount', async () => {
     render(<GiftRecurringCredits />);
     await userEvent.type(screen.getByLabelText(/Target organizations/), 'acme');
+    await userEvent.type(screen.getByLabelText('Notes:'), 'note');
 
     const amountInput = screen.getByLabelText(/Amount per billing period/);
     await userEvent.type(amountInput, '5000.5');

--- a/static/gsAdmin/views/giftRecurringCredits.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.tsx
@@ -1,0 +1,681 @@
+import {useMemo, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {useMutation} from '@tanstack/react-query';
+import moment from 'moment-timezone';
+import Papa from 'papaparse';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Input} from '@sentry/scraps/input';
+import {Link} from '@sentry/scraps/link';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {Client} from 'sentry/api';
+import {DATA_CATEGORY_INFO} from 'sentry/constants';
+import {ConfigStore} from 'sentry/stores/configStore';
+import type {DataCategoryExact} from 'sentry/types/core';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {getCells} from 'sentry/utils/cells';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+import {useApi} from 'sentry/utils/useApi';
+
+import {PageHeader} from 'admin/components/pageHeader';
+
+// Categories that can carry recurring EVENT credits. Mirrors
+// CreditType.data_types() in getsentry/models/recurringcredit.py, keyed by the
+// category's name_singular from /billing-config/.
+const GIFTABLE_CATEGORIES = new Set([
+  'error',
+  'transaction',
+  'span',
+  'profile_duration',
+  'profile_duration_ui',
+  'attachment',
+  'replay',
+  'log_byte',
+  'seer_user',
+  'trace_metric_byte',
+]);
+
+const MAX_BILLING_PERIODS = 24;
+
+// Display-unit handling: admins enter GB for byte categories and hours for
+// continuous profiling; the backend takes raw storage units and applies no
+// multiplier of its own, so the conversion happens here, mirroring the
+// server-side gift flow's get_category_value_with_multiplier.
+function categoryFormatting(nameSingular: string) {
+  const info = DATA_CATEGORY_INFO[nameSingular as DataCategoryExact];
+  const unitType = info?.formatting.unitType ?? 'count';
+  return {
+    multiplier: info?.formatting.reservedMultiplier ?? 1,
+    unitLabel:
+      unitType === 'bytes' ? 'GB' : unitType === 'durationHours' ? 'hours' : 'count',
+    isCount: unitType === 'count',
+  };
+}
+
+// Renders a gift as "<amount>/mo ×<periods> (<start> → <end>)". The window
+// spans exactly `periods` monthly billing periods (end = start + N months).
+function formatGiftSummary(
+  displayAmount: number,
+  periodStart: string,
+  periodEnd: string,
+  isCount: boolean,
+  unitLabel: string
+) {
+  const periods = Math.round(moment(periodEnd).diff(moment(periodStart), 'months', true));
+  const amount = isCount
+    ? displayAmount.toLocaleString()
+    : `${displayAmount} ${unitLabel}`;
+  return `${amount}/mo ×${periods} (${moment(periodStart).format('ll')} → ${moment(
+    periodEnd
+  ).format('ll')})`;
+}
+
+interface CategoryInfo {
+  api_name: string;
+  billed_category: number | null;
+  display_name: string;
+  name: string;
+  name_singular: string;
+  order: number;
+}
+
+interface BillingConfig {
+  category_info: Record<string, CategoryInfo>;
+}
+
+interface ResultRow {
+  code: string | null;
+  creditId: number | null;
+  id: number | null;
+  periodEnd: string | null;
+  periodStart: string | null;
+  // The org's plan id (e.g. "am3_team"); null when no subscription resolved.
+  plan: string | null;
+  slug: string | null;
+  status: string;
+}
+
+function downloadResultsCsv(results: ResultRow[]) {
+  const csv = Papa.unparse(
+    results.map(row => ({
+      org_id: row.id ?? '',
+      org_slug: row.slug ?? '',
+      plan: row.plan ?? '',
+      status: row.status,
+      code: row.code ?? '',
+      period_start: row.periodStart ?? '',
+      period_end: row.periodEnd ?? '',
+      credit_id: row.creditId ?? '',
+    }))
+  );
+  const blob = new Blob([csv], {type: 'text/csv'});
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'gift-recurring-credits-results.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+export function GiftRecurringCredits() {
+  const [dataCategory, setDataCategory] = useState('replay');
+  const [amount, setAmount] = useState<number | null>(null);
+  const [billingPeriods, setBillingPeriods] = useState<number | null>(3);
+  const [orgTokens, setOrgTokens] = useState('');
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [results, setResults] = useState<ResultRow[] | null>(null);
+  // The region and per-period amount the last results were submitted with,
+  // captured at submit time so the callout and the "new gift" column stay
+  // accurate even if the form changes afterward.
+  const [resultsRegion, setResultsRegion] = useState<string | null>(null);
+  const [resultsAmount, setResultsAmount] = useState(0);
+  const [resultsCategory, setResultsCategory] = useState('replay');
+  const inputFileRef = useRef<HTMLInputElement>(null);
+  const cells = getCells();
+  const [cell, setCell] = useState(cells[0] ?? null);
+
+  // The default api client forces a JSON Content-Type, which can't carry a
+  // multipart upload. This bespoke client omits Content-Type so the browser
+  // sets the multipart boundary itself.
+  const api = useApi({
+    api: new Client({headers: {Accept: 'application/json; charset=utf-8'}}),
+  });
+
+  const userPermissions = ConfigStore.get('user')?.permissions;
+  const hasBillingAdmin = !!userPermissions?.has?.('billing.admin');
+
+  const {data: billingConfig} = useApiQuery<BillingConfig>(
+    [getApiUrl('/billing-config/')],
+    {staleTime: Infinity}
+  );
+
+  const categoryOptions = useMemo(() => {
+    if (!billingConfig) {
+      return [];
+    }
+    return Object.entries(billingConfig.category_info)
+      .filter(
+        ([key, info]) =>
+          info.billed_category !== null &&
+          Number(key) === info.billed_category &&
+          GIFTABLE_CATEGORIES.has(info.name_singular)
+      )
+      .sort(([, a], [, b]) => a.order - b.order)
+      .map(([, info]) => ({
+        label: info.display_name,
+        value: info.name_singular,
+      }));
+  }, [billingConfig]);
+
+  // Orgs the backend couldn't find in the region the request was sent to. They
+  // may live in another region; the operator can re-run them there.
+  const notInRegionOrgs = (results ?? []).filter(
+    row => row.status === 'error' && row.code === 'unknown-org'
+  );
+  const notInRegionLabel =
+    notInRegionOrgs
+      .slice(0, 20)
+      .map(row => row.slug ?? row.id)
+      .join(', ') +
+    (notInRegionOrgs.length > 20 ? `, and ${notInRegionOrgs.length - 20} more` : '');
+
+  const {multiplier, unitLabel, isCount} = categoryFormatting(dataCategory);
+
+  // Formatting for the results table uses the category the request was
+  // submitted with, not whatever the dropdown shows now.
+  const resultsFormatting = categoryFormatting(resultsCategory);
+
+  const selectedCategoryLabel =
+    categoryOptions.find(option => option.value === dataCategory)?.label ?? dataCategory;
+
+  const amountText =
+    amount === null
+      ? 'The gifted amount'
+      : isCount
+        ? `${amount.toLocaleString()} ${selectedCategoryLabel.toLowerCase()}`
+        : `${amount} ${unitLabel}`;
+
+  const schedule = useMemo(() => {
+    if (
+      billingPeriods === null ||
+      !Number.isInteger(billingPeriods) ||
+      billingPeriods < 1 ||
+      billingPeriods > MAX_BILLING_PERIODS
+    ) {
+      return null;
+    }
+    const row = (index: number) => {
+      return {
+        key: index,
+        when:
+          index === 0
+            ? 'This billing period'
+            : index === 1
+              ? 'Next billing period'
+              : `About ${index} months from now`,
+        detail:
+          index === 0
+            ? 'starts now, applied immediately'
+            : index === billingPeriods - 1
+              ? 'the last gifted period'
+              : '',
+      };
+    };
+    // Keep the list short for large gifts: show the first few periods and the
+    // last, with an honest count of what's collapsed in between.
+    if (billingPeriods <= 5) {
+      return {
+        rows: Array.from({length: billingPeriods}, (_, index) => row(index)),
+        hiddenCount: 0,
+        tailRow: null,
+      };
+    }
+    return {
+      rows: [row(0), row(1), row(2)],
+      hiddenCount: billingPeriods - 4,
+      tailRow: row(billingPeriods - 1),
+    };
+  }, [billingPeriods]);
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    if (!/\.csv$/i.test(file.name)) {
+      if (inputFileRef.current) {
+        inputFileRef.current.value = '';
+      }
+      // A rejected reselection must not leave an earlier valid file staged, or
+      // that stale file would be the one POSTed.
+      setCsvFile(null);
+      setCsvFileName(null);
+      addErrorMessage('Please upload a .csv file.');
+      return;
+    }
+    setCsvFile(file);
+    setCsvFileName(file.name);
+  };
+
+  const {mutate, isPending} = useMutation({
+    // Clear any prior results up front so a run that fails can't leave the
+    // previous run's table and warnings on screen next to the error toast.
+    onMutate: () => setResults(null),
+    mutationFn: async () => {
+      const region = cell?.name ?? null;
+      const submittedAmount = amount ?? 0;
+      const formData = new FormData();
+      if (csvFile) {
+        formData.append('file', csvFile);
+      }
+      if (orgTokens.trim()) {
+        formData.append('orgsTokens', orgTokens);
+      }
+      formData.append('dataCategory', dataCategory);
+      formData.append('amount', String(Math.round((amount ?? 0) * multiplier)));
+      formData.append('billingPeriods', String(billingPeriods));
+      const response: {results: ResultRow[]} = await api.requestPromise(
+        `/_admin/cells/${cell?.name}/gift-recurring-credits/`,
+        {
+          method: 'POST',
+          host: cell?.locality_url,
+          data: formData,
+        }
+      );
+      return {
+        ...response,
+        region,
+        submittedAmount,
+        category: dataCategory,
+      };
+    },
+    onSuccess: response => {
+      setResults(response.results);
+      setResultsRegion(response.region);
+      setResultsAmount(response.submittedAmount);
+      setResultsCategory(response.category);
+      const errors = response.results.filter(row => row.status === 'error').length;
+      if (errors > 0) {
+        addErrorMessage(
+          `Gifting finished: ${errors} of ${response.results.length} orgs failed.`
+        );
+      } else {
+        addSuccessMessage(`Gifted recurring credits to ${response.results.length} orgs.`);
+      }
+    },
+    onError: (error: unknown) => {
+      // Surface the backend's own message (e.g. the org-count cap, which the
+      // backend serializer is the single source of truth for) rather than a
+      // generic failure.
+      let detail: string | undefined;
+      if (error instanceof RequestError) {
+        const orgsError = error.responseJSON?.orgs;
+        if (Array.isArray(orgsError) && typeof orgsError[0] === 'string') {
+          detail = orgsError[0];
+        } else if (typeof error.responseJSON?.detail === 'string') {
+          detail = error.responseJSON.detail;
+        }
+      }
+      addErrorMessage(detail ?? 'Gift recurring credits request failed.');
+    },
+  });
+
+  const canSubmit =
+    hasBillingAdmin &&
+    !isPending &&
+    cell !== null &&
+    (csvFile !== null || orgTokens.trim().length > 0) &&
+    amount !== null &&
+    amount > 0 &&
+    // Count categories are whole units, and the POST rounds the amount; block a
+    // fractional count so the submitted value always matches what's previewed.
+    (!isCount || Number.isInteger(amount)) &&
+    Math.round(amount * multiplier) > 0 &&
+    billingPeriods !== null &&
+    Number.isInteger(billingPeriods) &&
+    billingPeriods >= 1 &&
+    billingPeriods <= MAX_BILLING_PERIODS;
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // Mirror the button's disabled state so a submit that slips past it (a
+    // rapid double-click before isPending re-renders) can't fire a second POST.
+    if (!canSubmit) {
+      return;
+    }
+    mutate();
+  };
+
+  return (
+    <div>
+      <PageHeader title="Gift Recurring Credits" />
+      {!hasBillingAdmin && <Warning>Requires billing admin permissions.</Warning>}
+      <Column onSubmit={handleSubmit}>
+        <p>
+          Gift free volume for a data category to one or more organizations. The
+          organization gets the volume right away and again at the start of each billing
+          period, for the number of periods you choose below. Only organizations on legacy
+          billing can be gifted this way.
+        </p>
+        <CompactSelect
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix="Region" />
+          )}
+          value={cell ? cell.locality_url : undefined}
+          options={cells.map(c => ({
+            label: c.name,
+            value: c.locality_url,
+          }))}
+          onChange={option => {
+            const cellOption = cells.find(c => c.locality_url === option.value);
+            if (cellOption !== undefined) {
+              setCell(cellOption);
+            }
+          }}
+        />
+        <CompactSelect
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix="Data Category" />
+          )}
+          value={dataCategory}
+          options={categoryOptions}
+          onChange={option => setDataCategory(option.value)}
+        />
+        <label htmlFor="amount">Amount per billing period ({unitLabel}):</label>
+        <NarrowInput
+          type="number"
+          id="amount"
+          name="amount"
+          min={isCount ? 1 : 0}
+          step={isCount ? 1 : 'any'}
+          value={amount === null ? '' : amount}
+          onChange={e => setAmount(e.target.value === '' ? null : Number(e.target.value))}
+          placeholder={isCount ? '5000' : '5'}
+        />
+        <label htmlFor="billingPeriods">How many monthly billing periods?</label>
+        <NarrowInput
+          type="number"
+          id="billingPeriods"
+          name="billingPeriods"
+          min={1}
+          max={MAX_BILLING_PERIODS}
+          step={1}
+          value={billingPeriods === null ? '' : billingPeriods}
+          onChange={e =>
+            setBillingPeriods(e.target.value === '' ? null : Number(e.target.value))
+          }
+        />
+        {schedule && (
+          <PreviewBox data-test-id="schedule-preview">
+            <PreviewSummary>
+              {amountText} every billing period, for {billingPeriods} monthly period
+              {billingPeriods === 1 ? '' : 's'}.
+            </PreviewSummary>
+            <PreviewNote>
+              The current billing period is already in progress — the organization gets
+              the full amount for it right away, then again when each of the periods below
+              begins.
+            </PreviewNote>
+            <PreviewList>
+              {schedule.rows.map(row => (
+                <li key={row.key}>
+                  <PreviewWhen>{row.when}</PreviewWhen>
+                  {row.detail ? <PreviewDetail> — {row.detail}</PreviewDetail> : null}
+                </li>
+              ))}
+              {schedule.hiddenCount > 0 && (
+                <PreviewEllipsis>
+                  …and {schedule.hiddenCount} more monthly period
+                  {schedule.hiddenCount === 1 ? '' : 's'}
+                </PreviewEllipsis>
+              )}
+              {schedule.tailRow && (
+                <li key={schedule.tailRow.key}>
+                  <PreviewWhen>{schedule.tailRow.when}</PreviewWhen>
+                  {schedule.tailRow.detail ? (
+                    <PreviewDetail> — {schedule.tailRow.detail}</PreviewDetail>
+                  ) : null}
+                </li>
+              )}
+            </PreviewList>
+            <PreviewNote>
+              Every billing period after these {billingPeriods} gets nothing — the gift is
+              not permanent.
+            </PreviewNote>
+            <PreviewNote data-test-id="no-rollover-note">
+              Unused credits don't roll over — each billing period gets the full amount
+              fresh, and whatever isn't used that period is lost.
+            </PreviewNote>
+          </PreviewBox>
+        )}
+        <label htmlFor="orgs">
+          Target organizations (ids and/or slugs, separated by commas or newlines —
+          numeric tokens are treated as org ids):
+        </label>
+        <OrgTextarea
+          id="orgs"
+          name="orgs"
+          rows={4}
+          value={orgTokens}
+          onChange={e => setOrgTokens(e.target.value)}
+          placeholder={'12345\nacme-corp'}
+        />
+        <UploadRow>
+          <UploadInput
+            name="csv"
+            type="file"
+            aria-label="csv-upload"
+            accept=".csv"
+            ref={inputFileRef}
+            onChange={handleFileChange}
+            hidden
+          />
+          <Button size="xs" onClick={() => inputFileRef.current?.click()}>
+            Upload CSV
+          </Button>
+          {csvFileName ? (
+            <span>
+              {csvFileName}{' '}
+              <Button
+                size="xs"
+                variant="link"
+                aria-label="clear-csv"
+                onClick={() => {
+                  setCsvFile(null);
+                  setCsvFileName(null);
+                  if (inputFileRef.current) {
+                    inputFileRef.current.value = '';
+                  }
+                }}
+              >
+                clear
+              </Button>
+            </span>
+          ) : (
+            <UploadHint>
+              CSV with an <code>org_id</code> and/or <code>org_slug</code> column (org id
+              wins when both are set).
+            </UploadHint>
+          )}
+        </UploadRow>
+        <Button
+          variant="primary"
+          type="submit"
+          disabled={!canSubmit}
+          data-test-id="gift-submit"
+        >
+          Gift Credits
+        </Button>
+      </Column>
+      {results && (
+        <ResultsSection data-test-id="results">
+          <h4>Results</h4>
+          {notInRegionOrgs.length > 0 && (
+            <Alert.Container>
+              <Alert
+                variant="warning"
+                showIcon={false}
+                data-test-id="not-in-region-warning"
+              >
+                {notInRegionOrgs.length} of {results.length} orgs were not found in the{' '}
+                {resultsRegion ?? 'selected'} region and were not processed:{' '}
+                {notInRegionLabel}. If they belong to a different region, re-run this tool
+                with that region selected.
+              </Alert>
+            </Alert.Container>
+          )}
+          <Button size="xs" onClick={() => downloadResultsCsv(results)}>
+            Download results CSV
+          </Button>
+          <ResultsTable>
+            <thead>
+              <tr>
+                <th>Org ID</th>
+                <th>Org Slug</th>
+                <th>Plan</th>
+                <th>Status</th>
+                <th>Code</th>
+                <th>New gift</th>
+                <th>Credit ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((row, index) => {
+                return (
+                  <tr key={index}>
+                    <td>{row.id ?? '—'}</td>
+                    <td>
+                      {row.slug ? (
+                        <Link to={`/_admin/customers/${row.slug}/`}>{row.slug}</Link>
+                      ) : (
+                        (row.id ?? '—')
+                      )}
+                    </td>
+                    <td>{row.plan ?? '—'}</td>
+                    <td>{row.status}</td>
+                    <td>{row.code ?? '—'}</td>
+                    <td>
+                      {row.status === 'error' || !row.periodStart || !row.periodEnd
+                        ? '—'
+                        : formatGiftSummary(
+                            resultsAmount,
+                            row.periodStart,
+                            row.periodEnd,
+                            resultsFormatting.isCount,
+                            resultsFormatting.unitLabel
+                          )}
+                    </td>
+                    <td>{row.creditId ?? '—'}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </ResultsTable>
+        </ResultsSection>
+      )}
+    </div>
+  );
+}
+
+const Column = styled('form')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.md};
+
+  > * {
+    margin: 0;
+  }
+  > button {
+    width: fit-content;
+  }
+`;
+
+const Warning = styled('p')`
+  color: ${p => p.theme.tokens.content.danger};
+  font-weight: bold;
+`;
+
+const NarrowInput = styled(Input)`
+  width: 200px;
+`;
+
+const PreviewBox = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+  padding: ${p => p.theme.space.lg};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: ${p => p.theme.tokens.background.secondary};
+`;
+
+const PreviewSummary = styled('div')`
+  font-weight: bold;
+`;
+
+const PreviewNote = styled('div')`
+  font-size: ${p => p.theme.font.size.sm};
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const PreviewList = styled('ol')`
+  margin: 0;
+  padding-left: ${p => p.theme.space.xl};
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xs};
+`;
+
+const PreviewWhen = styled('span')`
+  font-weight: bold;
+`;
+
+const PreviewDetail = styled('span')`
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const PreviewEllipsis = styled('li')`
+  list-style: none;
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const OrgTextarea = styled('textarea')`
+  font-family: ${p => p.theme.font.family.mono};
+  padding: ${p => p.theme.space.sm};
+`;
+
+const UploadInput = styled('input')`
+  position: absolute;
+  opacity: 0;
+`;
+
+const UploadRow = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+`;
+
+const UploadHint = styled('span')`
+  font-size: ${p => p.theme.font.size.sm};
+`;
+
+const ResultsSection = styled('div')`
+  margin-top: ${p => p.theme.space.xl};
+`;
+
+const ResultsTable = styled('table')`
+  width: 100%;
+  margin-top: ${p => p.theme.space.md};
+
+  th,
+  td {
+    padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+    text-align: left;
+  }
+`;

--- a/static/gsAdmin/views/giftRecurringCredits.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.tsx
@@ -139,6 +139,7 @@ export function GiftRecurringCredits() {
   const [orgTokens, setOrgTokens] = useState('');
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [ticketUrl, setTicketUrl] = useState('');
   const [notes, setNotes] = useState('');
   const [dryRun, setDryRun] = useState(true);
   const [skipCurrentPeriod, setSkipCurrentPeriod] = useState(false);
@@ -300,6 +301,7 @@ export function GiftRecurringCredits() {
       formData.append('amount', String(Math.round((amount ?? 0) * multiplier)));
       formData.append('billingPeriods', String(billingPeriods));
       formData.append('skipCurrentPeriod', String(skipCurrentPeriod));
+      formData.append('ticketUrl', ticketUrl);
       formData.append('notes', notes);
       formData.append('dryRun', String(dryRun));
       const response: {results: ResultRow[]} = await api.requestPromise(
@@ -544,6 +546,15 @@ export function GiftRecurringCredits() {
             </UploadHint>
           )}
         </UploadRow>
+        <label htmlFor="ticketUrl">Ticket URL (optional):</label>
+        <Input
+          type="url"
+          id="ticketUrl"
+          name="ticketUrl"
+          value={ticketUrl}
+          onChange={e => setTicketUrl(e.target.value)}
+          placeholder="https://linear.app/getsentry/issue/…"
+        />
         <label htmlFor="notes">Notes:</label>
         <OrgTextarea
           id="notes"

--- a/static/gsAdmin/views/giftRecurringCredits.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.tsx
@@ -88,9 +88,18 @@ interface BillingConfig {
   category_info: Record<string, CategoryInfo>;
 }
 
+interface ExistingGift {
+  // Raw (storage-unit) amount, as stored on the credit; converted for display.
+  amount: number;
+  periodEnd: string;
+  periodStart: string;
+}
+
 interface ResultRow {
   code: string | null;
   creditId: number | null;
+  // The gift this one would overwrite, or null when there's nothing to replace.
+  existingGift: ExistingGift | null;
   id: number | null;
   periodEnd: string | null;
   periodStart: string | null;
@@ -108,6 +117,7 @@ function downloadResultsCsv(results: ResultRow[]) {
       plan: row.plan ?? '',
       status: row.status,
       code: row.code ?? '',
+      existing_gift: row.existingGift ? 'yes' : 'no',
       period_start: row.periodStart ?? '',
       period_end: row.periodEnd ?? '',
       credit_id: row.creditId ?? '',
@@ -516,6 +526,20 @@ export function GiftRecurringCredits() {
       {results && (
         <ResultsSection data-test-id="results">
           <h4>Results</h4>
+          {results.some(row => row.existingGift) && (
+            <Alert.Container>
+              <Alert
+                variant="warning"
+                showIcon={false}
+                data-test-id="existing-gift-warning"
+              >
+                {results.filter(row => row.existingGift).length} of {results.length} orgs
+                already have an active recurring gift for this category. Gifting will
+                overwrite the existing gift's amount and schedule rather than add a second
+                one.
+              </Alert>
+            </Alert.Container>
+          )}
           {notInRegionOrgs.length > 0 && (
             <Alert.Container>
               <Alert
@@ -541,6 +565,7 @@ export function GiftRecurringCredits() {
                 <th>Plan</th>
                 <th>Status</th>
                 <th>Code</th>
+                <th>Current gift</th>
                 <th>New gift</th>
                 <th>Credit ID</th>
               </tr>
@@ -560,6 +585,17 @@ export function GiftRecurringCredits() {
                     <td>{row.plan ?? '—'}</td>
                     <td>{row.status}</td>
                     <td>{row.code ?? '—'}</td>
+                    <td>
+                      {row.existingGift
+                        ? formatGiftSummary(
+                            row.existingGift.amount / resultsFormatting.multiplier,
+                            row.existingGift.periodStart,
+                            row.existingGift.periodEnd,
+                            resultsFormatting.isCount,
+                            resultsFormatting.unitLabel
+                          )
+                        : '—'}
+                    </td>
                     <td>
                       {row.status === 'error' || !row.periodStart || !row.periodEnd
                         ? '—'

--- a/static/gsAdmin/views/giftRecurringCredits.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.tsx
@@ -139,6 +139,7 @@ export function GiftRecurringCredits() {
   const [orgTokens, setOrgTokens] = useState('');
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [dryRun, setDryRun] = useState(true);
   const [results, setResults] = useState<ResultRow[] | null>(null);
   // The region and per-period amount the last results were submitted with,
   // captured at submit time so the callout and the "new gift" column stay
@@ -280,6 +281,7 @@ export function GiftRecurringCredits() {
     mutationFn: async () => {
       const region = cell?.name ?? null;
       const submittedAmount = amount ?? 0;
+      const submittedDryRun = dryRun;
       const formData = new FormData();
       if (csvFile) {
         formData.append('file', csvFile);
@@ -290,6 +292,7 @@ export function GiftRecurringCredits() {
       formData.append('dataCategory', dataCategory);
       formData.append('amount', String(Math.round((amount ?? 0) * multiplier)));
       formData.append('billingPeriods', String(billingPeriods));
+      formData.append('dryRun', String(dryRun));
       const response: {results: ResultRow[]} = await api.requestPromise(
         `/_admin/cells/${cell?.name}/gift-recurring-credits/`,
         {
@@ -303,6 +306,7 @@ export function GiftRecurringCredits() {
         region,
         submittedAmount,
         category: dataCategory,
+        dryRun: submittedDryRun,
       };
     },
     onSuccess: response => {
@@ -313,10 +317,14 @@ export function GiftRecurringCredits() {
       const errors = response.results.filter(row => row.status === 'error').length;
       if (errors > 0) {
         addErrorMessage(
-          `Gifting finished: ${errors} of ${response.results.length} orgs failed.`
+          `${response.dryRun ? 'Dry run' : 'Gifting'} finished: ${errors} of ${response.results.length} orgs failed.`
         );
       } else {
-        addSuccessMessage(`Gifted recurring credits to ${response.results.length} orgs.`);
+        addSuccessMessage(
+          response.dryRun
+            ? `Dry run passed for ${response.results.length} orgs.`
+            : `Gifted recurring credits to ${response.results.length} orgs.`
+        );
       }
     },
     onError: (error: unknown) => {
@@ -514,13 +522,25 @@ export function GiftRecurringCredits() {
             </UploadHint>
           )}
         </UploadRow>
+        <CheckboxRow>
+          <input
+            type="checkbox"
+            id="dryRun"
+            name="dryRun"
+            checked={dryRun}
+            onChange={e => setDryRun(e.target.checked)}
+          />
+          <label htmlFor="dryRun">
+            Dry run (validate and preview per-org results without creating credits)
+          </label>
+        </CheckboxRow>
         <Button
           variant="primary"
           type="submit"
           disabled={!canSubmit}
           data-test-id="gift-submit"
         >
-          Gift Credits
+          {dryRun ? 'Run Dry Run' : 'Gift Credits'}
         </Button>
       </Column>
       {results && (
@@ -699,6 +719,12 @@ const UploadRow = styled('div')`
 
 const UploadHint = styled('span')`
   font-size: ${p => p.theme.font.size.sm};
+`;
+
+const CheckboxRow = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
 `;
 
 const ResultsSection = styled('div')`

--- a/static/gsAdmin/views/giftRecurringCredits.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.tsx
@@ -140,6 +140,7 @@ export function GiftRecurringCredits() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvFileName, setCsvFileName] = useState<string | null>(null);
   const [dryRun, setDryRun] = useState(true);
+  const [skipCurrentPeriod, setSkipCurrentPeriod] = useState(false);
   const [results, setResults] = useState<ResultRow[] | null>(null);
   // The region and per-period amount the last results were submitted with,
   // captured at submit time so the callout and the "new gift" column stay
@@ -221,18 +222,23 @@ export function GiftRecurringCredits() {
     ) {
       return null;
     }
+    // When the current period is skipped, every gifted period sits one month
+    // further out (the first gift is the next period, not this one).
     const row = (index: number) => {
+      const monthsOut = skipCurrentPeriod ? index + 1 : index;
       return {
         key: index,
         when:
-          index === 0
+          monthsOut === 0
             ? 'This billing period'
-            : index === 1
+            : monthsOut === 1
               ? 'Next billing period'
-              : `About ${index} months from now`,
+              : `About ${monthsOut} months from now`,
         detail:
           index === 0
-            ? 'starts now, applied immediately'
+            ? skipCurrentPeriod
+              ? 'the first gifted period'
+              : 'starts now, applied immediately'
             : index === billingPeriods - 1
               ? 'the last gifted period'
               : '',
@@ -252,7 +258,7 @@ export function GiftRecurringCredits() {
       hiddenCount: billingPeriods - 4,
       tailRow: row(billingPeriods - 1),
     };
-  }, [billingPeriods]);
+  }, [billingPeriods, skipCurrentPeriod]);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -292,6 +298,7 @@ export function GiftRecurringCredits() {
       formData.append('dataCategory', dataCategory);
       formData.append('amount', String(Math.round((amount ?? 0) * multiplier)));
       formData.append('billingPeriods', String(billingPeriods));
+      formData.append('skipCurrentPeriod', String(skipCurrentPeriod));
       formData.append('dryRun', String(dryRun));
       const response: {results: ResultRow[]} = await api.requestPromise(
         `/_admin/cells/${cell?.name}/gift-recurring-credits/`,
@@ -429,6 +436,18 @@ export function GiftRecurringCredits() {
             setBillingPeriods(e.target.value === '' ? null : Number(e.target.value))
           }
         />
+        <CheckboxRow>
+          <input
+            type="checkbox"
+            id="skipCurrentPeriod"
+            name="skipCurrentPeriod"
+            checked={skipCurrentPeriod}
+            onChange={e => setSkipCurrentPeriod(e.target.checked)}
+          />
+          <label htmlFor="skipCurrentPeriod">
+            Skip the current billing period (start at the next period instead of now)
+          </label>
+        </CheckboxRow>
         {schedule && (
           <PreviewBox data-test-id="schedule-preview">
             <PreviewSummary>
@@ -436,9 +455,9 @@ export function GiftRecurringCredits() {
               {billingPeriods === 1 ? '' : 's'}.
             </PreviewSummary>
             <PreviewNote>
-              The current billing period is already in progress — the organization gets
-              the full amount for it right away, then again when each of the periods below
-              begins.
+              {skipCurrentPeriod
+                ? 'The current billing period is skipped — the first grant lands when the next billing period begins, then again at the start of each period below.'
+                : 'The current billing period is already in progress — the organization gets the full amount for it right away, then again when each of the periods below begins.'}
             </PreviewNote>
             <PreviewList>
               {schedule.rows.map(row => (

--- a/static/gsAdmin/views/giftRecurringCredits.tsx
+++ b/static/gsAdmin/views/giftRecurringCredits.tsx
@@ -139,6 +139,7 @@ export function GiftRecurringCredits() {
   const [orgTokens, setOrgTokens] = useState('');
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [notes, setNotes] = useState('');
   const [dryRun, setDryRun] = useState(true);
   const [skipCurrentPeriod, setSkipCurrentPeriod] = useState(false);
   const [results, setResults] = useState<ResultRow[] | null>(null);
@@ -299,6 +300,7 @@ export function GiftRecurringCredits() {
       formData.append('amount', String(Math.round((amount ?? 0) * multiplier)));
       formData.append('billingPeriods', String(billingPeriods));
       formData.append('skipCurrentPeriod', String(skipCurrentPeriod));
+      formData.append('notes', notes);
       formData.append('dryRun', String(dryRun));
       const response: {results: ResultRow[]} = await api.requestPromise(
         `/_admin/cells/${cell?.name}/gift-recurring-credits/`,
@@ -365,7 +367,8 @@ export function GiftRecurringCredits() {
     billingPeriods !== null &&
     Number.isInteger(billingPeriods) &&
     billingPeriods >= 1 &&
-    billingPeriods <= MAX_BILLING_PERIODS;
+    billingPeriods <= MAX_BILLING_PERIODS &&
+    notes.trim().length > 0;
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -541,6 +544,15 @@ export function GiftRecurringCredits() {
             </UploadHint>
           )}
         </UploadRow>
+        <label htmlFor="notes">Notes:</label>
+        <OrgTextarea
+          id="notes"
+          name="notes"
+          rows={2}
+          value={notes}
+          onChange={e => setNotes(e.target.value)}
+          placeholder="Why these orgs are being gifted"
+        />
         <CheckboxRow>
           <input
             type="checkbox"

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -157,6 +157,9 @@ export function Layout() {
                 <NavLink to="/_admin/billing-plans/">Billing Plans</NavLink>
                 <NavLink to="/_admin/invoices/">Invoices</NavLink>
                 <NavLink to="/_admin/billing-platform/">Billing Platform</NavLink>
+                <NavLink to="/_admin/gift-recurring-credits/">
+                  Gift Recurring Credits
+                </NavLink>
                 <NavLink to="/_admin/spike-projection-generation/">
                   Spike Projection Generation
                 </NavLink>

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -384,6 +384,8 @@ export type Subscription = {
    */
   companyName?: string | null;
   countryCode?: string | null;
+  // Gifted recurring credits (active + upcoming), staff-only (gsAdmin).
+  giftCredits?: RecurringCredit[];
 
   // Refetch usage data if Subscription is updated
   isDeleted?: boolean;


### PR DESCRIPTION
Stacked on #119435 (base branch: `aleal/feat/admin-gift-recurring-credits-ui`).

Frontend counterpart to the getsentry gift-recurring-credit extras branch, one commit per feature. Review the base PR (#119435) first; the diff here is only what sits on top of it.

### Features
- **Dry-run preview mode** — a checkbox (default on) that toggles dry run; the submit button reflects the mode (**Run Dry Run** vs **Gift Credits**) and the success toast reports the mode the request was actually sent with.
- **Skip the current billing period** — a checkbox to start the gift at the next period; the schedule preview shifts each period out one month.
- **Required reason note** — a required Notes field submitted with the gift.
- **Optional ticket URL** — an optional Ticket URL field (Linear placeholder).
- **Customer-page gift display** — a "Recurring Credit Gifts" section on the gsAdmin customer detail page listing active/upcoming gifts (consumes the backend `giftCredits` field).

The per-gift value cap is enforced server-side only, so it has no UI here. More UI features may be peeled in over time.
