### PR TITLE
feat(utils): Add mismatch logging options to `SafeRolloutComparator`

### DIFF
--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -13,6 +13,7 @@ from sentry.options.manager import (
 )
 from sentry.utils import metrics
 from sentry.utils.safe import trim
+from sentry.utils.sdk import sdk_logger
 from sentry.utils.types import Bool, Dict, Float, Sequence
 
 logger = logging.getLogger(__name__)
@@ -89,6 +90,10 @@ class SafeRolloutComparator:
 
     # This identifies your overall rollout, and is used in option names and metrics/log tagging
     ROLLOUT_NAME: str
+    # Whether to log using the regular Python logger (which logs to both GCP and Sentry), or the SDK
+    # logger (which logs only to Sentry). Useful for situations where mismatch logs might include
+    # customer data. Defaults to False (meaning the Python logger is used).
+    internal_logs_only: bool = False
 
     @classmethod
     def _should_run_experiment_option(cls) -> str:
@@ -197,6 +202,10 @@ class SafeRolloutComparator:
 
     @classmethod
     def _default_serialize_for_log(cls, value: Any) -> Any:
+        # The internal-only logger handles serialization itself
+        if cls.internal_logs_only:
+            return value
+
         if isinstance(value, (str, int, float, bool)) or value is None:
             return value
         if isinstance(value, dict):
@@ -224,22 +233,41 @@ class SafeRolloutComparator:
         if not cls._should_log_mismatch(callsite):
             return
 
-        serialize = data_serializer or cls._default_serialize_for_log
-
-        logger.info(
-            "saferollout.mismatch",
-            extra={
-                "rollout_name": cls.ROLLOUT_NAME,
-                "callsite": callsite,
-                "source_of_truth": source_of_truth,
-                "exact_match": is_exact_match,
-                "reasonable_match": is_reasonable_match,
-                "is_null_result": is_experimental_data_nullish,
-                "debug_context": trim(cls._default_serialize_for_log(debug_context)),
-                "control_data_raw": trim(serialize(control_data)),
-                "experimental_data_raw": trim(serialize(experimental_data)),
-            },
+        serialize = (
+            data_serializer
+            # For comparators using internal logs only, `_default_serialize_for_log` is a
+            # pass-through, since our SDK logging wrapper (which internal-only comparators use for
+            # logging) handles serialization itself. For comparators using the Python logger, it
+            # preserves structure but stringifies values of unknown types.
+            or cls._default_serialize_for_log
         )
+
+        base_logging_data = {
+            "rollout_name": cls.ROLLOUT_NAME,
+            "callsite": callsite,
+            "source_of_truth": source_of_truth,
+            "exact_match": is_exact_match,
+            "reasonable_match": is_reasonable_match,
+            "is_null_result": is_experimental_data_nullish,
+            "debug_context": cls._default_serialize_for_log(debug_context),
+            "control_data_raw": serialize(control_data),
+            "experimental_data_raw": serialize(experimental_data),
+        }
+
+        if cls.internal_logs_only:
+            sdk_logger.info("saferollout.mismatch", attributes=base_logging_data)
+        else:
+            logger.info(
+                "saferollout.mismatch",
+                extra={
+                    **base_logging_data,
+                    # Trimming has to be handled here rather than in `_default_serialize_for_log`
+                    # because the latter is recursive, and we only want to trim at the end.
+                    "debug_context": trim(base_logging_data["debug_context"]),
+                    "control_data_raw": trim(base_logging_data["control_data_raw"]),
+                    "experimental_data_raw": trim(base_logging_data["experimental_data_raw"]),
+                },
+            )
 
     @classmethod
     def _is_valid_sample_rate(cls, value: Any) -> bool:

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -94,6 +94,10 @@ class SafeRolloutComparator:
     # logger (which logs only to Sentry). Useful for situations where mismatch logs might include
     # customer data. Defaults to False (meaning the Python logger is used).
     internal_logs_only: bool = False
+    # Custom serializer to use when logging control and experimental data in cases where they don't
+    # match. Can also be passed directly to `compare`, `check_and_choose`, and
+    # `check_and_choose_with_timings` for callsite-specific serialization.
+    data_serializer: Callable[[TData], Any] | None = None
 
     @classmethod
     def _should_run_experiment_option(cls) -> str:
@@ -235,6 +239,7 @@ class SafeRolloutComparator:
 
         serialize = (
             data_serializer
+            or cls.data_serializer
             # For comparators using internal logs only, `_default_serialize_for_log` is a
             # pass-through, since our SDK logging wrapper (which internal-only comparators use for
             # logging) handles serialization itself. For comparators using the Python logger, it

--- a/src/sentry/utils/rollout.py
+++ b/src/sentry/utils/rollout.py
@@ -18,7 +18,7 @@ from sentry.utils.types import Bool, Dict, Float, Sequence
 
 logger = logging.getLogger(__name__)
 
-TData = TypeVar("TData")
+TData = TypeVar("TData")  # The type of data being compared
 
 SourceOfTruth = Literal["control", "experimental", "neither", "both"]
 

--- a/tests/sentry/utils/test_rollout.py
+++ b/tests/sentry/utils/test_rollout.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +7,7 @@ from sentry.options import all as all_options
 from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils.rollout import SafeRolloutComparator
+from sentry.utils.safe import trim
 
 
 class TestRolloutComparator(SafeRolloutComparator):
@@ -209,3 +211,153 @@ class SafeRolloutComparatorTestCase(TestCase):
         assert mock_check_and_choose.called
         assert mock_check_and_choose.call_args.kwargs["debug_context"] == {"x": "y"}
         assert mock_check_and_choose.call_args.kwargs["data_serializer"] is serializer
+
+    @override_options({TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: ["*"]})
+    def test_serializer_use(self) -> None:
+        maybe_log_mismatch_kwargs: Any = {
+            "callsite": "dogpark",
+            "source_of_truth": "neither",
+            "is_exact_match": True,
+            "is_reasonable_match": True,
+            "is_experimental_data_nullish": False,
+            "control_data": {"dogs are great"},
+            "experimental_data": {"adopt, don't shop"},
+            "debug_context": {"fetch": "the ball"},
+            "data_serializer": None,
+        }
+
+        mock_default_serializer = MagicMock(return_value="default serializer result")
+        mock_class_level_serializer = MagicMock(return_value="class-level serializer result")
+        mock_callsite_level_serializer = MagicMock(return_value="callsite-level serializer result")
+
+        # When neither a class-level nor callsite-level custom serializer is provided, the default
+        # serializer is used for the control and experimental data, and for the debug context
+        with (
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch.object(
+                TestRolloutComparator, "_default_serialize_for_log", mock_default_serializer
+            ),
+        ):
+            TestRolloutComparator._maybe_log_mismatch(**maybe_log_mismatch_kwargs)
+
+            mock_default_serializer.assert_any_call({"dogs are great"})
+            mock_default_serializer.assert_any_call({"adopt, don't shop"})
+            mock_default_serializer.assert_any_call({"fetch": "the ball"})
+
+            logger_extra = mock_python_logger.call_args.kwargs["extra"]
+            assert logger_extra["control_data_raw"] == "default serializer result"
+            assert logger_extra["experimental_data_raw"] == "default serializer result"
+            assert logger_extra["debug_context"] == "default serializer result"
+
+        # When a class-level serializer but no callsite-level serializer is provided, the
+        # class-level serializer is used for the control and experimental data, and the default
+        # serializer is used for the debug context
+        with (
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch.object(
+                TestRolloutComparator, "_default_serialize_for_log", mock_default_serializer
+            ),
+            patch.object(TestRolloutComparator, "data_serializer", mock_class_level_serializer),
+        ):
+            TestRolloutComparator._maybe_log_mismatch(**maybe_log_mismatch_kwargs)
+
+            mock_class_level_serializer.assert_any_call({"dogs are great"})
+            mock_class_level_serializer.assert_any_call({"adopt, don't shop"})
+            mock_default_serializer.assert_any_call({"fetch": "the ball"})
+
+            logger_extra = mock_python_logger.call_args.kwargs["extra"]
+            assert logger_extra["control_data_raw"] == "class-level serializer result"
+            assert logger_extra["experimental_data_raw"] == "class-level serializer result"
+            assert logger_extra["debug_context"] == "default serializer result"
+
+        # When a callsite-level serializer but no class-level serializer is provided, the
+        # callsite-level serializer is used for the control and experimental data, and the default
+        # serializer is used for the debug context
+        with (
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch.object(
+                TestRolloutComparator, "_default_serialize_for_log", mock_default_serializer
+            ),
+            patch.dict(maybe_log_mismatch_kwargs, data_serializer=mock_callsite_level_serializer),
+        ):
+            TestRolloutComparator._maybe_log_mismatch(**maybe_log_mismatch_kwargs)
+
+            mock_callsite_level_serializer.assert_any_call({"dogs are great"})
+            mock_callsite_level_serializer.assert_any_call({"adopt, don't shop"})
+            mock_default_serializer.assert_any_call({"fetch": "the ball"})
+
+            logger_extra = mock_python_logger.call_args.kwargs["extra"]
+            assert logger_extra["control_data_raw"] == "callsite-level serializer result"
+            assert logger_extra["experimental_data_raw"] == "callsite-level serializer result"
+            assert logger_extra["debug_context"] == "default serializer result"
+
+        # When both a class-level serializer and a callsite-level serializer are provided, the
+        # callsite-level serializer takes precedence and is used for the control and experimental
+        # data, and the default serializer is used for the debug context
+        with (
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch.object(TestRolloutComparator, "data_serializer", mock_class_level_serializer),
+            patch.object(
+                TestRolloutComparator, "_default_serialize_for_log", mock_default_serializer
+            ),
+            patch.dict(maybe_log_mismatch_kwargs, data_serializer=mock_callsite_level_serializer),
+        ):
+            TestRolloutComparator._maybe_log_mismatch(**maybe_log_mismatch_kwargs)
+
+            mock_callsite_level_serializer.assert_any_call({"dogs are great"})
+            mock_callsite_level_serializer.assert_any_call({"adopt, don't shop"})
+            mock_default_serializer.assert_any_call({"fetch": "the ball"})
+
+            logger_extra = mock_python_logger.call_args.kwargs["extra"]
+            assert logger_extra["control_data_raw"] == "callsite-level serializer result"
+            assert logger_extra["experimental_data_raw"] == "callsite-level serializer result"
+            assert logger_extra["debug_context"] == "default serializer result"
+
+    @override_options({TEST_CALLSITE_MISMATCH_LOG_ALLOWLIST_OPTION: ["*"]})
+    def test_internal_only_logging(self) -> None:
+        maybe_log_mismatch_kwargs: Any = {
+            "callsite": "dogpark",
+            "source_of_truth": "neither",
+            "is_exact_match": True,
+            "is_reasonable_match": True,
+            "is_experimental_data_nullish": False,
+            "control_data": {"dogs are great"},
+            "experimental_data": {"adopt, don't shop"},
+            "debug_context": {"fetch": "the ball"},
+            "data_serializer": None,
+        }
+
+        # The option defaults to `False`
+        assert TestRolloutComparator.internal_logs_only is False
+
+        with (
+            patch("sentry.utils.rollout.trim", wraps=trim) as trim_spy,
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch("sentry.utils.rollout.sdk_logger.info") as mock_sdk_logger,
+        ):
+            TestRolloutComparator._maybe_log_mismatch(**maybe_log_mismatch_kwargs)
+
+            assert trim_spy.call_count == 3  # For control data, experimental data, debug context
+            mock_python_logger.assert_called()
+            mock_sdk_logger.assert_not_called()
+            # By default, `_default_serialize_for_log` turns sets into lists
+            assert mock_python_logger.call_args.kwargs["extra"]["control_data_raw"] == [
+                "dogs are great"
+            ]
+
+        with (
+            patch.object(TestRolloutComparator, "internal_logs_only", True),
+            patch("sentry.utils.rollout.trim", wraps=trim) as trim_spy,
+            patch("sentry.utils.rollout.logger.info") as mock_python_logger,
+            patch("sentry.utils.rollout.sdk_logger.info") as mock_sdk_logger,
+        ):
+            TestRolloutComparator._maybe_log_mismatch(**maybe_log_mismatch_kwargs)
+
+            assert trim_spy.call_count == 0
+            mock_python_logger.assert_not_called()
+            mock_sdk_logger.assert_called()
+            # If we're only logging internally, `_default_serialize_for_log` is just a pass through,
+            # and leaves serialization to to the SDK logger
+            assert mock_sdk_logger.call_args.kwargs["attributes"]["control_data_raw"] == {
+                "dogs are great"
+            }


### PR DESCRIPTION
This makes two improvements to the logging our `SafeRolloutComparator` does when it finds a mismatch between the control and experimental data. Specifically, it adds the following options:

- `internal_logs_only`: A boolean which defaults to false, but which, when set to true, makes the comparator use our logs product directly (so that logs go only to Sentry) rather than the python logger (which logs to both Sentry and GCP). This will allow us to log more data when there's a mismatch, without worrying about leaking anything customer-related to a third-party service.

- `data_serializer`: A callable which will be used to serialize the control and experimental data before it's logged. This serves the same purpose as the parameter of the same name which can be passed to `compare`, `check_and_choose`, and `check_and_choose_with_timings`, but allows it to be set on the class so it doesn't have to be passed every time one of those methods is called.