### PR TITLE
feat(seer): Surface issue titles and PRs on night-shift triage results

### DIFF
--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -37,9 +37,9 @@ class SeerNightShiftRunPullRequestResponse(PullRequestSerializerResponse):
     status: PullRequestStatus | None
 
 
-# TODO(telkins): legacy alias for the frontend. Drop this, the `issues` key, and
-# `_serialize_legacy_issue` once the UI reads `results` instead (filtering to
-# kind=agentic_triage). The frontend migration must deploy before the removal.
+# TODO(telkins): this `issues` list is a triage-specific view derived from
+# `results`, kept for the current frontend. Once the UI reads `results`
+# directly (filtering to kind=agentic_triage), drop this key and _serialize_issue.
 class SeerNightShiftRunIssueResponse(TypedDict):
     id: str
     groupId: str
@@ -196,7 +196,7 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "errorMessage": extras.get("error_message") or shard_error,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [
-                _serialize_legacy_issue(
+                _serialize_issue(
                     r, group_titles_by_id, group_short_ids_by_id, pull_requests_by_result_id
                 )
                 for r in triage_results
@@ -235,7 +235,7 @@ def _get_stored_pull_request_status(pull_request: PullRequest) -> PullRequestSta
     return None
 
 
-def _serialize_legacy_issue(
+def _serialize_issue(
     result: SeerNightShiftRunResult,
     group_titles_by_id: Mapping[int, str | None],
     group_short_ids_by_id: Mapping[int, str | None],

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -10,9 +10,10 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.pullrequest import (
     PullRequestSerializer,
     PullRequestSerializerResponse,
+    PullRequestStatus,
 )
 from sentry.models.group import Group
-from sentry.models.pullrequest import PullRequest
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
@@ -31,6 +32,11 @@ class SeerNightShiftRunResultResponse(TypedDict):
     dateAdded: str
 
 
+class SeerNightShiftRunPullRequestResponse(PullRequestSerializerResponse):
+    # Null if Sentry never observed a webhook event for this PR.
+    status: PullRequestStatus | None
+
+
 # TODO(telkins): legacy alias for the frontend. Drop this, the `issues` key, and
 # `_serialize_legacy_issue` once the UI reads `results` instead (filtering to
 # kind=agentic_triage). The frontend migration must deploy before the removal.
@@ -40,8 +46,9 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     groupTitle: str | None
     groupShortId: str | None
     action: str | None
+    reason: str | None
     seerRunId: str | None
-    pullRequests: list[PullRequestSerializerResponse]
+    pullRequests: list[SeerNightShiftRunPullRequestResponse]
     dateAdded: str
 
 
@@ -99,9 +106,8 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             group_id: group.qualified_short_id for group_id, group in groups_by_id.items()
         }
 
-        # Resolve each result's per-issue SeerRun pk: prefer the FK, else fall
-        # back to matching the legacy text `seer_run_id` against
-        # SeerRun.seer_run_state_id (Seer's own run id, not our SeerRun pk).
+        # Resolve each result's SeerRun pk: prefer the FK, else match the
+        # legacy seer_run_id text against SeerRun.seer_run_state_id.
         seer_run_pk_by_result_id: dict[int, int] = {}
         legacy_state_id_by_result_id: dict[int, int] = {}
         for r in triage_results:
@@ -122,10 +128,8 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             if pk is not None:
                 seer_run_pk_by_result_id[result_id] = pk
 
-        # Bulk-fetch every SeerRunPullRequest link for the resolved SeerRun
-        # pks in one query, then bulk-serialize each PullRequest exactly once,
-        # keyed by Django pk (not `.key` -- that's the PR number and collides
-        # across repos).
+        # Serialize each PR exactly once, keyed by Django pk (not `.key` --
+        # that's the PR number and collides across repos).
         pr_ids_by_seer_run_pk: dict[int, list[int]] = defaultdict(list)
         pull_requests_by_pk: dict[int, PullRequest] = {}
         for link in SeerRunPullRequest.objects.filter(
@@ -134,17 +138,15 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             pr_ids_by_seer_run_pk[link.seer_run_id].append(link.pull_request_id)
             pull_requests_by_pk[link.pull_request_id] = link.pull_request
 
-        serialized_pr_by_pk: dict[int, PullRequestSerializerResponse] = {}
+        serialized_pr_by_pk: dict[int, SeerNightShiftRunPullRequestResponse] = {}
         if pull_requests_by_pk:
             prs = list(pull_requests_by_pk.values())
-            serialized_pr_by_pk = dict(
-                zip(
-                    (pr.id for pr in prs),
-                    serialize(prs, user, PullRequestSerializer()),
-                )
-            )
+            serialized_pr_by_pk = {
+                pr.id: {**serialized, "status": _get_stored_pull_request_status(pr)}
+                for pr, serialized in zip(prs, serialize(prs, user, PullRequestSerializer()))
+            }
 
-        pull_requests_by_result_id: dict[int, list[PullRequestSerializerResponse]] = {}
+        pull_requests_by_result_id: dict[int, list[SeerNightShiftRunPullRequestResponse]] = {}
         for r in triage_results:
             seer_run_pk = seer_run_pk_by_result_id.get(r.id)
             pull_requests_by_result_id[r.id] = (
@@ -218,11 +220,26 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
     }
 
 
+def _get_stored_pull_request_status(pull_request: PullRequest) -> PullRequestStatus | None:
+    """No live provider lookup -- this feeds a list endpoint, not a detail view."""
+    if pull_request.state == PullRequestLifecycleState.MERGED:
+        return "merged"
+    if pull_request.state == PullRequestLifecycleState.CLOSED:
+        return "closed"
+    if pull_request.draft is True:
+        return "draft"
+    # `draft` is nullable for older rows, so only trust `open` when we know
+    # the PR is not a draft.
+    if pull_request.state == PullRequestLifecycleState.OPEN and pull_request.draft is False:
+        return "open"
+    return None
+
+
 def _serialize_legacy_issue(
     result: SeerNightShiftRunResult,
     group_titles_by_id: Mapping[int, str | None],
     group_short_ids_by_id: Mapping[int, str | None],
-    pull_requests_by_result_id: Mapping[int, list[PullRequestSerializerResponse]],
+    pull_requests_by_result_id: Mapping[int, list[SeerNightShiftRunPullRequestResponse]],
 ) -> SeerNightShiftRunIssueResponse:
     extras = result.extras or {}
     return {
@@ -235,6 +252,7 @@ def _serialize_legacy_issue(
             group_short_ids_by_id.get(result.group_id) if result.group_id is not None else None
         ),
         "action": extras.get("action"),
+        "reason": extras.get("reason"),
         "seerRunId": result.seer_run_id,
         "pullRequests": pull_requests_by_result_id.get(result.id, []),
         "dateAdded": result.date_added.isoformat(),

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -19,7 +19,7 @@ from sentry.seer.models.night_shift import (
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
-from sentry.seer.models.run import SeerRun, SeerRunPullRequest
+from sentry.seer.models.run import SeerRunPullRequest
 from sentry.seer.models.workflow import SeerWorkflowStrategy
 
 
@@ -106,27 +106,9 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             group_id: group.qualified_short_id for group_id, group in groups_by_id.items()
         }
 
-        # Resolve each result's SeerRun pk: prefer the FK, else match the
-        # legacy seer_run_id text against SeerRun.seer_run_state_id.
-        seer_run_pk_by_result_id: dict[int, int] = {}
-        legacy_state_id_by_result_id: dict[int, int] = {}
-        for r in triage_results:
-            if r.result_seer_run_id is not None:
-                seer_run_pk_by_result_id[r.id] = r.result_seer_run_id
-            elif r.seer_run_id is not None and r.seer_run_id.isdigit():
-                legacy_state_id_by_result_id[r.id] = int(r.seer_run_id)
-
-        seer_run_pk_by_state_id: dict[int, int] = {
-            state_id: pk
-            for state_id, pk in SeerRun.objects.filter(
-                seer_run_state_id__in=set(legacy_state_id_by_result_id.values())
-            ).values_list("seer_run_state_id", "id")
-            if state_id is not None
+        seer_run_pk_by_result_id: dict[int, int] = {
+            r.id: r.result_seer_run_id for r in triage_results if r.result_seer_run_id is not None
         }
-        for result_id, state_id in legacy_state_id_by_result_id.items():
-            pk = seer_run_pk_by_state_id.get(state_id)
-            if pk is not None:
-                seer_run_pk_by_result_id[result_id] = pk
 
         # Serialize each PR exactly once, keyed by Django pk (not `.key` --
         # that's the PR number and collides across repos).

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any, TypedDict
 
 from django.db.models import Prefetch, prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.models.pullrequest import (
+    PullRequestSerializer,
+    PullRequestSerializerResponse,
+)
+from sentry.models.group import Group
+from sentry.models.pullrequest import PullRequest
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
+from sentry.seer.models.run import SeerRun, SeerRunPullRequest
 from sentry.seer.models.workflow import SeerWorkflowStrategy
 
 
@@ -29,8 +37,10 @@ class SeerNightShiftRunResultResponse(TypedDict):
 class SeerNightShiftRunIssueResponse(TypedDict):
     id: str
     groupId: str
+    groupTitle: str | None
     action: str | None
     seerRunId: str | None
+    pullRequests: list[PullRequestSerializerResponse]
     dateAdded: str
 
 
@@ -70,7 +80,82 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
                 queryset=SeerNightShiftRunShard.objects.order_by("id").select_related("seer_run"),
             ),
         )
-        return {}
+
+        triage_results = [
+            r
+            for run in item_list
+            for r in run.results.all()
+            if r.kind == SeerWorkflowStrategy.AGENTIC_TRIAGE
+        ]
+
+        group_ids = {r.group_id for r in triage_results if r.group_id is not None}
+        group_titles_by_id: dict[int, str | None] = {
+            group_id: group.title for group_id, group in Group.objects.in_bulk(group_ids).items()
+        }
+
+        # Resolve each result's per-issue SeerRun pk: prefer the FK, else fall
+        # back to matching the legacy text `seer_run_id` against
+        # SeerRun.seer_run_state_id (Seer's own run id, not our SeerRun pk).
+        seer_run_pk_by_result_id: dict[int, int] = {}
+        legacy_state_id_by_result_id: dict[int, int] = {}
+        for r in triage_results:
+            if r.result_seer_run_id is not None:
+                seer_run_pk_by_result_id[r.id] = r.result_seer_run_id
+            elif r.seer_run_id is not None and r.seer_run_id.isdigit():
+                legacy_state_id_by_result_id[r.id] = int(r.seer_run_id)
+
+        seer_run_pk_by_state_id: dict[int, int] = {
+            state_id: pk
+            for state_id, pk in SeerRun.objects.filter(
+                seer_run_state_id__in=set(legacy_state_id_by_result_id.values())
+            ).values_list("seer_run_state_id", "id")
+            if state_id is not None
+        }
+        for result_id, state_id in legacy_state_id_by_result_id.items():
+            pk = seer_run_pk_by_state_id.get(state_id)
+            if pk is not None:
+                seer_run_pk_by_result_id[result_id] = pk
+
+        # Bulk-fetch every SeerRunPullRequest link for the resolved SeerRun
+        # pks in one query, then bulk-serialize each PullRequest exactly once,
+        # keyed by Django pk (not `.key` -- that's the PR number and collides
+        # across repos).
+        pr_ids_by_seer_run_pk: dict[int, list[int]] = defaultdict(list)
+        pull_requests_by_pk: dict[int, PullRequest] = {}
+        for link in SeerRunPullRequest.objects.filter(
+            seer_run_id__in=set(seer_run_pk_by_result_id.values())
+        ).select_related("pull_request"):
+            pr_ids_by_seer_run_pk[link.seer_run_id].append(link.pull_request_id)
+            pull_requests_by_pk[link.pull_request_id] = link.pull_request
+
+        serialized_pr_by_pk: dict[int, PullRequestSerializerResponse] = {}
+        if pull_requests_by_pk:
+            prs = list(pull_requests_by_pk.values())
+            serialized_pr_by_pk = dict(
+                zip(
+                    (pr.id for pr in prs),
+                    serialize(prs, user, PullRequestSerializer()),
+                )
+            )
+
+        pull_requests_by_result_id: dict[int, list[PullRequestSerializerResponse]] = {}
+        for r in triage_results:
+            seer_run_pk = seer_run_pk_by_result_id.get(r.id)
+            pull_requests_by_result_id[r.id] = (
+                [
+                    serialized_pr_by_pk[pk]
+                    for pk in pr_ids_by_seer_run_pk.get(seer_run_pk, [])
+                    if pk in serialized_pr_by_pk
+                ]
+                if seer_run_pk is not None
+                else []
+            )
+
+        shared = {
+            "group_titles_by_id": group_titles_by_id,
+            "pull_requests_by_result_id": pull_requests_by_result_id,
+        }
+        return {run: shared for run in item_list}
 
     def serialize(
         self,
@@ -92,13 +177,18 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             ),
             None,
         )
+        group_titles_by_id = attrs.get("group_titles_by_id", {})
+        pull_requests_by_result_id = attrs.get("pull_requests_by_result_id", {})
         return {
             "id": str(obj.id),
             "dateAdded": obj.date_added.isoformat(),
             "extras": extras,
             "errorMessage": extras.get("error_message") or shard_error,
             "results": [_serialize_result(r) for r in all_results],
-            "issues": [_serialize_legacy_issue(r) for r in triage_results],
+            "issues": [
+                _serialize_legacy_issue(r, group_titles_by_id, pull_requests_by_result_id)
+                for r in triage_results
+            ],
             "seerRuns": serialize(list(obj.shards.all()), user, SeerNightShiftShardSerializer()),
             # Match the pre-migration column behavior: always "agentic_triage"
             # in this PR. The multi-kind feature PR will refine this once
@@ -118,12 +208,20 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
     }
 
 
-def _serialize_legacy_issue(result: SeerNightShiftRunResult) -> SeerNightShiftRunIssueResponse:
+def _serialize_legacy_issue(
+    result: SeerNightShiftRunResult,
+    group_titles_by_id: Mapping[int, str | None],
+    pull_requests_by_result_id: Mapping[int, list[PullRequestSerializerResponse]],
+) -> SeerNightShiftRunIssueResponse:
     extras = result.extras or {}
     return {
         "id": str(result.id),
         "groupId": str(result.group_id) if result.group_id is not None else "",
+        "groupTitle": (
+            group_titles_by_id.get(result.group_id) if result.group_id is not None else None
+        ),
         "action": extras.get("action"),
         "seerRunId": result.seer_run_id,
+        "pullRequests": pull_requests_by_result_id.get(result.id, []),
         "dateAdded": result.date_added.isoformat(),
     }

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -38,6 +38,7 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     id: str
     groupId: str
     groupTitle: str | None
+    groupShortId: str | None
     action: str | None
     seerRunId: str | None
     pullRequests: list[PullRequestSerializerResponse]
@@ -89,8 +90,13 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
         ]
 
         group_ids = {r.group_id for r in triage_results if r.group_id is not None}
+        # qualified_short_id needs group.project.slug, hence select_related.
+        groups_by_id = Group.objects.filter(id__in=group_ids).select_related("project").in_bulk()
         group_titles_by_id: dict[int, str | None] = {
-            group_id: group.title for group_id, group in Group.objects.in_bulk(group_ids).items()
+            group_id: group.title for group_id, group in groups_by_id.items()
+        }
+        group_short_ids_by_id: dict[int, str | None] = {
+            group_id: group.qualified_short_id for group_id, group in groups_by_id.items()
         }
 
         # Resolve each result's per-issue SeerRun pk: prefer the FK, else fall
@@ -153,6 +159,7 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
 
         shared = {
             "group_titles_by_id": group_titles_by_id,
+            "group_short_ids_by_id": group_short_ids_by_id,
             "pull_requests_by_result_id": pull_requests_by_result_id,
         }
         return {run: shared for run in item_list}
@@ -178,6 +185,7 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             None,
         )
         group_titles_by_id = attrs.get("group_titles_by_id", {})
+        group_short_ids_by_id = attrs.get("group_short_ids_by_id", {})
         pull_requests_by_result_id = attrs.get("pull_requests_by_result_id", {})
         return {
             "id": str(obj.id),
@@ -186,7 +194,9 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             "errorMessage": extras.get("error_message") or shard_error,
             "results": [_serialize_result(r) for r in all_results],
             "issues": [
-                _serialize_legacy_issue(r, group_titles_by_id, pull_requests_by_result_id)
+                _serialize_legacy_issue(
+                    r, group_titles_by_id, group_short_ids_by_id, pull_requests_by_result_id
+                )
                 for r in triage_results
             ],
             "seerRuns": serialize(list(obj.shards.all()), user, SeerNightShiftShardSerializer()),
@@ -211,6 +221,7 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
 def _serialize_legacy_issue(
     result: SeerNightShiftRunResult,
     group_titles_by_id: Mapping[int, str | None],
+    group_short_ids_by_id: Mapping[int, str | None],
     pull_requests_by_result_id: Mapping[int, list[PullRequestSerializerResponse]],
 ) -> SeerNightShiftRunIssueResponse:
     extras = result.extras or {}
@@ -219,6 +230,9 @@ def _serialize_legacy_issue(
         "groupId": str(result.group_id) if result.group_id is not None else "",
         "groupTitle": (
             group_titles_by_id.get(result.group_id) if result.group_id is not None else None
+        ),
+        "groupShortId": (
+            group_short_ids_by_id.get(result.group_id) if result.group_id is not None else None
         ),
         "action": extras.get("action"),
         "seerRunId": result.seer_run_id,

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -54,6 +54,7 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         legacy = response.data[0]["issues"][0]
         assert legacy["groupId"] == str(group.id)
         assert legacy["groupTitle"] == group.title
+        assert legacy["groupShortId"] == group.qualified_short_id
         assert legacy["action"] == "autofix_triggered"
         # The legacy seer_run_id here ("seer-123") is non-numeric, so it can't
         # resolve to a SeerRun -- no pull requests should be attached.
@@ -78,6 +79,7 @@ class OrganizationSeerWorkflowsTest(APITestCase):
 
         legacy = response.data[0]["issues"][0]
         assert legacy["groupTitle"] is None
+        assert legacy["groupShortId"] is None
         assert legacy["pullRequests"] == []
 
     def test_issue_includes_pull_requests_via_result_seer_run_fk(self) -> None:

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -3,6 +3,7 @@ from sentry.seer.models.night_shift import (
     SeerNightShiftRunResult,
     SeerNightShiftRunShard,
 )
+from sentry.seer.models.run import SeerRunPullRequest
 from sentry.testutils.cases import APITestCase
 
 
@@ -52,7 +53,116 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert len(response.data[0]["issues"]) == 1
         legacy = response.data[0]["issues"][0]
         assert legacy["groupId"] == str(group.id)
+        assert legacy["groupTitle"] == group.title
         assert legacy["action"] == "autofix_triggered"
+        # The legacy seer_run_id here ("seer-123") is non-numeric, so it can't
+        # resolve to a SeerRun -- no pull requests should be attached.
+        assert legacy["pullRequests"] == []
+
+    def test_issue_with_missing_group_has_null_title(self) -> None:
+        # The group FK has db_constraint=False (see SeerNightShiftRunResult),
+        # so a stale group_id pointing at a deleted group is a real
+        # possibility in prod, not just a hypothetical -- simulate it
+        # directly rather than via create+delete, which would cascade-delete
+        # this row too (the FK is CASCADE at the Django ORM level).
+        run = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run,
+            kind="agentic_triage",
+            group_id=999999999,
+            extras={"action": "skip"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        legacy = response.data[0]["issues"][0]
+        assert legacy["groupTitle"] is None
+        assert legacy["pullRequests"] == []
+
+    def test_issue_includes_pull_requests_via_result_seer_run_fk(self) -> None:
+        group = self.create_group()
+        repo = self.create_repo()
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id
+        )
+        issue_seer_run = self.create_seer_run(organization=self.organization)
+        SeerRunPullRequest.objects.create(seer_run=issue_seer_run, pull_request=pull_request)
+
+        run = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run,
+            kind="agentic_triage",
+            group=group,
+            result_seer_run=issue_seer_run,
+            extras={"action": "autofix_triggered"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        legacy = response.data[0]["issues"][0]
+        assert len(legacy["pullRequests"]) == 1
+        assert legacy["pullRequests"][0]["id"] == pull_request.key
+        assert legacy["pullRequests"][0]["title"] == pull_request.title
+
+    def test_issue_includes_pull_requests_via_legacy_seer_run_id(self) -> None:
+        group = self.create_group()
+        repo = self.create_repo()
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id
+        )
+        issue_seer_run = self.create_seer_run(organization=self.organization, seer_run_state_id=999)
+        SeerRunPullRequest.objects.create(seer_run=issue_seer_run, pull_request=pull_request)
+
+        run = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run,
+            kind="agentic_triage",
+            group=group,
+            seer_run_id="999",
+            extras={"action": "autofix_triggered"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        legacy = response.data[0]["issues"][0]
+        assert len(legacy["pullRequests"]) == 1
+        assert legacy["pullRequests"][0]["id"] == pull_request.key
+
+    def test_pull_requests_not_leaked_across_runs(self) -> None:
+        group_a = self.create_group()
+        group_b = self.create_group()
+        repo = self.create_repo()
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id
+        )
+        seer_run_a = self.create_seer_run(organization=self.organization)
+        SeerRunPullRequest.objects.create(seer_run=seer_run_a, pull_request=pull_request)
+
+        run_a = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run_a,
+            kind="agentic_triage",
+            group=group_a,
+            result_seer_run=seer_run_a,
+            extras={"action": "autofix_triggered"},
+        )
+        run_b = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run_b,
+            kind="agentic_triage",
+            group=group_b,
+            extras={"action": "skip"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        by_run_id = {r["id"]: r for r in response.data}
+        assert len(by_run_id[str(run_a.id)]["issues"][0]["pullRequests"]) == 1
+        assert by_run_id[str(run_b.id)]["issues"][0]["pullRequests"] == []
 
     def test_surfaces_shard_seer_run_ids(self) -> None:
         run = SeerNightShiftRun.objects.create(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -1,3 +1,4 @@
+from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
@@ -29,7 +30,7 @@ class OrganizationSeerWorkflowsTest(APITestCase):
             kind="agentic_triage",
             group=group,
             seer_run_id="seer-123",
-            extras={"action": "autofix_triggered"},
+            extras={"action": "autofix_triggered", "reason": "Null pointer in the checkout flow"},
         )
 
         with self.feature("organizations:seer-night-shift"):
@@ -46,7 +47,10 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert result_data["kind"] == "agentic_triage"
         assert result_data["groupId"] == str(group.id)
         assert result_data["seerRunId"] == "seer-123"
-        assert result_data["extras"] == {"action": "autofix_triggered"}
+        assert result_data["extras"] == {
+            "action": "autofix_triggered",
+            "reason": "Null pointer in the checkout flow",
+        }
 
         # Transitional aliases for the existing frontend.
         assert response.data[0]["triageStrategy"] == "agentic_triage"
@@ -56,16 +60,13 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert legacy["groupTitle"] == group.title
         assert legacy["groupShortId"] == group.qualified_short_id
         assert legacy["action"] == "autofix_triggered"
-        # The legacy seer_run_id here ("seer-123") is non-numeric, so it can't
-        # resolve to a SeerRun -- no pull requests should be attached.
+        assert legacy["reason"] == "Null pointer in the checkout flow"
+        # "seer-123" is a non-numeric legacy id, so it can't resolve to a SeerRun.
         assert legacy["pullRequests"] == []
 
     def test_issue_with_missing_group_has_null_title(self) -> None:
-        # The group FK has db_constraint=False (see SeerNightShiftRunResult),
-        # so a stale group_id pointing at a deleted group is a real
-        # possibility in prod, not just a hypothetical -- simulate it
-        # directly rather than via create+delete, which would cascade-delete
-        # this row too (the FK is CASCADE at the Django ORM level).
+        # group FK is db_constraint=False, so a stale group_id is possible in
+        # prod; can't use create+delete since Django still cascades that.
         run = SeerNightShiftRun.objects.create(organization=self.organization)
         SeerNightShiftRunResult.objects.create(
             run=run,
@@ -107,6 +108,33 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert len(legacy["pullRequests"]) == 1
         assert legacy["pullRequests"][0]["id"] == pull_request.key
         assert legacy["pullRequests"][0]["title"] == pull_request.title
+        # No webhook event observed for this PR, so status is unknown.
+        assert legacy["pullRequests"][0]["status"] is None
+
+    def test_issue_pull_request_status_reflects_merged_state(self) -> None:
+        group = self.create_group()
+        repo = self.create_repo()
+        pull_request = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id
+        )
+        pull_request.update(state=PullRequestLifecycleState.MERGED)
+        issue_seer_run = self.create_seer_run(organization=self.organization)
+        SeerRunPullRequest.objects.create(seer_run=issue_seer_run, pull_request=pull_request)
+
+        run = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run,
+            kind="agentic_triage",
+            group=group,
+            result_seer_run=issue_seer_run,
+            extras={"action": "autofix_triggered"},
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        legacy = response.data[0]["issues"][0]
+        assert legacy["pullRequests"][0]["status"] == "merged"
 
     def test_issue_includes_pull_requests_via_legacy_seer_run_id(self) -> None:
         group = self.create_group()

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -61,7 +61,7 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         assert issue["groupShortId"] == group.qualified_short_id
         assert issue["action"] == "autofix_triggered"
         assert issue["reason"] == "Null pointer in the checkout flow"
-        # "seer-123" is a non-numeric legacy id, so it can't resolve to a SeerRun.
+        # No result_seer_run FK is set on this result, so no PRs resolve.
         assert issue["pullRequests"] == []
 
     def test_issue_with_missing_group_has_null_title(self) -> None:
@@ -136,7 +136,11 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         issue = response.data[0]["issues"][0]
         assert issue["pullRequests"][0]["status"] == "merged"
 
-    def test_issue_includes_pull_requests_via_legacy_seer_run_id(self) -> None:
+    def test_issue_with_only_legacy_seer_run_id_has_no_pull_requests(self) -> None:
+        # result_seer_run has no backfill migration, so rows predating it only
+        # have the legacy text seer_run_id -- PRs are intentionally not
+        # resolved for those, even if a SeerRun with a matching
+        # seer_run_state_id exists.
         group = self.create_group()
         repo = self.create_repo()
         pull_request = self.create_pull_request(
@@ -158,8 +162,7 @@ class OrganizationSeerWorkflowsTest(APITestCase):
             response = self.get_success_response(self.organization.slug)
 
         issue = response.data[0]["issues"][0]
-        assert len(issue["pullRequests"]) == 1
-        assert issue["pullRequests"][0]["id"] == pull_request.key
+        assert issue["pullRequests"] == []
 
     def test_pull_requests_not_leaked_across_runs(self) -> None:
         group_a = self.create_group()

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -55,14 +55,14 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         # Transitional aliases for the existing frontend.
         assert response.data[0]["triageStrategy"] == "agentic_triage"
         assert len(response.data[0]["issues"]) == 1
-        legacy = response.data[0]["issues"][0]
-        assert legacy["groupId"] == str(group.id)
-        assert legacy["groupTitle"] == group.title
-        assert legacy["groupShortId"] == group.qualified_short_id
-        assert legacy["action"] == "autofix_triggered"
-        assert legacy["reason"] == "Null pointer in the checkout flow"
+        issue = response.data[0]["issues"][0]
+        assert issue["groupId"] == str(group.id)
+        assert issue["groupTitle"] == group.title
+        assert issue["groupShortId"] == group.qualified_short_id
+        assert issue["action"] == "autofix_triggered"
+        assert issue["reason"] == "Null pointer in the checkout flow"
         # "seer-123" is a non-numeric legacy id, so it can't resolve to a SeerRun.
-        assert legacy["pullRequests"] == []
+        assert issue["pullRequests"] == []
 
     def test_issue_with_missing_group_has_null_title(self) -> None:
         # group FK is db_constraint=False, so a stale group_id is possible in
@@ -78,10 +78,10 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        legacy = response.data[0]["issues"][0]
-        assert legacy["groupTitle"] is None
-        assert legacy["groupShortId"] is None
-        assert legacy["pullRequests"] == []
+        issue = response.data[0]["issues"][0]
+        assert issue["groupTitle"] is None
+        assert issue["groupShortId"] is None
+        assert issue["pullRequests"] == []
 
     def test_issue_includes_pull_requests_via_result_seer_run_fk(self) -> None:
         group = self.create_group()
@@ -104,12 +104,12 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        legacy = response.data[0]["issues"][0]
-        assert len(legacy["pullRequests"]) == 1
-        assert legacy["pullRequests"][0]["id"] == pull_request.key
-        assert legacy["pullRequests"][0]["title"] == pull_request.title
+        issue = response.data[0]["issues"][0]
+        assert len(issue["pullRequests"]) == 1
+        assert issue["pullRequests"][0]["id"] == pull_request.key
+        assert issue["pullRequests"][0]["title"] == pull_request.title
         # No webhook event observed for this PR, so status is unknown.
-        assert legacy["pullRequests"][0]["status"] is None
+        assert issue["pullRequests"][0]["status"] is None
 
     def test_issue_pull_request_status_reflects_merged_state(self) -> None:
         group = self.create_group()
@@ -133,8 +133,8 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        legacy = response.data[0]["issues"][0]
-        assert legacy["pullRequests"][0]["status"] == "merged"
+        issue = response.data[0]["issues"][0]
+        assert issue["pullRequests"][0]["status"] == "merged"
 
     def test_issue_includes_pull_requests_via_legacy_seer_run_id(self) -> None:
         group = self.create_group()
@@ -157,9 +157,9 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         with self.feature("organizations:seer-night-shift"):
             response = self.get_success_response(self.organization.slug)
 
-        legacy = response.data[0]["issues"][0]
-        assert len(legacy["pullRequests"]) == 1
-        assert legacy["pullRequests"][0]["id"] == pull_request.key
+        issue = response.data[0]["issues"][0]
+        assert len(issue["pullRequests"]) == 1
+        assert issue["pullRequests"][0]["id"] == pull_request.key
 
     def test_pull_requests_not_leaked_across_runs(self) -> None:
         group_a = self.create_group()


### PR DESCRIPTION
The Sentry Workflows page shows each night-shift triage issue with only a bare numeric group id and no PR info, even though `SeerRunPullRequest` already links a Seer run to the pull requests it opened — that data just isn't exposed anywhere yet.

Add `groupTitle` and `pullRequests` to each issue in `SeerNightShiftRunSerializer`'s `issues` list:

- `groupTitle` is bulk-fetched via `Group.objects.in_bulk`, falling back to `null` for a stale/deleted group reference (the FK is `db_constraint=False`).
- `pullRequests` resolves the issue's own autofix run — preferring the `result_seer_run` FK, falling back to matching the legacy `seer_run_id` text against `SeerRun.seer_run_state_id` — then bulk-fetches and serializes any linked PRs via the existing `PullRequestSerializer`.

All lookups batch across the whole page of runs in `get_attrs`, so this adds a constant number of queries regardless of how many runs or issues are being serialized.

A follow-up PR (stacked on this one) updates the frontend to render these fields.