### PR TITLE
feat(sentry-apps): add urls to issue workflow webhook payloads

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -562,7 +562,7 @@ def workflow_notification(
 
         install, issue, user = webhook_data
         data = kwargs.get("data", {})
-        data.update({"issue": serialize(issue)})
+        data.update({"issue": _webhook_issue_data(group=issue, serialized_group=serialize(issue))})
 
     send_webhooks(installation=install, event=event, data=data, actor=user)
 

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1600,8 +1600,21 @@ class TestWorkflowNotification(TestCase):
         assert kwargs["url"] == self.sentry_app.webhook_url
         assert kwargs["headers"]["Sentry-Hook-Resource"] == "issue"
         data = json.loads(kwargs["data"])
+        issue_data = data["data"]["issue"]
         assert data["action"] == "resolved"
-        assert data["data"]["issue"]["id"] == str(self.issue.id)
+        assert issue_data["id"] == str(self.issue.id)
+        assert (
+            issue_data["url"]
+            == f"http://testserver/api/0/organizations/{self.organization.slug}/issues/{self.issue.id}/"
+        )
+        assert (
+            issue_data["web_url"]
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.issue.id}/"
+        )
+        assert (
+            issue_data["project_url"]
+            == f"http://testserver/organizations/{self.organization.slug}/issues/?project={self.project.id}"
+        )
 
         # SLO assertions
         assert_success_metric(mock_record)


### PR DESCRIPTION
Somewhat of a follow up to https://github.com/getsentry/sentry/pull/93780. Add urls to the other webhooks outside of just `issue.created`, so we include URLs for the other issue lifecycle webhook events.