### PR TITLE
feat(billing): Define retention policy category identity

### DIFF
--- a/src/sentry/billing/platform/services/retention/__init__.py
+++ b/src/sentry/billing/platform/services/retention/__init__.py
@@ -1,0 +1,27 @@
+from sentry.billing.platform.services.retention.category_mapping import (
+    RETENTION_CATEGORY_DECISIONS,
+    RetentionAliasGroup,
+    RetentionCategoryDecision,
+    RetentionCategoryMapping,
+    RetentionConfigKey,
+    UnsupportedRetentionCategory,
+    UnsupportedRetentionCategoryError,
+    UnsupportedRetentionCategoryReason,
+    classify_retention_category,
+    filter_supported_retention_categories,
+    require_retention_category_mapping,
+)
+
+__all__ = [
+    "RETENTION_CATEGORY_DECISIONS",
+    "RetentionAliasGroup",
+    "RetentionCategoryDecision",
+    "RetentionCategoryMapping",
+    "RetentionConfigKey",
+    "UnsupportedRetentionCategory",
+    "UnsupportedRetentionCategoryError",
+    "UnsupportedRetentionCategoryReason",
+    "classify_retention_category",
+    "filter_supported_retention_categories",
+    "require_retention_category_mapping",
+]

--- a/src/sentry/billing/platform/services/retention/category_mapping.py
+++ b/src/sentry/billing/platform/services/retention/category_mapping.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+
+from sentry_protos.billing.v1.data_category_pb2 import DataCategory as ProtoDataCategory
+
+from sentry.constants import DataCategory
+
+
+class RetentionConfigKey(StrEnum):
+    LOG = "log"
+    SPAN = "span"
+    TRACE_METRIC = "traceMetric"
+
+
+class RetentionAliasGroup(StrEnum):
+    LOG = "log"
+    SPAN = "span"
+    TRACE_METRIC = "trace_metric"
+
+
+class UnsupportedRetentionCategoryReason(StrEnum):
+    UNSPECIFIED = "unspecified"
+    UNKNOWN = "unknown"
+    NOT_ESTABLISHED = "not_established"
+
+
+@dataclass(frozen=True)
+class RetentionCategoryMapping:
+    policy_category: int
+    runtime_category: DataCategory
+    wire_key: RetentionConfigKey | None
+    alias_group: RetentionAliasGroup
+
+
+@dataclass(frozen=True)
+class UnsupportedRetentionCategory:
+    policy_category: int
+    reason: UnsupportedRetentionCategoryReason
+
+
+RetentionCategoryDecision = RetentionCategoryMapping | UnsupportedRetentionCategory
+
+
+_SUPPORTED_DECISIONS: dict[int, RetentionCategoryMapping] = {
+    ProtoDataCategory.DATA_CATEGORY_LOG_BYTE: RetentionCategoryMapping(
+        policy_category=ProtoDataCategory.DATA_CATEGORY_LOG_BYTE,
+        runtime_category=DataCategory.LOG_BYTE,
+        wire_key=RetentionConfigKey.LOG,
+        alias_group=RetentionAliasGroup.LOG,
+    ),
+    ProtoDataCategory.DATA_CATEGORY_TRANSACTION: RetentionCategoryMapping(
+        policy_category=ProtoDataCategory.DATA_CATEGORY_TRANSACTION,
+        runtime_category=DataCategory.TRANSACTION,
+        wire_key=RetentionConfigKey.SPAN,
+        alias_group=RetentionAliasGroup.SPAN,
+    ),
+    ProtoDataCategory.DATA_CATEGORY_SPAN: RetentionCategoryMapping(
+        policy_category=ProtoDataCategory.DATA_CATEGORY_SPAN,
+        runtime_category=DataCategory.SPAN,
+        wire_key=RetentionConfigKey.SPAN,
+        alias_group=RetentionAliasGroup.SPAN,
+    ),
+    ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC: RetentionCategoryMapping(
+        policy_category=ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC,
+        runtime_category=DataCategory.TRACE_METRIC,
+        wire_key=RetentionConfigKey.TRACE_METRIC,
+        alias_group=RetentionAliasGroup.TRACE_METRIC,
+    ),
+}
+
+_UNSUPPORTED_REASONS: dict[int, UnsupportedRetentionCategoryReason] = {
+    ProtoDataCategory.DATA_CATEGORY_UNSPECIFIED: UnsupportedRetentionCategoryReason.UNSPECIFIED,
+    ProtoDataCategory.DATA_CATEGORY_ERROR: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_ATTACHMENT: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_REPLAY: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_MONITOR: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_USER_REPORT_V2: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_DURATION: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_DURATION_UI: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_SEER_AUTOFIX: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_SEER_SCANNER: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_SIZE_ANALYSIS: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_INSTALLABLE_BUILD: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_DEFAULT: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_SECURITY: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_CHUNK: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_CHUNK_UI: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_SPAN_INDEXED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_TRANSACTION_PROCESSED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_TRANSACTION_INDEXED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_INDEXED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_METRIC_BUCKET: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_ATTACHMENT_ITEM: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_LOG_ITEM: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_BACKEND: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_PROFILE_UI: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC_BYTE: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+    ProtoDataCategory.DATA_CATEGORY_UNKNOWN: UnsupportedRetentionCategoryReason.UNKNOWN,
+}
+
+_RETENTION_CATEGORY_DECISIONS: dict[int, RetentionCategoryDecision] = {
+    **{
+        category: UnsupportedRetentionCategory(policy_category=category, reason=reason)
+        for category, reason in _UNSUPPORTED_REASONS.items()
+    },
+    **_SUPPORTED_DECISIONS,
+}
+
+RETENTION_CATEGORY_DECISIONS: Mapping[int, RetentionCategoryDecision] = MappingProxyType(
+    _RETENTION_CATEGORY_DECISIONS
+)
+
+
+class UnsupportedRetentionCategoryError(ValueError):
+    pass
+
+
+def classify_retention_category(policy_category: int) -> RetentionCategoryDecision:
+    category = int(policy_category)
+    decision = RETENTION_CATEGORY_DECISIONS.get(category)
+    if decision is not None:
+        return decision
+    return UnsupportedRetentionCategory(
+        policy_category=category,
+        reason=UnsupportedRetentionCategoryReason.UNKNOWN,
+    )
+
+
+def require_retention_category_mapping(policy_category: int) -> RetentionCategoryMapping:
+    decision = classify_retention_category(policy_category)
+    if isinstance(decision, RetentionCategoryMapping):
+        return decision
+
+    try:
+        category_name = ProtoDataCategory.Name(
+            ProtoDataCategory.ValueType(decision.policy_category)
+        )
+    except ValueError:
+        category_name = "unknown"
+    raise UnsupportedRetentionCategoryError(
+        f"Unsupported retention policy category {category_name} ({decision.policy_category}): "
+        f"{decision.reason.value}"
+    )
+
+
+def filter_supported_retention_categories(
+    policy_categories: Iterable[int],
+) -> tuple[RetentionCategoryMapping, ...]:
+    mappings = []
+    for policy_category in policy_categories:
+        decision = classify_retention_category(policy_category)
+        if isinstance(decision, RetentionCategoryMapping):
+            mappings.append(decision)
+    return tuple(mappings)

--- a/src/sentry/billing/platform/services/retention/category_mapping.py
+++ b/src/sentry/billing/platform/services/retention/category_mapping.py
@@ -64,6 +64,15 @@ _SUPPORTED_DECISIONS: dict[int, RetentionCategoryMapping] = {
         wire_key=RetentionConfigKey.SPAN,
         alias_group=RetentionAliasGroup.SPAN,
     ),
+    # Indexed spans share the one span product with TRANSACTION and SPAN. The
+    # runtime identity stays distinct so two platform categories do not emit the
+    # same runtime key.
+    ProtoDataCategory.DATA_CATEGORY_SPAN_INDEXED: RetentionCategoryMapping(
+        policy_category=ProtoDataCategory.DATA_CATEGORY_SPAN_INDEXED,
+        runtime_category=DataCategory.SPAN_INDEXED,
+        wire_key=RetentionConfigKey.SPAN,
+        alias_group=RetentionAliasGroup.SPAN,
+    ),
     ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC: RetentionCategoryMapping(
         policy_category=ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC,
         runtime_category=DataCategory.TRACE_METRIC,
@@ -90,7 +99,6 @@ _UNSUPPORTED_REASONS: dict[int, UnsupportedRetentionCategoryReason] = {
     ProtoDataCategory.DATA_CATEGORY_SECURITY: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
     ProtoDataCategory.DATA_CATEGORY_PROFILE_CHUNK: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
     ProtoDataCategory.DATA_CATEGORY_PROFILE_CHUNK_UI: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
-    ProtoDataCategory.DATA_CATEGORY_SPAN_INDEXED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
     ProtoDataCategory.DATA_CATEGORY_TRANSACTION_PROCESSED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
     ProtoDataCategory.DATA_CATEGORY_TRANSACTION_INDEXED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
     ProtoDataCategory.DATA_CATEGORY_PROFILE_INDEXED: UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,

--- a/tests/sentry/billing/platform/services/retention/test_category_mapping.py
+++ b/tests/sentry/billing/platform/services/retention/test_category_mapping.py
@@ -1,0 +1,222 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+from sentry_protos.billing.v1.data_category_pb2 import DataCategory as ProtoDataCategory
+
+from sentry.billing.platform.services.retention import (
+    RETENTION_CATEGORY_DECISIONS,
+    RetentionAliasGroup,
+    RetentionCategoryMapping,
+    RetentionConfigKey,
+    UnsupportedRetentionCategory,
+    UnsupportedRetentionCategoryError,
+    UnsupportedRetentionCategoryReason,
+    classify_retention_category,
+    filter_supported_retention_categories,
+    require_retention_category_mapping,
+)
+from sentry.constants import DataCategory
+from sentry.quotas.base import RETENTIONS_CONFIG_MAPPING
+
+EXPECTED_PROTO_CATEGORIES = {
+    ("DATA_CATEGORY_UNKNOWN", -1),
+    ("DATA_CATEGORY_UNSPECIFIED", 0),
+    ("DATA_CATEGORY_ERROR", 1),
+    ("DATA_CATEGORY_TRANSACTION", 2),
+    ("DATA_CATEGORY_ATTACHMENT", 3),
+    ("DATA_CATEGORY_PROFILE", 4),
+    ("DATA_CATEGORY_REPLAY", 5),
+    ("DATA_CATEGORY_MONITOR", 6),
+    ("DATA_CATEGORY_SPAN", 7),
+    ("DATA_CATEGORY_USER_REPORT_V2", 8),
+    ("DATA_CATEGORY_PROFILE_DURATION", 9),
+    ("DATA_CATEGORY_LOG_BYTE", 10),
+    ("DATA_CATEGORY_PROFILE_DURATION_UI", 11),
+    ("DATA_CATEGORY_SEER_AUTOFIX", 12),
+    ("DATA_CATEGORY_SEER_SCANNER", 13),
+    ("DATA_CATEGORY_SIZE_ANALYSIS", 14),
+    ("DATA_CATEGORY_INSTALLABLE_BUILD", 15),
+    ("DATA_CATEGORY_TRACE_METRIC", 16),
+    ("DATA_CATEGORY_DEFAULT", 17),
+    ("DATA_CATEGORY_SECURITY", 18),
+    ("DATA_CATEGORY_PROFILE_CHUNK", 19),
+    ("DATA_CATEGORY_PROFILE_CHUNK_UI", 20),
+    ("DATA_CATEGORY_SPAN_INDEXED", 21),
+    ("DATA_CATEGORY_TRANSACTION_PROCESSED", 22),
+    ("DATA_CATEGORY_TRANSACTION_INDEXED", 23),
+    ("DATA_CATEGORY_PROFILE_INDEXED", 24),
+    ("DATA_CATEGORY_METRIC_BUCKET", 25),
+    ("DATA_CATEGORY_ATTACHMENT_ITEM", 26),
+    ("DATA_CATEGORY_LOG_ITEM", 27),
+    ("DATA_CATEGORY_PROFILE_BACKEND", 30),
+    ("DATA_CATEGORY_PROFILE_UI", 31),
+    ("DATA_CATEGORY_TRACE_METRIC_BYTE", 32),
+}
+
+SUPPORTED_MAPPINGS = (
+    (
+        ProtoDataCategory.DATA_CATEGORY_LOG_BYTE,
+        DataCategory.LOG_BYTE,
+        RetentionConfigKey.LOG,
+        RetentionAliasGroup.LOG,
+    ),
+    (
+        ProtoDataCategory.DATA_CATEGORY_TRANSACTION,
+        DataCategory.TRANSACTION,
+        RetentionConfigKey.SPAN,
+        RetentionAliasGroup.SPAN,
+    ),
+    (
+        ProtoDataCategory.DATA_CATEGORY_SPAN,
+        DataCategory.SPAN,
+        RetentionConfigKey.SPAN,
+        RetentionAliasGroup.SPAN,
+    ),
+    (
+        ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC,
+        DataCategory.TRACE_METRIC,
+        RetentionConfigKey.TRACE_METRIC,
+        RetentionAliasGroup.TRACE_METRIC,
+    ),
+)
+
+
+def test_all_proto_categories_have_an_explicit_retention_decision() -> None:
+    actual_categories = {
+        (value.name, value.number) for value in ProtoDataCategory.DESCRIPTOR.values
+    }
+
+    assert actual_categories == EXPECTED_PROTO_CATEGORIES
+    assert set(RETENTION_CATEGORY_DECISIONS) == {number for _, number in EXPECTED_PROTO_CATEGORIES}
+
+
+@pytest.mark.parametrize(
+    ("policy_category", "runtime_category", "wire_key", "alias_group"),
+    SUPPORTED_MAPPINGS,
+)
+def test_supported_mapping(
+    policy_category: int,
+    runtime_category: DataCategory,
+    wire_key: RetentionConfigKey,
+    alias_group: RetentionAliasGroup,
+) -> None:
+    decision = classify_retention_category(policy_category)
+
+    assert decision == RetentionCategoryMapping(
+        policy_category=policy_category,
+        runtime_category=runtime_category,
+        wire_key=wire_key,
+        alias_group=alias_group,
+    )
+
+
+@pytest.mark.parametrize(
+    ("policy_category", "reason"),
+    [
+        (
+            ProtoDataCategory.DATA_CATEGORY_UNSPECIFIED,
+            UnsupportedRetentionCategoryReason.UNSPECIFIED,
+        ),
+        (ProtoDataCategory.DATA_CATEGORY_UNKNOWN, UnsupportedRetentionCategoryReason.UNKNOWN),
+    ],
+)
+def test_special_unsupported_category(
+    policy_category: int, reason: UnsupportedRetentionCategoryReason
+) -> None:
+    assert classify_retention_category(policy_category) == UnsupportedRetentionCategory(
+        policy_category=policy_category,
+        reason=reason,
+    )
+
+
+def test_every_other_named_category_is_not_established() -> None:
+    supported = {category for category, _, _, _ in SUPPORTED_MAPPINGS}
+    special = {
+        ProtoDataCategory.DATA_CATEGORY_UNSPECIFIED,
+        ProtoDataCategory.DATA_CATEGORY_UNKNOWN,
+    }
+
+    for _, policy_category in EXPECTED_PROTO_CATEGORIES:
+        if policy_category in supported | special:
+            continue
+        assert classify_retention_category(policy_category) == UnsupportedRetentionCategory(
+            policy_category=policy_category,
+            reason=UnsupportedRetentionCategoryReason.NOT_ESTABLISHED,
+        )
+
+
+def test_arbitrary_future_category_is_unknown() -> None:
+    assert classify_retention_category(9999) == UnsupportedRetentionCategory(
+        policy_category=9999,
+        reason=UnsupportedRetentionCategoryReason.UNKNOWN,
+    )
+
+
+def test_mapping_is_frozen() -> None:
+    mapping = require_retention_category_mapping(ProtoDataCategory.DATA_CATEGORY_LOG_BYTE)
+
+    with pytest.raises(FrozenInstanceError):
+        mapping.policy_category = ProtoDataCategory.DATA_CATEGORY_ERROR  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "policy_category",
+    [
+        ProtoDataCategory.DATA_CATEGORY_ERROR,
+        ProtoDataCategory.DATA_CATEGORY_UNSPECIFIED,
+        ProtoDataCategory.DATA_CATEGORY_UNKNOWN,
+        9999,
+    ],
+)
+def test_required_lookup_rejects_unsupported_category(policy_category: int) -> None:
+    with pytest.raises(UnsupportedRetentionCategoryError, match=str(policy_category)):
+        require_retention_category_mapping(policy_category)
+
+
+def test_filter_supported_categories_is_explicit_and_ordered() -> None:
+    filtered = filter_supported_retention_categories(
+        [
+            ProtoDataCategory.DATA_CATEGORY_LOG_BYTE,
+            ProtoDataCategory.DATA_CATEGORY_ERROR,
+            ProtoDataCategory.DATA_CATEGORY_TRANSACTION,
+            ProtoDataCategory.DATA_CATEGORY_UNKNOWN,
+            ProtoDataCategory.DATA_CATEGORY_SPAN,
+            ProtoDataCategory.DATA_CATEGORY_LOG_BYTE,
+        ]
+    )
+
+    assert [mapping.policy_category for mapping in filtered] == [
+        ProtoDataCategory.DATA_CATEGORY_LOG_BYTE,
+        ProtoDataCategory.DATA_CATEGORY_TRANSACTION,
+        ProtoDataCategory.DATA_CATEGORY_SPAN,
+        ProtoDataCategory.DATA_CATEGORY_LOG_BYTE,
+    ]
+
+
+def test_filter_empty_or_all_unsupported_categories() -> None:
+    assert filter_supported_retention_categories([]) == ()
+    assert (
+        filter_supported_retention_categories(
+            [ProtoDataCategory.DATA_CATEGORY_ERROR, ProtoDataCategory.DATA_CATEGORY_REPLAY]
+        )
+        == ()
+    )
+
+
+def test_span_alias_keeps_distinct_runtime_categories() -> None:
+    transaction = require_retention_category_mapping(ProtoDataCategory.DATA_CATEGORY_TRANSACTION)
+    span = require_retention_category_mapping(ProtoDataCategory.DATA_CATEGORY_SPAN)
+
+    assert transaction.runtime_category != span.runtime_category
+    assert transaction.wire_key == span.wire_key == RetentionConfigKey.SPAN
+    assert transaction.alias_group == span.alias_group == RetentionAliasGroup.SPAN
+
+
+def test_supported_wire_mapping_matches_existing_retention_config() -> None:
+    actual = {
+        mapping.runtime_category: mapping.wire_key.value
+        for mapping in RETENTION_CATEGORY_DECISIONS.values()
+        if isinstance(mapping, RetentionCategoryMapping) and mapping.wire_key is not None
+    }
+
+    assert actual == RETENTIONS_CONFIG_MAPPING

--- a/tests/sentry/billing/platform/services/retention/test_category_mapping.py
+++ b/tests/sentry/billing/platform/services/retention/test_category_mapping.py
@@ -73,6 +73,12 @@ SUPPORTED_MAPPINGS = (
         RetentionAliasGroup.SPAN,
     ),
     (
+        ProtoDataCategory.DATA_CATEGORY_SPAN_INDEXED,
+        DataCategory.SPAN_INDEXED,
+        RetentionConfigKey.SPAN,
+        RetentionAliasGroup.SPAN,
+    ),
+    (
         ProtoDataCategory.DATA_CATEGORY_TRACE_METRIC,
         DataCategory.TRACE_METRIC,
         RetentionConfigKey.TRACE_METRIC,
@@ -213,10 +219,15 @@ def test_span_alias_keeps_distinct_runtime_categories() -> None:
 
 
 def test_supported_wire_mapping_matches_existing_retention_config() -> None:
+    # The adapter may map runtime categories the legacy map does not project
+    # (for example SPAN_INDEXED). Assert it agrees with the legacy map on every
+    # runtime category the legacy map covers, rather than requiring exact
+    # equality with the broader adapter set.
     actual = {
         mapping.runtime_category: mapping.wire_key.value
         for mapping in RETENTION_CATEGORY_DECISIONS.values()
         if isinstance(mapping, RetentionCategoryMapping) and mapping.wire_key is not None
     }
 
-    assert actual == RETENTIONS_CONFIG_MAPPING
+    for runtime_category, wire_key in RETENTIONS_CONFIG_MAPPING.items():
+        assert actual[runtime_category] == wire_key


### PR DESCRIPTION
Retention policy categories now have an explicit, immutable relationship to Sentry runtime categories, retention wire keys, and alias groups. This keeps billing protobuf identity distinct from runtime identity—for example, transactions and spans remain separate runtime categories while sharing the established `span` retention projection.

Only the four mappings already used by current retention configuration are enabled: log bytes, transactions, spans, and trace metrics. Every other named billing protobuf category is explicitly classified as unsupported, and the exhaustive tests require a deliberate retention decision whenever that enum changes. The adapter is pure preparation for package policy work and does not change Relay configuration, customer serialization, quota routing, or other runtime behavior.

Focused coverage exercises all supported and unsupported decisions, unknown future values, strict and filtering lookup semantics, alias behavior, immutability, and parity with the existing retention wire mapping.