### PR TITLE
feat(seer): Experimenting around

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2510,6 +2510,10 @@ function buildRoutes(): RouteObject[] {
       component: make(() => import('sentry/views/autofixIssuesDemo')),
     },
     {
+      path: 'autofix/overview/',
+      component: make(() => import('sentry/views/seerWorkflows/overview')),
+    },
+    {
       path: 'views/:viewId/',
       component: errorHandler(OverviewWrapper),
     },

--- a/static/app/views/autofixIssuesDemo/useAutofixIssues.tsx
+++ b/static/app/views/autofixIssuesDemo/useAutofixIssues.tsx
@@ -1,10 +1,12 @@
 import {useMemo} from 'react';
-import {skipToken, useQueries, useQuery} from '@tanstack/react-query';
+import {useQueries, useQuery} from '@tanstack/react-query';
 
 import {
   type ExplorerAutofixState,
   getOrderedAutofixSections,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {Level} from 'sentry/types/event';
+import type {PlatformKey} from 'sentry/types/platform';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -37,19 +39,11 @@ const DEMO_QUESTIONS = [
   'What is the complexity of the fix? Count or estimate number of lines and files touched.',
 ];
 
-// Keep the issue page size at/under the runs endpoint's outputs page cap (10)
-// so a single runs request covers every group on the page.
+// Issues per page; also bounds the per-group runs/state request fan-out.
 const PER_PAGE = 10;
 
-// The furthest phase an autofix run has reached, derived from its state.
-// NOTE: 'pr_merged' is intentionally never produced here — the autofix state
-// endpoint only reports up to "PR opened" (repo_pr_states.pr_creation_status
-// tops out at 'completed'). GitHub merge status lives on sentry.PullRequest and
-// would need a separate backend join to surface. Kept in the union so the UI
-// can label it once that data is available.
 export type AutofixPhase = 'rca' | 'planning' | 'coding' | 'pr_open' | 'pr_merged';
 
-// Human labels for each phase.
 export const AUTOFIX_PHASE_LABELS: Record<AutofixPhase, string> = {
   rca: 'Root cause',
   planning: 'Planning',
@@ -88,47 +82,67 @@ function deriveAutofixPhase(runState: ExplorerAutofixState | null): AutofixPhase
 }
 
 // One answered question, mirrors the run output in
-// src/sentry/api/serializers/models/seer_run.py.
-interface RunQuestion {
+// src/sentry/api/serializers/models/seer_run.py
+export interface RunQuestion {
   answer: string;
   key: string;
   // The question text, echoed back only for user-supplied questions.
   question?: string;
 }
 
+// A pull request linked to a run, serialized by PullRequestSerializer
+// src/sentry/api/serializers/models/pullrequest.py
+// `status` is 'open' | 'merged' | 'closed' | 'draft' | 'unknown'.
+interface RunPullRequest {
+  status: string | null;
+  mergedAt?: string | null;
+}
+
 // Subset of the runs list response we consume
-// (src/sentry/api/serializers/models/seer_run.py).
+// src/sentry/api/serializers/models/seer_run.py
 interface SeerRun {
   groupId: string | null;
   id: string;
   lastTriggeredAt: string;
-  // Present only when ?outputs is requested (and the feature is on).
+  source: string | null;
+  // Present only when ?outputs is requested.
   outputs?: RunQuestion[];
+  // Linked PRs with merge status.
+  pullRequests?: RunPullRequest[];
 }
 
 // Subset of the issue-stream group we render.
 interface Issue {
+  // Event count over the stats period. Endpoint sadly returns a string.
+  count: string;
   culprit: string;
   id: string;
+  lastSeen: string;
+  level: Level;
+  project: {slug: string; platform?: PlatformKey};
   seerAutofixLastTriggered: string | null;
   seerFixabilityScore: number | null;
   shortId: string;
   title: string;
+  userCount: number;
 }
 
 export interface AutofixIssue extends Issue {
-  // The furthest autofix phase this issue's run has reached, or null when the
-  // per-group autofix state hasn't loaded yet / has no run.
   autofixPhase: AutofixPhase | null;
-  // Whether the per-group autofix state is still loading.
   autofixPhasePending: boolean;
-  // The most recent explorer/autofix run for this issue's group, if any.
+  autofixState: ExplorerAutofixState | null;
   run: SeerRun | null;
 }
 
 interface UseAutofixIssuesParams {
   cursor?: string;
   query?: string;
+  // One-shot questions asked about each run (repeatable `question` param,
+  // capped at 5 by the endpoint). Defaults to this page's demo set.
+  questions?: string[];
+  // Runs-endpoint filter to enrich issues with. Defaults to the explorer runs
+  // autofix creates; pass e.g. 'type:explorer' to include all trigger sources.
+  runsQuery?: string;
 }
 
 interface UseAutofixIssuesResult {
@@ -141,13 +155,14 @@ interface UseAutofixIssuesResult {
 
 /**
  * Fetches a page of autofix issues from the issue stream and enriches each one
- * with its most recent Seer run (including one-shot outputs). The runs request
- * is scoped to exactly the groups on the page via ``group:[...]``, so we make
- * one extra request per page rather than fetching every run in the org.
+ * with its most recent Seer run (including one-shot outputs) and its autofix
+ * state — one runs request and one state request per group on the page.
  */
 export function useAutofixIssues({
   query,
   cursor,
+  questions = DEMO_QUESTIONS,
+  runsQuery: runsQueryFilter = RUNS_QUERY,
 }: UseAutofixIssuesParams): UseAutofixIssuesResult {
   const organization = useOrganization();
 
@@ -160,6 +175,10 @@ export function useAutofixIssues({
         cursor,
         project: -1,
         statsPeriod: '90d',
+        // Explicit endpoint default: last-seen desc selects the issues still
+        // actively occurring as the candidate pool; callers order the loaded
+        // page themselves (the overview applies a triage sort).
+        sort: 'date',
         limit: PER_PAGE,
       },
       staleTime: 30_000,
@@ -171,17 +190,25 @@ export function useAutofixIssues({
   const groupIds = useMemo(() => issues.map(issue => issue.id), [issues]);
   const runsEnabled = groupIds.length > 0;
 
-  // 2. Enrich with the runs for exactly those groups (one group-scoped request).
-  const runsQuery = useQuery(
-    apiOptions.as<SeerRun[]>()('/organizations/$organizationIdOrSlug/seer/runs/', {
-      path: runsEnabled ? {organizationIdOrSlug: organization.slug} : skipToken,
-      query: {
-        query: `${RUNS_QUERY} group:[${groupIds.join(',')}]`,
-        question: DEMO_QUESTIONS,
-      },
-      staleTime: 30_000,
-    })
-  );
+  // 2. Enrich with each group's latest run, one request per group with
+  // per_page=1. A single batched group:[...] request looked cheaper, but the
+  // endpoint caps outputs-enabled pages at 10 runs ordered by recency — when
+  // the page's groups collectively have more runs than that, the oldest
+  // groups' runs fall off and their issues silently lose all answers. Per-
+  // group requests make coverage guaranteed with the same total one-shot work.
+  const runResults = useQueries({
+    queries: groupIds.map(groupId =>
+      apiOptions.as<SeerRun[]>()('/organizations/$organizationIdOrSlug/seer/runs/', {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {
+          query: `${runsQueryFilter} group:${groupId}`,
+          question: questions,
+          per_page: 1,
+        },
+        staleTime: 30_000,
+      })
+    ),
+  });
 
   // 3. Fetch the full autofix state per group to derive its phase. This is one
   // request per issue on the page (bounded by PER_PAGE) -- the runs list
@@ -200,43 +227,37 @@ export function useAutofixIssues({
     ),
   });
 
-  // 4. Join runs (outputs) and autofix phase onto each issue by group id. Runs
-  // come back ordered by last_triggered_at desc, so the first run seen for a
-  // group is the latest.
-  const runByGroupId = useMemo(() => {
-    const map = new Map<string, SeerRun>();
-    for (const run of runsQuery.data ?? []) {
-      if (run.groupId && !map.has(run.groupId)) {
-        map.set(run.groupId, run);
-      }
-    }
-    return map;
-  }, [runsQuery.data]);
-
+  // 4. Join each group's run (outputs) and autofix phase onto its issue.
   // Computed each render (not memoized): useQueries returns a new array every
   // render, so it can't go in a useMemo dep array (@tanstack/query/no-unstable-
   // deps). The map is cheap -- at most PER_PAGE rows.
   const enriched: AutofixIssue[] = issues.map((issue, i) => {
     const autofixResult = autofixResults[i];
+    const autofixState = autofixResult?.data?.autofix ?? null;
+    // The server already scopes each request to its group; the find() guards
+    // against mocks/responses carrying runs for other groups.
+    const runs = runResults[i]?.data;
+    const run = runs?.find(candidate => candidate.groupId === issue.id) ?? null;
     return {
       ...issue,
-      run: runByGroupId.get(issue.id) ?? null,
-      autofixPhase: deriveAutofixPhase(autofixResult?.data?.autofix ?? null),
+      run,
+      autofixPhase: deriveAutofixPhase(autofixState),
       autofixPhasePending: autofixResult?.isPending ?? false,
+      autofixState,
     };
   });
 
   return {
     issues: enriched,
-    isPending: issuesQuery.isPending || (runsEnabled && runsQuery.isPending),
-    isError: issuesQuery.isError || runsQuery.isError,
+    isPending:
+      issuesQuery.isPending ||
+      (runsEnabled && runResults.some(result => result.isPending)),
+    // A failed per-group runs request degrades that row to run-less rather
+    // than erroring the whole page.
+    isError: issuesQuery.isError,
     refetch: () => {
       issuesQuery.refetch();
-      // Only refetch the runs query when it's enabled; refetching a disabled
-      // (skipToken) query logs a React Query error.
-      if (runsEnabled) {
-        runsQuery.refetch();
-      }
+      runResults.forEach(result => result.refetch());
       autofixResults.forEach(result => result.refetch());
     },
     pageLinks: issuesQuery.data?.headers.Link,

--- a/static/app/views/seerWorkflows/overview/attentionBadge.tsx
+++ b/static/app/views/seerWorkflows/overview/attentionBadge.tsx
@@ -1,0 +1,198 @@
+import styled from '@emotion/styled';
+import type {LocationDescriptor} from 'history';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconCode, IconCommit, IconPullRequest, IconRefresh, IconUser} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import type {AttentionReason, OverviewRow} from './types';
+
+type LinkButtonVariant = React.ComponentProps<typeof LinkButton>['variant'];
+
+export const ATTENTION_REASONS: AttentionReason[] = [
+  'awaiting_input',
+  'review_pr',
+  'code_changes_ready',
+  'solution_ready',
+  'errored',
+];
+
+export const ATTENTION_META: Record<
+  AttentionReason,
+  {
+    Icon: React.ComponentType<{size?: 'xs' | 'sm' | 'md'}>;
+    description: string;
+    label: string;
+    variant: LinkButtonVariant;
+  }
+> = {
+  awaiting_input: {
+    Icon: IconUser,
+    label: t('Add context'),
+    variant: 'primary',
+    description: t(
+      'Autofix paused and is asking for more information before it can proceed.'
+    ),
+  },
+  review_pr: {
+    Icon: IconPullRequest,
+    label: t('Review PR'),
+    variant: 'warning',
+    description: t('Autofix opened a pull request. Review and merge it.'),
+  },
+  code_changes_ready: {
+    Icon: IconCommit,
+    label: t('Open PR'),
+    variant: 'secondary',
+    description: t('Autofix wrote a diff. Review it and open a pull request.'),
+  },
+  solution_ready: {
+    Icon: IconCode,
+    label: t('Generate code'),
+    variant: 'secondary',
+    description: t(
+      'Autofix proposed a fix. Continue the pipeline to generate code changes.'
+    ),
+  },
+  errored: {
+    Icon: IconRefresh,
+    label: t('Retry'),
+    variant: 'secondary',
+    description: t('Autofix run errored. Open it to investigate or retry.'),
+  },
+};
+
+export function getAttentionReason(row: OverviewRow): AttentionReason | null {
+  // A run that's still working has nothing actionable yet.
+  if (row.isProcessing) {
+    return null;
+  }
+  if (row.autofixRunStatus === 'NEED_MORE_INFORMATION') {
+    return 'awaiting_input';
+  }
+  if (row.autofixRunStatus === 'ERROR') {
+    return 'errored';
+  }
+  const set = new Set(row.outcomes);
+  // A merged PR needs nothing further; when merge state is unknown (the
+  // deployed API doesn't return it yet) an opened PR reads as needing review.
+  if (row.prMerged) {
+    return null;
+  }
+  if (set.has('pr_opened')) {
+    return 'review_pr';
+  }
+  if (set.has('code_changes')) {
+    return 'code_changes_ready';
+  }
+  if (set.has('solution')) {
+    return 'solution_ready';
+  }
+  return null;
+}
+
+// Actionable tiers ordered by urgency-to-a-human: blocked-on-you first, then
+// nearest-to-shipping, with the low-confidence retry last.
+const ATTENTION_TRIAGE_RANK: Record<AttentionReason, number> = {
+  awaiting_input: 0,
+  review_pr: 1,
+  code_changes_ready: 2,
+  solution_ready: 3,
+  errored: 4,
+};
+
+/**
+ * Queue position for the overview's triage sort: everything a human can act on
+ * (ranked by urgency), then rows whose state is still loading (parked in the
+ * middle so they don't leap from the top when they resolve), then Seer-is-
+ * working, then diagnosed-only, with merged wins sinking to the bottom as an
+ * archive shelf. Lower sorts first.
+ */
+export function getTriageRank(row: OverviewRow, attention: AttentionReason | null) {
+  if (attention !== null) {
+    return ATTENTION_TRIAGE_RANK[attention];
+  }
+  if (row.statePending) {
+    return 5;
+  }
+  if (row.isProcessing) {
+    return 6;
+  }
+  if (row.prMerged) {
+    return 8;
+  }
+  // Diagnosed-only: informational, optional next step.
+  return 7;
+}
+
+const AccentLinkButton = styled(LinkButton)`
+  background: ${p => p.theme.tokens.background.accent};
+  border-color: ${p => p.theme.tokens.border.accent};
+  color: ${p => p.theme.tokens.content.accent};
+  &:hover {
+    color: ${p => p.theme.tokens.content.accent};
+  }
+`;
+
+const SuccessLinkButton = styled(LinkButton)`
+  background: ${p => p.theme.tokens.background.success};
+  border-color: ${p => p.theme.tokens.border.success};
+  color: ${p => p.theme.tokens.content.success};
+  &:hover {
+    color: ${p => p.theme.tokens.content.success};
+  }
+`;
+
+const MutedLinkButton = styled(LinkButton)`
+  background: transparent;
+  border-color: ${p => p.theme.tokens.border.neutral};
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+export function AttentionBadge({
+  reason,
+  to,
+}: {
+  reason: AttentionReason;
+  to: LocationDescriptor;
+}) {
+  const meta = ATTENTION_META[reason];
+
+  if (reason === 'code_changes_ready') {
+    return (
+      <Tooltip title={meta.description} skipWrapper>
+        <AccentLinkButton size="zero" icon={<meta.Icon />} to={to}>
+          {meta.label}
+        </AccentLinkButton>
+      </Tooltip>
+    );
+  }
+  if (reason === 'solution_ready') {
+    return (
+      <Tooltip title={meta.description} skipWrapper>
+        <SuccessLinkButton size="zero" icon={<meta.Icon />} to={to}>
+          {meta.label}
+        </SuccessLinkButton>
+      </Tooltip>
+    );
+  }
+  if (reason === 'errored') {
+    return (
+      <Tooltip title={meta.description} skipWrapper>
+        <MutedLinkButton size="zero" icon={<meta.Icon />} to={to}>
+          {meta.label}
+        </MutedLinkButton>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip title={meta.description} skipWrapper>
+      <LinkButton size="zero" variant={meta.variant} icon={<meta.Icon />} to={to}>
+        {meta.label}
+      </LinkButton>
+    </Tooltip>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
@@ -1,0 +1,248 @@
+import {
+  type ExplorerAutofixState,
+  getAutofixArtifactFromSection,
+  getOrderedAutofixSections,
+  isCodeChangesArtifact,
+  isCodeChangesSection,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {
+  AutofixIssue,
+  RunQuestion,
+} from 'sentry/views/autofixIssuesDemo/useAutofixIssues';
+
+import {RUN_QUESTIONS} from './runQuestions';
+import {mapRunSourceToTrigger} from './triggerBadge';
+import type {
+  AutofixOutcome,
+  AutofixRunStatus,
+  OverviewRow,
+  PatchStats,
+  RunAnalysisEntry,
+} from './types';
+
+const OUTCOME_ORDER: AutofixOutcome[] = [
+  'root_cause',
+  'solution',
+  'code_changes',
+  'pr_opened',
+];
+
+/**
+ * Every pipeline stage the run has produced so far, in stage order.
+ *
+ * Cumulative (unlike deriveAutofixPhase's single furthest phase) because the
+ * attention logic tests stage membership: "code changes but no PR" is a
+ * different action than "PR opened".
+ */
+function deriveAutofixOutcomes(runState: ExplorerAutofixState | null): AutofixOutcome[] {
+  const reached = new Set<AutofixOutcome>();
+  for (const section of getOrderedAutofixSections(runState)) {
+    switch (section.step) {
+      case 'root_cause':
+        reached.add('root_cause');
+        break;
+      case 'solution':
+        reached.add('solution');
+        break;
+      case 'code_changes':
+      case 'coding_agents':
+        reached.add('code_changes');
+        break;
+      case 'pull_request':
+        reached.add('pr_opened');
+        break;
+      default:
+        break;
+    }
+  }
+  return OUTCOME_ORDER.filter(outcome => reached.has(outcome));
+}
+
+function deriveRunStatus(state: ExplorerAutofixState | null): AutofixRunStatus {
+  switch (state?.status) {
+    case 'awaiting_user_input':
+      return 'NEED_MORE_INFORMATION';
+    case 'error':
+      return 'ERROR';
+    default:
+      return 'COMPLETED';
+  }
+}
+
+function extractPatchStats(state: ExplorerAutofixState | null): PatchStats | undefined {
+  const section = getOrderedAutofixSections(state).find(isCodeChangesSection);
+  if (!section) {
+    return undefined;
+  }
+  const artifact = getAutofixArtifactFromSection(section);
+  if (!isCodeChangesArtifact(artifact)) {
+    return undefined;
+  }
+  // Disambiguate paths with the repo name only when the diff spans repos.
+  const multiRepo = new Set(artifact.map(filePatch => filePatch.repo_name)).size > 1;
+  const fileList = artifact
+    .map(filePatch => ({
+      path: multiRepo
+        ? `${filePatch.repo_name}:${filePatch.patch.path}`
+        : filePatch.patch.path,
+      added: filePatch.patch.added,
+      removed: filePatch.patch.removed,
+    }))
+    // Most-changed files first, so a capped tooltip shows what matters.
+    .sort((a, b) => b.added + b.removed - (a.added + a.removed));
+  return {
+    fileList,
+    files: artifact.length,
+    added: artifact.reduce((sum, filePatch) => sum + filePatch.patch.added, 0),
+    removed: artifact.reduce((sum, filePatch) => sum + filePatch.patch.removed, 0),
+  };
+}
+
+function extractPr(
+  state: ExplorerAutofixState | null
+): Pick<OverviewRow, 'prNumber' | 'prUrl'> {
+  const pr = Object.values(state?.repo_pr_states ?? {}).find(
+    repoPr => repoPr.pr_creation_status === 'completed' && repoPr.pr_url
+  );
+  return pr ? {prUrl: pr.pr_url ?? undefined, prNumber: pr.pr_number ?? undefined} : {};
+}
+
+// The pending-input payload is untyped (Record<string, unknown>). The canonical
+// ask_user_question shape is {questions: [{question, options}]} (see
+// usePendingUserInput's AskUserQuestionData); fall back to a flat key otherwise.
+function extractPendingQuestion(state: ExplorerAutofixState | null): string | undefined {
+  if (state?.status !== 'awaiting_user_input') {
+    return undefined;
+  }
+  const data = state.pending_user_input?.data ?? {};
+  if (Array.isArray(data.questions)) {
+    const [first] = data.questions as Array<{question?: unknown}>;
+    if (typeof first?.question === 'string' && first.question.trim()) {
+      return first.question;
+    }
+  }
+  for (const key of ['question', 'text', 'message']) {
+    const value = data[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Join the run's answered questions back to their question configs.
+ *
+ * Matches primarily on the echoed question text (the endpoint echoes prompts
+ * back for user-supplied questions), falling back to position — answers are
+ * returned in question order. Empty answers mean "not applicable" (the prompts
+ * ask for an empty string) and are dropped.
+ */
+// A headline longer than this means the model ignored the 14-word instruction
+// (or the pipe landed somewhere unintended) — treat it as a parse failure.
+const MAX_HEADLINE_LENGTH = 140;
+
+// The root_cause prompt asks for "headline|root cause". Split on the first
+// pipe; strip stray emphasis/quote characters the model might wrap it in.
+function parseRootCause(answer: string): {answer: string; headline?: string} {
+  const pipeIndex = answer.indexOf('|');
+  if (pipeIndex === -1) {
+    return {answer};
+  }
+  const headline = answer
+    .slice(0, pipeIndex)
+    .trim()
+    .replace(/^["'*_]+|["'*_]+$/g, '');
+  const rootCause = answer.slice(pipeIndex + 1).trim();
+  if (!headline || headline.length > MAX_HEADLINE_LENGTH || !rootCause) {
+    return {answer};
+  }
+  return {answer: rootCause, headline};
+}
+
+// The model sometimes emits inline "•" bullets run together in one paragraph;
+// markdown only renders a list when each item is its own "- " line. The bullet
+// may be followed by no space ("•Item"), so the trailing \s is optional.
+function normalizeBulletList(answer: string): string {
+  if (!answer.includes('•')) {
+    return answer;
+  }
+  const [head = '', ...items] = answer.split(/\s*•\s*/);
+  return [head.trim(), ...items.map(item => `- ${item.trim()}`)]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function buildAnalysis(outputs: RunQuestion[] | undefined): {
+  entries: RunAnalysisEntry[];
+  headline?: string;
+} {
+  if (!outputs?.length) {
+    return {entries: []};
+  }
+  const byPrompt = new Map(RUN_QUESTIONS.map(question => [question.prompt, question]));
+  const entries: RunAnalysisEntry[] = [];
+  let headline: string | undefined;
+  outputs.forEach((output, index) => {
+    const config =
+      (output.question ? byPrompt.get(output.question) : undefined) ??
+      RUN_QUESTIONS[index];
+    if (!config || !output.answer) {
+      return;
+    }
+    let answer = output.answer;
+    if (config.key === 'root_cause') {
+      const rootCause = parseRootCause(output.answer);
+      headline = rootCause.headline;
+      answer = rootCause.answer;
+    } else if (config.key === 'reviewer_notes') {
+      answer = normalizeBulletList(output.answer);
+    }
+    entries.push({
+      key: config.key,
+      label: config.label,
+      placement: config.placement,
+      answer,
+    });
+  });
+  return {entries, headline};
+}
+
+function buildOverviewRow(issue: AutofixIssue): OverviewRow {
+  const state = issue.autofixState;
+  const eventCount = Number(issue.count);
+  const {entries: analysis, headline} = buildAnalysis(issue.run?.outputs);
+
+  return {
+    headline,
+    id: issue.id,
+    shortId: issue.shortId,
+    title: issue.title,
+    level: issue.level,
+    project: issue.project,
+    eventCount: Number.isFinite(eventCount) ? eventCount : 0,
+    userCount: issue.userCount,
+    lastSeen: issue.lastSeen,
+    fixabilityScore: issue.seerFixabilityScore,
+    lastActivityAt:
+      state?.updated_at ??
+      issue.run?.lastTriggeredAt ??
+      issue.seerAutofixLastTriggered ??
+      issue.lastSeen,
+    autofixRunStatus: deriveRunStatus(state),
+    prMerged: (issue.run?.pullRequests ?? []).some(pr => pr.status === 'merged'),
+    isProcessing: state?.status === 'processing',
+    statePending: issue.autofixPhasePending,
+    outcomes: deriveAutofixOutcomes(state),
+    trigger: mapRunSourceToTrigger(issue.run?.source ?? null),
+    rawSource: issue.run?.source ?? null,
+    analysis,
+    patchStats: extractPatchStats(state),
+    pendingQuestion: extractPendingQuestion(state),
+    ...extractPr(state),
+  };
+}
+
+export function buildOverviewRows(issues: AutofixIssue[]): OverviewRow[] {
+  return issues.map(buildOverviewRow);
+}

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1,0 +1,551 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import AutofixOverview from 'sentry/views/seerWorkflows/overview';
+import {RUN_QUESTIONS} from 'sentry/views/seerWorkflows/overview/runQuestions';
+
+describe('AutofixOverview', () => {
+  const organization = OrganizationFixture({
+    features: ['seer-night-shift-ui'],
+  });
+  const basePath = `/organizations/${organization.slug}/issues/autofix/overview/`;
+
+  const issue = GroupFixture({
+    id: '2',
+    shortId: 'PROJ-1',
+    title: 'TypeError in checkout cart',
+    count: '100',
+    userCount: 5,
+    seerFixabilityScore: 0.75,
+  });
+
+  // A run that reached every stage and opened a PR.
+  const autofixState = {
+    run_id: 1,
+    status: 'completed',
+    updated_at: '2026-07-14T10:00:00Z',
+    blocks: [
+      {
+        id: 'b1',
+        timestamp: '2026-07-14T09:00:00Z',
+        message: {
+          role: 'assistant',
+          content: 'rca',
+          metadata: {step: 'root_cause'},
+        },
+      },
+      {
+        id: 'b2',
+        timestamp: '2026-07-14T09:10:00Z',
+        message: {
+          role: 'assistant',
+          content: 'plan',
+          metadata: {step: 'solution'},
+        },
+      },
+      {
+        id: 'b3',
+        timestamp: '2026-07-14T09:20:00Z',
+        message: {
+          role: 'assistant',
+          content: 'code',
+          metadata: {step: 'code_changes'},
+        },
+        merged_file_patches: [
+          {
+            repo_name: 'getsentry/sentry',
+            diff: '--- a/src/cart.py\n+++ b/src/cart.py',
+            patch: {
+              path: 'src/cart.py',
+              source_file: 'src/cart.py',
+              target_file: 'src/cart.py',
+              type: 'M',
+              added: 42,
+              removed: 7,
+              hunks: [],
+            },
+          },
+        ],
+      },
+    ],
+    repo_pr_states: {
+      'getsentry/sentry': {
+        repo_name: 'getsentry/sentry',
+        branch_name: 'fix/cart',
+        commit_sha: null,
+        pr_creation_error: null,
+        pr_creation_status: 'completed',
+        pr_id: null,
+        pr_number: 123,
+        pr_url: 'https://github.com/getsentry/sentry/pull/123',
+        title: 'Fix nil cart',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [issue],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body: [
+        {
+          id: 'run-1',
+          type: 'explorer',
+          groupId: '2',
+          source: 'night_shift',
+          lastTriggeredAt: '2026-07-14T09:00:00Z',
+          dateCreated: '2026-07-14T09:00:00Z',
+          outputs: [
+            {
+              key: 'user_0',
+              question: RUN_QUESTIONS[0]!.prompt,
+              answer:
+                'Proxy requests fail without Authorization header|Commit c5bb895 stopped sending the Authorization header.',
+            },
+            {
+              key: 'user_1',
+              question: RUN_QUESTIONS[1]!.prompt,
+              answer:
+                'JWT viewer auth landed before the proxy supported it, so requests fail; the run opened a PR restoring the header.',
+            },
+            {
+              key: 'user_2',
+              question: RUN_QUESTIONS[2]!.prompt,
+              answer: 'Restores the Authorization header as a fallback.',
+            },
+            {
+              key: 'user_3',
+              question: RUN_QUESTIONS[3]!.prompt,
+              // Inline "•" bullets — the normalizer must split them into a list.
+              answer:
+                '• Confirm the fallback header does not leak the key. • Verify the proxy accepts both headers.',
+            },
+          ],
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/`,
+      body: {autofix: autofixState},
+    });
+  });
+
+  function renderPage(query: Record<string, string> = {}) {
+    return render(<AutofixOverview />, {
+      organization,
+      initialRouterConfig: {location: {pathname: basePath, query}},
+    });
+  }
+
+  it('gates the page behind the seer-night-shift-ui feature', () => {
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({features: []}),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+    expect(screen.queryByText('Autofix Overview')).not.toBeInTheDocument();
+  });
+
+  it('renders a card with real run metadata', async () => {
+    renderPage();
+
+    // The Seer headline replaces the raw issue title and links to the issue.
+    const titleLink = await screen.findByRole('link', {
+      name: 'Proxy requests fail without Authorization header',
+    });
+    expect(titleLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/2/`
+    );
+    // night_shift source maps to the Workflow trigger badge.
+    expect(screen.getByText('Workflow')).toBeInTheDocument();
+
+    // An opened PR reads as needing review and links out to the PR; the PR
+    // number lives in the tooltip, not the label.
+    expect(screen.getByRole('button', {name: 'Review PR'})).toHaveAttribute(
+      'href',
+      'https://github.com/getsentry/sentry/pull/123'
+    );
+
+    // Exact patch stats from merged_file_patches, not an LLM estimate.
+    expect(screen.getByText('1 file')).toBeInTheDocument();
+    expect(screen.getByText('+42')).toBeInTheDocument();
+    expect(screen.getByText('−7')).toBeInTheDocument();
+
+    // Hovering the diff pill lists the changed files.
+    await userEvent.hover(screen.getByText('1 file'));
+    expect(await screen.findByText('src/cart.py')).toBeInTheDocument();
+
+    // Issue impact numbers, abbreviated.
+    expect(screen.getByText(/100 events/)).toBeInTheDocument();
+  });
+
+  it('shows a single body block and collapses the full analysis', async () => {
+    renderPage();
+
+    // The body is either/or: code was drafted, so the proposed-fix block
+    // renders and the summary does not (it would describe the same change).
+    expect(await screen.findByText('Proposed fix')).toBeVisible();
+    expect(
+      screen.getByText('Restores the Authorization header as a fallback.')
+    ).toBeVisible();
+    expect(
+      screen.queryByText(
+        'JWT viewer auth landed before the proxy supported it, so requests fail; the run opened a PR restoring the header.'
+      )
+    ).not.toBeInTheDocument();
+
+    // The timestamp is labeled as run activity.
+    expect(screen.getByText(/^updated/)).toBeInTheDocument();
+
+    // Root cause, notes, and the short id stay behind the disclosure.
+    const disclosure = screen.getByRole('button', {name: 'Full analysis'});
+    expect(
+      screen.getByText('Commit c5bb895 stopped sending the Authorization header.')
+    ).not.toBeVisible();
+    expect(screen.getByText('PROJ-1')).not.toBeVisible();
+
+    await userEvent.click(disclosure);
+
+    expect(screen.getByText('PROJ-1')).toBeVisible();
+    // Section headings are the clean labels, never the raw prompt text.
+    expect(screen.getByText('Root cause')).toBeVisible();
+    expect(
+      screen.getByText('Commit c5bb895 stopped sending the Authorization header.')
+    ).toBeVisible();
+    // Code was drafted, so the notes section is a review checklist, with the
+    // inline-bullet answer normalized into separate list items.
+    expect(screen.getByText('Review checklist')).toBeVisible();
+    expect(
+      screen.getByText('Confirm the fallback header does not leak the key.')
+    ).toBeVisible();
+    expect(screen.getByText('Verify the proxy accepts both headers.')).toBeVisible();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+    // Fixability lives in the expanded state as a bucketed tag (0.75 > 0.7).
+    expect(screen.getByText('High fixability')).toBeVisible();
+  });
+
+  it('shows Diagnosis and Next steps when no code was drafted', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body: [
+        {
+          id: 'run-1',
+          type: 'explorer',
+          groupId: '2',
+          source: 'autofix',
+          lastTriggeredAt: '2026-07-14T09:00:00Z',
+          dateCreated: '2026-07-14T09:00:00Z',
+          outputs: [
+            {
+              key: 'user_1',
+              question: RUN_QUESTIONS[1]!.prompt,
+              answer: 'A mechanism sentence without any drafted fix.',
+            },
+            {
+              key: 'user_3',
+              question: RUN_QUESTIONS[3]!.prompt,
+              answer: '- Decide whether Seer should generate a fix.',
+            },
+          ],
+        },
+      ],
+    });
+
+    renderPage();
+
+    // No headline answer → the raw issue title renders.
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+
+    // No drafted fix → the body block is the Diagnosis variant.
+    expect(screen.getByText('Diagnosis')).toBeVisible();
+    expect(
+      screen.getByText('A mechanism sentence without any drafted fix.')
+    ).toBeVisible();
+    expect(screen.queryByText('Proposed fix')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Full analysis'}));
+
+    // …and the notes section is Next steps rather than a review checklist.
+    expect(screen.getByText('Next steps')).toBeVisible();
+    expect(screen.getByText('Decide whether Seer should generate a fix.')).toBeVisible();
+    expect(screen.queryByText('Review checklist')).not.toBeInTheDocument();
+  });
+
+  it('toggles quick filters from the stat cards via the URL', async () => {
+    const {router} = renderPage();
+
+    // Wait for the card to load so the stat counts reflect the row.
+    expect(await screen.findByRole('button', {name: 'Review PR'})).toBeInTheDocument();
+
+    // The PR-opened row counts toward "Awaiting your review".
+    const statCard = screen.getByRole('button', {
+      name: /Awaiting your review/,
+    });
+    expect(statCard).toHaveTextContent('1');
+
+    await userEvent.click(statCard);
+    expect(router.location.query.quick).toBe('review_pr');
+
+    await userEvent.click(statCard);
+    expect(router.location.query.quick).toBeUndefined();
+  });
+
+  it('applies the outcome filter with AND semantics', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/`,
+      body: {
+        autofix: {
+          run_id: 1,
+          status: 'completed',
+          updated_at: '2026-07-14T10:00:00Z',
+          blocks: [
+            {
+              id: 'b1',
+              timestamp: '2026-07-14T09:00:00Z',
+              message: {
+                role: 'assistant',
+                content: 'rca',
+                metadata: {step: 'root_cause'},
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    renderPage();
+
+    const title = 'Proxy requests fail without Authorization header';
+    expect(await screen.findByRole('link', {name: title})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /Outcome/}));
+
+    await userEvent.click(screen.getByRole('option', {name: 'Root cause'}));
+    expect(await screen.findByRole('link', {name: title})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('option', {name: 'Code changes'}));
+    expect(await screen.findByText('No issues match your filters.')).toBeInTheDocument();
+  });
+
+  it('falls back to a View run action when nothing needs attention', async () => {
+    // A run that only found a root cause: no attention reason, but the card
+    // should still offer a way into the run (Seer drawer deep link).
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/`,
+      body: {
+        autofix: {
+          run_id: 1,
+          status: 'completed',
+          updated_at: '2026-07-14T10:00:00Z',
+          blocks: [
+            {
+              id: 'b1',
+              timestamp: '2026-07-14T09:00:00Z',
+              message: {
+                role: 'assistant',
+                content: 'rca',
+                metadata: {step: 'root_cause'},
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    renderPage();
+
+    const viewRun = await screen.findByRole('button', {name: 'View run'});
+    expect(viewRun).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/2/?seerDrawer=true`
+    );
+  });
+
+  it('shows merged state and enables the Merged PRs card when the API returns PR state', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body: [
+        {
+          id: 'run-1',
+          type: 'explorer',
+          groupId: '2',
+          source: 'autofix',
+          lastTriggeredAt: '2026-07-14T09:00:00Z',
+          dateCreated: '2026-07-14T09:00:00Z',
+          pullRequests: [{status: 'merged', mergedAt: '2026-07-15T09:00:00Z'}],
+          outputs: [],
+        },
+      ],
+    });
+
+    const {router} = renderPage();
+
+    // The merged run wears a Merged tag instead of a Review PR action.
+    expect(await screen.findByText('Merged')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Review PR'})).not.toBeInTheDocument();
+
+    // The Merged PRs stat card is live and counts the row.
+    const mergedCard = screen.getByRole('button', {name: /Merged PRs/});
+    expect(mergedCard).toBeEnabled();
+    expect(mergedCard).toHaveTextContent('1');
+
+    await userEvent.click(mergedCard);
+    expect(router.location.query.quick).toBe('merged');
+  });
+
+  it('orders cards as a triage queue: actionable, then working, then merged', async () => {
+    // A merged, B awaiting PR review, C still processing → B, C, A.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [
+        GroupFixture({id: '2', title: 'Issue A'}),
+        GroupFixture({id: '3', title: 'Issue B'}),
+        GroupFixture({id: '4', title: 'Issue C'}),
+      ],
+    });
+    const runFor = (groupId: string, pullRequests: unknown[]) => ({
+      id: `run-${groupId}`,
+      type: 'explorer',
+      groupId,
+      source: 'autofix',
+      lastTriggeredAt: '2026-07-14T09:00:00Z',
+      dateCreated: '2026-07-14T09:00:00Z',
+      pullRequests,
+      outputs: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body: [
+        runFor('2', [{status: 'merged', mergedAt: '2026-07-15T09:00:00Z'}]),
+        runFor('3', []),
+        runFor('4', []),
+      ],
+    });
+    // A and B both reached an opened PR; A's merged flag comes from its run.
+    for (const issueId of ['2', '3']) {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${issueId}/autofix/`,
+        body: {autofix: autofixState},
+      });
+    }
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/4/autofix/`,
+      body: {
+        autofix: {...autofixState, status: 'processing', repo_pr_states: {}},
+      },
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Merged')).toBeInTheDocument();
+    const titles = screen
+      .getAllByRole('link')
+      .map(link => link.textContent)
+      .filter(text => text === 'Issue A' || text === 'Issue B' || text === 'Issue C');
+    expect(titles).toEqual(['Issue B', 'Issue C', 'Issue A']);
+  });
+
+  it('always enables the Merged PRs card, showing 0 when nothing is merged', async () => {
+    renderPage();
+
+    const mergedCard = await screen.findByRole('button', {name: /Merged PRs/});
+    expect(mergedCard).toBeEnabled();
+    expect(mergedCard).toHaveTextContent('0');
+  });
+
+  it('surfaces the blocking question when a run awaits user input', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/2/autofix/`,
+      body: {
+        autofix: {
+          run_id: 1,
+          status: 'awaiting_user_input',
+          updated_at: '2026-07-14T10:00:00Z',
+          blocks: [
+            {
+              id: 'b1',
+              timestamp: '2026-07-14T09:00:00Z',
+              message: {
+                role: 'assistant',
+                content: 'rca',
+                metadata: {step: 'root_cause'},
+              },
+            },
+          ],
+          // Canonical ask_user_question shape: the text is nested under
+          // questions[0].question, not a flat key.
+          pending_user_input: {
+            id: 'input-1',
+            input_type: 'ask_user_question',
+            data: {
+              questions: [{question: 'Which environment should I target?', options: []}],
+            },
+          },
+        },
+      },
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('Seer asked: Which environment should I target?')
+    ).toBeInTheDocument();
+  });
+
+  it('normalizes space-less • bullets into a markdown list', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      body: [
+        {
+          id: 'run-1',
+          type: 'explorer',
+          groupId: '2',
+          source: 'autofix',
+          lastTriggeredAt: '2026-07-14T09:00:00Z',
+          dateCreated: '2026-07-14T09:00:00Z',
+          outputs: [
+            {
+              key: 'user_3',
+              question: RUN_QUESTIONS[3]!.prompt,
+              // No space after the • — the normalizer must still split these.
+              answer: '•Confirm the header is not leaked. •Verify both headers work.',
+            },
+          ],
+        },
+      ],
+    });
+
+    renderPage();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Full analysis'}));
+
+    expect(screen.getByText('Confirm the header is not leaked.')).toBeVisible();
+    expect(screen.getByText('Verify both headers work.')).toBeVisible();
+    expect(screen.queryByText(/•/)).not.toBeInTheDocument();
+  });
+
+  it('renders an error state and can retry', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      statusCode: 500,
+      body: {detail: 'boom'},
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -1,0 +1,502 @@
+import {useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Pagination} from '@sentry/scraps/pagination';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import Feature from 'sentry/components/acl/feature';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {IconFilter, IconFix, IconMerge, IconPullRequest, IconUser} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useAutofixIssues} from 'sentry/views/autofixIssuesDemo/useAutofixIssues';
+
+import {
+  ATTENTION_META,
+  ATTENTION_REASONS,
+  getAttentionReason,
+  getTriageRank,
+} from './attentionBadge';
+import {buildOverviewRows} from './buildOverviewRows';
+import {IssueCard} from './issueCard';
+import {RUN_QUESTION_PROMPTS} from './runQuestions';
+import type {AttentionReason, AutofixOutcome} from './types';
+
+// Only autofix runs. `source` is the run's origin surface (autofix, chat,
+// night_shift orchestration, ...), not the autofix trigger — so this keeps
+// autofixes (including night-shift-triggered ones, which are source=autofix)
+// and drops non-autofix runs like the night-shift triage feature run. How the
+// autofix was triggered lives in the run's referrer/auto_run_source, which the
+// API doesn't expose yet; badging/filtering by it is a follow-up.
+const OVERVIEW_RUNS_QUERY = 'type:explorer source:autofix';
+
+const OUTCOME_FILTER_OPTIONS: Array<{label: string; value: AutofixOutcome}> = [
+  {value: 'root_cause', label: t('Root cause')},
+  {value: 'solution', label: t('Solution')},
+  {value: 'code_changes', label: t('Code changes')},
+  {value: 'pr_opened', label: t('PR opened')},
+];
+
+// TODO(seer): Re-enable the "Triggered by" filter once the backend exposes the
+// autofix trigger. A run's `source` is its origin surface (always "autofix"
+// here after the source:autofix filter), not how the autofix was triggered —
+// that lives in the referrer / auto_run_source, which the runs API does not
+// return yet. Until it does, this filter can only ever resolve to "manual", so
+// it (and its options/parse/check/dropdown below) is disabled.
+// const TRIGGER_FILTER_OPTIONS: Array<{label: string; value: AutofixTrigger}> =
+//   SELECTABLE_TRIGGERS.map(value => ({
+//     value,
+//     label: TRIGGER_META[value].label,
+//   }));
+
+const ATTENTION_FILTER_OPTIONS: Array<{
+  label: string;
+  value: AttentionReason;
+}> = ATTENTION_REASONS.map(value => ({
+  value,
+  label: ATTENTION_META[value].label,
+}));
+
+type QuickFilterValue = 'review_pr' | 'awaiting_input' | 'code_changes_ready' | 'merged';
+
+type SortValue = 'triage' | 'activity' | 'events';
+
+const SORT_OPTIONS: Array<{label: string; value: SortValue}> = [
+  {value: 'triage', label: t('Needs you first')},
+  {value: 'activity', label: t('Recent activity')},
+  {value: 'events', label: t('Most events')},
+];
+
+const PERIOD_FILTER_OPTIONS: Array<{label: string; value: string}> = [
+  {value: '', label: t('All time')},
+  {value: '24h', label: t('Last 24 hours')},
+  {value: '7d', label: t('Last 7 days')},
+  {value: '30d', label: t('Last 30 days')},
+];
+
+const PERIOD_TO_DAYS: Record<string, number> = {
+  '24h': 1,
+  '7d': 7,
+  '30d': 30,
+};
+
+export default function AutofixOverview() {
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const cursor = decodeScalar(location.query.cursor);
+  const outcomeFilter = decodeList(location.query.outcome) as AutofixOutcome[];
+  // TODO(seer): trigger filter disabled — see TRIGGER_FILTER_OPTIONS above.
+  // const triggerFilter = decodeList(location.query.trigger) as AutofixTrigger[];
+  const attentionFilter = decodeList(location.query.attention) as AttentionReason[];
+  const quickFilter = decodeScalar(location.query.quick) as QuickFilterValue | undefined;
+  const period = decodeScalar(location.query.period);
+  const sort = (decodeScalar(location.query.sort) as SortValue | undefined) ?? 'triage';
+
+  const {issues, isPending, isError, refetch, pageLinks} = useAutofixIssues({
+    query: '',
+    cursor,
+    runsQuery: OVERVIEW_RUNS_QUERY,
+    questions: RUN_QUESTION_PROMPTS,
+  });
+
+  const updateQuery = (patch: Record<string, string | string[] | undefined>) => {
+    navigate(
+      {
+        pathname: location.pathname,
+        query: {...location.query, ...patch},
+      },
+      {replace: true}
+    );
+  };
+
+  const toggleQuickFilter = (value: QuickFilterValue) => {
+    updateQuery({quick: quickFilter === value ? undefined : value});
+  };
+
+  const periodCutoffMs = useMemo(() => {
+    const days = PERIOD_TO_DAYS[period ?? ''];
+    return days === undefined ? null : Date.now() - days * 24 * 60 * 60 * 1000;
+  }, [period]);
+
+  // Computed each render (not memoized): the hook's enriched issues array is a
+  // new reference every render and there is at most a page's worth of rows.
+  const rowsWithAttention = buildOverviewRows(issues).map(row => ({
+    row,
+    attention: getAttentionReason(row),
+  }));
+
+  const filteredRows = rowsWithAttention.filter(({row, attention}) => {
+    if (outcomeFilter.length && !outcomeFilter.every(o => row.outcomes.includes(o))) {
+      return false;
+    }
+    // TODO(seer): trigger filter disabled — see TRIGGER_FILTER_OPTIONS above.
+    // if (triggerFilter.length && (!row.trigger || !triggerFilter.includes(row.trigger))) {
+    //   return false;
+    // }
+    if (attentionFilter.length) {
+      if (!attention || !attentionFilter.includes(attention)) {
+        return false;
+      }
+    }
+    if (quickFilter === 'merged') {
+      if (!row.prMerged) {
+        return false;
+      }
+    } else if (quickFilter && attention !== quickFilter) {
+      return false;
+    }
+    if (periodCutoffMs !== null && Date.parse(row.lastActivityAt) < periodCutoffMs) {
+      return false;
+    }
+    return true;
+  });
+
+  // Default is the triage-queue order, what needs a human first
+  // (by urgency tier), highest impact within a tier, run recency as
+  // the tiebreak.
+  const byActivity = (
+    a: (typeof filteredRows)[number],
+    b: (typeof filteredRows)[number]
+  ) => Date.parse(b.row.lastActivityAt) - Date.parse(a.row.lastActivityAt);
+  const sortedRows = [...filteredRows].sort((a, b) => {
+    if (sort === 'activity') {
+      return byActivity(a, b);
+    }
+    if (sort === 'events') {
+      return b.row.eventCount - a.row.eventCount || byActivity(a, b);
+    }
+    return (
+      getTriageRank(a.row, a.attention) - getTriageRank(b.row, b.attention) ||
+      b.row.eventCount - a.row.eventCount ||
+      byActivity(a, b)
+    );
+  });
+
+  const stats = {
+    reviewPr: 0,
+    awaitingInput: 0,
+    codeChangesReady: 0,
+    merged: 0,
+  };
+  for (const {row, attention} of filteredRows) {
+    if (row.prMerged) {
+      stats.merged++;
+    }
+    if (attention === 'review_pr') {
+      stats.reviewPr++;
+    }
+    if (attention === 'awaiting_input') {
+      stats.awaitingInput++;
+    }
+    if (attention === 'code_changes_ready') {
+      stats.codeChangesReady++;
+    }
+  }
+
+  const hasActiveFilters =
+    outcomeFilter.length > 0 ||
+    attentionFilter.length > 0 ||
+    quickFilter !== undefined ||
+    (period !== undefined && period !== '');
+
+  const clearAllFilters = () => {
+    updateQuery({
+      outcome: undefined,
+      attention: undefined,
+      quick: undefined,
+      period: undefined,
+    });
+  };
+
+  return (
+    <Feature
+      organization={organization}
+      features="seer-night-shift-ui"
+      renderDisabled={() => <NoAccess />}
+    >
+      <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
+        <Stack gap="lg" padding="xl">
+          <Flex justify="between" align="start" gap="md">
+            <Stack gap="2xs">
+              <Heading as="h1">{t('Autofix Overview')}</Heading>
+              <Text as="p" variant="muted">
+                {t(
+                  'Issues where Autofix has produced a root cause, solution, code changes, or pull request.'
+                )}
+              </Text>
+            </Stack>
+            <Flex gap="sm" align="center">
+              <LinkButton to={`/organizations/${organization.slug}/issues/autofix/`}>
+                {t('Workflow runs')}
+              </LinkButton>
+              <LinkButton to={`/organizations/${organization.slug}/issues/autofix/runs/`}>
+                {t('Runs demo')}
+              </LinkButton>
+            </Flex>
+          </Flex>
+
+          <Container width={{md: '100%', lg: '85%'}}>
+            <Grid
+              columns={{xs: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)'}}
+              gap="md"
+              marginBottom="md"
+            >
+              <StatCard
+                Icon={IconUser}
+                iconVariant="primary"
+                label={t('Awaiting your input')}
+                value={stats.awaitingInput}
+                isActive={quickFilter === 'awaiting_input'}
+                onClick={() => toggleQuickFilter('awaiting_input')}
+              />
+              <StatCard
+                Icon={IconFix}
+                iconVariant="secondary"
+                label={t('Code changes ready')}
+                value={stats.codeChangesReady}
+                isActive={quickFilter === 'code_changes_ready'}
+                onClick={() => toggleQuickFilter('code_changes_ready')}
+              />
+              <StatCard
+                Icon={IconPullRequest}
+                iconVariant="warning"
+                label={t('Awaiting your review')}
+                value={stats.reviewPr}
+                isActive={quickFilter === 'review_pr'}
+                onClick={() => toggleQuickFilter('review_pr')}
+              />
+              <StatCard
+                Icon={IconMerge}
+                iconVariant="success"
+                label={t('Merged PRs')}
+                value={stats.merged}
+                isActive={quickFilter === 'merged'}
+                onClick={() => toggleQuickFilter('merged')}
+              />
+            </Grid>
+            <Container
+              background="secondary"
+              border="muted"
+              radius="md"
+              padding="sm md"
+              marginBottom="md"
+            >
+              <Flex justify="between" align="center" gap="md" wrap="wrap">
+                <Flex gap="md" align="center" wrap="wrap">
+                  <IconFilter size="sm" variant="muted" aria-hidden />
+                  <CompactSelect
+                    multiple
+                    value={outcomeFilter}
+                    options={OUTCOME_FILTER_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({
+                        outcome: selected.map(o => String(o.value)),
+                      })
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Outcome')}
+                      />
+                    )}
+                  />
+                  {/* TODO(seer): "Triggered by" filter disabled until the runs
+                      API exposes the autofix trigger (referrer/auto_run_source);
+                      see TRIGGER_FILTER_OPTIONS above.
+                  <CompactSelect
+                    multiple
+                    value={triggerFilter}
+                    options={TRIGGER_FILTER_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({
+                        trigger: selected.map(o => String(o.value)),
+                      })
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Triggered by')}
+                      />
+                    )}
+                  /> */}
+                  <CompactSelect
+                    multiple
+                    value={attentionFilter}
+                    options={ATTENTION_FILTER_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({
+                        attention: selected.map(o => String(o.value)),
+                      })
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Needs attention')}
+                      />
+                    )}
+                  />
+                  <CompactSelect
+                    value={period ?? ''}
+                    options={PERIOD_FILTER_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({
+                        period:
+                          selected.value === '' ? undefined : String(selected.value),
+                      })
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Activity')}
+                      />
+                    )}
+                  />
+                  <CompactSelect
+                    value={sort}
+                    options={SORT_OPTIONS}
+                    onChange={selected =>
+                      updateQuery({
+                        // Default sort keeps the URL clean.
+                        sort:
+                          selected.value === 'triage'
+                            ? undefined
+                            : String(selected.value),
+                      })
+                    }
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        size="sm"
+                        prefix={t('Sort')}
+                      />
+                    )}
+                  />
+                </Flex>
+                {hasActiveFilters ? (
+                  <Button size="xs" variant="link" onClick={clearAllFilters}>
+                    {t('Clear all')}
+                  </Button>
+                ) : null}
+              </Flex>
+            </Container>
+
+            {isError ? (
+              <LoadingError onRetry={refetch} />
+            ) : isPending ? (
+              <LoadingIndicator />
+            ) : sortedRows.length === 0 ? (
+              <Container border="primary" radius="md" padding="xl">
+                <Text as="p" variant="muted" align="center">
+                  {hasActiveFilters
+                    ? t('No issues match your filters.')
+                    : t('No completed autofix runs yet.')}
+                </Text>
+              </Container>
+            ) : (
+              <Stack gap="md">
+                {sortedRows.map(({row}) => (
+                  <IssueCard key={row.id} row={row} orgSlug={organization.slug} />
+                ))}
+              </Stack>
+            )}
+
+            {!isPending && !isError && <Pagination pageLinks={pageLinks} />}
+          </Container>
+        </Stack>
+      </SentryDocumentTitle>
+    </Feature>
+  );
+}
+
+function NoAccess() {
+  return (
+    <Stack flex={1} padding="2xl 3xl">
+      <Alert.Container>
+        <Alert variant="warning" showIcon={false}>
+          {t("You don't have access to this feature")}
+        </Alert>
+      </Alert.Container>
+    </Stack>
+  );
+}
+
+type StatIconVariant = 'success' | 'warning' | 'primary' | 'secondary';
+
+const StatCardButton = styled('button')<{isActive: boolean}>`
+  cursor: ${p => (p.disabled ? 'default' : 'pointer')};
+  background: ${p =>
+    p.isActive ? p.theme.tokens.background.secondary : p.theme.tokens.background.primary};
+  border: 1px solid
+    ${p => (p.isActive ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => `${p.theme.space.md} ${p.theme.space.lg}`};
+  text-align: left;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+  &:hover {
+    border-color: ${p =>
+      p.disabled ? p.theme.tokens.border.primary : p.theme.tokens.border.accent};
+  }
+  &:focus-visible {
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
+    outline-offset: 1px;
+  }
+`;
+
+function StatCard({
+  Icon,
+  iconVariant,
+  label,
+  value,
+  isActive,
+  onClick,
+  extra,
+}: {
+  Icon: typeof IconUser;
+  iconVariant: StatIconVariant;
+  isActive: boolean;
+  label: string;
+  value: number | string;
+  extra?: React.ReactNode;
+  onClick?: () => void;
+}) {
+  return (
+    <StatCardButton
+      type="button"
+      isActive={isActive}
+      aria-pressed={isActive}
+      onClick={onClick}
+      disabled={!onClick}
+    >
+      <Stack gap="xs">
+        <Flex gap="xs" align="center">
+          <Icon size="xs" variant={iconVariant} aria-hidden />
+          <Text size="xs" variant="muted" uppercase>
+            {label}
+          </Text>
+          {extra}
+        </Flex>
+        <Heading as="h2" size="2xl">
+          {value}
+        </Heading>
+      </Stack>
+    </StatCardButton>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -1,0 +1,391 @@
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {LinkButton} from '@sentry/scraps/button';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {ErrorLevel} from 'sentry/components/events/errorLevel';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {TimeSince} from 'sentry/components/timeSince';
+import {
+  IconArrow,
+  IconCircleCheckmark,
+  IconCommit,
+  IconFocus,
+  IconMerge,
+  IconPullRequest,
+  IconSearch,
+} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import {ellipsize} from 'sentry/utils/string/ellipsize';
+
+import {ATTENTION_META, AttentionBadge, getAttentionReason} from './attentionBadge';
+import {TriggerBadge} from './triggerBadge';
+import type {OverviewRow, PatchStats} from './types';
+
+const TitleLink = styled(Link)`
+  color: inherit;
+  &:hover {
+    color: inherit;
+    text-decoration: underline;
+  }
+`;
+
+// The most-changed files shown on hover before collapsing into "+N more".
+const MAX_TOOLTIP_FILES = 5;
+
+// Per-file breakdown for the diff pill's tooltip: path left, churn right,
+// biggest files first (fileList is pre-sorted by churn).
+function PatchFilesTooltip({stats}: {stats: PatchStats}) {
+  const shown = stats.fileList.slice(0, MAX_TOOLTIP_FILES);
+  const hidden = stats.fileList.length - shown.length;
+  return (
+    <Stack gap="2xs" align="stretch">
+      {shown.map(file => (
+        <Flex key={file.path} gap="lg" justify="between" align="baseline">
+          <Text size="xs" monospace align="left">
+            {file.path}
+          </Text>
+          <Text size="xs" monospace wrap="nowrap">
+            <Text size="xs" variant="success">
+              +{file.added}
+            </Text>{' '}
+            <Text size="xs" variant="danger">
+              −{file.removed}
+            </Text>
+          </Text>
+        </Flex>
+      ))}
+      {hidden > 0 && (
+        <Text size="xs" variant="muted" align="left">
+          {tn('+%s more file', '+%s more files', hidden)}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+// Buckets the raw 0–1 score into a scannable label; the 0.7 threshold matches
+// isIssueQuickFixable (sentry/components/events/autofix/utils).
+function FixabilityTag({score}: {score: number}) {
+  const high = score > 0.7;
+  const label = high
+    ? t('High fixability')
+    : score > 0.4
+      ? t('Medium fixability')
+      : t('Low fixability');
+  return (
+    <Tooltip title={t('Fixability score: %s', score.toFixed(2))}>
+      <Tag variant={high ? 'success' : 'muted'}>{label}</Tag>
+    </Tooltip>
+  );
+}
+
+export function IssueCard({orgSlug, row}: {orgSlug: string; row: OverviewRow}) {
+  const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
+  // Deep-link into the issue page with the Seer drawer already open, so the
+  // run itself is one click away (matches the issue details ?seerDrawer param).
+  const runUrl = {pathname: issueUrl, query: {seerDrawer: 'true'}};
+  const attention = getAttentionReason(row);
+  // The body shows exactly one block: the proposed fix when the run drafted
+  // code (the fix prompt returns an empty answer otherwise, and empty answers
+  // never become entries), else the diagnosis summary.
+  const summary = row.analysis.find(entry => entry.key === 'summary');
+  const proposedFix = row.analysis.find(entry => entry.key === 'fix_summary');
+  const bodyEntry = proposedFix ?? summary;
+  const isFixBody = bodyEntry?.key === 'fix_summary';
+  const detailEntries = row.analysis.filter(entry => entry.placement === 'details');
+
+  const eventCountLabel =
+    row.eventCount === 1
+      ? t('1 event')
+      : t('%s events', formatAbbreviatedNumber(row.eventCount));
+  const userCountLabel =
+    row.userCount === 1
+      ? t('1 user')
+      : t('%s users', formatAbbreviatedNumber(row.userCount));
+
+  return (
+    <Container background="primary" border="primary" radius="md" padding="lg">
+      <Stack gap="md">
+        {/* Header: title + change size + action */}
+        <Flex justify="between" align="start" gap="md">
+          <Flex gap="sm" align="center" minWidth="0" flex="1">
+            <ErrorLevel level={row.level} />
+            {/* The ellipsis Text is the shrinking flex item (overflow:hidden
+                  resolves its min-width to 0); the Link must nest inside it or
+                  the anchor refuses to shrink and the title overflows the card.
+                  When Seer produced a plain-language headline it replaces the
+                  raw issue title, which stays reachable via the tooltip and
+                  the expanded details. */}
+            <Text bold ellipsis>
+              {row.headline ? (
+                <Tooltip
+                  maxWidth={480}
+                  title={
+                    <Stack gap="2xs">
+                      <Text size="xs" bold uppercase variant="muted" align="left">
+                        {t('Raw issue title')}
+                      </Text>
+                      <Text size="xs" align="left">
+                        {ellipsize(row.title, 200)}
+                      </Text>
+                    </Stack>
+                  }
+                >
+                  <TitleLink to={issueUrl}>{row.headline}</TitleLink>
+                </Tooltip>
+              ) : (
+                <TitleLink to={issueUrl}>{row.title}</TitleLink>
+              )}
+            </Text>
+          </Flex>
+          <Flex gap="sm" align="center" flexShrink={0}>
+            {/* No stage chip here: the action verb already encodes the stage
+                  (Review PR ⇒ PR opened, Open PR ⇒ code drafted, …) and the
+                  Outcome filter covers querying by it. One fact + one action. */}
+            {row.patchStats && (
+              <Tooltip
+                title={<PatchFilesTooltip stats={row.patchStats} />}
+                maxWidth={480}
+                skipWrapper
+              >
+                {/* Contained like its Tag/button neighbors so the diff size
+                      doesn't read as floating text */}
+                <Container
+                  border="muted"
+                  radius="sm"
+                  background="secondary"
+                  padding="2xs sm"
+                >
+                  <Text size="xs" variant="muted" monospace wrap="nowrap">
+                    {tn('%s file', '%s files', row.patchStats.files)}{' '}
+                    <Text size="xs" variant="success">
+                      +{row.patchStats.added}
+                    </Text>{' '}
+                    <Text size="xs" variant="danger">
+                      −{row.patchStats.removed}
+                    </Text>
+                  </Text>
+                </Container>
+              </Tooltip>
+            )}
+            {row.statePending ? (
+              <Text variant="muted">{'…'}</Text>
+            ) : row.isProcessing ? (
+              <Tag variant="info">{t('Running')}</Tag>
+            ) : row.prMerged ? (
+              <Tooltip title={t('The pull request for this fix was merged.')}>
+                <Tag variant="success" icon={<IconMerge />}>
+                  {t('Merged')}
+                </Tag>
+              </Tooltip>
+            ) : attention === 'review_pr' && row.prUrl ? (
+              <Tooltip
+                title={
+                  row.prNumber
+                    ? t(
+                        'Autofix opened pull request #%s. Review and merge it.',
+                        row.prNumber
+                      )
+                    : ATTENTION_META.review_pr.description
+                }
+                skipWrapper
+              >
+                <LinkButton
+                  size="zero"
+                  variant="warning"
+                  icon={<IconPullRequest />}
+                  href={row.prUrl}
+                  external
+                >
+                  {ATTENTION_META.review_pr.label}
+                </LinkButton>
+              </Tooltip>
+            ) : attention ? (
+              <AttentionBadge reason={attention} to={runUrl} />
+            ) : (
+              <Tooltip title={t('Open the Seer run for this issue.')} skipWrapper>
+                <LinkButton size="zero" variant="secondary" to={runUrl}>
+                  {t('View run')}
+                </LinkButton>
+              </Tooltip>
+            )}
+            {row.prUrl && attention !== 'review_pr' && (
+              <LinkButton
+                size="zero"
+                variant="link"
+                icon={<IconPullRequest />}
+                href={row.prUrl}
+                external
+              >
+                {row.prNumber ? `#${row.prNumber}` : t('PR')}
+              </LinkButton>
+            )}
+          </Flex>
+        </Flex>
+
+        {/* The question autofix is blocked on, surfaced right on the card */}
+        {row.pendingQuestion && (
+          <Text size="sm" variant="accent">
+            {t('Seer asked: %s', row.pendingQuestion)}
+          </Text>
+        )}
+
+        {/* The body is exactly ONE block, either/or: the proposed fix when the
+            run drafted code (the fix text supersedes the summary, which would
+            describe the same change twice), otherwise the diagnosis summary.
+            Same anatomy for both; icon + label color tell them apart. */}
+        {bodyEntry && (
+          <Container
+            background="secondary"
+            border="muted"
+            radius="md"
+            padding="sm md"
+            maxWidth="90ch"
+          >
+            <Stack gap="xs">
+              <Flex gap="xs" align="center">
+                {isFixBody ? (
+                  <IconCommit size="xs" variant="success" aria-hidden />
+                ) : (
+                  <IconSearch size="xs" variant="muted" aria-hidden />
+                )}
+                <Text size="xs" bold uppercase variant={isFixBody ? 'success' : 'muted'}>
+                  {isFixBody ? t('Proposed fix') : t('Diagnosis')}
+                </Text>
+              </Flex>
+              <Text size="sm" density="comfortable" as="div">
+                <SeerMarkdown raw={bodyEntry.answer} />
+              </Text>
+            </Stack>
+          </Container>
+        )}
+
+        {/* Footer: the collapsed analysis on the left, project pinned in the
+            card's bottom-right corner */}
+        <Flex justify="between" align="start" gap="md" borderTop="muted" paddingTop="sm">
+          <Container flex="1" minWidth="0">
+            {detailEntries.length > 0 && (
+              <Disclosure size="xs">
+                <Disclosure.Title>{t('Full analysis')}</Disclosure.Title>
+                <Disclosure.Content>
+                  <Stack gap="md" paddingTop="xs">
+                    {/* Compact identity strip: the short id and Seer's
+                        fixability read — the raw title lives in the headline
+                        tooltip, not here */}
+                    <Flex gap="sm" align="center">
+                      <Text size="xs" monospace variant="muted">
+                        {row.shortId}
+                      </Text>
+                      {typeof row.fixabilityScore === 'number' && (
+                        <FixabilityTag score={row.fixabilityScore} />
+                      )}
+                    </Flex>
+                    {/* Sections share the body blocks' icon+label voice and
+                        sit side by side on wide screens instead of leaving
+                        the card's right half empty */}
+                    <Grid
+                      columns={{xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))'}}
+                      gap="lg xl"
+                      align="start"
+                    >
+                      {detailEntries.map(entry => {
+                        const section =
+                          entry.key === 'reviewer_notes'
+                            ? isFixBody
+                              ? {
+                                  label: t('Review checklist'),
+                                  icon: (
+                                    <IconCircleCheckmark
+                                      size="xs"
+                                      variant="muted"
+                                      aria-hidden
+                                    />
+                                  ),
+                                }
+                              : {
+                                  label: t('Next steps'),
+                                  icon: (
+                                    <IconArrow
+                                      direction="right"
+                                      size="xs"
+                                      variant="muted"
+                                      aria-hidden
+                                    />
+                                  ),
+                                }
+                            : {
+                                label: entry.label,
+                                icon: <IconFocus size="xs" variant="muted" aria-hidden />,
+                              };
+                        return (
+                          <Stack key={entry.key} gap="xs">
+                            <Flex gap="xs" align="center">
+                              {section.icon}
+                              <Text size="xs" bold uppercase variant="muted">
+                                {section.label}
+                              </Text>
+                            </Flex>
+                            <Text size="sm" density="comfortable" as="div">
+                              <SeerMarkdown raw={entry.answer} />
+                            </Text>
+                          </Stack>
+                        );
+                      })}
+                    </Grid>
+                  </Stack>
+                </Disclosure.Content>
+              </Disclosure>
+            )}
+          </Container>
+          {/* Provenance + vitals read as one quiet metadata line */}
+          <Flex gap="md" align="center" flexShrink={0}>
+            {/* "Manual" is the default trigger and reads as noise on every
+                card; only non-default triggers earn a badge */}
+            {row.trigger !== 'manual' && (
+              <TriggerBadge trigger={row.trigger} rawSource={row.rawSource} />
+            )}
+            <Flex gap="xs" align="center">
+              <Tooltip
+                title={
+                  row.userCount > 0
+                    ? t(
+                        '%s events and %s affected users in the last 90 days',
+                        row.eventCount.toLocaleString(),
+                        row.userCount.toLocaleString()
+                      )
+                    : t('%s events in the last 90 days', row.eventCount.toLocaleString())
+                }
+              >
+                <Text size="xs" variant="muted">
+                  {eventCountLabel}
+                  {row.userCount > 0 && ` · ${userCountLabel}`}
+                </Text>
+              </Tooltip>
+              <Text size="xs" variant="muted" aria-hidden>
+                {'·'}
+              </Text>
+              <Text size="xs" variant="muted" wrap="nowrap">
+                <TimeSince
+                  date={row.lastActivityAt}
+                  prefix={t('updated')}
+                  tooltipPrefix={t('Last activity on this Seer run')}
+                />
+              </Text>
+            </Flex>
+            <Tooltip title={t('Project')} skipWrapper>
+              <ProjectBadge project={row.project} avatarSize={14} disableLink />
+            </Tooltip>
+          </Flex>
+        </Flex>
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/runQuestions.tsx
+++ b/static/app/views/seerWorkflows/overview/runQuestions.tsx
@@ -1,0 +1,87 @@
+import {t} from 'sentry/locale';
+
+import type {AnswerPlacement} from './types';
+
+interface RunQuestionConfig {
+  key: string;
+  label: string;
+  placement: AnswerPlacement;
+  // The prompt sent to the runs endpoint as a `question` param. Answered per
+  // run over its full history by Seer's agent_question one-shot; editing the
+  // text invalidates that (run, question) cache entry, so fresh answers show
+  // on the next load. Prompts are universal and self-adapt to the run's stage;
+  // "return an empty string" lets the UI skip sections that don't apply.
+  prompt: string;
+}
+
+// The one-shot questions the overview asks about each run (the endpoint caps
+// user questions at 5). Order matters: answers come back positionally.
+export const RUN_QUESTIONS: RunQuestionConfig[] = [
+  {
+    key: 'root_cause',
+    label: t('Root cause'),
+    placement: 'details',
+    prompt:
+      'Answer in two parts separated by a single pipe character. First a ' +
+      'headline: at most 14 words of plain language describing what is broken ' +
+      'and where, the way a good bug-report title would — no error class names ' +
+      'unless essential, no markdown or code formatting, no pipe characters in ' +
+      'it. ' +
+      'Then the pipe. Then the root cause: what actually breaks and why, in ' +
+      'one or two short sentences (at most 40 words), naming the responsible ' +
+      'function, commit, or configuration — inline code is allowed in this ' +
+      'part, but no headers, bullets, or code blocks. If the run did not ' +
+      'establish a root cause, still give the headline, then the pipe, then ' +
+      'one sentence on why it could not (e.g. could not reproduce, missing ' +
+      'context).',
+  },
+  {
+    key: 'summary',
+    label: t('Summary'),
+    placement: 'face',
+    prompt:
+      'One sentence of at most 25 words (a semicolon is fine): the failure ' +
+      "mechanism, then the run's concrete outcome — what the opened PR or " +
+      'drafted fix changes and where, or the issue-specific reason the run ' +
+      'skipped or stopped early. Name files and identifiers, not activities: ' +
+      'never content-free phrases like "this run produced a diagnosis" or ' +
+      '"implemented code changes". No first person, no filler. Inline code ' +
+      'allowed; no headers, bullets, or code blocks.',
+  },
+  {
+    key: 'fix_summary',
+    label: t('Proposed fix'),
+    placement: 'face',
+    prompt:
+      'If this run drafted code changes or opened a pull request, describe in ' +
+      'at most two sentences (max 45 words) what the changes are and why they ' +
+      'fix the root cause — name the files or functions touched and the ' +
+      'behavior change. Describe the change itself, never the author: no ' +
+      'first person ("I modified…") and no narration like "the solution ' +
+      'modifies" — e.g. "Adds an early return in `captureMcpShutdownSummary` ' +
+      'so info-level shutdowns no longer create issues." If the run did not ' +
+      'produce code changes, return an empty string. Inline code allowed for ' +
+      'file or function names; no markdown headers, bullets, or code blocks.',
+  },
+  {
+    key: 'reviewer_notes',
+    // Placeholder — the card derives the display label from whether the run
+    // drafted code: "Review checklist" vs "Next steps".
+    label: t('Notes'),
+    placement: 'details',
+    prompt:
+      'If this run drafted code changes or opened a pull request: a review ' +
+      'checklist — three to five markdown bullets a reviewer should verify ' +
+      'before trusting or merging the change, each naming the specific risk, ' +
+      'assumption, or untested path and why it matters (at most 25 words per ' +
+      'bullet). If the run produced no code: next steps instead — two to four ' +
+      'markdown bullets on how an engineer should take this forward (what to ' +
+      'confirm in the codebase, what decision to make, whether to have Seer ' +
+      'generate code), concrete and specific to this issue, never generic ' +
+      'advice. Every bullet must start on its own line with "- " (hyphen, ' +
+      'space) — never use the "•" character or run bullets together in one ' +
+      'paragraph. No first person; inline code allowed; no markdown headers.',
+  },
+];
+
+export const RUN_QUESTION_PROMPTS = RUN_QUESTIONS.map(question => question.prompt);

--- a/static/app/views/seerWorkflows/overview/triggerBadge.tsx
+++ b/static/app/views/seerWorkflows/overview/triggerBadge.tsx
@@ -1,0 +1,105 @@
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {IconBot, IconBroadcast, IconSeer, IconSiren, IconUser} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+import type {AutofixTrigger} from './types';
+
+// The full set of triggers the UI can label. Only `manual` and `night_shift`
+// are derivable today (see mapRunSourceToTrigger): they come from the runs
+// list's `source` field. The `issue_summary`/`alert`/
+// `post_process` buckets live on `AutofixData.request.options.auto_run_source`
+// (src/sentry/seer/autofix/issue_summary.py), which the runs list response
+// doesn't expose — they're kept here so the badge/type is ready once it does.
+const TRIGGER_META: Record<
+  AutofixTrigger,
+  {
+    Icon: typeof IconUser;
+    description: string;
+    label: string;
+  }
+> = {
+  manual: {
+    Icon: IconUser,
+    label: t('Manual'),
+    description: t(
+      'A user kicked off this Autofix run from the issue details page, an API call, or Slack.'
+    ),
+  },
+  issue_summary: {
+    Icon: IconSeer,
+    label: t('Issue summary'),
+    description: t(
+      'Auto-started from the issue summary on the issue details page when the issue looked fixable.'
+    ),
+  },
+  alert: {
+    Icon: IconSiren,
+    label: t('Alert'),
+    description: t('Auto-started when an alert rule for this issue fired.'),
+  },
+  post_process: {
+    Icon: IconBroadcast,
+    label: t('Post-process'),
+    description: t('Auto-started when new events arrived for this issue.'),
+  },
+  night_shift: {
+    Icon: IconBot,
+    label: t('Workflow'),
+    description: t('Triggered by the Sentry Workflows night-shift agentic triage run.'),
+  },
+};
+
+/**
+ * Map a SeerRun.source value onto a known trigger. Sources come from
+ * SeerAgentRunSource (src/sentry/seer/models/run.py); anything unmapped
+ * (bug-fixer, dashboard_generate, future values) returns null and renders the
+ * raw-source fallback badge instead.
+ */
+export function mapRunSourceToTrigger(source: string | null): AutofixTrigger | null {
+  switch (source) {
+    case 'autofix':
+    case 'slack_thread':
+    case 'chat':
+      return 'manual';
+    case 'night_shift':
+      return 'night_shift';
+    default:
+      return null;
+  }
+}
+
+export function TriggerBadge({
+  trigger,
+  rawSource,
+}: {
+  rawSource?: string | null;
+  trigger?: AutofixTrigger | null;
+}) {
+  if (!trigger) {
+    if (!rawSource) {
+      return null;
+    }
+    // Unknown source: show it verbatim rather than guessing a bucket.
+    return (
+      <Tooltip title={t('Triggered by %s.', rawSource)} skipWrapper>
+        <Flex gap="xs" align="center">
+          <IconSeer size="xs" variant="muted" aria-hidden />
+          <Text size="sm">{rawSource}</Text>
+        </Flex>
+      </Tooltip>
+    );
+  }
+
+  const meta = TRIGGER_META[trigger];
+  return (
+    <Tooltip title={meta.description} skipWrapper>
+      <Flex gap="xs" align="center">
+        <meta.Icon size="xs" variant="muted" aria-hidden />
+        <Text size="sm">{meta.label}</Text>
+      </Flex>
+    </Tooltip>
+  );
+}

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -1,0 +1,89 @@
+import type {Level} from 'sentry/types/event';
+import type {PlatformKey} from 'sentry/types/platform';
+
+export type AutofixOutcome = 'root_cause' | 'solution' | 'code_changes' | 'pr_opened';
+
+// Terminal-ish run status buckets the overview cares about, mapped from
+// ExplorerAutofixState.status. A run that is still 'processing' is reported
+// as COMPLETED here with `isProcessing` set on the row instead.
+export type AutofixRunStatus = 'COMPLETED' | 'ERROR' | 'NEED_MORE_INFORMATION';
+
+// How the run was started. Sources without a mapping render a fallback
+// badge with the raw source text.
+export type AutofixTrigger =
+  | 'manual'
+  | 'issue_summary'
+  | 'alert'
+  | 'post_process'
+  | 'night_shift';
+
+export type AttentionReason =
+  | 'awaiting_input'
+  | 'solution_ready'
+  | 'code_changes_ready'
+  | 'review_pr'
+  | 'errored';
+
+// Where an answered run question renders on the card: on the face (always
+// visible) or inside the collapsed "Full analysis" disclosure.
+export type AnswerPlacement = 'face' | 'details';
+
+// One answered run question joined to its question config
+// See ./runQuestions.ts
+export interface RunAnalysisEntry {
+  answer: string;
+  key: string;
+  label: string;
+  placement: AnswerPlacement;
+}
+
+// One changed file within the run's drafted diff.
+interface PatchFile {
+  added: number;
+  // Prefixed with "repo:" only when the diff spans more than one repository.
+  path: string;
+  removed: number;
+}
+
+// Aggregate stats over the run's merged file patches.
+export interface PatchStats {
+  added: number;
+  // Per-file breakdown, sorted by churn (added+removed) descending.
+  fileList: PatchFile[];
+  files: number;
+  removed: number;
+}
+
+// One issue + its latest autofix run, flattened for the overview cards.
+export interface OverviewRow {
+  analysis: RunAnalysisEntry[];
+  autofixRunStatus: AutofixRunStatus;
+  eventCount: number;
+  id: string;
+  // Most recent activity on the run (state update, trigger, or issue-level
+  // last-trigger timestamp) - drives sorting and the period filter.
+  lastActivityAt: string;
+  lastSeen: string;
+  level: Level;
+  outcomes: AutofixOutcome[];
+  prMerged: boolean;
+  project: {slug: string; platform?: PlatformKey};
+  shortId: string;
+  // Whether the per-issue autofix state request is still in flight.
+  statePending: boolean;
+  title: string;
+  userCount: number;
+  fixabilityScore?: number | null;
+  // Plain-language title from the run's root-cause answer (see runQuestions).
+  // Falls back to the raw issue title.
+  headline?: string;
+  isProcessing?: boolean;
+  patchStats?: PatchStats;
+  // The question autofix paused on, when status is NEED_MORE_INFORMATION and
+  // the pending input payload carries readable text.
+  pendingQuestion?: string;
+  prNumber?: number;
+  prUrl?: string;
+  rawSource?: string | null;
+  trigger?: AutofixTrigger | null;
+}


### PR DESCRIPTION
A new demo route `/issues/autofix/overview/` — a card-based "mission control" for issues Autofix has worked on. 
Each card answers, at a glance: **what broke, what Seer did, why, and what a human should do next.**

## Card anatomy

```
▍<LLM headline, replaces raw JSON-blob issue titles>   [1 file +27 −3] [Open PR]
<one-sentence summary: failure mechanism; concrete run outcome>
┌ PROPOSED FIX ────────────────────────────────────────────────┐
│ what the drafted change is and why it fixes the root cause   │  ← only when code was drafted
└──────────────────────────────────────────────────────────────┘
────────────────────────────────────────────────────────────────
▸ Full analysis         148K events · updated a day ago · ⬡ sentry
```

- **Action button encodes run state** (Review PR / Open PR / Generate code / View run / Retry / Running) and deep-links to the PR or the issue's Seer drawer (`?seerDrawer=true`). Stage chips were deliberately removed — the verb carries the state.
- **Exact diff stats** (`1 file +27 −3`) come from the run's `merged_file_patches`, not LLM estimates.
- **Clickable stat cards** (Awaiting input / Code changes ready / Awaiting review / Merged PRs) double as quick filters; Outcome/Trigger/Attention/Activity dropdowns filter client-side over the loaded page.
- **Full analysis** (collapsed): issue id + raw title, fixability tag, root cause, needs-you action (with parsed DECIDE/VERIFY/REVIEW/PROVIDE tag), reviewer notes.

## How the LLM content works

Five one-shot questions are asked per run via the runs endpoint's repeatable `question` param (`seer-run-questions` feature; answered by Seer's `agent_question` one-shot over the run's history; cached in Redis per (run, prompt-hash) for 24h). All prompts live in **`static/app/views/seerWorkflows/overview/runQuestions.tsx`** — editing a prompt string invalidates only that prompt's cache, so iteration needs no backend change. Two prompts return parseable pseudo-structure (`headline|root cause`, `CATEGORY|sentence`) with plain-text fallbacks when parsing fails.