### PR TITLE
fix(explore): lock span id column in table editor

### DIFF
--- a/static/app/views/explore/contexts/dragNDropContext.tsx
+++ b/static/app/views/explore/contexts/dragNDropContext.tsx
@@ -26,11 +26,13 @@ interface DragNDropContextProps<T> {
   }) => React.ReactNode;
   columns: T[];
   setColumns: (columns: T[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
+  canReorder?: (oldIndex: number, newIndex: number) => boolean;
 }
 
 export function DragNDropContext<T>({
   columns,
   setColumns,
+  canReorder,
   children,
 }: DragNDropContextProps<T>) {
   const {
@@ -42,6 +44,7 @@ export function DragNDropContext<T>({
   } = useDragNDropColumns({
     columns,
     setColumns,
+    canReorder,
   });
 
   const sensors = useSensors(

--- a/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
@@ -88,6 +88,37 @@ describe('useDragNDropColumns', () => {
     expect(columns).toEqual(['span_id', 'timestamp', 'span.op']);
   });
 
+  it('should reject a reorder before moving columns or unique IDs', () => {
+    let columns!: string[];
+    let setColumns: (columns: string[]) => void;
+    let editableColumns!: Array<Column<string>>;
+    let onDragEnd: (arg: any) => void;
+
+    function TestPage() {
+      [columns, setColumns] = useState(initialColumns);
+      ({editableColumns, onDragEnd} = useDragNDropColumns({
+        columns,
+        setColumns,
+        canReorder: (oldIndex, newIndex) => oldIndex === newIndex,
+      }));
+      return null;
+    }
+
+    render(<TestPage />);
+
+    const uniqueIdsBefore = editableColumns.map(column => column.uniqueId);
+
+    act(() =>
+      onDragEnd({
+        active: {id: 1},
+        over: {id: 3},
+      })
+    );
+
+    expect(columns).toEqual(initialColumns);
+    expect(editableColumns.map(column => column.uniqueId)).toEqual(uniqueIdsBefore);
+  });
+
   it('should generate unique UUIDs for editable columns', () => {
     let columns!: string[];
     let setColumns: (columns: string[]) => void;

--- a/static/app/views/explore/hooks/useDragNDropColumns.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.tsx
@@ -13,11 +13,13 @@ export type Column<T> = {
 interface UseDragAndDropColumnsProps<T> {
   columns: T[];
   setColumns: (columns: T[], op: 'insert' | 'update' | 'delete' | 'reorder') => void;
+  canReorder?: (oldIndex: number, newIndex: number) => boolean;
 }
 
 export function useDragNDropColumns<T>({
   columns,
   setColumns,
+  canReorder,
 }: UseDragAndDropColumnsProps<T>) {
   const uniqueIdsRef = useRef<string[]>([]);
 
@@ -58,7 +60,7 @@ export function useDragNDropColumns<T>({
     if (active.id !== over?.id) {
       const oldIndex = editableColumns.findIndex(({id}) => id === active.id);
       const newIndex = editableColumns.findIndex(({id}) => id === over?.id);
-      if (oldIndex < 0 || newIndex < 0) {
+      if (oldIndex < 0 || newIndex < 0 || canReorder?.(oldIndex, newIndex) === false) {
         return;
       }
       uniqueIdsRef.current = arrayMove(uniqueIdsRef.current, oldIndex, newIndex);

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -135,6 +135,35 @@ describe('ColumnEditorModal', () => {
     expect(onColumnsChange).toHaveBeenCalledWith(['project']);
   });
 
+  it('disables editing, removing, and reordering required columns', () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'project']}
+            onColumnsChange={() => {}}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={{}}
+            requiredTags={['id']}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    expect(screen.getAllByTestId('editor-column')[0]).toBeDisabled();
+    expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
+    expect(screen.getAllByLabelText('Drag to reorder')[0]).toBeDisabled();
+
+    expect(screen.getAllByTestId('editor-column')[1]).toBeEnabled();
+    expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
+    expect(screen.getAllByLabelText('Drag to reorder')[1]).toBeEnabled();
+  });
+
   it('handles duplicate columns without collapsing rows', async () => {
     const onColumnsChange = jest.fn();
 

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -135,7 +135,7 @@ describe('ColumnEditorModal', () => {
     expect(onColumnsChange).toHaveBeenCalledWith(['project']);
   });
 
-  it('disables editing, removing, and reordering required columns', () => {
+  it('disables editing, removing, and reordering required columns', async () => {
     renderGlobalModal();
 
     act(() => {
@@ -155,11 +155,18 @@ describe('ColumnEditorModal', () => {
       );
     });
 
-    expect(screen.getAllByTestId('editor-column')[0]).toBeDisabled();
+    // Wait for the modal to render
+    expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
+
+    // Check required column (id) - should be disabled
+    const idColumnButton = screen.getByRole('button', {name: 'Column id string'});
+    expect(idColumnButton).toBeDisabled();
     expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
     expect(screen.getAllByLabelText('Drag to reorder')[0]).toBeDisabled();
 
-    expect(screen.getAllByTestId('editor-column')[1]).toBeEnabled();
+    // Check non-required column (project) - should be enabled
+    const projectColumnButton = screen.getByRole('button', {name: 'Column project string'});
+    expect(projectColumnButton).toBeEnabled();
     expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
     expect(screen.getAllByLabelText('Drag to reorder')[1]).toBeEnabled();
   });

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -155,17 +155,16 @@ describe('ColumnEditorModal', () => {
       );
     });
 
-    // Wait for the modal to render
     expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
 
-    // Check required column (id) - should be disabled
     const idColumnButton = screen.getByRole('button', {name: 'Column id string'});
     expect(idColumnButton).toBeDisabled();
     expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
     expect(screen.getAllByLabelText('Drag to reorder')[0]).toBeDisabled();
 
-    // Check non-required column (project) - should be enabled
-    const projectColumnButton = screen.getByRole('button', {name: 'Column project string'});
+    const projectColumnButton = screen.getByRole('button', {
+      name: 'Column project string',
+    });
     expect(projectColumnButton).toBeEnabled();
     expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
     expect(screen.getAllByLabelText('Drag to reorder')[1]).toBeEnabled();

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -162,11 +162,11 @@ describe('ColumnEditorModal', () => {
       hidden: true,
     });
 
-    const idColumnButton = allColumnButtons.find(
-      btn => btn.getAttribute('aria-label') === 'Column id string'
+    const idColumnButton = allColumnButtons.find(btn =>
+      btn.textContent?.includes('Column id string')
     );
-    const projectColumnButton = allColumnButtons.find(
-      btn => btn.getAttribute('aria-label') === 'Column project string'
+    const projectColumnButton = allColumnButtons.find(btn =>
+      btn.textContent?.includes('Column project string')
     );
 
     expect(idColumnButton).toBeDefined();

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -157,35 +157,17 @@ describe('ColumnEditorModal', () => {
 
     expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
 
-    const allColumnButtons = screen.getAllByRole('button', {
-      name: /^Column.*string$/,
-      hidden: true,
-    });
+    const [idColumn, projectColumn] = screen.getAllByTestId('editor-column');
+    const idRow = within(idColumn!.parentElement!);
+    const projectRow = within(projectColumn!.parentElement!);
 
-    const idColumnButton = allColumnButtons.find(btn =>
-      btn.textContent?.includes('Column id string')
-    );
-    const projectColumnButton = allColumnButtons.find(btn =>
-      btn.textContent?.includes('Column project string')
-    );
+    expect(idRow.getByRole('button', {name: 'Column id string'})).toBeDisabled();
+    expect(idRow.getByRole('button', {name: 'Remove Column'})).toBeDisabled();
+    expect(idRow.getByRole('button', {name: 'Drag to reorder'})).toBeDisabled();
 
-    expect(idColumnButton).toBeDefined();
-    expect(idColumnButton).toHaveAttribute('aria-disabled', 'true');
-
-    expect(projectColumnButton).toBeDefined();
-    expect(projectColumnButton).not.toHaveAttribute('aria-disabled', 'true');
-
-    expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
-    expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
-
-    expect(screen.getAllByLabelText('Drag to reorder')[0]).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-    expect(screen.getAllByLabelText('Drag to reorder')[1]).not.toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    expect(projectRow.getByRole('button', {name: 'Column project string'})).toBeEnabled();
+    expect(projectRow.getByRole('button', {name: 'Remove Column'})).toBeEnabled();
+    expect(projectRow.getByRole('button', {name: 'Drag to reorder'})).toBeEnabled();
   });
 
   it('handles duplicate columns without collapsing rows', async () => {

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -157,18 +157,25 @@ describe('ColumnEditorModal', () => {
 
     expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
 
-    const columnButtons = screen.getAllByRole('button', {name: /^Column/});
-    expect(columnButtons[0]).toHaveAccessibleName('Column id string');
-    expect(columnButtons[0]).toHaveAttribute('aria-disabled', 'true');
+    const idColumnButton = screen.getByRole('button', {
+      name: 'Column id string',
+      hidden: true,
+    });
+    expect(idColumnButton).toHaveAttribute('aria-disabled', 'true');
+
+    const projectColumnButton = screen.getByRole('button', {
+      name: 'Column project string',
+      hidden: true,
+    });
+    expect(projectColumnButton).not.toHaveAttribute('aria-disabled', 'true');
+
     expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
+    expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
+
     expect(screen.getAllByLabelText('Drag to reorder')[0]).toHaveAttribute(
       'aria-disabled',
       'true'
     );
-
-    expect(columnButtons[1]).toHaveAccessibleName('Column project string');
-    expect(columnButtons[1]).not.toHaveAttribute('aria-disabled', 'true');
-    expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
     expect(screen.getAllByLabelText('Drag to reorder')[1]).not.toHaveAttribute(
       'aria-disabled',
       'true'

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -159,14 +159,20 @@ describe('ColumnEditorModal', () => {
 
     const columnButtons = screen.getAllByRole('button', {name: /^Column/});
     expect(columnButtons[0]).toHaveAccessibleName('Column id string');
-    expect(columnButtons[0]).toBeDisabled();
+    expect(columnButtons[0]).toHaveAttribute('aria-disabled', 'true');
     expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
-    expect(screen.getAllByLabelText('Drag to reorder')[0]).toBeDisabled();
+    expect(screen.getAllByLabelText('Drag to reorder')[0]).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
 
     expect(columnButtons[1]).toHaveAccessibleName('Column project string');
-    expect(columnButtons[1]).toBeEnabled();
+    expect(columnButtons[1]).not.toHaveAttribute('aria-disabled', 'true');
     expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
-    expect(screen.getAllByLabelText('Drag to reorder')[1]).toBeEnabled();
+    expect(screen.getAllByLabelText('Drag to reorder')[1]).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 
   it('handles duplicate columns without collapsing rows', async () => {

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -157,15 +157,14 @@ describe('ColumnEditorModal', () => {
 
     expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
 
-    const idColumnButton = screen.getByRole('button', {name: 'Column id string'});
-    expect(idColumnButton).toBeDisabled();
+    const columnButtons = screen.getAllByRole('button', {name: /^Column/});
+    expect(columnButtons[0]).toHaveAccessibleName('Column id string');
+    expect(columnButtons[0]).toBeDisabled();
     expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();
     expect(screen.getAllByLabelText('Drag to reorder')[0]).toBeDisabled();
 
-    const projectColumnButton = screen.getByRole('button', {
-      name: 'Column project string',
-    });
-    expect(projectColumnButton).toBeEnabled();
+    expect(columnButtons[1]).toHaveAccessibleName('Column project string');
+    expect(columnButtons[1]).toBeEnabled();
     expect(screen.getAllByLabelText('Remove Column')[1]).toBeEnabled();
     expect(screen.getAllByLabelText('Drag to reorder')[1]).toBeEnabled();
   });

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -157,16 +157,22 @@ describe('ColumnEditorModal', () => {
 
     expect(await screen.findByRole('button', {name: 'Apply'})).toBeInTheDocument();
 
-    const idColumnButton = screen.getByRole('button', {
-      name: 'Column id string',
+    const allColumnButtons = screen.getAllByRole('button', {
+      name: /^Column.*string$/,
       hidden: true,
     });
+
+    const idColumnButton = allColumnButtons.find(
+      btn => btn.getAttribute('aria-label') === 'Column id string'
+    );
+    const projectColumnButton = allColumnButtons.find(
+      btn => btn.getAttribute('aria-label') === 'Column project string'
+    );
+
+    expect(idColumnButton).toBeDefined();
     expect(idColumnButton).toHaveAttribute('aria-disabled', 'true');
 
-    const projectColumnButton = screen.getByRole('button', {
-      name: 'Column project string',
-      hidden: true,
-    });
+    expect(projectColumnButton).toBeDefined();
     expect(projectColumnButton).not.toHaveAttribute('aria-disabled', 'true');
 
     expect(screen.getAllByLabelText('Remove Column')[0]).toBeDisabled();

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -95,28 +95,24 @@ export function ColumnEditorModal({
     closeModal();
   }
 
-  function handleTempColumnsChange(
-    nextColumns: string[],
-    operation: 'insert' | 'update' | 'delete' | 'reorder'
-  ) {
-    if (operation !== 'reorder' || !requiredTags?.length) {
-      setTempColumns(nextColumns);
-      return;
+  function canReorderColumn(oldIndex: number, newIndex: number) {
+    if (!requiredTags?.length) {
+      return true;
     }
 
-    setTempColumns(currentColumns => {
-      const reorderedColumns = nextColumns.filter(column => !requiredTags.includes(column));
-      currentColumns.forEach((column, index) => {
-        if (requiredTags.includes(column)) {
-          reorderedColumns.splice(index, 0, column);
-        }
-      });
-      return reorderedColumns;
-    });
+    const startIndex = Math.min(oldIndex, newIndex);
+    const endIndex = Math.max(oldIndex, newIndex);
+    return !tempColumns
+      .slice(startIndex, endIndex + 1)
+      .some(column => requiredTags.includes(column));
   }
 
   return (
-    <DragNDropContext columns={tempColumns} setColumns={handleTempColumnsChange}>
+    <DragNDropContext
+      columns={tempColumns}
+      setColumns={setTempColumns}
+      canReorder={canReorderColumn}
+    >
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => (
         <Fragment>
           <Header closeButton data-test-id="editor-header">

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -95,8 +95,28 @@ export function ColumnEditorModal({
     closeModal();
   }
 
+  function handleTempColumnsChange(
+    nextColumns: string[],
+    operation: 'insert' | 'update' | 'delete' | 'reorder'
+  ) {
+    if (operation !== 'reorder' || !requiredTags?.length) {
+      setTempColumns(nextColumns);
+      return;
+    }
+
+    setTempColumns(currentColumns => {
+      const reorderedColumns = nextColumns.filter(column => !requiredTags.includes(column));
+      currentColumns.forEach((column, index) => {
+        if (requiredTags.includes(column)) {
+          reorderedColumns.splice(index, 0, column);
+        }
+      });
+      return reorderedColumns;
+    });
+  }
+
   return (
-    <DragNDropContext columns={tempColumns} setColumns={setTempColumns}>
+    <DragNDropContext columns={tempColumns} setColumns={handleTempColumnsChange}>
       {({insertColumn, updateColumnAtIndex, deleteColumnAtIndex, editableColumns}) => (
         <Fragment>
           <Header closeButton data-test-id="editor-header">
@@ -183,6 +203,7 @@ function ColumnEditorRow({
 }: ColumnEditorRowProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
+    disabled: required,
   });
 
   const [search, setSearch] = useState('');
@@ -314,7 +335,12 @@ function ColumnEditorRow({
       }}
       {...attributes}
     >
-      <StyledDragReorderButton size="sm" iconSize="sm" {...listeners} />
+      <StyledDragReorderButton
+        size="sm"
+        iconSize="sm"
+        disabled={required}
+        {...listeners}
+      />
       <StyledCompactSelect
         data-test-id="editor-column"
         options={options}

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -147,6 +147,7 @@ export function ExploreTables(props: ExploreTablesProps) {
           stringTags={validatedStringTags}
           numberTags={validatedNumberTags}
           booleanTags={validatedBooleanTags}
+          requiredTags={['id']}
           validatedFieldTypes={validatedFieldTypes}
         />
       ),


### PR DESCRIPTION
The Explore span samples table now keeps the `id` column fixed in its original position because it is required to open a span's trace waterfall. Its field selector, remove action, and drag handle are disabled, and other columns cannot be dragged across it.

Reorder validation happens before either the column values or stable row IDs are moved, preventing rejected drags from attaching row state to the wrong column. Regression coverage verifies both the locked controls and rejected reorder behavior.

Refs EXP-1097