### PR TITLE
feat(processing): Define new async tasks

### DIFF
--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -336,6 +336,16 @@ symbolicate_event = make_task_fn(
     queue="events.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
 )
+symbolicate_minidump = make_task_fn(
+    name="sentry.tasks.store.symbolicate_minidump",
+    queue="events.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
+)
+symbolicate_applecrashreport = make_task_fn(
+    name="sentry.tasks.store.symbolicate_applecrashreport",
+    queue="events.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
+)
 symbolicate_js_event = make_task_fn(
     name="sentry.tasks.symbolicate_js_event",
     queue="events.symbolicate_js_event",
@@ -352,5 +362,15 @@ symbolicate_jvm_event = make_task_fn(
 symbolicate_event_from_reprocessing = make_task_fn(
     name="sentry.tasks.store.symbolicate_event_from_reprocessing",
     queue="events.reprocessing.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
+)
+symbolicate_minidump_from_reprocessing = make_task_fn(
+    name="sentry.tasks.store.symbolicate_minidump",
+    queue="events.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
+)
+symbolicate_applecrashreport_from_reprocessing = make_task_fn(
+    name="sentry.tasks.store.symbolicate_applecrashreport",
+    queue="events.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
 )

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -361,12 +361,12 @@ symbolicate_jvm_event = make_task_fn(
 # Reprocessing variants, only for "native" events:
 symbolicate_minidump_from_reprocessing = make_task_fn(  # will not show up in TASK_FNS
     name="sentry.tasks.store.symbolicate_minidump_from_reprocessing",
-    queue="events.symbolicate_event",
+    queue="events.reprocessing.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
 )
 symbolicate_applecrashreport_from_reprocessing = make_task_fn(  # will not show up in TASK_FNS
     name="sentry.tasks.store.symbolicate_applecrashreport_from_reprocessing",
-    queue="events.symbolicate_event",
+    queue="events.reprocessing.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
 )
 symbolicate_event_from_reprocessing = make_task_fn(

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -331,18 +331,18 @@ def make_task_fn(name: str, queue: str, task_kind: SymbolicatorTaskKind) -> Symb
 # New tasks and metrics are welcome to use the correct naming scheme as they are not
 # burdened by aforementioned legacy concerns.
 
-symbolicate_event = make_task_fn(
-    name="sentry.tasks.store.symbolicate_event",
-    queue="events.symbolicate_event",
-    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
-)
-symbolicate_minidump = make_task_fn(
+symbolicate_minidump = make_task_fn(  # will not show up in TASK_FNS
     name="sentry.tasks.store.symbolicate_minidump",
     queue="events.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
 )
-symbolicate_applecrashreport = make_task_fn(
+symbolicate_applecrashreport = make_task_fn(  # will not show up in TASK_FNS
     name="sentry.tasks.store.symbolicate_applecrashreport",
+    queue="events.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
+)
+symbolicate_event = make_task_fn(
+    name="sentry.tasks.store.symbolicate_event",
     queue="events.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=False),
 )
@@ -359,18 +359,18 @@ symbolicate_jvm_event = make_task_fn(
 
 
 # Reprocessing variants, only for "native" events:
+symbolicate_minidump_from_reprocessing = make_task_fn(  # will not show up in TASK_FNS
+    name="sentry.tasks.store.symbolicate_minidump_from_reprocessing",
+    queue="events.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
+)
+symbolicate_applecrashreport_from_reprocessing = make_task_fn(  # will not show up in TASK_FNS
+    name="sentry.tasks.store.symbolicate_applecrashreport_from_reprocessing",
+    queue="events.symbolicate_event",
+    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
+)
 symbolicate_event_from_reprocessing = make_task_fn(
     name="sentry.tasks.store.symbolicate_event_from_reprocessing",
     queue="events.reprocessing.symbolicate_event",
-    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
-)
-symbolicate_minidump_from_reprocessing = make_task_fn(
-    name="sentry.tasks.store.symbolicate_minidump",
-    queue="events.symbolicate_event",
-    task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
-)
-symbolicate_applecrashreport_from_reprocessing = make_task_fn(
-    name="sentry.tasks.store.symbolicate_applecrashreport",
-    queue="events.symbolicate_event",
     task_kind=SymbolicatorTaskKind(platform=SymbolicatorPlatform.native, is_reprocessing=True),
 )


### PR DESCRIPTION
Declare tasks needed for a redo of https://github.com/getsentry/sentry/pull/119256, which was reverted because it had no task backward-compatibility.

The new tasks are created with `SymbolicatorPlatform.native`, so when an old worker receives the request to symbolicate a minidump or apple crash report, it will run the following code and select the correct function:

https://github.com/getsentry/sentry/blob/e6de82ec13f9186aa1ca7693612831983a72c9c4/src/sentry/tasks/symbolication.py#L129-L131

Worst-case, an old worker will run a native symbolication task twice for the same event because it contains a minidump and a native stack trace.

ref: RELAY-256
