### PR TITLE
chore(msteams): Record msteams client secret expiry metric

### DIFF
--- a/src/sentry/integrations/msteams/client.py
+++ b/src/sentry/integrations/msteams/client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import logging
 import time
 from abc import ABC
+from datetime import datetime, timezone
 from typing import TypedDict
 from urllib.parse import urlencode
 
@@ -16,6 +18,9 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.shared_integrations.client.proxy import IntegrationProxyClient, infer_org_integration
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode, control_silo_function
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
 
 # five minutes which is industry standard clock skew tolerance
 CLOCK_SKEW = 60 * 5
@@ -166,11 +171,35 @@ class TokenData(TypedDict):
 def get_token_data() -> TokenData:
     client_id = options.get("msteams.client-id")
     client_secret = options.get("msteams.client-secret")
+    _record_client_secret_expiry()
     client = OAuthMsTeamsClient(client_id, client_secret)
     resp = client.exchange_token()
     # calculate the expiration date but offset because of the delay in receiving the response
     expires_at = int(time.time()) + int(resp["expires_in"]) - CLOCK_SKEW
     return {"access_token": resp["access_token"], "expires_at": expires_at}
+
+
+def _record_client_secret_expiry() -> None:
+    """Record the time remaining before the MS Teams client secret expires."""
+    expires_at = options.get("msteams.client-secret-expires-at")
+    if not expires_at:
+        return
+
+    try:
+        expiry = datetime.fromisoformat(expires_at)
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+
+        seconds_until_expiry = (expiry - datetime.now(timezone.utc)).total_seconds()
+        metrics.gauge(
+            "integrations.msteams.client_secret.seconds_until_expiry",
+            seconds_until_expiry,
+            sample_rate=0.01,
+        )
+    except ValueError:
+        logger.exception("MS Teams client secret expiry is not a valid ISO format")
+    except Exception:
+        logger.exception("Failed to record MS Teams client secret expiry")
 
 
 class MsTeamsJwtClient(ApiClient):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -753,6 +753,11 @@ register("vercel.integration-slug", default="sentry", flags=FLAG_AUTOMATOR_MODIF
 # MsTeams Integration
 register("msteams.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("msteams.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register(
+    "msteams.client-secret-expires-at",
+    default="",
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 register("msteams.app-id")
 
 # Discord Integration

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from requests import Request
 
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.msteams.client import MsTeamsClient
+from sentry.integrations.msteams.client import MsTeamsClient, get_token_data
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
@@ -20,6 +20,7 @@ from sentry.silo.util import (
     PROXY_SIGNATURE_HEADER,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import control_silo_test
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
 
@@ -108,6 +109,37 @@ class MsTeamsClientTest(TestCase):
                 "expires_at": self.expires_at,
                 "service_url": "https://smba.trafficmanager.net/amer/",
             }
+
+    @responses.activate
+    def test_records_client_secret_expiry_gauge(self) -> None:
+        with (
+            patch("sentry.integrations.msteams.client.metrics") as mock_metrics,
+            self.options({"msteams.client-secret-expires-at": "2020-09-01T00:00:00Z"}),
+            freeze_time("2020-08-01T00:00:00Z"),
+        ):
+            get_token_data()
+
+            # 2020-08-01 -> 2020-09-01 is 31 days.
+            mock_metrics.gauge.assert_called_once_with(
+                "integrations.msteams.client_secret.seconds_until_expiry",
+                31 * 24 * 60 * 60,
+                sample_rate=0.01,
+            )
+
+    @responses.activate
+    def test_skips_client_secret_expiry_gauge_when_unset(self) -> None:
+        with patch("sentry.integrations.msteams.client.metrics") as mock_metrics:
+            get_token_data()
+            mock_metrics.gauge.assert_not_called()
+
+    @responses.activate
+    def test_skips_client_secret_expiry_gauge_when_invalid(self) -> None:
+        with (
+            patch("sentry.integrations.msteams.client.metrics") as mock_metrics,
+            self.options({"msteams.client-secret-expires-at": "not-a-date"}),
+        ):
+            get_token_data()
+            mock_metrics.gauge.assert_not_called()
 
     @responses.activate
     def test_simple(self) -> None:


### PR DESCRIPTION
Ref INC-2367

In order to create a more reliable mechanism for remembering to rotate our keys, this PR adds a new metric which records the time until expiry for this secret. This is recorded each time the token is accessed, with a low sample rate to avoid over-recording.

There aren't any good ways to get the expiration date from the application, so I've added a new option which we will need to manually update when the keys have been rotated: `msteams.client-secret-expires-at`.

The idea here is that we will be able to create a monitor which alerts us when we get close to token expiration.