### PR TITLE
feat(ui): Add org feature flag controls (frontend only)

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -112,6 +112,7 @@ import {useNotificationPermission} from 'sentry/serviceWorker/client/useNotifica
 import {CMDKAction} from './cmdk';
 import {CommandPaletteSlot} from './commandPaletteSlot';
 import {useCommandPaletteState} from './commandPaletteStateContext';
+import {FeatureFlagCommandPaletteActions} from './featureFlagCommandPaletteActions';
 
 const DSN_ICONS: React.ReactElement[] = [
   <IconIssues key="issues" />,
@@ -756,6 +757,7 @@ export function GlobalCommandPaletteActions() {
 
       {user.isStaff && (
         <CMDKAction display={{label: t('Admin')}}>
+          <FeatureFlagCommandPaletteActions />
           <CMDKAction
             display={{label: t('Open _admin'), icon: <IconOpen />}}
             keywords={[t('superuser')]}

--- a/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.spec.tsx
@@ -1,0 +1,132 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {
+  makeCloseButton,
+  makeClosableHeader,
+  ModalBody,
+  ModalFooter,
+} from '@sentry/scraps/modal';
+
+import {CommandPaletteProvider} from 'sentry/components/commandPalette/ui/cmdk';
+import {CommandPalette} from 'sentry/components/commandPalette/ui/commandPalette';
+import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {mockElementSize} from 'sentry/utils/fixtures/virtualization';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
+
+import {
+  FeatureFlagCommandPaletteActions,
+  setLocalFeatureFlagOverride,
+} from './featureFlagCommandPaletteActions';
+
+const LOCALSTORAGE_KEY = 'feature-flag-overrides';
+
+mockElementSize();
+
+function makeRenderProps(closeModal: jest.Mock) {
+  return {
+    closeModal,
+    Body: ModalBody,
+    Footer: ModalFooter,
+    Header: makeClosableHeader(closeModal),
+    CloseButton: makeCloseButton(closeModal),
+  };
+}
+
+function SlotOutlets() {
+  return (
+    <div style={{display: 'none'}}>
+      <CommandPaletteSlot.Outlet name="task">
+        {props => <div {...props} />}
+      </CommandPaletteSlot.Outlet>
+      <CommandPaletteSlot.Outlet name="page">
+        {props => <div {...props} />}
+      </CommandPaletteSlot.Outlet>
+      <CommandPaletteSlot.Outlet name="global">
+        {props => <div {...props} />}
+      </CommandPaletteSlot.Outlet>
+    </div>
+  );
+}
+
+function renderFeatureFlagActions(organization = OrganizationFixture()) {
+  render(
+    <CommandPaletteProvider>
+      <FeatureFlagCommandPaletteActions />
+      <SlotOutlets />
+      <CommandPalette {...makeRenderProps(jest.fn())} />
+    </CommandPaletteProvider>,
+    {organization}
+  );
+}
+
+describe('FeatureFlagCommandPaletteActions', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    OrganizationStore.reset();
+  });
+
+  it('persists an override and updates the active organization immediately', () => {
+    const organization = OrganizationFixture({features: ['enabled-feature']});
+
+    setLocalFeatureFlagOverride(organization, 'new-feature', true);
+
+    expect(localStorageWrapper.getItem(LOCALSTORAGE_KEY)).toBe('{"new-feature":true}');
+    const updatedFeatures = OrganizationStore.get().organization?.features;
+    expect(updatedFeatures).toHaveLength(2);
+    expect(updatedFeatures).toContain('enabled-feature');
+    expect(updatedFeatures).toContain('new-feature');
+    expect(organization.features).toEqual(['enabled-feature']);
+  });
+
+  it('toggles an existing feature flag without reloading', async () => {
+    const organization = OrganizationFixture({features: ['enabled-feature']});
+    renderFeatureFlagActions(organization);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Search commands'}),
+      'Toggle Org Feature Flag'
+    );
+    await userEvent.click(
+      await screen.findByRole('option', {name: /Toggle Org Feature Flag/})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: /enabled-feature/}));
+
+    expect(localStorageWrapper.getItem(LOCALSTORAGE_KEY)).toBe(
+      '{"enabled-feature":false}'
+    );
+    expect(OrganizationStore.get().organization?.features).not.toContain(
+      'enabled-feature'
+    );
+  });
+
+  it('adds a new enabled feature flag from the modal', async () => {
+    const organization = OrganizationFixture({features: []});
+    renderFeatureFlagActions(organization);
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Search commands'}),
+      'Add Feature Flag'
+    );
+    await userEvent.click(await screen.findByRole('option', {name: /Add Feature Flag/}));
+    renderGlobalModal({organization});
+    await userEvent.type(
+      await screen.findByRole('textbox', {name: 'Feature flag name'}),
+      'new-feature'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Add Feature Flag'}));
+
+    await waitFor(() =>
+      expect(OrganizationStore.get().organization?.features).toContain('new-feature')
+    );
+    expect(localStorageWrapper.getItem(LOCALSTORAGE_KEY)).toBe('{"new-feature":true}');
+  });
+});

--- a/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.spec.tsx
@@ -1,23 +1,12 @@
+import {Fragment} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {
-  render,
-  renderGlobalModal,
-  screen,
-  userEvent,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {
-  makeCloseButton,
-  makeClosableHeader,
-  ModalBody,
-  ModalFooter,
-} from '@sentry/scraps/modal';
+import {GlobalModal} from '@sentry/scraps/modal';
 
-import {CommandPaletteProvider} from 'sentry/components/commandPalette/ui/cmdk';
-import {CommandPalette} from 'sentry/components/commandPalette/ui/commandPalette';
 import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {CommandPaletteHotkeys} from 'sentry/components/commandPalette/ui/commandPaletteStateContext';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {mockElementSize} from 'sentry/utils/fixtures/virtualization';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
@@ -30,16 +19,6 @@ import {
 const LOCALSTORAGE_KEY = 'feature-flag-overrides';
 
 mockElementSize();
-
-function makeRenderProps(closeModal: jest.Mock) {
-  return {
-    closeModal,
-    Body: ModalBody,
-    Footer: ModalFooter,
-    Header: makeClosableHeader(closeModal),
-    CloseButton: makeCloseButton(closeModal),
-  };
-}
 
 function SlotOutlets() {
   return (
@@ -59,13 +38,19 @@ function SlotOutlets() {
 
 function renderFeatureFlagActions(organization = OrganizationFixture()) {
   render(
-    <CommandPaletteProvider>
+    <Fragment>
+      <CommandPaletteHotkeys />
       <FeatureFlagCommandPaletteActions />
       <SlotOutlets />
-      <CommandPalette {...makeRenderProps(jest.fn())} />
-    </CommandPaletteProvider>,
+      <GlobalModal />
+    </Fragment>,
     {organization}
   );
+}
+
+async function openCommandPalette() {
+  await userEvent.keyboard('{Control>}k{/Control}');
+  return screen.findByRole('textbox', {name: 'Search commands'});
 }
 
 describe('FeatureFlagCommandPaletteActions', () => {
@@ -91,6 +76,7 @@ describe('FeatureFlagCommandPaletteActions', () => {
     const organization = OrganizationFixture({features: ['enabled-feature']});
     renderFeatureFlagActions(organization);
 
+    await openCommandPalette();
     await userEvent.type(
       screen.getByRole('textbox', {name: 'Search commands'}),
       'Toggle Org Feature Flag'
@@ -108,16 +94,51 @@ describe('FeatureFlagCommandPaletteActions', () => {
     );
   });
 
+  it('keeps a disabled feature flag in the list after returning to it', async () => {
+    const organization = OrganizationFixture({features: ['enabled-feature']});
+    renderFeatureFlagActions(organization);
+
+    await openCommandPalette();
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Search commands'}),
+      'Toggle Org Feature Flag'
+    );
+    await userEvent.click(
+      await screen.findByRole('option', {name: /Toggle Org Feature Flag/})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: /enabled-feature/}));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('textbox', {name: 'Search commands'})
+      ).not.toBeInTheDocument()
+    );
+
+    await openCommandPalette();
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Search commands'}),
+      'Toggle Org Feature Flag'
+    );
+    await userEvent.click(
+      await screen.findByRole('option', {name: /Toggle Org Feature Flag/})
+    );
+
+    const disabledFlag = await screen.findByRole('option', {
+      name: 'enabled-feature',
+    });
+    expect(disabledFlag).toHaveTextContent('Disabled');
+  });
+
   it('adds a new enabled feature flag from the modal', async () => {
     const organization = OrganizationFixture({features: []});
     renderFeatureFlagActions(organization);
 
+    await openCommandPalette();
     await userEvent.type(
       screen.getByRole('textbox', {name: 'Search commands'}),
       'Add Feature Flag'
     );
     await userEvent.click(await screen.findByRole('option', {name: /Add Feature Flag/}));
-    renderGlobalModal({organization});
     await userEvent.type(
       await screen.findByRole('textbox', {name: 'Feature flag name'}),
       'new-feature'

--- a/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.tsx
@@ -24,7 +24,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {CMDKAction} from './cmdk';
 
 interface AddOrgFeatureFlagModalProps extends ModalRenderProps {
-  organization: Organization;
+  onSubmit: (name: string, value: boolean) => void;
 }
 
 export function setLocalFeatureFlagOverride(
@@ -70,7 +70,7 @@ function AddOrgFeatureFlagModal({
   Footer,
   Header,
   closeModal,
-  organization,
+  onSubmit,
 }: AddOrgFeatureFlagModalProps) {
   const [name, setName] = useState('');
   const [isEnabled, setIsEnabled] = useState(true);
@@ -80,7 +80,7 @@ function AddOrgFeatureFlagModal({
     if (!normalizedName) {
       return;
     }
-    setLocalFeatureFlagOverrideWithFeedback(organization, normalizedName, isEnabled);
+    onSubmit(normalizedName, isEnabled);
     closeModal();
   };
 
@@ -129,12 +129,21 @@ function AddOrgFeatureFlagModal({
 
 export function FeatureFlagCommandPaletteActions() {
   const organization = useOrganization();
+  const [overrides, setOverrides] = useState(() =>
+    FeatureFlagOverrides.singleton().getStoredOverrides()
+  );
   const {enabledFlags, featureStateKey, flagNames} = useMemo(() => {
-    const overrides = FeatureFlagOverrides.singleton().getStoredOverrides();
     const names = Array.from(
       new Set([...organization.features, ...Object.keys(overrides)])
     ).sort((a, b) => a.localeCompare(b));
     const enabled = new Set(organization.features);
+    Object.entries(overrides).forEach(([name, value]) => {
+      if (value) {
+        enabled.add(name);
+      } else {
+        enabled.delete(name);
+      }
+    });
 
     return {
       enabledFlags: enabled,
@@ -143,7 +152,12 @@ export function FeatureFlagCommandPaletteActions() {
         .join(','),
       flagNames: names,
     };
-  }, [organization.features]);
+  }, [organization.features, overrides]);
+
+  const setOverride = (name: string, value: boolean) => {
+    setLocalFeatureFlagOverrideWithFeedback(organization, name, value);
+    setOverrides(current => ({...current, [name]: value}));
+  };
 
   return (
     <CMDKAction
@@ -176,12 +190,7 @@ export function FeatureFlagCommandPaletteActions() {
                     ),
                   },
                   keywords: [name, isEnabled ? t('enabled') : t('disabled')],
-                  onAction: () =>
-                    setLocalFeatureFlagOverrideWithFeedback(
-                      organization,
-                      name,
-                      !isEnabled
-                    ),
+                  onAction: () => setOverride(name, !isEnabled),
                 };
               }),
             enabled: state === 'selected',
@@ -194,7 +203,7 @@ export function FeatureFlagCommandPaletteActions() {
         keywords={[t('new flag'), t('create flag'), t('override')]}
         onAction={() =>
           openModal(modalProps => (
-            <AddOrgFeatureFlagModal {...modalProps} organization={organization} />
+            <AddOrgFeatureFlagModal {...modalProps} onSubmit={setOverride} />
           ))
         }
       />

--- a/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/ui/featureFlagCommandPaletteActions.tsx
@@ -1,0 +1,203 @@
+import {Fragment, useMemo, useState} from 'react';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Button} from '@sentry/scraps/button';
+import {Input} from '@sentry/scraps/input';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
+import {cmdkQueryOptions} from 'sentry/components/commandPalette/types';
+import {IconAdd, IconFlag} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
+import type {Organization} from 'sentry/types/organization';
+import {FeatureFlagOverrides} from 'sentry/utils/featureFlagOverrides';
+import {
+  addOrganizationFeaturesHandler,
+  buildSentryFeaturesHandler,
+} from 'sentry/utils/featureFlags';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {CMDKAction} from './cmdk';
+
+interface AddOrgFeatureFlagModalProps extends ModalRenderProps {
+  organization: Organization;
+}
+
+export function setLocalFeatureFlagOverride(
+  organization: Organization,
+  name: string,
+  value: boolean
+) {
+  FeatureFlagOverrides.singleton().setStoredOverride(name, value);
+
+  const features = new Set(organization.features);
+  if (value) {
+    features.add(name);
+  } else {
+    features.delete(name);
+  }
+
+  const updatedOrganization = {
+    ...organization,
+    features: Array.from(features),
+  };
+  addOrganizationFeaturesHandler({
+    organization: updatedOrganization,
+    handler: buildSentryFeaturesHandler('feature.organizations:'),
+  });
+  OrganizationStore.onUpdate(updatedOrganization, {replace: true});
+}
+
+function setLocalFeatureFlagOverrideWithFeedback(
+  organization: Organization,
+  name: string,
+  value: boolean
+) {
+  setLocalFeatureFlagOverride(organization, name, value);
+  addSuccessMessage(
+    value
+      ? t('Enabled local feature flag override: %s', name)
+      : t('Disabled local feature flag override: %s', name)
+  );
+}
+
+function AddOrgFeatureFlagModal({
+  Body,
+  Footer,
+  Header,
+  closeModal,
+  organization,
+}: AddOrgFeatureFlagModalProps) {
+  const [name, setName] = useState('');
+  const [isEnabled, setIsEnabled] = useState(true);
+  const normalizedName = name.trim().toLowerCase();
+
+  const submit = () => {
+    if (!normalizedName) {
+      return;
+    }
+    setLocalFeatureFlagOverrideWithFeedback(organization, normalizedName, isEnabled);
+    closeModal();
+  };
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h4" size="md">
+          {t('Add Org Feature Flag')}
+        </Heading>
+      </Header>
+      <Body>
+        <Stack gap="lg">
+          <Input
+            aria-label={t('Feature flag name')}
+            autoFocus
+            onChange={event => setName(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                submit();
+              }
+            }}
+            placeholder={t('Feature flag name')}
+            value={name}
+          />
+          <Flex align="center" gap="md">
+            <Switch
+              aria-label={t('Feature flag enabled')}
+              checked={isEnabled}
+              onChange={() => setIsEnabled(value => !value)}
+            />
+            <Text>{isEnabled ? t('Enabled') : t('Disabled')}</Text>
+          </Flex>
+        </Stack>
+      </Body>
+      <Footer>
+        <Flex justify="end" gap="md">
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button disabled={!normalizedName} onClick={submit} variant="primary">
+            {t('Add Feature Flag')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}
+
+export function FeatureFlagCommandPaletteActions() {
+  const organization = useOrganization();
+  const {enabledFlags, featureStateKey, flagNames} = useMemo(() => {
+    const overrides = FeatureFlagOverrides.singleton().getStoredOverrides();
+    const names = Array.from(
+      new Set([...organization.features, ...Object.keys(overrides)])
+    ).sort((a, b) => a.localeCompare(b));
+    const enabled = new Set(organization.features);
+
+    return {
+      enabledFlags: enabled,
+      featureStateKey: names
+        .map(name => `${name}:${enabled.has(name) ? '1' : '0'}`)
+        .join(','),
+      flagNames: names,
+    };
+  }, [organization.features]);
+
+  return (
+    <CMDKAction
+      display={{label: t('Feature Flags'), icon: <IconFlag />}}
+      keywords={[t('features'), t('flags'), t('override'), t('toggle')]}
+    >
+      <CMDKAction
+        display={{label: t('Toggle Org Feature Flag'), icon: <IconFlag />}}
+        prompt={t('Search for a feature flag...')}
+        resource={(_query, {state}) =>
+          // `featureStateKey` represents `flagNames` and `enabledFlags`.
+          // eslint-disable-next-line @tanstack/query/exhaustive-deps
+          cmdkQueryOptions({
+            queryKey: [
+              'cmdk-admin-feature-flag-toggle',
+              organization.slug,
+              featureStateKey,
+            ],
+            queryFn: () =>
+              flagNames.map(name => {
+                const isEnabled = enabledFlags.has(name);
+                return {
+                  display: {
+                    label: name,
+                    icon: <IconFlag />,
+                    trailingItem: (
+                      <Tag variant={isEnabled ? 'success' : 'muted'}>
+                        {isEnabled ? t('Enabled') : t('Disabled')}
+                      </Tag>
+                    ),
+                  },
+                  keywords: [name, isEnabled ? t('enabled') : t('disabled')],
+                  onAction: () =>
+                    setLocalFeatureFlagOverrideWithFeedback(
+                      organization,
+                      name,
+                      !isEnabled
+                    ),
+                };
+              }),
+            enabled: state === 'selected',
+            staleTime: Infinity,
+          })
+        }
+      />
+      <CMDKAction
+        display={{label: t('Add Feature Flag'), icon: <IconAdd />}}
+        keywords={[t('new flag'), t('create flag'), t('override')]}
+        onAction={() =>
+          openModal(modalProps => (
+            <AddOrgFeatureFlagModal {...modalProps} organization={organization} />
+          ))
+        }
+      />
+    </CMDKAction>
+  );
+}


### PR DESCRIPTION
adds a staff-only Cmd+K admin for toggling organization feature flags and adding local overrides, including flags that do not exist yet.

Updates the active organization immediately so feature-gated UI rerenders without a full page reload. Uses the same persisted overrides as the Sentry toolbar.