### PR TITLE
fix(search): Preserve negation on quoted colon-value filters

### DIFF
--- a/static/app/components/searchSyntax/mutableSearch.spec.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.spec.tsx
@@ -426,6 +426,11 @@ describe('MutableSearch', () => {
         string: 'bad things user:id:123',
       },
       {
+        name: 'should preserve negation on colon values',
+        object: new MutableSearch(['bad', 'things', '!user:"id:123"']),
+        string: 'bad things !user:id:123',
+      },
+      {
         name: 'should escape quote tags with double quotes',
         object: new MutableSearch([
           'bad',

--- a/static/app/components/searchSyntax/mutableSearch.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.tsx
@@ -214,7 +214,8 @@ function parseToFlatTokens(query: string): Token[] {
           !/\s/.test(rawVal)
         ) {
           const op = t.operator ?? '';
-          text = `${keyName}:${op}${rawVal}`;
+          const negation = t.negated ? '!' : '';
+          text = `${negation}${keyName}:${op}${rawVal}`;
         }
 
         let wildcard: WildcardOperators | undefined;


### PR DESCRIPTION
The MutableSearch colon-value special case (which strips quotes from values like user:"id:123" -> user:id:123) rebuilt the token text from the key, operator, and value but omitted the negation. For text filters the leading "!" is stored in the separate negated field, so it was silently dropped.

This surfaced on the Issue Details page, which normalizes the query through MutableSearch: a negated filter such as !message:"gpu::" flipped to the positive message:gpu::, inverting the filter and returning almost no events.

Re-add the negation prefix when rebuilding the text, and guard it with a regression test.

Fixes GH-119703
Refs ID-1705