### PR TITLE
feat(conversations): Let the layout use available horizontal space

### DIFF
--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -17,6 +17,7 @@ const DEFAULT_STORAGE_KEY = 'conversation-split-size';
 
 const CONTENT_MIN_WIDTH = 400;
 const DETAIL_MIN_WIDTH = 400;
+const MAX_CONTENT_WIDTH = 2000;
 const SPLIT_LAYOUT_STORAGE_KEY = 'conversation-split-layout-size';
 
 /**
@@ -160,8 +161,6 @@ export function ConversationContentLayout({
     </Flex>
   );
 }
-
-const MAX_CONTENT_WIDTH = 2000;
 
 function MeasuredContentSplit({
   content,

--- a/static/app/views/explore/conversations/components/conversationLayout.tsx
+++ b/static/app/views/explore/conversations/components/conversationLayout.tsx
@@ -17,7 +17,6 @@ const DEFAULT_STORAGE_KEY = 'conversation-split-size';
 
 const CONTENT_MIN_WIDTH = 400;
 const DETAIL_MIN_WIDTH = 400;
-const CONTENT_WIDTH_RATIO = 0.6;
 const SPLIT_LAYOUT_STORAGE_KEY = 'conversation-split-layout-size';
 
 /**
@@ -126,9 +125,6 @@ export function ConversationContentLayout({
   leftPadding?: React.ComponentProps<typeof Container>['padding'];
   right?: React.ReactNode;
 }) {
-  const measureRef = useRef<HTMLDivElement>(null);
-  const {width} = useDimensions({elementRef: measureRef});
-
   return (
     <Flex flex="1" minWidth="0" minHeight="0" overflow="hidden">
       <ConversationLeftPanel>
@@ -139,28 +135,25 @@ export function ConversationContentLayout({
           width="100%"
           background="secondary"
         >
-          <Flex ref={measureRef} height="100%" width="100%" minHeight="0" minWidth="0">
-            {width > 0 ? (
-              <MeasuredContentSplit
-                width={width}
-                detail={right}
-                content={
-                  <Container
-                    flex="1"
-                    minWidth="0"
-                    minHeight="0"
-                    padding={leftPadding}
-                    background="primary"
-                    border="primary"
-                    radius="md"
-                    overflowX="hidden"
-                    overflowY="auto"
-                  >
-                    {left}
-                  </Container>
-                }
-              />
-            ) : null}
+          <Flex height="100%" width="100%" minHeight="0" minWidth="0">
+            <MeasuredContentSplit
+              detail={right}
+              content={
+                <Container
+                  flex="1"
+                  minWidth="0"
+                  minHeight="0"
+                  padding={leftPadding}
+                  background="primary"
+                  border="primary"
+                  radius="md"
+                  overflowX="hidden"
+                  overflowY="auto"
+                >
+                  {left}
+                </Container>
+              }
+            />
           </Flex>
         </Container>
       </ConversationLeftPanel>
@@ -168,30 +161,27 @@ export function ConversationContentLayout({
   );
 }
 
+const MAX_CONTENT_WIDTH = 2000;
+
 function MeasuredContentSplit({
   content,
   detail,
-  width,
 }: {
   content: React.ReactNode;
-  width: number;
   detail?: React.ReactNode;
 }) {
-  const defaultContent = Math.max(
-    CONTENT_MIN_WIDTH,
-    Math.round((width - DIVIDER_WIDTH) * CONTENT_WIDTH_RATIO)
-  );
   const [storedSize, setStoredSize] = useLocalStorageState(
     SPLIT_LAYOUT_STORAGE_KEY,
-    defaultContent
+    MAX_CONTENT_WIDTH
   );
 
   return (
     <SplitPanel
       orientation={{xs: 'vertical', md: 'horizontal'}}
-      defaultSize={defaultContent}
+      defaultSize={MAX_CONTENT_WIDTH}
       initialSize={storedSize}
       minSize={CONTENT_MIN_WIDTH}
+      maxSize={MAX_CONTENT_WIDTH}
       fillMinSize={DETAIL_MIN_WIDTH}
       onResizeEnd={({endSize}) => setStoredSize(endSize)}
       sized={
@@ -201,6 +191,7 @@ function MeasuredContentSplit({
           minHeight="0"
           paddingRight={{xs: '0', md: 'md'}}
           paddingBottom={{xs: 'md', md: '0'}}
+          maxWidth={`${MAX_CONTENT_WIDTH}px`}
         >
           {content}
         </Stack>

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -91,7 +91,6 @@ export function ConversationViewContainer({children}: {children: React.ReactNode
       overflow="hidden"
       border={hasConversationsRedesign ? undefined : 'primary'}
       radius={hasConversationsRedesign ? undefined : 'md'}
-      maxWidth={hasConversationsRedesign ? '1340px' : undefined}
       background="primary"
       display="flex"
     >


### PR DESCRIPTION
Users reported that the conversations view left large empty margins on wide screens: the content was capped at a fixed width, so most of the horizontal space went unused no matter how big the window was.

The layout now stretches to fill the available width. The conversation content expands across the screen (up to a generous ceiling so lines stay readable), and opening a span uses the remaining space to the right for the detail pane instead of squeezing both into a fixed-width column.

Fixes TET-2673