### PR TITLE
ref(dashboards): unregister visibility-dashboards-async-queue flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -379,8 +379,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
-    # Enable an async queue for dashboard widget queries
-    manager.add("organizations:visibility-dashboards-async-queue", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the new explore page
     manager.add("organizations:visibility-explore-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable high date range options on new explore page


### PR DESCRIPTION
Unregister `organizations:visibility-dashboards-async-queue`. This flag was fully rolled out to 100% GA in the automator in getsentry/sentry-options-automator#7753 on 5/8, and hasn't been touched since. Frontend references were removed in #119673.

Split from the frontend change because `static/` and `src/` are not atomically deployed. Merge after #119673 has deployed so the feature stays on during the transition.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
_Generated by [Claude Code](https://claude.ai/code/session_019wFGJcniL7R6d6ZFwiQCeL)_