### PR TITLE
fix(issues): Center runtime highlight text

### DIFF
--- a/static/app/components/events/highlights/highlightsIconSummary.tsx
+++ b/static/app/components/events/highlights/highlightsIconSummary.tsx
@@ -121,7 +121,7 @@ export function HighlightsIconSummary({event, group}: HighlightsIconSummaryProps
         <ScrollCarousel gap="xl" aria-label={t('Icon highlights')}>
           {runtimeInfo && (
             <Fragment>
-              <Tooltip title={runtimeInfo.tooltip} isHoverable>
+              <Tooltip title={runtimeInfo.tooltip} isHoverable skipWrapper>
                 <Container as="span" padding="xs 0">
                   <Text>{runtimeInfo.label}</Text>
                 </Container>


### PR DESCRIPTION
before

<img width="422" height="88" alt="image" src="https://github.com/user-attachments/assets/bcb1647f-3877-4430-9f5e-fb982b0e105e" />


after

<img width="378" height="54" alt="image" src="https://github.com/user-attachments/assets/2fa9ce9f-14f2-4846-acf5-8d761246b168" />
