### PR TITLE
feat(difs): Dual-write DIFs to Objectstore

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -178,7 +178,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm-project-details-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM-first project creation wizard A/B test (project creation flow, not new-org onboarding)
     manager.add("organizations:onboarding-scm-project-creation-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Write newly created debug files to Objectstore.
+    # Additionally write newly created debug files to Objectstore.
     manager.add("organizations:objectstore-debugfiles-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Redirect debug file download requests to read directly from Objectstore, instead of proxying file contents through Sentry.
     manager.add("organizations:objectstore-debugfiles-direct-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -178,7 +178,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm-project-details-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM-first project creation wizard A/B test (project creation flow, not new-org onboarding)
     manager.add("organizations:onboarding-scm-project-creation-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Additionally write newly created debug files to Objectstore.
+    # Double-write newly created debug files to Objectstore.
     manager.add("organizations:objectstore-debugfiles-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Redirect debug file download requests to read directly from Objectstore, instead of proxying file contents through Sentry.
     manager.add("organizations:objectstore-debugfiles-direct-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -344,7 +344,7 @@ class ProjectDebugFile(Model):
             try:
                 self._get_objectstore_session().delete(self.storage_path)
             except Exception:
-                logger.info("Failed to delete ProjectDebugFile, will be cleaned up by TTI")
+                logger.exception("Failed to delete ProjectDebugFile, will be cleaned up by TTI")
         if self.file is not None:
             # If another debug file row still references this File, keep the File.
             # Concurrent last-reference deletes can still leave an unreferenced File
@@ -567,16 +567,20 @@ def create_dif_from_id(
         filename = (
             f"{os.path.basename(meta.debug_id)}{_dif_file_extension(meta.file_format, file_type)}"
         )
-        with file.getfile() as source:
-            storage_path = _upload_dif_to_objectstore(
-                session, source, content_type, file_size, filename
-            )
-        objectstore_metadata = {
-            "storage_path": storage_path,
-            "content_type": content_type,
-            "file_size": file_size,
-            "date_created": timezone.now(),
-        }
+        try:
+            with file.getfile() as source:
+                storage_path = _upload_dif_to_objectstore(
+                    session, source, content_type, file_size, filename
+                )
+        except Exception:
+            logger.exception("Failed to dual-write debug file to Objectstore")
+        else:
+            objectstore_metadata = {
+                "storage_path": storage_path,
+                "content_type": content_type,
+                "file_size": file_size,
+                "date_created": timezone.now(),
+            }
 
     dif = ProjectDebugFile.objects.create(
         file=file,

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -345,7 +345,7 @@ class ProjectDebugFile(Model):
             # Objectstore-backed files cannot be referenced by multiple debug file rows.
             try:
                 self._get_objectstore_session().delete(self.storage_path)
-            except (Project.DoesNotExist, RequestError):
+            except (Project.DoesNotExist, RequestError, HTTPError):
                 logger.info("Failed to delete ProjectDebugFile, will be cleaned up by TTI")
         if self.file is not None:
             # If another debug file row still references this File, keep the File.

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -340,12 +340,10 @@ class ProjectDebugFile(Model):
         ret = super().delete(*args, **kwargs)
 
         if self.storage_path is not None:
-            from sentry.models.project import Project
-
             # Objectstore-backed files cannot be referenced by multiple debug file rows.
             try:
                 self._get_objectstore_session().delete(self.storage_path)
-            except (Project.DoesNotExist, RequestError, HTTPError):
+            except Exception:
                 logger.info("Failed to delete ProjectDebugFile, will be cleaned up by TTI")
         if self.file is not None:
             # If another debug file row still references this File, keep the File.

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -347,7 +347,7 @@ class ProjectDebugFile(Model):
                 self._get_objectstore_session().delete(self.storage_path)
             except (Project.DoesNotExist, RequestError):
                 logger.info("Failed to delete ProjectDebugFile, will be cleaned up by TTI")
-        elif self.file is not None:
+        if self.file is not None:
             # If another debug file row still references this File, keep the File.
             # Concurrent last-reference deletes can still leave an unreferenced File
             # row behind, but no surviving ProjectDebugFile should point to a deleted
@@ -543,54 +543,6 @@ def create_dif_from_id(
 
     content_type = DIF_MIMETYPES[meta.file_format]
 
-    if features.has("organizations:objectstore-debugfiles-write", project.organization):
-        session = get_debug_files_session(project.organization_id, project.id)
-        file_type = (meta.data or {}).get("type")
-        filename = (
-            f"{os.path.basename(meta.debug_id)}{_dif_file_extension(meta.file_format, file_type)}"
-        )
-        if file is not None:
-            with file.getfile() as source:
-                storage_path = _upload_dif_to_objectstore(
-                    session, source, content_type, file_size, filename
-                )
-        elif fileobj is not None:
-            storage_path = _upload_dif_to_objectstore(
-                session, fileobj, content_type, file_size, filename
-            )
-        else:
-            raise RuntimeError("missing file object")
-
-        metrics.distribution(
-            "storage.put.size",
-            file_size,
-            tags={"usecase": "debug-files", "compression": "none"},
-            unit="byte",
-        )
-
-        dif = ProjectDebugFile.objects.create(
-            file=None,
-            storage_path=storage_path,
-            content_type=content_type,
-            file_size=file_size,
-            date_created=timezone.now(),
-            checksum=checksum,
-            debug_id=meta.debug_id,
-            code_id=meta.code_id,
-            cpu_name=meta.arch,
-            object_name=object_name,
-            project_id=project.id,
-            data=meta.data,
-        )
-
-        # The DIF we've just created might actually be removed here again. But since
-        # this can happen at any time in near or distant future, we don't care and
-        # assume a successful upload. The DIF will be reported to the uploader and
-        # reprocessing can start.
-        clean_redundant_difs(project, meta.debug_id)
-
-        return dif, True
-
     if file is None:
         file = File.objects.create(
             name=meta.debug_id,
@@ -610,6 +562,24 @@ def create_dif_from_id(
         unit="byte",
     )
 
+    objectstore_metadata: dict[str, Any] = {}
+    if features.has("organizations:objectstore-debugfiles-write", project.organization):
+        session = get_debug_files_session(project.organization_id, project.id)
+        file_type = (meta.data or {}).get("type")
+        filename = (
+            f"{os.path.basename(meta.debug_id)}{_dif_file_extension(meta.file_format, file_type)}"
+        )
+        with file.getfile() as source:
+            storage_path = _upload_dif_to_objectstore(
+                session, source, content_type, file_size, filename
+            )
+        objectstore_metadata = {
+            "storage_path": storage_path,
+            "content_type": content_type,
+            "file_size": file_size,
+            "date_created": timezone.now(),
+        }
+
     dif = ProjectDebugFile.objects.create(
         file=file,
         checksum=file.checksum,
@@ -619,6 +589,7 @@ def create_dif_from_id(
         object_name=object_name,
         project_id=project.id,
         data=meta.data,
+        **objectstore_metadata,
     )
 
     # The DIF we've just created might actually be removed here again. But since

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -448,13 +448,13 @@ class DifAssembleProguardCloneBackendTransitionTest(APITestCase):
             project_id=self.project.id,
             debug_id="11111111-1111-1111-1111-111111111111",
         )
-        # The source stays file-backed; the clone is written to Objectstore.
-        assert second_dif.file_id is None
+        # The source stays file-backed; the clone is written to both backends.
+        assert second_dif.file_id is not None
         assert second_dif.storage_path is not None
         assert second_dif.get_file().read() == file_contents
 
-    def test_clone_objectstore_backed_source_to_file(self) -> None:
-        """An Objectstore-backed source (created during rollout) is cloned after the write flag is disabled, producing a file-backed clone."""
+    def test_clone_dual_written_source_to_file(self) -> None:
+        """A dual-written source is cloned after the write flag is disabled, producing a file-backed clone."""
 
         file_contents = b"proguard mapping"
         checksum = sha1(file_contents).hexdigest()
@@ -468,7 +468,7 @@ class DifAssembleProguardCloneBackendTransitionTest(APITestCase):
             project_id=self.project.id,
             debug_id="00000000-0000-0000-0000-000000000000",
         )
-        assert first_dif.file_id is None
+        assert first_dif.file_id is not None
         assert first_dif.storage_path is not None
 
         with self.feature({"organizations:objectstore-debugfiles-write": False}):

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -373,9 +373,10 @@ class CreateDebugFileTest(APITestCase):
             dif, created = create_dif_from_file(self.project, file, self.file_path)
 
         assert created
-        assert dif.file_id is None
+        assert dif.file_id is not None
         assert dif.storage_path is not None
         assert dif.content_type == "application/x-mach-binary"
+        assert dif.file.getfile().read() == content
         assert dif.get_file().read() == content
 
     @requires_objectstore
@@ -387,13 +388,32 @@ class CreateDebugFileTest(APITestCase):
             dif, created = self.create_dif(fileobj=BytesIO(content))
 
         assert created
-        assert dif.file_id is None
+        assert dif.file_id is not None
         assert dif.storage_path is not None
         assert dif.content_type == "application/x-mach-binary"
         assert dif.file_size == len(content)
         assert dif.checksum == checksum
         assert dif.get_file_size() == len(content)
+        assert dif.file.getfile().read() == content
         assert dif.get_file().read() == content
+
+    @requires_objectstore
+    def test_delete_dual_written_dif(self) -> None:
+        content = b"objectstore-dif-content"
+        with self.feature("organizations:objectstore-debugfiles-write"):
+            dif, created = self.create_dif(fileobj=BytesIO(content))
+
+        assert created
+        file_id = dif.file_id
+        storage_path = dif.storage_path
+        assert file_id is not None
+        assert storage_path is not None
+
+        dif.delete()
+
+        assert not File.objects.filter(id=file_id).exists()
+        with pytest.raises(RequestError):
+            get_debug_files_session(self.organization.id, self.project.id).get(storage_path)
 
     def test_keep_disjoint_difs(self) -> None:
         file = self.create_file(

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -6,6 +6,7 @@ import time
 import zipfile
 from io import BytesIO
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from django.core.files.base import ContentFile
@@ -397,6 +398,21 @@ class CreateDebugFileTest(APITestCase):
         assert dif.get_file_size() == len(content)
         assert dif.file.getfile().read() == content
         assert dif.get_file().read() == content
+
+    @requires_objectstore
+    def test_objectstore_write_failure_preserves_legacy_dif(self) -> None:
+        content = b"objectstore-dif-content"
+
+        with (
+            self.feature("organizations:objectstore-debugfiles-write"),
+            patch("sentry.models.debugfile._upload_dif_to_objectstore", side_effect=RuntimeError),
+        ):
+            dif, created = self.create_dif(fileobj=BytesIO(content))
+
+        assert created
+        assert dif.file_id is not None
+        assert dif.storage_path is None
+        assert dif.file.getfile().read() == content
 
     @requires_objectstore
     def test_delete_dual_written_dif(self) -> None:

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -374,6 +374,7 @@ class CreateDebugFileTest(APITestCase):
 
         assert created
         assert dif.file_id is not None
+        assert dif.file is not None
         assert dif.storage_path is not None
         assert dif.content_type == "application/x-mach-binary"
         assert dif.file.getfile().read() == content


### PR DESCRIPTION
This changes the semantics of the `objectstore-debugfiles-write` feature flag to double write newly uploaded DIFs to Objectstore and `File`, instead of writing exclusively to Objectstore.
This makes it easy to roll back the change by disabling the flag with no data loss.

The deletion path still deletes from both storages, and the upload path code has been simplified to reduce duplication, now that we can assume we always create a `File`, and only create the object in Objectstore as something on top rather than either or.

Closes FS-442