### PR TITLE
fix(alerts): Ensure that incompatible metric alert messages are only shown for ticketing actions

### DIFF
--- a/static/app/views/automations/utils/getIncompatibleActionWarning.tsx
+++ b/static/app/views/automations/utils/getIncompatibleActionWarning.tsx
@@ -4,15 +4,14 @@ import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 
-const METRIC_DETECTOR_SUPPORTED_ACTIONS = new Set<ActionType>([
-  ActionType.EMAIL,
-  ActionType.SLACK,
-  ActionType.SLACK_STAGING,
-  ActionType.MSTEAMS,
-  ActionType.PAGERDUTY,
-  ActionType.OPSGENIE,
-  ActionType.DISCORD,
-  ActionType.SENTRY_APP,
+// Ticketing actions deliver via the issue-alert (create-a-ticket) path, which is
+// not wired up for metric issues. Every other action type fires for metric issues.
+const METRIC_DETECTOR_UNSUPPORTED_ACTIONS = new Set<ActionType>([
+  ActionType.GITHUB,
+  ActionType.GITHUB_ENTERPRISE,
+  ActionType.JIRA,
+  ActionType.JIRA_SERVER,
+  ActionType.AZURE_DEVOPS,
 ]);
 
 const SEER_ACTIVITY_SUPPORTED_ACTIONS = new Set<ActionType>([
@@ -48,7 +47,7 @@ export function getIncompatibleActionWarnings(
   }
 
   if (
-    !METRIC_DETECTOR_SUPPORTED_ACTIONS.has(action.type) &&
+    METRIC_DETECTOR_UNSUPPORTED_ACTIONS.has(action.type) &&
     connectedDetectors.some(detector => detector.type === 'metric_issue')
   ) {
     warnings.push(t('This action will not fire for metric issues.'));


### PR DESCRIPTION
Closes ISWF-3032

We were maintaining a whitelist on the frontend for actions which were supported by metric issues. It looks like it became out of date at some point since we added a fallback to support webhooks, but never updated this list.

I'm changing it from a whitelist to a blacklist to specifically target the ticketing actions which are the only unsupported action types.