### PR TITLE
feat(dashboards): add ordering changes to starred dashboards ordering

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -8,9 +8,11 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import (
     Case,
     Exists,
+    F,
     IntegerField,
     OrderBy,
     OuterRef,
+    Subquery,
     Value,
     When,
 )
@@ -309,7 +311,10 @@ def sync_prebuilt_dashboards_favorited(organization: Organization, user_id: int)
     """
     Checks if pre-favorited prebuilt dashboards have a DashboardFavoriteUser record for the
     user, and creates them if they don't. This ensures that certain prebuilt dashboards are
-    favorited by default for all users, preserving any existing stared ones.
+    favorited by default for all users, preserving any existing starred ones.
+
+    New prebuilts are inserted alphabetically while the user's prebuilt stars are still in
+    their default (alphabetical) order.
     """
     enabled_prebuilt_dashboards = get_enabled_prebuilt_dashboards(organization)
     pre_favorited_ids = [
@@ -319,9 +324,24 @@ def sync_prebuilt_dashboards_favorited(organization: Organization, user_id: int)
         return
 
     with transaction.atomic(router.db_for_write(DashboardFavoriteUser)):
-        # Exclude any dashboard the user has already starred or that has unfavorited. We don't
-        # exclude by favorited=False so we never re-star something the user chose to unstar.
-        prebuilt_dashboards_without_favorite = (
+        prebuilt_favorited = list(
+            DashboardFavoriteUser.objects.filter(
+                organization=organization,
+                user_id=user_id,
+                favorited=True,
+                dashboard__prebuilt_id__isnull=False,
+            )
+            .order_by("position")
+            .select_related("dashboard")
+        )
+        # We want to know if the dashboards are alphabetically ordered (default) or
+        # have been rearranged, and respect whatever order they're in
+        favorited_titles = [f.dashboard.title for f in prebuilt_favorited]
+        is_default_order = favorited_titles == sorted(favorited_titles)
+
+        # Get any favorited dashboards, custom or prebuilt, belonging to the user.
+        # Don't explicitly exclude those with favorite=False to not show unfavorited dashboards.
+        missing_dashboards = (
             Dashboard.objects.filter(
                 organization=organization,
                 prebuilt_id__in=pre_favorited_ids,
@@ -332,14 +352,19 @@ def sync_prebuilt_dashboards_favorited(organization: Organization, user_id: int)
                     user_id=user_id,
                 ).values_list("dashboard_id", flat=True)
             )
-            .order_by("prebuilt_id")
+            .order_by("title")
         )
-        for dashboard in prebuilt_dashboards_without_favorite:
-            DashboardFavoriteUser.objects.insert_favorite_dashboard(
-                organization=organization,
-                user_id=user_id,
-                dashboard=dashboard,
-            )
+        for dashboard in missing_dashboards:
+            if is_default_order:
+                DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+                    organization, user_id, dashboard
+                )
+            else:
+                DashboardFavoriteUser.objects.insert_favorite_dashboard(
+                    organization=organization,
+                    user_id=user_id,
+                    dashboard=dashboard,
+                )
 
 
 class OrganizationDashboardsPermission(OrganizationPermission):
@@ -415,6 +440,10 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:dashboards-basic", organization, actor=request.user):
             return Response(status=404)
 
+        has_dashboards_starred = features.has(
+            "organizations:dashboards-starred", organization, actor=request.user
+        )
+
         if features.has(
             "organizations:dashboards-prebuilt-insights-dashboards",
             organization,
@@ -434,7 +463,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             except Exception as err:
                 sentry_sdk.capture_exception(err)
 
-            if features.has("organizations:dashboards-starred", organization, actor=request.user):
+            if has_dashboards_starred:
                 try:
                     favorite_lock = locks.get(
                         f"dashboards:sync_prebuilt_dashboards_favorited:{organization.id}:{request.user.id}",
@@ -559,7 +588,14 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                 Case(When(created_by_id=request.user.id, then=-1), default=1),
                 "-last_visited",
             ]
-
+        elif "onlyFavorites" in filters and has_dashboards_starred:
+            favorite_dashboards = DashboardFavoriteUser.objects.get_favorite_dashboards(
+                organization, request.user.id
+            ).filter(dashboard_id=OuterRef("id"))
+            dashboards = dashboards.annotate(
+                favorite_position=Subquery(favorite_dashboards.values("position")[:1])
+            )
+            order_by = [F("favorite_position").asc(nulls_last=True), "title"]
         else:
             order_by = ["title"]
 

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -199,7 +199,17 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
         back to appending at the end when nothing sorts later.
         """
         with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
-            if self.get_favorite_dashboard(organization, user_id, dashboard):
+            existing = (
+                self.filter(
+                    organization=organization,
+                    user_id=user_id,
+                    dashboard=dashboard,
+                )
+                .select_for_update()
+                .first()
+            )
+
+            if existing and existing.favorited:
                 return False
 
             next_prebuilt = (
@@ -226,12 +236,17 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
                     position__gte=position,
                 ).update(position=models.F("position") + 1)
 
-            self.create(
-                organization=organization,
-                user_id=user_id,
-                dashboard=dashboard,
-                position=position,
-            )
+            if existing:
+                existing.favorited = True
+                existing.position = position
+                existing.save(update_fields=["favorited", "position"])
+            else:
+                self.create(
+                    organization=organization,
+                    user_id=user_id,
+                    dashboard=dashboard,
+                    position=position,
+                )
             return True
 
     def unfavorite_dashboard(

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -187,6 +187,53 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
                 )
             return True
 
+    def insert_favorite_dashboard_alphabetically(
+        self,
+        organization: Organization,
+        user_id: int,
+        dashboard: Dashboard,
+    ) -> bool:
+        """
+        Inserts a favorited dashboard at the position of the next prebuilt favorited
+        dashboard whose title sorts after this one, shifting later positions by 1. Falls
+        back to appending at the end when nothing sorts later.
+        """
+        with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
+            if self.get_favorite_dashboard(organization, user_id, dashboard):
+                return False
+
+            next_prebuilt = (
+                self.filter(
+                    organization=organization,
+                    user_id=user_id,
+                    favorited=True,
+                    position__isnull=False,
+                    dashboard__prebuilt_id__isnull=False,
+                    dashboard__title__gt=dashboard.title,
+                )
+                .order_by("position")
+                .first()
+            )
+
+            position: int
+            if next_prebuilt is None or next_prebuilt.position is None:
+                position = self.get_last_position(organization, user_id) + 1
+            else:
+                position = next_prebuilt.position
+                self.filter(
+                    organization=organization,
+                    user_id=user_id,
+                    position__gte=position,
+                ).update(position=models.F("position") + 1)
+
+            self.create(
+                organization=organization,
+                user_id=user_id,
+                dashboard=dashboard,
+                position=position,
+            )
+            return True
+
     def unfavorite_dashboard(
         self, organization: Organization, user_id: int, dashboard: Dashboard
     ) -> bool:

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -305,6 +305,31 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         # sorted by title by default
         assert values == ["Dashboard 3", "Dashboard 4", "Dashboard 5"]
 
+    def test_get_only_favorites_ordered_by_position(self) -> None:
+        d_a = Dashboard.objects.create(
+            title="Alpha", created_by_id=self.user.id, organization=self.organization
+        )
+        d_b = Dashboard.objects.create(
+            title="Bravo", created_by_id=self.user.id, organization=self.organization
+        )
+        d_c = Dashboard.objects.create(
+            title="Charlie", created_by_id=self.user.id, organization=self.organization
+        )
+        d_a.favorited_by = [self.user.id]
+        d_b.favorited_by = [self.user.id]
+        d_c.favorited_by = [self.user.id]
+        # Reorder so position order is Charlie, Alpha, Bravo (not title order)
+        DashboardFavoriteUser.objects.reorder_favorite_dashboards(
+            organization=self.organization,
+            user_id=self.user.id,
+            new_dashboard_positions=[d_c.id, d_a.id, d_b.id],
+        )
+        self.login_as(self.user)
+        with self.feature("organizations:dashboards-starred"):
+            response = self.client.get(self.url, data={"filter": "onlyFavorites"})
+        assert response.status_code == 200, response.content
+        assert [row["title"] for row in response.data] == ["Charlie", "Alpha", "Bravo"]
+
     def test_get_only_favorites_with_sort(self) -> None:
         user_1 = self.create_user(username="user_1")
         self.create_member(organization=self.organization, user=user_1)
@@ -355,6 +380,34 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
 
         values = [row["title"] for row in response.data]
         assert values == ["Dashboard 4", "Dashboard 3", "Dashboard 5"]
+
+    def test_get_only_favorites_explicit_sort_overrides_position_with_flag(self) -> None:
+        d_a = Dashboard.objects.create(
+            title="Alpha", created_by_id=self.user.id, organization=self.organization
+        )
+        d_b = Dashboard.objects.create(
+            title="Bravo", created_by_id=self.user.id, organization=self.organization
+        )
+        d_c = Dashboard.objects.create(
+            title="Charlie", created_by_id=self.user.id, organization=self.organization
+        )
+        d_a.favorited_by = [self.user.id]
+        d_b.favorited_by = [self.user.id]
+        d_c.favorited_by = [self.user.id]
+        # Reorder positions to the reverse of dateCreated order
+        DashboardFavoriteUser.objects.reorder_favorite_dashboards(
+            organization=self.organization,
+            user_id=self.user.id,
+            new_dashboard_positions=[d_c.id, d_b.id, d_a.id],
+        )
+        self.login_as(self.user)
+        with self.feature("organizations:dashboards-starred"):
+            response = self.client.get(
+                self.url, data={"filter": "onlyFavorites", "sort": "dateCreated"}
+            )
+        assert response.status_code == 200, response.content
+        # Explicit sort wins over per-user position order even with the flag on
+        assert [row["title"] for row in response.data] == ["Alpha", "Bravo", "Charlie"]
 
     def test_get_exclude_favorites_with_no_sort(self) -> None:
         user_1 = self.create_user(username="user_1")
@@ -2252,6 +2305,23 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
             ).values_list("prebuilt_id", flat=True)
         )
         assert favorited_prebuilt_ids == pre_favorited_prebuilt_ids
+
+    def test_endpoint_auto_stars_prebuilts_in_alphabetical_order(self) -> None:
+        with self.feature(
+            [
+                "organizations:dashboards-prebuilt-insights-dashboards",
+                "organizations:dashboards-sync-all-registered-prebuilt-dashboards",
+                "organizations:dashboards-starred",
+            ]
+        ):
+            response = self.do_request("get", self.url, {"filter": "onlyFavorites"})
+        assert response.status_code == 200
+
+        # The sidebar (onlyFavorites) returns auto-starred prebuilts by position, and the
+        # auto-star inserts them alphabetically, mirroring Explore.
+        titles = [row["title"] for row in response.data]
+        assert titles == sorted(titles)
+        assert titles == ["AI Agents Overview", "Backend Overview", "Web Vitals"]
 
     def test_post_with_text_widget(self) -> None:
         data = {

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -186,8 +186,6 @@ class DashboardFavoriteUserTest(TestCase):
         assert dashboard.position == 0
 
     def create_prebuilt_dashboard(self, title: str, prebuilt_id: int) -> Dashboard:
-        # Prebuilt dashboards must have created_by_id NULL (db check constraint), which
-        # the create_dashboard factory can't produce, so build the row directly.
         return Dashboard.objects.create(
             title=title,
             organization=self.organization,
@@ -199,8 +197,6 @@ class DashboardFavoriteUserTest(TestCase):
         web_vitals = self.create_prebuilt_dashboard("Web Vitals", 6)
         backend = self.create_prebuilt_dashboard("Backend Overview", 12)
 
-        # Insert the later-sorting title first, then the earlier one, so the earlier
-        # one has to be slotted in before it (shifting the later one down).
         DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
             self.organization, self.user.id, web_vitals
         )

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -208,6 +208,8 @@ class DashboardFavoriteUserTest(TestCase):
             DashboardFavoriteUser.objects.get_favorite_dashboards(self.organization, self.user.id)
         )
         assert [f.dashboard_id for f in favorites] == [backend.id, web_vitals.id]
+        assert favorites[0].position is not None
+        assert favorites[1].position is not None
         assert favorites[0].position < favorites[1].position
 
     def test_insert_alphabetically_appends_when_nothing_sorts_later(self) -> None:
@@ -225,6 +227,8 @@ class DashboardFavoriteUserTest(TestCase):
             DashboardFavoriteUser.objects.get_favorite_dashboards(self.organization, self.user.id)
         )
         assert [f.dashboard_id for f in favorites] == [backend.id, web_vitals.id]
+        assert favorites[0].position is not None
+        assert favorites[1].position is not None
         assert favorites[0].position < favorites[1].position
 
     def test_insert_alphabetically_is_noop_when_already_favorited(self) -> None:
@@ -236,9 +240,11 @@ class DashboardFavoriteUserTest(TestCase):
             )
             is True
         )
-        first_position = DashboardFavoriteUser.objects.get_favorite_dashboard(
+        first_favorite = DashboardFavoriteUser.objects.get_favorite_dashboard(
             self.organization, self.user.id, web_vitals
-        ).position
+        )
+        assert first_favorite is not None
+        first_position = first_favorite.position
 
         assert (
             DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
@@ -247,12 +253,11 @@ class DashboardFavoriteUserTest(TestCase):
             is False
         )
         assert DashboardFavoriteUser.objects.filter(favorited=True).count() == 1
-        assert (
-            DashboardFavoriteUser.objects.get_favorite_dashboard(
-                self.organization, self.user.id, web_vitals
-            ).position
-            == first_position
+        second_favorite = DashboardFavoriteUser.objects.get_favorite_dashboard(
+            self.organization, self.user.id, web_vitals
         )
+        assert second_favorite is not None
+        assert second_favorite.position == first_position
 
 
 class DashboardRevisionTest(TestCase):

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -185,6 +185,79 @@ class DashboardFavoriteUserTest(TestCase):
         assert dashboard is not None
         assert dashboard.position == 0
 
+    def create_prebuilt_dashboard(self, title: str, prebuilt_id: int) -> Dashboard:
+        # Prebuilt dashboards must have created_by_id NULL (db check constraint), which
+        # the create_dashboard factory can't produce, so build the row directly.
+        return Dashboard.objects.create(
+            title=title,
+            organization=self.organization,
+            created_by_id=None,
+            prebuilt_id=prebuilt_id,
+        )
+
+    def test_insert_alphabetically_shifts_later_prebuilts(self) -> None:
+        web_vitals = self.create_prebuilt_dashboard("Web Vitals", 6)
+        backend = self.create_prebuilt_dashboard("Backend Overview", 12)
+
+        # Insert the later-sorting title first, then the earlier one, so the earlier
+        # one has to be slotted in before it (shifting the later one down).
+        DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+            self.organization, self.user.id, web_vitals
+        )
+        DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+            self.organization, self.user.id, backend
+        )
+
+        favorites = list(
+            DashboardFavoriteUser.objects.get_favorite_dashboards(self.organization, self.user.id)
+        )
+        assert [f.dashboard_id for f in favorites] == [backend.id, web_vitals.id]
+        assert favorites[0].position < favorites[1].position
+
+    def test_insert_alphabetically_appends_when_nothing_sorts_later(self) -> None:
+        backend = self.create_prebuilt_dashboard("Backend Overview", 12)
+        web_vitals = self.create_prebuilt_dashboard("Web Vitals", 6)
+
+        DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+            self.organization, self.user.id, backend
+        )
+        DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+            self.organization, self.user.id, web_vitals
+        )
+
+        favorites = list(
+            DashboardFavoriteUser.objects.get_favorite_dashboards(self.organization, self.user.id)
+        )
+        assert [f.dashboard_id for f in favorites] == [backend.id, web_vitals.id]
+        assert favorites[0].position < favorites[1].position
+
+    def test_insert_alphabetically_is_noop_when_already_favorited(self) -> None:
+        web_vitals = self.create_prebuilt_dashboard("Web Vitals", 6)
+
+        assert (
+            DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+                self.organization, self.user.id, web_vitals
+            )
+            is True
+        )
+        first_position = DashboardFavoriteUser.objects.get_favorite_dashboard(
+            self.organization, self.user.id, web_vitals
+        ).position
+
+        assert (
+            DashboardFavoriteUser.objects.insert_favorite_dashboard_alphabetically(
+                self.organization, self.user.id, web_vitals
+            )
+            is False
+        )
+        assert DashboardFavoriteUser.objects.filter(favorited=True).count() == 1
+        assert (
+            DashboardFavoriteUser.objects.get_favorite_dashboard(
+                self.organization, self.user.id, web_vitals
+            ).position
+            == first_position
+        )
+
 
 class DashboardRevisionTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
This PR is one of many to bring the "starred dashboards" sidebar to parity with Explore's "starred queries" sidebar.

This PR makes the starred dashboards list order match the users's saved position (rearranging PR coming soon), as well as seeding auto-starred prebuilt dashboards alphabetically, all feature flagged and w/ tests atm. This mirrors the behavior explore's starred queries work as well. 

Closes BROWSE-611