### PR TITLE
fix(derived data): Log when the project-level task has nothing to do

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -58,6 +58,10 @@ def process_project_derived_data(project_id: int, **kwargs: object) -> None:
     )
 
     if not group_ids:
+        logger.info(
+            "process_project_derived_data.all_groups_covered",
+            extra={"project_id": project_id},
+        )
         return
 
     starts = [group_ids[i] for i in range(0, len(group_ids), batch_size)]


### PR DESCRIPTION
Kicking off a task and there being no sign of it ever running is a bad experience.
This ensures that it always logs when it finishes with info on what happened.