### PR TITLE
Revert "ref(feedback): emit metric instead of outcome for ingest denylist (#97970)"

### DIFF
--- a/src/sentry/feedback/tasks/update_user_reports.py
+++ b/src/sentry/feedback/tasks/update_user_reports.py
@@ -5,6 +5,7 @@ import sentry_sdk
 from django.utils import timezone
 
 from sentry import quotas
+from sentry.constants import DataCategory
 from sentry.feedback.lib.utils import FeedbackCreationSource, is_in_feedback_denylist
 from sentry.feedback.usecases.ingest.shim_to_feedback import shim_to_feedback
 from sentry.models.project import Project
@@ -17,6 +18,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import metrics
 from sentry.utils.iterators import chunked
+from sentry.utils.outcomes import Outcome, track_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -122,6 +124,18 @@ def update_user_reports(
                             event,
                             project,
                             FeedbackCreationSource.UPDATE_USER_REPORTS_TASK,
+                        )
+                    else:
+                        track_outcome(
+                            org_id=project.organization_id,
+                            project_id=project.id,
+                            key_id=None,
+                            outcome=Outcome.RATE_LIMITED,
+                            reason="feedback_denylist",
+                            timestamp=datetime.fromisoformat(event.timestamp),
+                            event_id=event.event_id,
+                            category=DataCategory.USER_REPORT_V2,
+                            quantity=1,
                         )
                 # XXX(aliu): If a report has environment_id but not group_id, this report was shimmed from a feedback issue, so no need to shim again.
                 report.update(group_id=event.group_id, environment_id=event.get_environment().id)

--- a/src/sentry/feedback/tasks/update_user_reports.py
+++ b/src/sentry/feedback/tasks/update_user_reports.py
@@ -123,9 +123,6 @@ def update_user_reports(
                             project,
                             FeedbackCreationSource.UPDATE_USER_REPORTS_TASK,
                         )
-                    else:
-                        metrics.incr("feedback.ingest.denylist")
-
                 # XXX(aliu): If a report has environment_id but not group_id, this report was shimmed from a feedback issue, so no need to shim again.
                 report.update(group_id=event.group_id, environment_id=event.get_environment().id)
                 updated_reports += 1

--- a/src/sentry/feedback/usecases/ingest/shim_to_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/shim_to_feedback.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
+from sentry.constants import DataCategory
 from sentry.feedback.lib.types import UserReportDict
 from sentry.feedback.lib.utils import FeedbackCreationSource, is_in_feedback_denylist
 from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issue
 from sentry.models.project import Project
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
+from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -28,7 +31,17 @@ def shim_to_feedback(
     legacy user report and event to create the new feedback.
     """
     if is_in_feedback_denylist(project.organization):
-        metrics.incr("feedback.ingest.denylist")
+        track_outcome(
+            org_id=project.organization_id,
+            project_id=project.id,
+            key_id=None,
+            outcome=Outcome.RATE_LIMITED,
+            reason="feedback_denylist",
+            timestamp=datetime.fromisoformat(event.timestamp),
+            event_id=event.event_id,
+            category=DataCategory.USER_REPORT_V2,
+            quantity=1,
+        )
         return
 
     try:

--- a/src/sentry/feedback/usecases/ingest/userreport.py
+++ b/src/sentry/feedback/usecases/ingest/userreport.py
@@ -50,8 +50,17 @@ def save_userreport(
                 "user_report.create_user_report.filtered",
                 tags={"reason": "org.denylist", "referrer": source.value},
             )
-            metrics.incr("feedback.ingest.denylist")
-
+            track_outcome(
+                org_id=project.organization_id,
+                project_id=project.id,
+                key_id=None,
+                outcome=Outcome.RATE_LIMITED,
+                reason="feedback_denylist",
+                timestamp=start_time,
+                event_id=None,  # Note report["event_id"] is id of the associated event, not the report itself.
+                category=DataCategory.USER_REPORT_V2,
+                quantity=1,
+            )
             if (
                 source == FeedbackCreationSource.USER_REPORT_DJANGO_ENDPOINT
                 or source == FeedbackCreationSource.CRASH_REPORT_EMBED_FORM

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -12,6 +12,7 @@ from usageaccountant import UsageUnit
 
 from sentry import features
 from sentry.attachments import CachedAttachment, attachment_cache, store_attachments_for_event
+from sentry.constants import DataCategory
 from sentry.event_manager import save_attachment
 from sentry.feedback.lib.utils import FeedbackCreationSource, is_in_feedback_denylist
 from sentry.feedback.usecases.ingest.userreport import Conflict, save_userreport
@@ -31,6 +32,7 @@ from sentry.utils import metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.dates import to_datetime
 from sentry.utils.event_tracker import TransactionStageStatus, track_sampled_event
+from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.snuba import RateLimitExceeded
 from sentry.utils.tracing import start_span
 
@@ -262,7 +264,17 @@ def process_event(
                     project_id=project_id,
                 )
             else:
-                metrics.incr("feedback.ingest.filtered", tags={"reason": "org.denylist"})
+                track_outcome(
+                    org_id=project.organization_id,
+                    project_id=project_id,
+                    key_id=None,
+                    outcome=Outcome.RATE_LIMITED,
+                    reason="feedback_denylist",
+                    timestamp=to_datetime(start_time),
+                    event_id=event_id,
+                    category=DataCategory.USER_REPORT_V2,
+                    quantity=1,
+                )
         else:
             # Preprocess this event, which spawns either process_event or
             # save_event. Pass data explicitly to avoid fetching it again from the

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -262,7 +262,7 @@ def process_event(
                     project_id=project_id,
                 )
             else:
-                metrics.incr("feedback.ingest.denylist")
+                metrics.incr("feedback.ingest.filtered", tags={"reason": "org.denylist"})
         else:
             # Preprocess this event, which spawns either process_event or
             # save_event. Pass data explicitly to avoid fetching it again from the


### PR DESCRIPTION
Reverts #97970. The custom metric went unused and we'd prefer to track all dropped feedback in outcomes. DD dash: https://app.datadoghq.com/s/FH6-Y3/hmx-2zi-zqy 