### PR TITLE
feat(autofix): trigger PR iteration from failed check suites

### DIFF
--- a/src/sentry/scm/stream.py
+++ b/src/sentry/scm/stream.py
@@ -15,6 +15,9 @@ from sentry.scm.types import (
     PullRequestReviewEvent,
     SubscriptionEvent,
 )
+from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
+    pr_iteration_from_check_suite_listener as pr_iteration_from_check_suite_listener,
+)
 
 # DEFAULT LISTENERS
 #

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+import sentry_sdk
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 from scm.types import GetBranchProtocol, GetRepositoryProtocol
@@ -241,6 +242,21 @@ def get_iterations(state: SeerRunState) -> list[Iteration]:
         if metadata.get("step") == AutofixStep.PR_ITERATION.value:
             iter_idx = metadata.get("iteration_index")
             assert iter_idx is not None, "PR_ITERATION block missing iteration_index"
+
+            # PR_ITERATION is always started with feedback today (UI + consume
+            # queue). Missing metadata is unexpected; report but keep going.
+            raw_feedback = metadata.get("feedback")
+            if not raw_feedback or (isinstance(raw_feedback, str) and not raw_feedback.strip()):
+                sentry_sdk.capture_message(
+                    "PR_ITERATION block missing feedback metadata",
+                    level="warning",
+                    extras={
+                        "run_id": state.run_id,
+                        "block_index": i,
+                        "iteration_index": iter_idx,
+                        "block_id": block.id,
+                    },
+                )
 
             iterations.append(Iteration(index=int(iter_idx), start_index=i, blocks=[block]))
         elif iterations:

--- a/src/sentry/seer/autofix/constants.py
+++ b/src/sentry/seer/autofix/constants.py
@@ -63,6 +63,7 @@ class AutofixReferrer(enum.StrEnum):
     MCP = "api.mcp"
     WEB = "api.web"
     GITHUB_PR_COMMENT = "github.pr_comment"
+    GITHUB_CHECK_SUITE = "github.check_suite"
     UNKNOWN = "unknown"
 
 

--- a/src/sentry/seer/autofix/pr_iteration/feedback.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 from django.utils import timezone
 from pydantic import BaseModel, Field, ValidationError, parse_raw_as, root_validator
 
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
     GithubPrReviewCommentFeedbackSource,
@@ -15,7 +16,10 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeed
 from sentry.utils import json
 
 FeedbackSource = Annotated[
-    UserUIFeedbackSource | GithubPrCommentFeedbackSource | GithubPrReviewCommentFeedbackSource,
+    UserUIFeedbackSource
+    | GithubPrCommentFeedbackSource
+    | GithubPrReviewCommentFeedbackSource
+    | CheckSuiteFeedbackSource,
     Field(discriminator="type"),
 ]
 
@@ -23,10 +27,6 @@ FeedbackSource = Annotated[
 class Feedback(BaseModel):
     source: FeedbackSource
     timestamp: datetime = Field(default_factory=timezone.now)
-    # `text` (verbatim prompt text) and `ui_text` (UI display) are derived from
-    # `source` by `_populate`. They are declared as real fields, not properties,
-    # so pydantic serializes them via .dict()/.json() at every nesting level —
-    # the frontend and Seer prompt metadata read them off the wire.
     text: str = ""
     ui_text: str = ""
 
@@ -35,13 +35,6 @@ class Feedback(BaseModel):
         source = values.get("source")
         if source is None:
             return values
-        # Backwards compat: feedback serialized before sources produced their own
-        # text stored it at the top level, and those sources lack the fields this
-        # derivation needs (e.g. user-ui had no `user_feedback`), so `source.text`
-        # comes back empty. Fall back to the persisted top-level value so old
-        # run_state blocks in Seer keep rendering. Seer's run_state TTL is nominally
-        # 30 days, but a continuously-triggered run can retain old blocks
-        # indefinitely, so this fallback is permanent.
         values["text"] = source.text or values.get("text") or ""
         values["ui_text"] = (
             source.ui_text or source.text or values.get("ui_text") or values.get("text") or ""

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, Field, PrivateAttr, root_validator
+from scm import actions as scm_actions
+from scm.helpers import iter_all_pages
+from scm.types import ListCheckRunsForRefProtocol
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.repository import Repository
+from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask, FeedbackSourceBase
+
+logger = logging.getLogger(__name__)
+
+_SEER_GITHUB_PROVIDER = "integrations:github"
+
+
+class GithubCheckSuiteApp(BaseModel):
+    name: str
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuitePullRequest(BaseModel):
+    id: int
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuite(BaseModel):
+    id: int
+    head_sha: str
+    check_runs_url: str
+    app: GithubCheckSuiteApp
+    conclusion: str | None = None
+    pull_requests: list[GithubCheckSuitePullRequest] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuiteRepository(BaseModel):
+    html_url: str
+    id: int | None = None
+    full_name: str | None = None
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuiteInstallation(BaseModel):
+    id: int
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuiteEvent(BaseModel):
+    check_suite: GithubCheckSuite
+    repository: GithubCheckSuiteRepository
+    installation: GithubCheckSuiteInstallation | None = None
+
+    class Config:
+        extra = "allow"
+
+
+def get_check_suite_url(event: GithubCheckSuiteEvent) -> str:
+    return (
+        f"{event.repository.html_url}/commit/{event.check_suite.head_sha}/checks"
+        f"?check_suite_id={event.check_suite.id}"
+    )
+
+
+def resolve_check_suite_repository(event: GithubCheckSuiteEvent) -> Repository | None:
+    installation_id = event.installation.id if event.installation else None
+    repository_id = event.repository.id
+    if installation_id is None or repository_id is None:
+        logger.info(
+            "autofix.pr_iteration.check_suite.repository.missing_ids",
+            extra={"installation_id": installation_id, "repository_id": repository_id},
+        )
+        return None
+
+    contexts = integration_service.organization_contexts(
+        provider=IntegrationProviderSlug.GITHUB.value,
+        external_id=str(installation_id),
+    )
+    if contexts.integration is None or not contexts.organization_integrations:
+        logger.info(
+            "autofix.pr_iteration.check_suite.repository.missing_integration",
+            extra={
+                "installation_id": installation_id,
+                "repository_id": repository_id,
+                "has_integration": contexts.integration is not None,
+                "organization_integration_count": len(contexts.organization_integrations),
+            },
+        )
+        return None
+
+    repo = (
+        Repository.objects.filter(
+            organization_id__in=[oi.organization_id for oi in contexts.organization_integrations],
+            provider=_SEER_GITHUB_PROVIDER,
+            external_id=str(repository_id),
+        )
+        .exclude(status=ObjectStatus.HIDDEN)
+        .first()
+    )
+    logger.info(
+        "autofix.pr_iteration.check_suite.repository.resolved",
+        extra={
+            "installation_id": installation_id,
+            "repository_id": repository_id,
+            "organization_ids": [oi.organization_id for oi in contexts.organization_integrations],
+            "repo_id": repo.id if repo else None,
+            "repo_name": repo.name if repo else None,
+        },
+    )
+    return repo
+
+
+class CheckSuiteFeedbackSource(FeedbackSourceBase):
+    type: Literal["check-suite"] = "check-suite"
+    event: GithubCheckSuiteEvent
+    app_name: str = ""
+    check_suite_url: str = ""
+
+    @root_validator
+    def _populate_event_fields(cls, values: dict[str, object]) -> dict[str, object]:
+        event = values.get("event")
+        if event is None:
+            return values
+        assert isinstance(event, GithubCheckSuiteEvent)
+        values["app_name"] = event.check_suite.app.name
+        values["check_suite_url"] = get_check_suite_url(event)
+        return values
+
+    @property
+    def text(self) -> str:
+        check_suite = self.event.check_suite
+        details = [
+            f"conclusion: {check_suite.conclusion}",
+            f"app: {self.app_name}",
+            f"check suite: {self.check_suite_url}",
+            f"check runs: {check_suite.check_runs_url}",
+        ]
+        return "\n".join(
+            [
+                "A GitHub check suite on the pull request failed",
+                "\n".join(details),
+                "Fetch the failing check runs to see which checks failed and why, ",
+                "then update the pull request to fix the failure.",
+                "Assume the failure is caused by the code changes you made, not by a "
+                "problem with CI itself. Investigate and fix your code first. "
+                "Only if you are certain the failure is genuinely in the CI setup "
+                "(e.g. the workflow configuration) and cannot be fixed by changing "
+                "the code, make no code change at all.",
+            ]
+        )
+
+    @property
+    def ui_text(self) -> str | None:
+        return f"check suite for app {self.app_name} failed"
+
+    _repository: Repository | None = PrivateAttr(default=None)
+    _repository_resolved: bool = PrivateAttr(default=False)
+
+    @property
+    def repository(self) -> Repository | None:
+        if not self._repository_resolved:
+            self._repository = resolve_check_suite_repository(self.event)
+            self._repository_resolved = True
+        return self._repository
+
+    def _matches_current_head(self, run_state: SeerRunState) -> tuple[str | None, str | None, bool]:
+        """Whether the check suite ran on the PR's *current* head commit.
+
+        A ``check_suite`` webhook fires for any commit on the PR (including
+        commits a human pushed or commits Seer made earlier in the run). We only
+        act on failures for the commit that is currently the PR head for this
+        run: if Seer has since pushed a newer commit, the CI failure is out of
+        date and reacting to it would waste an iteration on stale code.
+        """
+        head_sha = self.event.check_suite.head_sha
+        repo_name = self.event.repository.full_name
+        pr_state = run_state.repo_pr_states.get(repo_name) if repo_name else None
+        matched = bool(head_sha and pr_state and pr_state.commit_sha == head_sha)
+        return head_sha, repo_name, matched
+
+    def should_queue(self, run_state: SeerRunState) -> bool:
+        head_sha, repo_name, matched = self._matches_current_head(run_state)
+        logger.info(
+            "autofix.pr_iteration.check_suite.should_queue.evaluated",
+            extra={
+                "run_id": run_state.run_id,
+                "head_sha": head_sha,
+                "repo_name": repo_name,
+                "matched": matched,
+                "repo_pr_state_count": len(run_state.repo_pr_states),
+            },
+        )
+        return matched
+
+    def should_consume(self, run_state: SeerRunState) -> bool:
+        head_sha, repo_name, matched = self._matches_current_head(run_state)
+        logger.info(
+            "autofix.pr_iteration.check_suite.should_consume.evaluated",
+            extra={
+                "run_id": run_state.run_id,
+                "head_sha": head_sha,
+                "repo_name": repo_name,
+                "matched": matched,
+                "repo_pr_state_count": len(run_state.repo_pr_states),
+            },
+        )
+        return matched
+
+    def should_trigger(self, run_state: SeerRunState) -> ConsumeTask | None:
+        # Queue a consume task immediately once every check run has completed;
+        # skip while some are still pending.
+        head_sha = self.event.check_suite.head_sha
+        if not head_sha:
+            logger.info(
+                "autofix.pr_iteration.check_suite.should_trigger.missing_head_sha",
+                extra={"run_id": run_state.run_id},
+            )
+            return ConsumeTask.Now
+
+        repo = self.repository
+        if repo is None:
+            logger.info(
+                "autofix.pr_iteration.check_suite.should_trigger.no_repository",
+                extra={"run_id": run_state.run_id, "head_sha": head_sha},
+            )
+            return ConsumeTask.Now
+
+        organization_id = repo.organization_id
+        repo_id = repo.id
+
+        # Importing the SCM factory while feedback models are initialized pulls
+        # in integration handlers before Django finishes registering apps.
+        from sentry.scm.factory import new as make_scm
+
+        try:
+            scm = make_scm(organization_id, repo_id, referrer="seer")
+        except Exception:
+            logger.warning(
+                "autofix.pr_iteration.should_trigger.scm_init_failed",
+                extra={"organization_id": organization_id, "repo_id": repo_id},
+                exc_info=True,
+            )
+            return ConsumeTask.Now
+
+        if not isinstance(scm, ListCheckRunsForRefProtocol):
+            logger.warning(
+                "autofix.pr_iteration.should_trigger.unsupported_provider",
+                extra={"organization_id": organization_id, "repo_id": repo_id},
+            )
+            return ConsumeTask.Now
+
+        try:
+            for page in iter_all_pages(
+                lambda pagination: scm_actions.list_check_runs_for_ref(
+                    scm, head_sha, pagination=pagination
+                )
+            ):
+                incomplete_count = sum(1 for run in page["data"] if run["status"] != "completed")
+                logger.info(
+                    "autofix.pr_iteration.check_suite.should_trigger.check_runs_page",
+                    extra={
+                        "run_id": run_state.run_id,
+                        "organization_id": organization_id,
+                        "repo_id": repo_id,
+                        "head_sha": head_sha,
+                        "check_run_count": len(page["data"]),
+                        "incomplete_count": incomplete_count,
+                    },
+                )
+                if incomplete_count:
+                    return None
+        except Exception:
+            logger.warning(
+                "autofix.pr_iteration.should_trigger.list_check_runs_failed",
+                extra={
+                    "organization_id": organization_id,
+                    "repo_id": repo_id,
+                    "head_sha": head_sha,
+                },
+                exc_info=True,
+            )
+
+        return ConsumeTask.Now
+
+
+__all__ = (
+    "CheckSuiteFeedbackSource",
+    "GithubCheckSuite",
+    "GithubCheckSuiteApp",
+    "GithubCheckSuiteEvent",
+    "GithubCheckSuiteInstallation",
+    "GithubCheckSuitePullRequest",
+    "GithubCheckSuiteRepository",
+    "get_check_suite_url",
+    "resolve_check_suite_repository",
+)

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Literal
 
 from pydantic import BaseModel, Field, PrivateAttr, root_validator
@@ -223,8 +224,9 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
         return matched
 
     def should_trigger(self, run_state: SeerRunState) -> ConsumeTask | None:
-        # Queue a consume task immediately once every check run has completed;
-        # skip while some are still pending.
+        # Always queue a consume task for this run: immediately once every check
+        # run has completed, or after a delay while some are still pending (they
+        # can get stuck, so we trigger anyway rather than wait forever).
         head_sha = self.event.check_suite.head_sha
         if not head_sha:
             logger.info(
@@ -284,7 +286,7 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
                     },
                 )
                 if incomplete_count:
-                    return None
+                    return ConsumeTask.Later(timedelta(hours=1))
         except Exception:
             logger.warning(
                 "autofix.pr_iteration.should_trigger.list_check_runs_failed",

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -19,6 +19,10 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask, 
 logger = logging.getLogger(__name__)
 
 _SEER_GITHUB_PROVIDER = "integrations:github"
+# Hard cap on consecutive PR iterations driven solely by automated check-suite
+# feedback. Once the last N iterations were all check-suite-only, stop triggering
+# further check-suite iterations (they'd loop forever without human input).
+CHECK_SUITE_ITERATION_HARD_CAP = 3
 
 
 class GithubCheckSuiteApp(BaseModel):
@@ -127,6 +131,31 @@ def resolve_check_suite_repository(event: GithubCheckSuiteEvent) -> Repository |
     return repo
 
 
+def _check_suite_iteration_cap_reached(run_state: SeerRunState) -> bool:
+    """Whether the last N PR iterations used only automated check-suite feedback."""
+    from sentry.seer.autofix.autofix_agent import get_iterations
+    from sentry.seer.autofix.pr_iteration.feedback import parse_feedback
+
+    cap = CHECK_SUITE_ITERATION_HARD_CAP
+    if cap <= 0:
+        return False
+
+    last_iterations = get_iterations(run_state)[-cap:]
+    if len(last_iterations) < cap:
+        return False
+
+    for iteration in last_iterations:
+        feedbacks = [
+            feedback
+            for block in iteration.blocks
+            for feedback in parse_feedback((block.message.metadata or {}).get("feedback", ""))
+        ]
+        if any(not isinstance(feedback.source, CheckSuiteFeedbackSource) for feedback in feedbacks):
+            return False
+
+    return True
+
+
 class CheckSuiteFeedbackSource(FeedbackSourceBase):
     type: Literal["check-suite"] = "check-suite"
     event: GithubCheckSuiteEvent
@@ -224,7 +253,14 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
         return matched
 
     def should_trigger(self, run_state: SeerRunState) -> ConsumeTask | None:
-        # Always queue a consume task for this run: immediately once every check
+        if _check_suite_iteration_cap_reached(run_state):
+            logger.info(
+                "autofix.pr_iteration.check_suite.should_trigger.hard_cap_reached",
+                extra={"run_id": run_state.run_id},
+            )
+            return None
+
+        # Otherwise queue a consume task for this run: immediately once every check
         # run has completed, or after a delay while some are still pending (they
         # can get stuck, so we trigger anyway rather than wait forever).
         head_sha = self.event.check_suite.head_sha

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
+from functools import cached_property
 from typing import Literal
 
-from pydantic import BaseModel, Field, PrivateAttr, root_validator
+import sentry_sdk
+from pydantic import BaseModel, Field, root_validator
 from scm import actions as scm_actions
 from scm.helpers import iter_all_pages
 from scm.types import ListCheckRunsForRefProtocol
@@ -14,7 +17,9 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask, FeedbackSourceBase
+from sentry.seer.models import SeerApiError
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +88,13 @@ def get_check_suite_url(event: GithubCheckSuiteEvent) -> str:
     )
 
 
-def resolve_check_suite_repository(event: GithubCheckSuiteEvent) -> Repository | None:
+def resolve_check_suite_repositories(event: GithubCheckSuiteEvent) -> list[Repository]:
+    """All Sentry repos matching this GitHub check-suite installation + external id.
+
+    A single GitHub App installation can be linked to multiple Sentry orgs, each
+    with its own ``Repository`` row. Callers that need an org-scoped Seer run
+    should try each candidate rather than assuming ``.first()`` is correct.
+    """
     installation_id = event.installation.id if event.installation else None
     repository_id = event.repository.id
     if installation_id is None or repository_id is None:
@@ -91,7 +102,7 @@ def resolve_check_suite_repository(event: GithubCheckSuiteEvent) -> Repository |
             "autofix.pr_iteration.check_suite.repository.missing_ids",
             extra={"installation_id": installation_id, "repository_id": repository_id},
         )
-        return None
+        return []
 
     contexts = integration_service.organization_contexts(
         provider=IntegrationProviderSlug.GITHUB.value,
@@ -107,28 +118,37 @@ def resolve_check_suite_repository(event: GithubCheckSuiteEvent) -> Repository |
                 "organization_integration_count": len(contexts.organization_integrations),
             },
         )
-        return None
+        return []
 
-    repo = (
+    organization_ids = [oi.organization_id for oi in contexts.organization_integrations]
+    repos = list(
         Repository.objects.filter(
-            organization_id__in=[oi.organization_id for oi in contexts.organization_integrations],
+            organization_id__in=organization_ids,
             provider=_SEER_GITHUB_PROVIDER,
             external_id=str(repository_id),
-        )
-        .exclude(status=ObjectStatus.HIDDEN)
-        .first()
+        ).exclude(status=ObjectStatus.HIDDEN)
     )
     logger.info(
         "autofix.pr_iteration.check_suite.repository.resolved",
         extra={
             "installation_id": installation_id,
             "repository_id": repository_id,
-            "organization_ids": [oi.organization_id for oi in contexts.organization_integrations],
-            "repo_id": repo.id if repo else None,
-            "repo_name": repo.name if repo else None,
+            "organization_ids": organization_ids,
+            "repo_ids": [repo.id for repo in repos],
+            "repo_organization_ids": [repo.organization_id for repo in repos],
         },
     )
-    return repo
+    return repos
+
+
+@dataclass(frozen=True)
+class CheckSuiteAutofixRun:
+    """The Autofix run tied to a check-suite PR, plus the Sentry repo used to find it."""
+
+    repository: Repository
+    run_state: SeerRunState
+    pr_id: int
+    group_id: int
 
 
 def _check_suite_iteration_cap_reached(run_state: SeerRunState) -> bool:
@@ -199,15 +219,54 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
     def ui_text(self) -> str | None:
         return f"check suite for app {self.app_name} failed"
 
-    _repository: Repository | None = PrivateAttr(default=None)
-    _repository_resolved: bool = PrivateAttr(default=False)
+    @cached_property
+    def repositories(self) -> list[Repository]:
+        return resolve_check_suite_repositories(self.event)
 
-    @property
-    def repository(self) -> Repository | None:
-        if not self._repository_resolved:
-            self._repository = resolve_check_suite_repository(self.event)
-            self._repository_resolved = True
-        return self._repository
+    @cached_property
+    def autofix_run(self) -> CheckSuiteAutofixRun | None:
+        """Find the single Autofix run for this check suite's PR(s).
+
+        Assumes one Autofix run ↔ PR in Sentry. Tries each PR × candidate org until
+        Seer returns a run with ``repo_pr_states`` and a ``group_id``.
+        """
+        repos = self.repositories
+        if not repos:
+            return None
+
+        for pr_id in (pr.id for pr in self.event.check_suite.pull_requests):
+            for candidate in repos:
+                try:
+                    state = get_agent_state_from_pr_id(
+                        candidate.organization_id, _SEER_GITHUB_PROVIDER, pr_id
+                    )
+                except SeerApiError as e:
+                    sentry_sdk.capture_exception(e)
+                    continue
+
+                if state is None or not state.repo_pr_states:
+                    continue
+
+                group_id = state.metadata.get("group_id") if state.metadata else None
+                if not group_id:
+                    logger.warning(
+                        "autofix.pr_iteration.check_suite.missing_group_id",
+                        extra={
+                            "organization_id": candidate.organization_id,
+                            "pr_id": pr_id,
+                            "run_id": state.run_id,
+                        },
+                    )
+                    continue
+
+                return CheckSuiteAutofixRun(
+                    repository=candidate,
+                    run_state=state,
+                    pr_id=pr_id,
+                    group_id=group_id,
+                )
+
+        return None
 
     def _matches_current_head(self, run_state: SeerRunState) -> tuple[str | None, str | None, bool]:
         """Whether the check suite ran on the PR's *current* head commit.
@@ -275,16 +334,18 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
             )
             return ConsumeTask.Now
 
-        repo = self.repository
-        if repo is None:
-            logger.info(
-                "autofix.pr_iteration.check_suite.should_trigger.no_repository",
+        resolved = self.autofix_run
+        if resolved is None:
+            # Listener only calls should_trigger after resolving a run; missing
+            # here means a bug or a test that skipped resolution.
+            logger.error(
+                "autofix.pr_iteration.check_suite.should_trigger.missing_autofix_run",
                 extra={"run_id": run_state.run_id, "head_sha": head_sha},
             )
             return ConsumeTask.Now
 
-        organization_id = repo.organization_id
-        repo_id = repo.id
+        organization_id = resolved.repository.organization_id
+        repo_id = resolved.repository.id
 
         # Importing the SCM factory while feedback models are initialized pulls
         # in integration handlers before Django finishes registering apps.
@@ -343,6 +404,7 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
 
 
 __all__ = (
+    "CheckSuiteAutofixRun",
     "CheckSuiteFeedbackSource",
     "GithubCheckSuite",
     "GithubCheckSuiteApp",
@@ -351,5 +413,5 @@ __all__ = (
     "GithubCheckSuitePullRequest",
     "GithubCheckSuiteRepository",
     "get_check_suite_url",
-    "resolve_check_suite_repository",
+    "resolve_check_suite_repositories",
 )

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -226,6 +226,7 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
 
     def should_queue(self, run_state: SeerRunState) -> bool:
         head_sha, repo_name, matched = self._matches_current_head(run_state)
+        cap_reached = matched and _check_suite_iteration_cap_reached(run_state)
         logger.info(
             "autofix.pr_iteration.check_suite.should_queue.evaluated",
             extra={
@@ -233,10 +234,13 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
                 "head_sha": head_sha,
                 "repo_name": repo_name,
                 "matched": matched,
+                "hard_cap_reached": cap_reached,
                 "repo_pr_state_count": len(run_state.repo_pr_states),
             },
         )
-        return matched
+        # Hard cap also blocks enqueue so failed suites don't pile up in Redis
+        # with no check-suite consume path to drain them.
+        return matched and not cap_reached
 
     def should_consume(self, run_state: SeerRunState) -> bool:
         head_sha, repo_name, matched = self._matches_current_head(run_state)
@@ -323,6 +327,7 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
                 )
                 if incomplete_count:
                     return ConsumeTask.Later(timedelta(hours=1))
+
         except Exception:
             logger.warning(
                 "autofix.pr_iteration.should_trigger.list_check_runs_failed",

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -176,6 +176,19 @@ def _check_suite_iteration_cap_reached(run_state: SeerRunState) -> bool:
     return True
 
 
+def _processed_check_suite_ids(run_state: SeerRunState) -> set[int]:
+    """Check suite ids already turned into feedback on this run (for consume dedupe)."""
+    from sentry.seer.autofix.autofix_agent import get_iterations
+    from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import _blocks_feedback
+
+    ids: set[int] = set()
+    for iteration in get_iterations(run_state):
+        for item in _blocks_feedback(iteration.blocks):
+            if isinstance(item.source, CheckSuiteFeedbackSource):
+                ids.add(item.source.event.check_suite.id)
+    return ids
+
+
 class CheckSuiteFeedbackSource(FeedbackSourceBase):
     type: Literal["check-suite"] = "check-suite"
     event: GithubCheckSuiteEvent
@@ -303,6 +316,8 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
 
     def should_consume(self, run_state: SeerRunState) -> bool:
         head_sha, repo_name, matched = self._matches_current_head(run_state)
+        suite_id = self.event.check_suite.id
+        already_processed = suite_id in _processed_check_suite_ids(run_state)
         logger.info(
             "autofix.pr_iteration.check_suite.should_consume.evaluated",
             extra={
@@ -310,10 +325,14 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
                 "head_sha": head_sha,
                 "repo_name": repo_name,
                 "matched": matched,
+                "check_suite_id": suite_id,
+                "already_processed": already_processed,
                 "repo_pr_state_count": len(run_state.repo_pr_states),
             },
         )
-        return matched
+        # Dedupe against prior check-suite feedback so webhook retries of the same
+        # suite can't burn iterations when the PR head is unchanged.
+        return matched and not already_processed
 
     def should_trigger(self, run_state: SeerRunState) -> ConsumeTask | None:
         if _check_suite_iteration_cap_reached(run_state):

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -1,0 +1,116 @@
+import logging
+
+import orjson
+from scm import actions as scm_actions
+from scm.types import ListCheckRunsForRefProtocol
+
+from sentry.scm.factory import new as make_scm
+from sentry.scm.private.event_stream import scm_event_stream
+from sentry.scm.types import CheckSuiteEvent
+from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
+from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
+from sentry.seer.autofix.pr_iteration.queue import try_enqueue_autofix_feedback
+from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
+
+logger = logging.getLogger(__name__)
+
+CONCLUSIONS = ["failure", "timed_out", "action_required", "startup_failure"]
+_SEER_GITHUB_PROVIDER = "integrations:github"
+
+
+@scm_event_stream.listen_for(event_type="check_suite")
+def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
+    if check_suite_event.action != "completed":
+        return None
+
+    if check_suite_event.check_suite["conclusion"] not in CONCLUSIONS:
+        return None
+
+    raw = orjson.loads(check_suite_event.subscription_event["event"])
+
+    source = CheckSuiteFeedbackSource(event=raw)
+    event = source.event
+    repo = source.repository
+    if repo is None:
+        return None
+
+    organization_id = repo.organization_id
+    check_suite = event.check_suite
+    pr_ids = [pr.id for pr in check_suite.pull_requests]
+    if not pr_ids:
+        return None
+
+    for pr_id in pr_ids:
+        agent_state = get_agent_state_from_pr_id(organization_id, _SEER_GITHUB_PROVIDER, pr_id)
+        if agent_state is None or not agent_state.repo_pr_states:
+            continue
+
+        group_id = agent_state.metadata.get("group_id") if agent_state.metadata else None
+        if not group_id:
+            logger.warning(
+                "autofix.pr_iteration.check_suite.missing_group_id",
+                extra={
+                    "organization_id": organization_id,
+                    "pr_id": pr_id,
+                    "run_id": agent_state.run_id,
+                },
+            )
+            continue
+
+        # `source.text` / `source.ui_text` are derived from the check-suite event.
+        feedback = Feedback(source=source)
+
+        enqueued = try_enqueue_autofix_feedback(
+            run_id=agent_state.run_id,
+            organization_id=organization_id,
+            group_id=group_id,
+            feedback=feedback,
+            referrer=AutofixReferrer.GITHUB_CHECK_SUITE,
+            run_state=agent_state,
+        )
+        if not enqueued:
+            continue
+
+        # Only consume once every check run on the head commit has finished.
+        # We gate on check *runs* rather than check *suites*: apps often register
+        # a check suite on the PR that never runs anything (it sits `queued`
+        # forever), so an "all suites completed" gate would never fire.
+        head_sha = check_suite.head_sha
+        try:
+            scm = make_scm(organization_id, repo.id, referrer="seer")
+        except Exception:
+            logger.warning(
+                "autofix.pr_iteration.check_suite.scm_init_failed",
+                extra={
+                    "organization_id": organization_id,
+                    "repo_id": repo.id,
+                    "pr_id": pr_id,
+                    "run_id": agent_state.run_id,
+                    "head_sha": head_sha,
+                },
+                exc_info=True,
+            )
+            scm = None
+        if isinstance(scm, ListCheckRunsForRefProtocol) and head_sha:
+            check_runs = scm_actions.list_check_runs_for_ref(scm, head_sha)["data"]
+            incomplete_count = sum(1 for run in check_runs if run["status"] != "completed")
+            if incomplete_count:
+                continue
+
+        logger.info(
+            "autofix.pr_iteration.check_suite.trigger_consume",
+            extra={
+                "organization_id": organization_id,
+                "repo_id": repo.id,
+                "pr_id": pr_id,
+                "run_id": agent_state.run_id,
+            },
+        )
+        trigger_consume_pr_iteration_feedback(
+            run_id=agent_state.run_id,
+            organization_id=organization_id,
+            feedback=feedback,
+            run_state=agent_state,
+        )

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -2,6 +2,7 @@ import logging
 
 import orjson
 import sentry_sdk
+from pydantic import ValidationError
 
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
@@ -26,9 +27,14 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     if check_suite_event.check_suite["conclusion"] not in CONCLUSIONS:
         return None
 
-    raw = orjson.loads(check_suite_event.subscription_event["event"])
+    try:
+        raw = orjson.loads(check_suite_event.subscription_event["event"])
+        source = CheckSuiteFeedbackSource(event=raw)
+    except (orjson.JSONDecodeError, ValidationError, TypeError, ValueError) as e:
+        # Malformed webhook payload — report and drop; do not fail the listener task.
+        sentry_sdk.capture_exception(e)
+        return None
 
-    source = CheckSuiteFeedbackSource(event=raw)
     event = source.event
     repo = source.repository
     if repo is None:

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -6,17 +6,15 @@ from pydantic import ValidationError
 
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
-from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.queue import try_enqueue_autofix_feedback
-from sentry.seer.models import SeerApiError
 
 logger = logging.getLogger(__name__)
 
-CONCLUSIONS = ["failure", "timed_out", "action_required", "startup_failure"]
-_SEER_GITHUB_PROVIDER = "integrations:github"
+# Values match scm BuildConclusion after GitHub normalization (startup_failure → failure).
+CONCLUSIONS = ["failure", "timed_out", "action_required"]
 
 
 @scm_event_stream.listen_for(event_type="check_suite")
@@ -35,73 +33,45 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
         sentry_sdk.capture_exception(e)
         return None
 
-    event = source.event
-    repo = source.repository
-    if repo is None:
+    resolved = source.autofix_run
+    if resolved is None:
         return None
 
+    repo = resolved.repository
+    agent_state = resolved.run_state
     organization_id = repo.organization_id
-    check_suite = event.check_suite
-    pr_ids = [pr.id for pr in check_suite.pull_requests]
-    if not pr_ids:
+    feedback = Feedback(source=source)
+
+    enqueued = try_enqueue_autofix_feedback(
+        run_id=agent_state.run_id,
+        organization_id=organization_id,
+        group_id=resolved.group_id,
+        feedback=feedback,
+        referrer=AutofixReferrer.GITHUB_CHECK_SUITE,
+        run_state=agent_state,
+    )
+    if not enqueued:
         return None
 
-    for pr_id in pr_ids:
-        try:
-            agent_state = get_agent_state_from_pr_id(organization_id, _SEER_GITHUB_PROVIDER, pr_id)
-        except SeerApiError as e:
-            # One PR's Seer failure must not abort the rest of the suite.
-            sentry_sdk.capture_exception(e)
-            continue
+    # Defer Now/Later/skip to `should_trigger` (incomplete check runs schedule
+    # a delayed consume rather than dropping the scheduled task entirely).
+    logger.info(
+        "autofix.pr_iteration.check_suite.trigger_consume",
+        extra={
+            "organization_id": organization_id,
+            "repo_id": repo.id,
+            "pr_id": resolved.pr_id,
+            "run_id": agent_state.run_id,
+        },
+    )
+    # Lazy: tasks.seer.pr_iteration → scm.factory → github → jira client
+    # which calls absolute_uri() at import time (needs options cache).
+    # stream.py is loaded in AppConfig.ready before options init.
+    from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
 
-        if agent_state is None or not agent_state.repo_pr_states:
-            continue
-
-        group_id = agent_state.metadata.get("group_id") if agent_state.metadata else None
-        if not group_id:
-            logger.warning(
-                "autofix.pr_iteration.check_suite.missing_group_id",
-                extra={
-                    "organization_id": organization_id,
-                    "pr_id": pr_id,
-                    "run_id": agent_state.run_id,
-                },
-            )
-            continue
-
-        # `source.text` / `source.ui_text` are derived from the check-suite event.
-        feedback = Feedback(source=source)
-
-        enqueued = try_enqueue_autofix_feedback(
-            run_id=agent_state.run_id,
-            organization_id=organization_id,
-            group_id=group_id,
-            feedback=feedback,
-            referrer=AutofixReferrer.GITHUB_CHECK_SUITE,
-            run_state=agent_state,
-        )
-        if not enqueued:
-            continue
-
-        # Defer Now/Later/skip to `should_trigger` (incomplete check runs schedule
-        # a delayed consume rather than dropping the scheduled task entirely).
-        logger.info(
-            "autofix.pr_iteration.check_suite.trigger_consume",
-            extra={
-                "organization_id": organization_id,
-                "repo_id": repo.id,
-                "pr_id": pr_id,
-                "run_id": agent_state.run_id,
-            },
-        )
-        # Lazy: tasks.seer.pr_iteration → scm.factory → github → jira client
-        # which calls absolute_uri() at import time (needs options cache).
-        # stream.py is loaded in AppConfig.ready before options init.
-        from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
-
-        trigger_consume_pr_iteration_feedback(
-            run_id=agent_state.run_id,
-            organization_id=organization_id,
-            feedback=feedback,
-            run_state=agent_state,
-        )
+    trigger_consume_pr_iteration_feedback(
+        run_id=agent_state.run_id,
+        organization_id=organization_id,
+        feedback=feedback,
+        run_state=agent_state,
+    )

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -1,6 +1,7 @@
 import logging
 
 import orjson
+import sentry_sdk
 
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
@@ -9,6 +10,7 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.queue import try_enqueue_autofix_feedback
+from sentry.seer.models import SeerApiError
 from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
 
 logger = logging.getLogger(__name__)
@@ -40,7 +42,13 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
         return None
 
     for pr_id in pr_ids:
-        agent_state = get_agent_state_from_pr_id(organization_id, _SEER_GITHUB_PROVIDER, pr_id)
+        try:
+            agent_state = get_agent_state_from_pr_id(organization_id, _SEER_GITHUB_PROVIDER, pr_id)
+        except SeerApiError as e:
+            # One PR's Seer failure must not abort the rest of the suite.
+            sentry_sdk.capture_exception(e)
+            continue
+
         if agent_state is None or not agent_state.repo_pr_states:
             continue
 

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -11,7 +11,6 @@ from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.queue import try_enqueue_autofix_feedback
 from sentry.seer.models import SeerApiError
-from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +88,11 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
                 "run_id": agent_state.run_id,
             },
         )
+        # Lazy: tasks.seer.pr_iteration → scm.factory → github → jira client
+        # which calls absolute_uri() at import time (needs options cache).
+        # stream.py is loaded in AppConfig.ready before options init.
+        from sentry.tasks.seer.pr_iteration import trigger_consume_pr_iteration_feedback
+
         trigger_consume_pr_iteration_feedback(
             run_id=agent_state.run_id,
             organization_id=organization_id,

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -1,10 +1,7 @@
 import logging
 
 import orjson
-from scm import actions as scm_actions
-from scm.types import ListCheckRunsForRefProtocol
 
-from sentry.scm.factory import new as make_scm
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
@@ -73,32 +70,8 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
         if not enqueued:
             continue
 
-        # Only consume once every check run on the head commit has finished.
-        # We gate on check *runs* rather than check *suites*: apps often register
-        # a check suite on the PR that never runs anything (it sits `queued`
-        # forever), so an "all suites completed" gate would never fire.
-        head_sha = check_suite.head_sha
-        try:
-            scm = make_scm(organization_id, repo.id, referrer="seer")
-        except Exception:
-            logger.warning(
-                "autofix.pr_iteration.check_suite.scm_init_failed",
-                extra={
-                    "organization_id": organization_id,
-                    "repo_id": repo.id,
-                    "pr_id": pr_id,
-                    "run_id": agent_state.run_id,
-                    "head_sha": head_sha,
-                },
-                exc_info=True,
-            )
-            scm = None
-        if isinstance(scm, ListCheckRunsForRefProtocol) and head_sha:
-            check_runs = scm_actions.list_check_runs_for_ref(scm, head_sha)["data"]
-            incomplete_count = sum(1 for run in check_runs if run["status"] != "completed")
-            if incomplete_count:
-                continue
-
+        # Defer Now/Later/skip to `should_trigger` (incomplete check runs schedule
+        # a delayed consume rather than dropping the scheduled task entirely).
         logger.info(
             "autofix.pr_iteration.check_suite.trigger_consume",
             extra={

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -33,6 +33,7 @@ from sentry.seer.autofix.autofix_agent import (
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
     GithubPrCommentFeedbackType,
@@ -167,6 +168,7 @@ def consume_queued_autofix_feedback(
         # Keyed by (source class, comment id): issue-comment and review-comment
         # ids come from separate GitHub namespaces, so dedupe within each type.
         seen_comment_keys: set[tuple[type, int]] = set()
+        seen_check_suite_ids: set[int] = set()
         for item in queued_items:
             if not item.feedback.source.should_consume(state):
                 logger.info(
@@ -190,6 +192,11 @@ def consume_queued_autofix_feedback(
                     if key in seen_comment_keys:
                         continue
                     seen_comment_keys.add(key)
+            elif isinstance(source, CheckSuiteFeedbackSource):
+                suite_id = source.event.check_suite.id
+                if suite_id in seen_check_suite_ids:
+                    continue
+                seen_check_suite_ids.add(suite_id)
 
             feedback_items.append(item.feedback)
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -3,10 +3,15 @@ from unittest.mock import MagicMock, patch
 import orjson
 
 from sentry.scm.types import CheckSuiteEvent
-from sentry.seer.agent.client_models import RepoPRState, SeerRunState
+from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.pr_iteration.feedback import Feedback
-from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
+from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
+    CHECK_SUITE_ITERATION_HARD_CAP,
+    CheckSuiteFeedbackSource,
+)
+from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
     pr_iteration_from_check_suite_listener,
 )
@@ -154,3 +159,94 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert isinstance(kwargs["feedback"], Feedback)
         assert isinstance(kwargs["feedback"].source, CheckSuiteFeedbackSource)
         mock_trigger_consume.assert_called_once()
+
+
+def _check_suite_source() -> CheckSuiteFeedbackSource:
+    return CheckSuiteFeedbackSource(
+        event={
+            "check_suite": {
+                "id": 1,
+                "head_sha": "abc",
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {"html_url": "https://github.com/owner/repo"},
+        }
+    )
+
+
+def _check_suite_feedback() -> Feedback:
+    return Feedback(source=_check_suite_source())
+
+
+def _iteration_block(index: int, *feedbacks: Feedback) -> MemoryBlock:
+    return MemoryBlock(
+        id=f"iter-{index}",
+        message=Message(
+            role="assistant",
+            metadata={
+                "step": "pr_iteration",
+                "iteration_index": str(index),
+                "feedback": serialize_feedback(feedbacks),
+            },
+        ),
+        timestamp="2024-01-01T00:00:00Z",
+    )
+
+
+def _run_state(*, blocks: list[MemoryBlock]) -> SeerRunState:
+    return SeerRunState(
+        run_id=1,
+        blocks=blocks,
+        status="completed",
+        updated_at="2024-01-01T00:00:00Z",
+    )
+
+
+class CheckSuiteHardCapTest(TestCase):
+    def _source(self) -> CheckSuiteFeedbackSource:
+        return _check_suite_source()
+
+    def test_none_when_cap_reached(self) -> None:
+        cap = CHECK_SUITE_ITERATION_HARD_CAP
+        blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap)]
+
+        assert self._source().should_trigger(_run_state(blocks=blocks)) is None
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    def test_not_capped_when_fewer_than_cap_iterations(self, _mock: MagicMock) -> None:
+        cap = CHECK_SUITE_ITERATION_HARD_CAP
+        blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap - 1)]
+
+        assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    def test_not_capped_when_one_iteration_has_non_check_suite_feedback(
+        self, _mock: MagicMock
+    ) -> None:
+        cap = CHECK_SUITE_ITERATION_HARD_CAP
+        blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap - 1)]
+        blocks.append(
+            _iteration_block(
+                cap,
+                _check_suite_feedback(),
+                Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it")),
+            )
+        )
+
+        assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    def test_only_last_n_iterations_considered(self, _mock: MagicMock) -> None:
+        cap = CHECK_SUITE_ITERATION_HARD_CAP
+        blocks = [_iteration_block(0, Feedback(source=UserUIFeedbackSource(user_id=1)))]
+        blocks += [_iteration_block(i, _check_suite_feedback()) for i in range(1, cap + 1)]
+
+        assert self._source().should_trigger(_run_state(blocks=blocks)) is None
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.CHECK_SUITE_ITERATION_HARD_CAP", 0)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    def test_cap_disabled_when_zero(self, _mock: MagicMock) -> None:
+        blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(10)]
+
+        assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -1,0 +1,156 @@
+from unittest.mock import MagicMock, patch
+
+import orjson
+
+from sentry.scm.types import CheckSuiteEvent
+from sentry.seer.agent.client_models import RepoPRState, SeerRunState
+from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
+from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
+    pr_iteration_from_check_suite_listener,
+)
+from sentry.testutils.cases import TestCase
+
+CHECK_PATH = "sentry.seer.autofix.pr_iteration.listeners.check_suite"
+CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
+
+
+class PrIterationFromCheckSuiteListenerTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group(project=self.project)
+
+    def _event(
+        self, raw: dict | None = None, *, action="completed", conclusion="failure"
+    ) -> CheckSuiteEvent:
+        return CheckSuiteEvent(
+            action=action,
+            check_suite={
+                "id": "1",
+                "status": "completed",
+                "conclusion": conclusion,
+                "html_url": "",
+                "pull_request_ids": [],
+            },
+            subscription_event={"event": orjson.dumps(raw or {}).decode()},
+        )
+
+    def _raw(self, *, pull_requests: list[dict] | None = None) -> dict:
+        return {
+            "check_suite": {
+                "id": 1,
+                "head_sha": "abc",
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+                "pull_requests": pull_requests or [],
+            },
+            "repository": {"html_url": "https://github.com/owner/repo"},
+        }
+
+    def _agent_state(self) -> SeerRunState:
+        return SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+            metadata={"group_id": self.group.id},
+        )
+
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    def test_skips_non_completed_action(self, mock_get_state: MagicMock) -> None:
+        pr_iteration_from_check_suite_listener(self._event(action="requested"))
+        mock_get_state.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    def test_skips_uninteresting_conclusion(self, mock_get_state: MagicMock) -> None:
+        pr_iteration_from_check_suite_listener(self._event(conclusion="success"))
+        mock_get_state.assert_not_called()
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    def test_no_repository(self, mock_get_state: MagicMock, _mock_resolve: MagicMock) -> None:
+        pr_iteration_from_check_suite_listener(self._event(self._raw()))
+        mock_get_state.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id", return_value=None)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_skips_pr_without_run(
+        self,
+        mock_resolve: MagicMock,
+        _mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        raw = self._raw(pull_requests=[{"id": 555}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        mock_enqueue.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_skips_run_missing_group_id(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        state = self._agent_state()
+        state.metadata = {}
+        mock_get_state.return_value = state
+        raw = self._raw(pull_requests=[{"id": 555}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        mock_enqueue.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=False)
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_does_not_trigger_when_not_enqueued(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        _mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_get_state.return_value = self._agent_state()
+        raw = self._raw(pull_requests=[{"id": 555}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        mock_trigger_consume.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{CHECK_PATH}.make_scm")
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_enqueues_and_triggers_for_matched_run(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        _mock_make_scm: MagicMock,
+        mock_trigger_consume: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_get_state.return_value = self._agent_state()
+        raw = self._raw(pull_requests=[{"id": 555}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        mock_enqueue.assert_called_once()
+        _, kwargs = mock_enqueue.call_args
+        assert kwargs["run_id"] == 67890
+        assert kwargs["referrer"] == AutofixReferrer.GITHUB_CHECK_SUITE
+        assert isinstance(kwargs["feedback"], Feedback)
+        assert isinstance(kwargs["feedback"].source, CheckSuiteFeedbackSource)
+        mock_trigger_consume.assert_called_once()

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -19,6 +19,8 @@ from sentry.testutils.cases import TestCase
 
 CHECK_PATH = "sentry.seer.autofix.pr_iteration.listeners.check_suite"
 CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
+# Lazy-imported inside the listener (must not load at AppConfig.ready).
+TRIGGER_CONSUME_PATH = "sentry.tasks.seer.pr_iteration.trigger_consume_pr_iteration_feedback"
 
 
 class PrIterationFromCheckSuiteListenerTest(TestCase):
@@ -121,7 +123,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
         mock_enqueue.assert_not_called()
 
-    @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=False)
     @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
@@ -140,7 +142,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
         mock_trigger_consume.assert_not_called()
 
-    @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
     @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
@@ -166,7 +168,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_trigger_consume.assert_called_once()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
     @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -165,6 +165,33 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert isinstance(kwargs["feedback"].source, CheckSuiteFeedbackSource)
         mock_trigger_consume.assert_called_once()
 
+    @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
+    @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_seer_error_on_one_pr_continues_to_remaining(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_capture: MagicMock,
+    ) -> None:
+        from sentry.seer.models import SeerApiError
+
+        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        error = SeerApiError("transient", 500)
+        mock_get_state.side_effect = [error, self._agent_state()]
+        raw = self._raw(pull_requests=[{"id": 111}, {"id": 222}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        assert mock_get_state.call_count == 2
+        mock_capture.assert_called_once_with(error)
+        mock_enqueue.assert_called_once()
+        mock_trigger_consume.assert_called_once()
+
 
 def _check_suite_source() -> CheckSuiteFeedbackSource:
     return CheckSuiteFeedbackSource(

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -134,7 +134,6 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_trigger_consume.assert_not_called()
 
     @patch(f"{CHECK_PATH}.trigger_consume_pr_iteration_feedback")
-    @patch(f"{CHECK_PATH}.make_scm")
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
     @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
@@ -143,7 +142,6 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_resolve: MagicMock,
         mock_get_state: MagicMock,
         mock_enqueue: MagicMock,
-        _mock_make_scm: MagicMock,
         mock_trigger_consume: MagicMock,
     ) -> None:
         mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
@@ -170,7 +168,10 @@ def _check_suite_source() -> CheckSuiteFeedbackSource:
                 "check_runs_url": "https://github.com/owner/repo/check-runs",
                 "app": {"name": "CI"},
             },
-            "repository": {"html_url": "https://github.com/owner/repo"},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
         }
     )
 
@@ -207,11 +208,22 @@ class CheckSuiteHardCapTest(TestCase):
     def _source(self) -> CheckSuiteFeedbackSource:
         return _check_suite_source()
 
+    def _run_state_on_head(self, *, blocks: list[MemoryBlock]) -> SeerRunState:
+        state = _run_state(blocks=blocks)
+        state.repo_pr_states = {"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")}
+        return state
+
     def test_none_when_cap_reached(self) -> None:
         cap = CHECK_SUITE_ITERATION_HARD_CAP
         blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap)]
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) is None
+
+    def test_should_queue_false_when_cap_reached(self) -> None:
+        cap = CHECK_SUITE_ITERATION_HARD_CAP
+        blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap)]
+
+        assert not self._source().should_queue(self._run_state_on_head(blocks=blocks))
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
     def test_not_capped_when_fewer_than_cap_iterations(self, _mock: MagicMock) -> None:

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -9,6 +9,7 @@ from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedba
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CHECK_SUITE_ITERATION_HARD_CAP,
+    CheckSuiteAutofixRun,
     CheckSuiteFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
@@ -290,7 +291,14 @@ def _run_state(*, blocks: list[MemoryBlock]) -> SeerRunState:
 
 class CheckSuiteHardCapTest(TestCase):
     def _source(self) -> CheckSuiteFeedbackSource:
-        return _check_suite_source()
+        source = _check_suite_source()
+        source.__dict__["autofix_run"] = CheckSuiteAutofixRun(
+            repository=MagicMock(organization_id=1, id=2),
+            run_state=_run_state(blocks=[]),
+            pr_id=1,
+            group_id=1,
+        )
+        return source
 
     def _run_state_on_head(self, *, blocks: list[MemoryBlock]) -> SeerRunState:
         state = _run_state(blocks=blocks)
@@ -309,17 +317,23 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert not self._source().should_queue(self._run_state_on_head(blocks=blocks))
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
-    def test_not_capped_when_fewer_than_cap_iterations(self, _mock: MagicMock) -> None:
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch("sentry.scm.factory.new")
+    def test_not_capped_when_fewer_than_cap_iterations(self, mock_new: MagicMock, _pages) -> None:
+        mock_new.return_value = MagicMock()
         cap = CHECK_SUITE_ITERATION_HARD_CAP
         blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap - 1)]
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch("sentry.scm.factory.new")
     def test_not_capped_when_one_iteration_has_non_check_suite_feedback(
-        self, _mock: MagicMock
+        self, mock_new: MagicMock, _pages
     ) -> None:
+        mock_new.return_value = MagicMock()
         cap = CHECK_SUITE_ITERATION_HARD_CAP
         blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap - 1)]
         blocks.append(
@@ -332,8 +346,7 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
-    def test_only_last_n_iterations_considered(self, _mock: MagicMock) -> None:
+    def test_only_last_n_iterations_considered(self) -> None:
         cap = CHECK_SUITE_ITERATION_HARD_CAP
         blocks = [_iteration_block(0, Feedback(source=UserUIFeedbackSource(user_id=1)))]
         blocks += [_iteration_block(i, _check_suite_feedback()) for i in range(1, cap + 1)]
@@ -341,8 +354,11 @@ class CheckSuiteHardCapTest(TestCase):
         assert self._source().should_trigger(_run_state(blocks=blocks)) is None
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.CHECK_SUITE_ITERATION_HARD_CAP", 0)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
-    def test_cap_disabled_when_zero(self, _mock: MagicMock) -> None:
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch("sentry.scm.factory.new")
+    def test_cap_disabled_when_zero(self, mock_new: MagicMock, _pages) -> None:
+        mock_new.return_value = MagicMock()
         blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(10)]
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -88,6 +88,28 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         pr_iteration_from_check_suite_listener(self._event(self._raw()))
         mock_get_state.assert_not_called()
 
+    @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    def test_invalid_payload_captures_and_returns(
+        self, mock_get_state: MagicMock, mock_capture: MagicMock
+    ) -> None:
+        # Missing required check_suite fields (head_sha, check_runs_url, app).
+        raw = {"check_suite": {"id": 1}, "repository": {"html_url": "https://github.com/o/r"}}
+        pr_iteration_from_check_suite_listener(self._event(raw))
+        mock_capture.assert_called_once()
+        mock_get_state.assert_not_called()
+
+    @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
+    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    def test_invalid_json_captures_and_returns(
+        self, mock_get_state: MagicMock, mock_capture: MagicMock
+    ) -> None:
+        event = self._event()
+        event.subscription_event["event"] = "not-json"
+        pr_iteration_from_check_suite_listener(event)
+        mock_capture.assert_called_once()
+        mock_get_state.assert_not_called()
+
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
     @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id", return_value=None)
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -72,24 +72,24 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
             metadata={"group_id": self.group.id},
         )
 
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
     def test_skips_non_completed_action(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(action="requested"))
         mock_get_state.assert_not_called()
 
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
     def test_skips_uninteresting_conclusion(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(conclusion="success"))
         mock_get_state.assert_not_called()
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
     def test_no_repository(self, mock_get_state: MagicMock, _mock_resolve: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(self._raw()))
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
     def test_invalid_payload_captures_and_returns(
         self, mock_get_state: MagicMock, mock_capture: MagicMock
     ) -> None:
@@ -100,7 +100,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
     def test_invalid_json_captures_and_returns(
         self, mock_get_state: MagicMock, mock_capture: MagicMock
     ) -> None:
@@ -111,15 +111,15 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id", return_value=None)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id", return_value=None)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
     def test_skips_pr_without_run(
         self,
         mock_resolve: MagicMock,
         _mock_get_state: MagicMock,
         mock_enqueue: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id)]
         raw = self._raw(pull_requests=[{"id": 555}])
 
         pr_iteration_from_check_suite_listener(self._event(raw))
@@ -127,15 +127,15 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_enqueue.assert_not_called()
 
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
     def test_skips_run_missing_group_id(
         self,
         mock_resolve: MagicMock,
         mock_get_state: MagicMock,
         mock_enqueue: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id)]
         state = self._agent_state()
         state.metadata = {}
         mock_get_state.return_value = state
@@ -147,8 +147,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=False)
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
     def test_does_not_trigger_when_not_enqueued(
         self,
         mock_resolve: MagicMock,
@@ -156,7 +156,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         _mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id)]
         mock_get_state.return_value = self._agent_state()
         raw = self._raw(pull_requests=[{"id": 555}])
 
@@ -166,8 +166,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
     def test_enqueues_and_triggers_for_matched_run(
         self,
         mock_resolve: MagicMock,
@@ -175,7 +175,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id)]
         mock_get_state.return_value = self._agent_state()
         raw = self._raw(pull_requests=[{"id": 555}])
 
@@ -189,11 +189,11 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert isinstance(kwargs["feedback"].source, CheckSuiteFeedbackSource)
         mock_trigger_consume.assert_called_once()
 
-    @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.sentry_sdk.capture_exception")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
     def test_seer_error_on_one_pr_continues_to_remaining(
         self,
         mock_resolve: MagicMock,
@@ -204,7 +204,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
     ) -> None:
         from sentry.seer.models import SeerApiError
 
-        mock_resolve.return_value = MagicMock(organization_id=self.organization.id)
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id)]
         error = SeerApiError("transient", 500)
         mock_get_state.side_effect = [error, self._agent_state()]
         raw = self._raw(pull_requests=[{"id": 111}, {"id": 222}])
@@ -214,6 +214,32 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert mock_get_state.call_count == 2
         mock_capture.assert_called_once_with(error)
         mock_enqueue.assert_called_once()
+        mock_trigger_consume.assert_called_once()
+
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    def test_tries_each_org_until_agent_state_found(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+    ) -> None:
+        wrong_org_repo = MagicMock(organization_id=111, id=1)
+        right_org_repo = MagicMock(organization_id=self.organization.id, id=2)
+        mock_resolve.return_value = [wrong_org_repo, right_org_repo]
+        mock_get_state.side_effect = [None, self._agent_state()]
+        raw = self._raw(pull_requests=[{"id": 555}])
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        assert mock_get_state.call_count == 2
+        mock_get_state.assert_any_call(111, "integrations:github", 555)
+        mock_get_state.assert_any_call(self.organization.id, "integrations:github", 555)
+        _, kwargs = mock_enqueue.call_args
+        assert kwargs["organization_id"] == self.organization.id
         mock_trigger_consume.assert_called_once()
 
 
@@ -283,14 +309,14 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert not self._source().should_queue(self._run_state_on_head(blocks=blocks))
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
     def test_not_capped_when_fewer_than_cap_iterations(self, _mock: MagicMock) -> None:
         cap = CHECK_SUITE_ITERATION_HARD_CAP
         blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(cap - 1)]
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
     def test_not_capped_when_one_iteration_has_non_check_suite_feedback(
         self, _mock: MagicMock
     ) -> None:
@@ -306,7 +332,7 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
     def test_only_last_n_iterations_considered(self, _mock: MagicMock) -> None:
         cap = CHECK_SUITE_ITERATION_HARD_CAP
         blocks = [_iteration_block(0, Feedback(source=UserUIFeedbackSource(user_id=1)))]
@@ -315,7 +341,7 @@ class CheckSuiteHardCapTest(TestCase):
         assert self._source().should_trigger(_run_state(blocks=blocks)) is None
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.CHECK_SUITE_ITERATION_HARD_CAP", 0)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
     def test_cap_disabled_when_zero(self, _mock: MagicMock) -> None:
         blocks = [_iteration_block(i, _check_suite_feedback()) for i in range(10)]
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -38,7 +38,14 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
                 "html_url": "",
                 "pull_request_ids": [],
             },
-            subscription_event={"event": orjson.dumps(raw or {}).decode()},
+            subscription_event={
+                "event": orjson.dumps(raw or {}).decode(),
+                "event_type_hint": "check_suite",
+                "extra": {},
+                "received_at": 0,
+                "sentry_meta": None,
+                "type": "github",
+            },
         )
 
     def _raw(self, *, pull_requests: list[dict] | None = None) -> dict:

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -1,6 +1,7 @@
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.seer.autofix.pr_iteration.queue import (
     peek_queued_autofix_feedback,
@@ -37,3 +38,21 @@ class TryEnqueueAutofixFeedbackTest(TestCase):
         queued = peek_queued_autofix_feedback(4242)
         assert len(queued) == 1
         assert queued[0].feedback.text == "fix it"
+
+    def test_skips_stale_feedback(self) -> None:
+        feedback = Feedback(
+            source=CheckSuiteFeedbackSource(
+                event={
+                    "check_suite": {
+                        "id": 1,
+                        "head_sha": "abc",
+                        "check_runs_url": "https://github.com/owner/repo/check-runs",
+                        "app": {"name": "CI"},
+                    },
+                    "repository": {"html_url": "https://github.com/owner/repo"},
+                }
+            ),
+        )
+
+        assert self._enqueue(run_id=4343, feedback=feedback) is False
+        assert peek_queued_autofix_feedback(4343) == []

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -446,7 +446,7 @@ class CheckSuiteShouldTriggerTest(TestCase):
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
-    def test_none_when_a_check_suite_not_completed(
+    def test_later_when_a_check_suite_not_completed(
         self,
         mock_resolve: MagicMock,
         mock_new: MagicMock,
@@ -456,7 +456,7 @@ class CheckSuiteShouldTriggerTest(TestCase):
         mock_new.return_value = MagicMock()
         mock_pages.return_value = [{"data": [{"status": "in_progress"}]}]
 
-        assert self._source().should_trigger(_run_state()) is None
+        assert self._source().should_trigger(_run_state()) == ConsumeTask.Later(timedelta(hours=1))
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -1,15 +1,21 @@
 from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
 
-from sentry.seer.agent.client_models import MemoryBlock, Message, SeerRunState
+from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.pr_iteration.feedback import (
     Feedback,
     parse_feedback,
     serialize_feedback,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
+    CheckSuiteFeedbackSource,
+    get_check_suite_url,
+    resolve_check_suite_repository,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubIssueComment,
     GithubPrCommentFeedbackSource,
@@ -18,6 +24,20 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
+
+CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
+
+
+def _check_suite_event() -> dict:
+    return {
+        "check_suite": {
+            "id": 1,
+            "head_sha": "abc",
+            "check_runs_url": "https://github.com/owner/repo/check-runs",
+            "app": {"name": "CI"},
+        },
+        "repository": {"html_url": "https://github.com/owner/repo"},
+    }
 
 
 def _run_state(*, blocks=None, repo_pr_states=None, status="completed") -> SeerRunState:
@@ -57,22 +77,43 @@ def _review_feedback(
 
 
 class ParseSerializeFeedbackTest(TestCase):
+    def test_check_suite_event_requires_expected_fields_and_preserves_extra_fields(self) -> None:
+        event = _check_suite_event()
+        event["extra"] = "value"
+        source = CheckSuiteFeedbackSource(event=event)
+
+        assert source.event.dict()["extra"] == "value"
+        assert source.app_name == "CI"
+        assert get_check_suite_url(source.event) == (
+            "https://github.com/owner/repo/commit/abc/checks?check_suite_id=1"
+        )
+        assert source.check_suite_url == get_check_suite_url(source.event)
+
+        del event["check_suite"]["check_runs_url"]
+        with pytest.raises(ValidationError):
+            CheckSuiteFeedbackSource(event=event)
+
     def test_round_trips_all_source_types(self) -> None:
         items = [
             Feedback(source=UserUIFeedbackSource(user_id=7, user_feedback="ui")),
             Feedback(
                 source=GithubPrCommentFeedbackSource(comment={"id": 99, "body": "@sentry comment"})
             ),
+            Feedback(
+                source=CheckSuiteFeedbackSource(event=_check_suite_event()),
+            ),
         ]
 
         parsed = parse_feedback(serialize_feedback(items))
 
         # text is derived from each source: user-ui echoes the typed feedback,
-        # pr-comment parses the comment body.
+        # pr-comment parses the comment body, check-suite builds an instruction.
         assert parsed[0].text == "ui"
         assert parsed[1].text == "comment"
+        assert parsed[2].text.startswith("A GitHub check suite on the pull request failed")
         assert isinstance(parsed[0].source, UserUIFeedbackSource)
         assert isinstance(parsed[1].source, GithubPrCommentFeedbackSource)
+        assert isinstance(parsed[2].source, CheckSuiteFeedbackSource)
         assert parsed[0].source.user_id == 7
         assert parsed[1].source.comment.id == 99
 
@@ -87,6 +128,9 @@ class ParseSerializeFeedbackTest(TestCase):
     def test_serializes_ui_text(self) -> None:
         items = [
             Feedback(source=UserUIFeedbackSource(user_id=7, user_feedback="ui")),
+            Feedback(
+                source=CheckSuiteFeedbackSource(event=_check_suite_event()),
+            ),
         ]
 
         serialized = serialize_feedback(items)
@@ -95,6 +139,8 @@ class ParseSerializeFeedbackTest(TestCase):
         # user-ui has no distinct UI text, so it falls back to `text`.
         assert parsed[0].source.ui_text is None
         assert parsed[0].ui_text == "ui"
+        assert parsed[1].source.ui_text == "check suite for app CI failed"
+        assert parsed[1].ui_text == "check suite for app CI failed"
 
     def test_invalid_json_returns_empty(self) -> None:
         assert parse_feedback("not json") == []
@@ -260,3 +306,245 @@ class ConsumeTaskTest(TestCase):
     def test_later_with_negative_timedelta_returns_zero(self) -> None:
         task = ConsumeTask.Later(when=timedelta(seconds=-10))
         assert task.countdown() == 0
+
+
+class CheckSuiteShouldQueueTest(TestCase):
+    def _event(self, *, head_sha="abc", repo_name="owner/repo") -> dict:
+        return {
+            "check_suite": {
+                "id": 1,
+                "head_sha": head_sha,
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {
+                "full_name": repo_name,
+                "html_url": "https://github.com/owner/repo",
+            },
+        }
+
+    def test_true_when_matches_repo_pr_state(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event())
+        state = _run_state(
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")}
+        )
+
+        assert source.should_queue(state) is True
+
+    def test_false_when_only_matches_block_commit_sha(self) -> None:
+        # A past block's SHA no longer counts: only the PR's current head
+        # (repo_pr_states) is valid, so a suite for a superseded commit is dropped.
+        source = CheckSuiteFeedbackSource(event=self._event())
+        block = MemoryBlock(
+            id="b1",
+            message=Message(role="assistant"),
+            timestamp="2024-01-01T00:00:00Z",
+            pr_commit_shas={"owner/repo": "abc"},
+        )
+
+        assert source.should_queue(_run_state(blocks=[block])) is False
+
+    def test_false_when_no_match(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event())
+        state = _run_state(
+            repo_pr_states={
+                "owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="different")
+            }
+        )
+
+        assert source.should_queue(state) is False
+
+    def test_false_when_missing_head_sha(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event(head_sha=""))
+
+        assert source.should_queue(_run_state()) is False
+
+    def test_false_when_missing_repo_name(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event(repo_name=""))
+
+        assert source.should_queue(_run_state()) is False
+
+
+class CheckSuiteShouldConsumeTest(TestCase):
+    def _event(self, *, head_sha="abc", repo_name="owner/repo") -> dict:
+        return {
+            "check_suite": {
+                "id": 1,
+                "head_sha": head_sha,
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {
+                "full_name": repo_name,
+                "html_url": "https://github.com/owner/repo",
+            },
+        }
+
+    def test_true_when_matches_current_head(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event())
+        state = _run_state(
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")}
+        )
+
+        assert source.should_consume(state) is True
+
+    def test_false_when_head_superseded(self) -> None:
+        # PR head advanced past the commit the suite ran on -> out of date.
+        source = CheckSuiteFeedbackSource(event=self._event())
+        state = _run_state(
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="newer")}
+        )
+
+        assert source.should_consume(state) is False
+
+    def test_false_when_no_repo_pr_state(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event())
+
+        assert source.should_consume(_run_state()) is False
+
+
+class CheckSuiteShouldTriggerTest(TestCase):
+    def _source(self, head_sha="abc") -> CheckSuiteFeedbackSource:
+        return CheckSuiteFeedbackSource(
+            event={
+                "check_suite": {
+                    "id": 1,
+                    "head_sha": head_sha,
+                    "check_runs_url": "https://github.com/owner/repo/check-runs",
+                    "app": {"name": "CI"},
+                },
+                "repository": {"html_url": "https://github.com/owner/repo"},
+            }
+        )
+
+    def test_now_when_no_head_sha(self) -> None:
+        assert self._source(head_sha="").should_trigger(_run_state()) == ConsumeTask.Now
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
+    def test_now_when_repository_none(self, _mock_resolve: MagicMock) -> None:
+        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+
+    @patch("sentry.scm.factory.new", side_effect=Exception("boom"))
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_now_when_scm_init_fails(self, mock_resolve: MagicMock, _mock_new: MagicMock) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
+
+        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", type("Other", (), {}))
+    @patch("sentry.scm.factory.new")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_now_when_unsupported_provider(
+        self, mock_resolve: MagicMock, mock_new: MagicMock
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
+        mock_new.return_value = MagicMock()
+
+        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch("sentry.scm.factory.new")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_none_when_a_check_suite_not_completed(
+        self,
+        mock_resolve: MagicMock,
+        mock_new: MagicMock,
+        mock_pages: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
+        mock_new.return_value = MagicMock()
+        mock_pages.return_value = [{"data": [{"status": "in_progress"}]}]
+
+        assert self._source().should_trigger(_run_state()) is None
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch("sentry.scm.factory.new")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_now_when_all_completed(
+        self,
+        mock_resolve: MagicMock,
+        mock_new: MagicMock,
+        mock_pages: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
+        mock_new.return_value = MagicMock()
+        mock_pages.return_value = [{"data": [{"status": "completed"}]}]
+
+        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", side_effect=Exception("boom"))
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch("sentry.scm.factory.new")
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
+    def test_now_when_list_check_suites_fails(
+        self,
+        mock_resolve: MagicMock,
+        mock_new: MagicMock,
+        _mock_pages: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
+        mock_new.return_value = MagicMock()
+
+        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+
+
+class ResolveCheckSuiteRepositoryTest(TestCase):
+    def test_none_when_missing_ids(self) -> None:
+        assert (
+            resolve_check_suite_repository(
+                CheckSuiteFeedbackSource(event=_check_suite_event()).event
+            )
+            is None
+        )
+        assert (
+            resolve_check_suite_repository(
+                CheckSuiteFeedbackSource(
+                    event={**_check_suite_event(), "installation": {"id": 1}}
+                ).event
+            )
+            is None
+        )
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
+    def test_none_when_no_integration(self, mock_contexts: MagicMock) -> None:
+        mock_contexts.return_value = MagicMock(integration=None, organization_integrations=[])
+
+        result = resolve_check_suite_repository(
+            CheckSuiteFeedbackSource(
+                event={
+                    **_check_suite_event(),
+                    "installation": {"id": 1},
+                    "repository": {"id": 2, "html_url": "https://github.com/owner/repo"},
+                }
+            ).event
+        )
+
+        assert result is None
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
+    def test_returns_matching_repo(self, mock_contexts: MagicMock) -> None:
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="2",
+            name="owner/repo",
+        )
+        mock_contexts.return_value = MagicMock(
+            integration=MagicMock(),
+            organization_integrations=[MagicMock(organization_id=self.organization.id)],
+        )
+
+        result = resolve_check_suite_repository(
+            CheckSuiteFeedbackSource(
+                event={
+                    **_check_suite_event(),
+                    "installation": {"id": 1},
+                    "repository": {"id": 2, "html_url": "https://github.com/owner/repo"},
+                }
+            ).event
+        )
+
+        assert result is not None
+        assert result.id == repo.id

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -12,6 +12,7 @@ from sentry.seer.autofix.pr_iteration.feedback import (
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
+    CheckSuiteAutofixRun,
     CheckSuiteFeedbackSource,
     get_check_suite_url,
     resolve_check_suite_repository,
@@ -417,77 +418,77 @@ class CheckSuiteShouldTriggerTest(TestCase):
             }
         )
 
+    def _source_with_autofix_run(
+        self, head_sha="abc", *, repo: MagicMock | None = None
+    ) -> CheckSuiteFeedbackSource:
+        source = self._source(head_sha=head_sha)
+        source.__dict__["autofix_run"] = CheckSuiteAutofixRun(
+            repository=repo or MagicMock(organization_id=1, id=2),
+            run_state=_run_state(),
+            pr_id=1,
+            group_id=1,
+        )
+        return source
+
     def test_now_when_no_head_sha(self) -> None:
         assert self._source(head_sha="").should_trigger(_run_state()) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository", return_value=None)
-    def test_now_when_repository_none(self, _mock_resolve: MagicMock) -> None:
-        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+    def test_now_when_autofix_run_missing(self) -> None:
+        source = self._source()
+        source.__dict__["autofix_run"] = None
+
+        assert source.should_trigger(_run_state()) == ConsumeTask.Now
 
     @patch("sentry.scm.factory.new", side_effect=Exception("boom"))
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
-    def test_now_when_scm_init_fails(self, mock_resolve: MagicMock, _mock_new: MagicMock) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
-
-        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+    def test_now_when_scm_init_fails(self, _mock_new: MagicMock) -> None:
+        assert self._source_with_autofix_run().should_trigger(_run_state()) == ConsumeTask.Now
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", type("Other", (), {}))
     @patch("sentry.scm.factory.new")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
-    def test_now_when_unsupported_provider(
-        self, mock_resolve: MagicMock, mock_new: MagicMock
-    ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
+    def test_now_when_unsupported_provider(self, mock_new: MagicMock) -> None:
         mock_new.return_value = MagicMock()
 
-        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+        assert self._source_with_autofix_run().should_trigger(_run_state()) == ConsumeTask.Now
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
     def test_later_when_a_check_suite_not_completed(
         self,
-        mock_resolve: MagicMock,
         mock_new: MagicMock,
         mock_pages: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
         mock_new.return_value = MagicMock()
         mock_pages.return_value = [{"data": [{"status": "in_progress"}]}]
 
-        assert self._source().should_trigger(_run_state()) == ConsumeTask.Later(timedelta(hours=1))
+        assert self._source_with_autofix_run().should_trigger(_run_state()) == ConsumeTask.Later(
+            timedelta(hours=1)
+        )
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
     def test_now_when_all_completed(
         self,
-        mock_resolve: MagicMock,
         mock_new: MagicMock,
         mock_pages: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
         mock_new.return_value = MagicMock()
         mock_pages.return_value = [{"data": [{"status": "completed"}]}]
 
-        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+        assert self._source_with_autofix_run().should_trigger(_run_state()) == ConsumeTask.Now
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", side_effect=Exception("boom"))
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repository")
     def test_now_when_list_check_suites_fails(
         self,
-        mock_resolve: MagicMock,
         mock_new: MagicMock,
         _mock_pages: MagicMock,
     ) -> None:
-        mock_resolve.return_value = MagicMock(organization_id=1, id=2)
         mock_new.return_value = MagicMock()
 
-        assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
+        assert self._source_with_autofix_run().should_trigger(_run_state()) == ConsumeTask.Now
 
 
 class ResolveCheckSuiteRepositoryTest(TestCase):
@@ -548,3 +549,43 @@ class ResolveCheckSuiteRepositoryTest(TestCase):
 
         assert result is not None
         assert result.id == repo.id
+
+    @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
+    def test_returns_all_matching_repos_across_orgs(self, mock_contexts: MagicMock) -> None:
+        from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
+            resolve_check_suite_repositories,
+        )
+
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        repo_a = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="2",
+            name="owner/repo",
+        )
+        repo_b = self.create_repo(
+            project=other_project,
+            provider="integrations:github",
+            external_id="2",
+            name="owner/repo",
+        )
+        mock_contexts.return_value = MagicMock(
+            integration=MagicMock(),
+            organization_integrations=[
+                MagicMock(organization_id=self.organization.id),
+                MagicMock(organization_id=other_org.id),
+            ],
+        )
+
+        result = resolve_check_suite_repositories(
+            CheckSuiteFeedbackSource(
+                event={
+                    **_check_suite_event(),
+                    "installation": {"id": 1},
+                    "repository": {"id": 2, "html_url": "https://github.com/owner/repo"},
+                }
+            ).event
+        )
+
+        assert {repo.id for repo in result} == {repo_a.id, repo_b.id}

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -15,7 +15,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteAutofixRun,
     CheckSuiteFeedbackSource,
     get_check_suite_url,
-    resolve_check_suite_repository,
+    resolve_check_suite_repositories,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubIssueComment,
@@ -491,28 +491,28 @@ class CheckSuiteShouldTriggerTest(TestCase):
         assert self._source_with_autofix_run().should_trigger(_run_state()) == ConsumeTask.Now
 
 
-class ResolveCheckSuiteRepositoryTest(TestCase):
-    def test_none_when_missing_ids(self) -> None:
+class ResolveCheckSuiteRepositoriesTest(TestCase):
+    def test_empty_when_missing_ids(self) -> None:
         assert (
-            resolve_check_suite_repository(
+            resolve_check_suite_repositories(
                 CheckSuiteFeedbackSource(event=_check_suite_event()).event
             )
-            is None
+            == []
         )
         assert (
-            resolve_check_suite_repository(
+            resolve_check_suite_repositories(
                 CheckSuiteFeedbackSource(
                     event={**_check_suite_event(), "installation": {"id": 1}}
                 ).event
             )
-            is None
+            == []
         )
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
-    def test_none_when_no_integration(self, mock_contexts: MagicMock) -> None:
+    def test_empty_when_no_integration(self, mock_contexts: MagicMock) -> None:
         mock_contexts.return_value = MagicMock(integration=None, organization_integrations=[])
 
-        result = resolve_check_suite_repository(
+        result = resolve_check_suite_repositories(
             CheckSuiteFeedbackSource(
                 event={
                     **_check_suite_event(),
@@ -522,10 +522,10 @@ class ResolveCheckSuiteRepositoryTest(TestCase):
             ).event
         )
 
-        assert result is None
+        assert result == []
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
-    def test_returns_matching_repo(self, mock_contexts: MagicMock) -> None:
+    def test_returns_matching_repos(self, mock_contexts: MagicMock) -> None:
         repo = self.create_repo(
             project=self.project,
             provider="integrations:github",
@@ -537,7 +537,7 @@ class ResolveCheckSuiteRepositoryTest(TestCase):
             organization_integrations=[MagicMock(organization_id=self.organization.id)],
         )
 
-        result = resolve_check_suite_repository(
+        result = resolve_check_suite_repositories(
             CheckSuiteFeedbackSource(
                 event={
                     **_check_suite_event(),
@@ -547,15 +547,10 @@ class ResolveCheckSuiteRepositoryTest(TestCase):
             ).event
         )
 
-        assert result is not None
-        assert result.id == repo.id
+        assert [r.id for r in result] == [repo.id]
 
     @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
     def test_returns_all_matching_repos_across_orgs(self, mock_contexts: MagicMock) -> None:
-        from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
-            resolve_check_suite_repositories,
-        )
-
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
         repo_a = self.create_repo(

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -403,6 +403,52 @@ class CheckSuiteShouldConsumeTest(TestCase):
 
         assert source.should_consume(_run_state()) is False
 
+    def test_false_when_check_suite_already_processed(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event())
+        prior = Feedback(source=CheckSuiteFeedbackSource(event=self._event()))
+        block = MemoryBlock(
+            id="iter-0",
+            message=Message(
+                role="assistant",
+                metadata={
+                    "step": "pr_iteration",
+                    "iteration_index": "0",
+                    "feedback": serialize_feedback([prior]),
+                },
+            ),
+            timestamp="2024-01-01T00:00:00Z",
+        )
+        state = _run_state(
+            blocks=[block],
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+        )
+
+        assert source.should_consume(state) is False
+
+    def test_true_when_different_check_suite_id(self) -> None:
+        source = CheckSuiteFeedbackSource(event=self._event())
+        other_event = self._event()
+        other_event["check_suite"] = {**other_event["check_suite"], "id": 99}
+        prior = Feedback(source=CheckSuiteFeedbackSource(event=other_event))
+        block = MemoryBlock(
+            id="iter-0",
+            message=Message(
+                role="assistant",
+                metadata={
+                    "step": "pr_iteration",
+                    "iteration_index": "0",
+                    "feedback": serialize_feedback([prior]),
+                },
+            ),
+            timestamp="2024-01-01T00:00:00Z",
+        )
+        state = _run_state(
+            blocks=[block],
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", commit_sha="abc")},
+        )
+
+        assert source.should_consume(state) is True
+
 
 class CheckSuiteShouldTriggerTest(TestCase):
     def _source(self, head_sha="abc") -> CheckSuiteFeedbackSource:

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -346,6 +346,22 @@ class TestIterationHelpers(TestCase):
         with pytest.raises(AssertionError):
             get_iterations(state)
 
+    @patch("sentry.seer.autofix.autofix_agent.sentry_sdk.capture_message")
+    def test_get_iterations_missing_feedback_reports_without_raising(
+        self, mock_capture: MagicMock
+    ) -> None:
+        # _iteration_block intentionally omits feedback metadata.
+        state = _state_with_blocks([_iteration_block(1)])
+
+        iterations = get_iterations(state)
+
+        assert [it.index for it in iterations] == [1]
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.args[0] == "PR_ITERATION block missing feedback metadata"
+        assert mock_capture.call_args.kwargs["level"] == "warning"
+        assert mock_capture.call_args.kwargs["extras"]["run_id"] == 67890
+        assert mock_capture.call_args.kwargs["extras"]["iteration_index"] == "1"
+
     def test_get_latest_iteration_index_returns_zero_without_iterations(self) -> None:
         state = _state_with_blocks([])
         assert get_latest_iteration_index(state) == 0


### PR DESCRIPTION
- add check suite feedback source, check suite webhook listener so failed GitHub check suites can drive autofix PR iterations. 
- Only act when the suite head matches the current PR head
- delay 1h while checks are still pending
- hard-cap consecutive check-suite-only iterations at 3