### PR TITLE
fix(spans): query gen AI reasoning level attribute

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -301,8 +301,8 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             search_type="currency",
         ),
         ResolvedAttribute(
-            public_alias="gen_ai.request.reasoning_effort",
-            internal_name="gen_ai.request.reasoning_effort",
+            public_alias="gen_ai.request.reasoning.level",
+            internal_name="gen_ai.request.reasoning.level",
             search_type="string",
         ),
         ResolvedAttribute(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -250,7 +250,7 @@ SPAN_EAP_COLUMN_MAP = {
     "user.ip": "attr_str[sentry.user.ip]",
     "user.geo.subregion": "attr_str[sentry.user.geo.subregion]",
     "user.geo.country_code": "attr_str[sentry.user.geo.country_code]",
-    "gen_ai.request.reasoning_effort": "attr_str[gen_ai.request.reasoning_effort]",
+    "gen_ai.request.reasoning.level": "attr_str[gen_ai.request.reasoning.level]",
     "cloudflare.durable_object.query.bindings": "attr_num[cloudflare.durable_object.query.bindings]",
     "cloudflare.durable_object.response.rows_read": "attr_num[cloudflare.durable_object.response.rows_read]",
     "cloudflare.durable_object.response.rows_written": "attr_num[cloudflare.durable_object.response.rows_written]",

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -57,6 +57,7 @@ from sentry.search.eap.utils import can_expose_attribute_to_api
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.utils.snuba import SPAN_EAP_COLUMN_MAP
 
 
 class AttributeVisibilityTest(TestCase):
@@ -1120,6 +1121,18 @@ def _make_deprecated_metadata(
         is_in_otel=False,
         visibility=Visibility.PUBLIC,
         deprecation=DeprecationInfo(replacement=replacement, status=status),
+    )
+
+
+def test_reasoning_level_attribute_is_queryable() -> None:
+    attr = SPAN_ATTRIBUTE_DEFINITIONS["gen_ai.request.reasoning.level"]
+
+    assert attr.public_alias == "gen_ai.request.reasoning.level"
+    assert attr.internal_name == "gen_ai.request.reasoning.level"
+    assert attr.search_type == "string"
+    assert (
+        SPAN_EAP_COLUMN_MAP["gen_ai.request.reasoning.level"]
+        == "attr_str[gen_ai.request.reasoning.level]"
     )
 
 


### PR DESCRIPTION
Updates EAP span queryability mappings from the unused `gen_ai.request.reasoning_effort` key to the released `gen_ai.request.reasoning.level` convention.

References TET-2603.