### PR TITLE
chore(scm-project-creation-flow): Fixing flaky test

### DIFF
--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -44,7 +44,11 @@ class CreateProjectTest(AcceptanceTestCase):
         self.browser.wait_until(xpath="//h2[text()='Configure Laravel SDK']")
         project1 = Project.objects.get(organization=self.org, slug="php-laravel")
         self.browser.click('[aria-label="Back to Platform Selection"]')
-        self.browser.click("[data-test-id='platform-javascript-nextjs']")
+        self.browser.wait_until("[data-test-id='platform-javascript-nextjs']")
+        self.browser.driver.execute_script(
+            "arguments[0].click()",
+            self.browser.element("[data-test-id='platform-javascript-nextjs']"),
+        )
         self.browser.click('[data-test-id="create-project"]')
         self.browser.wait_until(xpath="//h2[text()='Configure Next.js SDK']")
         project2 = Project.objects.get(organization=self.org, slug="javascript-nextjs")


### PR DESCRIPTION
- Wait for the platform-javascript-nextjs card to render after going back before interacting with it.
- Click it via JS execute_script so the sticky header can't intercept the click and flake the test, common pattern in the codebase