### PR TITLE
deps(ui): Upgrade jest-fetch-mock to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "idb-keyval": "6.2.2",
     "invariant": "^2.2.4",
     "jed": "^1.1.0",
-    "jest-fetch-mock": "^3.0.3",
+    "jest-fetch-mock": "4.2.0",
     "js-beautify": "^2.0.3",
     "js-cookie": "3.0.7",
     "jsonrepair": "^3.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.1
       jest-fetch-mock:
-        specifier: ^3.0.3
-        version: 3.0.3(encoding@0.1.13)
+        specifier: 4.2.0
+        version: 4.2.0(encoding@0.1.13)
       js-beautify:
         specifier: ^2.0.3
         version: 2.0.3
@@ -6592,8 +6592,9 @@ packages:
     peerDependencies:
       '@jest/globals': '>=27.5.1'
 
-  jest-fetch-mock@3.0.3:
-    resolution: {integrity: sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==}
+  jest-fetch-mock@4.2.0:
+    resolution: {integrity: sha512-/Yya+k/bopdCSG+cEIL9Kxj1cr4j73DeOQiroicwrTkTEfyMsnQxrugjSopn8RnwginmX/Nlsp57BGy1I1mQSg==}
+    engines: {node: '>=18'}
 
   jest-haste-map@30.4.1:
     resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
@@ -7780,9 +7781,6 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
-
-  promise-polyfill@8.3.0:
-    resolution: {integrity: sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==}
 
   promise-retry@2.0.1:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
@@ -15865,10 +15863,9 @@ snapshots:
     dependencies:
       '@jest/globals': 30.4.1
 
-  jest-fetch-mock@3.0.3(encoding@0.1.13):
+  jest-fetch-mock@4.2.0(encoding@0.1.13):
     dependencies:
       cross-fetch: 3.1.8(encoding@0.1.13)
-      promise-polyfill: 8.3.0
     transitivePeerDependencies:
       - encoding
 
@@ -17523,8 +17520,6 @@ snapshots:
   progress@2.0.3: {}
 
   promise-inflight@1.0.1: {}
-
-  promise-polyfill@8.3.0: {}
 
   promise-retry@2.0.1:
     dependencies:

--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -1,7 +1,8 @@
+import fetchMock from 'jest-fetch-mock';
+
 import {setWindowLocation} from 'sentry-test/utils';
 
-import type {Client} from 'sentry/api';
-import {Request} from 'sentry/api';
+import {Client, Request} from 'sentry/api';
 import {PROJECT_MOVED} from 'sentry/constants/apiErrorCodes';
 import type {ResponseMeta} from 'sentry/types/api';
 
@@ -13,6 +14,10 @@ describe('api', () => {
   beforeEach(() => {
     api = new MockApiClient();
     setWindowLocation('https://sentry.io/');
+  });
+
+  afterEach(() => {
+    fetchMock.resetMocks();
   });
 
   describe('Client', () => {
@@ -35,6 +40,15 @@ describe('api', () => {
 
         expect(req1.aborter?.abort).toHaveBeenCalledTimes(1);
         expect(req2.aborter?.abort).toHaveBeenCalledTimes(1);
+      });
+
+      it('aborts an in-flight fetch request', async () => {
+        fetchMock.mockResponse(() => '');
+        const request = new Client().request('/test');
+
+        request.cancel();
+
+        await expect(request.requestPromise).rejects.toHaveProperty('name', 'AbortError');
       });
     });
   });

--- a/static/app/views/detectors/list/cron.spec.tsx
+++ b/static/app/views/detectors/list/cron.spec.tsx
@@ -162,11 +162,16 @@ describe('CronDetectorsList', () => {
       incident_updates: [],
     });
 
-    fetchMock.mockResponse(req => {
-      return req.url.includes('status.sentry.io/api/v2/incidents.json')
-        ? Promise.resolve(JSON.stringify({incidents: [incident]}))
-        : Promise.reject(new Error('not found'));
-    });
+    fetchMock
+      .mockResponse(req =>
+        Promise.reject(new Error(`Unexpected fetch: ${req.method} ${req.url}`))
+      )
+      .routeOnce(
+        /\/api\/v2\/incidents\.json$/,
+        fetchMock.Response(JSON.stringify({incidents: [incident]}), {
+          headers: {'Content-Type': 'application/json'},
+        })
+      );
 
     const {router} = render(<CronDetectorsList />, {organization, initialRouterConfig});
 

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -27,7 +27,7 @@ import * as performanceForSentry from 'sentry/utils/performanceForSentry';
 setLocale(DEFAULT_LOCALE_DATA);
 
 /**
- * Setup fetch mocks (needed to define the `Request` global)
+ * Enable fetch mocks and provide fetch primitives missing from jsdom.
  */
 enableFetchMocks();
 


### PR DESCRIPTION
Upgrade jest-fetch-mock from 3.0.3 to 4.2.0 and update the direct fetch mocks for the new route and Response APIs.

Adds coverage for fetch cancellation now that mocked aborts follow the platform behavior.