### PR TITLE
perf(GAL): Switch project backfill cursor from activity ID to datetime

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -115,6 +115,7 @@ def reset_and_backfill_group_action_log(
 def backfill_group_action_log_for_project(
     project_id: int,
     last_activity_id: int = 0,
+    cursor_datetime: str | None = None,
     **kwargs: object,
 ) -> None:
     task_state = current_task()
@@ -136,14 +137,16 @@ def backfill_group_action_log_for_project(
     except Project.DoesNotExist:
         return
 
+    parsed_cursor = datetime.fromisoformat(cursor_datetime) if cursor_datetime else None
+
     try:
-        _backfill_project(project, last_activity_id, activation_id)
+        _backfill_project(project, parsed_cursor, activation_id)
     except Exception:
         logger.exception(
             "backfill_group_action_log.task_failed",
             extra={
                 "project_id": project_id,
-                "last_activity_id": last_activity_id,
+                "cursor_datetime": cursor_datetime,
             },
         )
         raise
@@ -151,7 +154,7 @@ def backfill_group_action_log_for_project(
 
 def _backfill_project(
     project: Project,
-    last_activity_id: int,
+    cursor_dt: datetime | None,
     activation_id: str | None = None,
 ) -> None:
     batch_size: int = options.get("issues.backfill_group_action_log.batch_size")
@@ -164,13 +167,13 @@ def _backfill_project(
         )
         return
 
-    activities = list(
-        Activity.objects.filter(
-            project_id=project.id,
-            id__gt=last_activity_id,
-            group_id__isnull=False,
-        ).order_by("id")[:batch_size]
+    qs = Activity.objects.filter(
+        project_id=project.id,
+        group_id__isnull=False,
     )
+    if cursor_dt is not None:
+        qs = qs.filter(datetime__gte=cursor_dt)
+    activities = list(qs.order_by("datetime")[:batch_size])
 
     if not activities:
         logger.info(
@@ -183,7 +186,7 @@ def _backfill_project(
         "backfill_group_action_log.batch_starting",
         extra={
             "project_id": project.id,
-            "last_activity_id": last_activity_id,
+            "cursor_datetime": cursor_dt.isoformat() if cursor_dt else None,
             "batch_size": len(activities),
             "first_activity_id": activities[0].id,
             "last_activity_id_in_batch": activities[-1].id,
@@ -247,6 +250,8 @@ def _backfill_project(
         tags={"reason": "translation_error"},
     )
 
+    next_cursor = activities[-1].datetime.isoformat()
+
     logger.info(
         "backfill_group_action_log.batch_complete",
         extra={
@@ -254,7 +259,7 @@ def _backfill_project(
             "converted_count": converted_count,
             "skipped_count": skipped_count,
             "error_count": error_count,
-            "last_activity_id_in_batch": activities[-1].id,
+            "next_cursor_datetime": next_cursor,
         },
     )
 
@@ -262,7 +267,7 @@ def _backfill_project(
         backfill_group_action_log_for_project.apply_async(
             kwargs={
                 "project_id": project.id,
-                "last_activity_id": activities[-1].id,
+                "cursor_datetime": next_cursor,
             },
             countdown=inter_batch_delay_s,
             headers={"sentry-propagate-traces": False},

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -172,6 +172,9 @@ def _backfill_project(
         group_id__isnull=False,
     )
     if cursor_dt is not None:
+        # gte not gt: may re-fetch the last row from the previous batch, but the
+        # idempotency key (ON CONFLICT DO NOTHING) makes that a no-op. Avoids
+        # skipping rows that share a timestamp at the batch boundary.
         qs = qs.filter(datetime__gte=cursor_dt)
     activities = list(qs.order_by("datetime")[:batch_size])
 

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -320,7 +320,7 @@ class BackfillGroupActionLogForProjectTest(TestCase):
         mock_apply.assert_called_once()
         call_kwargs = mock_apply.call_args.kwargs["kwargs"]
         assert call_kwargs["project_id"] == self.project.id
-        assert call_kwargs["last_activity_id"] > 0
+        assert call_kwargs["cursor_datetime"] is not None
 
     def test_completes_when_no_activities(self) -> None:
         with (
@@ -361,18 +361,18 @@ class BackfillGroupActionLogForProjectTest(TestCase):
         assert entry.date_added == activity.datetime
 
     def test_resumes_from_cursor(self) -> None:
-        a1 = self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
         self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
+        a2 = self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)
 
         with self._options(), patch.object(backfill_group_action_log_for_project, "apply_async"):
             backfill_group_action_log_for_project(
                 self.project.id,
-                last_activity_id=a1.id,
+                cursor_datetime=a2.datetime.isoformat(),
             )
 
-        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 1
-        entry = GroupActionLogEntry.objects.get(group_id=self.group.id)
-        assert entry.idempotency_key != f"activity:{a1.id}"
+        entries = GroupActionLogEntry.objects.filter(group_id=self.group.id)
+        assert entries.count() == 1
+        assert entries[0].idempotency_key == f"activity:{a2.id}"
 
     def test_handles_validation_errors(self) -> None:
         self._create_activity(ActivityType.SET_RESOLVED, user_id=self.user.id)


### PR DESCRIPTION
## Summary
- The Activity table has indexes on `(project_id, datetime)` and `(project_id, type)` but **not** `(project_id, id)`
- The backfill query `WHERE project_id = X AND id > Y ORDER BY id` was hitting statement timeouts on large projects
- Switch to `datetime`-based cursor to use the existing `(project_id, datetime)` index
- Idempotency keys still use `activity.id` — only the pagination cursor changed

## Test plan
- [x] All 24 tests pass
- Validated against production project that previously timed out