### PR TITLE
fix(project-creation): Stop the SCM alert section bouncing on option switch

### DIFF
--- a/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
+++ b/static/app/views/onboarding/components/scmAlertFrequencySection.tsx
@@ -13,6 +13,7 @@ import {
 
 import {ScmAlertFrequency} from './scmAlertFrequency';
 import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
 import {ScmCollapsibleSection} from './scmCollapsibleSection';
 import {ScmIssueAlertNotificationOptions} from './scmIssueAlertNotificationOptions';
 
@@ -42,11 +43,18 @@ export function ScmAlertFrequencySection({
   const collapsible = analyticsFlow === 'project-creation';
 
   // Notification options are irrelevant when the user opts out of alerts, so
-  // hide them for "create alerts later" (mirrors issueAlertOptions).
-  const notificationOptions =
-    alertRuleConfig.alertSetting === RuleAction.CREATE_ALERT_LATER ? null : (
+  // hide them for "create alerts later" (mirrors issueAlertOptions). Route the
+  // show/hide through the shared height tween: on the custom -> "set up later"
+  // switch the custom-threshold body collapses via its own ScmCollapsibleReveal,
+  // so snapping this block to null at the same time bounces the whole form.
+  // Animating its height keeps the shift smooth and anchored from the bottom.
+  const notificationOptions = (
+    <ScmCollapsibleReveal
+      open={alertRuleConfig.alertSetting !== RuleAction.CREATE_ALERT_LATER}
+    >
       <ScmIssueAlertNotificationOptions {...notificationProps} />
-    );
+    </ScmCollapsibleReveal>
+  );
 
   const footer = (
     <Flex gap="sm" align="center">

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -284,7 +284,7 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
               width="100%"
               border="primary"
               radius="lg"
-              layout="size"
+              layout
             >
               <Layout.Title>{t('Create a new project')}</Layout.Title>
 


### PR DESCRIPTION
## TLDR

Switching between alert options in the SCM project-details form no longer bounces the whole form from the top; the height now shifts from the bottom as content appears and collapses.

## Details

The bounce only reproduced on the switch *to* "I'll set up alerts later" (custom → high-priority was fine), because that is the only transition that also removes the notification-options block — so the fix has to make both the card and that block animate together rather than one snapping while the other tweens.

The create-project card in `scmCreateProject.tsx` used framer-motion `layout="size"`, which scale-animates a size change without correcting position, so the top edge drifted as the box scaled. Switching to full `layout` corrects position (the top stays anchored) *and* animates size, so the card border tracks its content height in lockstep with the `layout="position"` children under the same `LayoutGroup` instead of snapping.

The notification-options block in `scmAlertFrequencySection.tsx` flipped between a rendered component and `null` with no transition. When the custom-threshold body collapsed via its own height tween, the block vanished in a single frame, snapping the height. It now hides through the shared `ScmCollapsibleReveal` so it collapses with the same tween. This also fixes the onboarding surface, which has no `LayoutGroup` and would otherwise snap regardless of the card change.

Full `layout` was the third value tried on the card. `layout="size"` (the original) bounces because it never corrects position; removing the layout prop entirely makes the border resize instantly while the `layout="position"` children transform outside it, so content briefly renders past the card edge. Full `layout` is the only value that keeps the top anchored and the border synced with the content.

Fixes CORE-264