### PR TITLE
feat(GAL): Trigger derived data rebuild after project backfill completes

### DIFF
--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -211,9 +211,9 @@ def _backfill_project(
         )
     activities = list(qs.order_by("datetime", "id")[:batch_size])
 
-    if not activities:
-        from sentry.issues.derived.tasks import process_project_derived_data
+    from sentry.issues.derived.tasks import process_project_derived_data
 
+    if not activities:
         logger.info(
             "backfill_group_action_log.project_completed",
             extra={"project_id": project.id},
@@ -315,3 +315,5 @@ def _backfill_project(
         )
         if activation_id:
             mark_spawned(_TASK_KEY, activation_id)
+    else:
+        process_project_derived_data.delay(project_id=project.id)

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -212,10 +212,13 @@ def _backfill_project(
     activities = list(qs.order_by("datetime", "id")[:batch_size])
 
     if not activities:
+        from sentry.issues.derived.tasks import process_project_derived_data
+
         logger.info(
             "backfill_group_action_log.project_completed",
             extra={"project_id": project.id},
         )
+        process_project_derived_data.delay(project_id=project.id)
         return
 
     logger.info(

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -316,4 +316,8 @@ def _backfill_project(
         if activation_id:
             mark_spawned(_TASK_KEY, activation_id)
     else:
+        logger.info(
+            "backfill_group_action_log.project_completed",
+            extra={"project_id": project.id},
+        )
         process_project_derived_data.delay(project_id=project.id)

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -190,6 +190,8 @@ def _backfill_project(
     cursor_id: int = 0,
     activation_id: str | None = None,
 ) -> None:
+    from sentry.issues.derived.tasks import process_project_derived_data
+
     batch_size: int = options.get("issues.backfill_group_action_log.batch_size")
     inter_batch_delay_s: int = options.get("issues.backfill_group_action_log.inter_batch_delay_s")
 
@@ -210,8 +212,6 @@ def _backfill_project(
             params=[cursor_dt, cursor_id],
         )
     activities = list(qs.order_by("datetime", "id")[:batch_size])
-
-    from sentry.issues.derived.tasks import process_project_derived_data
 
     if not activities:
         logger.info(

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -454,3 +454,10 @@ class BackfillGroupActionLogForProjectTest(TestCase):
             )
 
         mock_reset.assert_not_called()
+
+    @patch("sentry.issues.derived.tasks.process_project_derived_data.delay")
+    def test_triggers_derived_data_on_completion(self, mock_derived: Any) -> None:
+        with self._options():
+            backfill_group_action_log_for_project(self.project.id)
+
+        mock_derived.assert_called_once_with(project_id=self.project.id)


### PR DESCRIPTION
## Summary
- When the project-level GAL backfill chain finishes (no more activities to process), fire `process_project_derived_data` to rebuild `GroupDerivedData` for all groups missing it
- This ensures derived data is up-to-date after a backfill, especially after a reset that deletes all `GroupDerivedData` rows
- `process_project_derived_data` only processes groups without an existing `GroupDerivedData` row, so it's safe to call unconditionally

## Test plan
- [x] New test `test_triggers_derived_data_on_completion` verifies the task is called on backfill completion
- [x] All 28 existing backfill tests pass