### PR TITLE
feat(replays): roll out FutureTrackingProducer to eap_items

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3846,6 +3846,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Rolls out FutureTrackingProducer as the replays eap_items producer
+register(
+    "tasks.producer.replays-eap-items.rollout",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Rolls out the new TaskProducer to processing_errors tasks
 register(
     "tasks.producer.processing-errors.rollout",

--- a/src/sentry/replays/lib/kafka.py
+++ b/src/sentry/replays/lib/kafka.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka import FutureTrackingProducer, KafkaPayload
 from arroyo.types import Topic as ArroyoTopic
 from sentry_kafka_schemas.codecs import Codec
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
@@ -47,17 +47,19 @@ def _get_eap_items_producer(name: str = "sentry.replays.lib.kafka.eap_items"):
 
 
 eap_producer = SingletonProducer(_get_eap_items_producer)
-_eap_task_producer_name = "sentry.replays.lib.kafka.eap_items_taskproducer"
-eap_items_taskproducer = get_task_producer(
-    producer_name=_eap_task_producer_name,
+_eap_task_producer_name = "sentry.replays.lib.kafka.eap_items_ftp"
+eap_items_ft_producer = FutureTrackingProducer(
+    name=_eap_task_producer_name,
     producer_factory=partial(_get_eap_items_producer, name=_eap_task_producer_name),
 )
 
 
 def write_trace_items(trace_items: list[TraceItem]) -> None:
     """Publish trace-items to the EAP trace-items topic."""
-    if _in_process_replay_recording_task():
-        producer: SingletonProducer | TaskProducer = eap_items_taskproducer
+    if _in_process_replay_recording_task() or in_random_rollout(
+        "tasks.producer.replays-eap-items.rollout"
+    ):
+        producer: SingletonProducer | FutureTrackingProducer = eap_items_ft_producer
     else:
         producer = eap_producer
     topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"])

--- a/tests/sentry/replays/unit/test_event_logger.py
+++ b/tests/sentry/replays/unit/test_event_logger.py
@@ -28,6 +28,7 @@ from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 _ARROYO_PRODUCER_OPTIONS = {
     "arroyo.producer.record_poll_metrics": [],
     "arroyo.producer.poll_metric_frequency": 10,
+    "tasks.producer.replays-eap-items.rollout": 0.0,
 }
 
 


### PR DESCRIPTION
In #119245, after being set to use `FutureTrackingProducer` over `SingletonProducer`, the replay `eap_items` producer filled its produce buffer which caused issues. In #119565 I added polling metrics for our producers to see how often they poll librdkafka.

This PR allows configuring the replay `eap_items` producer to use `FutureTrackingProducer` based on a rollout option, which will let us gradually cut over to `FutureTrackingProducer` until we start to see the produce buffer begin to fill up. Once this happens, I expect to also see the poll rate go down.