### PR TITLE
chore(seer-activity): Remove the lonely button

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/base.py
+++ b/src/sentry/notifications/notification_action/activity_registry/base.py
@@ -19,7 +19,7 @@ from sentry.notifications.platform.templates.activity import (
     SetResolvedInReleaseNotificationData,
 )
 from sentry.notifications.platform.types import NotificationTarget
-from sentry.types.activity import ActivityType
+from sentry.types.activity import SEER_ACTIVITY_TYPES, ActivityType
 from sentry.users.services.user.service import user_service
 from sentry.utils.http import absolute_uri
 from sentry.workflow_engine.models import Action, Workflow
@@ -78,12 +78,16 @@ def build_activity_notification_data(
     except Workflow.DoesNotExist:
         raise ValueError(f"Workflow not found: {invocation.workflow_id}")
 
+    issue_url_params: dict[str, str] = {}
+    if ActivityType(activity.type) in SEER_ACTIVITY_TYPES:
+        issue_url_params.update({"seerDrawer": "true"})
+
     action_data = dict(
         source=source,
         activity_type=activity.type,
         notification_uuid=invocation.notification_uuid,
         issue_short_id=group.qualified_short_id,
-        issue_url=absolute_uri(group.get_absolute_url()),
+        issue_url=absolute_uri(group.get_absolute_url(params=issue_url_params)),
         issue_title=build_attachment_title(group) or "",
         issue_culprit=group.culprit,
         issue_description=build_attachment_text(group),

--- a/src/sentry/notifications/platform/templates/activity/seer/base.py
+++ b/src/sentry/notifications/platform/templates/activity/seer/base.py
@@ -7,7 +7,6 @@ from sentry.notifications.platform.templates.activity.base import (
 )
 from sentry.notifications.platform.types import (
     CodeTextBlock,
-    NotificationRenderedAction,
     NotificationRenderedTemplate,
     NotificationSection,
     NotificationTextBlock,
@@ -22,11 +21,6 @@ def get_subject(label: str, data: ActivityNotificationData) -> list[Notification
         return [PlainTextBlock(text=f"{label} for a Sentry Issue")]
 
 
-def get_view_autofix_button(data: ActivityNotificationData) -> NotificationRenderedAction:
-    link = f"{data.issue_url}?seerDrawer=true"
-    return NotificationRenderedAction(label="View Autofix", link=link)
-
-
 def build_template(
     data: ActivityNotificationData,
     subject: list[NotificationTextBlock],
@@ -37,6 +31,4 @@ def build_template(
         footer.append(PlainTextBlock(text=FOOTER_DELIMITER))
         footer.append(PlainTextBlock(text=f"Run ID: {data.activity_data.get('run_id')}"))
 
-    return NotificationRenderedTemplate(
-        subject=subject, body=body, actions=[get_view_autofix_button(data)], footer=footer
-    )
+    return NotificationRenderedTemplate(subject=subject, body=body, footer=footer)

--- a/tests/sentry/notifications/notification_action/activity_registry/test_base.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_base.py
@@ -67,7 +67,7 @@ class TestBuildActivityData(BaseWorkflowTest):
         assert data.activity_type == ActivityType.SEER_RCA_STARTED.value
         assert data.notification_uuid == "test-uuid"
         assert data.issue_short_id == self.group.qualified_short_id
-        assert data.issue_url == absolute_uri(self.group.get_absolute_url())
+        assert absolute_uri(self.group.get_absolute_url()) in data.issue_url
         assert data.issue_culprit == self.group.culprit
         assert data.alert_url is not None
         assert data.activity_data == activity.data

--- a/tests/sentry/notifications/platform/templates/workflow_engine/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/workflow_engine/test_activity.py
@@ -13,14 +13,12 @@ from sentry.notifications.platform.templates.activity.base import (
 )
 from sentry.notifications.platform.templates.activity.seer.base import (
     get_subject,
-    get_view_autofix_button,
 )
 from sentry.notifications.platform.templates.activity.set_resolved.base import (
     get_resolution_subject,
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
-    NotificationRenderedAction,
     NotificationTextBlockType,
 )
 from sentry.testutils.cases import TestCase
@@ -124,13 +122,6 @@ class ActivitySeerAlertBaseTest(TestCase):
         subject = get_subject("Root Cause Analysis Started", data)
         assert len(subject) == 1
         assert "a Sentry Issue" in subject[0].text
-
-    def test_get_view_autofix_button(self) -> None:
-        data = create_activity_notification_example(ActivityType.SEER_RCA_STARTED)
-        action = get_view_autofix_button(data)
-        assert isinstance(action, NotificationRenderedAction)
-        assert action.label == "View Autofix"
-        assert "seerDrawer=true" in action.link
 
 
 class ActivitySetResolvedAlertBaseTest(TestCase):


### PR DESCRIPTION
removing the button, adding the `?seerDrawer=true` param to the group link directly

<img width="422" height="200" alt="image" src="https://github.com/user-attachments/assets/f12ff5cd-ac68-4fde-beeb-3faa26ca4cc1" />


