### PR TITLE
feat(issue-progress): Add frontend rendering for new PR lifecycle activities

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -801,21 +801,21 @@ export interface GroupActivityPullRequestClosed extends GroupActivityBase {
   type: GroupActivityType.PULL_REQUEST_CLOSED;
 }
 
-export interface GroupActivityPullRequestReopened extends GroupActivityBase {
+interface GroupActivityPullRequestReopened extends GroupActivityBase {
   data: {
     pullRequest?: PullRequest | null;
   };
   type: GroupActivityType.PULL_REQUEST_REOPENED;
 }
 
-export interface GroupActivityPullRequestMerged extends GroupActivityBase {
+interface GroupActivityPullRequestMerged extends GroupActivityBase {
   data: {
     pullRequest?: PullRequest | null;
   };
   type: GroupActivityType.PULL_REQUEST_MERGED;
 }
 
-export interface GroupActivityPullRequestUnlinked extends GroupActivityBase {
+interface GroupActivityPullRequestUnlinked extends GroupActivityBase {
   data: {
     pullRequest?: PullRequest | null;
   };

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -610,6 +610,9 @@ export enum GroupActivityType {
   SEER_ITERATION_STARTED = 'seer_iteration_started',
   SEER_ITERATION_COMPLETED = 'seer_iteration_completed',
   PULL_REQUEST_CLOSED = 'pull_request_closed',
+  PULL_REQUEST_REOPENED = 'pull_request_reopened',
+  PULL_REQUEST_MERGED = 'pull_request_merged',
+  PULL_REQUEST_UNLINKED = 'pull_request_unlinked',
 }
 
 export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
@@ -796,6 +799,27 @@ export interface GroupActivityPullRequestClosed extends GroupActivityBase {
     pullRequest?: PullRequest | null;
   };
   type: GroupActivityType.PULL_REQUEST_CLOSED;
+}
+
+export interface GroupActivityPullRequestReopened extends GroupActivityBase {
+  data: {
+    pullRequest?: PullRequest | null;
+  };
+  type: GroupActivityType.PULL_REQUEST_REOPENED;
+}
+
+export interface GroupActivityPullRequestMerged extends GroupActivityBase {
+  data: {
+    pullRequest?: PullRequest | null;
+  };
+  type: GroupActivityType.PULL_REQUEST_MERGED;
+}
+
+export interface GroupActivityPullRequestUnlinked extends GroupActivityBase {
+  data: {
+    pullRequest?: PullRequest | null;
+  };
+  type: GroupActivityType.PULL_REQUEST_UNLINKED;
 }
 
 export interface GroupActivitySetIgnored extends GroupActivityBase {
@@ -1039,7 +1063,10 @@ export type GroupActivity =
   | GroupActivitySeerPrCreated
   | GroupActivitySeerIterationStarted
   | GroupActivitySeerIterationCompleted
-  | GroupActivityPullRequestClosed;
+  | GroupActivityPullRequestClosed
+  | GroupActivityPullRequestReopened
+  | GroupActivityPullRequestMerged
+  | GroupActivityPullRequestUnlinked;
 
 export type Activity = GroupActivity;
 

--- a/static/app/views/issueDetails/activitySection/activityColorConfig.tsx
+++ b/static/app/views/issueDetails/activitySection/activityColorConfig.tsx
@@ -15,6 +15,8 @@ export function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
     case GroupActivityType.SET_RESOLVED_IN_RELEASE:
     case GroupActivityType.SET_RESOLVED_IN_COMMIT:
     case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST:
+    case GroupActivityType.PULL_REQUEST_REOPENED:
+    case GroupActivityType.PULL_REQUEST_MERGED:
     case GroupActivityType.MARK_REVIEWED:
     case GroupActivityType.SEER_RCA_COMPLETED:
     case GroupActivityType.SEER_SOLUTION_COMPLETED:
@@ -29,6 +31,7 @@ export function getActivityColorConfig(theme: Theme, type: GroupActivityType) {
     case GroupActivityType.SET_UNRESOLVED:
     case GroupActivityType.SET_REGRESSION:
     case GroupActivityType.PULL_REQUEST_CLOSED:
+    case GroupActivityType.PULL_REQUEST_UNLINKED:
       return {
         ...defaultConfig,
         icon: theme.tokens.graphics.danger.vibrant,

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -193,6 +193,7 @@ export function getCompactGroupActivityItem({
   issueCategory,
 }: GetCompactGroupActivityItemParams): CompactGroupActivityItem {
   const issuesLink = `/organizations/${organization.slug}/issues/`;
+  const activityContext = {id: activity.id, type: activity.type};
 
   switch (activity.type) {
     case GroupActivityType.NOTE:
@@ -557,8 +558,8 @@ export function getCompactGroupActivityItem({
     }
   }
 
-  Sentry.captureMessage('Unknown group activity type', {
-    contexts: {activity},
+  Sentry.captureMessage(`Unknown group activity type: ${activityContext.type}`, {
+    contexts: {activity: activityContext},
   });
 
   return {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {Link} from '@sentry/scraps/link';
 
@@ -278,6 +279,51 @@ export function getCompactGroupActivityItem({
           : null,
       };
     }
+    case GroupActivityType.PULL_REQUEST_REOPENED: {
+      const pullRequest = activity.data.pullRequest;
+      return {
+        title: pullRequest
+          ? tct('Pull request [pullRequest] reopened', {
+              pullRequest: <PullRequestChip pullRequest={pullRequest} />,
+            })
+          : t('Pull request reopened'),
+        details: pullRequest
+          ? tct('on [provider]', {
+              provider: getPullRequestProvider(pullRequest),
+            })
+          : null,
+      };
+    }
+    case GroupActivityType.PULL_REQUEST_MERGED: {
+      const pullRequest = activity.data.pullRequest;
+      return {
+        title: pullRequest
+          ? tct('Pull request [pullRequest] merged', {
+              pullRequest: <PullRequestChip pullRequest={pullRequest} />,
+            })
+          : t('Pull request merged'),
+        details: pullRequest
+          ? tct('on [provider]', {
+              provider: getPullRequestProvider(pullRequest),
+            })
+          : null,
+      };
+    }
+    case GroupActivityType.PULL_REQUEST_UNLINKED: {
+      const pullRequest = activity.data.pullRequest;
+      return {
+        title: pullRequest
+          ? tct('Pull request [pullRequest] unlinked', {
+              pullRequest: <PullRequestChip pullRequest={pullRequest} />,
+            })
+          : t('Pull request unlinked'),
+        details: pullRequest
+          ? tct('on [provider]', {
+              provider: getPullRequestProvider(pullRequest),
+            })
+          : null,
+      };
+    }
     case GroupActivityType.SET_UNRESOLVED: {
       if ('forecast' in activity.data && activity.data.forecast) {
         return {
@@ -510,6 +556,10 @@ export function getCompactGroupActivityItem({
       };
     }
   }
+
+  Sentry.captureMessage('Unknown group activity type', {
+    contexts: {activity},
+  });
 
   return {
     title: t('Activity'),

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/variant.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/variant.ts
@@ -8,6 +8,7 @@ export type ActivityMarkerState = ProgressState | 'activity';
 export function getActivityMarkerState(item: GroupActivity): ActivityMarkerState {
   switch (item.type) {
     case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST:
+    case GroupActivityType.PULL_REQUEST_REOPENED:
     case GroupActivityType.REFERENCED_IN_COMMIT:
     case GroupActivityType.SEER_PR_CREATED:
       return ProgressState.FIX_PROPOSED;
@@ -16,6 +17,7 @@ export function getActivityMarkerState(item: GroupActivity): ActivityMarkerState
     case GroupActivityType.SET_RESOLVED_IN_RELEASE:
     case GroupActivityType.SET_RESOLVED_IN_COMMIT:
     case GroupActivityType.MARK_REVIEWED:
+    case GroupActivityType.PULL_REQUEST_MERGED:
       return ProgressState.FIX_APPLIED;
     case GroupActivityType.SET_ESCALATING:
     case GroupActivityType.SEER_RCA_COMPLETED:

--- a/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
@@ -19,11 +19,14 @@ import {
   IconGlobe,
   IconGraph,
   IconJira,
+  IconLinkBroken,
   IconLock,
+  IconMerge,
   IconMute,
   IconNext,
   IconPlay,
   IconPrevious,
+  IconPullRequest,
   IconPullRequestClosed,
   IconRefresh,
   IconSeer,
@@ -85,6 +88,18 @@ export const groupActivityTypeIconMapping: Record<
   },
   [GroupActivityType.PULL_REQUEST_CLOSED]: {
     Component: IconPullRequestClosed,
+    defaultProps: {},
+  },
+  [GroupActivityType.PULL_REQUEST_REOPENED]: {
+    Component: IconPullRequest,
+    defaultProps: {},
+  },
+  [GroupActivityType.PULL_REQUEST_MERGED]: {
+    Component: IconMerge,
+    defaultProps: {},
+  },
+  [GroupActivityType.PULL_REQUEST_UNLINKED]: {
+    Component: IconLinkBroken,
     defaultProps: {},
   },
   [GroupActivityType.SET_UNRESOLVED]: {Component: IconClose, defaultProps: {}},

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -60,6 +60,7 @@ export function getGroupActivityItem(
   teams: Team[]
 ) {
   const author = <strong>{getAuthorName(activity)}</strong>;
+  const activityContext = {id: activity.id, type: activity.type};
   const issuesLink = `/organizations/${organization.slug}/issues/`;
   const isFeedback = issueCategory === IssueCategoryEnum.FEEDBACK;
 
@@ -879,8 +880,8 @@ export function getGroupActivityItem(
         };
       }
       default:
-        Sentry.captureMessage('Unknown group activity type', {
-          contexts: {activity},
+        Sentry.captureMessage(`Unknown group activity type: ${activityContext.type}`, {
+          contexts: {activity: activityContext},
         });
         return {title: '', message: ''}; // should never hit (?)
     }

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import moment from 'moment-timezone';
 
 import {ExternalLink, Link} from '@sentry/scraps/link';
@@ -39,7 +40,10 @@ function getAuthorName(item: GroupActivity) {
   }
   if (
     (item.type === GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST ||
-      item.type === GroupActivityType.PULL_REQUEST_CLOSED) &&
+      item.type === GroupActivityType.PULL_REQUEST_CLOSED ||
+      item.type === GroupActivityType.PULL_REQUEST_REOPENED ||
+      item.type === GroupActivityType.PULL_REQUEST_MERGED ||
+      item.type === GroupActivityType.PULL_REQUEST_UNLINKED) &&
     item.data.pullRequest?.author?.name &&
     !item.data.pullRequest.author.email?.endsWith('@localhost')
   ) {
@@ -507,6 +511,48 @@ export function getGroupActivityItem(
           ),
         };
       }
+      case GroupActivityType.PULL_REQUEST_REOPENED: {
+        const {pullRequest} = activity.data;
+        return {
+          title: t('Pull Request Reopened'),
+          message: pullRequest ? (
+            <PullRequestLink
+              pullRequest={pullRequest}
+              repository={pullRequest.repository}
+            />
+          ) : (
+            t('PR not available')
+          ),
+        };
+      }
+      case GroupActivityType.PULL_REQUEST_MERGED: {
+        const {pullRequest} = activity.data;
+        return {
+          title: t('Pull Request Merged'),
+          message: pullRequest ? (
+            <PullRequestLink
+              pullRequest={pullRequest}
+              repository={pullRequest.repository}
+            />
+          ) : (
+            t('PR not available')
+          ),
+        };
+      }
+      case GroupActivityType.PULL_REQUEST_UNLINKED: {
+        const {pullRequest} = activity.data;
+        return {
+          title: t('Pull Request Unlinked'),
+          message: pullRequest ? (
+            <PullRequestLink
+              pullRequest={pullRequest}
+              repository={pullRequest.repository}
+            />
+          ) : (
+            t('PR not available')
+          ),
+        };
+      }
       case GroupActivityType.SET_UNRESOLVED: {
         // TODO(nisanthan): Remove after migrating records to SET_ESCALATING
         const {data} = activity;
@@ -833,6 +879,9 @@ export function getGroupActivityItem(
         };
       }
       default:
+        Sentry.captureMessage('Unknown group activity type', {
+          contexts: {activity},
+        });
         return {title: '', message: ''}; // should never hit (?)
     }
   }

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1750,21 +1750,52 @@ describe('ActivitySection', () => {
     expect(screen.queryByText('sentry[bot]')).not.toBeInTheDocument();
   });
 
-  it('does not attribute a PR closure to the pull request author', async () => {
-    const pullRequest = PullRequestFixture({
-      id: '1234',
-      author: {name: 'Shashank N Jarmale', email: 'shash@sentry.io'},
-    });
+  it.each([
+    [GroupActivityType.PULL_REQUEST_CLOSED, 'Pull Request Closed'],
+    [GroupActivityType.PULL_REQUEST_REOPENED, 'Pull Request Reopened'],
+    [GroupActivityType.PULL_REQUEST_MERGED, 'Pull Request Merged'],
+    [GroupActivityType.PULL_REQUEST_UNLINKED, 'Pull Request Unlinked'],
+  ] as const)('renders %s in the legacy activity UI', async (type, title) => {
+    const pullRequest = PullRequestFixture();
     const prGroup = GroupFixture({
-      id: '1348',
       activity: [
         {
-          type: GroupActivityType.PULL_REQUEST_CLOSED,
-          id: 'pr-author-4',
+          type,
+          id: `pr-${type}`,
           dateCreated: '2020-01-01T00:00:00',
-          data: {
-            pullRequest,
-          },
+          data: {pullRequest},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={prGroup} project={prGroup.project}>
+        <ActivitySection group={prGroup} />
+      </GroupDataContextProvider>
+    );
+
+    expect(await screen.findByText(title)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'example/repo-name #3: Fix first issue'})
+    ).toHaveAttribute('href', pullRequest.externalUrl);
+  });
+
+  it.each([
+    [GroupActivityType.PULL_REQUEST_CLOSED, 'closed'],
+    [GroupActivityType.PULL_REQUEST_REOPENED, 'reopened'],
+    [GroupActivityType.PULL_REQUEST_MERGED, 'merged'],
+    [GroupActivityType.PULL_REQUEST_UNLINKED, 'unlinked'],
+  ] as const)('renders %s in the new activity UI', async (type, action) => {
+    const pullRequest = PullRequestFixture();
+    const prGroup = GroupFixture({
+      activity: [
+        {
+          type,
+          id: `pr-${type}`,
+          dateCreated: '2020-01-01T00:00:00',
+          data: {pullRequest},
           user: null,
         },
       ],
@@ -1781,8 +1812,11 @@ describe('ActivitySection', () => {
     );
 
     expect(await screen.findByTestId('activity-timeline')).toHaveTextContent(
-      'Pull request #1234 closed on GitHub'
+      `Pull request #3 ${action} on GitHub`
     );
-    expect(screen.queryByText('Shashank N Jarmale')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '#3'})).toHaveAttribute(
+      'href',
+      pullRequest.externalUrl
+    );
   });
 });


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/119523

Also adds a `Sentry.captureMessage` when the frontend code hits an unknown type

<img width="514" height="211" alt="CleanShot 2026-07-14 at 11 56 24" src="https://github.com/user-attachments/assets/ebd0fa3d-4bc6-432f-a6e8-df8fc2970f8e" />
