### PR TITLE
feat(autofix): render unknown PR iteration feedback sources

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -859,6 +859,32 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('Make the button blue')).toBeInTheDocument();
     });
 
+    it('renders queued feedback with missing source attribution', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue'}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('(unknown): Make the button blue')).toBeInTheDocument();
+    });
+
     it('shows the code changes for queued feedback without the feature flag', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -105,7 +105,7 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
       return {
         ...base,
         sourceType: 'other',
-        source: (parsed.source as {type?: string} | undefined)?.type ?? 'unknown',
+        source: parsed.source?.type ?? 'unknown',
       };
   }
 }

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -70,8 +70,13 @@ interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   githubUsername?: string;
 }
 
+interface OtherFeedback extends ParsedBaseFeedback {
+  source: string;
+  sourceType: 'other';
+}
+
 // What `parseFeedback` can produce from the stored JSON alone.
-type ParsedFeedback = UserUiFeedback | GithubPrCommentFeedback;
+type ParsedFeedback = UserUiFeedback | GithubPrCommentFeedback | OtherFeedback;
 
 // A parsed feedback enriched with the iteration context the caller supplies.
 type IterationFeedback = ParsedFeedback & {
@@ -97,7 +102,11 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
       };
     }
     default:
-      return null;
+      return {
+        ...base,
+        sourceType: 'other',
+        source: (parsed.source as {type?: string} | undefined)?.type ?? 'unknown',
+      };
   }
 }
 
@@ -434,6 +443,15 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   );
 }
 
+function feedbackLinkUrl(item: IterationFeedback): string | undefined {
+  switch (item.sourceType) {
+    case 'github-pr-comment':
+      return item.commentUrl;
+    default:
+      return undefined;
+  }
+}
+
 function FeedbackAttribution({item}: {item: IterationFeedback}) {
   switch (item.sourceType) {
     case 'github-pr-comment':
@@ -485,6 +503,7 @@ const FeedbackProse = styled(Prose)<{muted?: boolean}>`
 
 function FeedbackItem({item}: {item: IterationFeedback}) {
   const isQueued = item.status === 'queued';
+  const linkUrl = feedbackLinkUrl(item);
   return (
     <Flex gap="md" align="start" justify="between">
       <Flex gap="md" align="start" flex="1" minWidth={0}>
@@ -495,11 +514,15 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
           <FeedbackAttribution item={item} />
         </Flex>
         <Flex align="center" minWidth={0} minHeight="1lh">
-          {item.sourceType === 'github-pr-comment' ? (
-            <ExternalLink href={item.commentUrl}>{item.text}</ExternalLink>
+          {linkUrl ? (
+            <ExternalLink href={linkUrl}>{item.text}</ExternalLink>
           ) : (
             <FeedbackProse muted={isQueued}>
-              <p>{item.text}</p>
+              <p>
+                {item.sourceType === 'other'
+                  ? `(${item.source}): ${item.text}`
+                  : item.text}
+              </p>
             </FeedbackProse>
           )}
         </Flex>


### PR DESCRIPTION
add default rendering for unknown feedback sources as a fall back in the UI

this makes it easy to test backend changes where we have new types of feedback sources before we actually make the UI change