### PR TITLE
perf(explore): Re-balance heat map chunk loading

### DIFF
--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.spec.tsx
@@ -52,40 +52,26 @@ describe('partitionDateTimeIntoHeatMapWindows', () => {
 
   describe('Absolute ranges', () => {
     it('Partitions into aligned, non-overlapping, progressive windows', () => {
-      // 720 buckets (30d @ 1h). Asserts the invariants of a progressive
-      // partition rather than the exact widths, so the sizing constants can be
-      // retuned without rewriting the test.
-      const totalHours = 720;
+      // 720 buckets (30d @ 1h), progressive → widths [341, 227, 152].
       const {windows, timeDomain} = partitionDateTimeIntoHeatMapWindows(
-        absolute(BASE_MS, BASE_MS + totalHours * HOUR),
+        absolute(BASE_MS, BASE_MS + 720 * HOUR),
         '1h',
         'progressive'
       );
 
-      expect(timeDomain).toEqual({start: BASE_MS, end: BASE_MS + totalHours * HOUR});
+      expect(timeDomain).toEqual({start: BASE_MS, end: BASE_MS + 720 * HOUR});
       const absoluteWindows = windows as Array<{end: string; start: string}>;
-      const spans = absoluteWindows.map(spanHours);
 
-      // Split into multiple windows.
-      expect(absoluteWindows.length).toBeGreaterThan(1);
+      expect(absoluteWindows.map(spanHours)).toEqual([341, 227, 152]);
 
       // Contiguous (no overlap), covering the whole range.
       expect(moment.utc(absoluteWindows[0]!.start).valueOf()).toBe(BASE_MS);
       expect(moment.utc(absoluteWindows.at(-1)!.end).valueOf()).toBe(
-        BASE_MS + totalHours * HOUR
+        BASE_MS + 720 * HOUR
       );
       for (let i = 1; i < absoluteWindows.length; i++) {
         expect(absoluteWindows[i]!.start).toBe(absoluteWindows[i - 1]!.end);
       }
-
-      // Progressive: windows shrink toward the present (oldest first, so spans
-      // are non-increasing).
-      for (let i = 1; i < spans.length; i++) {
-        expect(spans[i]!).toBeLessThanOrEqual(spans[i - 1]!);
-      }
-
-      // The rebalance goal: no single chunk is more than half the grid.
-      expect(Math.max(...spans)).toBeLessThan(totalHours / 2);
     });
 
     it('Partitions equally when asked', () => {
@@ -110,44 +96,17 @@ describe('partitionDateTimeIntoHeatMapWindows', () => {
     });
 
     it('Partitions into statsPeriod offsets that overlap the newer neighbor', () => {
-      // Asserts the structure of a relative partition (newest-first, bounded
-      // older windows that overlap their newer neighbor) rather than the exact
-      // offsets, so the sizing constants can be retuned freely.
       const {windows} = partitionDateTimeIntoHeatMapWindows(
         relative('30d'),
         '1h',
         'progressive'
       );
 
-      const parsed = windows as Array<{
-        statsPeriod?: string;
-        statsPeriodEnd?: string;
-        statsPeriodStart?: string;
-      }>;
-      const secondsAgo = (value: string) => parseInt(value, 10);
-
-      expect(parsed.length).toBeGreaterThan(1);
-
-      // The newest window runs to now: a bare statsPeriod with no explicit end.
-      expect(parsed[0]).toEqual({statsPeriod: expect.any(String)});
-
-      // Older windows are bounded ranges.
-      for (const window of parsed.slice(1)) {
-        expect(window.statsPeriodStart).toEqual(expect.any(String));
-        expect(window.statsPeriodEnd).toEqual(expect.any(String));
-      }
-
-      // Each window's older edge ("seconds ago"), and its newer edge (0 for the
-      // live window that runs to now).
-      const olderEdge = parsed.map(w => secondsAgo((w.statsPeriodStart ?? w.statsPeriod)!));
-      const newerEdge = parsed.map(w => (w.statsPeriodEnd ? secondsAgo(w.statsPeriodEnd) : 0));
-
-      for (let i = 1; i < parsed.length; i++) {
-        // Newest-first: each window reaches further into the past.
-        expect(olderEdge[i]!).toBeGreaterThan(olderEdge[i - 1]!);
-        // ...and overlaps its newer neighbor (its newer edge sits inside it).
-        expect(newerEdge[i]!).toBeLessThan(olderEdge[i - 1]!);
-      }
+      expect(windows).toEqual([
+        {statsPeriod: '547200s'}, //                                  [152h ago, now]
+        {statsPeriodStart: '1364400s', statsPeriodEnd: '540000s'}, //  [379h, 150h]
+        {statsPeriodStart: '2592000s', statsPeriodEnd: '1357200s'}, // [720h, 377h]
+      ]);
     });
   });
 });

--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.spec.tsx
@@ -52,26 +52,40 @@ describe('partitionDateTimeIntoHeatMapWindows', () => {
 
   describe('Absolute ranges', () => {
     it('Partitions into aligned, non-overlapping, progressive windows', () => {
-      // 720 buckets (30d @ 1h), progressive → widths [55, 166, 499].
+      // 720 buckets (30d @ 1h). Asserts the invariants of a progressive
+      // partition rather than the exact widths, so the sizing constants can be
+      // retuned without rewriting the test.
+      const totalHours = 720;
       const {windows, timeDomain} = partitionDateTimeIntoHeatMapWindows(
-        absolute(BASE_MS, BASE_MS + 720 * HOUR),
+        absolute(BASE_MS, BASE_MS + totalHours * HOUR),
         '1h',
         'progressive'
       );
 
-      expect(timeDomain).toEqual({start: BASE_MS, end: BASE_MS + 720 * HOUR});
+      expect(timeDomain).toEqual({start: BASE_MS, end: BASE_MS + totalHours * HOUR});
       const absoluteWindows = windows as Array<{end: string; start: string}>;
+      const spans = absoluteWindows.map(spanHours);
 
-      expect(absoluteWindows.map(spanHours)).toEqual([499, 166, 55]);
+      // Split into multiple windows.
+      expect(absoluteWindows.length).toBeGreaterThan(1);
 
       // Contiguous (no overlap), covering the whole range.
       expect(moment.utc(absoluteWindows[0]!.start).valueOf()).toBe(BASE_MS);
       expect(moment.utc(absoluteWindows.at(-1)!.end).valueOf()).toBe(
-        BASE_MS + 720 * HOUR
+        BASE_MS + totalHours * HOUR
       );
       for (let i = 1; i < absoluteWindows.length; i++) {
         expect(absoluteWindows[i]!.start).toBe(absoluteWindows[i - 1]!.end);
       }
+
+      // Progressive: windows shrink toward the present (oldest first, so spans
+      // are non-increasing).
+      for (let i = 1; i < spans.length; i++) {
+        expect(spans[i]!).toBeLessThanOrEqual(spans[i - 1]!);
+      }
+
+      // The rebalance goal: no single chunk is more than half the grid.
+      expect(Math.max(...spans)).toBeLessThan(totalHours / 2);
     });
 
     it('Partitions equally when asked', () => {
@@ -96,17 +110,44 @@ describe('partitionDateTimeIntoHeatMapWindows', () => {
     });
 
     it('Partitions into statsPeriod offsets that overlap the newer neighbor', () => {
+      // Asserts the structure of a relative partition (newest-first, bounded
+      // older windows that overlap their newer neighbor) rather than the exact
+      // offsets, so the sizing constants can be retuned freely.
       const {windows} = partitionDateTimeIntoHeatMapWindows(
         relative('30d'),
         '1h',
         'progressive'
       );
 
-      expect(windows).toEqual([
-        {statsPeriod: '198000s'}, //                                 [55h ago, now]
-        {statsPeriodStart: '795600s', statsPeriodEnd: '190800s'}, //  [221h, 53h]
-        {statsPeriodStart: '2592000s', statsPeriodEnd: '788400s'}, // [720h, 219h]
-      ]);
+      const parsed = windows as Array<{
+        statsPeriod?: string;
+        statsPeriodEnd?: string;
+        statsPeriodStart?: string;
+      }>;
+      const secondsAgo = (value: string) => parseInt(value, 10);
+
+      expect(parsed.length).toBeGreaterThan(1);
+
+      // The newest window runs to now: a bare statsPeriod with no explicit end.
+      expect(parsed[0]).toEqual({statsPeriod: expect.any(String)});
+
+      // Older windows are bounded ranges.
+      for (const window of parsed.slice(1)) {
+        expect(window.statsPeriodStart).toEqual(expect.any(String));
+        expect(window.statsPeriodEnd).toEqual(expect.any(String));
+      }
+
+      // Each window's older edge ("seconds ago"), and its newer edge (0 for the
+      // live window that runs to now).
+      const olderEdge = parsed.map(w => secondsAgo((w.statsPeriodStart ?? w.statsPeriod)!));
+      const newerEdge = parsed.map(w => (w.statsPeriodEnd ? secondsAgo(w.statsPeriodEnd) : 0));
+
+      for (let i = 1; i < parsed.length; i++) {
+        // Newest-first: each window reaches further into the past.
+        expect(olderEdge[i]!).toBeGreaterThan(olderEdge[i - 1]!);
+        // ...and overlaps its newer neighbor (its newer edge sits inside it).
+        expect(newerEdge[i]!).toBeLessThan(olderEdge[i - 1]!);
+      }
     });
   });
 });

--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
@@ -108,9 +108,9 @@ export function dateTimeAsHeatMapWindow(datetime: DateTimeFilter): HeatMapWindow
 
 /**
  * Splits buckets across windows, newest/smallest first, with the oldest window
- * taking the remainder. Returns the per-window bucket counts. `progressive`
- * weights each older window `GROWTH_FACTOR`× larger than the one after it;
- * `equal` weights them uniformly.
+ * taking the remainder. Returns the per-window bucket counts. e.g., 720 buckets
+ * becomes progressive (weights 1:1.5:2.25): `[152, 227, 341]`; equal: `[240, 240,
+ * 240]`.
  */
 function distributeBucketCount(
   totalBuckets: number,
@@ -127,7 +127,8 @@ function distributeBucketCount(
 
   for (let i = 0; i < CHUNK_COUNT - 1 && remaining > 0; i++) {
     // This window's weighted share of the total, floored at 1 bucket and capped
-    // at what's left. The final (oldest) window takes whatever remains.
+    // at what's left. e.g., progressive 720: 152 (=round(720/4.75)), 227, then the
+    // oldest window takes the remaining 341.
     const target = Math.round((totalBuckets * weights[i]!) / weightSum);
     const count = Math.min(Math.max(target, 1), remaining);
     bucketDistribution.push(count);
@@ -220,8 +221,7 @@ function pageFilterDateTimeToTimeDomain(
 const CHUNK_COUNT = 3;
 
 // For the `progressive` strategy: each older window is this many times larger
-// than the one after it. Kept below the golden ratio (~1.618) so the largest
-// (oldest) window stays under half the grid.
+// than the one after it.
 const GROWTH_FACTOR = 1.5;
 
 // Ranges shorter than this aren't worth partitioning — a single request is fast.

--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
@@ -108,9 +108,9 @@ export function dateTimeAsHeatMapWindow(datetime: DateTimeFilter): HeatMapWindow
 
 /**
  * Splits buckets across windows, newest/smallest first, with the oldest window
- * taking the remainder. Returns the per-window bucket counts. e.g., 720 buckets
- * becomes progressive (weights 1:3:9): `[55, 166, 499]`; equal: `[240, 240,
- * 240]`.
+ * taking the remainder. Returns the per-window bucket counts. `progressive`
+ * weights each older window `GROWTH_FACTOR`× larger than the one after it;
+ * `equal` weights them uniformly.
  */
 function distributeBucketCount(
   totalBuckets: number,
@@ -127,8 +127,7 @@ function distributeBucketCount(
 
   for (let i = 0; i < CHUNK_COUNT - 1 && remaining > 0; i++) {
     // This window's weighted share of the total, floored at 1 bucket and capped
-    // at what's left. e.g., progressive 720: 55 (=round(720/13)), 166, then the
-    // oldest window takes the remaining 499.
+    // at what's left. The final (oldest) window takes whatever remains.
     const target = Math.round((totalBuckets * weights[i]!) / weightSum);
     const count = Math.min(Math.max(target, 1), remaining);
     bucketDistribution.push(count);
@@ -221,8 +220,9 @@ function pageFilterDateTimeToTimeDomain(
 const CHUNK_COUNT = 3;
 
 // For the `progressive` strategy: each older window is this many times larger
-// than the one after it.
-const GROWTH_FACTOR = 3;
+// than the one after it. Kept below the golden ratio (~1.618) so the largest
+// (oldest) window stays under half the grid.
+const GROWTH_FACTOR = 1.5;
 
 // Ranges shorter than this aren't worth partitioning — a single request is fast.
 const MINIMUM_PARTITION_RANGE = 1000 * 60 * 60 * 24; // 1 day

--- a/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
+++ b/static/app/views/explore/metrics/hooks/partitionHeatMapWindows.tsx
@@ -109,7 +109,7 @@ export function dateTimeAsHeatMapWindow(datetime: DateTimeFilter): HeatMapWindow
 /**
  * Splits buckets across windows, newest/smallest first, with the oldest window
  * taking the remainder. Returns the per-window bucket counts. e.g., 720 buckets
- * becomes progressive (weights 1:1.5:2.25): `[152, 227, 341]`; equal: `[240, 240,
+ * becomes progressive (weights 1:3:9): `[55, 166, 499]`; equal: `[240, 240,
  * 240]`.
  */
 function distributeBucketCount(
@@ -127,8 +127,8 @@ function distributeBucketCount(
 
   for (let i = 0; i < CHUNK_COUNT - 1 && remaining > 0; i++) {
     // This window's weighted share of the total, floored at 1 bucket and capped
-    // at what's left. e.g., progressive 720: 152 (=round(720/4.75)), 227, then the
-    // oldest window takes the remaining 341.
+    // at what's left. e.g., progressive 720: 55 (=round(720/13)), 166, then the
+    // oldest window takes the remaining 499.
     const target = Math.round((totalBuckets * weights[i]!) / weightSum);
     const count = Math.min(Math.max(target, 1), remaining);
     bucketDistribution.push(count);


### PR DESCRIPTION
The current Heat Map chunk loading progression _heavily_ biases towards new data. The most recent chunk is very small and loads fast, and the old chunk is really big and loads slowly. This isn't very good, since we're not getting most of the gains from split loading. The Heat Map is not interactive during load (maybe I should fix this actually) so it's better to just have bigger more event chunks.

With this PR, the oldest chunk is ~50% of the data, which seems decent.

Closes DAIN-1791