### PR TITLE
debug(code-review): add sentry-org webhook handler instrumentation

### DIFF
--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -83,6 +83,14 @@ def handle_webhook_event(
     except Exception:
         logger.warning("github.webhook.code_review.failed_to_set_tags")
 
+    if organization.slug == "sentry":
+        logs_extra = dict(tags)
+        if github_delivery_id:
+            logs_extra["github_delivery_id"] = github_delivery_id
+        logs_extra["github_event_type"] = github_event.value
+        logs_extra["github_event_action"] = event.get("action", "unknown")
+        logger.info("github.webhook.code_review.received", extra=logs_extra)
+
     handler = EVENT_TYPE_TO_HANDLER[github_event]
 
     from ..utils import get_pr_author_id
@@ -101,10 +109,18 @@ def handle_webhook_event(
                 github_event_action=event.get("action", "unknown"),
                 reason=preflight.denial_reason,
             )
-            if organization.slug == "sentry":
+        if organization.slug == "sentry":
+            preflight_logs_extra = dict(tags)
+            preflight_logs_extra["allowed"] = preflight.allowed
+            if preflight.denial_reason:
                 sentry_sdk.set_tag("denial_reason", preflight.denial_reason)
                 sentry_sdk.set_attribute("denial_reason", preflight.denial_reason)
-                logger.info("github.webhook.code_review.denied")
+                preflight_logs_extra["denial_reason"] = preflight.denial_reason
+                logger.info("github.webhook.code_review.denied", extra=preflight_logs_extra)
+            else:
+                logger.info(
+                    "github.webhook.code_review.denied_no_reason", extra=preflight_logs_extra
+                )
         return
 
     # Ensure only one request per delivery_id within the TTL window: skip if already processed

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -61,6 +61,21 @@ def handle_webhook_event(
         integration: The GitHub integration
         **kwargs: Additional keyword arguments
     """
+    if organization.slug == "sentry":
+        logs_extra = {
+            "sentry_organization_id": str(organization.id),
+            "sentry_organization_slug": organization.slug,
+            "github_event_type": github_event.value,
+            "github_event_action": event.get("action", "unknown"),
+            "repo_id": str(repo.id),
+            "repo_name": repo.name,
+        }
+        if github_delivery_id:
+            logs_extra["github_delivery_id"] = github_delivery_id
+        if integration is not None:
+            logs_extra["sentry_integration_id"] = str(integration.id)
+        logger.info("github.webhook.code_review.received", extra=logs_extra)
+
     if integration is None:
         return
 
@@ -83,14 +98,6 @@ def handle_webhook_event(
     except Exception:
         logger.warning("github.webhook.code_review.failed_to_set_tags")
 
-    if organization.slug == "sentry":
-        logs_extra = dict(tags)
-        if github_delivery_id:
-            logs_extra["github_delivery_id"] = github_delivery_id
-        logs_extra["github_event_type"] = github_event.value
-        logs_extra["github_event_action"] = event.get("action", "unknown")
-        logger.info("github.webhook.code_review.received", extra=logs_extra)
-
     handler = EVENT_TYPE_TO_HANDLER[github_event]
 
     from ..utils import get_pr_author_id
@@ -109,6 +116,7 @@ def handle_webhook_event(
                 github_event_action=event.get("action", "unknown"),
                 reason=preflight.denial_reason,
             )
+
         if organization.slug == "sentry":
             preflight_logs_extra = dict(tags)
             preflight_logs_extra["allowed"] = preflight.allowed

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -120,7 +120,7 @@ def handle_webhook_event(
             )
 
         if organization.slug == "sentry":
-            preflight_logs_extra = dict(tags)
+            preflight_logs_extra: dict[str, Any] = dict(tags)
             preflight_logs_extra["allowed"] = preflight.allowed
             if preflight.denial_reason:
                 sentry_sdk.set_tag("denial_reason", preflight.denial_reason)

--- a/src/sentry/seer/code_review/webhooks/handlers.py
+++ b/src/sentry/seer/code_review/webhooks/handlers.py
@@ -72,8 +72,10 @@ def handle_webhook_event(
         }
         if github_delivery_id:
             logs_extra["github_delivery_id"] = github_delivery_id
+
         if integration is not None:
             logs_extra["sentry_integration_id"] = str(integration.id)
+
         logger.info("github.webhook.code_review.received", extra=logs_extra)
 
     if integration is None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Temporary debug instrumentation to diagnose why code reviews stopped for the `sentry` org (no `:eyes:`, no bot review, no existing webhook logs/metrics).

## Changes

In `handle_webhook_event` (`sentry.seer.code_review.webhooks.handlers`):

1. **Entry log** — when `organization.slug == "sentry"`, log `github.webhook.code_review.received` **immediately on entry**, before the `integration is None` early return, so we can tell whether GitHub events reach this handler even when integration is missing.
2. **Preflight log** — for the sentry org, log on the not-allowed preflight path even when `denial_reason` is missing (`github.webhook.code_review.denied` / `github.webhook.code_review.denied_no_reason`).

## How to verify

After deploy, trigger `@sentry review` on a getsentry PR and check explore logs for:
- `github.webhook.code_review.received`
- `github.webhook.code_review.denied` / `denied_no_reason`

If `received` never appears, the drop is before this handler. If it appears and then `denied*`, preflight is the culprit.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C09RHKAF05C/p1784149453540159?thread_ts=1784149453.540159&cid=C09RHKAF05C)

<div><a href="https://cursor.com/agents/bc-2660c051-c5ee-54d1-ace7-ccf501459bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2660c051-c5ee-54d1-ace7-ccf501459bb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

