### PR TITLE
ref(trace-items): Always store metric context at org level

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -106,21 +106,6 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         except NoProjects:
             return Response({"detail": "No projects available."}, status=400)
 
-        # Scope to a single project, or org-wide for the all-projects sentinel
-        # (`-1`/`$all`); no subset in between.
-        if self.get_requested_project_params_unchecked(request).has_all_projects_sentinel:
-            scope_project = None
-        elif len(snuba_params.projects) == 1:
-            scope_project = snuba_params.projects[0]
-        else:
-            return Response(
-                {
-                    "detail": "Pass a single `project`, or all projects "
-                    "(`-1`/`$all`) for organization-wide context."
-                },
-                status=400,
-            )
-
         adjusted_start, adjusted_end = adjust_start_end_window(
             snuba_params.start_date, snuba_params.end_date
         )
@@ -161,9 +146,11 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         }
         # Race-safe: the lookup kwargs match the unique constraints, so a losing
         # concurrent INSERT is caught by update_or_create rather than 500ing.
+        # Metric context is always org-level for now (project-scoped context is
+        # not supported yet), so it is never scoped to a specific project.
         context, created = TraceItemAttributeValueContext.objects.update_or_create(
             organization=organization,
-            project=scope_project,
+            project=None,
             item_type=TraceItemTypes.get_id_for_type_name(
                 SupportedTraceItemType.TRACEMETRICS.value
             ),

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -71,13 +71,14 @@ class OrganizationTraceItemMetricContextEndpointTest(
         assert response.data["attributeValue"] == "checkout.requests"
         assert response.data["dataset"] == "tracemetrics"
         assert response.data["attributeType"] == "counter"
-        assert response.data["project"] == str(self.project.id)
+        # Context is always org-level for now, even though a project was passed.
+        assert response.data["project"] is None
         assert response.data["brief"] == "Checkout requests"
         assert response.data["additionalContext"] == "Longer notes about the metric."
 
         context = TraceItemAttributeValueContext.objects.get(
             organization=self.organization,
-            project=self.project,
+            project=None,
             attribute_value="checkout.requests",
         )
         assert context.attribute_name == "metric.name"
@@ -210,35 +211,26 @@ class OrganizationTraceItemMetricContextEndpointTest(
         assert response.status_code == 400, response.data
         assert "metricType" in response.data
 
-    def test_org_wide_context(self) -> None:
+    def test_writes_org_level_for_multiple_projects(self) -> None:
+        # Any project selection (including multiple projects) writes org-level
+        # context — the project scope is not used.
+        other_project = self.create_project(organization=self.organization)
         self.store_metric("checkout.requests")
 
-        response = self.do_request(
-            "checkout.requests",
-            {
-                "metricType": "counter",
-                "brief": "Checkout requests",
+        url = reverse(
+            self.viewname,
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "metric": "checkout.requests",
             },
-            query={"project": -1},
         )
-
-        assert response.status_code == 201, response.data
-        assert response.data["project"] is None
-        context = TraceItemAttributeValueContext.objects.get(attribute_value="checkout.requests")
-        assert context.project_id is None
-
-    def test_org_wide_context_all_projects_sentinel(self) -> None:
-        self.store_metric("checkout.requests")
-
-        # `$all` is the other all-projects sentinel and must also scope org-wide.
-        response = self.do_request(
-            "checkout.requests",
-            {
-                "metricType": "counter",
-                "brief": "Checkout requests",
-            },
-            query={"project": "$all"},
-        )
+        with self.feature(self.feature_flags):
+            response = self.client.put(
+                url,
+                {"metricType": "counter", "brief": "Checkout requests"},
+                format="json",
+                QUERY_STRING=f"project={self.project.id}&project={other_project.id}",
+            )
 
         assert response.status_code == 201, response.data
         assert response.data["project"] is None


### PR DESCRIPTION
The metric context `PUT /organizations/{org}/trace-items/metrics/{metric}/context/` endpoint no longer supports project-scoped context. It always writes **org-level** context (`project = NULL`), regardless of the `project` query param.

## Behavior change

Before, the endpoint scoped context to a single project (or org-wide for the `-1`/`$all` sentinel) and rejected multi-project requests with a 400. Now:

- The `project` selection is used only for the metric-existence check; the stored row is always org-level.
- Any project selection — including multiple projects — is accepted (no more 400).

## Why

Project-scoped metric context introduced cross-project ambiguity on the read side (which project's context represents a metric aggregated across a selection?) that the UI doesn't need. Keeping metric context org-level for now removes that ambiguity and keeps the write model simple. Project-scoped context can be layered back in later if a per-project UI appears.

Backend-only.