### PR TITLE
fix(pr-metrics): Emit a fallback event when the judge forward fails

### DIFF
--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -59,6 +59,14 @@ class PullRequestVerdict(models.TextChoices):
     MERGED_UNCHANGED = "merged_unchanged"
     MERGED_WITH_ITERATION = "merged_with_iteration"
     CLOSED_UNMERGED = "closed_unmerged"
+    # A real terminal verdict, but only ever assigned locally when the judge
+    # forward fails for a PR select_verdict couldn't read reliable activity data
+    # for (INDETERMINATE) — unlike select_fallback_verdict's other merged
+    # outcomes, there's no trustworthy signal to call unchanged vs. iterated, so
+    # this says so explicitly rather than guessing. Never a judge *result* — Seer
+    # always settles a real outcome when it succeeds, so this is excluded from
+    # RESULT_VERDICTS.
+    MERGED_UNKNOWN_ITERATION = "merged_unknown_iteration"
     # Transient, internal: a terminal event whose outcome a judge must decide has
     # been claimed and forwarded to Seer, but the judged verdict hasn't returned.
     # Reuses the verdict column as the redelivery guard so a redelivered terminal

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -157,6 +157,32 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
     return PullRequestVerdict.CLOSED_UNMERGED
 
 
+def select_judge_failure_fallback_verdict(
+    pull_request: PullRequest, deferral: VerdictDeferral
+) -> PullRequestVerdict:
+    """The verdict for a judge-eligible PR whose forward to Seer failed.
+
+    A partial event (no conversation analysis, a less-specialized verdict) beats
+    no event at all, so this settles the row locally rather than leaving it
+    claimed at ``JUDGE_IN_PROGRESS`` forever. Judge-eligible PRs are forwarded to
+    Seer for either deferral reason, unlike ``select_fallback_verdict``'s
+    judge-*ineligible* callers, which only ever see ``NEEDS_JUDGE``:
+
+    - ``NEEDS_JUDGE`` carries real activity/engagement data, so this reuses
+      ``select_fallback_verdict`` exactly as the judge-ineligible path does.
+    - ``INDETERMINATE`` merged PRs have no reliable activity data at all —
+      reusing ``select_fallback_verdict`` here would silently read that absence
+      as "no commits after open" and mislabel an actually-iterated PR as
+      unchanged, so this settles on ``MERGED_UNKNOWN_ITERATION`` instead of
+      guessing. Closed PRs don't need the same care: ``select_fallback_verdict``
+      already settles ``CLOSED_UNMERGED`` unconditionally regardless of deferral
+      reason, so there's nothing INDETERMINATE-specific to change there.
+    """
+    if pull_request.merged_at is not None and deferral is VerdictDeferral.INDETERMINATE:
+        return PullRequestVerdict.MERGED_UNKNOWN_ITERATION
+    return select_fallback_verdict(pull_request)
+
+
 # Diagnosis label Sentry can derive on its own (unlike the judge's free-string
 # vocabulary): the deterministic closed-unmerged path's "why", read straight off
 # the PR's own check-suite activity rather than a judge's opinion.

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -38,7 +38,14 @@ from sentry.pr_metrics.contracts import (
     PrCloseJudgeRequest,
     PrConversationAnalysis,
 )
-from sentry.pr_metrics.emit import active_attributions, emit_pr_metrics_row
+from sentry.pr_metrics.emit import (
+    CI_FAILING_AT_CLOSE,
+    VerdictDeferral,
+    active_attributions,
+    ci_failing_at_close,
+    emit_pr_metrics_row,
+    select_judge_failure_fallback_verdict,
+)
 from sentry.pr_metrics.utils import iso_or_none, resolved_group_ids
 from sentry.seer.code_review.models import SeerCodeReviewRepoDefinition
 from sentry.seer.code_review.utils import build_repo_definition
@@ -61,11 +68,14 @@ seer_pr_metrics_connection_pool = connection_from_url(
     timeout=settings.SEER_DEFAULT_TIMEOUT,
 )
 
-# The verdicts Seer may return: every real outcome, never an internal sentinel.
-# The callback rejects JUDGE_IN_PROGRESS / WAITING_EVENT_COOLDOWN coming back from Seer.
+# The verdicts Seer may return: every real outcome, never an internal sentinel and
+# never Sentry's own judge-failure fallback (Seer always settles a real outcome
+# when it succeeds — MERGED_UNKNOWN_ITERATION only exists for when it doesn't).
+# The callback rejects any of these three coming back from Seer.
 RESULT_VERDICTS = frozenset(PullRequestVerdict.values) - {
     PullRequestVerdict.JUDGE_IN_PROGRESS,
     PullRequestVerdict.WAITING_EVENT_COOLDOWN,
+    PullRequestVerdict.MERGED_UNKNOWN_ITERATION,
 }
 
 
@@ -174,7 +184,9 @@ def _build_judge_request(pull_request: PullRequest, repository: Repository) -> P
     )
 
 
-def forward_pr_to_seer_judge(pull_request: PullRequest, repository: Repository) -> None:
+def forward_pr_to_seer_judge(
+    pull_request: PullRequest, repository: Repository, deferral: VerdictDeferral
+) -> None:
     """Forward a needs-judge terminal PR event to Seer (Sentry → Seer).
 
     The outbound half of the round-trip: when ``select_verdict`` can't settle the
@@ -183,33 +195,81 @@ def forward_pr_to_seer_judge(pull_request: PullRequest, repository: Repository) 
     the ``JUDGE_IN_PROGRESS`` sentinel before dispatch, so this never double-fires
     on a redelivery.
 
-    Raises ``HTTPError`` on a retryable Seer status (5xx/429) so the enclosing task
-    retries. A permanent rejection (4xx) is logged and dropped — observe-only: the
-    row stays claimed and simply never emits, an accepted loss until a reaper lands.
+    Raises ``HTTPError`` on a retryable Seer status (5xx/429 — urllib3 also
+    raises connection-level failures, e.g. timeouts, as ``HTTPError`` subclasses,
+    so those retry too) so the enclosing task's ``Retry`` policy retries it;
+    still silently exhausted after ``MAX_RETRIES`` with no further action, an
+    accepted residual gap. Anything else — a permanent rejection (4xx), or any
+    other error building or sending the request — settles the row with a
+    deterministic fallback verdict and emits a partial event instead of leaving
+    it claimed forever: no conversation analysis and a less-specialized verdict
+    beat no event at all. ``deferral`` is ``select_verdict``'s original outcome,
+    needed to pick the right fallback — see ``select_judge_failure_fallback_verdict``.
     """
-    payload = _build_judge_request(pull_request, repository)
     log_extra = {
         "organization_id": pull_request.organization_id,
         "repository_id": pull_request.repository_id,
         "repo_name": repository.name,
         "pull_request_id": pull_request.id,
     }
-    response = make_signed_seer_api_request(
-        connection_pool=seer_pr_metrics_connection_pool,
-        path=SEER_PR_METRICS_JUDGE_PATH,
-        body=payload.json().encode("utf-8"),
-        viewer_context=SeerViewerContext(organization_id=pull_request.organization_id),
-    )
-    if response.status >= 500 or response.status == 429:
-        raise HTTPError(f"Seer judge forward returned retryable status {response.status}")
-    if response.status >= 400:
-        logger.warning(
-            "pr_metrics.judge.forward_rejected", extra={**log_extra, "status": response.status}
+    try:
+        payload = _build_judge_request(pull_request, repository)
+        response = make_signed_seer_api_request(
+            connection_pool=seer_pr_metrics_connection_pool,
+            path=SEER_PR_METRICS_JUDGE_PATH,
+            body=payload.json().encode("utf-8"),
+            viewer_context=SeerViewerContext(organization_id=pull_request.organization_id),
         )
-        metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "client_error"})
+        if response.status >= 500 or response.status == 429:
+            raise HTTPError(f"Seer judge forward returned retryable status {response.status}")
+        if response.status >= 400:
+            logger.warning(
+                "pr_metrics.judge.forward_rejected",
+                extra={**log_extra, "status": response.status},
+            )
+            metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "client_error"})
+            _settle_judge_failure_fallback(pull_request, deferral, log_extra)
+            return
+    except HTTPError:
+        raise
+    except Exception:
+        logger.exception("pr_metrics.judge.forward_error", extra=log_extra)
+        metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "error"})
+        _settle_judge_failure_fallback(pull_request, deferral, log_extra)
         return
     metrics.incr("pr_metrics.judge.forwarded")
     logger.info("pr_metrics.judge.forwarded", extra=log_extra)
+
+
+def _settle_judge_failure_fallback(
+    pull_request: PullRequest, deferral: VerdictDeferral, log_extra: Mapping[str, Any]
+) -> None:
+    """Claim a judge-eligible PR off ``JUDGE_IN_PROGRESS`` with a fallback verdict.
+
+    Mirrors ``update_pr_metrics``'s single-emit guard: a compare-and-set off the
+    forward sentinel (or an unclaimed null, covering the brief redelivery window
+    before the sentinel lands) so a redelivered forward can't emit twice.
+    """
+    verdict = select_judge_failure_fallback_verdict(pull_request, deferral)
+    diagnosis_labels = (
+        [CI_FAILING_AT_CLOSE]
+        if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request)
+        else None
+    )
+    with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
+        settled = (
+            PullRequestMetrics.objects.filter(pull_request=pull_request)
+            .filter(Q(verdict=PullRequestVerdict.JUDGE_IN_PROGRESS) | Q(verdict__isnull=True))
+            .update(verdict=verdict)
+        )
+        if not settled:
+            logger.info("pr_metrics.judge.fallback_skipped", extra=log_extra)
+            metrics.incr("pr_metrics.judge.fallback_skipped", tags={"reason": "already_settled"})
+            return
+
+    emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
+    metrics.incr("pr_metrics.judge.fallback_emitted", tags={"verdict": verdict})
+    logger.info("pr_metrics.judge.fallback_emitted", extra={**log_extra, "verdict": verdict})
 
 
 def _parse_attributions(

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -17,6 +17,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
+from sentry.pr_metrics.emit import VerdictDeferral
 from sentry.pr_metrics.judge import forward_pr_to_seer_judge
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -49,13 +50,18 @@ def forward_pr_to_seer_task(
     pull_request_id: int,
     organization_id: int,
     repository_id: int,
+    deferral: str,
 ) -> None:
     """Forward a needs-judge terminal PR event to Seer, off the webhook request path.
 
     The webhook claims the ``JUDGE_IN_PROGRESS`` sentinel and enqueues this; the
     forward itself is a blocking signed HTTP call, so it can't run inline in the
-    webhook. Retries on a retryable Seer status (via ``forward_pr_to_seer_judge``);
-    a PR or repo that vanished between enqueue and run is permanent and dropped.
+    webhook. Retries on a retryable Seer status (via ``forward_pr_to_seer_judge``,
+    which also settles a deterministic fallback verdict on a non-retryable
+    failure — see its docstring); a PR or repo that vanished between enqueue and
+    run is permanent and dropped. ``deferral`` is ``select_verdict``'s original
+    ``VerdictDeferral`` reason, carried through so a fallback verdict can be
+    chosen correctly if the forward fails.
     """
     log_extra = {
         "pull_request_id": pull_request_id,
@@ -82,7 +88,7 @@ def forward_pr_to_seer_task(
         metrics.incr("pr_metrics.judge.forward_failed", tags={"reason": "repo_not_found"})
         return
 
-    forward_pr_to_seer_judge(pull_request, repository)
+    forward_pr_to_seer_judge(pull_request, repository, VerdictDeferral(deferral))
 
 
 @instrumented_task(

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -327,6 +327,7 @@ def _forward_to_judge(
             pull_request_id=pr.id,
             organization_id=organization.id,
             repository_id=pr.repository_id,
+            deferral=deferral.value,
         )
     except Exception:
         # The claim committed but the enqueue didn't, so no task will settle this

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -17,6 +17,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.pr_metrics.attribution import record_attribution_signal
+from sentry.pr_metrics.emit import VerdictDeferral
 from sentry.pr_metrics.judge import (
     _MAX_FORWARDED_CHECK_ROWS,
     forward_pr_to_seer_judge,
@@ -472,7 +473,7 @@ class ForwardPrToSeerJudgeTest(TestCase):
     @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
     def test_forwards_terminal_facts_and_repo_identity(self, mock_request: Any) -> None:
         mock_request.return_value = self._response(202)
-        forward_pr_to_seer_judge(self.pull_request, self.repo)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
 
         kwargs = mock_request.call_args.kwargs
         assert kwargs["path"] == "/v1/pr-metrics/pr-close-judge"
@@ -515,7 +516,7 @@ class ForwardPrToSeerJudgeTest(TestCase):
             event_type=PullRequestActivityType.REVIEW_SUBMITTED,
             payload={"review_state": "changes_requested"},
         )
-        forward_pr_to_seer_judge(self.pull_request, self.repo)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
 
         activity = orjson.loads(mock_request.call_args.kwargs["body"])["activity"]
         by_type = {e["event_type"]: e["payload"] for e in activity}
@@ -560,7 +561,7 @@ class ForwardPrToSeerJudgeTest(TestCase):
             date_added=base + timedelta(hours=10),
         )
 
-        forward_pr_to_seer_judge(self.pull_request, self.repo)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
 
         activity = orjson.loads(mock_request.call_args.kwargs["body"])["activity"]
         check_events = [e for e in activity if e["event_type"] == "check_run_completed"]
@@ -591,7 +592,7 @@ class ForwardPrToSeerJudgeTest(TestCase):
     def test_close_action_is_closed_when_unmerged(self, mock_request: Any) -> None:
         mock_request.return_value = self._response(202)
         self.pull_request.update(merged_at=None, merge_commit_sha=None)
-        forward_pr_to_seer_judge(self.pull_request, self.repo)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
 
         body = orjson.loads(mock_request.call_args.kwargs["body"])
         assert body["close_action"] == "closed"
@@ -599,19 +600,99 @@ class ForwardPrToSeerJudgeTest(TestCase):
 
     @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
     def test_retryable_status_raises_for_task_retry(self, mock_request: Any) -> None:
-        # 5xx/429 raise so the enclosing task's Retry policy kicks in.
+        # 5xx/429 raise so the enclosing task's Retry policy kicks in, and the
+        # row is left untouched (still claimable) rather than settled early.
         mock_request.return_value = self._response(503)
         with pytest.raises(HTTPError):
-            forward_pr_to_seer_judge(self.pull_request, self.repo)
+            forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
 
-    @patch("sentry.pr_metrics.judge.metrics")
-    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
-    def test_client_error_is_dropped_not_retried(
-        self, mock_request: Any, mock_metrics: Any
-    ) -> None:
-        # A permanent 4xx is observe-only: no raise (no retry), the row stays claimed.
-        mock_request.return_value = self._response(404)
-        forward_pr_to_seer_judge(self.pull_request, self.repo)
-        mock_metrics.incr.assert_any_call(
-            "pr_metrics.judge.forward_failed", tags={"reason": "client_error"}
+    def _track(self) -> None:
+        # A valid attribution makes the PR "tracked" so emit isn't skipped.
+        record_attribution_signal(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
         )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
+    def test_client_error_falls_back_and_emits(self, mock_request: Any, mock_record: Any) -> None:
+        # A permanent 4xx no longer drops the row silently: a partial event with
+        # a deterministic fallback verdict beats no event at all.
+        self._track()
+        mock_request.return_value = self._response(404)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
+
+        # Merged with no commits after open (setUp creates none) -> unchanged,
+        # same as select_fallback_verdict's judge-ineligible path.
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert _last_row(mock_record).verdict == "merged_unchanged"
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
+    def test_forward_error_falls_back_and_emits(self, mock_request: Any, mock_record: Any) -> None:
+        # Any other error building/sending the request (not a retryable Seer
+        # status) settles the same fallback rather than crashing the task bare.
+        self._track()
+        mock_request.side_effect = ValueError("boom")
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
+    def test_indeterminate_merged_falls_back_to_unknown_iteration(
+        self, mock_request: Any, mock_record: Any
+    ) -> None:
+        # INDETERMINATE means select_verdict had no reliable activity data to
+        # read "no commits after open" from, so a merged PR can't reuse
+        # select_fallback_verdict's activity-based read without risking a wrong
+        # label -- it settles on the explicitly-unknown verdict instead.
+        self._track()
+        mock_request.return_value = self._response(404)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.INDETERMINATE)
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unknown_iteration"
+        )
+        assert _last_row(mock_record).verdict == "merged_unknown_iteration"
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
+    def test_indeterminate_closed_falls_back_to_closed_unmerged(
+        self, mock_request: Any, mock_record: Any
+    ) -> None:
+        # Unlike the merged case, INDETERMINATE doesn't change the closed
+        # outcome: select_fallback_verdict's CLOSED_UNMERGED is unconditional
+        # regardless of deferral reason.
+        self._track()
+        self.pull_request.update(merged_at=None, merge_commit_sha=None)
+        mock_request.return_value = self._response(404)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.INDETERMINATE)
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "closed_unmerged"
+        )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.pr_metrics.judge.make_signed_seer_api_request")
+    def test_fallback_skipped_when_already_settled(
+        self, mock_request: Any, mock_record: Any
+    ) -> None:
+        # A redelivered forward that lost the race to an earlier settle (success
+        # or an earlier fallback) must not emit a second row.
+        self._track()
+        PullRequestMetrics.objects.filter(pull_request=self.pull_request).update(
+            verdict=PullRequestVerdict.MERGED_UNCHANGED
+        )
+        mock_request.return_value = self._response(404)
+        forward_pr_to_seer_judge(self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE)
+
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 0

--- a/tests/sentry/pr_metrics/test_tasks.py
+++ b/tests/sentry/pr_metrics/test_tasks.py
@@ -1,6 +1,7 @@
 from typing import Any
 from unittest.mock import patch
 
+from sentry.pr_metrics.emit import VerdictDeferral
 from sentry.pr_metrics.tasks import forward_pr_to_seer_task
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
@@ -21,12 +22,15 @@ class ForwardPrToSeerTaskTest(TestCase):
             pull_request_id=overrides.get("pull_request_id", self.pull_request.id),
             organization_id=overrides.get("organization_id", self.organization.id),
             repository_id=overrides.get("repository_id", self.repo.id),
+            deferral=overrides.get("deferral", VerdictDeferral.NEEDS_JUDGE.value),
         )
 
     @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_judge")
     def test_forwards_resolved_pr_and_repo(self, mock_forward: Any) -> None:
         self._run()
-        mock_forward.assert_called_once_with(self.pull_request, self.repo)
+        mock_forward.assert_called_once_with(
+            self.pull_request, self.repo, VerdictDeferral.NEEDS_JUDGE
+        )
 
     @patch("sentry.pr_metrics.tasks.forward_pr_to_seer_judge")
     def test_missing_pull_request_is_dropped(self, mock_forward: Any) -> None:

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2045,6 +2045,7 @@ class HandleWebhookForPrMetricsJudgeForwardTest(TestCase):
             pull_request_id=self.pull_request.id,
             organization_id=self.organization.id,
             repository_id=self.repo.id,
+            deferral="needs_judge",
         )
 
     @patch(f"{MODULE}.forward_pr_to_seer_task.delay")


### PR DESCRIPTION
Today, if the request to Seer's judge fails (a 4xx rejection, or any
other error building/sending it), the PR's metrics row stays claimed at
`JUDGE_IN_PROGRESS` forever and no analytics event is ever emitted. A
partial event beats no event, so this settles the row locally with a
deterministic fallback verdict and emits instead.

Reuses `select_fallback_verdict`'s push-activity read for the
`NEEDS_JUDGE` deferral reason, matching the existing judge-ineligible
fallback path. For `INDETERMINATE` (no reliable activity data), a merged
PR settles on a new `MERGED_UNKNOWN_ITERATION` verdict rather than
risking a wrong label from absent data; a closed PR still settles on
`CLOSED_UNMERGED`, same as `select_fallback_verdict` already does
unconditionally there.

Retryable failures (5xx/429, and connection-level errors, which urllib3
also raises as `HTTPError`) still propagate to the task's `Retry` policy
unchanged, and are still silently exhausted after 5 attempts with no
further action — an accepted residual gap not addressed here.

Refs CW-1674