### PR TITLE
fix(seer): Ellipsize issue titles and show only PR number in workflows

### DIFF
--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -330,7 +330,7 @@ describe('SeerWorkflows', () => {
 
     // A single button carries both the PR and its status -- no separate
     // "Autofix queued" tag, which would contradict a merged PR.
-    const prChip = screen.getByRole('button', {name: 'Merged: Fix the ValueError'});
+    const prChip = screen.getByRole('button', {name: 'Merged #42'});
     expect(prChip).toHaveAttribute('href', 'https://github.com/getsentry/sentry/pull/42');
     expect(prChip).toHaveAttribute('target', '_blank');
     expect(screen.queryByText('Autofix queued')).not.toBeInTheDocument();
@@ -383,16 +383,12 @@ describe('SeerWorkflows', () => {
 
     await userEvent.click(await screen.findByRole('button', {name: 'Expand run'}));
 
-    expect(screen.getByText('Merged: Fix the ValueError')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: 'Merged: Fix the ValueError'})
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', {name: 'Merged: Fix the ValueError'})
-    ).not.toBeInTheDocument();
+    expect(screen.getByText('Merged #42')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Merged #42'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'Merged #42'})).not.toBeInTheDocument();
   });
 
-  it('shows the plain PR title with no status prefix when status is unobserved', async () => {
+  it('shows the plain PR number with no status prefix when status is unobserved', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,
       body: [
@@ -439,7 +435,7 @@ describe('SeerWorkflows', () => {
 
     await userEvent.click(await screen.findByRole('button', {name: 'Expand run'}));
 
-    expect(screen.getByRole('button', {name: 'Fix the ValueError'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: '#42'})).toBeInTheDocument();
     expect(screen.queryByText('Autofix queued')).not.toBeInTheDocument();
   });
 

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -748,18 +748,20 @@ function IssueRow({
   return (
     <Container background="primary" border="muted" radius="md" padding="sm md">
       <Stack gap="xs">
-        <Flex justify="between" align="center" gap="md" wrap="wrap">
-          <Link to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}>
-            <Text size="sm" ellipsis>
-              {issue.groupShortId ? (
-                <Text bold as="span">
-                  {issue.groupShortId}{' '}
-                </Text>
-              ) : null}
-              {title}
-            </Text>
-          </Link>
-          <Stack gap="xs" align="end">
+        <Flex justify="between" align="center" gap="md">
+          <Container flex="1" minWidth="0">
+            <Link to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}>
+              <Text size="sm" ellipsis>
+                {issue.groupShortId ? (
+                  <Text bold as="span">
+                    {issue.groupShortId}{' '}
+                  </Text>
+                ) : null}
+                {title}
+              </Text>
+            </Link>
+          </Container>
+          <Stack gap="xs" align="end" flexShrink={0}>
             {issue.pullRequests.length > 0 ? (
               issue.pullRequests.map(pullRequest => (
                 <IssuePullRequestChip
@@ -820,23 +822,28 @@ function IssuePullRequestChip({
 }: {
   pullRequest: SeerNightShiftRunPullRequest;
 }) {
-  const title = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
   const status = pullRequest.status ?? 'unknown';
   const Icon = PR_STATUS_ICON[status] ?? IconPullRequest;
+  // The chip stays compact -- just the PR number (and its status when notable);
+  // the full title would blow out the row, so it lives on hover instead.
+  const number = `#${pullRequest.id}`;
   const label = PR_STATUS_PREFIXED.has(status)
-    ? `${getPullRequestStatusLabel(status)}: ${title}`
-    : title;
-  if (!pullRequest.externalUrl) {
-    return (
-      <Tag variant="muted" icon={<Icon />}>
-        {label}
-      </Tag>
-    );
-  }
-  return (
+    ? `${getPullRequestStatusLabel(status)} ${number}`
+    : number;
+  const tooltipTitle = pullRequest.title ?? t('Pull request #%s', pullRequest.id);
+  const chip = pullRequest.externalUrl ? (
     <LinkButton size="xs" icon={<Icon />} href={pullRequest.externalUrl} external>
-      <Text ellipsis>{label}</Text>
+      {label}
     </LinkButton>
+  ) : (
+    <Tag variant="muted" icon={<Icon />}>
+      {label}
+    </Tag>
+  );
+  return (
+    <Tooltip title={tooltipTitle} skipWrapper>
+      {chip}
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
Follow-ups to the Sentry Workflows page redesign (#119662) — two visual fixes in the expanded issue list. Frontend-only; no API changes (the PR number was already in the payload as `pullRequest.id`).

### 1. Ellipsize long issue titles
A long issue title grew unbounded and pushed the PR button onto the next line — the existing `Text ellipsis` never engaged because the title `Link` was an unconstrained flex item (`min-width: auto`). Wrapped it in a shrinkable `Container` (`flex="1" minWidth="0"`), pinned the PR column with `flexShrink={0}`, and dropped `wrap` so the title truncates and the button stays on the same row.

### 2. PR chip shows only the number
The chip label was `pullRequest.title ?? "Pull request #<n>"`, so it rendered the full PR title and only fell back to the number when the title was null (hence "sometimes it shows the number, sometimes it doesn't"). It now always shows `#<number>` with the status prefix and icon retained; the full title moved to a hover tooltip so it isn't lost.

### Tests
- `index.spec.tsx`: 25/25 pass (updated assertions for the new `#42` / `Merged #42` labels)
- `pnpm typecheck` and `lint:js` clean
