### PR TITLE
feat(autofix): Add fun messages, improve loading conditions for enabling notifications in autofix

### DIFF
--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -26,7 +26,6 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import type {useAiConfig} from 'sentry/views/issueDetails/hooks/useAiConfig';
 
 interface SeerDrawerContentProps {
@@ -82,6 +81,8 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
           {message}
         </Alert>
       ))}
+
+      <SeerEnableNotifications status={autofix.runState?.status} />
     </Stack>
   );
 }
@@ -93,8 +94,6 @@ interface SeerDrawerArtifactsProps {
 }
 
 function SeerDrawerArtifacts({autofix, groupId, sections}: SeerDrawerArtifactsProps) {
-  const organization = useOrganization();
-
   return (
     <Fragment>
       {sections.map(section => {
@@ -137,11 +136,6 @@ function SeerDrawerArtifacts({autofix, groupId, sections}: SeerDrawerArtifactsPr
         // TODO: maybe send a log?
         return null;
       })}
-
-      {organization.features.includes('autofix-browser-notifications') &&
-        sections.some(section => section.status === 'processing') && (
-          <SeerEnableNotifications />
-        )}
     </Fragment>
   );
 }

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -55,6 +55,7 @@ export function SeerEnableNotifications({status}: Props) {
   } = usePrompt({
     feature: PROMPT_FEATURE,
     organization,
+    options: {enabled: isEligible},
   });
 
   const shouldRender =
@@ -72,7 +73,7 @@ export function SeerEnableNotifications({status}: Props) {
   }, [isSuccessVisible, permission]);
 
   useEffect(() => {
-    if (shouldRender) {
+    if (!shouldRender) {
       return;
     }
     trackAnalytics('seer-enable-notifications.rendered', {
@@ -81,7 +82,7 @@ export function SeerEnableNotifications({status}: Props) {
     });
   }, [analyticsArea, organization, shouldRender]);
 
-  if (shouldRender) {
+  if (!shouldRender) {
     return null;
   }
 

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -62,32 +62,26 @@ export function SeerEnableNotifications({status}: Props) {
     return () => {};
   }, [isSuccessVisible, permission]);
 
-  useEffect(() => {
-    if (!isServiceWorkerSupported || !supportsNotifications || isPromptDismissed) {
-      return;
-    }
-    trackAnalytics('seer-enable-notifications.rendered', {
-      organization,
-      surface: analyticsArea,
-    });
-  }, [
-    analyticsArea,
-    controller,
-    isPromptDismissed,
-    isServiceWorkerSupported,
-    organization,
-    supportsNotifications,
-  ]);
-
-  if (
+  const shouldNotRender =
     !organization.features.includes('autofix-browser-notifications') ||
     !isServiceWorkerSupported ||
     !supportsNotifications ||
     isLoadingPromptDismissed ||
     isPromptDismissed === true ||
     isPromptError ||
-    status !== 'processing'
-  ) {
+    status !== 'processing';
+
+  useEffect(() => {
+    if (shouldNotRender) {
+      return;
+    }
+    trackAnalytics('seer-enable-notifications.rendered', {
+      organization,
+      surface: analyticsArea,
+    });
+  }, [analyticsArea, organization, shouldNotRender]);
+
+  if (shouldNotRender) {
     return null;
   }
 

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -9,6 +9,7 @@ import {Text} from '@sentry/scraps/text';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
+import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {IconSubscribed} from 'sentry/icons/iconSubscribed';
 import {t} from 'sentry/locale';
 import {useServiceWorker} from 'sentry/serviceWorker/client/serviceWorkerContext';
@@ -20,7 +21,18 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 const SUCCESS_VISIBLE_DURATION_MS = 25_000;
 const PROMPT_FEATURE = 'autofix-sw-notification';
 
-export function SeerEnableNotifications() {
+interface Props {
+  status: undefined | ExplorerAutofixState['status'];
+}
+
+const funMessages = [
+  t("It's ok to go watch a cat video."),
+  t('Seer can take a minute to reply, but it feels like an eternity.'),
+  t('By the time you enable this Seer should be done.'),
+  t("Allowing notifications doesn't bias the results, but I wish it would."),
+];
+
+export function SeerEnableNotifications({status}: Props) {
   const organization = useOrganization();
   const [isSuccessVisible, setIsSuccessVisible] = useState(false);
   const {isServiceWorkerSupported, controller} = useServiceWorker();
@@ -29,7 +41,11 @@ export function SeerEnableNotifications() {
 
   const analyticsArea = useAnalyticsArea();
 
-  const {isPromptDismissed, snoozePrompt} = usePrompt({
+  const {
+    isPromptDismissed,
+    snoozePrompt,
+    isLoading: isLoadingPromptDismissed,
+  } = usePrompt({
     feature: PROMPT_FEATURE,
     organization,
   });
@@ -63,9 +79,12 @@ export function SeerEnableNotifications() {
   ]);
 
   if (
+    !organization.features.includes('autofix-browser-notifications') ||
     !isServiceWorkerSupported ||
     !supportsNotifications ||
-    isPromptDismissed !== false
+    isLoadingPromptDismissed ||
+    isPromptDismissed === true ||
+    status !== 'processing'
   ) {
     return null;
   }
@@ -115,9 +134,12 @@ export function SeerEnableNotifications() {
   }
 
   if (permission === 'default') {
+    const funMessage = funMessages[Math.floor(Math.random() * funMessages.length)]!;
+
     return (
       <Stack gap="lg" justify="center" align="center">
-        <Text>{t('Get a notification when Seer has an update')}</Text>
+        <Text align="center">{t('Get notified when Seer has an update.')}</Text>
+        <Text align="center">{funMessage}</Text>
 
         <Flex gap="lg" align="center">
           <Flex align="center" gap="md">

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -45,6 +45,7 @@ export function SeerEnableNotifications({status}: Props) {
     isPromptDismissed,
     snoozePrompt,
     isLoading: isLoadingPromptDismissed,
+    isError: isPromptError,
   } = usePrompt({
     feature: PROMPT_FEATURE,
     organization,
@@ -84,6 +85,7 @@ export function SeerEnableNotifications({status}: Props) {
     !supportsNotifications ||
     isLoadingPromptDismissed ||
     isPromptDismissed === true ||
+    isPromptError ||
     status !== 'processing'
   ) {
     return null;

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -41,15 +41,24 @@ export function SeerEnableNotifications({status}: Props) {
 
   const analyticsArea = useAnalyticsArea();
 
+  const isEligible =
+    organization.features.includes('autofix-browser-notifications') &&
+    isServiceWorkerSupported &&
+    supportsNotifications &&
+    status === 'processing';
+
   const {
     isPromptDismissed,
     snoozePrompt,
-    isLoading: isLoadingPromptDismissed,
+    isLoading: isPromptLoading,
     isError: isPromptError,
   } = usePrompt({
     feature: PROMPT_FEATURE,
     organization,
   });
+
+  const shouldRender =
+    isEligible && !isPromptDismissed && !isPromptLoading && !isPromptError;
 
   useEffect(() => {
     if (isSuccessVisible && permission === 'granted') {
@@ -62,26 +71,17 @@ export function SeerEnableNotifications({status}: Props) {
     return () => {};
   }, [isSuccessVisible, permission]);
 
-  const shouldNotRender =
-    !organization.features.includes('autofix-browser-notifications') ||
-    !isServiceWorkerSupported ||
-    !supportsNotifications ||
-    isLoadingPromptDismissed ||
-    isPromptDismissed === true ||
-    isPromptError ||
-    status !== 'processing';
-
   useEffect(() => {
-    if (shouldNotRender) {
+    if (shouldRender) {
       return;
     }
     trackAnalytics('seer-enable-notifications.rendered', {
       organization,
       surface: analyticsArea,
     });
-  }, [analyticsArea, organization, shouldNotRender]);
+  }, [analyticsArea, organization, shouldRender]);
 
-  if (shouldNotRender) {
+  if (shouldRender) {
     return null;
   }
 


### PR DESCRIPTION
New messages like this to prompt users:
<img width="647" height="390" alt="SCR-20260715-mnml" src="https://github.com/user-attachments/assets/04b61efe-452a-4e55-b3cd-39b0c26fbb20" />


Also added an improved `isLoading` check, and centralized the feature-flag condition along with simplified status/processing check.