### PR TITLE
fix(tracemetrics): Allow equations in validation endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_validate.py
+++ b/src/sentry/api/endpoints/organization_events_validate.py
@@ -10,16 +10,13 @@ from rest_framework.response import Response
 from sentry_protos.snuba.v1.endpoint_trace_item_attributes_pb2 import TraceItemAttributeNamesRequest
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey
-from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
-    ExistsFilter,
-    OrFilter,
-    TraceItemFilter,
-)
+from sentry_protos.snuba.v1.trace_item_filter_pb2 import ExistsFilter, OrFilter, TraceItemFilter
 
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase, UnknownEnvironments
 from sentry.api.utils import handle_query_errors
+from sentry.discover.arithmetic import is_equation, strip_equation
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.search.eap import constants
@@ -348,6 +345,7 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
         # Validate orderby
         orderby_validity = []
         orderby_columns = self.get_orderby(request)
+        equation_list = self.get_equation_list(organization, request)
         if orderby_columns:
             for orderby in orderby_columns:
                 stripped_orderby = orderby.lstrip("-")
@@ -364,6 +362,13 @@ class OrganizationEventsValidateEndpoint(OrganizationEventsEndpointBase):
                         )
                         found = True
                         break
+                if not found and is_equation(stripped_orderby):
+                    equation_body = strip_equation(stripped_orderby)
+                    if equation_body in equation_list:
+                        orderby_validity.append(
+                            AttributeValidation(attrType=None, error=None, name=orderby, valid=True)
+                        )
+                        found = True
                 if not found:
                     response.valid = False
                     orderby_validity.append(

--- a/tests/sentry/api/endpoints/test_organization_events_validate.py
+++ b/tests/sentry/api/endpoints/test_organization_events_validate.py
@@ -309,6 +309,51 @@ class OrganizationEventsValidateEndpointTest(APITestCase, SnubaTestCase, SpanTes
             },
         ]
 
+    def test_valid_equation_orderby(self) -> None:
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "dataset": "spans",
+                "field": [
+                    "equation|avg(span.duration) * 2",
+                    "span.duration",
+                ],
+                "orderby": ["-equation|avg(span.duration) * 2"],
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["valid"]
+        assert response.data["orderby"] == [
+            {
+                "error": None,
+                "name": "-equation|avg(span.duration) * 2",
+                "valid": True,
+                "attrType": None,
+            },
+        ]
+
+    def test_invalid_equation_orderby(self) -> None:
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "dataset": "spans",
+                "field": ["span.duration"],
+                "orderby": ["-equation|avg(span.duration) * 2"],
+            }
+        )
+
+        assert response.status_code == 400, response.content
+        assert not response.data["valid"]
+        assert response.data["orderby"] == [
+            {
+                "error": "Orderby must also be a selected field",
+                "name": "-equation|avg(span.duration) * 2",
+                "valid": False,
+                "attrType": None,
+            },
+        ]
+
     def test_invalid_environment(self) -> None:
         response = self.do_request(
             {


### PR DESCRIPTION
At the moment, any equations get dropped from the orderby check, so attempting to validate a query with an orderby that is an equation will return a validation error. Instead, use the orderby and look it up in the fields. If it's in fields, it should be a valid request.

This fixes issues where Seer is trying to generate an equation with the assisted query agent, and the request is failing with, e.g.:
```
{
error: "Failed to execute query. Please review the reason and try again.",
reason: "Query validation failed:
- orderby '-equation|avg(value, dashboards.on_completion_hook.generation_attempts, distribution, none) * 2': Orderby must also be a selected field",
success: false
}
```