### PR TITLE
fix(ui): show gen AI reasoning level attribute

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -100,7 +100,7 @@ export enum SpanFields {
   GEN_AI_AGENT_NAME = 'gen_ai.agent.name',
   GEN_AI_FUNCTION_ID = 'gen_ai.function_id',
   GEN_AI_REQUEST_MODEL = 'gen_ai.request.model',
-  GEN_AI_REQUEST_REASONING_EFFORT = 'gen_ai.request.reasoning_effort',
+  GEN_AI_REQUEST_REASONING_LEVEL = 'gen_ai.request.reasoning.level',
   GEN_AI_REQUEST_MESSAGES = 'gen_ai.request.messages',
   GEN_AI_RESPONSE_TEXT = 'gen_ai.response.text',
   GEN_AI_RESPONSE_OBJECT = 'gen_ai.response.object',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -177,10 +177,10 @@ describe('getHighlightedSpanAttributes', () => {
     expect(result.find(attr => attr.name === 'Cost')).toBeDefined();
   });
 
-  it('should include reasoning effort when attribute is present', () => {
+  it('should include reasoning level when attribute is present', () => {
     const attributes = {
       'gen_ai.operation.type': 'ai_client',
-      'gen_ai.request.reasoning_effort': 'high',
+      'gen_ai.request.reasoning.level': 'high',
     };
 
     const result = getHighlightedSpanAttributes({
@@ -188,12 +188,12 @@ describe('getHighlightedSpanAttributes', () => {
       attributes,
     });
 
-    const reasoningEffort = result.find(attr => attr.name === 'Reasoning Effort');
-    expect(reasoningEffort).toBeDefined();
-    expect(reasoningEffort?.value).toBe('high');
+    const reasoningLevel = result.find(attr => attr.name === 'Reasoning Level');
+    expect(reasoningLevel).toBeDefined();
+    expect(reasoningLevel?.value).toBe('high');
   });
 
-  it('should not include reasoning effort when attribute is absent', () => {
+  it('should not include reasoning level when attribute is absent', () => {
     const attributes = {
       'gen_ai.operation.type': 'ai_client',
     };
@@ -203,7 +203,7 @@ describe('getHighlightedSpanAttributes', () => {
       attributes,
     });
 
-    expect(result.find(attr => attr.name === 'Reasoning Effort')).toBeUndefined();
+    expect(result.find(attr => attr.name === 'Reasoning Level')).toBeUndefined();
   });
 
   it('should include tokens attribute when values are present', () => {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -136,11 +136,11 @@ function getAISpanAttributes({
     });
   }
 
-  const reasoningEffort = attributes[SpanFields.GEN_AI_REQUEST_REASONING_EFFORT];
-  if (reasoningEffort) {
+  const reasoningLevel = attributes[SpanFields.GEN_AI_REQUEST_REASONING_LEVEL];
+  if (reasoningLevel) {
     highlightedAttributes.push({
-      name: t('Reasoning Effort'),
-      value: reasoningEffort.toString(),
+      name: t('Reasoning Level'),
+      value: reasoningLevel.toString(),
     });
   }
 


### PR DESCRIPTION
Updates the trace drawer highlighted AI attribute from `gen_ai.request.reasoning_effort` to `gen_ai.request.reasoning.level`, and renames the UI label to Reasoning Level.

References TET-2603.