### PR TITLE
fix(issues): Scope commit resolution to release projects

### DIFF
--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -187,9 +187,11 @@ def update_group_resolutions(release, commit_author_by_commit):
         .select_related("commit")
         .values("commit_id", "commit__key", "commit__repository_id")
     )
+    release_project_ids = list(release.projects.values_list("id", flat=True))
 
     commit_resolutions = list(
         GroupLink.objects.filter(
+            project_id__in=release_project_ids,
             linked_type=GroupLink.LinkedType.commit,
             linked_id__in=[rc["commit_id"] for rc in release_commits],
         ).values_list("group_id", "linked_id")
@@ -212,6 +214,7 @@ def update_group_resolutions(release, commit_author_by_commit):
 
     pull_request_resolutions = list(
         GroupLink.objects.filter(
+            project_id__in=release_project_ids,
             relationship=GroupLink.Relationship.resolves,
             linked_type=GroupLink.LinkedType.pull_request,
             linked_id__in=pr_ids_by_merge_commit,

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -197,6 +197,35 @@ class FindReferencedGroupsTest(TestCase):
         assert serialized_data["commit"]["id"] == commit.key
         assert serialized_data["commit"]["pullRequest"]["id"] == pr.key
 
+    def test_pull_request_resolves_only_when_released_to_issue_project(self) -> None:
+        frontend_project = self.project
+        backend_project = self.create_project(organization=frontend_project.organization)
+        group = self.create_group(project=frontend_project)
+        repo = self.create_repo(project=frontend_project, name="example-monorepo")
+        merge_commit_sha = sha1(uuid4().hex.encode("utf-8")).hexdigest()
+        pull_request = self.create_pull_request(
+            repository_id=repo.id,
+            organization_id=frontend_project.organization_id,
+            message=f"Fixes {group.qualified_short_id}",
+        )
+        pull_request.update(merge_commit_sha=merge_commit_sha)
+        backend_release = self.create_release(project=backend_project, version="backend@1.0.0")
+
+        backend_release.set_commits([{"id": merge_commit_sha, "repository": repo.name}])
+
+        assert not GroupResolution.objects.filter(group=group, release=backend_release).exists()
+        group.refresh_from_db()
+        assert group.status == GroupStatus.UNRESOLVED
+
+        frontend_release = self.create_release(project=frontend_project, version="frontend@1.0.0")
+        frontend_release.set_commits([{"id": merge_commit_sha, "repository": repo.name}])
+
+        resolution = GroupResolution.objects.get(group=group)
+        assert resolution.release == frontend_release
+        assert resolution.status == GroupResolution.Status.resolved
+        group.refresh_from_db()
+        assert group.status == GroupStatus.RESOLVED
+
 
 class PullRequestRetentionTest(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -523,6 +523,35 @@ class SetCommitsTestCase(TestCase):
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
         assert not GroupInbox.objects.filter(group=group).exists()
 
+    @receivers_raise_on_send()
+    def test_commit_resolves_only_when_released_to_issue_project(self) -> None:
+        org = self.create_organization(owner=Factories.create_user())
+        frontend_project = self.create_project(organization=org, name="frontend")
+        backend_project = self.create_project(organization=org, name="backend")
+        frontend_group = self.create_group(project=frontend_project)
+        repo = self.create_repo(project=backend_project, name="test/monorepo")
+        commit = self.create_commit(
+            repo=repo,
+            message=f"fixes {frontend_group.qualified_short_id}",
+        )
+        backend_release = self.create_release(project=backend_project, version="backend@1.0.0")
+
+        backend_release.set_commits([{"id": commit.key, "repository": repo.name}])
+
+        assert list(backend_release.projects.all()) == [backend_project]
+        assert not GroupResolution.objects.filter(
+            group=frontend_group, release=backend_release
+        ).exists()
+        assert Group.objects.get(id=frontend_group.id).status == GroupStatus.UNRESOLVED
+
+        frontend_release = self.create_release(project=frontend_project, version="frontend@1.0.0")
+        frontend_release.set_commits([{"id": commit.key, "repository": repo.name}])
+
+        resolution = GroupResolution.objects.get(group=frontend_group)
+        assert resolution.release == frontend_release
+        assert resolution.status == GroupResolution.Status.resolved
+        assert Group.objects.get(id=frontend_group.id).status == GroupStatus.RESOLVED
+
     @patch("sentry.analytics.record")
     @receivers_raise_on_send()
     def test_resolution_records_commit_provider(self, mock_record: MagicMock) -> None:


### PR DESCRIPTION
Commits included in a release could resolve issues from another project in the same organization, which records a release the issue's project never deployed.

Only resolve commit and pull request links for projects attached to the release. The issue stays unresolved until the same commit ships in its own project, then resolves normally.

fixes #119411. This intentionally does not fall back to an unrelated release.