### PR TITLE
fix(relocation): make SaaS export replies transaction-safe

### DIFF
--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -7,7 +7,7 @@ import logging
 from datetime import UTC, datetime
 from io import BytesIO
 
-from django.db import router
+from django.db import router, transaction
 from django.db.utils import IntegrityError
 from django.utils import timezone
 from sentry_sdk import capture_exception
@@ -106,30 +106,42 @@ class DBBackedRelocationExportService(CellRelocationExportService):
                 capture_exception(e)
                 return
 
-            # TODO(azaslavsky): finish transfer from `encrypted_contents` -> `encrypted_bytes`.
-            fp = BytesIO(bytes(encrypted_bytes or []))
-            file = File.objects.create(name="raw-relocation-data.tar", type=RELOCATION_FILE_TYPE)
-            file.putfile(fp, blob_size=RELOCATION_BLOB_SIZE, logger=logger)
-            logger.info("SaaS -> SaaS relocation underlying File created", extra=logger_data)
-
-            # This write ensures that the entire chain triggered by `uploading_start` remains
-            # idempotent, since only one (relocation_uuid, relocation_file_kind) pairing can exist
-            # in that database's table at a time. If we try to write a second, it will fail due to
-            # that unique constraint.
+            # Claim this relocation file before uploading its blob. The inner transaction keeps a
+            # duplicate claim from marking the outer transaction for rollback and also rolls back
+            # the duplicate's placeholder File.
             try:
-                RelocationFile.objects.create(
-                    relocation=relocation,
-                    file=file,
-                    kind=RelocationFile.Kind.RAW_USER_DATA.value,
-                )
+                with transaction.atomic(using=router.db_for_write(RelocationFile)):
+                    file = File.objects.create(
+                        name="raw-relocation-data.tar", type=RELOCATION_FILE_TYPE
+                    )
+                    RelocationFile.objects.create(
+                        relocation=relocation,
+                        file=file,
+                        kind=RelocationFile.Kind.RAW_USER_DATA.value,
+                    )
             except IntegrityError:
-                # We already have the file, we can proceed.
-                pass
+                if RelocationFile.objects.filter(
+                    relocation=relocation,
+                    kind=RelocationFile.Kind.RAW_USER_DATA.value,
+                ).exists():
+                    logger.info(
+                        "SaaS -> SaaS relocation reply already processed", extra=logger_data
+                    )
+                else:
+                    raise
+            else:
+                # TODO(azaslavsky): finish transfer from `encrypted_contents` -> `encrypted_bytes`.
+                fp = BytesIO(bytes(encrypted_bytes or []))
+                file.putfile(fp, blob_size=RELOCATION_BLOB_SIZE, logger=logger)
+                logger.info("SaaS -> SaaS relocation underlying File created", extra=logger_data)
 
-            logger.info("SaaS -> SaaS relocation RelocationFile saved", extra=logger_data)
+                logger.info("SaaS -> SaaS relocation RelocationFile saved", extra=logger_data)
 
-            uploading_complete.apply_async(args=[str(relocation.uuid)])
-            logger.info("SaaS -> SaaS relocation next task scheduled", extra=logger_data)
+            transaction.on_commit(
+                lambda: uploading_complete.apply_async(args=[str(relocation.uuid)]),
+                using=router.db_for_write(Relocation),
+            )
+            logger.info("SaaS -> SaaS relocation next task registered", extra=logger_data)
 
 
 class ProxyingRelocationExportService(ControlRelocationExportService):

--- a/tests/sentry/relocation/tasks/test_transfer.py
+++ b/tests/sentry/relocation/tasks/test_transfer.py
@@ -3,8 +3,11 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from django.utils import timezone
 
+from sentry.models.files.file import File
+from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.utils import get_relocation_storage
 from sentry.models.organization import Organization
 from sentry.relocation.models.relocation import Relocation, RelocationFile
@@ -13,6 +16,7 @@ from sentry.relocation.models.relocationtransfer import (
     RegionRelocationTransfer,
     RelocationTransferState,
 )
+from sentry.relocation.services.relocation_export.impl import DBBackedRelocationExportService
 from sentry.relocation.tasks.transfer import (
     find_relocation_transfer_control,
     find_relocation_transfer_region,
@@ -171,7 +175,8 @@ class ProcessRelocationTransferControlTest(TestCase):
             BytesIO(b"export data"),
         )
 
-        process_relocation_transfer_control(transfer_id=transfer.id)
+        with self.capture_on_commit_callbacks(execute=True):
+            process_relocation_transfer_control(transfer_id=transfer.id)
 
         assert mock_uploading_complete.apply_async.called, "task should be spawned"
         # Should be removed on completion.
@@ -179,6 +184,49 @@ class ProcessRelocationTransferControlTest(TestCase):
         # the relocation RPC call should create a file on the cell
         with assume_test_silo_mode(SiloMode.CELL):
             assert RelocationFile.objects.filter(relocation=relocation).exists()
+
+    @patch("sentry.relocation.tasks.process.uploading_complete")
+    def test_duplicate_reply_retries_continuation(self, mock_uploading_complete: MagicMock) -> None:
+        encrypted_bytes = list(b"export data")
+        mock_uploading_complete.apply_async.side_effect = [
+            RuntimeError("task broker unavailable"),
+            None,
+        ]
+        with assume_test_silo_mode(SiloMode.CELL):
+            relocation = Relocation.objects.create(
+                creator_id=self.user.id,
+                owner_id=self.user.id,
+                want_org_slugs=["acme-org"],
+                step=Relocation.Step.UPLOADING.value,
+            )
+            service = DBBackedRelocationExportService()
+
+            with (
+                pytest.raises(RuntimeError, match="task broker unavailable"),
+                self.capture_on_commit_callbacks(execute=True),
+            ):
+                service.reply_with_export(
+                    relocation_uuid=str(relocation.uuid),
+                    requesting_region_name="de",
+                    replying_region_name="us",
+                    org_slug=self.organization.slug,
+                    encrypted_bytes=encrypted_bytes,
+                )
+
+            with self.capture_on_commit_callbacks(execute=True):
+                service.reply_with_export(
+                    relocation_uuid=str(relocation.uuid),
+                    requesting_region_name="de",
+                    replying_region_name="us",
+                    org_slug=self.organization.slug,
+                    encrypted_bytes=encrypted_bytes,
+                )
+
+            relocation_file = RelocationFile.objects.get(relocation=relocation)
+            assert File.objects.count() == 1
+            assert FileBlob.objects.filter(file=relocation_file.file_id).count() == 1
+            assert RelocationFile.objects.filter(relocation=relocation).count() == 1
+            assert mock_uploading_complete.apply_async.call_count == 2
 
 
 @cell_silo_test(cells=TEST_REGIONS)


### PR DESCRIPTION
## Summary

- claim the unique relocation file before writing SaaS-to-SaaS export bytes to external storage
- isolate duplicate-link conflicts in a savepoint so they do not roll back the outer transaction
- enqueue `uploading_complete` only after commit, and retry dispatch when a duplicate reply follows a broker failure
- cover duplicate delivery without creating another `File`, blob, or `RelocationFile`

## Why

`File.putfile()` writes to non-transactional object storage before the unique `RelocationFile` link is created. A duplicate link can raise inside the outer atomic block, rolling back the database rows after the blob write, while immediate task dispatch can run against that rolled-back state.

## Tests

- `.venv/bin/prek run -q --files src/sentry/relocation/services/relocation_export/impl.py tests/sentry/relocation/tasks/test_transfer.py`