### PR TITLE
fix(autofix): Import usePrompt instead of usePrompts for checking autofix-sw-notification

### DIFF
--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -94,6 +94,7 @@ interface SeerDrawerArtifactsProps {
 
 function SeerDrawerArtifacts({autofix, groupId, sections}: SeerDrawerArtifactsProps) {
   const organization = useOrganization();
+
   return (
     <Fragment>
       {sections.map(section => {

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -62,7 +62,11 @@ export function SeerEnableNotifications() {
     supportsNotifications,
   ]);
 
-  if (!isServiceWorkerSupported || !supportsNotifications || isPromptDismissed) {
+  if (
+    !isServiceWorkerSupported ||
+    !supportsNotifications ||
+    isPromptDismissed !== false
+  ) {
     return null;
   }
 
@@ -140,7 +144,7 @@ export function SeerEnableNotifications() {
               analyticsParams={{surface: analyticsArea}}
               variant="transparent"
               size="sm"
-              onClick={() => snoozePrompt(PROMPT_FEATURE)}
+              onClick={() => snoozePrompt()}
             >
               {t("Don't ask again")}
             </Button>

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -7,7 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {usePrompts} from 'sentry/actionCreators/prompts';
+import {usePrompt} from 'sentry/actionCreators/prompts';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {IconSubscribed} from 'sentry/icons/iconSubscribed';
 import {t} from 'sentry/locale';
@@ -29,8 +29,8 @@ export function SeerEnableNotifications() {
 
   const analyticsArea = useAnalyticsArea();
 
-  const {isPromptDismissed, snoozePrompt} = usePrompts({
-    features: [PROMPT_FEATURE],
+  const {isPromptDismissed, snoozePrompt} = usePrompt({
+    feature: PROMPT_FEATURE,
     organization,
   });
 
@@ -122,7 +122,7 @@ export function SeerEnableNotifications() {
               analyticsEventKey="seer-enable-notifications.notify-me.clicked"
               analyticsParams={{surface: analyticsArea}}
               variant="primary"
-              size="md"
+              size="sm"
               onClick={() => {
                 askNotificationPermission().then(() => {
                   setIsSuccessVisible(true);
@@ -139,7 +139,7 @@ export function SeerEnableNotifications() {
               analyticsEventKey="seer-enable-notifications.snooze.clicked"
               analyticsParams={{surface: analyticsArea}}
               variant="transparent"
-              size="md"
+              size="sm"
               onClick={() => snoozePrompt(PROMPT_FEATURE)}
             >
               {t("Don't ask again")}


### PR DESCRIPTION
Calling `usePrompts` with one item in the list wasn't right, the `isPromptDismissed` value was an object and i wasn't using it properly before :(

Now it's returned as a `boolean | undefined` instead of `Record<string, boolean>` which is what the code expects.


Also i tweaked the button sizes to look better imo
| Before | After |
| --- | --- |
| <img width="1283" height="944" alt="SCR-20260710-pchn" src="https://github.com/user-attachments/assets/eb3e9e11-c850-41d4-be50-e68dbfaf5a73" /> | <img width="691" height="287" alt="SCR-20260715-kujz" src="https://github.com/user-attachments/assets/86f8ac96-b654-4933-bbef-a86998c1698e" />
