### PR TITLE
fix(GAL): Re-enable gating around activity double-write

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -124,6 +124,10 @@ class ActivityManager(BaseManager["Activity"]):
 
     def create(self, **kwargs: Any) -> Activity:
         activity: Activity = super().create(**kwargs)
+
+        if not options.get("group_action_log.activity.double-write") and not in_test_environment():
+            return activity
+
         group_id = kwargs.get("group_id")
         if group_id is None:
             group = kwargs.get("group")
@@ -149,6 +153,8 @@ class ActivityManager(BaseManager["Activity"]):
 
     def bulk_create(self, *args: Any) -> list[Activity]:
         activities: list[Activity] = super().bulk_create(*args)
+        if not options.get("group_action_log.activity.double-write") and not in_test_environment():
+            return activities
         try:
             actions_with_activities = [
                 (activity_to_action(activity), activity) for activity in activities

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3928,3 +3928,11 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Allows GroupActionLogEntries to be written from Activity creation.
+register(
+    "group_action_log.activity.double-write",
+    default=False,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)


### PR DESCRIPTION
Gated behind group_action_log.activity.double-write option
