### PR TITLE
feat: refresh logs empty-state copy / include prompt

### DIFF
--- a/static/app/gettingStartedDocs/apple-ios/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/logs.tsx
@@ -97,7 +97,9 @@ SentrySDK.start { options in
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/apple-macos/logs.tsx
+++ b/static/app/gettingStartedDocs/apple-macos/logs.tsx
@@ -97,7 +97,9 @@ SentrySDK.start { options in
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/dotnet/logs.tsx
+++ b/static/app/gettingStartedDocs/dotnet/logs.tsx
@@ -18,7 +18,9 @@ export const logsVerify = (params: DocsParams): ContentBlock => ({
   content: [
     {
       type: 'text',
-      text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+      text: t(
+        'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+      ),
     },
     {
       type: 'code',

--- a/static/app/gettingStartedDocs/go/logs.tsx
+++ b/static/app/gettingStartedDocs/go/logs.tsx
@@ -92,7 +92,9 @@ func main() {
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/java-spring/logs.tsx
+++ b/static/app/gettingStartedDocs/java-spring/logs.tsx
@@ -71,7 +71,9 @@ Sentry.init { options ->
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/java/logs.tsx
+++ b/static/app/gettingStartedDocs/java/logs.tsx
@@ -71,7 +71,9 @@ Sentry.init { options ->
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/javascript/logs.tsx
+++ b/static/app/gettingStartedDocs/javascript/logs.tsx
@@ -96,7 +96,9 @@ Sentry.init({
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',
@@ -104,6 +106,28 @@ Sentry.init({
           code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          text:
+            docsPlatform === 'nextjs'
+              ? tct(
+                  'Already using console.log, Pino, Winston, or Consola? See our [link:integrations].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/logs/#integrations" />
+                    ),
+                  }
+                )
+              : tct(
+                  'Already using console.log? Capture console calls as Sentry Logs with the [link:consoleLoggingIntegration].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/logs/#console-integration" />
+                    ),
+                  }
+                ),
         },
       ],
     },
@@ -221,7 +245,7 @@ Sentry.init({
         {
           type: 'text',
           text: t(
-            'To confirm that logs are working correctly, run your application and check the Sentry logs page for the collected logs.'
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
           ),
         },
         {
@@ -230,6 +254,28 @@ Sentry.init({
           code: `import * as Sentry from "${packageName}";
 
 Sentry.logger.info('User triggered test log', { log_source: 'sentry_test' })`,
+        },
+        {
+          type: 'alert',
+          alertType: 'info',
+          text:
+            docsPlatform === 'nextjs'
+              ? tct(
+                  'Already using console.log, Pino, Winston, or Consola? See our [link:integrations].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/logs/#integrations" />
+                    ),
+                  }
+                )
+              : tct(
+                  'Already using console.log? Capture console calls as Sentry Logs with the [link:consoleLoggingIntegration].',
+                  {
+                    link: (
+                      <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/node/logs/#console-integration" />
+                    ),
+                  }
+                ),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -562,7 +562,7 @@ export const getNodeLogsOnboarding = <
           {
             type: 'text',
             text: t(
-              'Send a test log from your app to verify logs are arriving in Sentry.'
+              'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
             ),
           },
           {

--- a/static/app/gettingStartedDocs/react-native/logs.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/logs.spec.tsx
@@ -20,6 +20,12 @@ function renderMockRequests({
     method: 'GET',
     body: [ProjectKeysFixture()[0]],
   });
+  // Polled by useEventWaiter to detect the project's first log.
+  MockApiClient.addMockResponse({
+    url: `/projects/${organization.slug}/${project.slug}/`,
+    method: 'GET',
+    body: project,
+  });
   MockApiClient.addMockResponse({
     url: `/customers/${organization.slug}/`,
     method: 'GET',

--- a/static/app/gettingStartedDocs/react-native/logs.tsx
+++ b/static/app/gettingStartedDocs/react-native/logs.tsx
@@ -59,7 +59,9 @@ Sentry.init({
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/rust/logs.tsx
+++ b/static/app/gettingStartedDocs/rust/logs.tsx
@@ -89,7 +89,9 @@ export const logs: OnboardingConfig = {
       content: [
         {
           type: 'text',
-          text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
         },
         {
           type: 'code',

--- a/static/app/gettingStartedDocs/unreal/logs.tsx
+++ b/static/app/gettingStartedDocs/unreal/logs.tsx
@@ -14,7 +14,9 @@ export const logsVerify = (params: DocsParams): ContentBlock => ({
   content: [
     {
       type: 'text',
-      text: t('Send a test log from your app to verify logs are arriving in Sentry.'),
+      text: t(
+        'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+      ),
     },
     {
       type: 'code',

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -66,6 +66,11 @@ export type LogsAnalyticsEventParameters = {
     platform: PlatformKey | 'unknown';
     supports_onboarding_checklist: boolean;
   };
+  'logs.onboarding_ai_prompt_copied': {
+    organization: Organization;
+    platform: PlatformKey | 'unknown';
+    source: 'copy_button' | 'code_snippet';
+  };
   'logs.onboarding_platform_docs_viewed': {
     organization: Organization;
     platform: PlatformKey | 'unknown';
@@ -120,6 +125,8 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
   'logs.explorer.setup_button_clicked': 'Logs Setup Button Clicked',
   'logs.explorer.table_tab_changed': 'Logs Explorer: Table Tab Changed',
   'logs.onboarding': 'Logs Explore Empty State (Onboarding)',
+  'logs.onboarding_ai_prompt_copied':
+    'Logs Explore Empty State (Onboarding) - AI Prompt Copied',
   'logs.issue_details.drawer_opened': 'Issues Page Logs Drawer Opened',
   'logs.timestamp_tooltip.add_timezone_clicked':
     'Logs Timestamp Tooltip Add Timezone Clicked',

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -69,7 +69,7 @@ export type LogsAnalyticsEventParameters = {
   'logs.onboarding_ai_prompt_copied': {
     organization: Organization;
     platform: PlatformKey | 'unknown';
-    source: 'copy_button' | 'code_snippet';
+    source: 'install_command' | 'prompt';
   };
   'logs.onboarding_platform_docs_viewed': {
     organization: Organization;

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -181,7 +181,7 @@ describe('LogsPage', () => {
     expect(sdkMock).toHaveBeenCalled();
 
     await waitFor(() => {
-      expect(screen.getByText('Your Source for Log-ical Data')).toBeInTheDocument();
+      expect(screen.getByText('Logs in Sentry')).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import connectDotsImg from 'sentry-images/spot/performance-connect-dots.svg';
 
-import {Button, LinkButton} from '@sentry/scraps/button';
+import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
@@ -38,7 +38,6 @@ import {PanelBody} from 'sentry/components/panels/panelBody';
 import {BodyTitle, SetupTitle} from 'sentry/components/updatedEmptyState';
 import {withoutLoggingSupport} from 'sentry/data/platformCategories';
 import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
-import {IconCopy} from 'sentry/icons/iconCopy';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -48,7 +47,6 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeInteger} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
-import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -67,24 +65,11 @@ type OnboardingProps = {
   project: Project;
 };
 
-const AI_SETUP_PROMPT =
-  'Use curl to download and read the instructions at https://raw.githubusercontent.com/getsentry/sentry-for-ai/refs/heads/main/skills-legacy/sentry-instrument-logging/SKILL.md.\n\nFollow those instructions to configure logging for this project. Afterward, suggest several useful example log statements that follow the practices described in the skill.';
+const INSTALL_PLUGIN_COMMAND =
+  'npx @sentry/ai install "Please instrument Sentry logging. Include some examples following best practices."';
 
-function CopyPromptButton({prompt, onCopy}: {onCopy: () => void; prompt: string}) {
-  const {copy} = useCopyToClipboard();
-  return (
-    <Button
-      size="xs"
-      icon={<IconCopy />}
-      onClick={() => {
-        copy(prompt, {successMessage: t('Prompt copied to clipboard')});
-        onCopy();
-      }}
-    >
-      {t('Copy Prompt')}
-    </Button>
-  );
-}
+const AI_SETUP_PROMPT =
+  'Please instrument Sentry logging. Include some examples following best practices.';
 
 const LOG_DRAIN_PLATFORM_DOCS: Record<string, {name: string; url: string}> = {
   'node-cloudflare-pages': {
@@ -145,7 +130,7 @@ function OnboardingPanel({
 }) {
   const organization = useOrganization();
 
-  const trackPromptCopied = (source: 'copy_button' | 'code_snippet') => {
+  const trackPromptCopied = (source: 'install_command' | 'prompt') => {
     trackAnalytics('logs.onboarding_ai_prompt_copied', {
       organization,
       platform: project.platform ?? 'unknown',
@@ -182,32 +167,29 @@ function OnboardingPanel({
                   <LogDrainsLink project={project} />
                 </Setup>
                 <Preview>
-                  <PreviewHeader>
-                    <BodyTitle>{t('AI-Assisted Setup')}</BodyTitle>
-                    <CopyPromptButton
-                      prompt={AI_SETUP_PROMPT}
-                      onCopy={() => trackPromptCopied('copy_button')}
-                    />
-                  </PreviewHeader>
+                  <BodyTitle>{t('AI-Assisted Setup')}</BodyTitle>
                   <SubTitle>
-                    {tct(
-                      'Run this prompt in your favorite coding agent. It uses your own API tokens to configure Sentry logging and generate example logs that follow [link:logging best practices].',
-                      {
-                        link: (
-                          <ExternalLink href="https://blog.sentry.io/logging-best-practices/" />
-                        ),
-                      }
-                    )}
+                    {t('First, run this command to install the Sentry plugin')}
                   </SubTitle>
                   <PromptSnippet>
                     <OnboardingCodeSnippet
+                      language="bash"
+                      onCopy={() => trackPromptCopied('install_command')}
+                    >
+                      {INSTALL_PLUGIN_COMMAND}
+                    </OnboardingCodeSnippet>
+                  </PromptSnippet>
+                  <SubTitle>{t('Then paste this in your agent of choice')}</SubTitle>
+                  <PromptSnippet>
+                    <OnboardingCodeSnippet
                       language="text"
-                      onCopy={() => trackPromptCopied('code_snippet')}
+                      onCopy={() => trackPromptCopied('prompt')}
                     >
                       {AI_SETUP_PROMPT}
                     </OnboardingCodeSnippet>
                   </PromptSnippet>
                 </Preview>
+                <OrDivider aria-hidden>{t('OR')}</OrDivider>
               </Body>
             </div>
           </TabSelectionScope>
@@ -500,6 +482,22 @@ const Preview = styled('div')`
   padding: ${p => p.theme.space['3xl']};
 `;
 
+// Sits on top of the vertical divider (Setup's :after) at the horizontal center
+// of Body, with a panel-colored background to break the line.
+const OrDivider = styled('div')`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  padding: ${p => p.theme.space.sm} 0;
+  background: ${p => p.theme.tokens.background.primary};
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.sm};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  letter-spacing: 0.05em;
+`;
+
 const Body = styled('div')`
   display: grid;
   position: relative;
@@ -532,17 +530,11 @@ const Divider = styled('hr')`
   margin-bottom: 0;
 `;
 
-const PreviewHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: ${p => p.theme.space.md};
-`;
-
 // Wrapper keeps the code block sized to its content instead of stretching to
 // fill the (tall) preview column.
 const PromptSnippet = styled('div')`
   margin-top: ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space['2xl']};
 `;
 
 const OnboardingContainer = styled('div')`

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -47,6 +47,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeInteger} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
+import {useEventWaiter} from 'sentry/utils/useEventWaiter';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -230,6 +231,13 @@ function Onboarding({organization, project}: OnboardingProps) {
     ? withoutLoggingSupport.has(project.platform)
     : false;
 
+  const receivedFirstLog = !!useEventWaiter({
+    eventType: 'log',
+    organization,
+    project,
+    disabled: doesNotSupportLogging,
+  });
+
   const analyticsPlatform = currentPlatform?.id ?? project.platform ?? 'unknown';
 
   useEffect(() => {
@@ -387,7 +395,11 @@ function Onboarding({organization, project}: OnboardingProps) {
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />
-                  <EventWaitingIndicator />
+                  {receivedFirstLog ? (
+                    <EventReceivedIndicator />
+                  ) : (
+                    <EventWaitingIndicator />
+                  )}
                 </GuidedSteps.ButtonWrapper>
               ) : (
                 <GuidedSteps.ButtonWrapper>
@@ -424,6 +436,19 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
   font-size: ${p => p.theme.font.size.md};
   color: ${p => p.theme.colors.pink500};
   padding-right: ${p => p.theme.space['3xl']};
+`;
+
+const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...p}>
+    {'🎉 '}
+    {t("We've received this project's first log!")}
+  </div>
+))`
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+  font-size: ${p => p.theme.font.size.md};
+  color: ${p => p.theme.tokens.content.success};
 `;
 
 const SubTitle = styled('div')`

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {Fragment, useEffect} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -66,11 +66,10 @@ type OnboardingProps = {
   project: Project;
 };
 
-const INSTALL_PLUGIN_COMMAND =
-  'npx @sentry/ai install "Please instrument Sentry logging. Include some examples following best practices."';
-
 const AI_SETUP_PROMPT =
   'Please instrument Sentry logging. Include some examples following best practices.';
+
+const INSTALL_PLUGIN_COMMAND = `npx @sentry/ai install "${AI_SETUP_PROMPT}"`;
 
 const LOG_DRAIN_PLATFORM_DOCS: Record<string, {name: string; url: string}> = {
   'node-cloudflare-pages': {
@@ -179,34 +178,52 @@ function OnboardingPanel({
                   <LogDrainsLink project={project} />
                 </Setup>
                 <Preview>
-                  <BodyTitle>{t('AI-Assisted Setup')}</BodyTitle>
-                  <SubTitle>
-                    {t('First, run this command to install the Sentry plugin')}
-                  </SubTitle>
-                  <PromptSnippet>
-                    <OnboardingCodeSnippet
-                      language="bash"
-                      onCopy={() => trackPromptCopied('install_command')}
-                    >
-                      {INSTALL_PLUGIN_COMMAND}
-                    </OnboardingCodeSnippet>
-                  </PromptSnippet>
-                  <SubTitle>{t('Then paste this in your agent of choice')}</SubTitle>
-                  <PromptSnippet>
-                    <OnboardingCodeSnippet
-                      language="text"
-                      onCopy={() => trackPromptCopied('prompt')}
-                    >
-                      {AI_SETUP_PROMPT}
-                    </OnboardingCodeSnippet>
-                  </PromptSnippet>
-                  {receivedFirstLog ? (
-                    <EventReceivedIndicator />
+                  {doesNotSupportLogging ? (
+                    // Platforms without logging support can't run the AI-assisted
+                    // setup (and would never receive a first log), so show the
+                    // product preview instead of the setup prompts.
+                    <Fragment>
+                      <BodyTitle>{t('Preview a Sentry Log')}</BodyTitle>
+                      <Arcade
+                        src="https://demo.arcade.software/dLjHGrPJITrt7JKpmX5V?embed"
+                        loading="lazy"
+                        allowFullScreen
+                      />
+                    </Fragment>
                   ) : (
-                    <EventWaitingIndicator />
+                    <Fragment>
+                      <BodyTitle>{t('AI-Assisted Setup')}</BodyTitle>
+                      <SubTitle>
+                        {t('First, run this command to install the Sentry plugin')}
+                      </SubTitle>
+                      <PromptSnippet>
+                        <OnboardingCodeSnippet
+                          language="bash"
+                          onCopy={() => trackPromptCopied('install_command')}
+                        >
+                          {INSTALL_PLUGIN_COMMAND}
+                        </OnboardingCodeSnippet>
+                      </PromptSnippet>
+                      <SubTitle>{t('Then paste this in your agent of choice')}</SubTitle>
+                      <PromptSnippet>
+                        <OnboardingCodeSnippet
+                          language="text"
+                          onCopy={() => trackPromptCopied('prompt')}
+                        >
+                          {AI_SETUP_PROMPT}
+                        </OnboardingCodeSnippet>
+                      </PromptSnippet>
+                      {receivedFirstLog ? (
+                        <EventReceivedIndicator />
+                      ) : (
+                        <EventWaitingIndicator />
+                      )}
+                    </Fragment>
                   )}
                 </Preview>
-                <OrDivider aria-hidden>{t('OR')}</OrDivider>
+                {doesNotSupportLogging ? null : (
+                  <OrDivider aria-hidden>{t('OR')}</OrDivider>
+                )}
               </Body>
             </div>
           </TabSelectionScope>
@@ -568,6 +585,14 @@ const PromptSnippet = styled('div')`
 
 const OnboardingContainer = styled('div')`
   margin-top: ${p => p.theme.space.md};
+`;
+
+const Arcade = styled('iframe')`
+  width: 750px;
+  max-width: 100%;
+  margin-top: ${p => p.theme.space['2xl']};
+  height: 522px;
+  border: 0;
 `;
 
 type LogsTabOnboardingProps = {

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -131,6 +131,17 @@ function OnboardingPanel({
 }) {
   const organization = useOrganization();
 
+  const doesNotSupportLogging = project.platform
+    ? withoutLoggingSupport.has(project.platform)
+    : false;
+
+  const receivedFirstLog = !!useEventWaiter({
+    eventType: 'log',
+    organization,
+    project,
+    disabled: doesNotSupportLogging,
+  });
+
   const trackPromptCopied = (source: 'install_command' | 'prompt') => {
     trackAnalytics('logs.onboarding_ai_prompt_copied', {
       organization,
@@ -189,6 +200,11 @@ function OnboardingPanel({
                       {AI_SETUP_PROMPT}
                     </OnboardingCodeSnippet>
                   </PromptSnippet>
+                  {receivedFirstLog ? (
+                    <EventReceivedIndicator />
+                  ) : (
+                    <EventWaitingIndicator />
+                  )}
                 </Preview>
                 <OrDivider aria-hidden>{t('OR')}</OrDivider>
               </Body>
@@ -230,13 +246,6 @@ function Onboarding({organization, project}: OnboardingProps) {
   const doesNotSupportLogging = project.platform
     ? withoutLoggingSupport.has(project.platform)
     : false;
-
-  const receivedFirstLog = !!useEventWaiter({
-    eventType: 'log',
-    organization,
-    project,
-    disabled: doesNotSupportLogging,
-  });
 
   const analyticsPlatform = currentPlatform?.id ?? project.platform ?? 'unknown';
 
@@ -395,11 +404,6 @@ function Onboarding({organization, project}: OnboardingProps) {
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />
-                  {receivedFirstLog ? (
-                    <EventReceivedIndicator />
-                  ) : (
-                    <EventWaitingIndicator />
-                  )}
                 </GuidedSteps.ButtonWrapper>
               ) : (
                 <GuidedSteps.ButtonWrapper>

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import connectDotsImg from 'sentry-images/spot/performance-connect-dots.svg';
 
-import {LinkButton} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
@@ -13,6 +13,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
 import {
   OnboardingCopyMarkdownButton,
   useCopySetupInstructionsEnabled,
@@ -37,6 +38,7 @@ import {PanelBody} from 'sentry/components/panels/panelBody';
 import {BodyTitle, SetupTitle} from 'sentry/components/updatedEmptyState';
 import {withoutLoggingSupport} from 'sentry/data/platformCategories';
 import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
+import {IconCopy} from 'sentry/icons/iconCopy';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -46,8 +48,10 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeInteger} from 'sentry/utils/queryString';
 import {useApi} from 'sentry/utils/useApi';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   ExploreBodySearch,
   ExploreFilterSection,
@@ -62,6 +66,25 @@ type OnboardingProps = {
   organization: Organization;
   project: Project;
 };
+
+const AI_SETUP_PROMPT =
+  'Use curl to download and read the instructions at https://raw.githubusercontent.com/getsentry/sentry-for-ai/refs/heads/main/skills-legacy/sentry-instrument-logging/SKILL.md.\n\nFollow those instructions to configure logging for this project. Afterward, suggest several useful example log statements that follow the practices described in the skill.';
+
+function CopyPromptButton({prompt, onCopy}: {onCopy: () => void; prompt: string}) {
+  const {copy} = useCopyToClipboard();
+  return (
+    <Button
+      size="xs"
+      icon={<IconCopy />}
+      onClick={() => {
+        copy(prompt, {successMessage: t('Prompt copied to clipboard')});
+        onCopy();
+      }}
+    >
+      {t('Copy Prompt')}
+    </Button>
+  );
+}
 
 const LOG_DRAIN_PLATFORM_DOCS: Record<string, {name: string; url: string}> = {
   'node-cloudflare-pages': {
@@ -120,6 +143,16 @@ function OnboardingPanel({
   children: React.ReactNode;
   project: Project;
 }) {
+  const organization = useOrganization();
+
+  const trackPromptCopied = (source: 'copy_button' | 'code_snippet') => {
+    trackAnalytics('logs.onboarding_ai_prompt_copied', {
+      organization,
+      platform: project.platform ?? 'unknown',
+      source,
+    });
+  };
+
   return (
     <Panel>
       <PanelBody>
@@ -149,12 +182,31 @@ function OnboardingPanel({
                   <LogDrainsLink project={project} />
                 </Setup>
                 <Preview>
-                  <BodyTitle>{t('Preview a Sentry Log')}</BodyTitle>
-                  <Arcade
-                    src="https://demo.arcade.software/dLjHGrPJITrt7JKpmX5V?embed"
-                    loading="lazy"
-                    allowFullScreen
-                  />
+                  <PreviewHeader>
+                    <BodyTitle>{t('AI-Assisted Setup')}</BodyTitle>
+                    <CopyPromptButton
+                      prompt={AI_SETUP_PROMPT}
+                      onCopy={() => trackPromptCopied('copy_button')}
+                    />
+                  </PreviewHeader>
+                  <SubTitle>
+                    {tct(
+                      'Run this prompt in your favorite coding agent. It uses your own API tokens to configure Sentry logging and generate example logs that follow [link:logging best practices].',
+                      {
+                        link: (
+                          <ExternalLink href="https://blog.sentry.io/logging-best-practices/" />
+                        ),
+                      }
+                    )}
+                  </SubTitle>
+                  <PromptSnippet>
+                    <OnboardingCodeSnippet
+                      language="text"
+                      onCopy={() => trackPromptCopied('code_snippet')}
+                    >
+                      {AI_SETUP_PROMPT}
+                    </OnboardingCodeSnippet>
+                  </PromptSnippet>
                 </Preview>
               </Body>
             </div>
@@ -480,12 +532,17 @@ const Divider = styled('hr')`
   margin-bottom: 0;
 `;
 
-const Arcade = styled('iframe')`
-  width: 750px;
-  max-width: 100%;
-  margin-top: ${p => p.theme.space['2xl']};
-  height: 522px;
-  border: 0;
+const PreviewHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${p => p.theme.space.md};
+`;
+
+// Wrapper keeps the code block sized to its content instead of stretching to
+// fill the (tall) preview column.
+const PromptSnippet = styled('div')`
+  margin-top: ${p => p.theme.space.md};
 `;
 
 const OnboardingContainer = styled('div')`

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -490,7 +490,7 @@ const OrDivider = styled('div')`
   top: 50%;
   transform: translate(-50%, -50%);
   z-index: 1;
-  padding: ${p => p.theme.space.sm} 0;
+  padding: ${p => p.theme.space.sm};
   background: ${p => p.theme.tokens.background.primary};
   color: ${p => p.theme.tokens.content.secondary};
   font-size: ${p => p.theme.font.size.sm};

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -40,6 +40,7 @@ import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {pulsingIndicatorStyles} from 'sentry/styles/pulsingIndicator';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -127,19 +128,13 @@ function OnboardingPanel({
             <div>
               <HeaderWrapper>
                 <HeaderText>
-                  <Title>{t('Your Source for Log-ical Data')}</Title>
+                  <Title>{t('Logs in Sentry')}</Title>
                   <SubTitle>
-                    {t(
-                      "It's about time we offered something a bit more robust than breadcrumbs. With logs, you'll be able to have a lot more control and context over all your data."
-                    )}
+                    {t('Search and visualize application logs at scale.')}
                   </SubTitle>
                   <BulletList>
-                    <li>
-                      {t('Access logs in real time and query them by any attribute')}
-                    </li>
-                    <li>
-                      {t('Correlate your logs with errors and traces for full context')}
-                    </li>
+                    <li>{t('View logs in context with errors and traces')}</li>
+                    <li>{t('Query, filter, and group logs by any attribute')}</li>
                     <li>
                       {t('Build alerts and dashboard widgets based on log queries')}
                     </li>
@@ -358,6 +353,7 @@ function Onboarding({organization, project}: OnboardingProps) {
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />
+                  <EventWaitingIndicator />
                 </GuidedSteps.ButtonWrapper>
               ) : (
                 <GuidedSteps.ButtonWrapper>
@@ -372,6 +368,29 @@ function Onboarding({organization, project}: OnboardingProps) {
     </OnboardingPanel>
   );
 }
+
+const PulsingIndicator = styled('div')`
+  ${pulsingIndicatorStyles};
+  flex-shrink: 0;
+`;
+
+const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
+  <div {...p}>
+    {t("Waiting for this project's first log")}
+    <PulsingIndicator />
+  </div>
+))`
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 0 ${p => p.theme.space.md};
+  z-index: 10;
+  gap: ${p => p.theme.space.md};
+  flex-grow: 1;
+  font-size: ${p => p.theme.font.size.md};
+  color: ${p => p.theme.colors.pink500};
+  padding-right: ${p => p.theme.space['3xl']};
+`;
 
 const SubTitle = styled('div')`
   margin-bottom: ${p => p.theme.space.md};

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import connectDotsImg from 'sentry-images/spot/performance-connect-dots.svg';
 
+import {FeatureBadge} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -192,7 +193,12 @@ function OnboardingPanel({
                     </Fragment>
                   ) : (
                     <Fragment>
-                      <BodyTitle>{t('AI-Assisted Setup')}</BodyTitle>
+                      <BodyTitle>
+                        <Flex align="center" gap="sm">
+                          {t('AI-Assisted Setup')}
+                          <FeatureBadge type="experimental" />
+                        </Flex>
+                      </BodyTitle>
                       <SubTitle>
                         {t('First, run this command to install the Sentry plugin')}
                       </SubTitle>


### PR DESCRIPTION
* Updates the copy for the logs empty state screen.
* Adds a one step prompt that a user can copy, to replace the multi-step setup.

<img width="1229" height="565" alt="Screenshot 2026-07-15 at 1 43 59 PM" src="https://github.com/user-attachments/assets/eb4cab13-6cea-4d5b-bff7-622cc0989d97" />

~Note, the prompt currently feels a bit janky to me, I would like to use whatever @evanpurkhiser suggests is the best approach:~

In discussion with @evanpurkhiser and @itsdangold, I think we landed on a prompt / command that's reasonable:

**Command:**

```
npx @sentry/ai install "Please instrument Sentry logging. Include some examples following best practices."
```

**Prompt:**

```
Please instrument Sentry logging. Include some examples following best practices.
```

---

**Note:**

We now handle a platform that doesn't support logging by showing the old empty state UI:

<img width="835" height="640" alt="Screenshot 2026-07-15 at 12 02 48 PM" src="https://github.com/user-attachments/assets/3c473d38-4202-4c3a-9f01-d4465ed78a6a" />

