### PR TITLE
fix(logs): Set correct groupBy for Open in Explore with tables

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -70,9 +70,9 @@ describe('getWidgetExploreUrl', () => {
     expectUrl(url).toMatch({
       path: '/organizations/org-slug/explore/logs/',
       params: [
+        ['aggregateField', '{"groupBy":""}'],
         ['aggregateField', '{"chartType":1,"yAxes":["count(message)"]}'],
         ['interval', '3h'],
-        ['logsGroupBy', ''],
         ['mode', 'aggregate'],
         ['project', '17762'],
         ['statsPeriod', '14d'],
@@ -100,11 +100,11 @@ describe('getWidgetExploreUrl', () => {
     expectUrl(url).toMatch({
       path: '/organizations/org-slug/explore/logs/',
       params: [
+        ['aggregateField', '{"groupBy":"message"}'],
         ['aggregateField', '{"chartType":1,"yAxes":["count(message)"]}'],
         ['interval', '3h'],
         ['logsFields', 'timestamp'],
         ['logsFields', 'message'],
-        ['logsGroupBy', 'message'],
         ['mode', 'aggregate'],
         ['project', ''],
         ['statsPeriod', '14d'],

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -363,13 +363,17 @@ function _getWidgetExploreUrl(
         ? [OurLogKnownFieldKey.TIMESTAMP, ...queryParams.field]
         : queryParams.field;
 
+    const logsAggregateFields = [
+      ...queryParams.groupBy.map(g => ({groupBy: g})),
+      ...logsVisualize,
+    ];
+
     return getLogsUrl({
       organization: queryParams.organization,
       selection: queryParams.selection,
       query: queryParams.query,
       field: logsField,
-      groupBy: queryParams.groupBy,
-      aggregateFields: logsVisualize,
+      aggregateFields: logsAggregateFields,
       interval: queryParams.interval,
       mode: queryParams.mode,
       referrer: queryParams.referrer,


### PR DESCRIPTION
It seems like we've migrated away from using the `logsGroupBy` param and instead they're represented as an `aggregateField`. There's a chance we can add a cleanup and remove the `groupBy` parameter from the URL creation helper but that will be an additional cleanup PR after this bug fix.
