### PR TITLE
ref(billing): add SeatAssignmentReason enum to SeatAssignmentResult

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from enum import IntEnum, unique
+from enum import Enum, IntEnum, unique
 from functools import total_ordering
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
@@ -333,6 +333,19 @@ def _limit_from_settings(x: Any) -> int | None:
     return int(x or 0) or None
 
 
+class SeatAssignmentReason(Enum):
+    """Why a seat assignment check succeeded or failed."""
+
+    ASSIGNABLE = "assignable"
+    """Seat can be assigned — quota and feature requirements are met."""
+
+    FEATURE_NOT_AVAILABLE = "feature_not_available"
+    """The data category is not available on the organization's plan."""
+
+    QUOTA_EXCEEDED = "quota_exceeded"
+    """No reserved or on-demand budget remaining for the data category."""
+
+
 @dataclass
 class SeatAssignmentResult:
     assignable: bool
@@ -342,6 +355,10 @@ class SeatAssignmentResult:
     reason: str = ""
     """
     The human readable reason the assignment can be made or not.
+    """
+    assignment_reason: SeatAssignmentReason = SeatAssignmentReason.ASSIGNABLE
+    """
+    Machine-readable classification of why the seat is or is not assignable.
     """
 
     def __post_init__(self) -> None:

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -348,18 +348,19 @@ class SeatAssignmentReason(Enum):
 
 @dataclass
 class SeatAssignmentResult:
-    assignable: bool
+    assignment_reason: SeatAssignmentReason = SeatAssignmentReason.ASSIGNABLE
     """
-    Can the seat assignment be made?
+    Machine-readable classification of why the seat is or is not assignable.
     """
     reason: str = ""
     """
     The human readable reason the assignment can be made or not.
     """
-    assignment_reason: SeatAssignmentReason = SeatAssignmentReason.ASSIGNABLE
-    """
-    Machine-readable classification of why the seat is or is not assignable.
-    """
+
+    @property
+    def assignable(self) -> bool:
+        """Whether the seat can be assigned, derived from ``assignment_reason``."""
+        return self.assignment_reason == SeatAssignmentReason.ASSIGNABLE
 
     def __post_init__(self) -> None:
         if not self.assignable and not self.reason:
@@ -662,7 +663,7 @@ class Quota(Service):
         Determines if a monitor can be assigned a seat. If it is not possible
         to assign a monitor a seat, a reason will be included in the response
         """
-        return SeatAssignmentResult(assignable=True)
+        return SeatAssignmentResult()
 
     def check_assign_seat(self, seat_object: SeatObject) -> SeatAssignmentResult:
         """
@@ -670,14 +671,14 @@ class Quota(Service):
         If it is not possible to assign a monitor a seat, a reason
         will be included in the response.
         """
-        return SeatAssignmentResult(assignable=True)
+        return SeatAssignmentResult()
 
     def check_assign_monitor_seats(self, monitor: list[Monitor]) -> SeatAssignmentResult:
         """
         Determines if a list of monitor can be assigned seat. If it is not possible
         to assign a seat to all given monitors, a reason will be included in the response
         """
-        return SeatAssignmentResult(assignable=True)
+        return SeatAssignmentResult()
 
     def check_assign_seats(
         self,
@@ -688,7 +689,7 @@ class Quota(Service):
         If it is not possible to assign a seat to all given objects, a reason
         will be included in the response.
         """
-        return SeatAssignmentResult(assignable=True)
+        return SeatAssignmentResult()
 
     def assign_monitor_seat(self, monitor: Monitor) -> int:
         """

--- a/tests/sentry/monitors/endpoints/test_base_monitor_details.py
+++ b/tests/sentry/monitors/endpoints/test_base_monitor_details.py
@@ -22,7 +22,7 @@ from sentry.monitors.models import (
 )
 from sentry.monitors.types import DATA_SOURCE_CRON_MONITOR
 from sentry.monitors.utils import ensure_cron_detector, get_timeout_at
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.utils.outcomes import Outcome
@@ -792,7 +792,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
     @patch("sentry.quotas.backend.check_assign_seat")
     @patch("sentry.quotas.backend.assign_seat")
     def test_activate_monitor_success(self, assign_seat: MagicMock, check_seat: MagicMock) -> None:
-        check_seat.return_value = SeatAssignmentResult(assignable=True)
+        check_seat.return_value = SeatAssignmentResult()
         assign_seat.return_value = Outcome.ACCEPTED
 
         monitor = self._create_monitor()
@@ -811,7 +811,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
     def test_no_activate_if_already_activated(
         self, assign_seat: MagicMock, check_seat: MagicMock
     ) -> None:
-        check_seat.return_value = SeatAssignmentResult(assignable=True)
+        check_seat.return_value = SeatAssignmentResult()
         assign_seat.return_value = Outcome.ACCEPTED
 
         monitor = self._create_monitor()
@@ -842,7 +842,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
     def test_update_slug_sends_right_slug_to_assign(
         self, assign_seat, check_seat, update_monitor_slug
     ):
-        check_seat.return_value = SeatAssignmentResult(assignable=True)
+        check_seat.return_value = SeatAssignmentResult()
 
         def dummy_assign(data_category=None, seat_object=None):
             assert seat_object.slug == old_slug
@@ -870,7 +870,7 @@ class BaseUpdateMonitorTest(MonitorTestCase):
     @patch("sentry.quotas.backend.assign_seat")
     def test_activate_monitor_invalid(self, assign_seat: MagicMock, check_seat: MagicMock) -> None:
         result = SeatAssignmentResult(
-            assignable=False,
+            assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED,
             reason="Over quota",
         )
         check_seat.return_value = result

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -15,7 +15,7 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.rule import Rule, RuleSource
 from sentry.monitors.models import Monitor, MonitorStatus, ScheduleType, is_monitor_muted
 from sentry.monitors.utils import get_detector_for_monitor
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
@@ -952,7 +952,7 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
         monitor_one = self._create_monitor(slug="monitor_one", status=ObjectStatus.DISABLED)
         monitor_two = self._create_monitor(slug="monitor_two", status=ObjectStatus.DISABLED)
         result = SeatAssignmentResult(
-            assignable=False,
+            assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED,
             reason="Over quota",
         )
         check_assign_seats.return_value = result

--- a/tests/sentry/monitors/test_validators.py
+++ b/tests/sentry/monitors/test_validators.py
@@ -25,7 +25,7 @@ from sentry.monitors.validators import (
     MonitorIncidentDetectorValidator,
     MonitorValidator,
 )
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.types.actor import Actor
@@ -1326,7 +1326,9 @@ class MonitorIncidentDetectorValidatorTest(BaseMonitorValidatorTestCase):
 
     @patch(
         "sentry.quotas.backend.check_assign_seat",
-        return_value=SeatAssignmentResult(assignable=False, reason="No seats available"),
+        return_value=SeatAssignmentResult(
+            assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED, reason="No seats available"
+        ),
     )
     def test_update_enable_no_seat_available(self, mock_check_seat):
         """

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -4,7 +4,13 @@ from sentry.constants import DataCategory, ObjectStatus
 from sentry.models.projectkey import ProjectKey
 from sentry.monitors.constants import PermitCheckInStatus
 from sentry.monitors.models import Monitor
-from sentry.quotas.base import Quota, QuotaConfig, QuotaScope, SeatAssignmentResult
+from sentry.quotas.base import (
+    Quota,
+    QuotaConfig,
+    QuotaScope,
+    SeatAssignmentReason,
+    SeatAssignmentResult,
+)
 from sentry.testutils.cases import TestCase
 from sentry.utils.outcomes import Outcome
 
@@ -178,6 +184,10 @@ def test_quota_config_sort_is_deterministic_regardless_of_input_order() -> None:
 
 def test_seat_assignable_must_have_reason() -> None:
     with pytest.raises(ValueError):
-        SeatAssignmentResult(assignable=False)
-    SeatAssignmentResult(assignable=False, reason="because I said so")
-    SeatAssignmentResult(assignable=True)
+        SeatAssignmentResult(assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED)
+    result = SeatAssignmentResult(
+        assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED, reason="because I said so"
+    )
+    assert not result.assignable
+    result = SeatAssignmentResult()
+    assert result.assignable

--- a/tests/sentry/uptime/consumers/test_results_consumer.py
+++ b/tests/sentry/uptime/consumers/test_results_consumer.py
@@ -31,7 +31,7 @@ from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import ObjectStatus
 from sentry.models.files.file import File
 from sentry.models.group import Group, GroupStatus
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.testutils.abstract import Abstract
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
@@ -908,7 +908,9 @@ class ProcessResultTest(ConfigPusherTestMixin, metaclass=abc.ABCMeta):
             mock.patch(
                 "sentry.uptime.autodetect.result_handler.update_uptime_detector",
                 side_effect=UptimeMonitorNoSeatAvailable(
-                    SeatAssignmentResult(assignable=False, reason="Testing")
+                    SeatAssignmentResult(
+                        assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED, reason="Testing"
+                    )
                 ),
             ),
             self.tasks(),

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_details.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.uptime.endpoints.serializers import UptimeDetectorSerializer
 from sentry.uptime.models import UptimeSubscription, get_uptime_subscription
 from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
@@ -293,7 +293,10 @@ class ProjectUptimeAlertDetailsPutEndpointTest(ProjectUptimeAlertDetailsBaseEndp
     )
     @mock.patch(
         "sentry.quotas.backend.check_assign_seat",
-        return_value=SeatAssignmentResult(assignable=False, reason="Assignment failed in test"),
+        return_value=SeatAssignmentResult(
+            assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED,
+            reason="Assignment failed in test",
+        ),
     )
     def test_status_enable_no_seat_assignment(
         self, _mock_check_assign_seat: mock.MagicMock, _mock_assign_seat: mock.MagicMock

--- a/tests/sentry/uptime/endpoints/test_validators.py
+++ b/tests/sentry/uptime/endpoints/test_validators.py
@@ -5,7 +5,7 @@ from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
     CHECKSTATUS_SUCCESS,
 )
 
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.testutils.cases import TestCase, UptimeTestCase
 from sentry.uptime.endpoints.validators import (
     UptimeDomainCheckFailureValidator,
@@ -258,7 +258,9 @@ class UptimeDomainCheckFailureValidatorTest(UptimeTestCase):
 
     @mock.patch(
         "sentry.quotas.backend.check_assign_seat",
-        return_value=SeatAssignmentResult(assignable=False, reason="No seats available"),
+        return_value=SeatAssignmentResult(
+            assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED, reason="No seats available"
+        ),
     )
     def test_update_enable_no_seat_available(self, mock_check_assign_seat: mock.MagicMock) -> None:
         """Test that enabling fails with validation error when no seats are available."""

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -9,7 +9,7 @@ from pytest import raises
 from sentry.conf.types.uptime import UptimeRegionConfig
 from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
-from sentry.quotas.base import SeatAssignmentResult
+from sentry.quotas.base import SeatAssignmentReason, SeatAssignmentResult
 from sentry.testutils.cases import UptimeTestCase
 from sentry.testutils.helpers import override_options
 from sentry.testutils.skips import requires_kafka
@@ -1108,7 +1108,9 @@ class EnableUptimeDetectorTest(UptimeTestCase):
 
     @mock.patch(
         "sentry.quotas.backend.check_assign_seat",
-        return_value=SeatAssignmentResult(assignable=False, reason="Testing"),
+        return_value=SeatAssignmentResult(
+            assignment_reason=SeatAssignmentReason.QUOTA_EXCEEDED, reason="Testing"
+        ),
     )
     @mock.patch(
         "sentry.quotas.backend.assign_seat",


### PR DESCRIPTION
## Summary

- Adds a `SeatAssignmentReason` enum (`ASSIGNABLE`, `FEATURE_NOT_AVAILABLE`, `QUOTA_EXCEEDED`) to `SeatAssignmentResult`
- Allows callers like `assign_seat` in getsentry to branch on a machine-readable classification instead of re-running feature/quota checks
- New `assignment_reason` field defaults to `ASSIGNABLE` for backwards compatibility

## Test plan

- [x] Existing `test_base.py` quota tests pass
- [x] All getsentry seat-related tests pass (55/55)

Companion PR: https://github.com/getsentry/getsentry/pull/21081