### PR TITLE
feat(dashboards): add reorder and starred endpoints

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -152,6 +152,10 @@ from sentry.dashboards.endpoints.organization_dashboard_widget_details import (
     OrganizationDashboardWidgetDetailsEndpoint,
 )
 from sentry.dashboards.endpoints.organization_dashboards import OrganizationDashboardsEndpoint
+from sentry.dashboards.endpoints.organization_dashboards_starred import (
+    OrganizationDashboardsStarredEndpoint,
+    OrganizationDashboardsStarredOrderEndpoint,
+)
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.data_secrecy.api.waive_data_secrecy import WaiveDataSecrecyEndpoint
@@ -1516,6 +1520,16 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/dashboards/$",
         OrganizationDashboardsEndpoint.as_view(),
         name="sentry-api-0-organization-dashboards",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/dashboards/starred/$",
+        OrganizationDashboardsStarredEndpoint.as_view(),
+        name="sentry-api-0-organization-dashboard-starred",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/dashboards/starred/order/$",
+        OrganizationDashboardsStarredOrderEndpoint.as_view(),
+        name="sentry-api-0-organization-dashboard-starred-order",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/dashboards/widgets/$",

--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -38,6 +38,7 @@ from sentry.apidocs.response_types import (
 from sentry.dashboards.endpoints.organization_dashboards import OrganizationDashboardsPermission
 from sentry.models.dashboard import (
     Dashboard,
+    DashboardFavoriteUser,
     DashboardRevision,
 )
 from sentry.models.organization import Organization
@@ -281,6 +282,21 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
             return Response(status=401)
 
         is_favorited = request.data.get("isFavorited")
+
+        if features.has("organizations:dashboards-starred", organization, actor=request.user):
+            if is_favorited:
+                DashboardFavoriteUser.objects.insert_favorite_dashboard(
+                    organization=organization,
+                    user_id=request.user.id,
+                    dashboard=dashboard,
+                )
+            else:
+                DashboardFavoriteUser.objects.unfavorite_dashboard(
+                    organization=organization,
+                    user_id=request.user.id,
+                    dashboard=dashboard,
+                )
+            return Response(status=204)
 
         current_favorites = set(dashboard.favorited_by)
 

--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -281,10 +281,10 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
         if not request.user.is_authenticated:
             return Response(status=401)
 
-        is_favorited = request.data.get("isFavorited")
+        should_favorite = request.data.get("shouldFavorite", request.data.get("isFavorited"))
 
         if features.has("organizations:dashboards-starred", organization, actor=request.user):
-            if is_favorited:
+            if should_favorite:
                 DashboardFavoriteUser.objects.insert_favorite_dashboard(
                     organization=organization,
                     user_id=request.user.id,
@@ -300,9 +300,9 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
 
         current_favorites = set(dashboard.favorited_by)
 
-        if is_favorited and request.user.id not in current_favorites:
+        if should_favorite and request.user.id not in current_favorites:
             current_favorites.add(request.user.id)
-        elif not is_favorited and request.user.id in current_favorites:
+        elif not should_favorite and request.user.id in current_favorites:
             current_favorites.remove(request.user.id)
         else:
             return Response(status=204)

--- a/src/sentry/dashboards/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards_starred.py
@@ -1,0 +1,109 @@
+import sentry_sdk
+from django.db import IntegrityError, router, transaction
+from rest_framework import status
+from rest_framework.exceptions import ParseError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.paginator import GenericOffsetPaginator
+from sentry.api.serializers.base import serialize
+from sentry.api.serializers.models.dashboard import DashboardListSerializer
+from sentry.api.serializers.rest_framework.dashboard import DashboardStarredOrderSerializer
+from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
+from sentry.models.organization import Organization
+
+
+class MemberPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["member:read", "member:write"],
+        "PUT": ["member:read", "member:write"],
+    }
+
+
+@cell_silo_endpoint
+class OrganizationDashboardsStarredEndpoint(OrganizationEndpoint):
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.DASHBOARDS
+    permission_classes = (MemberPermission,)
+
+    def has_feature(self, organization: Organization, request: Request) -> bool:
+        return features.has("organizations:dashboards-starred", organization, actor=request.user)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        if not self.has_feature(organization, request):
+            return self.respond(status=status.HTTP_404_NOT_FOUND)
+
+        favorites = DashboardFavoriteUser.objects.get_favorite_dashboards(
+            organization=organization, user_id=request.user.id
+        ).select_related("dashboard")
+
+        if favorites.filter(position__isnull=True).exists():
+            # Commit the order of the dashboards of this current response if there are any
+            # that don't have a position assigned
+            DashboardFavoriteUser.objects.reorder_favorite_dashboards(
+                organization=organization,
+                user_id=request.user.id,
+                new_dashboard_positions=[favorite.dashboard.id for favorite in favorites],
+            )
+
+        def data_fn(offset: int, limit: int) -> list[Dashboard]:
+            return [favorite.dashboard for favorite in favorites[offset : offset + limit]]
+
+        return self.paginate(
+            request=request,
+            paginator=GenericOffsetPaginator(data_fn=data_fn),
+            on_results=lambda x: serialize(
+                x,
+                request.user,
+                serializer=DashboardListSerializer(),
+                context={"organization": organization},
+            ),
+            default_per_page=25,
+        )
+
+
+@cell_silo_endpoint
+class OrganizationDashboardsStarredOrderEndpoint(OrganizationEndpoint):
+    publish_status = {"PUT": ApiPublishStatus.PRIVATE}
+    owner = ApiOwner.DASHBOARDS
+    permission_classes = (MemberPermission,)
+
+    def has_feature(self, organization: Organization, request: Request) -> bool:
+        return features.has("organizations:dashboards-starred", organization, actor=request.user)
+
+    def put(self, request: Request, organization: Organization) -> Response:
+        if not request.user.is_authenticated:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        if not self.has_feature(organization, request):
+            return self.respond(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = DashboardStarredOrderSerializer(
+            data=request.data, context={"organization": organization, "user": request.user}
+        )
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        dashboard_ids = serializer.validated_data["dashboard_ids"]
+
+        try:
+            with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
+                DashboardFavoriteUser.objects.reorder_favorite_dashboards(
+                    organization=organization,
+                    user_id=request.user.id,
+                    new_dashboard_positions=dashboard_ids,
+                )
+        except (IntegrityError, ValueError) as e:
+            sentry_sdk.capture_exception(e)
+            raise ParseError("Mismatch between existing and provided starred dashboards.")
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -90,7 +90,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.custominboundfilter import CustomInboundFilter
-from sentry.models.dashboard import Dashboard
+from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
 from sentry.models.dashboard_widget import (
     DashboardWidget,
     DashboardWidgetDisplayTypes,
@@ -2319,6 +2319,25 @@ class Factories:
             title = petname.generate(2, " ", letters=10).title()
         return Dashboard.objects.create(
             organization=organization, title=title, created_by_id=created_by.id, **kwargs
+        )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_dashboard_favorite_user(
+        dashboard: Dashboard,
+        user: User,
+        organization: Organization | None = None,
+        position: int | None = None,
+        **kwargs,
+    ) -> DashboardFavoriteUser:
+        if organization is None:
+            organization = dashboard.organization
+        return DashboardFavoriteUser.objects.create(
+            dashboard=dashboard,
+            user_id=user.id,
+            organization=organization,
+            position=position,
+            **kwargs,
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -709,6 +709,9 @@ class Fixtures:
     def create_dashboard(self, *args, **kwargs):
         return Factories.create_dashboard(*args, **kwargs)
 
+    def create_dashboard_favorite_user(self, *args, **kwargs):
+        return Factories.create_dashboard_favorite_user(*args, **kwargs)
+
     def create_dashboard_widget(self, *args, **kwargs):
         return Factories.create_dashboard_widget(*args, **kwargs)
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -107,6 +107,8 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/$revisionId/restore/'
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/visit/'
   | '/organizations/$organizationIdOrSlug/dashboards/generate/'
+  | '/organizations/$organizationIdOrSlug/dashboards/starred/'
+  | '/organizations/$organizationIdOrSlug/dashboards/starred/order/'
   | '/organizations/$organizationIdOrSlug/dashboards/widgets/'
   | '/organizations/$organizationIdOrSlug/data-conditions/'
   | '/organizations/$organizationIdOrSlug/data-export/'

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -4719,14 +4719,14 @@ class OrganizationDashboardFavoriteTest(OrganizationDashboardDetailsTestCase):
     def test_favorite_dashboard(self) -> None:
         assert self.user.id not in self.dashboard.favorited_by
         self.login_as(user=self.user)
-        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": "true"})
+        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": "true"})
         assert response.status_code == 204
         assert self.user.id in self.dashboard.favorited_by
 
     def test_unfavorite_dashboard(self) -> None:
         assert self.user_1.id in self.dashboard.favorited_by
         self.login_as(user=self.user_1)
-        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": False})
+        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": False})
         assert response.status_code == 204
         assert self.user_1.id not in self.dashboard.favorited_by
 
@@ -4746,7 +4746,7 @@ class OrganizationDashboardFavoriteTest(OrganizationDashboardDetailsTestCase):
 
         # assert if user can edit the favorite status of the dashboard
         assert self.user_2.id in self.dashboard.favorited_by
-        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": False})
+        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": False})
         assert response.status_code == 204
         assert self.user_2.id not in self.dashboard.favorited_by
 
@@ -4799,7 +4799,7 @@ class OrganizationDashboardFavoriteReorderingTest(OrganizationDashboardDetailsTe
             dashboard=preexisting_dashboard,
         )
         # Insert self.dashboard
-        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": "true"})
+        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": "true"})
         assert response.status_code == 204
 
         assert list(
@@ -4817,7 +4817,7 @@ class OrganizationDashboardFavoriteReorderingTest(OrganizationDashboardDetailsTe
     def test_unfavorite_dashboard(self) -> None:
         assert self.user_1.id in self.dashboard.favorited_by
         self.login_as(user=self.user_1)
-        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": False})
+        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": False})
         assert response.status_code == 204
         assert (
             DashboardFavoriteUser.objects.get_favorite_dashboard(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -13,6 +13,7 @@ from sentry.discover.models import DatasetSourcesTypes
 from sentry.explore.translation.dashboards_translation import translate_dashboard_widget
 from sentry.models.dashboard import (
     Dashboard,
+    DashboardFavoriteUser,
     DashboardRevision,
 )
 from sentry.models.dashboard_permissions import DashboardPermissions
@@ -4748,3 +4749,81 @@ class OrganizationDashboardFavoriteTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": False})
         assert response.status_code == 204
         assert self.user_2.id not in self.dashboard.favorited_by
+
+
+class OrganizationDashboardFavoriteReorderingTest(OrganizationDashboardDetailsTestCase):
+    """
+    These tests are intended to cover and eventually replace the existing
+    OrganizationDashboardFavoriteTest cases. These test the feature flagged
+    PUT logic for inserting and removing a dashboard from the favorite list.
+    """
+
+    features = ["organizations:dashboards-starred"]
+
+    def do_request(self, *args, **kwargs):
+        with self.feature(self.features):
+            return super().do_request(*args, **kwargs)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user_1 = self.create_user(email="user1@example.com")
+        self.create_member(user=self.user_1, organization=self.organization)
+
+        DashboardFavoriteUser.objects.insert_favorite_dashboard(
+            organization=self.organization,
+            user_id=self.user_1.id,
+            dashboard=self.dashboard,
+        )
+
+    def url(self, dashboard_id):
+        return reverse(
+            "sentry-api-0-organization-dashboard-favorite",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "dashboard_id": dashboard_id,
+            },
+        )
+
+    def test_insert_favorite_adds_dashboard_at_end_of_list(self) -> None:
+        assert self.user.id not in self.dashboard.favorited_by
+        self.login_as(user=self.user)
+
+        preexisting_dashboard = self.create_dashboard(
+            title="Preexisting Dashboard",
+            created_by=self.user,
+            organization=self.organization,
+        )
+        DashboardFavoriteUser.objects.insert_favorite_dashboard(
+            organization=self.organization,
+            user_id=self.user.id,
+            dashboard=preexisting_dashboard,
+        )
+        # Insert self.dashboard
+        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": "true"})
+        assert response.status_code == 204
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization,
+                user_id=self.user.id,
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [
+            preexisting_dashboard.id,
+            self.dashboard.id,
+        ]
+
+    def test_unfavorite_dashboard(self) -> None:
+        assert self.user_1.id in self.dashboard.favorited_by
+        self.login_as(user=self.user_1)
+        response = self.do_request("put", self.url(self.dashboard.id), data={"isFavorited": False})
+        assert response.status_code == 204
+        assert (
+            DashboardFavoriteUser.objects.get_favorite_dashboard(
+                organization=self.organization,
+                user_id=self.user_1.id,
+                dashboard=self.dashboard,
+            )
+            is None
+        )

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -4719,14 +4719,18 @@ class OrganizationDashboardFavoriteTest(OrganizationDashboardDetailsTestCase):
     def test_favorite_dashboard(self) -> None:
         assert self.user.id not in self.dashboard.favorited_by
         self.login_as(user=self.user)
-        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": "true"})
+        response = self.do_request(
+            "put", self.url(self.dashboard.id), data={"shouldFavorite": "true"}
+        )
         assert response.status_code == 204
         assert self.user.id in self.dashboard.favorited_by
 
     def test_unfavorite_dashboard(self) -> None:
         assert self.user_1.id in self.dashboard.favorited_by
         self.login_as(user=self.user_1)
-        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": False})
+        response = self.do_request(
+            "put", self.url(self.dashboard.id), data={"shouldFavorite": False}
+        )
         assert response.status_code == 204
         assert self.user_1.id not in self.dashboard.favorited_by
 
@@ -4746,7 +4750,9 @@ class OrganizationDashboardFavoriteTest(OrganizationDashboardDetailsTestCase):
 
         # assert if user can edit the favorite status of the dashboard
         assert self.user_2.id in self.dashboard.favorited_by
-        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": False})
+        response = self.do_request(
+            "put", self.url(self.dashboard.id), data={"shouldFavorite": False}
+        )
         assert response.status_code == 204
         assert self.user_2.id not in self.dashboard.favorited_by
 
@@ -4799,7 +4805,9 @@ class OrganizationDashboardFavoriteReorderingTest(OrganizationDashboardDetailsTe
             dashboard=preexisting_dashboard,
         )
         # Insert self.dashboard
-        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": "true"})
+        response = self.do_request(
+            "put", self.url(self.dashboard.id), data={"shouldFavorite": "true"}
+        )
         assert response.status_code == 204
 
         assert list(
@@ -4817,7 +4825,9 @@ class OrganizationDashboardFavoriteReorderingTest(OrganizationDashboardDetailsTe
     def test_unfavorite_dashboard(self) -> None:
         assert self.user_1.id in self.dashboard.favorited_by
         self.login_as(user=self.user_1)
-        response = self.do_request("put", self.url(self.dashboard.id), data={"shouldFavorite": False})
+        response = self.do_request(
+            "put", self.url(self.dashboard.id), data={"shouldFavorite": False}
+        )
         assert response.status_code == 204
         assert (
             DashboardFavoriteUser.objects.get_favorite_dashboard(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards_starred.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards_starred.py
@@ -1,0 +1,182 @@
+from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.models.dashboard import DashboardFavoriteUser
+from sentry.testutils.cases import OrganizationDashboardWidgetTestCase
+
+
+class StarredDashboardTestCase(OrganizationDashboardWidgetTestCase):
+    def do_request(self, *args, **kwargs):
+        with self.feature("organizations:dashboards-starred"):
+            return super().do_request(*args, **kwargs)
+
+
+class OrganizationDashboardsStarredTest(StarredDashboardTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.url = reverse(
+            "sentry-api-0-organization-dashboard-starred",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        self.dashboard_1 = self.create_dashboard(title="Dashboard 1")
+        self.dashboard_2 = self.create_dashboard(title="Dashboard 2")
+        self.dashboard_3 = self.create_dashboard(title="Dashboard 3")
+
+    def test_get_favorite_dashboards(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, 2)
+        self.create_dashboard_favorite_user(self.dashboard_2, self.user, self.organization, 0)
+        self.create_dashboard_favorite_user(self.dashboard_3, self.user, self.organization, 1)
+
+        response = self.do_request("get", self.url)
+        assert response.status_code == 200
+        assert len(response.data) == 3
+        assert [int(dashboard["id"]) for dashboard in response.data] == [
+            self.dashboard_2.id,
+            self.dashboard_3.id,
+            self.dashboard_1.id,
+        ]
+
+    def test_get_favorite_dashboards_only_returns_your_dashboards(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, 1)
+
+        # Add a dashboard starred by another user to verify that it is not returned
+        other_user = self.create_user("other@example.com")
+        other_dashboard = self.create_dashboard(title="Other Dashboard")
+        self.create_dashboard_favorite_user(other_dashboard, other_user, self.organization, 0)
+
+        response = self.do_request("get", self.url)
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert int(response.data[0]["id"]) == self.dashboard_1.id
+
+    def test_get_request_assigns_positions_if_missing(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, None)
+        self.create_dashboard_favorite_user(self.dashboard_2, self.user, self.organization, 2)
+        self.create_dashboard_favorite_user(self.dashboard_3, self.user, self.organization, None)
+
+        response = self.do_request("get", self.url)
+        assert response.status_code == 200
+        assert len(response.data) == 3
+
+        # Positioned dashboards are at the top of the list in this operation
+        assert (
+            DashboardFavoriteUser.objects.get(
+                organization=self.organization, user_id=self.user.id, dashboard=self.dashboard_2
+            ).position
+            == 0
+        )
+        assert (
+            DashboardFavoriteUser.objects.get(
+                organization=self.organization, user_id=self.user.id, dashboard=self.dashboard_1
+            ).position
+            == 1
+        )
+        assert (
+            DashboardFavoriteUser.objects.get(
+                organization=self.organization, user_id=self.user.id, dashboard=self.dashboard_3
+            ).position
+            == 2
+        )
+
+
+class OrganizationDashboardsStarredOrderTest(StarredDashboardTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.url = reverse(
+            "sentry-api-0-organization-dashboard-starred-order",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        self.dashboard_1 = self.create_dashboard(title="Dashboard 1")
+        self.dashboard_2 = self.create_dashboard(title="Dashboard 2")
+        self.dashboard_3 = self.create_dashboard(title="Dashboard 3")
+
+    def test_reorder_dashboards(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite_user(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite_user(self.dashboard_3, self.user, self.organization, 2)
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [
+            self.dashboard_1.id,
+            self.dashboard_2.id,
+            self.dashboard_3.id,
+        ]
+
+        response = self.do_request(
+            "put",
+            self.url,
+            data={"dashboard_ids": [self.dashboard_3.id, self.dashboard_1.id, self.dashboard_2.id]},
+        )
+        assert response.status_code == 204
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [
+            self.dashboard_3.id,
+            self.dashboard_1.id,
+            self.dashboard_2.id,
+        ]
+
+    def test_throws_an_error_if_dashboard_ids_are_not_unique(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite_user(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite_user(self.dashboard_3, self.user, self.organization, 2)
+
+        response = self.do_request(
+            "put",
+            self.url,
+            data={"dashboard_ids": [self.dashboard_1.id, self.dashboard_1.id, self.dashboard_2.id]},
+        )
+        assert response.status_code == 400
+        assert response.data == {
+            "dashboard_ids": ["Single dashboard cannot take up multiple positions"]
+        }
+
+    def test_throws_an_error_if_reordered_dashboard_ids_are_not_complete(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, 0)
+        self.create_dashboard_favorite_user(self.dashboard_2, self.user, self.organization, 1)
+        self.create_dashboard_favorite_user(self.dashboard_3, self.user, self.organization, 2)
+
+        response = self.do_request(
+            "put",
+            self.url,
+            data={"dashboard_ids": [self.dashboard_1.id, self.dashboard_2.id]},
+        )
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": ErrorDetail(
+                string="Mismatch between existing and provided starred dashboards.",
+                code="parse_error",
+            )
+        }
+
+    def test_allows_reordering_even_if_no_initial_positions(self) -> None:
+        self.create_dashboard_favorite_user(self.dashboard_1, self.user, self.organization, None)
+        self.create_dashboard_favorite_user(self.dashboard_2, self.user, self.organization, None)
+        self.create_dashboard_favorite_user(self.dashboard_3, self.user, self.organization, None)
+
+        response = self.do_request(
+            "put",
+            self.url,
+            data={"dashboard_ids": [self.dashboard_3.id, self.dashboard_1.id, self.dashboard_2.id]},
+        )
+        assert response.status_code == 204
+
+        assert list(
+            DashboardFavoriteUser.objects.filter(
+                organization=self.organization, user_id=self.user.id
+            )
+            .order_by("position")
+            .values_list("dashboard_id", flat=True)
+        ) == [self.dashboard_3.id, self.dashboard_1.id, self.dashboard_2.id]

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -1,7 +1,5 @@
 from sentry.models.dashboard import Dashboard, DashboardFavoriteUser, DashboardRevision
-from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
-from sentry.users.models.user import User
 
 
 class IncrementalNameTest(TestCase):
@@ -63,13 +61,6 @@ class IncrementalNameTest(TestCase):
 
 
 class DashboardFavoriteUserTest(TestCase):
-    def create_dashboard_favorite_user(
-        self, dashboard: Dashboard, user: User, organization: Organization, position: int | None
-    ) -> DashboardFavoriteUser:
-        return DashboardFavoriteUser.objects.create(
-            dashboard=dashboard, user_id=user.id, organization=organization, position=position
-        )
-
     def test_inserts_to_last_position(self) -> None:
         for index, title in enumerate(["Existing Favorite", "Another Favorite"]):
             dashboard = self.create_dashboard(title=title, organization=self.organization)


### PR DESCRIPTION
This PR is one of many to bring the "starred dashboards" sidebar to parity with Explore's "starred queries" sidebar.

This PR adds the starred and starred order endpoints to the dashboard set of endpoints. These are going to be pinged by the frontend to get a customers' favorite/starred dashboards, as well as the option to change their order. Added tests + a test factory as I saw a similar method to create favorite dashboards used in 2 different tests. 

Additionally, I saw that the backend doesn't currently add a position when it creates a dashboard, and to change it I would have had to make a change in the deprecated [favorited_by setter](https://github.com/getsentry/sentry/blob/d76680dc70924638e027ff71cf0e6ccda6bdfa3b/src/sentry/models/dashboard.py#L373), so I instead opted for the `insert_favorite_dashboard` (and remove) logic from the DashboardFavoriteUser manager, feature flagged atm. 

Closes BROWSE-612