### PR TITLE
fix(formatters): Add trillion suffix to abbreviated number formatting

### DIFF
--- a/static/app/utils/formatters.spec.tsx
+++ b/static/app/utils/formatters.spec.tsx
@@ -22,7 +22,9 @@ describe('formatAbbreviatedNumber()', () => {
     expect(formatAbbreviatedNumber(1000)).toBe('1K');
     expect(formatAbbreviatedNumber(10000000)).toBe('10M');
     expect(formatAbbreviatedNumber(100000000000)).toBe('100B');
-    expect(formatAbbreviatedNumber(1000000000000)).toBe('1000B');
+    expect(formatAbbreviatedNumber(1000000000000)).toBe('1T');
+    expect(formatAbbreviatedNumber(1500000000000)).toBe('1.5T');
+    expect(formatAbbreviatedNumber(1000000000000000)).toBe('1000T');
   });
 
   it('should abbreviate numbers that are strings', () => {
@@ -31,7 +33,7 @@ describe('formatAbbreviatedNumber()', () => {
     expect(formatAbbreviatedNumber('1000')).toBe('1K');
     expect(formatAbbreviatedNumber('10000000')).toBe('10M');
     expect(formatAbbreviatedNumber('100000000000')).toBe('100B');
-    expect(formatAbbreviatedNumber('1000000000000')).toBe('1000B');
+    expect(formatAbbreviatedNumber('1000000000000')).toBe('1T');
   });
 
   it('should round to 1 decimal place', () => {
@@ -49,10 +51,10 @@ describe('formatAbbreviatedNumber()', () => {
     expect(formatAbbreviatedNumber(1500, 3)).toBe('1.5K');
     expect(formatAbbreviatedNumber(1213122, 3)).toBe('1.21M');
     expect(formatAbbreviatedNumber(-1213122, 3)).toBe('-1.21M');
-    expect(formatAbbreviatedNumber(1500000000000, 3)).toBe('1500B');
+    expect(formatAbbreviatedNumber(1500000000000, 3)).toBe('1.5T');
 
     expect(formatAbbreviatedNumber('1249.23421', 3)).toBe('1.25K');
-    expect(formatAbbreviatedNumber('1239567891299', 3)).toBe('1240B');
+    expect(formatAbbreviatedNumber('1239567891299', 3)).toBe('1.24T');
     expect(formatAbbreviatedNumber('158.80421626984128', 3)).toBe('159');
   });
 
@@ -60,7 +62,7 @@ describe('formatAbbreviatedNumber()', () => {
     expect(formatAbbreviatedNumber(-100)).toBe('-100');
     expect(formatAbbreviatedNumber(-1095)).toBe('-1K');
     expect(formatAbbreviatedNumber(-10000000)).toBe('-10M');
-    expect(formatAbbreviatedNumber(-1000000000000)).toBe('-1000B');
+    expect(formatAbbreviatedNumber(-1000000000000)).toBe('-1T');
   });
 });
 
@@ -80,6 +82,7 @@ describe('formatAbbreviatedNumberWithDynamicPrecision()', () => {
     expect(formatAbbreviatedNumberWithDynamicPrecision(1000)).toBe('1K');
     expect(formatAbbreviatedNumberWithDynamicPrecision(10000000)).toBe('10M');
     expect(formatAbbreviatedNumberWithDynamicPrecision(100000000000)).toBe('100B');
+    expect(formatAbbreviatedNumberWithDynamicPrecision(1000000000000)).toBe('1T');
   });
 
   it('should abbreviate numbers that are strings', () => {
@@ -99,7 +102,7 @@ describe('formatAbbreviatedNumberWithDynamicPrecision()', () => {
     expect(formatAbbreviatedNumberWithDynamicPrecision(153789)).toBe('153.79K');
     expect(formatAbbreviatedNumberWithDynamicPrecision(1213122)).toBe('1.21M');
     expect(formatAbbreviatedNumberWithDynamicPrecision('1249.23421')).toBe('1.25K');
-    expect(formatAbbreviatedNumberWithDynamicPrecision('123956789129')).toBe('124B');
+    expect(formatAbbreviatedNumberWithDynamicPrecision('123956789129')).toBe('123.96B');
     expect(formatAbbreviatedNumberWithDynamicPrecision('158.80421626984128')).toBe(
       '158.8'
     );
@@ -227,7 +230,7 @@ describe('formatDollars', () => {
     [1000000, '$1M'],
     [1772313.1, '$1.77M'],
     [1000000000, '$1B'],
-    [1000000000000, '$1,000B'],
+    [1000000000000, '$1T'],
     [-100, '$-100'],
     [-1500, '$-1.5K'],
     [-1000000, '$-1M'],

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -32,6 +32,7 @@ export const MICROSECOND = 0.001;
 export const NANOSECOND = 0.000001;
 
 const numberFormatSteps = [
+  [1_000_000_000_000, 'T'],
   [1_000_000_000, 'B'],
   [1_000_000, 'M'],
   [1_000, 'K'],

--- a/static/app/utils/number/NUMBER_FORMATTING.md
+++ b/static/app/utils/number/NUMBER_FORMATTING.md
@@ -217,18 +217,19 @@ Each entry shows the function signature, the rounding/precision logic, and concr
 
 ### `formatAbbreviatedNumber(number, maximumSignificantDigits?, includeDecimals?)`
 
-[formatters.tsx](../formatters.tsx) · K/M/B abbreviations. If `shortValue > 10` or evenly divisible → integer. Otherwise truncates (via `formatFloat`) to `maxSigDigits` (default **1**). Falls through to `toLocaleString` for numbers < 1 000.
+[formatters.tsx](../formatters.tsx) · K/M/B/T abbreviations (maximum multiplier: **T**, trillions / `1e12`). If `shortValue > 10` or evenly divisible → integer. Otherwise truncates (via `formatFloat`) to `maxSigDigits` (default **1**). Falls through to `toLocaleString` for numbers < 1 000. Values ≥ 1 000 T (`1e15`) exceed the largest suffix and render as e.g. `"1000T"`.
 
-| Input        | `maxSigDigits` | `includeDecimals` | Output    |
-| ------------ | -------------- | ----------------- | --------- |
-| `999`        | —              | —                 | `"999"`   |
-| `1000`       | —              | —                 | `"1K"`    |
-| `1500`       | —              | —                 | `"1.5K"`  |
-| `15000`      | —              | —                 | `"15K"`   |
-| `1234567`    | —              | —                 | `"1.2M"`  |
-| `1234567`    | `3`            | —                 | `"1.23M"` |
-| `1000000000` | —              | —                 | `"1B"`    |
-| `-1500`      | —              | —                 | `"-1.5K"` |
+| Input           | `maxSigDigits` | `includeDecimals` | Output    |
+| --------------- | -------------- | ----------------- | --------- |
+| `999`           | —              | —                 | `"999"`   |
+| `1000`          | —              | —                 | `"1K"`    |
+| `1500`          | —              | —                 | `"1.5K"`  |
+| `15000`         | —              | —                 | `"15K"`   |
+| `1234567`       | —              | —                 | `"1.2M"`  |
+| `1234567`       | `3`            | —                 | `"1.23M"` |
+| `1000000000`    | —              | —                 | `"1B"`    |
+| `1000000000000` | —              | —                 | `"1T"`    |
+| `-1500`         | —              | —                 | `"-1.5K"` |
 
 ---
 
@@ -245,6 +246,7 @@ Each entry shows the function signature, the rounding/precision logic, and concr
 | `12345`   | `"12.3K"` |
 | `123456`  | `"123K"`  |
 | `1234567` | `"1.23M"` |
+| `1e12`    | `"1T"`    |
 
 ---
 


### PR DESCRIPTION
## Summary

`formatAbbreviatedNumber`'s SI-suffix table topped out at billions, so counts and chart y-axis labels at or above 1e12 rendered as e.g. `1000B` instead of `1T`. This adds a trillion (`T`) step to the suffix ladder.

Because `formatAbbreviatedNumber` (and, transitively, `formatAbbreviatedNumberWithDynamicPrecision` → `formatDollars`) backs count displays, chart axes, and dollar labels across the app, the fix propagates to every one of those surfaces.

## Changes

- **`formatters.tsx`**: Added `[1_000_000_000_000, 'T']` as the new top step of `numberFormatSteps`. The existing loop and the `numberFormatSteps[0][0]` max-step reference adapt automatically — no other logic changed.
- **`formatters.spec.tsx`**: Updated cases that encoded the old billion cap (`1e12` → `1T`, `formatDollars(1e12)` → `$1T`, etc.), added trillion coverage including a `1000T` overflow case. One dynamic-precision case shifted (`123956789129` now → `123.96B`), aligning it with how the equivalent millions range already formats.
- **`NUMBER_FORMATTING.md`**: Documented the new maximum multiplier (T / 1e12) and the ≥1e15 overflow behavior.

## Before 

<img width="822" height="488" alt="image" src="https://github.com/user-attachments/assets/b68e0b9b-6c1e-4bf8-932c-4b72c61ead9f" />

## After
<img width="822" height="382" alt="image" src="https://github.com/user-attachments/assets/764d4fdc-1124-4099-bec2-aed61494eae4" />


## Notes

The ladder stops at trillion; values ≥ 1,000T (1e15) will render as `1000T`. This is the intended ceiling.

Fixes DAIN-1766