### PR TITLE
feat(seer): persist and surface night shift skip_reason

### DIFF
--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -47,6 +47,7 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     groupShortId: str | None
     action: str | None
     reason: str | None
+    skipReason: str | None
     seerRunId: str | None
     pullRequests: list[SeerNightShiftRunPullRequestResponse]
     dateAdded: str
@@ -235,6 +236,7 @@ def _serialize_issue(
         ),
         "action": extras.get("action"),
         "reason": extras.get("reason"),
+        "skipReason": extras.get("skip_reason"),
         "seerRunId": result.seer_run_id,
         "pullRequests": pull_requests_by_result_id.get(result.id, []),
         "dateAdded": result.date_added.isoformat(),

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -157,6 +157,12 @@ def _process_verdicts(
         verdicts.append(v)
         if v.action in (TriageAction.SKIP, TriageAction.ROOT_CAUSE_ONLY):
             mark_skipped(v.group_id)
+            if v.action == TriageAction.SKIP:
+                sentry_sdk.metrics.count(
+                    "night_shift.skip_reason",
+                    1,
+                    attributes={"skip_reason": v.skip_reason or "unknown"},
+                )
         elif v.action == TriageAction.AUTOFIX:
             fixable_groups.append(group)
 
@@ -222,6 +228,8 @@ def _process_verdicts(
         extras: dict[str, Any] = {"action": str(v.action)}
         if v.reason:
             extras["reason"] = v.reason[:REASON_MAX_CHARS]
+        if v.action == TriageAction.SKIP and v.skip_reason:
+            extras["skip_reason"] = v.skip_reason
         seer_run_id: str | None = None
         result_seer_run: SeerRun | None = None
         if v.action == TriageAction.AUTOFIX and not dry_run:

--- a/src/sentry/seer/night_shift/models.py
+++ b/src/sentry/seer/night_shift/models.py
@@ -44,15 +44,18 @@ class NightShiftPayload(_Base):
 # Result payload (Seer -> Sentry): the triage verdicts pushed back.
 
 
-SkipReason = Literal["duplicate", "insufficient_info", "environmental", "ambiguous_root_cause"]
-
-
 class TriageVerdict(_Base):
     group_id: int
     action: TriageAction
     reason: str = ""
     # Only meaningful when action="skip"; None for autofix/root_cause_only.
-    skip_reason: SkipReason | None = None
+    # Deliberately a passthrough string, not a mirrored enum: Seer can add a
+    # new category on its own schedule without a synchronized Sentry deploy.
+    # `TriageResponse.parse_obj` validates a whole batch at once, so a closed
+    # enum here would drop every verdict in a delivery over one unrecognized
+    # skip_reason value. Only branch on the specific strings this code knows
+    # about (see night_shift/delivery.py); treat anything else as opaque.
+    skip_reason: str | None = None
 
 
 class TriageResponse(_Base):

--- a/src/sentry/seer/night_shift/models.py
+++ b/src/sentry/seer/night_shift/models.py
@@ -44,10 +44,15 @@ class NightShiftPayload(_Base):
 # Result payload (Seer -> Sentry): the triage verdicts pushed back.
 
 
+SkipReason = Literal["duplicate", "insufficient_info", "environmental", "ambiguous_root_cause"]
+
+
 class TriageVerdict(_Base):
     group_id: int
     action: TriageAction
     reason: str = ""
+    # Only meaningful when action="skip"; None for autofix/root_cause_only.
+    skip_reason: SkipReason | None = None
 
 
 class TriageResponse(_Base):

--- a/src/sentry/seer/night_shift/models.py
+++ b/src/sentry/seer/night_shift/models.py
@@ -48,13 +48,8 @@ class TriageVerdict(_Base):
     group_id: int
     action: TriageAction
     reason: str = ""
-    # Only meaningful when action="skip"; None for autofix/root_cause_only.
-    # Deliberately a passthrough string, not a mirrored enum: Seer can add a
-    # new category on its own schedule without a synchronized Sentry deploy.
-    # `TriageResponse.parse_obj` validates a whole batch at once, so a closed
-    # enum here would drop every verdict in a delivery over one unrecognized
-    # skip_reason value. Only branch on the specific strings this code knows
-    # about (see night_shift/delivery.py); treat anything else as opaque.
+    # Only meaningful when action="skip". A passthrough string rather than an
+    # enum, so a new category from Seer doesn't fail the whole batch to parse.
     skip_reason: str | None = None
 
 

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -857,7 +857,7 @@ function TriageIssuesDebugAddendum({
         {t('Per-issue internals')}
       </Text>
       <Grid
-        columns="max-content max-content max-content max-content"
+        columns="max-content max-content max-content max-content max-content"
         gap="sm xl"
         align="center"
       >
@@ -866,6 +866,9 @@ function TriageIssuesDebugAddendum({
         </Text>
         <Text bold size="xs" variant="muted">
           {t('Raw action')}
+        </Text>
+        <Text bold size="xs" variant="muted">
+          {t('Skip reason')}
         </Text>
         <Text bold size="xs" variant="muted">
           {t('Seer Run ID')}
@@ -877,6 +880,9 @@ function TriageIssuesDebugAddendum({
           </Text>,
           <Text key={`${issue.id}-action`} size="sm" monospace>
             {issue.action}
+          </Text>,
+          <Text key={`${issue.id}-skip-reason`} size="sm" variant="muted" monospace>
+            {issue.skipReason ?? '-'}
           </Text>,
           <Text key={`${issue.id}-seer`} size="sm" variant="muted" monospace>
             {issue.seerRunId ?? '-'}

--- a/static/app/views/seerWorkflows/types.ts
+++ b/static/app/views/seerWorkflows/types.ts
@@ -14,6 +14,7 @@ export type SeerNightShiftRunIssue = {
   pullRequests: SeerNightShiftRunPullRequest[];
   reason: string | null;
   seerRunId: string | null;
+  skipReason: string | null;
 };
 
 // A Seer run dispatched by a night shift run, openable in Explorer.

--- a/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_workflows.py
@@ -64,6 +64,27 @@ class OrganizationSeerWorkflowsTest(APITestCase):
         # No result_seer_run FK is set on this result, so no PRs resolve.
         assert issue["pullRequests"] == []
 
+    def test_skip_reason_surfaces_on_issue(self) -> None:
+        group = self.create_group()
+        run = SeerNightShiftRun.objects.create(organization=self.organization)
+        SeerNightShiftRunResult.objects.create(
+            run=run,
+            kind="agentic_triage",
+            group=group,
+            extras={
+                "action": "skip",
+                "reason": "plausible root cause but not confident",
+                "skip_reason": "ambiguous_root_cause",
+            },
+        )
+
+        with self.feature("organizations:seer-night-shift"):
+            response = self.get_success_response(self.organization.slug)
+
+        issue = response.data[0]["issues"][0]
+        assert issue["action"] == "skip"
+        assert issue["skipReason"] == "ambiguous_root_cause"
+
     def test_issue_with_missing_group_has_null_title(self) -> None:
         # group FK is db_constraint=False, so a stale group_id is possible in
         # prod; can't use create+delete since Django still cascades that.

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -311,6 +311,43 @@ class TestDeliverNightShiftResult(TestCase):
         result_row = SeerNightShiftRunResult.objects.get(run=run)
         assert "skip_reason" not in result_row.extras
 
+    def test_unrecognized_skip_reason_does_not_fail_delivery(self) -> None:
+        """skip_reason is a passthrough string, not a mirrored enum: a category
+        Seer added that this code doesn't know about yet must still parse and
+        persist, not fail the whole batch. See TriageVerdict.skip_reason."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {
+                    "group_id": group.id,
+                    "action": TriageAction.SKIP.value,
+                    "reason": "test appears flaky",
+                    "skip_reason": "flaky_test",
+                }
+            ]
+        }
+
+        with patch("sentry.seer.night_shift.delivery.logger") as mock_logger:
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+            mock_logger.exception.assert_not_called()
+
+        redis = redis_clusters.get("default")
+        redis.delete(skip_cache_key(group.id))
+
+        result_row = SeerNightShiftRunResult.objects.get(run=run)
+        assert result_row.extras["skip_reason"] == "flaky_test"
+
     def test_dry_run_skips_autofix(self) -> None:
         """Dry run mode should not trigger autofix but still persist verdict rows."""
         org = self.create_organization()

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -244,6 +244,73 @@ class TestDeliverNightShiftResult(TestCase):
         assert result_row.seer_run_id is None
         assert result_row.extras["action"] == TriageAction.ROOT_CAUSE_ONLY.value
 
+    def test_skip_verdict_persists_skip_reason(self) -> None:
+        """A SKIP verdict's skip_reason is persisted into the result row's extras."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {
+                    "group_id": group.id,
+                    "action": TriageAction.SKIP.value,
+                    "reason": "flaky test suspected",
+                    "skip_reason": "ambiguous_root_cause",
+                }
+            ]
+        }
+
+        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent"):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+        redis = redis_clusters.get("default")
+        redis.delete(skip_cache_key(group.id))
+
+        result_row = SeerNightShiftRunResult.objects.get(run=run)
+        assert result_row.extras["skip_reason"] == "ambiguous_root_cause"
+
+    def test_root_cause_only_verdict_does_not_persist_skip_reason(self) -> None:
+        """skip_reason is only meaningful for SKIP verdicts; a ROOT_CAUSE_ONLY
+        verdict must not carry one into extras even if Seer sent one."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {
+                    "group_id": group.id,
+                    "action": TriageAction.ROOT_CAUSE_ONLY.value,
+                    "reason": "needs investigation",
+                    "skip_reason": "ambiguous_root_cause",
+                }
+            ]
+        }
+
+        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent"):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+        redis = redis_clusters.get("default")
+        redis.delete(skip_cache_key(group.id))
+
+        result_row = SeerNightShiftRunResult.objects.get(run=run)
+        assert "skip_reason" not in result_row.extras
+
     def test_dry_run_skips_autofix(self) -> None:
         """Dry run mode should not trigger autofix but still persist verdict rows."""
         org = self.create_organization()


### PR DESCRIPTION
Consumer-side half of getsentry/seer#7351, which adds an additive `skip_reason` field (`duplicate`, `insufficient_info`, `environmental`, `ambiguous_root_cause`) to the night shift triage verdict so `skip` can be routed more granularly downstream — e.g. flagging `ambiguous_root_cause` cases as ones a human could take over, using the existing free-text `reason` as a root-cause starting point.

- Mirror `skip_reason` onto `TriageVerdict` in `sentry/seer/night_shift/models.py` (optional, defaults to `None` — safe against older Seer payloads that don't send it).
- Persist `skip_reason` into `SeerNightShiftRunResult.extras` for `SKIP` verdicts in `night_shift/delivery.py`, and emit a `night_shift.skip_reason` metric breakdown for observability.
- Surface it through the `seer-workflows` API serializer as `skipReason`.
- Add a "Skip reason" column to the per-issue internals debug table in the Seer Workflows admin view.

`ROOT_CAUSE_ONLY` already reuses its existing free-text `reason` as the root-cause note and is otherwise treated identically to `SKIP` — that didn't need any new handling, just confirming it.

Blocked on getsentry/seer#7351 landing so Seer actually starts sending `skip_reason`.
