### PR TITLE
feat(difs): Feature-gate Objectstore DIF reads

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -275,8 +275,12 @@ class DebugFilesEndpoint(ProjectEndpoint):
         if debug_file is None:
             raise Http404
 
-        if debug_file.storage_path is not None and features.has(
-            "organizations:objectstore-debugfiles-direct-read", project.organization
+        if (
+            debug_file.storage_path is not None
+            and debug_file.uses_objectstore_for_read()
+            and features.has(
+                "organizations:objectstore-debugfiles-direct-read", project.organization
+            )
         ):
             return HttpResponseRedirect(debug_file.get_objectstore_presigned_url(self.request))
 
@@ -840,9 +844,10 @@ def _clone_proguard_debug_file_for_reupload(
         }
 
     meta = build_proguard_reupload_dif_meta(debug_file, requested_debug_id)
-    if debug_file.file is not None:
+    if not debug_file.uses_objectstore_for_read():
+        assert debug_file.file is not None
         dif, created = create_dif_from_id(project, meta, file=debug_file.file)
-    elif debug_file.storage_path is not None:
+    else:
         source_fileobj = debug_file.get_file()
         try:
             # Spool into a temporary file to get a seekable stream.
@@ -852,8 +857,6 @@ def _clone_proguard_debug_file_for_reupload(
                 dif, created = create_dif_from_id(project, meta, fileobj=tmp)
         finally:
             source_fileobj.close()
-    else:
-        raise ValueError("ProjectDebugFile has neither file nor storage_path")
 
     if created:
         record_last_upload(project)

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -275,12 +275,8 @@ class DebugFilesEndpoint(ProjectEndpoint):
         if debug_file is None:
             raise Http404
 
-        if (
-            debug_file.storage_path is not None
-            and debug_file.uses_objectstore_for_read()
-            and features.has(
-                "organizations:objectstore-debugfiles-direct-read", project.organization
-            )
+        if debug_file.uses_objectstore_for_read() and features.has(
+            "organizations:objectstore-debugfiles-direct-read", project.organization
         ):
             return HttpResponseRedirect(debug_file.get_objectstore_presigned_url(self.request))
 

--- a/src/sentry/api/serializers/models/debug_file.py
+++ b/src/sentry/api/serializers/models/debug_file.py
@@ -23,12 +23,7 @@ class DebugFileSerializerResponse(TypedDict):
 @register(ProjectDebugFile)
 class DebugFileSerializer(Serializer[DebugFileSerializerResponse]):
     def serialize(self, obj, attrs, user, **kwargs) -> DebugFileSerializerResponse:
-        if obj.storage_path is not None:
-            headers = {"Content-Type": obj.get_content_type()}
-        elif obj.file is not None:
-            headers = obj.file.headers
-        else:
-            raise ValueError("ProjectDebugFile has neither file nor storage_path")
+        headers = {"Content-Type": obj.get_content_type()}
 
         return {
             "id": str(obj.id),

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -238,8 +238,12 @@ def _sync_project_debug_file(
             if not target_project:
                 return None
 
-            if source_project_debug_file.uses_objectstore_for_read():
-                source_fileobj = source_project_debug_file.get_file()
+            if source_project_debug_file.storage_path is not None:
+                source_fileobj = (
+                    source_project_debug_file._get_objectstore_session()
+                    .get(source_project_debug_file.storage_path)
+                    .payload
+                )
                 try:
                     target_storage_path = get_debug_files_session(
                         target_org.id, target_project.id
@@ -253,11 +257,7 @@ def _sync_project_debug_file(
 
             return ProjectDebugFile.objects.create(
                 project_id=target_project.id,
-                file=(
-                    None
-                    if source_project_debug_file.uses_objectstore_for_read()
-                    else source_project_debug_file.file
-                ),
+                file=source_project_debug_file.file,
                 storage_path=target_storage_path,
                 content_type=source_project_debug_file.content_type,
                 file_size=source_project_debug_file.file_size,

--- a/src/sentry/demo_mode/tasks.py
+++ b/src/sentry/demo_mode/tasks.py
@@ -238,7 +238,7 @@ def _sync_project_debug_file(
             if not target_project:
                 return None
 
-            if source_project_debug_file.storage_path is not None:
+            if source_project_debug_file.uses_objectstore_for_read():
                 source_fileobj = source_project_debug_file.get_file()
                 try:
                     target_storage_path = get_debug_files_session(
@@ -255,7 +255,7 @@ def _sync_project_debug_file(
                 project_id=target_project.id,
                 file=(
                     None
-                    if source_project_debug_file.storage_path is not None
+                    if source_project_debug_file.uses_objectstore_for_read()
                     else source_project_debug_file.file
                 ),
                 storage_path=target_storage_path,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -180,6 +180,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm-project-creation-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Double-write newly created debug files to Objectstore.
     manager.add("organizations:objectstore-debugfiles-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
+    # Read debug files from Objectstore when an Objectstore copy is available.
+    manager.add("organizations:objectstore-debugfiles-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Redirect debug file download requests to read directly from Objectstore, instead of proxying file contents through Sentry.
     manager.add("organizations:objectstore-debugfiles-direct-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Enable large ownership rule file size limit

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -197,8 +197,19 @@ class ProjectDebugFile(Model):
 
     __repr__ = sane_repr("object_name", "cpu_name", "debug_id")
 
+    def uses_objectstore_for_read(self) -> bool:
+        if self.storage_path is None:
+            return False
+        if self.file is None:
+            return True
+
+        from sentry.models.project import Project
+
+        organization = Project.objects.get_from_cache(id=self.project_id).organization
+        return features.has("organizations:objectstore-debugfiles-read", organization)
+
     def get_checksum(self) -> str:
-        if self.storage_path is not None:
+        if self.uses_objectstore_for_read():
             assert self.checksum is not None
             return self.checksum
         if self.file is not None:
@@ -207,7 +218,7 @@ class ProjectDebugFile(Model):
         raise ValueError("ProjectDebugFile has neither file nor storage_path")
 
     def get_content_type(self) -> str:
-        if self.storage_path is not None:
+        if self.uses_objectstore_for_read():
             assert self.content_type is not None
             return str(self.content_type)
         if self.file is not None:
@@ -215,7 +226,7 @@ class ProjectDebugFile(Model):
         raise ValueError("ProjectDebugFile has neither file nor storage_path")
 
     def get_file_size(self) -> int:
-        if self.storage_path is not None:
+        if self.uses_objectstore_for_read():
             assert self.file_size is not None
             return int(self.file_size)
         if self.file is not None:
@@ -223,7 +234,7 @@ class ProjectDebugFile(Model):
         raise ValueError("ProjectDebugFile has neither file nor storage_path")
 
     def get_date_created(self) -> datetime:
-        if self.storage_path is not None:
+        if self.uses_objectstore_for_read():
             assert self.date_created is not None
             return self.date_created
         if self.file is not None:
@@ -268,7 +279,8 @@ class ProjectDebugFile(Model):
     def get_file(self) -> IO[bytes]:
         """Returns the underlying contents as a file-like object. The caller is responsible for closing it."""
 
-        if self.storage_path is not None:
+        if self.uses_objectstore_for_read():
+            assert self.storage_path is not None
             try:
                 response = self._get_objectstore_session().get(self.storage_path)
                 return response.payload
@@ -296,7 +308,8 @@ class ProjectDebugFile(Model):
         return get_download_redirect_url(request, session, org_id, self.storage_path)
 
     def save_to(self, path: str) -> None:
-        if self.storage_path is not None:
+        if self.uses_objectstore_for_read():
+            assert self.storage_path is not None
             path = os.path.abspath(path)
             base = os.path.dirname(path)
             os.makedirs(base, exist_ok=True)

--- a/src/sentry/testutils/objectstore.py
+++ b/src/sentry/testutils/objectstore.py
@@ -27,6 +27,7 @@ def _wrap_test(func: Callable[..., Any], enabled: bool) -> Callable[..., Any]:
         with Feature(
             {
                 "organizations:objectstore-debugfiles-write": enabled,
+                "organizations:objectstore-debugfiles-read": enabled,
                 "organizations:objectstore-debugfiles-direct-read": enabled,
             }
         ):

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -355,6 +355,7 @@ class DebugFileObjectstoreRedirectTest(DebugFilesTestCases):
         download_id = self._upload_and_get_download_id()
 
         with (
+            self.feature("organizations:objectstore-debugfiles-read"),
             self.feature("organizations:objectstore-debugfiles-direct-read"),
             patch("sentry.auth.system.is_internal_ip", return_value=True),
         ):
@@ -369,6 +370,7 @@ class DebugFileObjectstoreRedirectTest(DebugFilesTestCases):
         download_id = self._upload_and_get_download_id()
 
         with (
+            self.feature("organizations:objectstore-debugfiles-read"),
             self.feature("organizations:objectstore-debugfiles-direct-read"),
             patch("sentry.auth.system.is_internal_ip", return_value=False),
         ):
@@ -380,6 +382,15 @@ class DebugFileObjectstoreRedirectTest(DebugFilesTestCases):
             f"/organizations/{self.organization.id}/objectstore/v1/objects/debug_files/" in location
         )
         assert "os_sig=" in location
+
+    def test_direct_read_requires_read_gate(self) -> None:
+        download_id = self._upload_and_get_download_id()
+
+        with self.feature("organizations:objectstore-debugfiles-direct-read"):
+            response = self.client.get(f"{self.url}?id={download_id}")
+
+        assert response.status_code == 200
+        assert close_streaming_response(response) == PROGUARD_SOURCE
 
 
 @debug_files_test_both_backends

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -311,11 +311,13 @@ class DifAssembleEndpoint(APITestCase):
             debug_id="11111111-1111-1111-1111-111111111111",
         )
 
-        if first_dif.storage_path is not None:
+        if first_dif.uses_objectstore_for_read():
             assert first_dif.storage_path != second_dif.storage_path
+            assert first_dif.file_id != second_dif.file_id
+            assert File.objects.filter(type="project.dif", checksum=checksum).count() == 2
         else:
             assert first_dif.file_id == second_dif.file_id
-        assert File.objects.filter(type="project.dif", checksum=checksum).count() <= 1
+            assert File.objects.filter(type="project.dif", checksum=checksum).count() == 1
 
     def test_reupload_proguard_with_same_debug_id_is_idempotent(self) -> None:
         file_contents = b"proguard mapping"

--- a/tests/sentry/demo_mode/test_tasks.py
+++ b/tests/sentry/demo_mode/test_tasks.py
@@ -295,6 +295,35 @@ class SyncArtifactBundlesTest(TestCase):
         with pytest.raises(ProjectDebugFile.DoesNotExist):
             target_project_debug_file.refresh_from_db()
 
+    @requires_objectstore
+    def test_sync_dual_written_project_debug_files(self) -> None:
+        source_project_debug_file = self.create_dif_file(self.source_proj_foo)
+        source_storage_path = get_debug_files_session(
+            self.source_org.id, self.source_proj_foo.id
+        ).put(b"objectstore-backed-debug-file", compression="none")
+        source_project_debug_file.update(
+            storage_path=source_storage_path,
+            content_type=source_project_debug_file.file.headers["Content-Type"],
+            file_size=source_project_debug_file.file.size,
+            date_created=source_project_debug_file.file.timestamp,
+        )
+        source_project_debug_file.refresh_from_db()
+
+        _sync_project_debug_files(
+            source_org=self.source_org,
+            target_org=self.target_org,
+            cutoff_date=self.last_three_days(),
+        )
+
+        target_project_debug_file = ProjectDebugFile.objects.get(
+            project_id=self.target_proj_foo.id,
+            debug_id=source_project_debug_file.debug_id,
+        )
+
+        assert target_project_debug_file.file_id == source_project_debug_file.file_id
+        assert target_project_debug_file.storage_path is not None
+        assert target_project_debug_file.storage_path != source_storage_path
+
     def test_sync_project_debug_files_with_old_uploads(self) -> None:
         source_project_debug_file = self.create_dif_file(
             self.source_proj_foo,

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -432,6 +432,41 @@ class CreateDebugFileTest(APITestCase):
         with pytest.raises(RequestError):
             get_debug_files_session(self.organization.id, self.project.id).get(storage_path)
 
+    @requires_objectstore
+    def test_read_gate_prefers_legacy_file_when_disabled(self) -> None:
+        legacy_content = b"legacy-content"
+        objectstore_content = b"objectstore-content"
+        with self.feature("organizations:objectstore-debugfiles-write"):
+            dif, created = self.create_dif(fileobj=BytesIO(legacy_content))
+
+        assert created
+        storage_path = dif.storage_path
+        assert storage_path is not None
+        session = get_debug_files_session(self.organization.id, self.project.id)
+        session.delete(storage_path)
+        replacement_storage_path = session.put(objectstore_content, compression="none")
+        dif.storage_path = replacement_storage_path
+        dif.save(update_fields=["storage_path"])
+
+        assert dif.get_file().read() == legacy_content
+
+        with self.feature("organizations:objectstore-debugfiles-read"):
+            assert dif.get_file().read() == objectstore_content
+
+    @requires_objectstore
+    def test_read_gate_does_not_fall_back_when_objectstore_read_fails(self) -> None:
+        with self.feature("organizations:objectstore-debugfiles-write"):
+            dif, created = self.create_dif(fileobj=BytesIO(b"legacy-content"))
+
+        assert created
+        with (
+            self.feature("organizations:objectstore-debugfiles-read"),
+            patch.object(dif, "_get_objectstore_session") as get_session,
+        ):
+            get_session.return_value.get.side_effect = RuntimeError("Objectstore unavailable")
+            with pytest.raises(RuntimeError):
+                dif.get_file()
+
     def test_keep_disjoint_difs(self) -> None:
         file = self.create_file(
             name="crash.dsym", checksum="dc1e3f3e411979d336c3057cce64294f3420f93a"


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/119805 changed the semantics of `organizations:objectstore-debugfiles-write` to be double-writing, this PR introduces a dedicated `organizations:objectstore-debugfiles-read` that governs reading from Objectstore.

Now reading is independent of writing: `organizations:objectstore-debugfiles-write` can be enabled to double-write new debug files to Objectstore, and `organizations:objectstore-debugfiles-read` can be enabled on top to actually read those files from Objectstore.
This gives us even more control and safety for the rollout.

`organizations:objectstore-debugfiles-direct-read` continues to be a separate feature flag that can be enabled on top of `-read` to additionally download directly from Objectstore via a 302 redirect, instead of streaming through Sentry.