### PR TITLE
ref(billing): bump sentry-protos to 0.45.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.41.2",
+  "sentry-protos>=0.45.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm==0.30.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.1.40" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.41.2" },
+    { name = "sentry-protos", specifier = ">=0.45.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = "==0.30.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.41.2"
+version = "0.45.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.41.2-py3-none-any.whl", hash = "sha256:d1f79428f060322503419fe8c830bc6873017b6b3467a6226f51d01888ce8ee8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.45.0-py3-none-any.whl", hash = "sha256:147a47ea2afd8779904a2ab4d3892e6ff9489da46aae8e7523086ff97b518a4a" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `sentry-protos` 0.41.2 → 0.45.0 to pick up the contract `add_user_configs` endpoint (getsentry/sentry-protos#365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)