### PR TITLE
feat(seer): Serialize pull requests on Seer runs

### DIFF
--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -9,11 +9,29 @@ from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.api.serializers.models.repository import RepositorySerializerResponse
 from sentry.api.serializers.release_details_types import Author
 from sentry.models.commitauthor import CommitAuthor
-from sentry.models.pullrequest import PullRequest, PullRequestAttribution
+from sentry.models.pullrequest import (
+    PullRequest,
+    PullRequestAttribution,
+    PullRequestLifecycleState,
+)
 from sentry.models.repository import Repository
 from sentry.pr_metrics.attribution import is_seer_attribution
 
 PullRequestStatus = Literal["merged", "open", "closed", "draft", "unknown"]
+
+
+def get_stored_pull_request_status(pull_request: PullRequest) -> PullRequestStatus | None:
+    if pull_request.state == PullRequestLifecycleState.MERGED:
+        return "merged"
+    if pull_request.state == PullRequestLifecycleState.CLOSED:
+        return "closed"
+    if pull_request.draft is True:
+        return "draft"
+    # `draft` is nullable for older rows, so only trust `open` when we know the PR
+    # is not a draft.
+    if pull_request.state == PullRequestLifecycleState.OPEN and pull_request.draft is False:
+        return "open"
+    return None
 
 
 class PullRequestSerializerResponse(TypedDict):
@@ -21,6 +39,8 @@ class PullRequestSerializerResponse(TypedDict):
     title: str | None
     message: str | None
     dateCreated: datetime
+    mergedAt: datetime | None
+    status: PullRequestStatus | None
     repository: RepositorySerializerResponse
     author: Author
     externalUrl: str
@@ -37,7 +57,6 @@ LinkedPullRequestAttributionResponse = LinkedPullRequestSeerAttributionResponse
 class LinkedPullRequestResponse(PullRequestSerializerResponse):
     attribution: LinkedPullRequestAttributionResponse | None
     dateLinked: datetime
-    status: PullRequestStatus
 
 
 def get_users_for_pull_requests(item_list, user=None):
@@ -80,6 +99,8 @@ class PullRequestSerializer(Serializer[PullRequestSerializerResponse]):
             "title": obj.title,
             "message": obj.message,
             "dateCreated": obj.date_added,
+            "mergedAt": obj.merged_at,
+            "status": get_stored_pull_request_status(obj),
             "repository": attrs["repository"],
             "author": attrs["user"],
             "externalUrl": attrs["external_url"],

--- a/src/sentry/api/serializers/models/seer_night_shift_run.py
+++ b/src/sentry/api/serializers/models/seer_night_shift_run.py
@@ -10,10 +10,9 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.pullrequest import (
     PullRequestSerializer,
     PullRequestSerializerResponse,
-    PullRequestStatus,
 )
 from sentry.models.group import Group
-from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.pullrequest import PullRequest
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
@@ -32,11 +31,6 @@ class SeerNightShiftRunResultResponse(TypedDict):
     dateAdded: str
 
 
-class SeerNightShiftRunPullRequestResponse(PullRequestSerializerResponse):
-    # Null if Sentry never observed a webhook event for this PR.
-    status: PullRequestStatus | None
-
-
 # TODO(telkins): this `issues` list is a triage-specific view derived from
 # `results`, kept for the current frontend. Once the UI reads `results`
 # directly (filtering to kind=agentic_triage), drop this key and _serialize_issue.
@@ -49,7 +43,7 @@ class SeerNightShiftRunIssueResponse(TypedDict):
     reason: str | None
     skipReason: str | None
     seerRunId: str | None
-    pullRequests: list[SeerNightShiftRunPullRequestResponse]
+    pullRequests: list[PullRequestSerializerResponse]
     dateAdded: str
 
 
@@ -121,15 +115,15 @@ class SeerNightShiftRunSerializer(Serializer[SeerNightShiftRunResponse]):
             pr_ids_by_seer_run_pk[link.seer_run_id].append(link.pull_request_id)
             pull_requests_by_pk[link.pull_request_id] = link.pull_request
 
-        serialized_pr_by_pk: dict[int, SeerNightShiftRunPullRequestResponse] = {}
+        serialized_pr_by_pk: dict[int, PullRequestSerializerResponse] = {}
         if pull_requests_by_pk:
             prs = list(pull_requests_by_pk.values())
             serialized_pr_by_pk = {
-                pr.id: {**serialized, "status": _get_stored_pull_request_status(pr)}
+                pr.id: serialized
                 for pr, serialized in zip(prs, serialize(prs, user, PullRequestSerializer()))
             }
 
-        pull_requests_by_result_id: dict[int, list[SeerNightShiftRunPullRequestResponse]] = {}
+        pull_requests_by_result_id: dict[int, list[PullRequestSerializerResponse]] = {}
         for r in triage_results:
             seer_run_pk = seer_run_pk_by_result_id.get(r.id)
             pull_requests_by_result_id[r.id] = (
@@ -203,26 +197,11 @@ def _serialize_result(result: SeerNightShiftRunResult) -> SeerNightShiftRunResul
     }
 
 
-def _get_stored_pull_request_status(pull_request: PullRequest) -> PullRequestStatus | None:
-    """No live provider lookup -- this feeds a list endpoint, not a detail view."""
-    if pull_request.state == PullRequestLifecycleState.MERGED:
-        return "merged"
-    if pull_request.state == PullRequestLifecycleState.CLOSED:
-        return "closed"
-    if pull_request.draft is True:
-        return "draft"
-    # `draft` is nullable for older rows, so only trust `open` when we know
-    # the PR is not a draft.
-    if pull_request.state == PullRequestLifecycleState.OPEN and pull_request.draft is False:
-        return "open"
-    return None
-
-
 def _serialize_issue(
     result: SeerNightShiftRunResult,
     group_titles_by_id: Mapping[int, str | None],
     group_short_ids_by_id: Mapping[int, str | None],
-    pull_requests_by_result_id: Mapping[int, list[SeerNightShiftRunPullRequestResponse]],
+    pull_requests_by_result_id: Mapping[int, list[PullRequestSerializerResponse]],
 ) -> SeerNightShiftRunIssueResponse:
     extras = result.extras or {}
     return {

--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any, NotRequired, TypedDict
 
-from sentry.api.serializers import Serializer, register
-from sentry.seer.models.run import SeerAgentRun, SeerRun
+from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.models.pullrequest import (
+    PullRequestSerializer,
+    PullRequestSerializerResponse,
+)
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunPullRequest
 
 
 # Within a run, outputs are ordered to match the questions that produced them
@@ -32,6 +37,7 @@ class SeerRunResponse(TypedDict):
     source: str | None
     projectId: str | None
     groupId: str | None
+    pullRequests: list[PullRequestSerializerResponse]
     # One-shot outputs (question answers), injected by the endpoint when
     # ?expand=questions and/or ?question= is passed; the serializer itself never
     # populates them.
@@ -48,12 +54,39 @@ class SeerRunSerializer(Serializer):
         agent_by_run_id = {
             agent.run_id: agent for agent in SeerAgentRun.objects.filter(run__in=item_list)
         }
-        return {run: {"agent": agent_by_run_id.get(run.id)} for run in item_list}
+
+        # A PR is opened by exactly one run (unique link), so each PR appears
+        # once; serialize them in one bulk pass through PullRequestSerializer.
+        pr_links = list(
+            SeerRunPullRequest.objects.filter(seer_run__in=item_list)
+            .select_related("pull_request")
+            .order_by("date_added")
+        )
+        prs = [link.pull_request for link in pr_links]
+        serialized_pr_by_id = {
+            pr.id: serialized
+            for pr, serialized in zip(prs, serialize(prs, user, PullRequestSerializer()))
+        }
+
+        pull_requests_by_run_id: dict[int, list[PullRequestSerializerResponse]] = defaultdict(list)
+        for link in pr_links:
+            pull_requests_by_run_id[link.seer_run_id].append(
+                serialized_pr_by_id[link.pull_request_id]
+            )
+
+        return {
+            run: {
+                "agent": agent_by_run_id.get(run.id),
+                "pull_requests": pull_requests_by_run_id.get(run.id, []),
+            }
+            for run in item_list
+        }
 
     def serialize(
         self, obj: SeerRun, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> SeerRunResponse:
         agent: SeerAgentRun | None = attrs.get("agent")
+        pull_requests = attrs.get("pull_requests", [])
         return {
             "id": str(obj.uuid),
             "type": obj.type,
@@ -68,4 +101,5 @@ class SeerRunSerializer(Serializer):
             "groupId": str(agent.group_id)
             if agent is not None and agent.group_id is not None
             else None,
+            "pullRequests": pull_requests,
         }

--- a/src/sentry/issues/endpoints/group_pull_requests.py
+++ b/src/sentry/issues/endpoints/group_pull_requests.py
@@ -16,13 +16,14 @@ from sentry.api.serializers.models.pullrequest import (
     LinkedPullRequestResponse,
     LinkedPullRequestSerializer,
     PullRequestStatus,
+    get_stored_pull_request_status,
 )
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
-from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 
 logger = logging.getLogger(__name__)
@@ -62,20 +63,6 @@ def _get_valid_group_pull_request_links(group: Group, organization_id: int) -> l
         .filter(Exists(valid_pull_requests))
         .order_by("-datetime")[:DEFAULT_LIMIT]
     )
-
-
-def _get_stored_pull_request_status(pull_request: PullRequest) -> PullRequestStatus | None:
-    if pull_request.state == PullRequestLifecycleState.MERGED:
-        return "merged"
-    if pull_request.state == PullRequestLifecycleState.CLOSED:
-        return "closed"
-    if pull_request.draft is True:
-        return "draft"
-    # `draft` is nullable for older rows, so only trust `open` when we know the PR
-    # is not a draft.
-    if pull_request.state == PullRequestLifecycleState.OPEN and pull_request.draft is False:
-        return "open"
-    return None
 
 
 def _get_pull_request_repo_name(repository: Repository) -> str:
@@ -158,7 +145,7 @@ def _get_provider_pull_request_status(
 def _get_pull_request_status(
     pull_request: PullRequest, repository: Repository | None
 ) -> PullRequestStatus:
-    stored_status = _get_stored_pull_request_status(pull_request)
+    stored_status = get_stored_pull_request_status(pull_request)
     if stored_status is not None:
         return stored_status
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
-from sentry.seer.models.run import SeerRunType
+from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.seer.run_questions import QUESTIONS, question_hash
 from sentry.seer.runs_query import filtered_runs_queryset
 from sentry.testutils.cases import APITestCase, TestCase
@@ -371,6 +371,45 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         data = response.data[0]
         assert data["id"] == str(run.uuid)
         assert data["userId"] == str(self.user.id)
+
+    def test_pull_requests_serialized_with_state(self) -> None:
+        run = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            last_triggered_at=before_now(minutes=1),
+        )
+        without_prs = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            last_triggered_at=before_now(minutes=10),
+        )
+        project = self.create_project(organization=self.organization)
+        repo = self.create_repo(project, name="getsentry/sentry")
+        merged_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="123"
+        )
+        merged_at = before_now(minutes=5)
+        merged_pr.update(state="merged", merged_at=merged_at)
+        open_pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="124"
+        )
+        SeerRunPullRequest.objects.create(seer_run=run, pull_request=merged_pr)
+        SeerRunPullRequest.objects.create(seer_run=run, pull_request=open_pr)
+
+        response = self.get_success_response(self.organization.slug)
+        by_id = {r["id"]: r for r in response.data}
+
+        # The PR number is exposed as the serializer's ``id`` (PullRequest.key).
+        prs_by_key = {pr["id"]: pr for pr in by_id[str(run.uuid)]["pullRequests"]}
+        assert prs_by_key["123"]["status"] == "merged"
+        assert prs_by_key["123"]["mergedAt"] == merged_at
+        # Standard PullRequestSerializer fields come through too.
+        assert "repository" in prs_by_key["123"]
+        # No webhook has reported a state for the second PR.
+        assert prs_by_key["124"]["status"] is None
+        assert prs_by_key["124"]["mergedAt"] is None
+
+        assert by_id[str(without_prs.uuid)]["pullRequests"] == []
 
     def test_outputs_absent_without_flag(self) -> None:
         self.create_seer_run(


### PR DESCRIPTION
Add a `pullRequests` field to SeerRunResponse.
In addition:
  - Refactor the two existing places (and this new case) where
    we serialize the PR so we don't duplicate the code.
  - Add `mergedAt` and`status` to this common code.
  
This is additive to the existing endpoints. 