### PR TITLE
fix(explore): Allow numeric attrs for drilldown

### DIFF
--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -173,6 +173,81 @@ describe('viewSamplesTarget', () => {
     });
   });
 
+  it('drill down with numeric group by value', () => {
+    const location = LocationFixture();
+    const target = viewSamplesTarget({
+      location,
+      query: '',
+      fields: ['foo'],
+      groupBys: ['org_id'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
+        org_id: 123,
+        'count(span.duration)': 10,
+      },
+      projects,
+    });
+    expect(target).toMatchObject({
+      query: {
+        field: ['foo', 'span.duration'],
+        mode: 'samples',
+        query: 'org_id:123',
+        sort: ['-span.duration'],
+      },
+    });
+  });
+
+  it('drill down replaces existing filter for the same key', () => {
+    const location = LocationFixture();
+    const target = viewSamplesTarget({
+      location,
+      query: 'bar:old_value',
+      fields: ['foo'],
+      groupBys: ['bar'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
+        bar: 'new_value',
+        'count(span.duration)': 10,
+      },
+      projects,
+    });
+    expect(target).toMatchObject({
+      query: {
+        field: ['foo', 'span.duration'],
+        mode: 'samples',
+        query: 'bar:new_value',
+        sort: ['-span.duration'],
+      },
+    });
+  });
+
+  it('drill down preserves existing filters for different keys', () => {
+    const location = LocationFixture();
+    const target = viewSamplesTarget({
+      location,
+      query: 'existing_key:existing_value',
+      fields: ['foo'],
+      groupBys: ['bar'],
+      visualizes: [visualize],
+      sorts: [sort],
+      row: {
+        bar: 'bar',
+        'count(span.duration)': 10,
+      },
+      projects,
+    });
+    expect(target).toMatchObject({
+      query: {
+        field: ['foo', 'span.duration'],
+        mode: 'samples',
+        query: 'existing_key:existing_value bar:bar',
+        sort: ['-span.duration'],
+      },
+    });
+  });
+
   it('drill down with no value group by uses !has filter', () => {
     const location = LocationFixture();
     const target = viewSamplesTarget({

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -327,6 +327,8 @@ export function generateTargetQuery({
       } else {
         search.setFilterValues(groupBy, [value]);
       }
+    } else if (typeof value === 'number') {
+      search.setFilterValues(groupBy, [String(value)]);
     } else if (!defined(value)) {
       search.addFilterValue('!has', groupBy);
     }


### PR DESCRIPTION
There were cases where drilldown filters for numeric attributes (e.g. group by `org_id`) were being dropped on Logs or Trace Explorer since they are numeric. Adds handling for values that are numeric in aggregate mode

Also adds some tests for filter replacement behaviour I thought was related to not applying numeric filters, but the coverage is still worth having.

To reproduce/test:
- Set up a logs explore query grouping by `org_id` on the sentry project
- Click "View Samples" on a row where the ID is defined
- On prod: See that the filter wasn't updated