### PR TITLE
fix(relocation): claim transfers before scheduling

### DIFF
--- a/src/sentry/relocation/tasks/transfer.py
+++ b/src/sentry/relocation/tasks/transfer.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from django.db.models import Subquery
+from django.db import router, transaction
 from django.utils import timezone
 from sentry_sdk import capture_exception
 from taskbroker_client.task import Task
@@ -25,6 +25,8 @@ from sentry.taskworker.namespaces import relocation_control_tasks, relocation_ta
 from sentry.types.cell import get_local_cell
 
 logger = logging.getLogger("sentry.relocation")
+
+TRANSFER_SCHEDULER_BATCH_SIZE = 100
 
 
 @instrumented_task(
@@ -54,19 +56,29 @@ def _find_relocation_transfer(
     due, and schedule processing tasks for them.
     """
     now = timezone.now()
-    scheduled_ids = model_cls.objects.filter(
-        scheduled_for__lte=now,
-        date_added__gte=now - MAX_AGE,
-    ).values_list("id", flat=True)
+    using = router.db_for_write(model_cls)
+    with transaction.atomic(using=using):
+        scheduled_ids = list(
+            model_cls.objects.using(using)
+            .select_for_update(skip_locked=True)
+            .filter(
+                scheduled_for__lte=now,
+                date_added__gte=now - MAX_AGE,
+            )
+            .order_by("scheduled_for", "id")
+            .values_list("id", flat=True)[:TRANSFER_SCHEDULER_BATCH_SIZE]
+        )
+
+        if scheduled_ids:
+            # Claim these transfers before publishing tasks. If publication fails or the scheduler
+            # exits, the lease makes them eligible for a later retry without another scheduler
+            # publishing them concurrently.
+            model_cls.objects.using(using).filter(id__in=scheduled_ids).update(
+                scheduled_for=now + RETRY_BACKOFF
+            )
 
     for transfer_id in scheduled_ids:
         process_task.delay(transfer_id=transfer_id)
-
-    if len(scheduled_ids):
-        # Advance next retry time in case these deliveries fail.
-        model_cls.objects.filter(id__in=Subquery(scheduled_ids)).update(
-            scheduled_for=timezone.now() + RETRY_BACKOFF
-        )
 
     # Garbage collect expired transfers. Because relocations are
     # expected to complete in 80min we should purge transfers older than

--- a/tests/sentry/relocation/tasks/test_transfer.py
+++ b/tests/sentry/relocation/tasks/test_transfer.py
@@ -1,8 +1,11 @@
+import threading
 from datetime import timedelta
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
+from django.db import connections
 from django.utils import timezone
 
 from sentry.models.files.utils import get_relocation_storage
@@ -20,7 +23,7 @@ from sentry.relocation.tasks.transfer import (
     process_relocation_transfer_region,
 )
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.silo import (
     assume_test_silo_mode,
     cell_silo_test,
@@ -90,6 +93,71 @@ class FindRelocationTransferControlTest(TestCase):
         find_relocation_transfer_control()
         assert not mock_process.delay.called
         assert not ControlRelocationTransfer.objects.filter(id=transfer.id).exists()
+
+    @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_control")
+    def test_enqueue_failure_keeps_claim(self, mock_process: MagicMock) -> None:
+        transfer = create_control_relocation_transfer(
+            organization=self.organization, scheduled_for=timezone.now() - timedelta(minutes=2)
+        )
+        mock_process.delay.side_effect = RuntimeError("task broker unavailable")
+
+        with pytest.raises(RuntimeError, match="task broker unavailable"):
+            find_relocation_transfer_control()
+
+        transfer.refresh_from_db()
+        assert transfer.scheduled_for > timezone.now()
+
+        mock_process.delay.reset_mock(side_effect=True)
+        find_relocation_transfer_control()
+        assert not mock_process.delay.called
+
+        transfer.update(scheduled_for=timezone.now() - timedelta(minutes=2))
+        find_relocation_transfer_control()
+        mock_process.delay.assert_called_once_with(transfer_id=transfer.id)
+
+
+@control_silo_test
+class FindRelocationTransferControlConcurrencyTest(TransactionTestCase):
+    @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_control")
+    def test_concurrent_schedulers_publish_once(self, mock_process: MagicMock) -> None:
+        transfer = create_control_relocation_transfer(
+            organization=self.organization, scheduled_for=timezone.now() - timedelta(minutes=2)
+        )
+        first_publish_started = threading.Event()
+        second_scheduler_finished = threading.Event()
+
+        def delay(**kwargs) -> None:
+            if not first_publish_started.is_set():
+                first_publish_started.set()
+                assert second_scheduler_finished.wait(timeout=5)
+
+        mock_process.delay.side_effect = delay
+
+        def run_first_scheduler() -> None:
+            try:
+                find_relocation_transfer_control()
+            finally:
+                connections.close_all()
+
+        def run_second_scheduler() -> None:
+            try:
+                find_relocation_transfer_control()
+            finally:
+                second_scheduler_finished.set()
+                connections.close_all()
+
+        first_scheduler = threading.Thread(target=run_first_scheduler)
+        first_scheduler.start()
+        assert first_publish_started.wait(timeout=5)
+
+        second_scheduler = threading.Thread(target=run_second_scheduler)
+        second_scheduler.start()
+        second_scheduler.join(timeout=5)
+        first_scheduler.join(timeout=5)
+
+        assert not first_scheduler.is_alive()
+        assert not second_scheduler.is_alive()
+        mock_process.delay.assert_called_once_with(transfer_id=transfer.id)
 
 
 class FindRelocationTransferRegionTest(TestCase):


### PR DESCRIPTION
## Summary

- claim due relocation transfers in bounded batches with `select_for_update(skip_locked=True)`
- advance retry leases transactionally before publishing processing tasks
- cover concurrent schedulers and recovery after an enqueue failure

## Tests

- `.venv/bin/prek run -q --files src/sentry/relocation/tasks/transfer.py tests/sentry/relocation/tasks/test_transfer.py`