### PR TITLE
perf(dynamic-sampling): Shuffle org PK order in scheduler

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -134,6 +134,7 @@ def schedule_per_org_calculations() -> None:
         task=run_calculations_per_org_task_entry,
         cycle_duration=CYCLE_DURATION,
         validate_item=validate_and_track,
+        shuffle=True,
     )
     scheduler.tick()
 


### PR DESCRIPTION
The rollout check (`id % 100000 / 100000 < rate`) correlates with PK order, causing uneven dispatch across ticks — we see 33k dispatched in one tick and 16k in another within the same cycle. Shuffling the PK snapshot at cycle start distributes eligible orgs evenly across all ticks.

Adds ~650ms to cycle init (once per 10-minute cycle).

Refs TET-2274