### PR TITLE
feat(weekly-reports): Combine error and performance issues into top issues

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -213,7 +213,7 @@ def _project_key_errors_snuba(
         ],
         groupby=[Column("group_id", entity=events_entity)],
         orderby=[OrderBy(Function("count", []), Direction.DESC)],
-        limit=Limit(3),
+        limit=Limit(5),
     )
 
     request = Request(
@@ -233,7 +233,7 @@ def _org_key_errors_snuba(
     ctx: OrganizationReportContext,
     project_ids: Sequence[int],
     referrer: str,
-    per_project_limit: int = 3,
+    per_project_limit: int = 5,
 ) -> dict[int, list[dict[str, Any]]]:
     if not project_ids:
         return {}
@@ -396,7 +396,7 @@ def _project_key_errors_eap(
         {"events.group_id": row["group_id"], "count()": row["count()"]}
         for row in normalized_rows
         if row["group_id"] in unresolved_group_ids
-    ][:3]
+    ][:5]
 
     return filtered_rows
 
@@ -494,7 +494,7 @@ def _project_key_performance_issues_snuba(
         ],
         groupby=[Column("group_id")],
         orderby=[OrderBy(Function("count", []), Direction.DESC)],
-        limit=Limit(3),
+        limit=Limit(5),
     )
     request = Request(
         dataset=Dataset.IssuePlatform.value,
@@ -530,7 +530,7 @@ def _project_key_performance_issues_eap(
             selected_columns=["group_id", "count()"],
             orderby=["-count()"],
             offset=0,
-            limit=3,
+            limit=5,
             referrer=referrer,
             config=SearchResolverConfig(),
             occurrence_category=OccurrenceCategory.ISSUE_PLATFORM,

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -734,8 +734,8 @@ def render_template_context(
             ),
         }
 
-    def key_errors():
-        def all_key_errors():
+    def top_issues():
+        def all_issues():
             for project_ctx in user_projects:
                 for group, count in project_ctx.key_errors_by_group:
                     display = get_group_display(group)
@@ -757,11 +757,6 @@ def render_template_context(
                         "group_substatus_text_color": substatus_text_color,
                     }
 
-        return heapq.nlargest(3, all_key_errors(), lambda d: d["count"])
-
-    def key_performance_issues():
-        def all_key_performance_issues():
-            for project_ctx in user_projects:
                 for group, group_history, count in project_ctx.key_performance_issues:
                     display = get_group_display(group)
                     (
@@ -787,7 +782,7 @@ def render_template_context(
                         "group_substatus_text_color": substatus_text_color,
                     }
 
-        return heapq.nlargest(3, all_key_performance_issues(), lambda d: d["count"])
+        return heapq.nlargest(5, all_issues(), lambda d: d["count"])
 
     def past_issues():
         def all_past_issues():
@@ -847,8 +842,7 @@ def render_template_context(
         "start": date_format(local_start),
         "end": date_format(local_end),
         "trends": trends(),
-        "key_errors": key_errors(),
-        "key_performance_issues": key_performance_issues(),
+        "top_issues": top_issues(),
         "past_issues": past_issues() if show_past_issues else [],
         "show_past_issues": show_past_issues,
         "issue_summary": issue_summary(),

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -418,33 +418,10 @@
   </div>
   {% endif %}
 
-  {% if key_errors|length > 0 and not enhanced_privacy %}
-  <div id="key-errors">
-    <h4>Issues with the most errors</h4>
-    {% for a in key_errors %}
-    <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
-      <div style="width: 10%;" class="issue-count">{{a.count|small_count:1}}</div>
-      <div style="width: 65%; min-width: 0; overflow: hidden;">
-        {% url 'sentry-organization-issue-detail' issue_id=a.group.id organization_slug=organization.slug as issue_detail %}
-        {% querystring referrer="weekly_report" notification_uuid=notification_uuid as query %}
-        <a title="{{a.title}}" class="issue-title"
-           href="{% org_url organization issue_detail query=query %}">{{a.title}}</a>
-        <div title="{{a.message}}" class="issue-message">{{a.message}}</div>
-        <div style="font-size: 12px; color: #80708F;">{{a.group.project.name}}</div>
-      </div>
-      {% if a.group_substatus and a.group_substatus_color %}
-      <span style="background-color: {{a.group_substatus_color}}; color: {{a.group_substatus_text_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{a.group_substatus}}</span>
-      {% else %}
-      <span style="background-color: {{a.status_color}}; border-radius: 8px; font-size: 12px; align-self: center; padding: 0 10px; margin-left: auto; text-align: center; line-height: 22px; white-space: nowrap; height: 22px;">{{a.status}}</span>
-      {% endif %}
-      </div>
-    {% endfor %}
-  </div>
-  {% endif %}
-  {% if key_performance_issues|length > 0 and not enhanced_privacy %}
-  <div id="key-performance-issues">
-    <h4>Most frequent performance issues</h4>
-    {% for a in key_performance_issues %}
+  {% if top_issues|length > 0 and not enhanced_privacy %}
+  <div id="top-issues">
+    <h4>Top Issues</h4>
+    {% for a in top_issues %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">
       <div style="width: 10%;" class="issue-count">{{a.count|small_count:1}}</div>
       <div style="width: 65%; min-width: 0; overflow: hidden;">

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -669,8 +669,7 @@ class WeeklyReportsTest(
                 "regression_substatus_count": 0,
                 "total_substatus_count": 2,
             }
-            assert len(context["key_errors"]) == 0
-            assert len(context["key_performance_issues"]) == 2
+            assert len(context["top_issues"]) == 2
             assert context["trends"]["total_error_count"] == 2
 
             assert "Weekly Report for" in message_params["subject"]
@@ -745,8 +744,7 @@ class WeeklyReportsTest(
                 "regression_substatus_count": 0,
                 "total_substatus_count": 4,
             }
-            assert len(context["key_errors"]) == 2
-            assert len(context["key_performance_issues"]) == 2
+            assert len(context["top_issues"]) == 4
             assert context["trends"]["total_error_count"] == 2
 
             assert "Weekly Report for" in message_params["subject"]
@@ -812,7 +810,7 @@ class WeeklyReportsTest(
                 "regression_substatus_count": 0,
                 "total_substatus_count": 2,
             }
-            assert len(context["key_errors"]) == 1
+            assert len(context["top_issues"]) == 1
 
     @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
@@ -899,7 +897,7 @@ class WeeklyReportsTest(
                 "regression_substatus_count": 0,
                 "total_substatus_count": 0,
             }
-            assert len(context["key_errors"]) == 0
+            assert len(context["top_issues"]) == 0
             assert context["trends"]["total_error_count"] == 2
 
             assert "Weekly Report for" in message_params["subject"]
@@ -1519,7 +1517,7 @@ class WeeklyReportsTest(
         unique_enum_count = len(enum_values)
         assert len(group_status_to_color) == unique_enum_count
 
-    def test_key_errors_and_performance_issues_share_substatus_badges(self) -> None:
+    def test_top_issues_share_substatus_badges(self) -> None:
         user = self.create_user()
         self.create_member(teams=[self.team], user=user, organization=self.organization)
         error_group = self.create_group(
@@ -1553,8 +1551,10 @@ class WeeklyReportsTest(
         rendered_context = render_template_context(ctx, user.id)
 
         assert rendered_context is not None
-        key_error = rendered_context["key_errors"][0]
-        performance_issue = rendered_context["key_performance_issues"][0]
+        assert len(rendered_context["top_issues"]) == 2
+        issues_by_group = {issue["group"].id: issue for issue in rendered_context["top_issues"]}
+        key_error = issues_by_group[error_group.id]
+        performance_issue = issues_by_group[performance_group.id]
         substatus_fields = (
             "group_substatus",
             "group_substatus_color",
@@ -1984,8 +1984,7 @@ class WeeklyReportsTest(
         ctx = message_params["context"]
 
         assert ctx["enhanced_privacy"]
-        assert len(ctx["key_errors"]) == 0
-        assert len(ctx["key_performance_issues"]) == 0
+        assert len(ctx["top_issues"]) == 0
         assert ctx["trends"]["total_error_count"] == 2
         assert ctx["issue_summary"] is not None
 
@@ -2433,4 +2432,4 @@ class WeeklyReportsTest(
             context = call_args.kwargs["context"]
             assert context["show_past_issues"] is False
             assert len(context["past_issues"]) == 0
-            assert len(context["key_errors"]) == 1
+            assert len(context["top_issues"]) == 1


### PR DESCRIPTION
Goal: combine error and performance issues to surface the most relevant "top issues" 

Resolves [ID-1645](https://linear.app/getsentry/issue/ID-1645/add-top-issues-section)

Changes
- take top 5 (instead of top 3)
- replace `key_errors()` with `top_issues()` in `src/sentry/tasks/summaries/weekly_reports.py`. `top_issues()` function aggregates top error + performance issues
- updated template to match under "Top Issues" in `src/sentry/templates/sentry/emails/reports/body.html`

<img width="1268" height="712" alt="image" src="https://github.com/user-attachments/assets/6bc2e14c-59a4-4732-a663-a51ce366e367" />
