### PR TITLE
meta(mypy): ignore transient mypy worker files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Brewfile.lock.json
 bin/rrweb-output
 model-manifest.json
 .mypy_cache
+.mypy_worker.*.json
 .devenv
 .yalc/
 yalc.lock


### PR DESCRIPTION
i know they are transient, but it bothers me when the mypy worker files show up in my git status panel, since im so frequently bouncing around files there, and they appear on file save. maybe this bothers other people too 👍 

<img width="378" height="165" alt="image" src="https://github.com/user-attachments/assets/13025967-538e-4b76-bd1b-457e4eb77419" />
