### PR TITLE
feat(viewer-context): Add project_id to ViewerContext

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -20,6 +20,7 @@ from sentry.exceptions import InvalidParams
 from sentry.models.project import Project
 from sentry.models.projectredirect import ProjectRedirect
 from sentry.utils.sdk import Scope, bind_organization_context
+from sentry.viewer_context import set_viewer_context_project
 
 from .organization import OrganizationPermission
 
@@ -208,6 +209,7 @@ class ProjectEndpoint(Endpoint):
         sentry_sdk.set_attribute("project", project.id)
 
         bind_organization_context(project.organization)
+        set_viewer_context_project(project.id)
 
         request._request.organization = (
             project.organization

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -34,7 +34,7 @@ from sentry.utils import json, metrics
 from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.projectflags import set_project_flag_and_signal
 from sentry.utils.safe import get_path
-from sentry.viewer_context import set_viewer_context_project
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +272,9 @@ def create_feedback_issue(
 
     feedback_message = event["contexts"]["feedback"]["message"]
 
-    set_viewer_context_project(project.id)
+    _seer_vc = ViewerContext(
+        organization_id=project.organization_id, project_id=project.id, actor_type=ActorType.SYSTEM
+    )
     viewer_context = SeerViewerContext(organization_id=project.organization_id)
 
     # Spam detection.
@@ -280,9 +282,10 @@ def create_feedback_issue(
     is_spam_enabled = spam_detection_enabled(project)
     if is_spam_enabled:
         # Will be None if the request fails
-        is_message_spam = is_spam_seer(
-            feedback_message, project.organization_id, viewer_context=viewer_context
-        )
+        with viewer_context_scope(_seer_vc):
+            is_message_spam = is_spam_seer(
+                feedback_message, project.organization_id, viewer_context=viewer_context
+            )
 
         metrics.incr(
             "feedback.create_feedback_issue.seer_spam_detection",
@@ -306,14 +309,15 @@ def create_feedback_issue(
     issue_fingerprint = [uuid4().hex]
 
     use_ai_title = should_query_seer
-    title = truncate_feedback_title(
-        get_feedback_title(
-            feedback_message,
-            project.organization_id,
-            use_ai_title,
-            viewer_context=viewer_context,
+    with viewer_context_scope(_seer_vc):
+        title = truncate_feedback_title(
+            get_feedback_title(
+                feedback_message,
+                project.organization_id,
+                use_ai_title,
+                viewer_context=viewer_context,
+            )
         )
-    )
 
     # Set feedback summary to the title without the "User Feedback: " prefix
     evidence_data["summary"] = title
@@ -347,9 +351,10 @@ def create_feedback_issue(
     # Generating labels using Seer, which will later be used to categorize feedbacks
     if should_query_seer:
         try:
-            labels = generate_labels(
-                feedback_message, project.organization_id, viewer_context=viewer_context
-            )
+            with viewer_context_scope(_seer_vc):
+                labels = generate_labels(
+                    feedback_message, project.organization_id, viewer_context=viewer_context
+                )
             # This will rarely happen unless the user writes a really long feedback message
             if len(labels) > MAX_AI_LABELS:
                 logger.info(

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -34,6 +34,7 @@ from sentry.utils import json, metrics
 from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.projectflags import set_project_flag_and_signal
 from sentry.utils.safe import get_path
+from sentry.viewer_context import set_viewer_context_project
 
 logger = logging.getLogger(__name__)
 
@@ -271,6 +272,7 @@ def create_feedback_issue(
 
     feedback_message = event["contexts"]["feedback"]["message"]
 
+    set_viewer_context_project(project.id)
     viewer_context = SeerViewerContext(organization_id=project.organization_id)
 
     # Spam detection.

--- a/src/sentry/issues/endpoints/bases/group.py
+++ b/src/sentry/issues/endpoints/bases/group.py
@@ -20,6 +20,7 @@ from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.grouplink import GroupLink
 from sentry.models.organization import Organization
 from sentry.utils.sdk import bind_organization_context
+from sentry.viewer_context import set_viewer_context_project
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,8 @@ class GroupEndpoint(Endpoint):
         # we didn't bind context above, so do it now
         if not organization:
             bind_organization_context(group.project.organization)
+
+        set_viewer_context_project(group.project_id)
 
         if group.status in EXCLUDED_STATUSES:
             raise ResourceDoesNotExist

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -109,7 +109,7 @@ def _resolve_viewer_context(
 
     return ViewerContext(
         organization_id=org_id,
-        project_id=vc.project_id if vc else None,
+        project_id=None if has_mismatch else (vc.project_id if vc else None),
         user_id=user_id,
         actor_type=vc.actor_type,
         token=None if has_mismatch else vc.token,

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -109,6 +109,7 @@ def _resolve_viewer_context(
 
     return ViewerContext(
         organization_id=org_id,
+        project_id=vc.project_id if vc else None,
         user_id=user_id,
         actor_type=vc.actor_type,
         token=None if has_mismatch else vc.token,

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -33,7 +33,7 @@ from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import json
-from sentry.viewer_context import set_viewer_context_project
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 logger = logging.getLogger("sentry.tasks.llm_issue_detection")
 
@@ -359,14 +359,16 @@ def detect_llm_issues_for_org(org_id: int, plan_tier: str = "business") -> None:
         plan_tier=plan_tier,
     )
 
-    set_viewer_context_project(project_id)
-    viewer_context = SeerViewerContext(organization_id=org_id)
-    response = make_issue_detection_request(
-        seer_request,
-        timeout=SEER_TIMEOUT_S,
-        retries=0,
-        viewer_context=viewer_context,
-    )
+    with viewer_context_scope(
+        ViewerContext(organization_id=org_id, project_id=project_id, actor_type=ActorType.SYSTEM)
+    ):
+        viewer_context = SeerViewerContext(organization_id=org_id)
+        response = make_issue_detection_request(
+            seer_request,
+            timeout=SEER_TIMEOUT_S,
+            retries=0,
+            viewer_context=viewer_context,
+        )
 
     if response.status == 202:
         return

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -33,6 +33,7 @@ from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import json
+from sentry.viewer_context import set_viewer_context_project
 
 logger = logging.getLogger("sentry.tasks.llm_issue_detection")
 
@@ -358,6 +359,7 @@ def detect_llm_issues_for_org(org_id: int, plan_tier: str = "business") -> None:
         plan_tier=plan_tier,
     )
 
+    set_viewer_context_project(project_id)
     viewer_context = SeerViewerContext(organization_id=org_id)
     response = make_issue_detection_request(
         seer_request,

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -185,17 +185,14 @@ def set_viewer_context_organization(organization_id: int) -> None:
 def set_viewer_context_project(project_id: int) -> None:
     """Update the current ``ViewerContext`` with a resolved project id.
 
-    Creates a new ViewerContext if none exists, so this is safe to call
-    from system-originated tasks that don't go through middleware.
+    No-op when no ViewerContext exists — use ``set_system_viewer_context``
+    for system-originated tasks without middleware.
     """
     ctx = get_viewer_context()
-    if ctx is not None and ctx.project_id == project_id:
+    if ctx is None or ctx.project_id == project_id:
         return
 
-    if ctx is None:
-        _viewer_context_var.set(ViewerContext(project_id=project_id))
-    else:
-        _viewer_context_var.set(dataclasses.replace(ctx, project_id=project_id))
+    _viewer_context_var.set(dataclasses.replace(ctx, project_id=project_id))
 
 
 # ---------------------------------------------------------------------------

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -185,7 +185,7 @@ def set_viewer_context_organization(organization_id: int) -> None:
 def set_viewer_context_project(project_id: int) -> None:
     """Update the current ``ViewerContext`` with a resolved project id.
 
-    No-op when no ViewerContext exists — use ``set_system_viewer_context``
+    No-op when no ViewerContext exists — use ``viewer_context_scope``
     for system-originated tasks without middleware.
     """
     ctx = get_viewer_context()

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -57,6 +57,7 @@ class ViewerContext:
     """
 
     organization_id: int | None = None
+    project_id: int | None = None
     user_id: int | None = None
     actor_type: ActorType = ActorType.UNKNOWN
 
@@ -69,6 +70,8 @@ class ViewerContext:
         result: dict[str, Any] = {"actor_type": self.actor_type.value}
         if self.organization_id is not None:
             result["organization_id"] = self.organization_id
+        if self.project_id is not None:
+            result["project_id"] = self.project_id
         if self.user_id is not None:
             result["user_id"] = self.user_id
         return result
@@ -82,6 +85,7 @@ class ViewerContext:
             actor_type = ActorType.UNKNOWN
         return cls(
             organization_id=data.get("organization_id"),
+            project_id=data.get("project_id"),
             user_id=data.get("user_id"),
             actor_type=actor_type,
         )
@@ -176,6 +180,15 @@ def set_viewer_context_organization(organization_id: int) -> None:
         return
 
     _viewer_context_var.set(dataclasses.replace(ctx, organization_id=organization_id))
+
+
+def set_viewer_context_project(project_id: int) -> None:
+    """Update the current ``ViewerContext`` with a resolved project id."""
+    ctx = get_viewer_context()
+    if ctx is None or ctx.project_id == project_id:
+        return
+
+    _viewer_context_var.set(dataclasses.replace(ctx, project_id=project_id))
 
 
 # ---------------------------------------------------------------------------

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -183,12 +183,19 @@ def set_viewer_context_organization(organization_id: int) -> None:
 
 
 def set_viewer_context_project(project_id: int) -> None:
-    """Update the current ``ViewerContext`` with a resolved project id."""
+    """Update the current ``ViewerContext`` with a resolved project id.
+
+    Creates a new ViewerContext if none exists, so this is safe to call
+    from system-originated tasks that don't go through middleware.
+    """
     ctx = get_viewer_context()
-    if ctx is None or ctx.project_id == project_id:
+    if ctx is not None and ctx.project_id == project_id:
         return
 
-    _viewer_context_var.set(dataclasses.replace(ctx, project_id=project_id))
+    if ctx is None:
+        _viewer_context_var.set(ViewerContext(project_id=project_id))
+    else:
+        _viewer_context_var.set(dataclasses.replace(ctx, project_id=project_id))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `project_id` field to `ViewerContext` dataclass with `serialize()`/`deserialize()` support
- Adds `set_viewer_context_project()` function (parallel to `set_viewer_context_organization()`)
- Calls it from `ProjectEndpoint.convert_args()` and `GroupEndpoint.convert_args()` so all project-scoped and issue-scoped endpoints populate `project_id` on the contextvar
- Passes `project_id` through `_resolve_viewer_context()` in `signed_seer_api.py` so it reaches Seer via the X-Viewer-Context JWT

Enables per-project cost attribution in the LLM proxy. Companion Seer PR: pending.

All changes are backward-compatible — `project_id` defaults to `None`, `serialize()` only emits it when non-None, and `deserialize()` uses `.get()`.

## Test plan
- [x] `tests/sentry/test_viewer_context.py` — 39 passed
- [x] `tests/sentry/test_viewer_context_jwt.py` — 15 passed
- [x] `tests/sentry/seer/test_signed_seer_api.py` — 7 passed
- [x] mypy clean on all changed files
- [x] Verified locally: `project_id` appears in JWT claims via django shell