### PR TITLE
fix(ourlogs): prefetch trace item details on hover for embedded rows

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -280,6 +280,40 @@ describe('logsTableRow', () => {
     jest.useRealTimers();
   });
 
+  it.isKnownFlake(
+    'hovering an embedded row causes prefetching of the row details',
+    async () => {
+      jest.useFakeTimers();
+      expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+      render(
+        <LogRowContent
+          dataRow={rowData}
+          highlightTerms={[]}
+          meta={LogFixtureMeta(rowData)}
+          sharedHoverTimeoutRef={{current: null}}
+          embedded
+          blockRowExpanding
+          onEmbeddedRowClick={jest.fn()}
+        />,
+        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+      );
+
+      const row = screen.getByTestId('log-table-row');
+      await userEvent.hover(row, {delay: null});
+
+      act(() => {
+        jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+      });
+
+      await waitFor(() => {
+        expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+      });
+      // Flush the .then() callback that reads cached data after prefetch
+      await act(async () => {});
+      jest.useRealTimers();
+    }
+  );
+
   it.isKnownFlake('renders row details', async () => {
     render(
       <LogRowContent

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -280,39 +280,36 @@ describe('logsTableRow', () => {
     jest.useRealTimers();
   });
 
-  it.isKnownFlake(
-    'hovering an embedded row causes prefetching of the row details',
-    async () => {
-      jest.useFakeTimers();
-      expect(rowDetailsMock).toHaveBeenCalledTimes(0);
-      render(
-        <LogRowContent
-          dataRow={rowData}
-          highlightTerms={[]}
-          meta={LogFixtureMeta(rowData)}
-          sharedHoverTimeoutRef={{current: null}}
-          embedded
-          blockRowExpanding
-          onEmbeddedRowClick={jest.fn()}
-        />,
-        {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
-      );
+  it('hovering an embedded row causes prefetching of the row details', async () => {
+    jest.useFakeTimers();
+    expect(rowDetailsMock).toHaveBeenCalledTimes(0);
+    render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{current: null}}
+        embedded
+        blockRowExpanding
+        onEmbeddedRowClick={jest.fn()}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
 
-      const row = screen.getByTestId('log-table-row');
-      await userEvent.hover(row, {delay: null});
+    const row = screen.getByTestId('log-table-row');
+    await userEvent.hover(row, {delay: null});
 
-      act(() => {
-        jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
-      });
+    act(() => {
+      jest.advanceTimersByTime(DEFAULT_TRACE_ITEM_HOVER_TIMEOUT + 1);
+    });
 
-      await waitFor(() => {
-        expect(rowDetailsMock).toHaveBeenCalledTimes(1);
-      });
-      // Flush the .then() callback that reads cached data after prefetch
-      await act(async () => {});
-      jest.useRealTimers();
-    }
-  );
+    await waitFor(() => {
+      expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+    });
+    // Flush the .then() callback that reads cached data after prefetch
+    await act(async () => {});
+    jest.useRealTimers();
+  });
 
   it.isKnownFlake('renders row details', async () => {
     render(

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -277,7 +277,6 @@ describe('logsTableRow', () => {
       timestamp: Math.trunc(rowDataTimestamp),
     });
     expect(rowDetailsMock.mock.calls[0]![1].query).not.toHaveProperty('statsPeriod');
-    jest.useRealTimers();
   });
 
   it('hovering an embedded row causes prefetching of the row details', async () => {
@@ -308,7 +307,6 @@ describe('logsTableRow', () => {
     });
     // Flush the .then() callback that reads cached data after prefetch
     await act(async () => {});
-    jest.useRealTimers();
   });
 
   it.isKnownFlake('renders row details', async () => {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -397,8 +397,8 @@ export const LogRowContent = memo(function LogRowContent({
     ? {isClickable: false}
     : blockRowExpanding
       ? onEmbeddedRowClick
-        ? {onClick, isClickable: true}
-        : {}
+        ? {...hoverProps, onClick, isClickable: true}
+        : {...hoverProps}
       : {
           ...hoverProps,
           onPointerUp,


### PR DESCRIPTION
Back in #115505 & #116804 I'd missed a place to put hover props in embedded row branches that cause hover to trigger prefetching.

Example from `/issues/7521426076?project=11276#logs`:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="287" height="152" alt="image" src="https://github.com/user-attachments/assets/3b207e99-c08b-4736-a8d5-1e24beaa78e3" />
</td>
<td>
<img width="287" height="152" alt="image" src="https://github.com/user-attachments/assets/eabad5a1-39d2-416f-ae69-b6b07f47a997" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-921
