### PR TITLE
feat(conversations): Explain empty conversation transcripts

### DIFF
--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -33,6 +33,7 @@ interface ConversationViewContentNewProps {
   focusedTool?: string | null;
   onDeselectSpan?: () => void;
   onSelectSpan?: (spanId: string) => void;
+  onViewTimeline?: () => void;
   selectedSpanId?: string | null;
 }
 
@@ -42,6 +43,7 @@ export function ConversationViewContentNew({
   selectedSpanId,
   onSelectSpan,
   onDeselectSpan,
+  onViewTimeline,
   focusedTool,
 }: ConversationViewContentNewProps) {
   const isTimeline = activeTab === 'timeline';
@@ -103,6 +105,7 @@ export function ConversationViewContentNew({
               nodes={nodes}
               selectedNodeId={selectedNode?.id ?? null}
               onSelectNode={handleSelectAndOpenDetail}
+              onViewTimeline={onViewTimeline}
             />
           ) : (
             <AiSpanTimeline

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -57,16 +57,58 @@ describe('MessagesPanelNew', () => {
     jest.clearAllMocks();
   });
 
-  it('renders empty message when no nodes provided', () => {
+  it('explains when a conversation has no inference spans', () => {
+    const toolNode = createMockToolNode({id: 'tool-1', toolName: 'search'});
+
     render(
       <MessagesPanelNew
-        nodes={[]}
+        nodes={[toolNode] as any}
         selectedNodeId={null}
         onSelectNode={mockOnSelectNode}
       />
     );
 
-    expect(screen.getByText('No messages found')).toBeInTheDocument();
+    expect(
+      screen.getByText("This conversation doesn't include any inference spans")
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No messages found')).not.toBeInTheDocument();
+  });
+
+  it('offers a shortcut to the Timeline when there are no inference spans', async () => {
+    const onViewTimeline = jest.fn();
+    const toolNode = createMockToolNode({id: 'tool-1', toolName: 'search'});
+
+    render(
+      <MessagesPanelNew
+        nodes={[toolNode] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+        onViewTimeline={onViewTimeline}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'View Timeline'}));
+    expect(onViewTimeline).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns and links to docs when inference spans captured no input/output', () => {
+    // A generation span exists, but it carries no request/response content.
+    const node = createMockNode({id: 'span-1'});
+
+    render(
+      <MessagesPanelNew
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(
+      screen.getByText("This conversation's messages weren't captured")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'Enable capturing inputs and outputs'})
+    ).toBeInTheDocument();
   });
 
   it('renders user and assistant messages', () => {

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -2,7 +2,9 @@ import {Fragment, memo, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Container, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
@@ -11,12 +13,12 @@ import {
   MessageBlock,
   UserMessageBlock,
 } from 'sentry/components/ai/chat/messageBlock';
-import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {Placeholder} from 'sentry/components/placeholder';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import {MessageToolCallsNew} from 'sentry/views/explore/conversations/components/messageToolCallsNew';
 import {
   TURN_META_WIDTH,
@@ -25,9 +27,11 @@ import {
 import {
   type ConversationMessage,
   extractMessagesFromNodes,
+  partitionSpansByType,
 } from 'sentry/views/explore/conversations/utils/conversationMessages';
 import {EMPTY_TEXT_CONTENT} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {getNumberAttr} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {getAiInstrumentationDocsLink} from 'sentry/views/insights/pages/agents/utils/docsLinks';
 import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -39,6 +43,11 @@ interface MessagesPanelNewProps {
   onSelectNode: (node: AITraceSpanNode) => void;
   selectedNodeId: string | null;
   isLoading?: boolean;
+  /**
+   * Switches the conversation view to the Timeline tab. Surfaced from the
+   * empty transcript state when a conversation has no inference spans.
+   */
+  onViewTimeline?: () => void;
 }
 
 /**
@@ -50,6 +59,7 @@ export function MessagesPanelNew({
   nodes,
   selectedNodeId,
   onSelectNode,
+  onViewTimeline,
   isLoading,
 }: MessagesPanelNewProps) {
   const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
@@ -79,9 +89,18 @@ export function MessagesPanelNew({
   }
 
   if (messages.length === 0) {
+    // A conversation with no renderable transcript falls into two buckets we can
+    // tell apart from the spans: inference (generation) spans that ran but never
+    // captured their inputs/outputs, versus a conversation that has no inference
+    // spans at all. Each gets its own explanation.
+    const {generationSpans} = partitionSpansByType(nodes);
     return (
       <PanelContainer>
-        <EmptyMessage>{t('No messages found')}</EmptyMessage>
+        {generationSpans.length > 0 ? (
+          <MissingContentNotice nodes={nodes} />
+        ) : (
+          <NoInferenceSpansNotice onViewTimeline={onViewTimeline} />
+        )}
       </PanelContainer>
     );
   }
@@ -283,6 +302,66 @@ function ReasoningSection({reasoning}: {reasoning: string}) {
         </MessageText>
       </Container>
     </CollapsibleContent>
+  );
+}
+
+/**
+ * Shown when inference spans ran but captured no input or output data, so
+ * there is nothing to render as a transcript. Points to the docs for enabling
+ * input/output capture, tailored to the project's platform.
+ */
+function MissingContentNotice({nodes}: {nodes: AITraceSpanNode[]}) {
+  const projectSlug = useMemo(
+    () => nodes.find(node => node.projectSlug)?.projectSlug,
+    [nodes]
+  );
+  const {projects} = useProjects({slugs: projectSlug ? [projectSlug] : []});
+  const platform = projectSlug
+    ? projects.find(project => project.slug === projectSlug)?.platform
+    : undefined;
+  const docsLink = getAiInstrumentationDocsLink(platform);
+
+  return (
+    <EmptyNotice>
+      <Text bold>{t("This conversation's messages weren't captured")}</Text>
+      <Text variant="muted" align="center">
+        {tct(
+          "Its inference spans don't include any input or output data. [link:Enable capturing inputs and outputs] in your SDK to see the transcript here.",
+          {link: <ExternalLink href={docsLink} />}
+        )}
+      </Text>
+    </EmptyNotice>
+  );
+}
+
+/**
+ * Shown when a conversation has spans but none of them are inference spans, so
+ * there is no transcript to build. Directs the user to the Timeline, where the
+ * conversation's other spans are shown.
+ */
+function NoInferenceSpansNotice({onViewTimeline}: {onViewTimeline?: () => void}) {
+  return (
+    <EmptyNotice>
+      <Text bold>{t("This conversation doesn't include any inference spans")}</Text>
+      <Text variant="muted" align="center">
+        {t('The other spans in this conversation are shown in the Timeline.')}
+      </Text>
+      {onViewTimeline && (
+        <Button size="sm" onClick={onViewTimeline}>
+          {t('View Timeline')}
+        </Button>
+      )}
+    </EmptyNotice>
+  );
+}
+
+function EmptyNotice({children}: {children: React.ReactNode}) {
+  return (
+    <Stack flex={1} align="center" justify="center" padding="xl" width="100%">
+      <Stack align="center" gap="md" maxWidth="32rem">
+        {children}
+      </Stack>
+    </Stack>
   );
 }
 

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -66,6 +66,10 @@ export function ConversationDetailPageNew() {
     setQueryState({spanId: null, focusedTool: null});
   }, [setQueryState]);
 
+  const handleViewTimeline = useCallback(() => {
+    setQueryState({tab: 'timeline'});
+  }, [setQueryState]);
+
   return (
     <ViewportConstrainedPage background="secondary">
       <TopBar.Slot name="title">
@@ -95,6 +99,7 @@ export function ConversationDetailPageNew() {
             selectedSpanId={queryState.spanId}
             onSelectSpan={handleSelectSpan}
             onDeselectSpan={handleDeselectSpan}
+            onViewTimeline={handleViewTimeline}
             focusedTool={queryState.focusedTool}
           />
         </ConversationViewContainer>

--- a/static/app/views/insights/pages/agents/utils/docsLinks.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.spec.ts
@@ -1,4 +1,5 @@
 import {
+  AI_AGENTS_GETTING_STARTED_DOCS_LINK,
   AI_INSTRUMENTATION_DOCS_LINKS,
   getAiInstrumentationDocsLink,
 } from 'sentry/views/insights/pages/agents/utils/docsLinks';
@@ -13,11 +14,17 @@ describe('getAiInstrumentationDocsLink', () => {
     }
   );
 
-  it.each(['python', 'python-django', 'php-laravel', 'ruby', undefined])(
-    'defaults to the Python guide for %s',
+  it.each(['python', 'python-django'])('returns the Python guide for %s', platform => {
+    expect(getAiInstrumentationDocsLink(platform)).toBe(
+      AI_INSTRUMENTATION_DOCS_LINKS.python
+    );
+  });
+
+  it.each(['php-laravel', 'ruby', undefined])(
+    'falls back to the getting-started guide for %s',
     platform => {
       expect(getAiInstrumentationDocsLink(platform)).toBe(
-        AI_INSTRUMENTATION_DOCS_LINKS.python
+        AI_AGENTS_GETTING_STARTED_DOCS_LINK
       );
     }
   );

--- a/static/app/views/insights/pages/agents/utils/docsLinks.spec.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.spec.ts
@@ -1,0 +1,24 @@
+import {
+  AI_INSTRUMENTATION_DOCS_LINKS,
+  getAiInstrumentationDocsLink,
+} from 'sentry/views/insights/pages/agents/utils/docsLinks';
+
+describe('getAiInstrumentationDocsLink', () => {
+  it.each(['javascript', 'javascript-react', 'node', 'node-express', 'bun', 'deno'])(
+    'returns the JavaScript guide for %s',
+    platform => {
+      expect(getAiInstrumentationDocsLink(platform)).toBe(
+        AI_INSTRUMENTATION_DOCS_LINKS.javascript
+      );
+    }
+  );
+
+  it.each(['python', 'python-django', 'php-laravel', 'ruby', undefined])(
+    'defaults to the Python guide for %s',
+    platform => {
+      expect(getAiInstrumentationDocsLink(platform)).toBe(
+        AI_INSTRUMENTATION_DOCS_LINKS.python
+      );
+    }
+  );
+});

--- a/static/app/views/insights/pages/agents/utils/docsLinks.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.ts
@@ -6,12 +6,16 @@ export const AI_INSTRUMENTATION_DOCS_LINKS = {
 } as const;
 
 /**
- * Resolves the AI agents instrumentation docs link for a project platform.
- * These pages document how to capture agent inputs and outputs. Defaults to
- * the Python guide when the platform is unknown, matching the onboarding flow.
+ * Resolves the AI agents instrumentation docs link, which document how to
+ * capture agent inputs and outputs. Accepts either a project platform
+ * (e.g. `javascript-react`, `node`) or an SDK language (`javascript`,
+ * `python`), and defaults to the Python guide when it can't be matched.
  */
-export function getAiInstrumentationDocsLink(platform?: string): string {
-  if (platform?.startsWith('javascript') || platform?.startsWith('node')) {
+export function getAiInstrumentationDocsLink(platformOrLanguage?: string): string {
+  if (
+    platformOrLanguage?.startsWith('javascript') ||
+    platformOrLanguage?.startsWith('node')
+  ) {
     return AI_INSTRUMENTATION_DOCS_LINKS.javascript;
   }
   return AI_INSTRUMENTATION_DOCS_LINKS.python;

--- a/static/app/views/insights/pages/agents/utils/docsLinks.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.ts
@@ -6,11 +6,19 @@ export const AI_INSTRUMENTATION_DOCS_LINKS = {
 } as const;
 
 /**
+ * Platform-agnostic AI agents overview. Used as the fallback when a platform
+ * has no SDK-specific instrumentation guide (e.g. PHP) rather than sending
+ * users to a guide for the wrong language.
+ */
+export const AI_AGENTS_GETTING_STARTED_DOCS_LINK =
+  'https://docs.sentry.io/product/insights/ai/agents/getting-started/';
+
+/**
  * Resolves the AI agents instrumentation docs link, which document how to
  * capture agent inputs and outputs. Accepts either a project platform
  * (e.g. `javascript-react`, `node`, `bun`, `deno`) or an SDK language
- * (`javascript`, `python`), and defaults to the Python guide when it can't
- * be matched.
+ * (`javascript`, `python`). Platforms without a dedicated guide fall back to
+ * the platform-agnostic getting-started page.
  */
 export function getAiInstrumentationDocsLink(platformOrLanguage?: string): string {
   if (
@@ -21,5 +29,8 @@ export function getAiInstrumentationDocsLink(platformOrLanguage?: string): strin
   ) {
     return AI_INSTRUMENTATION_DOCS_LINKS.javascript;
   }
-  return AI_INSTRUMENTATION_DOCS_LINKS.python;
+  if (platformOrLanguage?.startsWith('python')) {
+    return AI_INSTRUMENTATION_DOCS_LINKS.python;
+  }
+  return AI_AGENTS_GETTING_STARTED_DOCS_LINK;
 }

--- a/static/app/views/insights/pages/agents/utils/docsLinks.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.ts
@@ -8,13 +8,16 @@ export const AI_INSTRUMENTATION_DOCS_LINKS = {
 /**
  * Resolves the AI agents instrumentation docs link, which document how to
  * capture agent inputs and outputs. Accepts either a project platform
- * (e.g. `javascript-react`, `node`) or an SDK language (`javascript`,
- * `python`), and defaults to the Python guide when it can't be matched.
+ * (e.g. `javascript-react`, `node`, `bun`, `deno`) or an SDK language
+ * (`javascript`, `python`), and defaults to the Python guide when it can't
+ * be matched.
  */
 export function getAiInstrumentationDocsLink(platformOrLanguage?: string): string {
   if (
     platformOrLanguage?.startsWith('javascript') ||
-    platformOrLanguage?.startsWith('node')
+    platformOrLanguage?.startsWith('node') ||
+    platformOrLanguage === 'bun' ||
+    platformOrLanguage === 'deno'
   ) {
     return AI_INSTRUMENTATION_DOCS_LINKS.javascript;
   }

--- a/static/app/views/insights/pages/agents/utils/docsLinks.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.ts
@@ -5,11 +5,6 @@ export const AI_INSTRUMENTATION_DOCS_LINKS = {
     'https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module/',
 } as const;
 
-/**
- * Platform-agnostic AI agents overview. Used as the fallback when a platform
- * has no SDK-specific instrumentation guide (e.g. PHP) rather than sending
- * users to a guide for the wrong language.
- */
 export const AI_AGENTS_GETTING_STARTED_DOCS_LINK =
   'https://docs.sentry.io/product/insights/ai/agents/getting-started/';
 

--- a/static/app/views/insights/pages/agents/utils/docsLinks.ts
+++ b/static/app/views/insights/pages/agents/utils/docsLinks.ts
@@ -4,3 +4,15 @@ export const AI_INSTRUMENTATION_DOCS_LINKS = {
   javascript:
     'https://docs.sentry.io/platforms/javascript/guides/node/tracing/instrumentation/ai-agents-module/',
 } as const;
+
+/**
+ * Resolves the AI agents instrumentation docs link for a project platform.
+ * These pages document how to capture agent inputs and outputs. Defaults to
+ * the Python guide when the platform is unknown, matching the onboarding flow.
+ */
+export function getAiInstrumentationDocsLink(platform?: string): string {
+  if (platform?.startsWith('javascript') || platform?.startsWith('node')) {
+    return AI_INSTRUMENTATION_DOCS_LINKS.javascript;
+  }
+  return AI_INSTRUMENTATION_DOCS_LINKS.python;
+}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiIOAlert.tsx
@@ -17,7 +17,7 @@ import {
   getIsExecuteToolNode,
   getTraceNodeAttribute,
 } from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
-import {AI_INSTRUMENTATION_DOCS_LINKS} from 'sentry/views/insights/pages/agents/utils/docsLinks';
+import {getAiInstrumentationDocsLink} from 'sentry/views/insights/pages/agents/utils/docsLinks';
 import {hasAIInputAttribute} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput';
 import {hasAIOutputAttribute} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput';
 import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
@@ -242,15 +242,7 @@ function ManualContent({sdkLanguage}: {sdkLanguage: SupportedSDKLanguage}) {
     <Fragment>
       <Prose>
         {tct('Check out the [link:AI instrumentation docs] for more details.', {
-          link: (
-            <ExternalLink
-              href={
-                sdkLanguage === 'javascript'
-                  ? AI_INSTRUMENTATION_DOCS_LINKS.javascript
-                  : AI_INSTRUMENTATION_DOCS_LINKS.python
-              }
-            />
-          ),
+          link: <ExternalLink href={getAiInstrumentationDocsLink(sdkLanguage)} />,
         })}
       </Prose>
     </Fragment>


### PR DESCRIPTION
Opening a conversation whose transcript comes up empty previously showed a generic "No messages found" with no explanation. That was confusing — users had just seen activity for the conversation in the overview, so a blank panel read like a bug rather than an expected state.

The empty transcript now explains why there's nothing to show, tailored to the two cases we can tell apart:

- **Inference spans ran but captured no input/output** — we say the messages weren't captured and link to the docs for enabling input/output capture in the SDK, picked for the project's platform.
<img width="1432" height="843" alt="Screenshot 2026-07-16 at 09 24 17" src="https://github.com/user-attachments/assets/ff193e57-7d37-43c1-a78d-02ef9fb9d7d1" />

- **The conversation has no inference spans at all** — we say so and point to the Timeline, where the conversation's other spans are shown, with a shortcut to switch there.
<img width="1432" height="843" alt="Screenshot 2026-07-16 at 09 25 07" src="https://github.com/user-attachments/assets/289ba29d-0b17-450e-8b87-7ec97f755193" />


Scoped to the redesigned transcript (`gen-ai-conversations-redesign`).

Refs TET-2607