### PR TITLE
fix(weekly-report): Prevent populating cache on admin runs

### DIFF
--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -245,8 +245,10 @@ def prepare_organization_report(
 
         # Cache after delivery so a failed attempt doesn't poison the
         # previous-week lookup on retry.
-        if not dry_run and features.has(
-            "organizations:weekly-report-week-over-week-metric", ctx.organization
+        if (
+            not dry_run
+            and not email_override
+            and features.has("organizations:weekly-report-week-over-week-metric", ctx.organization)
         ):
             try:
                 project_metrics: dict[int, dict[str, int]] = {}
@@ -344,16 +346,21 @@ class OrganizationReportBatch:
             lifecycle.add_extra("user_id", user_id)
 
             if template_context and user_id:
-                dupe_check = _DuplicateDeliveryCheck(self, user_id, self.ctx.timestamp)
-                if not dupe_check.check_for_duplicate_delivery():
-                    was_sent = self.send_email(template_ctx=template_context, user_id=user_id)
-
-                    # Record delivery if email was sent successfully
-                    if was_sent:
-                        dupe_check.record_delivery()
+                # Admin sends (email_override) bypass duplicate detection so
+                # support/debugging re-sends always go through.
+                if self.email_override:
+                    self.send_email(template_ctx=template_context, user_id=user_id)
                 else:
-                    lifecycle.record_halt(WeeklyReportHaltReason.DUPLICATE_DELIVERY)
-                    metrics.incr("weekly_report.email.skipped", tags={"reason": "duplicate"})
+                    dupe_check = _DuplicateDeliveryCheck(self, user_id, self.ctx.timestamp)
+                    if not dupe_check.check_for_duplicate_delivery():
+                        was_sent = self.send_email(template_ctx=template_context, user_id=user_id)
+
+                        # Record delivery if email was sent successfully
+                        if was_sent:
+                            dupe_check.record_delivery()
+                    else:
+                        lifecycle.record_halt(WeeklyReportHaltReason.DUPLICATE_DELIVERY)
+                        metrics.incr("weekly_report.email.skipped", tags={"reason": "duplicate"})
 
     def send_email(self, template_ctx: Mapping[str, Any], user_id: int) -> bool:
         local_start, local_end = get_local_dates(self.ctx, user_id)
@@ -366,7 +373,10 @@ class OrganizationReportBatch:
             context=template_ctx,
             headers={"X-SMTPAPI": json.dumps({"category": "organization_weekly_report"})},
         )
-        if self.dry_run:
+        # Admin sends (email_override) always deliver the email regardless of
+        # dry_run so the admin tool is useful for debugging.  The dry_run
+        # script (schedule_organizations) never sets email_override.
+        if self.dry_run and not self.email_override:
             metrics.incr("weekly_report.email.skipped", tags={"reason": "dry_run"})
             return False
 

--- a/tests/sentry/tasks/test_weekly_reports.py
+++ b/tests/sentry/tasks/test_weekly_reports.py
@@ -1714,40 +1714,30 @@ class WeeklyReportsTest(
             },
         )
 
-    @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
-    def test_dry_run_simple(self, message_builder: mock.MagicMock, record: mock.MagicMock) -> None:
-        org = self.create_organization()
-        proj = self.create_project(organization=org)
-        # fill with data so report not skipped
-        self.store_event_outcomes(org.id, proj.id, self.two_days_ago, num_times=2)
+    def test_dry_run_without_email_override_blocks_send(
+        self, message_builder: mock.MagicMock
+    ) -> None:
+        """dry_run=True without email_override should not send."""
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.two_days_ago, num_times=2
+        )
+        self._set_option_value("always")
 
         prepare_organization_report(
             self.timestamp,
             ONE_DAY * 7,
-            org.id,
+            self.organization.id,
             self._dummy_batch_id,
             dry_run=True,
-            target_user=None,
-            email_override="doesntmatter@smad.com",
         )
 
-        with pytest.raises(AssertionError):
-            assert_any_analytics_event(
-                record,
-                WeeklyReportSent(
-                    user_id=None,
-                    organization_id=self.organization.id,
-                    notification_uuid="mock.ANY",
-                    user_project_count=1,
-                ),
-            )
-
         message_builder.return_value.send.assert_not_called()
+        message_builder.return_value.send_async.assert_not_called()
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
-    def test_dry_run_does_not_block_subsequent_send(self, message_builder: mock.MagicMock) -> None:
-        """A dry_run send should not poison the duplicate delivery check."""
+    def test_dry_run_with_email_override_still_sends(self, message_builder: mock.MagicMock) -> None:
+        """Admin sends (email_override) deliver the email even when dry_run=True."""
         user = self.create_user(email="dio@speedwagon.org")
         self.create_member(teams=[self.team], user=user, organization=self.organization)
         self.store_event_outcomes(
@@ -1763,9 +1753,32 @@ class WeeklyReportsTest(
             target_user=user.id,
             email_override="dio@speedwagon.org",
         )
-        message_builder.return_value.send.assert_not_called()
+
+        message_builder.return_value.send.assert_called_once_with(to=("dio@speedwagon.org",))
+
+    @mock.patch("sentry.tasks.summaries.weekly_reports.MessageBuilder")
+    def test_email_override_bypasses_duplicate_check(self, message_builder: mock.MagicMock) -> None:
+        """Admin sends should not be blocked by a prior delivery."""
+        user = self.create_user(email="dio@speedwagon.org")
+        self.create_member(teams=[self.team], user=user, organization=self.organization)
+        self.store_event_outcomes(
+            self.organization.id, self.project.id, self.two_days_ago, num_times=2
+        )
+        self._set_option_value("always")
+
+        # First: normal send (records delivery in duplicate check)
+        prepare_organization_report(
+            self.timestamp,
+            ONE_DAY * 7,
+            self.organization.id,
+            self._dummy_batch_id,
+            dry_run=False,
+        )
+        assert message_builder.return_value.send_async.called
 
         message_builder.reset_mock()
+
+        # Second: admin send for the same user — should still deliver
         prepare_organization_report(
             self.timestamp,
             ONE_DAY * 7,
@@ -1773,9 +1786,9 @@ class WeeklyReportsTest(
             self._dummy_batch_id,
             dry_run=False,
             target_user=user.id,
-            email_override="dio@speedwagon.org",
+            email_override="admin@example.com",
         )
-        message_builder.return_value.send.assert_called_once_with(to=("dio@speedwagon.org",))
+        message_builder.return_value.send.assert_called_once_with(to=("admin@example.com",))
 
     @mock.patch("sentry.tasks.summaries.weekly_reports.logger")
     @mock.patch("sentry.tasks.summaries.weekly_reports.prepare_template_context")


### PR DESCRIPTION
Goal: prevent cache was populating when sending test emails using admin. We currently only guard against `dry_run = true`, but extend that logic to `email_override` too. 

**Problem statement:**
1. `DuplicateDeliveryCheck` was not bypassed for admin sends (email_override)
2. `dry_run` (defaulting to `True` in the admin UI) suppressed email sending even for admin sends, making the tool a no-op by default.

**Changes:**
- Skip duplicate detection and delivery recording when email_override is set -- admin sends should always go through
- Allow `email_override` sends to bypass the `dry_run` email gate
- Skip WoW cache population when `email_override` is set