### PR TITLE
fix(integrations): Show admin tooltip on disabled Update Now button

### DIFF
--- a/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
@@ -100,9 +100,7 @@ describe('InstalledIntegration', () => {
 
     await userEvent.hover(updateButton);
     expect(
-      screen.queryByText(
-        'You must be an organization owner, manager or admin to update'
-      )
+      screen.queryByText('You must be an organization owner, manager or admin to update')
     ).not.toBeInTheDocument();
   });
 

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
@@ -1,9 +1,12 @@
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {ConfigStore} from 'sentry/stores/configStore';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {InstalledIntegration} from 'sentry/views/settings/organizationIntegrations/installedIntegration';
 
 describe('InstalledIntegration', () => {
@@ -77,5 +80,48 @@ describe('InstalledIntegration', () => {
         'You must be an organization owner, manager or admin to update'
       )
     ).toBeInTheDocument();
+  });
+
+  it('does not show the admin tooltip when Update Now is disabled for status', async () => {
+    render(
+      <InstalledIntegration
+        {...defaultProps}
+        integration={
+          OrganizationIntegrationsFixture({
+            organizationIntegrationStatus: 'disabled',
+          }) as any
+        }
+        requiresUpgrade
+      />
+    );
+
+    const updateButton = screen.getByRole('button', {name: 'Update Now'});
+    expect(updateButton).toBeDisabled();
+
+    await userEvent.hover(updateButton);
+    expect(
+      screen.queryByText(
+        'You must be an organization owner, manager or admin to update'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('allows superusers to update without the admin tooltip', () => {
+    const superuserOrg = OrganizationFixture({
+      access: ['org:read', 'org:superuser'],
+    });
+    OrganizationStore.onUpdate(superuserOrg, {replace: true});
+    ConfigStore.set('user', UserFixture({isSuperuser: true}));
+
+    render(
+      <InstalledIntegration
+        {...defaultProps}
+        organization={superuserOrg}
+        requiresUpgrade
+      />,
+      {organization: superuserOrg}
+    );
+
+    expect(screen.getByRole('button', {name: 'Update Now'})).toBeEnabled();
   });
 });

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.spec.tsx
@@ -2,7 +2,7 @@ import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegration
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {InstalledIntegration} from 'sentry/views/settings/organizationIntegrations/installedIntegration';
 
@@ -54,5 +54,28 @@ describe('InstalledIntegration', () => {
     render(<InstalledIntegration {...defaultProps} provider={provider} />);
 
     expect(screen.getByRole('button', {name: 'Uninstall'})).toBeInTheDocument();
+  });
+
+  it('shows an admin tooltip on the disabled Update Now button', async () => {
+    const lowerAccessOrg = OrganizationFixture({access: ['org:read']});
+
+    render(
+      <InstalledIntegration
+        {...defaultProps}
+        organization={lowerAccessOrg}
+        requiresUpgrade
+      />,
+      {organization: lowerAccessOrg}
+    );
+
+    const updateButton = screen.getByRole('button', {name: 'Update Now'});
+    expect(updateButton).toBeDisabled();
+
+    await userEvent.hover(updateButton);
+    expect(
+      await screen.findByText(
+        'You must be an organization owner, manager or admin to update'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -155,42 +155,51 @@ export class InstalledIntegration extends Component<Props> {
                 />
               </IntegrationItemBox>
               <div>
-                <Tooltip
-                  disabled={allowMemberConfiguration || hasAccess || superuser}
-                  position="left"
-                  title={t(
-                    'You must be an organization owner, manager or admin to configure'
-                  )}
-                >
-                  {requiresUpgrade && provider.key === 'github' && (
-                    <Button
-                      data-test-id="integration-upgrade-button"
-                      disabled={disableAction}
-                      icon={<IconWarning />}
-                      onClick={this.handleUpdatePermissionsClick}
-                      variant="primary"
-                      size="sm"
-                    >
-                      {t('Update Now')}
-                    </Button>
-                  )}
-                  {requiresUpgrade && provider.key !== 'github' && (
-                    <AddIntegrationButton
-                      analyticsParams={{
-                        view: 'integrations_directory_integration_detail',
-                        already_installed: true,
-                      }}
-                      buttonText={t('Update %s', provider.name)}
-                      data-test-id="integration-upgrade-button"
-                      disabled={disableAction}
-                      onAddIntegration={() => {}}
-                      organization={organization}
-                      provider={provider}
-                      variant="primary"
-                      size="sm"
-                    />
-                  )}
-                  {!provider.metadata.aspects?.directEnable && (
+                {requiresUpgrade && (
+                  <Tooltip
+                    disabled={!disableAction}
+                    position="left"
+                    title={t(
+                      'You must be an organization owner, manager or admin to update'
+                    )}
+                  >
+                    {provider.key === 'github' ? (
+                      <Button
+                        data-test-id="integration-upgrade-button"
+                        disabled={disableAction}
+                        icon={<IconWarning />}
+                        onClick={this.handleUpdatePermissionsClick}
+                        variant="primary"
+                        size="sm"
+                      >
+                        {t('Update Now')}
+                      </Button>
+                    ) : (
+                      <AddIntegrationButton
+                        analyticsParams={{
+                          view: 'integrations_directory_integration_detail',
+                          already_installed: true,
+                        }}
+                        buttonText={t('Update %s', provider.name)}
+                        data-test-id="integration-upgrade-button"
+                        disabled={disableAction}
+                        onAddIntegration={() => {}}
+                        organization={organization}
+                        provider={provider}
+                        variant="primary"
+                        size="sm"
+                      />
+                    )}
+                  </Tooltip>
+                )}
+                {!provider.metadata.aspects?.directEnable && (
+                  <Tooltip
+                    disabled={allowMemberConfiguration || hasAccess || superuser}
+                    position="left"
+                    title={t(
+                      'You must be an organization owner, manager or admin to configure'
+                    )}
+                  >
                     <StyledLinkButton
                       variant="transparent"
                       icon={<IconSettings />}
@@ -200,8 +209,8 @@ export class InstalledIntegration extends Component<Props> {
                     >
                       {t('Configure')}
                     </StyledLinkButton>
-                  )}
-                </Tooltip>
+                  </Tooltip>
+                )}
               </div>
               <div>
                 <Tooltip

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -142,9 +142,9 @@ export class InstalledIntegration extends Component<Props> {
       <Access access={['org:integrations']}>
         {({hasAccess}) => {
           const superuser = isActiveSuperuser();
-          const canConfigure =
-            (hasAccess || superuser) && this.integrationStatus === 'active';
-          const disableAction = !(hasAccess && this.integrationStatus === 'active');
+          const canUpdate = hasAccess || superuser;
+          const canConfigure = canUpdate && this.integrationStatus === 'active';
+          const disableAction = !canConfigure;
           const isPendingDeletion = this.integrationStatus === 'pending_deletion';
           return (
             <Fragment>
@@ -157,7 +157,7 @@ export class InstalledIntegration extends Component<Props> {
               <div>
                 {requiresUpgrade && (
                   <Tooltip
-                    disabled={!disableAction}
+                    disabled={canUpdate}
                     position="left"
                     title={t(
                       'You must be an organization owner, manager or admin to update'


### PR DESCRIPTION
The integration row **Update Now** button previously shared Configure's tooltip (`…to configure`), and for GitHub/GitLab that tooltip was disabled for members who can configure. So a disabled Update Now button showed no explanation.

Give Update Now its own tooltip with the same copy as the details-page banner: *"You must be an organization owner, manager or admin to update"*.

<img width="373" height="125" alt="image" src="https://github.com/user-attachments/assets/638a9f3a-14a9-4dcf-b968-b30f6e594f4b" />
