### PR TITLE
feat(action_log): Efficient project bulk GroupDerivedData generation task

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -1,6 +1,6 @@
 import enum
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, router, transaction
@@ -146,14 +146,21 @@ def _process_batch(
         return bool(_entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, 1))
 
 
+class GroupLogDeadlineExceeded(Exception):
+    """Raised when process_group_log cannot finish before its deadline."""
+
+
 def process_group_log(
     group_id: int,
     batch_size: int = DEFAULT_BATCH_SIZE,
     target_pipeline: Pipeline[GroupActionLogEntry] | None = None,
+    deadline: datetime | None = None,
 ) -> GroupDerivedData:
     """Fully drain all pending entries for a group, processing in batches.
 
     Raises Group.DoesNotExist if the group has been deleted.
+    Raises GroupLogDeadlineExceeded if *deadline* is reached before all
+    entries are processed.
     """
     p = target_pipeline or PIPELINE
 
@@ -162,6 +169,8 @@ def process_group_log(
 
     has_more = _process_batch(p, derived, group_id, batch_size)
     while has_more:
+        if deadline is not None and datetime.now(UTC) >= deadline:
+            raise GroupLogDeadlineExceeded(group_id)
         has_more = _process_batch(p, derived, group_id, batch_size)
 
     return derived

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -1,6 +1,6 @@
 import enum
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, router, transaction
@@ -154,15 +154,16 @@ def process_group_log(
     group_id: int,
     batch_size: int = DEFAULT_BATCH_SIZE,
     target_pipeline: Pipeline[GroupActionLogEntry] | None = None,
-    deadline: datetime | None = None,
+    timeout: timedelta | None = None,
 ) -> GroupDerivedData:
     """Fully drain all pending entries for a group, processing in batches.
 
     Raises Group.DoesNotExist if the group has been deleted.
-    Raises GroupLogDeadlineExceeded if *deadline* is reached before all
+    Raises GroupLogDeadlineExceeded if *timeout* elapses before all
     entries are processed.
     """
     p = target_pipeline or PIPELINE
+    deadline = datetime.now(UTC) + timeout if timeout is not None else None
 
     with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
         derived = _ensure_derived(group_id)

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -1,6 +1,7 @@
 import enum
 import logging
-from datetime import UTC, datetime, timedelta
+import time
+from datetime import datetime, timedelta
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, router, transaction
@@ -146,8 +147,8 @@ def _process_batch(
         return bool(_entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, 1))
 
 
-class GroupLogDeadlineExceeded(Exception):
-    """Raised when process_group_log cannot finish before its deadline."""
+class GroupLogTimeout(Exception):
+    """Raised when process_group_log cannot finish within its timeout."""
 
 
 def process_group_log(
@@ -159,19 +160,20 @@ def process_group_log(
     """Fully drain all pending entries for a group, processing in batches.
 
     Raises Group.DoesNotExist if the group has been deleted.
-    Raises GroupLogDeadlineExceeded if *timeout* elapses before all
+    Raises GroupLogTimeout if *timeout* elapses before all
     entries are processed.
     """
     p = target_pipeline or PIPELINE
-    deadline = datetime.now(UTC) + timeout if timeout is not None else None
+    timeout_seconds = timeout.total_seconds() if timeout is not None else None
+    start = time.monotonic()
 
     with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
         derived = _ensure_derived(group_id)
 
     has_more = _process_batch(p, derived, group_id, batch_size)
     while has_more:
-        if deadline is not None and datetime.now(UTC) >= deadline:
-            raise GroupLogDeadlineExceeded(group_id)
+        if timeout_seconds is not None and time.monotonic() - start >= timeout_seconds:
+            raise GroupLogTimeout(group_id)
         has_more = _process_batch(p, derived, group_id, batch_size)
 
     return derived

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -5,11 +5,13 @@ from datetime import timedelta
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
 BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)  # taskworker hard kill timeout
 BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)  # self-reschedule before the hard kill
+_BATCH_TASK_KEY = "process_project_derived_data_batch"
 
 
 @instrumented_task(
@@ -106,8 +108,21 @@ def process_project_derived_data_batch(
 
     Reschedules itself with the remaining range if the timeout is reached.
     """
+    from taskbroker_client.state import current_task
+
     from sentry.issues.derived.processing import GroupLogTimeout, process_group_log
     from sentry.models.group import Group
+    from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
+
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_BATCH_TASK_KEY, activation_id):
+        logger.info(
+            "process_project_derived_data_batch.duplicate_skipped",
+            extra={"project_id": project_id, "activation_id": activation_id},
+        )
+        metrics.incr("taskworker.selfchain.duplicate_skipped", tags={"task": _BATCH_TASK_KEY})
+        return
 
     timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
     start = time.monotonic()
@@ -122,27 +137,65 @@ def process_project_derived_data_batch(
         .values_list("id", flat=True)
     )
 
+    processed = 0
+    rescheduled = False
+
     for group_id in group_ids:
         remaining = timedelta(seconds=timeout_seconds - (time.monotonic() - start))
         try:
             process_group_log(group_id, timeout=remaining)
+            processed += 1
         except Group.DoesNotExist:
             logger.info(
                 "process_project_derived_data_batch.group_not_found",
                 extra={"group_id": group_id, "project_id": project_id},
             )
         except GroupLogTimeout:
+            rescheduled = True
+            metrics.incr(
+                "issues.derived.batch_rescheduled",
+                sample_rate=1.0,
+                tags={"reason": "group_timeout"},
+            )
             process_project_derived_data_batch.delay(
                 project_id=project_id,
                 group_id_start=group_id,
                 group_id_end=group_id_end,
             )
-            return
+            if activation_id:
+                mark_spawned(_BATCH_TASK_KEY, activation_id)
+            break
 
         if time.monotonic() - start >= timeout_seconds:
+            rescheduled = True
+            metrics.incr(
+                "issues.derived.batch_rescheduled",
+                sample_rate=1.0,
+                tags={"reason": "batch_timeout"},
+            )
             process_project_derived_data_batch.delay(
                 project_id=project_id,
                 group_id_start=group_id + 1,
                 group_id_end=group_id_end,
             )
-            return
+            if activation_id:
+                mark_spawned(_BATCH_TASK_KEY, activation_id)
+            break
+
+    metrics.incr(
+        "issues.derived.project_groups_processed",
+        amount=processed,
+        sample_rate=1.0,
+    )
+    logger.info(
+        "process_project_derived_data_batch.complete",
+        extra={
+            "project_id": project_id,
+            "group_id_start": group_id_start,
+            "group_id_end": group_id_end,
+            "processed": processed,
+            "total": len(group_ids),
+            "rescheduled": rescheduled,
+            "elapsed": time.monotonic() - start,
+        },
+    )

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import UTC, datetime, timedelta
+import time
+from datetime import timedelta
 
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -8,7 +9,7 @@ from sentry.taskworker.namespaces import issues_tasks
 logger = logging.getLogger(__name__)
 
 BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)
-BATCH_RETRIGGER_DEADLINE = timedelta(seconds=20)
+BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)
 
 
 @instrumented_task(
@@ -73,6 +74,15 @@ def process_project_derived_data(project_id: int, **kwargs: object) -> None:
             group_id_end=end,
         )
 
+    logger.info(
+        "process_project_derived_data.scheduled",
+        extra={
+            "project_id": project_id,
+            "group_count": len(group_ids),
+            "task_count": len(ranges),
+        },
+    )
+
 
 @instrumented_task(
     name="sentry.issues.derived.tasks.process_project_derived_data_batch",
@@ -86,10 +96,11 @@ def process_project_derived_data_batch(
     group_id_end: int,
     **kwargs: object,
 ) -> None:
-    from sentry.issues.derived.processing import GroupLogDeadlineExceeded, process_group_log
+    from sentry.issues.derived.processing import GroupLogTimeout, process_group_log
     from sentry.models.group import Group
 
-    deadline = datetime.now(UTC) + BATCH_RETRIGGER_DEADLINE
+    timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
+    start = time.monotonic()
 
     group_ids = list(
         Group.objects.filter(
@@ -102,7 +113,7 @@ def process_project_derived_data_batch(
     )
 
     for group_id in group_ids:
-        remaining = deadline - datetime.now(UTC)
+        remaining = timedelta(seconds=timeout_seconds - (time.monotonic() - start))
         try:
             process_group_log(group_id, timeout=remaining)
         except Group.DoesNotExist:
@@ -110,7 +121,7 @@ def process_project_derived_data_batch(
                 "process_project_derived_data_batch.group_not_found",
                 extra={"group_id": group_id, "project_id": project_id},
             )
-        except GroupLogDeadlineExceeded:
+        except GroupLogTimeout:
             process_project_derived_data_batch.delay(
                 project_id=project_id,
                 group_id_start=group_id,
@@ -118,7 +129,7 @@ def process_project_derived_data_batch(
             )
             return
 
-        if datetime.now(UTC) >= deadline:
+        if time.monotonic() - start >= timeout_seconds:
             process_project_derived_data_batch.delay(
                 project_id=project_id,
                 group_id_start=group_id + 1,

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -8,8 +8,8 @@ from sentry.taskworker.namespaces import issues_tasks
 
 logger = logging.getLogger(__name__)
 
-BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)
-BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)
+BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)  # taskworker hard kill timeout
+BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)  # self-reschedule before the hard kill
 
 
 @instrumented_task(
@@ -18,6 +18,7 @@ BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)
     silo_mode=SiloMode.CELL,
 )
 def process_group_log_task(group_id: int, **kwargs: object) -> None:
+    """Drain all pending action log entries for a single group into its derived data."""
     from sentry.issues.derived.processing import process_group_log
     from sentry.models.group import Group
 
@@ -33,6 +34,11 @@ def process_group_log_task(group_id: int, **kwargs: object) -> None:
     silo_mode=SiloMode.CELL,
 )
 def process_project_derived_data(project_id: int, **kwargs: object) -> None:
+    """Build derived data for all unprocessed groups in a project.
+
+    Finds groups without a GroupDerivedData row, partitions them into
+    ID ranges, and fans out a batch task for each range.
+    """
     from django.db.models import Exists, OuterRef
 
     from sentry import options
@@ -96,6 +102,10 @@ def process_project_derived_data_batch(
     group_id_end: int,
     **kwargs: object,
 ) -> None:
+    """Process derived data for groups in the ID range [group_id_start, group_id_end).
+
+    Reschedules itself with the remaining range if the timeout is reached.
+    """
     from sentry.issues.derived.processing import GroupLogTimeout, process_group_log
     from sentry.models.group import Group
 

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -102,8 +102,9 @@ def process_project_derived_data_batch(
     )
 
     for group_id in group_ids:
+        remaining = deadline - datetime.now(UTC)
         try:
-            process_group_log(group_id, deadline=deadline)
+            process_group_log(group_id, timeout=remaining)
         except Group.DoesNotExist:
             logger.info(
                 "process_project_derived_data_batch.group_not_found",

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -1,10 +1,14 @@
 import logging
+from datetime import UTC, datetime, timedelta
 
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 
 logger = logging.getLogger(__name__)
+
+BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)
+BATCH_RETRIGGER_DEADLINE = timedelta(seconds=20)
 
 
 @instrumented_task(
@@ -20,3 +24,103 @@ def process_group_log_task(group_id: int, **kwargs: object) -> None:
         process_group_log(group_id)
     except Group.DoesNotExist:
         logger.info("process_group_log_task.group_not_found", extra={"group_id": group_id})
+
+
+@instrumented_task(
+    name="sentry.issues.derived.tasks.process_project_derived_data",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def process_project_derived_data(project_id: int, **kwargs: object) -> None:
+    from django.db.models import Exists, OuterRef
+
+    from sentry import options
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
+    from sentry.models.group import Group
+
+    batch_size = options.get("issues.derived.project-batch-size")
+    max_tasks = options.get("issues.derived.project-max-tasks")
+
+    group_ids = list(
+        Group.objects.filter(project_id=project_id)
+        .exclude(Exists(GroupDerivedData.objects.filter(group_id=OuterRef("id"))))
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+
+    if not group_ids:
+        return
+
+    starts = [group_ids[i] for i in range(0, len(group_ids), batch_size)]
+    ends = starts[1:] + [group_ids[-1] + 1]
+    ranges = list(zip(starts, ends))
+
+    if len(ranges) > max_tasks:
+        logger.error(
+            "process_project_derived_data.too_many_tasks",
+            extra={
+                "project_id": project_id,
+                "task_count": len(ranges),
+                "max_tasks": max_tasks,
+            },
+        )
+        return
+
+    for start, end in ranges:
+        process_project_derived_data_batch.delay(
+            project_id=project_id,
+            group_id_start=start,
+            group_id_end=end,
+        )
+
+
+@instrumented_task(
+    name="sentry.issues.derived.tasks.process_project_derived_data_batch",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+    processing_deadline_duration=int(BATCH_PROCESSING_DEADLINE.total_seconds()),
+)
+def process_project_derived_data_batch(
+    project_id: int,
+    group_id_start: int,
+    group_id_end: int,
+    **kwargs: object,
+) -> None:
+    from sentry.issues.derived.processing import GroupLogDeadlineExceeded, process_group_log
+    from sentry.models.group import Group
+
+    deadline = datetime.now(UTC) + BATCH_RETRIGGER_DEADLINE
+
+    group_ids = list(
+        Group.objects.filter(
+            project_id=project_id,
+            id__gte=group_id_start,
+            id__lt=group_id_end,
+        )
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+
+    for group_id in group_ids:
+        try:
+            process_group_log(group_id, deadline=deadline)
+        except Group.DoesNotExist:
+            logger.info(
+                "process_project_derived_data_batch.group_not_found",
+                extra={"group_id": group_id, "project_id": project_id},
+            )
+        except GroupLogDeadlineExceeded:
+            process_project_derived_data_batch.delay(
+                project_id=project_id,
+                group_id_start=group_id,
+                group_id_end=group_id_end,
+            )
+            return
+
+        if datetime.now(UTC) >= deadline:
+            process_project_derived_data_batch.delay(
+                project_id=project_id,
+                group_id_start=group_id + 1,
+                group_id_end=group_id_end,
+            )
+            return

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3876,3 +3876,17 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Issues derived data
+register(
+    "issues.derived.project-batch-size",
+    default=500,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "issues.derived.project-max-tasks",
+    default=1000,
+    type=Int,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3877,13 +3877,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Issues derived data
+# Issues derived data — process_project_derived_data task
+# Number of groups per batch task when fanning out project-wide processing.
 register(
     "issues.derived.project-batch-size",
     default=500,
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Maximum number of batch tasks to schedule; aborts if exceeded.
 register(
     "issues.derived.project-max-tasks",
     default=1000,

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from django.db import router, transaction
@@ -43,6 +43,7 @@ from sentry.issues.derived.framework import (
 )
 from sentry.issues.derived.processing import (
     PIPELINE,
+    GroupLogTimeout,
     invalidate_group_derived_data,
     process_group_log,
 )
@@ -665,3 +666,24 @@ class DerivedDataTransactionTest(TestCase):
         assert GroupDerivedData.objects.filter(group_id=group.id).exists()
         derived = GroupDerivedData.objects.get(group_id=group.id)
         assert derived.view_count == 1
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class ProcessGroupLogTimeoutTest(TestCase):
+    def test_raises_when_timeout_exceeded(self) -> None:
+        group = self.create_group()
+        for _ in range(5):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+
+        with pytest.raises(GroupLogTimeout):
+            process_group_log(group.id, batch_size=1, timeout=timedelta(0))
+
+    def test_completes_with_generous_timeout(self) -> None:
+        group = self.create_group()
+        for _ in range(3):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+
+        derived = process_group_log(group.id, timeout=timedelta(minutes=5))
+        assert derived.view_count == 3

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -1,19 +1,11 @@
-from datetime import timedelta
-from typing import Any
 from unittest.mock import patch
 
-import pytest
-
 from sentry.issues.action_log.publish import publish_action
-from sentry.issues.action_log.types import (
-    SYSTEM_ACTOR,
-    ActionSource,
-    GroupAction,
-    GroupActionActor,
-    ViewAction,
-)
-from sentry.issues.derived.processing import GroupLogTimeout
+from sentry.issues.action_log.types import ActionSource, GroupActionActor, ViewAction
+from sentry.issues.derived import processing
+from sentry.issues.derived.processing import GroupLogTimeout, process_group_log
 from sentry.issues.derived.tasks import (
+    BATCH_RETRIGGER_TIMEOUT,
     process_project_derived_data,
     process_project_derived_data_batch,
 )
@@ -24,52 +16,43 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 
-SOURCE = ActionSource.API
 
-
-def _publish(*, group: Group, action: GroupAction, actor: GroupActionActor = SYSTEM_ACTOR) -> None:
-    with outbox_runner():
-        publish_action(
-            action,
-            source=SOURCE,
-            group_id=group.id,
-            project=group.project,
-            actor=actor,
-        )
-
-
-def _create_groups_with_entries(test_case: TestCase, count: int) -> list[Group]:
-    groups = []
-    for _ in range(count):
-        group = test_case.create_group(project=test_case.project)
-        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(test_case.user.id))
-        # Delete the derived data created by _publish so the task sees them as unprocessed
-        GroupDerivedData.objects.filter(group_id=group.id).delete()
-        groups.append(group)
-    return groups
+class DerivedDataTaskTestBase(TestCase):
+    def create_unprocessed_groups(self, count: int) -> list[Group]:
+        groups = []
+        for _ in range(count):
+            group = self.create_group(project=self.project)
+            with outbox_runner():
+                publish_action(
+                    ViewAction(),
+                    source=ActionSource.API,
+                    group_id=group.id,
+                    project=group.project,
+                    actor=GroupActionActor.user(self.user.id),
+                )
+            # Delete the derived data created by publish so the task sees them as unprocessed
+            GroupDerivedData.objects.filter(group_id=group.id).delete()
+            groups.append(group)
+        return groups
 
 
 @with_feature("projects:issue-action-log-write-to-db")
-class ProcessProjectDerivedDataTest(TestCase):
-    def test_no_groups(self) -> None:
-        process_project_derived_data(project_id=self.project.id)
-
+class ProcessProjectDerivedDataTest(DerivedDataTaskTestBase):
     def test_fans_out_batches(self) -> None:
-        groups = _create_groups_with_entries(self, 3)
+        groups = self.create_unprocessed_groups(3)
 
         with patch.object(process_project_derived_data_batch, "delay") as mock_delay:
             process_project_derived_data(project_id=self.project.id)
 
-        assert mock_delay.call_count == 1
-        call_kwargs = mock_delay.call_args[1]
         group_ids = sorted(g.id for g in groups)
-        assert call_kwargs["group_id_start"] == group_ids[0]
-        assert call_kwargs["group_id_end"] == group_ids[-1] + 1
+        mock_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )
 
     def test_skips_already_processed_groups(self) -> None:
-        from sentry.issues.derived.processing import process_group_log
-
-        groups = _create_groups_with_entries(self, 3)
+        groups = self.create_unprocessed_groups(3)
         group_ids = sorted(g.id for g in groups)
 
         # Pre-process first group
@@ -78,13 +61,12 @@ class ProcessProjectDerivedDataTest(TestCase):
         with patch.object(process_project_derived_data_batch, "delay") as mock_delay:
             process_project_derived_data(project_id=self.project.id)
 
-        assert mock_delay.call_count == 1
-        call_kwargs = mock_delay.call_args[1]
         # First group should be excluded from the range
-        assert call_kwargs["group_id_start"] == group_ids[1]
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args[1]["group_id_start"] == group_ids[1]
 
     def test_batching(self) -> None:
-        _create_groups_with_entries(self, 5)
+        self.create_unprocessed_groups(5)
 
         with (
             override_options({"issues.derived.project-batch-size": 2}),
@@ -95,7 +77,7 @@ class ProcessProjectDerivedDataTest(TestCase):
         assert mock_delay.call_count == 3
 
     def test_exceeds_max_tasks(self) -> None:
-        _create_groups_with_entries(self, 3)
+        self.create_unprocessed_groups(3)
 
         with (
             override_options(
@@ -108,14 +90,13 @@ class ProcessProjectDerivedDataTest(TestCase):
         ):
             process_project_derived_data(project_id=self.project.id)
 
-        # Should bail out without scheduling any tasks
-        assert mock_delay.call_count == 0
+        mock_delay.assert_not_called()
 
 
 @with_feature("projects:issue-action-log-write-to-db")
-class ProcessProjectDerivedDataBatchTest(TestCase):
+class ProcessProjectDerivedDataBatchTest(DerivedDataTaskTestBase):
     def test_processes_range(self) -> None:
-        groups = _create_groups_with_entries(self, 3)
+        groups = self.create_unprocessed_groups(3)
         group_ids = sorted(g.id for g in groups)
 
         process_project_derived_data_batch(
@@ -128,7 +109,7 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
             assert GroupDerivedData.objects.filter(group_id=group.id).exists()
 
     def test_skips_deleted_groups(self) -> None:
-        groups = _create_groups_with_entries(self, 3)
+        groups = self.create_unprocessed_groups(3)
         group_ids = sorted(g.id for g in groups)
         deleted_id = groups[1].id
         groups[1].delete()
@@ -142,32 +123,17 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
         assert not GroupDerivedData.objects.filter(group_id=deleted_id).exists()
 
     def test_reschedules_on_timeout(self) -> None:
-        from sentry.issues.derived import processing
-
-        groups = _create_groups_with_entries(self, 3)
+        groups = self.create_unprocessed_groups(3)
         group_ids = sorted(g.id for g in groups)
 
-        call_count = 0
-        original_process = processing.process_group_log
-
-        def process_then_expire(group_id: int, **kwargs: Any) -> object:
-            nonlocal call_count
-            call_count += 1
-            result = original_process(group_id, **kwargs)
-            if call_count == 1:
-                # Jump time past the timeout after the first group
-                mock_monotonic.return_value = start_time + 100
-            return result
-
-        start_time = 1000.0
-
+        # First call succeeds; monotonic then jumps past the timeout
         with (
             patch("sentry.issues.derived.tasks.time") as mock_time,
-            patch.object(processing, "process_group_log", side_effect=process_then_expire),
+            patch.object(processing, "process_group_log") as mock_process,
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):
-            mock_monotonic = mock_time.monotonic
-            mock_monotonic.return_value = start_time
+            expired = BATCH_RETRIGGER_TIMEOUT.total_seconds() + 1
+            mock_time.monotonic.side_effect = [0.0, 0.0, expired]
 
             process_project_derived_data_batch(
                 project_id=self.project.id,
@@ -175,28 +141,23 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
                 group_id_end=group_ids[-1] + 1,
             )
 
-        assert call_count == 1
-        assert mock_delay.call_count == 1
-        reschedule_kwargs = mock_delay.call_args[1]
-        assert reschedule_kwargs["group_id_start"] == group_ids[1]
-        assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
+        mock_process.assert_called_once()
+        mock_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[1],
+            group_id_end=group_ids[-1] + 1,
+        )
 
     def test_reschedules_on_group_log_timeout(self) -> None:
-        from sentry.issues.derived import processing
-
-        groups = _create_groups_with_entries(self, 3)
+        groups = self.create_unprocessed_groups(3)
         group_ids = sorted(g.id for g in groups)
 
-        call_count = 0
-
-        def raise_on_first(group_id: int, **kwargs: object) -> None:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise GroupLogTimeout(group_id)
-
         with (
-            patch.object(processing, "process_group_log", side_effect=raise_on_first),
+            patch.object(
+                processing,
+                "process_group_log",
+                side_effect=GroupLogTimeout("timed out"),
+            ),
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):
             process_project_derived_data_batch(
@@ -204,46 +165,9 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
                 group_id_start=group_ids[0],
                 group_id_end=group_ids[-1] + 1,
             )
-
-        assert call_count == 1
-        assert mock_delay.call_count == 1
-        reschedule_kwargs = mock_delay.call_args[1]
         # On GroupLogTimeout, reschedule starts from the SAME group
-        assert reschedule_kwargs["group_id_start"] == group_ids[0]
-        assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
-
-
-@with_feature("projects:issue-action-log-write-to-db")
-class ProcessGroupLogTimeoutTest(TestCase):
-    def test_raises_when_timeout_exceeded(self) -> None:
-        from sentry.issues.derived.processing import process_group_log
-
-        group = self.create_group()
-        for _ in range(5):
-            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
-        GroupDerivedData.objects.filter(group_id=group.id).delete()
-
-        with pytest.raises(GroupLogTimeout):
-            process_group_log(group.id, batch_size=1, timeout=timedelta(0))
-
-    def test_completes_without_timeout(self) -> None:
-        from sentry.issues.derived.processing import process_group_log
-
-        group = self.create_group()
-        for _ in range(3):
-            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
-        GroupDerivedData.objects.filter(group_id=group.id).delete()
-
-        derived = process_group_log(group.id)
-        assert derived.view_count == 3
-
-    def test_completes_with_generous_timeout(self) -> None:
-        from sentry.issues.derived.processing import process_group_log
-
-        group = self.create_group()
-        for _ in range(3):
-            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
-        GroupDerivedData.objects.filter(group_id=group.id).delete()
-
-        derived = process_group_log(group.id, timeout=timedelta(minutes=5))
-        assert derived.view_count == 3
+        mock_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -141,15 +142,15 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
         assert not GroupDerivedData.objects.filter(group_id=deleted_id).exists()
 
     def test_reschedules_on_timeout(self) -> None:
+        from sentry.issues.derived import processing
+
         groups = _create_groups_with_entries(self, 3)
         group_ids = sorted(g.id for g in groups)
 
         call_count = 0
-        original_process = __import__(
-            "sentry.issues.derived.processing", fromlist=["process_group_log"]
-        ).process_group_log
+        original_process = processing.process_group_log
 
-        def process_then_expire(group_id: int, **kwargs: object) -> object:
+        def process_then_expire(group_id: int, **kwargs: Any) -> object:
             nonlocal call_count
             call_count += 1
             result = original_process(group_id, **kwargs)
@@ -161,10 +162,7 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
 
         with (
             patch("sentry.issues.derived.tasks.datetime") as mock_datetime,
-            patch(
-                "sentry.issues.derived.processing.process_group_log",
-                side_effect=process_then_expire,
-            ),
+            patch.object(processing, "process_group_log", side_effect=process_then_expire),
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):
             mock_now = mock_datetime.now
@@ -183,6 +181,8 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
         assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
 
     def test_reschedules_on_group_log_deadline_exceeded(self) -> None:
+        from sentry.issues.derived import processing
+
         groups = _create_groups_with_entries(self, 3)
         group_ids = sorted(g.id for g in groups)
 
@@ -195,10 +195,7 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
                 raise GroupLogDeadlineExceeded(group_id)
 
         with (
-            patch(
-                "sentry.issues.derived.processing.process_group_log",
-                side_effect=raise_on_first,
-            ),
+            patch.object(processing, "process_group_log", side_effect=raise_on_first),
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):
             process_project_derived_data_batch(
@@ -216,8 +213,8 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
 
 
 @with_feature("projects:issue-action-log-write-to-db")
-class ProcessGroupLogDeadlineTest(TestCase):
-    def test_raises_when_deadline_exceeded(self) -> None:
+class ProcessGroupLogTimeoutTest(TestCase):
+    def test_raises_when_timeout_exceeded(self) -> None:
         from sentry.issues.derived.processing import process_group_log
 
         group = self.create_group()
@@ -225,11 +222,10 @@ class ProcessGroupLogDeadlineTest(TestCase):
             _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         GroupDerivedData.objects.filter(group_id=group.id).delete()
 
-        past = datetime.now(UTC) - timedelta(seconds=1)
         with pytest.raises(GroupLogDeadlineExceeded):
-            process_group_log(group.id, batch_size=1, deadline=past)
+            process_group_log(group.id, batch_size=1, timeout=timedelta(0))
 
-    def test_completes_without_deadline(self) -> None:
+    def test_completes_without_timeout(self) -> None:
         from sentry.issues.derived.processing import process_group_log
 
         group = self.create_group()
@@ -240,7 +236,7 @@ class ProcessGroupLogDeadlineTest(TestCase):
         derived = process_group_log(group.id)
         assert derived.view_count == 3
 
-    def test_completes_with_generous_deadline(self) -> None:
+    def test_completes_with_generous_timeout(self) -> None:
         from sentry.issues.derived.processing import process_group_log
 
         group = self.create_group()
@@ -248,6 +244,5 @@ class ProcessGroupLogDeadlineTest(TestCase):
             _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         GroupDerivedData.objects.filter(group_id=group.id).delete()
 
-        future = datetime.now(UTC) + timedelta(minutes=5)
-        derived = process_group_log(group.id, deadline=future)
+        derived = process_group_log(group.id, timeout=timedelta(minutes=5))
         assert derived.view_count == 3

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
 
@@ -12,7 +12,7 @@ from sentry.issues.action_log.types import (
     GroupActionActor,
     ViewAction,
 )
-from sentry.issues.derived.processing import GroupLogDeadlineExceeded
+from sentry.issues.derived.processing import GroupLogTimeout
 from sentry.issues.derived.tasks import (
     process_project_derived_data,
     process_project_derived_data_batch,
@@ -155,18 +155,19 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
             call_count += 1
             result = original_process(group_id, **kwargs)
             if call_count == 1:
-                mock_now.return_value = deadline_future
+                # Jump time past the timeout after the first group
+                mock_monotonic.return_value = start_time + 100
             return result
 
-        deadline_future = datetime.now(UTC) + timedelta(seconds=60)
+        start_time = 1000.0
 
         with (
-            patch("sentry.issues.derived.tasks.datetime") as mock_datetime,
+            patch("sentry.issues.derived.tasks.time") as mock_time,
             patch.object(processing, "process_group_log", side_effect=process_then_expire),
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):
-            mock_now = mock_datetime.now
-            mock_now.return_value = datetime.now(UTC)
+            mock_monotonic = mock_time.monotonic
+            mock_monotonic.return_value = start_time
 
             process_project_derived_data_batch(
                 project_id=self.project.id,
@@ -180,7 +181,7 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
         assert reschedule_kwargs["group_id_start"] == group_ids[1]
         assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
 
-    def test_reschedules_on_group_log_deadline_exceeded(self) -> None:
+    def test_reschedules_on_group_log_timeout(self) -> None:
         from sentry.issues.derived import processing
 
         groups = _create_groups_with_entries(self, 3)
@@ -192,7 +193,7 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise GroupLogDeadlineExceeded(group_id)
+                raise GroupLogTimeout(group_id)
 
         with (
             patch.object(processing, "process_group_log", side_effect=raise_on_first),
@@ -207,7 +208,7 @@ class ProcessProjectDerivedDataBatchTest(TestCase):
         assert call_count == 1
         assert mock_delay.call_count == 1
         reschedule_kwargs = mock_delay.call_args[1]
-        # On GroupLogDeadlineExceeded, reschedule starts from the SAME group
+        # On GroupLogTimeout, reschedule starts from the SAME group
         assert reschedule_kwargs["group_id_start"] == group_ids[0]
         assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
 
@@ -222,7 +223,7 @@ class ProcessGroupLogTimeoutTest(TestCase):
             _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         GroupDerivedData.objects.filter(group_id=group.id).delete()
 
-        with pytest.raises(GroupLogDeadlineExceeded):
+        with pytest.raises(GroupLogTimeout):
             process_group_log(group.id, batch_size=1, timeout=timedelta(0))
 
     def test_completes_without_timeout(self) -> None:

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -133,7 +133,7 @@ class ProcessProjectDerivedDataBatchTest(DerivedDataTaskTestBase):
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):
             expired = BATCH_RETRIGGER_TIMEOUT.total_seconds() + 1
-            mock_time.monotonic.side_effect = [0.0, 0.0, expired]
+            mock_time.monotonic.side_effect = [0.0, 0.0, expired, expired]
 
             process_project_derived_data_batch(
                 project_id=self.project.id,

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -1,0 +1,253 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from sentry.issues.action_log.publish import publish_action
+from sentry.issues.action_log.types import (
+    SYSTEM_ACTOR,
+    ActionSource,
+    GroupAction,
+    GroupActionActor,
+    ViewAction,
+)
+from sentry.issues.derived.processing import GroupLogDeadlineExceeded
+from sentry.issues.derived.tasks import (
+    process_project_derived_data,
+    process_project_derived_data_batch,
+)
+from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.models.group import Group
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.outbox import outbox_runner
+
+SOURCE = ActionSource.API
+
+
+def _publish(*, group: Group, action: GroupAction, actor: GroupActionActor = SYSTEM_ACTOR) -> None:
+    with outbox_runner():
+        publish_action(
+            action,
+            source=SOURCE,
+            group_id=group.id,
+            project=group.project,
+            actor=actor,
+        )
+
+
+def _create_groups_with_entries(test_case: TestCase, count: int) -> list[Group]:
+    groups = []
+    for _ in range(count):
+        group = test_case.create_group(project=test_case.project)
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(test_case.user.id))
+        # Delete the derived data created by _publish so the task sees them as unprocessed
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+        groups.append(group)
+    return groups
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class ProcessProjectDerivedDataTest(TestCase):
+    def test_no_groups(self) -> None:
+        process_project_derived_data(project_id=self.project.id)
+
+    def test_fans_out_batches(self) -> None:
+        groups = _create_groups_with_entries(self, 3)
+
+        with patch.object(process_project_derived_data_batch, "delay") as mock_delay:
+            process_project_derived_data(project_id=self.project.id)
+
+        assert mock_delay.call_count == 1
+        call_kwargs = mock_delay.call_args[1]
+        group_ids = sorted(g.id for g in groups)
+        assert call_kwargs["group_id_start"] == group_ids[0]
+        assert call_kwargs["group_id_end"] == group_ids[-1] + 1
+
+    def test_skips_already_processed_groups(self) -> None:
+        from sentry.issues.derived.processing import process_group_log
+
+        groups = _create_groups_with_entries(self, 3)
+        group_ids = sorted(g.id for g in groups)
+
+        # Pre-process first group
+        process_group_log(group_ids[0])
+
+        with patch.object(process_project_derived_data_batch, "delay") as mock_delay:
+            process_project_derived_data(project_id=self.project.id)
+
+        assert mock_delay.call_count == 1
+        call_kwargs = mock_delay.call_args[1]
+        # First group should be excluded from the range
+        assert call_kwargs["group_id_start"] == group_ids[1]
+
+    def test_batching(self) -> None:
+        _create_groups_with_entries(self, 5)
+
+        with (
+            override_options({"issues.derived.project-batch-size": 2}),
+            patch.object(process_project_derived_data_batch, "delay") as mock_delay,
+        ):
+            process_project_derived_data(project_id=self.project.id)
+
+        assert mock_delay.call_count == 3
+
+    def test_exceeds_max_tasks(self) -> None:
+        _create_groups_with_entries(self, 3)
+
+        with (
+            override_options(
+                {
+                    "issues.derived.project-batch-size": 1,
+                    "issues.derived.project-max-tasks": 2,
+                }
+            ),
+            patch.object(process_project_derived_data_batch, "delay") as mock_delay,
+        ):
+            process_project_derived_data(project_id=self.project.id)
+
+        # Should bail out without scheduling any tasks
+        assert mock_delay.call_count == 0
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class ProcessProjectDerivedDataBatchTest(TestCase):
+    def test_processes_range(self) -> None:
+        groups = _create_groups_with_entries(self, 3)
+        group_ids = sorted(g.id for g in groups)
+
+        process_project_derived_data_batch(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )
+
+        for group in groups:
+            assert GroupDerivedData.objects.filter(group_id=group.id).exists()
+
+    def test_skips_deleted_groups(self) -> None:
+        groups = _create_groups_with_entries(self, 3)
+        group_ids = sorted(g.id for g in groups)
+        deleted_id = groups[1].id
+        groups[1].delete()
+
+        process_project_derived_data_batch(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[-1] + 1,
+        )
+
+        assert not GroupDerivedData.objects.filter(group_id=deleted_id).exists()
+
+    def test_reschedules_on_timeout(self) -> None:
+        groups = _create_groups_with_entries(self, 3)
+        group_ids = sorted(g.id for g in groups)
+
+        call_count = 0
+        original_process = __import__(
+            "sentry.issues.derived.processing", fromlist=["process_group_log"]
+        ).process_group_log
+
+        def process_then_expire(group_id: int, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            result = original_process(group_id, **kwargs)
+            if call_count == 1:
+                mock_now.return_value = deadline_future
+            return result
+
+        deadline_future = datetime.now(UTC) + timedelta(seconds=60)
+
+        with (
+            patch("sentry.issues.derived.tasks.datetime") as mock_datetime,
+            patch(
+                "sentry.issues.derived.processing.process_group_log",
+                side_effect=process_then_expire,
+            ),
+            patch.object(process_project_derived_data_batch, "delay") as mock_delay,
+        ):
+            mock_now = mock_datetime.now
+            mock_now.return_value = datetime.now(UTC)
+
+            process_project_derived_data_batch(
+                project_id=self.project.id,
+                group_id_start=group_ids[0],
+                group_id_end=group_ids[-1] + 1,
+            )
+
+        assert call_count == 1
+        assert mock_delay.call_count == 1
+        reschedule_kwargs = mock_delay.call_args[1]
+        assert reschedule_kwargs["group_id_start"] == group_ids[1]
+        assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
+
+    def test_reschedules_on_group_log_deadline_exceeded(self) -> None:
+        groups = _create_groups_with_entries(self, 3)
+        group_ids = sorted(g.id for g in groups)
+
+        call_count = 0
+
+        def raise_on_first(group_id: int, **kwargs: object) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise GroupLogDeadlineExceeded(group_id)
+
+        with (
+            patch(
+                "sentry.issues.derived.processing.process_group_log",
+                side_effect=raise_on_first,
+            ),
+            patch.object(process_project_derived_data_batch, "delay") as mock_delay,
+        ):
+            process_project_derived_data_batch(
+                project_id=self.project.id,
+                group_id_start=group_ids[0],
+                group_id_end=group_ids[-1] + 1,
+            )
+
+        assert call_count == 1
+        assert mock_delay.call_count == 1
+        reschedule_kwargs = mock_delay.call_args[1]
+        # On GroupLogDeadlineExceeded, reschedule starts from the SAME group
+        assert reschedule_kwargs["group_id_start"] == group_ids[0]
+        assert reschedule_kwargs["group_id_end"] == group_ids[-1] + 1
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class ProcessGroupLogDeadlineTest(TestCase):
+    def test_raises_when_deadline_exceeded(self) -> None:
+        from sentry.issues.derived.processing import process_group_log
+
+        group = self.create_group()
+        for _ in range(5):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+
+        past = datetime.now(UTC) - timedelta(seconds=1)
+        with pytest.raises(GroupLogDeadlineExceeded):
+            process_group_log(group.id, batch_size=1, deadline=past)
+
+    def test_completes_without_deadline(self) -> None:
+        from sentry.issues.derived.processing import process_group_log
+
+        group = self.create_group()
+        for _ in range(3):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+
+        derived = process_group_log(group.id)
+        assert derived.view_count == 3
+
+    def test_completes_with_generous_deadline(self) -> None:
+        from sentry.issues.derived.processing import process_group_log
+
+        group = self.create_group()
+        for _ in range(3):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+
+        future = datetime.now(UTC) + timedelta(minutes=5)
+        derived = process_group_log(group.id, deadline=future)
+        assert derived.view_count == 3


### PR DESCRIPTION
We want to be able to generate GroupDerivedData coverage for an already-backfilled project. 
This adds a task that identifies all groups without GDD, and spawns child tasks to process those groups in chunks.
Each chunk processes its specified group id range until all are processed.
The chunk processing doesn't ignore cases with pre-existing GDD, as those may be groups it has partially processed, but up-to-date processing should be cheap enough for this to be fine in practice.

Note: this isn't intended to be the long-term approach to generation, but establishes a pattern for generation that lets us get coverage for projects efficiently now, and can be repurposed for no-downtime regeneration approaches later.