### PR TITLE
feat(external-mcp): Implement org level ui for configuring datadog integration

### DIFF
--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -144,10 +144,12 @@ class DatadogIntegration(IntegrationInstallation):
 
         validate_datadog_credentials(api_key, app_key, site)
 
+        name = f"Datadog ({site})"
         new_metadata: DatadogCredentials = {"api_key": api_key, "app_key": app_key, "site": site}
         integration_service.update_integration(
-            integration_id=self.model.id, metadata=dict(new_metadata)
+            integration_id=self.model.id, name=name, metadata=dict(new_metadata)
         )
+        self.model.name = name
         self.model.metadata = dict(new_metadata)
 
 

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any, TypedDict, cast
 
 from django.http.request import HttpRequest
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.identity.datadog.provider import DATADOG_VALID_SITES
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -20,6 +21,7 @@ from sentry.integrations.base import (
 from sentry.integrations.datadog.client import validate_datadog_credentials
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.pipeline.types import PipelineStepResult
@@ -47,6 +49,8 @@ metadata = IntegrationMetadata(
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/datadog",
     aspects={},
 )
+
+_SITE_CHOICES = [(site, f"{region} ({site})") for site, region in DATADOG_VALID_SITES.items()]
 
 
 class DatadogCredentials(TypedDict):
@@ -99,6 +103,52 @@ class DatadogIntegration(IntegrationInstallation):
 
     def get_client(self) -> Any:
         raise NotImplementedError
+
+    def get_organization_config(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "site",
+                "type": "select",
+                "label": _("Datadog Site"),
+                "choices": _SITE_CHOICES,
+                "required": True,
+            },
+            {
+                "name": "api_key",
+                "type": "secret",
+                "label": _("API Key"),
+                "help": _("Leave blank to keep the current key."),
+                "required": False,
+                "formatMessageValue": False,
+            },
+            {
+                "name": "app_key",
+                "type": "secret",
+                "label": _("Application Key"),
+                "help": _("Leave blank to keep the current key."),
+                "required": False,
+                "formatMessageValue": False,
+            },
+        ]
+
+    def get_config_data(self) -> Mapping[str, Any]:
+        data = dict(super().get_config_data())
+        data["site"] = self.credentials.get("site", "")
+        return data
+
+    def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
+        stored = self.credentials
+        api_key = data.get("api_key") or stored["api_key"]
+        app_key = data.get("app_key") or stored["app_key"]
+        site = data.get("site") or stored["site"]
+
+        validate_datadog_credentials(api_key, app_key, site)
+
+        new_metadata: DatadogCredentials = {"api_key": api_key, "app_key": app_key, "site": site}
+        integration_service.update_integration(
+            integration_id=self.model.id, metadata=dict(new_metadata)
+        )
+        self.model.metadata = dict(new_metadata)
 
 
 class DatadogIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -50,7 +50,7 @@ metadata = IntegrationMetadata(
     aspects={},
 )
 
-_SITE_CHOICES = [(site, f"{region} ({site})") for site, region in DATADOG_VALID_SITES.items()]
+_SITE_CHOICES = [(site, f"{site} ({region})") for site, region in DATADOG_VALID_SITES.items()]
 
 
 class DatadogCredentials(TypedDict):

--- a/static/app/components/pipeline/integrationDatadog/index.spec.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.spec.tsx
@@ -25,7 +25,7 @@ describe('DatadogCredentialsStep', () => {
 
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Datadog Site'}),
-      'US1 (datadoghq.com)'
+      'datadoghq.com (US1)'
     );
     await userEvent.type(screen.getByLabelText('API Key'), 'api-key');
     await userEvent.type(screen.getByLabelText('Application Key'), 'app-key');

--- a/static/app/components/pipeline/integrationDatadog/index.spec.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.spec.tsx
@@ -1,0 +1,63 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
+
+import {createMakeStepProps} from 'sentry/components/pipeline/testUtils';
+
+import {datadogIntegrationPipeline} from '.';
+
+const DatadogCredentialsStep = datadogIntegrationPipeline.steps[0].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 1});
+
+describe('DatadogCredentialsStep', () => {
+  it('renders the credentials form', () => {
+    render(<DatadogCredentialsStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByLabelText('API Key')).toBeInTheDocument();
+    expect(screen.getByLabelText('Application Key')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Datadog Site'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+  });
+
+  it('calls advance with credentials on submit', async () => {
+    const advance = jest.fn();
+    render(<DatadogCredentialsStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Datadog Site'}),
+      'US1 (datadoghq.com)'
+    );
+    await userEvent.type(screen.getByLabelText('API Key'), 'api-key');
+    await userEvent.type(screen.getByLabelText('Application Key'), 'app-key');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        apiKey: 'api-key',
+        appKey: 'app-key',
+        site: 'datadoghq.com',
+      });
+    });
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <DatadogCredentialsStep {...makeStepProps({stepData: {}, isAdvancing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+
+  it('disables submit button when isInitializing', () => {
+    render(
+      <DatadogCredentialsStep
+        {...makeStepProps({stepData: null, isInitializing: true})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/integrationDatadog/index.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.tsx
@@ -12,24 +12,12 @@ import type {
 import {pipelineComplete} from 'sentry/components/pipeline/types';
 import {t} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
-
-// Datadog sites and their region labels. Keep in sync with DATADOG_VALID_SITES in
-// src/sentry/identity/datadog/provider.py.
-const DATADOG_SITE_OPTIONS = [
-  {value: 'datadoghq.com', label: 'US1 (datadoghq.com)'},
-  {value: 'us3.datadoghq.com', label: 'US3 (us3.datadoghq.com)'},
-  {value: 'us5.datadoghq.com', label: 'US5 (us5.datadoghq.com)'},
-  {value: 'datadoghq.eu', label: 'EU (datadoghq.eu)'},
-  {value: 'ap1.datadoghq.com', label: 'AP1 (ap1.datadoghq.com)'},
-  {value: 'ap2.datadoghq.com', label: 'AP2 (ap2.datadoghq.com)'},
-  {value: 'ddog-gov.com', label: 'US1-FED (ddog-gov.com)'},
-  {value: 'us2.ddog-gov.com', label: 'US2-FED (us2.ddog-gov.com)'},
-];
+import {DATADOG_SITES, DATADOG_SITE_VALUES} from 'sentry/utils/seer/datadogSites';
 
 const credentialsSchema = z.object({
   apiKey: z.string().min(1, t('API key is required')),
   appKey: z.string().min(1, t('Application key is required')),
-  site: z.string().min(1, t('Site is required')),
+  site: z.enum(DATADOG_SITE_VALUES, {error: t('Site is required')}),
 });
 
 function DatadogCredentialsStep({
@@ -71,7 +59,7 @@ function DatadogCredentialsStep({
                 value={field.state.value}
                 onChange={value => field.handleChange(value)}
                 placeholder={t('Select your Datadog site')}
-                options={DATADOG_SITE_OPTIONS}
+                options={DATADOG_SITES}
               />
             </field.Layout.Stack>
           )}

--- a/static/app/components/pipeline/integrationDatadog/index.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.tsx
@@ -1,0 +1,126 @@
+import {useEffect} from 'react';
+import {z} from 'zod';
+
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import type {
+  PipelineDefinition,
+  PipelineStepProps,
+} from 'sentry/components/pipeline/types';
+import {pipelineComplete} from 'sentry/components/pipeline/types';
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+// Datadog sites and their region labels. Keep in sync with DATADOG_VALID_SITES in
+// src/sentry/identity/datadog/provider.py.
+const DATADOG_SITE_OPTIONS = [
+  {value: 'datadoghq.com', label: 'US1 (datadoghq.com)'},
+  {value: 'us3.datadoghq.com', label: 'US3 (us3.datadoghq.com)'},
+  {value: 'us5.datadoghq.com', label: 'US5 (us5.datadoghq.com)'},
+  {value: 'datadoghq.eu', label: 'EU (datadoghq.eu)'},
+  {value: 'ap1.datadoghq.com', label: 'AP1 (ap1.datadoghq.com)'},
+  {value: 'ap2.datadoghq.com', label: 'AP2 (ap2.datadoghq.com)'},
+  {value: 'ddog-gov.com', label: 'US1-FED (ddog-gov.com)'},
+  {value: 'us2.ddog-gov.com', label: 'US2-FED (us2.ddog-gov.com)'},
+];
+
+const credentialsSchema = z.object({
+  apiKey: z.string().min(1, t('API key is required')),
+  appKey: z.string().min(1, t('Application key is required')),
+  site: z.string().min(1, t('Site is required')),
+});
+
+function DatadogCredentialsStep({
+  advance,
+  advanceError,
+  isAdvancing,
+  isInitializing,
+}: PipelineStepProps<
+  Record<string, never>,
+  {apiKey: string; appKey: string; site: string}
+>) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {apiKey: '', appKey: '', site: ''},
+    validators: {onDynamic: credentialsSchema},
+    onSubmit: ({value}) => {
+      advance({apiKey: value.apiKey, appKey: value.appKey, site: value.site});
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {t(
+            'Enter an organization-level Datadog API key and application key so Seer can access your Datadog telemetry.'
+          )}
+        </Text>
+        <form.AppField name="site">
+          {field => (
+            <field.Layout.Stack label={t('Datadog Site')} required>
+              <field.Select
+                value={field.state.value}
+                onChange={value => field.handleChange(value)}
+                placeholder={t('Select your Datadog site')}
+                options={DATADOG_SITE_OPTIONS}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="apiKey">
+          {field => (
+            <field.Layout.Stack label={t('API Key')} required>
+              <field.Input
+                type="password"
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="********************************"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="appKey">
+          {field => (
+            <field.Layout.Stack label={t('Application Key')} required>
+              <field.Input
+                type="password"
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="****************************************"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <Flex>
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+export const datadogIntegrationPipeline = {
+  type: 'integration',
+  provider: 'datadog',
+  actionTitle: t('Installing Datadog'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'datadog_credentials',
+      shortDescription: t('Configuring Datadog credentials'),
+      component: DatadogCredentialsStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -4,6 +4,7 @@ import {bitbucketIntegrationPipeline} from './integrationBitbucket';
 import {bitbucketServerIntegrationPipeline} from './integrationBitbucketServer';
 import {claudeCodeIntegrationPipeline} from './integrationClaudeCode';
 import {cursorIntegrationPipeline} from './integrationCursor';
+import {datadogIntegrationPipeline} from './integrationDatadog';
 import {discordIntegrationPipeline} from './integrationDiscord';
 import {githubIntegrationPipeline} from './integrationGitHub';
 import {githubEnterpriseIntegrationPipeline} from './integrationGitHubEnterprise';
@@ -30,6 +31,7 @@ export const PIPELINE_REGISTRY = [
   bitbucketServerIntegrationPipeline,
   claudeCodeIntegrationPipeline,
   cursorIntegrationPipeline,
+  datadogIntegrationPipeline,
   discordIntegrationPipeline,
   dummyIntegrationPipeline,
   githubIntegrationPipeline,

--- a/static/app/components/seer/datadogPatConnectModal.tsx
+++ b/static/app/components/seer/datadogPatConnectModal.tsx
@@ -15,17 +15,7 @@ import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
-
-const DATADOG_SITES = [
-  {value: 'datadoghq.com', label: 'datadoghq.com (US1)'},
-  {value: 'us3.datadoghq.com', label: 'us3.datadoghq.com (US3)'},
-  {value: 'us5.datadoghq.com', label: 'us5.datadoghq.com (US5)'},
-  {value: 'datadoghq.eu', label: 'datadoghq.eu (EU)'},
-  {value: 'ddog-gov.com', label: 'ddog-gov.com (US1-FED)'},
-  {value: 'us2.ddog-gov.com', label: 'us2.ddog-gov.com (US2-FED)'},
-  {value: 'ap1.datadoghq.com', label: 'ap1.datadoghq.com (AP1)'},
-  {value: 'ap2.datadoghq.com', label: 'ap2.datadoghq.com (AP2)'},
-];
+import {DATADOG_SITES} from 'sentry/utils/seer/datadogSites';
 
 interface DatadogPatConnectModalProps extends ModalRenderProps {
   onSuccess: () => void;

--- a/static/app/utils/seer/datadogSites.ts
+++ b/static/app/utils/seer/datadogSites.ts
@@ -1,0 +1,16 @@
+// Keep in sync with DATADOG_VALID_SITES in src/sentry/identity/datadog/provider.py.
+export const DATADOG_SITES = [
+  {value: 'datadoghq.com', label: 'datadoghq.com (US1)'},
+  {value: 'us3.datadoghq.com', label: 'us3.datadoghq.com (US3)'},
+  {value: 'us5.datadoghq.com', label: 'us5.datadoghq.com (US5)'},
+  {value: 'datadoghq.eu', label: 'datadoghq.eu (EU)'},
+  {value: 'ap1.datadoghq.com', label: 'ap1.datadoghq.com (AP1)'},
+  {value: 'ap2.datadoghq.com', label: 'ap2.datadoghq.com (AP2)'},
+  {value: 'ddog-gov.com', label: 'ddog-gov.com (US1-FED)'},
+  {value: 'us2.ddog-gov.com', label: 'us2.ddog-gov.com (US2-FED)'},
+];
+
+export const DATADOG_SITE_VALUES = DATADOG_SITES.map(site => site.value) as [
+  string,
+  ...string[],
+];

--- a/tests/sentry/integrations/datadog/test_integration.py
+++ b/tests/sentry/integrations/datadog/test_integration.py
@@ -157,6 +157,35 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
         assert integration.metadata == {"api_key": "api", "app_key": "app", "site": "datadoghq.com"}
         assert responses.calls[0].request.headers["DD-API-KEY"] == "api"
 
+    @responses.activate
+    def test_update_organization_config_syncs_name_on_site_change(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-ext",
+            name="Datadog (datadoghq.com)",
+            metadata={"api_key": "api", "app_key": "app", "site": "datadoghq.com"},
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+        eu_url = "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp"
+        responses.add(responses.POST, eu_url, status=200, headers={"mcp-session-id": "sess-1"})
+        responses.add(
+            responses.POST,
+            eu_url,
+            status=200,
+            json={
+                "result": {
+                    "contents": [{"text": json.dumps({"user_uuid": "u-1", "org_uuid": "org-123"})}]
+                }
+            },
+        )
+
+        installation.update_organization_config({"site": "datadoghq.eu"})
+
+        integration.refresh_from_db()
+        assert integration.metadata["site"] == "datadoghq.eu"
+        assert integration.name == "Datadog (datadoghq.eu)"
+
     def test_provider_is_single_install_and_flagged(self) -> None:
         provider = self.provider()
         assert provider.key == "datadog"

--- a/tests/sentry/integrations/datadog/test_integration.py
+++ b/tests/sentry/integrations/datadog/test_integration.py
@@ -101,6 +101,62 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
         integration.refresh_from_db()
         assert integration.debug_data == {"site": "datadoghq.com"}
 
+    def test_get_organization_config_and_config_data(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-ext",
+            metadata={"api_key": "api", "app_key": "app", "site": "datadoghq.com"},
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        assert [f["name"] for f in installation.get_organization_config()] == [
+            "site",
+            "api_key",
+            "app_key",
+        ]
+        assert installation.get_config_data()["site"] == "datadoghq.com"
+
+    @responses.activate
+    def test_update_organization_config_revalidates_and_persists(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-ext",
+            metadata={"api_key": "old-api", "app_key": "old-app", "site": "datadoghq.com"},
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+        _mock_whoami({"user_uuid": "u-1", "org_uuid": "org-123"})
+
+        installation.update_organization_config(
+            {"api_key": "new-api", "app_key": "new-app", "site": "datadoghq.com"}
+        )
+
+        integration.refresh_from_db()
+        assert integration.metadata == {
+            "api_key": "new-api",
+            "app_key": "new-app",
+            "site": "datadoghq.com",
+        }
+        assert responses.calls[0].request.headers["DD-API-KEY"] == "new-api"
+
+    @responses.activate
+    def test_update_organization_config_keeps_omitted_secrets(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-ext",
+            metadata={"api_key": "api", "app_key": "app", "site": "datadoghq.com"},
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+        _mock_whoami({"user_uuid": "u-1", "org_uuid": "org-123"})
+
+        installation.update_organization_config({"site": "datadoghq.com"})
+
+        integration.refresh_from_db()
+        assert integration.metadata == {"api_key": "api", "app_key": "app", "site": "datadoghq.com"}
+        assert responses.calls[0].request.headers["DD-API-KEY"] == "api"
+
     def test_provider_is_single_install_and_flagged(self) -> None:
         provider = self.provider()
         assert provider.key == "datadog"

--- a/tests/sentry/integrations/datadog/test_integration.py
+++ b/tests/sentry/integrations/datadog/test_integration.py
@@ -1,9 +1,12 @@
 import hashlib
+import os
+import re
 from typing import Any
 
 import pytest
 import responses
 
+from sentry.identity.datadog.provider import DATADOG_VALID_SITES
 from sentry.integrations.datadog.integration import (
     DatadogIntegration,
     DatadogIntegrationProvider,
@@ -14,6 +17,17 @@ from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 
 MCP_URL = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+
+
+def test_frontend_datadog_sites_match_backend() -> None:
+    """The frontend site list is hand-maintained in a second language, so guard against it
+    drifting from DATADOG_VALID_SITES (the backend source of truth)."""
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 4)))
+    fe_path = os.path.join(repo_root, "static/app/utils/seer/datadogSites.ts")
+    with open(fe_path) as f:
+        frontend_sites = set(re.findall(r"value: '([^']+)'", f.read()))
+
+    assert frontend_sites == set(DATADOG_VALID_SITES)
 
 
 def _mock_whoami(whoami: dict[str, Any]) -> None:


### PR DESCRIPTION
This adds a UI in that allows us to configure the site, api key and application key for the datadog integration.

This is just an internal ui, we'll need to improve it a lot if we want to release it to customers.