### PR TITLE
Add issue status reconciliation on group details view

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -468,6 +468,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable writing issue action log entries to the database
     manager.add("projects:issue-action-log-write-to-db", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("projects:issue-status-reconciliation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable similarity embeddings API call
     # This feature is only available on the frontend using project details since the handler gets
     # project options and this is slow in the project index endpoint feature flag serialization

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -46,17 +46,19 @@ from sentry.issues.action_log import (
     resolve_action_actor,
     resolve_action_source,
 )
-from sentry.issues.action_log.types import ViewAction
+from sentry.issues.action_log.types import ReconcileStatusAction, ViewAction
 from sentry.issues.constants import (
     ISSUE_VIEW_CACHE_KEY_TTL,
     cache_key_for_issue_view,
     get_issue_tsdb_group_model,
 )
+from sentry.issues.derived.features import STATUS, IssueStatus
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
-from sentry.models.group import Group
+from sentry.models.group import Group, GroupStatus
 from sentry.models.groupinbox import get_inbox_details
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupowner import get_owner_details
@@ -80,6 +82,16 @@ logger = logging.getLogger(__name__)
 def get_group_global_count(group: Group) -> str:
     fetch_buffered_group_stats(group)
     return str(group.times_seen_with_pending)
+
+
+# Maps a concrete Group model status to the derived open/closed status. Transient
+# statuses (pending deletion/merge, reprocessing) are intentionally omitted: they
+# don't map cleanly to open/closed and shouldn't be reconciled.
+_MODEL_STATUS_TO_DERIVED_STATUS = {
+    GroupStatus.UNRESOLVED: IssueStatus.OPEN,
+    GroupStatus.RESOLVED: IssueStatus.CLOSED,
+    GroupStatus.IGNORED: IssueStatus.CLOSED,
+}
 
 
 @extend_schema(tags=["Events"])
@@ -115,6 +127,49 @@ class GroupDetailsEndpoint(GroupEndpoint):
     def _get_seen_by(self, request: Request, group: Group) -> list[dict[str, Any]]:
         seen_by = list(GroupSeen.objects.filter(group=group).order_by("-last_seen"))
         return [seen for seen in serialize(seen_by, request.user) if seen is not None]
+
+    def _reconcile_status(self, request: Request, group: Group) -> None:
+        """Detect divergence between the Group model status (source of truth) and
+        the action-log-derived status, and publish a ReconcileStatusAction to fix it.
+
+        This is a best-effort, non-essential side effect on a read path; callers
+        must ensure a failure here never breaks the group view.
+        """
+        if not features.has("projects:issue-status-reconciliation", group.project):
+            return
+
+        expected_status = _MODEL_STATUS_TO_DERIVED_STATUS.get(group.status)
+        if expected_status is None:
+            return
+
+        derived = GroupDerivedData.objects.filter(group_id=group.id).first()
+        if derived is None:
+            # Not tracked by the derived system yet; nothing to reconcile against.
+            return
+
+        raw = derived.data.get(STATUS.name)
+        derived_status = STATUS.from_json(raw) if raw is not None else STATUS.initial_value()
+        if derived_status == expected_status:
+            return
+
+        metrics.incr(
+            "issues.status_reconciliation.diverged",
+            sample_rate=1.0,
+            tags={
+                "derived_status": derived_status.value,
+                "expected_status": expected_status.value,
+            },
+        )
+        publish_action(
+            ReconcileStatusAction(
+                status=expected_status.value,
+                reason=f"derived status {derived_status.value} does not match expected status {expected_status.value}",
+            ),
+            source=resolve_action_source(request),
+            group_id=group.id,
+            project=group.project,
+            actor=resolve_action_actor(request),
+        )
 
     @staticmethod
     def __group_hourly_daily_stats(
@@ -339,6 +394,11 @@ class GroupDetailsEndpoint(GroupEndpoint):
                 project=group.project,
                 actor=resolve_action_actor(request),
             )
+
+            try:
+                self._reconcile_status(request, group)
+            except Exception:
+                logger.exception("group.details.get.reconcile_status_failed")
 
             metrics.incr(
                 "group.get.http_response",

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -84,10 +84,7 @@ def get_group_global_count(group: Group) -> str:
     return str(group.times_seen_with_pending)
 
 
-# Maps a concrete Group model status to the derived open/closed status. Transient
-# statuses (pending deletion/merge, reprocessing) are intentionally omitted: they
-# don't map cleanly to open/closed and shouldn't be reconciled.
-_MODEL_STATUS_TO_DERIVED_STATUS = {
+_GROUP_STATUS_TO_DERIVED_STATUS = {
     GroupStatus.UNRESOLVED: IssueStatus.OPEN,
     GroupStatus.RESOLVED: IssueStatus.CLOSED,
     GroupStatus.IGNORED: IssueStatus.CLOSED,
@@ -130,7 +127,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
 
     def _reconcile_status(self, request: Request, group: Group) -> None:
         """Detect divergence between the Group model status (source of truth) and
-        the action-log-derived status, and publish a ReconcileStatusAction to fix it.
+        the action-log-derived status and publish a ReconcileStatusAction to fix it.
 
         This is a best-effort, non-essential side effect on a read path; callers
         must ensure a failure here never breaks the group view.
@@ -138,13 +135,15 @@ class GroupDetailsEndpoint(GroupEndpoint):
         if not features.has("projects:issue-status-reconciliation", group.project):
             return
 
-        expected_status = _MODEL_STATUS_TO_DERIVED_STATUS.get(group.status)
+        expected_status = _GROUP_STATUS_TO_DERIVED_STATUS.get(group.status)
         if expected_status is None:
+            # XXX: some statuses like pending deletion, merge, etc. are skipped
+            # as they don't map to a derived status
             return
 
         derived = GroupDerivedData.objects.filter(group_id=group.id).first()
         if derived is None:
-            # Not tracked by the derived system yet; nothing to reconcile against.
+            # nothing to reconcile against
             return
 
         raw = derived.data.get(STATUS.name)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -9,8 +9,10 @@ from sentry import audit_log, buffer, tsdb
 from sentry.analytics.events.issue_viewed import IssueViewedEvent
 from sentry.buffer.redis import RedisBuffer
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
+from sentry.issues.action_log.types import ReconcileStatusAction
 from sentry.issues.constants import cache_key_for_issue_view
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
 from sentry.models.auditlogentry import AuditLogEntry
@@ -28,8 +30,10 @@ from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
@@ -330,6 +334,65 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
                 ),
             )
             assert cache.get(cache_key_for_issue_view(group.id, "mcp")) is None
+
+
+class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def _get(self, group: Group) -> None:
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+
+    @with_feature("projects:issue-status-reconciliation")
+    def test_diverged_closed_emits_reconcile_action(self) -> None:
+        group = self.create_group(status=GroupStatus.IGNORED, substatus=GroupSubStatus.FOREVER)
+        GroupDerivedData.objects.create(group=group, data={"status": "open"})
+
+        with capture_action_log() as log:
+            self._get(group)
+
+        log.assert_logged(ReconcileStatusAction, group_id=group.id, status="closed")
+
+    @with_feature("projects:issue-status-reconciliation")
+    def test_diverged_open_emits_reconcile_action(self) -> None:
+        group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
+        GroupDerivedData.objects.create(group=group, data={"status": "closed"})
+
+        with capture_action_log() as log:
+            self._get(group)
+
+        log.assert_logged(ReconcileStatusAction, group_id=group.id, status="open")
+
+    @with_feature("projects:issue-status-reconciliation")
+    def test_aligned_status_skips(self) -> None:
+        group = self.create_group(status=GroupStatus.RESOLVED, substatus=None)
+        GroupDerivedData.objects.create(group=group, data={"status": "closed"})
+
+        with capture_action_log() as log:
+            self._get(group)
+
+        log.assert_not_logged(ReconcileStatusAction)
+
+    @with_feature("projects:issue-status-reconciliation")
+    def test_no_derived_data_skips(self) -> None:
+        group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
+
+        with capture_action_log() as log:
+            self._get(group)
+
+        log.assert_not_logged(ReconcileStatusAction)
+
+    def test_feature_flag_off_skips(self) -> None:
+        group = self.create_group(status=GroupStatus.IGNORED, substatus=GroupSubStatus.FOREVER)
+        GroupDerivedData.objects.create(group=group, data={"status": "open"})
+
+        with capture_action_log() as log:
+            self._get(group)
+
+        log.assert_not_logged(ReconcileStatusAction)
 
 
 class GroupUpdateTest(APITestCase):


### PR DESCRIPTION
Check if the group status matches the derived status on the group view page - if it doesn't, we push a reconciliation status action to fix it. This is a starting point for the reconciliation behavior and may be extended or moved. 