### PR TITLE
fix(issues): Balance stack trace frame headers

### DIFF
--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -129,7 +129,10 @@ function FrameLocation({
   const frameLocationSuffix = formatFrameLocation('', frame.lineNo, frame.colNo);
 
   return (
-    <LocationWrapper>
+    <LocationWrapper
+      hasFunction={!!(frame.function ?? frame.rawFunction)}
+      isExpanded={isExpanded}
+    >
       {!isExpanded && leadsToApp ? (
         <LeadHint>
           {getLeadHint({event, hasNextFrame})}
@@ -169,20 +172,20 @@ function FrameContext({frame, platform}: {frame: Frame; platform: PlatformKey}) 
   return (
     <ContextWrapper>
       {hasFrameFunction ? (
-        <Fragment>
+        <FunctionContext>
           <Text as="span" size="xs" variant="muted" monospace>
             {t('in')}
           </Text>
           <FuncName>{frameFunctionName}</FuncName>
-        </Fragment>
+        </FunctionContext>
       ) : null}
       {showPackage ? (
-        <Fragment>
+        <PackageContext>
           <Text as="span" size="xs" variant="muted" monospace>
             {t('within')}
           </Text>
           <PkgName>{frame.package}</PkgName>
-        </Fragment>
+        </PackageContext>
       ) : null}
     </ContextWrapper>
   );
@@ -291,15 +294,18 @@ const ActionArea = styled('div')`
 const TrailingActions = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${p => p.theme.space.xs};
+  gap: ${p => p.theme.space['2xs']};
   margin-left: auto;
 `;
 
-const LocationWrapper = styled('span')`
+const LocationWrapper = styled('span')<{
+  hasFunction: boolean;
+  isExpanded: boolean;
+}>`
   display: inline-flex;
   align-items: baseline;
   min-width: 0;
-  max-width: 100%;
+  max-width: ${p => (!p.isExpanded && p.hasFunction ? '55%' : '100%')};
   flex: 0 1 auto;
   overflow: hidden;
 `;
@@ -333,12 +339,30 @@ const Path = styled('span')`
 const ContextWrapper = styled('span')`
   display: inline-flex;
   align-items: baseline;
-  flex: 0 999 auto;
+  flex: 0 1 auto;
   gap: ${p => p.theme.space.sm};
   max-width: 100%;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;
+`;
+
+const FunctionContext = styled('span')`
+  display: inline-flex;
+  align-items: baseline;
+  flex: 0 1 auto;
+  gap: ${p => p.theme.space.sm};
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const PackageContext = styled('span')`
+  display: inline-flex;
+  align-items: baseline;
+  flex: 0 999 auto;
+  gap: ${p => p.theme.space.sm};
+  min-width: 0;
+  overflow: hidden;
 `;
 
 const FuncName = styled('span')`

--- a/static/app/components/stackTrace/issueStackTrace/issueSourceLinkAction.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/issueSourceLinkAction.tsx
@@ -83,7 +83,7 @@ export function IssueSourceLinkAction({isHovering = false}: IssueSourceLinkActio
 
 const FrameActionsSlot = styled(Flex)<{reserveSpace: boolean}>`
   align-items: center;
-  gap: ${p => p.theme.space.sm};
+  gap: ${p => p.theme.space.xs};
   justify-content: flex-end;
   width: ${p => (p.reserveSpace ? 'max-content' : '0')};
   flex: ${p => (p.reserveSpace ? '0 0 max-content' : '0 0 0')};

--- a/static/app/components/stackTrace/stackTrace.stories.tsx
+++ b/static/app/components/stackTrace/stackTrace.stories.tsx
@@ -1323,7 +1323,7 @@ const WideHovercard = styled(WideHovercardBase)`
 
 const HoverActionsSlot = styled(Flex)<{visible: boolean}>`
   align-items: center;
-  gap: ${p => p.theme.space.sm};
+  gap: ${p => p.theme.space.xs};
   opacity: ${p => (p.visible ? 1 : 0)};
   pointer-events: ${p => (p.visible ? 'auto' : 'none')};
 `;


### PR DESCRIPTION
Long filenames in collapsed stack trace frames could take over the header and hide most of the function name. Long package names also competed equally with the more useful function context.

Give filenames a balanced cap only when a collapsed frame has a function, let package context yield first, and tighten the action spacing. Expanded and package-only frames keep the full available width.

before

<img width="847" height="190" alt="image" src="https://github.com/user-attachments/assets/75c7e674-bb71-4f10-8eb3-5288efdd55b4" />


after

<img width="828" height="189" alt="image" src="https://github.com/user-attachments/assets/de508fd7-9c89-49d9-bd6a-e5ba5e967409" />
