### PR TITLE
ref(dashboards): graduate visibility-dashboards-async-queue flag

### DIFF
--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -25,13 +25,9 @@ type Context = {
 const WidgetQueueContext = createContext<Context | undefined>(undefined);
 
 export function useWidgetQueryQueue() {
-  const organization = useOrganization();
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
   const queueContext = useContext(WidgetQueueContext);
 
-  return hasQueueFeature && queueContext ? queueContext : {queue: undefined};
+  return queueContext ? queueContext : {queue: undefined};
 }
 
 // Lowest known safe value for customers — used when the org option is unset so we

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
@@ -21,7 +21,6 @@ import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDisc
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {shouldUseOnDemandMetrics} from 'sentry/utils/performance/contexts/onDemandControl';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {
   doOnDemandMetricsRequest,
@@ -94,10 +93,6 @@ export function useErrorsAndTransactionsSeriesQuery(
     organization,
     filteredWidget,
     onDemandControlContext
-  );
-
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
   );
 
   const queryResults = useQueries({
@@ -225,13 +220,7 @@ export function useErrorsAndTransactionsSeriesQuery(
           return apiFetch<ErrorsAndTransactionsSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });
@@ -370,10 +359,6 @@ export function useErrorsAndTransactionsTableQuery(
     onDemandControlContext
   );
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map(query => {
       const eventView = eventViewFromWidget('', query, pageFilters);
@@ -434,13 +419,7 @@ export function useErrorsAndTransactionsTableQuery(
           return apiFetch<ErrorsAndTransactionsTableResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -18,7 +18,6 @@ import type {
 } from 'sentry/utils/discover/discoverQuery';
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {ErrorsConfig} from 'sentry/views/dashboards/datasetConfig/errors';
@@ -62,10 +61,6 @@ export function useErrorsSeriesQuery(
     () =>
       applyDashboardFiltersToWidget(widget, dashboardFilters, skipDashboardFilterParens),
     [widget, dashboardFilters, skipDashboardFilterParens]
-  );
-
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
   );
 
   const queryResults = useQueries({
@@ -124,13 +119,7 @@ export function useErrorsSeriesQuery(
           return apiFetch<ErrorsSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });
@@ -226,10 +215,6 @@ export function useErrorsTableQuery(
     [widget, dashboardFilters, skipDashboardFilterParens]
   );
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map(query => {
       const modifiedQuery = cloneDeep(query);
@@ -292,13 +277,7 @@ export function useErrorsTableQuery(
           return apiFetch<ErrorsTableResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
@@ -7,7 +7,6 @@ import {apiFetch, type ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {
@@ -54,10 +53,6 @@ export function useIssuesSeriesQuery(
     () =>
       applyDashboardFiltersToWidget(widget, dashboardFilters, skipDashboardFilterParens),
     [widget, dashboardFilters, skipDashboardFilterParens]
-  );
-
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
   );
 
   const queryResults = useQueries({
@@ -123,13 +118,7 @@ export function useIssuesSeriesQuery(
           return apiFetch<IssuesSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
         placeholderData: keepPreviousData,
@@ -226,10 +215,6 @@ export function useIssuesTableQuery(
     [widget, dashboardFilters, skipDashboardFilterParens]
   );
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map(query => {
       const queryParams: Record<string, unknown> = {
@@ -277,13 +262,7 @@ export function useIssuesTableQuery(
           return apiFetch<IssuesTableResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
@@ -18,7 +18,6 @@ import type {
 } from 'sentry/utils/discover/discoverQuery';
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {LogsConfig} from 'sentry/views/dashboards/datasetConfig/logs';
@@ -63,10 +62,6 @@ export function useLogsSeriesQuery(
     () =>
       applyDashboardFiltersToWidget(widget, dashboardFilters, skipDashboardFilterParens),
     [widget, dashboardFilters, skipDashboardFilterParens]
-  );
-
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
   );
 
   const queryResults = useQueries({
@@ -129,13 +124,7 @@ export function useLogsSeriesQuery(
           return apiFetch<LogsSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });
@@ -233,10 +222,6 @@ export function useLogsTableQuery(
   );
 
   // Check if organization has the async queue feature
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map(query => {
       const eventView = eventViewFromWidget('', query, pageFilters);
@@ -280,13 +265,7 @@ export function useLogsTableQuery(
           return apiFetch<LogsTableResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
@@ -8,7 +8,6 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getUtcDateString} from 'sentry/utils/dates';
 import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {MobileAppSizeConfig} from 'sentry/views/dashboards/datasetConfig/mobileAppSize';
@@ -54,10 +53,6 @@ export function useMobileAppSizeSeriesQuery(
   );
 
   // Check if organization has the async queue feature
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map((_, queryIndex) => {
       const requestData = getSeriesRequestData(
@@ -118,13 +113,7 @@ export function useMobileAppSizeSeriesQuery(
           return apiFetch<MobileAppSizeSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
@@ -48,10 +48,6 @@ export function useReleasesSeriesQuery(params: WidgetQueryParams): HookWidgetQue
     );
   }, [widget, dashboardFilters, skipDashboardFilterParens]);
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   // Compute validation error and request options together
   const {queryRequests, validationError} = useMemo(() => {
     try {
@@ -109,13 +105,7 @@ export function useReleasesSeriesQuery(params: WidgetQueryParams): HookWidgetQue
           return apiFetch<SessionApiResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
         select: selectJsonWithHeaders,
@@ -234,10 +224,6 @@ export function useReleasesTableQuery(params: WidgetQueryParams): HookWidgetQuer
     );
   }, [widget, dashboardFilters, skipDashboardFilterParens]);
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   // Compute validation error and request options together
   const {queryRequests, validationError} = useMemo(() => {
     try {
@@ -282,13 +268,7 @@ export function useReleasesTableQuery(params: WidgetQueryParams): HookWidgetQuer
           return apiFetch<SessionApiResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
         select: selectJsonWithHeaders,

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
@@ -26,7 +26,6 @@ import {
 } from 'sentry/utils/discover/fields';
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
@@ -81,10 +80,6 @@ export function useSpansSeriesQuery(
     () =>
       applyDashboardFiltersToWidget(widget, dashboardFilters, skipDashboardFilterParens),
     [widget, dashboardFilters, skipDashboardFilterParens]
-  );
-
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
   );
 
   const queryResults = useQueries({
@@ -149,13 +144,7 @@ export function useSpansSeriesQuery(
           return apiFetch<SpansSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });
@@ -282,10 +271,6 @@ export function useSpansTableQuery(
     [widget, dashboardFilters, skipDashboardFilterParens]
   );
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   // Use native useQueries with queue-integrated queryFn
   // React Query auto-refetches when keys change, but API calls go through the queue
   const queryResults = useQueries({
@@ -367,13 +352,7 @@ export function useSpansTableQuery(
           return apiFetch<SpansTableResponse>(modifiedContext);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -22,7 +22,6 @@ import {
 import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {decodeSorts} from 'sentry/utils/queryString';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import {SERIES_QUERY_DELIMITER} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import type {
@@ -74,10 +73,6 @@ export function useTraceMetricsSeriesQuery(
     () =>
       applyDashboardFiltersToWidget(widget, dashboardFilters, skipDashboardFilterParens),
     [widget, dashboardFilters, skipDashboardFilterParens]
-  );
-
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
   );
 
   const queryResults = useQueries({
@@ -161,13 +156,7 @@ export function useTraceMetricsSeriesQuery(
           return apiFetch<TraceMetricsSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });
@@ -284,10 +273,6 @@ export function useTraceMetricsTableQuery(
     [widget, dashboardFilters, skipDashboardFilterParens]
   );
 
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map(query => {
       const eventView = eventViewFromWidget('', query, pageFilters);
@@ -348,13 +333,7 @@ export function useTraceMetricsTableQuery(
           return apiFetch<TraceMetricsTableResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
@@ -22,7 +22,6 @@ import type {DiscoverQueryRequestParams} from 'sentry/utils/discover/genericDisc
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {shouldUseOnDemandMetrics} from 'sentry/utils/performance/contexts/onDemandControl';
-import {RequestError} from 'sentry/utils/requestError/requestError';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
 import {doOnDemandMetricsRequest} from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {TransactionsConfig} from 'sentry/views/dashboards/datasetConfig/transactions';
@@ -84,10 +83,6 @@ export function useTransactionsSeriesQuery(
   );
 
   // Check if organization has the async queue feature
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map((_, queryIndex) => {
       const requestData = getSeriesRequestData(
@@ -202,13 +197,7 @@ export function useTransactionsSeriesQuery(
           return apiFetch<TransactionsSeriesResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         placeholderData: keepPreviousData,
       });
@@ -315,10 +304,6 @@ export function useTransactionsTableQuery(
   );
 
   // Check if organization has the async queue feature
-  const hasQueueFeature = organization.features.includes(
-    'visibility-dashboards-async-queue'
-  );
-
   const queryResults = useQueries({
     queries: filteredWidget.queries.map(query => {
       // Clone the query to avoid mutating the original
@@ -392,13 +377,7 @@ export function useTransactionsTableQuery(
           return apiFetch<TransactionsTableResponse>(context);
         },
         enabled,
-        retry: hasQueueFeature
-          ? false
-          : (failureCount, error) => {
-              return (
-                error instanceof RequestError && error.status === 429 && failureCount < 10
-              );
-            },
+        retry: false,
         retryDelay: getRetryDelay,
         select: selectJsonWithHeaders,
       });


### PR DESCRIPTION
Graduate `organizations:visibility-dashboards-async-queue`. This flag was fully rolled out to 100% GA in the automator in getsentry/sentry-options-automator#7753 on 5/8, and hasn't been touched since. Removes the frontend feature checks so the dashboard widget query queue and no-retry behavior are always on.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wFGJcniL7R6d6ZFwiQCeL)_