### PR TITLE
feat(seer): Add autofix-browser-notifications feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -275,6 +275,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-stream", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable browser notifications for autofix runs
+    manager.add("organizations:autofix-browser-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Show the "Open in Seer Agent (debug)" button in the autofix drawer
     manager.add("organizations:autofix-seer-agent-debug", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable autofix introspection for early stopping of autofix runs


### PR DESCRIPTION
Register the `organizations:autofix-browser-notifications` feature flag.

The frontend gates browser notifications for autofix runs on this flag (`useExplorerAutofix.tsx`), so it is registered with `api_expose=True`.

Rollout config (enabling it for all employees) lives in the companion PR: getsentry/sentry-options-automator#8668.

## Changes
- Add `organizations:autofix-browser-notifications` to `src/sentry/features/temporary.py` as a FLAGPOLE `OrganizationFeature` with `api_expose=True`.