### PR TITLE
feat(conversations): Collapse tool calls in the transcript

### DIFF
--- a/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/conversationsAnalyticsEvents.tsx
@@ -4,6 +4,7 @@ export type ConversationsEventParameters = {
   'conversations.detail.copy-conversation': Record<string, unknown>;
   'conversations.detail.copy-conversation-id': Record<string, unknown>;
   'conversations.detail.expand-thinking': {expanded: boolean};
+  'conversations.detail.expand-tool-calls': {expanded: boolean};
   'conversations.detail.page-view': Record<string, unknown>;
   'conversations.detail.select-span': Record<string, unknown>;
   'conversations.detail.tab-switch': {
@@ -32,6 +33,7 @@ export const conversationsEventMap: Record<keyof ConversationsEventParameters, s
   'conversations.table.page-view': 'Conversations: Table Page View',
   'conversations.table.paginate': 'Conversations: Table Paginate',
   'conversations.detail.expand-thinking': 'Conversations: Detail Expand Thinking',
+  'conversations.detail.expand-tool-calls': 'Conversations: Detail Expand Tool Calls',
   'conversations.detail.page-view': 'Conversations: Detail Page View',
   'conversations.detail.tab-switch': 'Conversations: Detail Tab Switch',
   'conversations.detail.select-span': 'Conversations: Detail Select Span',

--- a/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
@@ -30,11 +30,18 @@ interface MessageToolCallsNewProps {
 }
 
 /**
- * Tool-call list for the redesigned transcript. Calls collapse behind a
- * `N tool calls` summary (with an error count) that is collapsed by default, to
- * keep tool-heavy turns compact. Each revealed row is an accent wrench +
- * `ToolTag` capped at the message width, with the duration right-aligned.
- * Selection shows an outline.
+ * A turn with fewer tool calls than this reads fine as a plain list, so it is
+ * left expanded; longer runs are the ones that bury the surrounding reasoning.
+ */
+const COLLAPSE_THRESHOLD = 5;
+
+/**
+ * Tool-call list for the redesigned transcript. Runs of at least
+ * `COLLAPSE_THRESHOLD` calls collapse behind a `N tool calls` summary (with an
+ * error count) that is collapsed by default, to keep tool-heavy turns compact;
+ * shorter runs render inline. Each row is an accent wrench + `ToolTag` capped
+ * at the message width, with the duration right-aligned. Selection shows an
+ * outline.
  */
 export function MessageToolCallsNew({
   toolCalls,
@@ -57,6 +64,11 @@ export function MessageToolCallsNew({
       ))}
     </Stack>
   );
+
+  // Short runs read fine as a plain list — only collapse the long ones.
+  if (toolCalls.length < COLLAPSE_THRESHOLD) {
+    return rows;
+  }
 
   const errorCount = toolCalls.filter(tool => tool.hasError).length;
 

--- a/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
+++ b/static/app/views/explore/conversations/components/messageToolCallsNew.tsx
@@ -3,7 +3,8 @@ import {css, useTheme} from '@emotion/react';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {t} from 'sentry/locale';
+import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
+import {t, tn} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {getDuration} from 'sentry/utils/duration/getDuration';
@@ -29,9 +30,11 @@ interface MessageToolCallsNewProps {
 }
 
 /**
- * Tool-call list for the redesigned transcript. Each call is a full-width
- * selectable row: accent wrench + `ToolTag` capped at the message width, with
- * the duration right-aligned. Selection shows an outline.
+ * Tool-call list for the redesigned transcript. Calls collapse behind a
+ * `N tool calls` summary (with an error count) that is collapsed by default, to
+ * keep tool-heavy turns compact. Each revealed row is an accent wrench +
+ * `ToolTag` capped at the message width, with the duration right-aligned.
+ * Selection shows an outline.
  */
 export function MessageToolCallsNew({
   toolCalls,
@@ -39,6 +42,61 @@ export function MessageToolCallsNew({
   nodeMap,
   onSelectNode,
 }: MessageToolCallsNewProps) {
+  const organization = useOrganization();
+
+  const rows = (
+    <Stack gap="xs" width="100%">
+      {toolCalls.map(tool => (
+        <ToolCallRow
+          key={tool.nodeId}
+          tool={tool}
+          node={nodeMap.get(tool.nodeId)}
+          isSelected={tool.nodeId === selectedToolCallId}
+          onSelectNode={onSelectNode}
+        />
+      ))}
+    </Stack>
+  );
+
+  const errorCount = toolCalls.filter(tool => tool.hasError).length;
+
+  return (
+    <CollapsibleContent
+      // Keep the group open when one of its calls is the current selection so a
+      // deep-linked/timeline-selected row stays visible instead of hidden.
+      defaultOpen={selectedToolCallId !== null}
+      title={
+        <Flex align="center" gap="sm">
+          <Text size="sm" variant="muted">
+            {tn('%s tool call', '%s tool calls', toolCalls.length)}
+          </Text>
+          {errorCount > 0 && (
+            <Text size="sm" variant="danger">
+              {tn('%s error', '%s errors', errorCount)}
+            </Text>
+          )}
+        </Flex>
+      }
+      onToggle={open =>
+        trackAnalytics('conversations.detail.expand-tool-calls', {
+          organization,
+          expanded: open,
+        })
+      }
+    >
+      <Container paddingTop="xs">{rows}</Container>
+    </CollapsibleContent>
+  );
+}
+
+interface ToolCallRowProps {
+  isSelected: boolean;
+  onSelectNode: (node: AITraceSpanNode) => void;
+  tool: ToolCall;
+  node?: AITraceSpanNode;
+}
+
+function ToolCallRow({tool, node, isSelected, onSelectNode}: ToolCallRowProps) {
   const organization = useOrganization();
   const theme = useTheme();
 
@@ -53,75 +111,65 @@ export function MessageToolCallsNew({
     }
   `;
 
+  const selectTool = () => {
+    trackAnalytics('conversations.message.click-tool-call', {
+      organization,
+    });
+    if (node) {
+      onSelectNode(node);
+    }
+  };
+
   return (
-    <Stack gap="xs" width="100%">
-      {toolCalls.map(tool => {
-        const toolNode = nodeMap.get(tool.nodeId);
-        const isToolSelected = tool.nodeId === selectedToolCallId;
-        const selectTool = () => {
-          trackAnalytics('conversations.message.click-tool-call', {
-            organization,
-          });
-          if (toolNode) {
-            onSelectNode(toolNode);
-          }
-        };
-        return (
-          <Container
-            key={tool.nodeId}
-            role="button"
-            tabIndex={0}
-            aria-pressed={isToolSelected}
-            aria-label={t('Select tool call %s', tool.name)}
-            radius="sm"
-            padding="sm sm"
-            cursor="pointer"
-            css={rowCss}
-            style={
-              isToolSelected
-                ? {
-                    outline: `2px solid ${
-                      tool.hasError
-                        ? theme.tokens.content.danger
-                        : theme.tokens.focus.default
-                    }`,
-                    outlineOffset: '-2px',
-                  }
-                : undefined
+    <Container
+      role="button"
+      tabIndex={0}
+      aria-pressed={isSelected}
+      aria-label={t('Select tool call %s', tool.name)}
+      radius="sm"
+      padding="sm sm"
+      cursor="pointer"
+      css={rowCss}
+      style={
+        isSelected
+          ? {
+              outline: `2px solid ${
+                tool.hasError ? theme.tokens.content.danger : theme.tokens.focus.default
+              }`,
+              outlineOffset: '-2px',
             }
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation();
-              selectTool();
-            }}
-            onKeyDown={(e: React.KeyboardEvent) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                e.stopPropagation();
-                selectTool();
-              }
-            }}
-          >
-            <Flex align="center" justify="between" gap="md" width="100%">
-              <Flex align="center" gap="sm" minWidth={0}>
-                {toolNode && <AiSpanStatusIcon node={toolNode} />}
-                <ToolTag name={tool.name} hasError={tool.hasError} />
-                {toolNode && <ToolInputPreview node={toolNode} />}
-              </Flex>
-              <TurnMeta
-                metric={toolNode ? <ToolOutputSize node={toolNode} /> : null}
-                duration={
-                  tool.duration === undefined || tool.duration <= 0 ? null : (
-                    <Text size="xs" variant="muted" tabular align="right">
-                      {getDuration(tool.duration, 2, true)}
-                    </Text>
-                  )
-                }
-              />
-            </Flex>
-          </Container>
-        );
-      })}
-    </Stack>
+          : undefined
+      }
+      onClick={(e: React.MouseEvent) => {
+        e.stopPropagation();
+        selectTool();
+      }}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          selectTool();
+        }
+      }}
+    >
+      <Flex align="center" justify="between" gap="md" width="100%">
+        <Flex align="center" gap="sm" minWidth={0}>
+          {node && <AiSpanStatusIcon node={node} />}
+          <ToolTag name={tool.name} hasError={tool.hasError} />
+          {node && <ToolInputPreview node={node} />}
+        </Flex>
+        <TurnMeta
+          metric={node ? <ToolOutputSize node={node} /> : null}
+          duration={
+            tool.duration === undefined || tool.duration <= 0 ? null : (
+              <Text size="xs" variant="muted" tabular align="right">
+                {getDuration(tool.duration, 2, true)}
+              </Text>
+            )
+          }
+        />
+      </Flex>
+    </Container>
   );
 }
 

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -31,9 +31,10 @@ function createMockNode(overrides: {
 function createMockToolNode(overrides: {
   id: string;
   toolName: string;
+  hasError?: boolean;
   startTimestamp?: number;
 }) {
-  const {id, toolName, startTimestamp = 1000} = overrides;
+  const {id, toolName, startTimestamp = 1000, hasError = false} = overrides;
   const end = startTimestamp + 100;
   return {
     id,
@@ -45,9 +46,45 @@ function createMockToolNode(overrides: {
     attributes: {
       [SpanFields.GEN_AI_OPERATION_TYPE]: 'tool',
       [SpanFields.GEN_AI_TOOL_NAME]: toolName,
+      ...(hasError ? {[SpanFields.SPAN_STATUS]: 'internal_error'} : {}),
     },
     errors: new Set(),
   };
+}
+
+// Builds a turn whose assistant message carries `toolNames.length` tool calls,
+// with the tool spans sitting between two generations so they merge onto the
+// second turn.
+function createNodesWithToolCalls(
+  toolNames: string[],
+  {errorToolNames = []}: {errorToolNames?: string[]} = {}
+) {
+  const requestMessages = JSON.stringify([{role: 'user', content: 'Question?'}]);
+  const firstGeneration = createMockNode({
+    id: 'span-1',
+    startTimestamp: 1000,
+    attributes: {
+      [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+      [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Let me check',
+    },
+  });
+  const toolNodes = toolNames.map((toolName, index) =>
+    createMockToolNode({
+      id: `tool-${index}`,
+      toolName,
+      startTimestamp: 1500 + index * 100,
+      hasError: errorToolNames.includes(toolName),
+    })
+  );
+  const secondGeneration = createMockNode({
+    id: 'span-2',
+    startTimestamp: 3000,
+    attributes: {
+      [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+      [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Here is the answer',
+    },
+  });
+  return [firstGeneration, ...toolNodes, secondGeneration];
 }
 
 describe('MessagesPanelNew', () => {
@@ -175,6 +212,73 @@ describe('MessagesPanelNew', () => {
     );
 
     expect(screen.getByText('weather')).toBeInTheDocument();
+  });
+
+  it('collapses a single tool call behind a summary by default', () => {
+    render(
+      <MessagesPanelNew
+        nodes={createNodesWithToolCalls(['weather']) as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    const summary = screen.getByText('1 tool call');
+    expect(summary).toBeInTheDocument();
+    expect(summary.closest('details')).not.toHaveAttribute('open');
+  });
+
+  it('collapses multiple tool calls behind a summary and expands on click', async () => {
+    render(
+      <MessagesPanelNew
+        nodes={createNodesWithToolCalls(['alpha', 'beta', 'gamma']) as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    // Collapsed by default: the summary is shown, the individual tools are not.
+    const summary = screen.getByText('3 tool calls');
+    expect(summary).toBeInTheDocument();
+    const details = summary.closest('details');
+    expect(details).not.toHaveAttribute('open');
+
+    // Expanding reveals every tool call.
+    await userEvent.click(summary);
+    expect(details).toHaveAttribute('open');
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('gamma')).toBeInTheDocument();
+  });
+
+  it('shows the error count in the tool call summary', () => {
+    render(
+      <MessagesPanelNew
+        nodes={
+          createNodesWithToolCalls(['alpha', 'beta', 'gamma'], {
+            errorToolNames: ['beta', 'gamma'],
+          }) as any
+        }
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('3 tool calls')).toBeInTheDocument();
+    expect(screen.getByText('2 errors')).toBeInTheDocument();
+  });
+
+  it('expands the tool call group when one of its calls is selected', () => {
+    render(
+      <MessagesPanelNew
+        nodes={createNodesWithToolCalls(['alpha', 'beta', 'gamma']) as any}
+        selectedNodeId="tool-1"
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    const details = screen.getByText('3 tool calls').closest('details');
+    expect(details).toHaveAttribute('open');
   });
 
   it('selects assistant messages on click but not user messages', async () => {

--- a/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.spec.tsx
@@ -214,21 +214,7 @@ describe('MessagesPanelNew', () => {
     expect(screen.getByText('weather')).toBeInTheDocument();
   });
 
-  it('collapses a single tool call behind a summary by default', () => {
-    render(
-      <MessagesPanelNew
-        nodes={createNodesWithToolCalls(['weather']) as any}
-        selectedNodeId={null}
-        onSelectNode={mockOnSelectNode}
-      />
-    );
-
-    const summary = screen.getByText('1 tool call');
-    expect(summary).toBeInTheDocument();
-    expect(summary.closest('details')).not.toHaveAttribute('open');
-  });
-
-  it('collapses multiple tool calls behind a summary and expands on click', async () => {
+  it('renders a short run of tool calls inline without a summary', () => {
     render(
       <MessagesPanelNew
         nodes={createNodesWithToolCalls(['alpha', 'beta', 'gamma']) as any}
@@ -237,8 +223,22 @@ describe('MessagesPanelNew', () => {
       />
     );
 
-    // Collapsed by default: the summary is shown, the individual tools are not.
-    const summary = screen.getByText('3 tool calls');
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('gamma')).toBeInTheDocument();
+    expect(screen.queryByText('3 tool calls')).not.toBeInTheDocument();
+  });
+
+  it('collapses a long run of tool calls behind a summary and expands on click', async () => {
+    render(
+      <MessagesPanelNew
+        nodes={createNodesWithToolCalls(['t1', 't2', 't3', 't4', 't5']) as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    // Collapsed by default: the summary is shown inside a closed details.
+    const summary = screen.getByText('5 tool calls');
     expect(summary).toBeInTheDocument();
     const details = summary.closest('details');
     expect(details).not.toHaveAttribute('open');
@@ -246,17 +246,16 @@ describe('MessagesPanelNew', () => {
     // Expanding reveals every tool call.
     await userEvent.click(summary);
     expect(details).toHaveAttribute('open');
-    expect(screen.getByText('alpha')).toBeInTheDocument();
-    expect(screen.getByText('beta')).toBeInTheDocument();
-    expect(screen.getByText('gamma')).toBeInTheDocument();
+    expect(screen.getByText('t1')).toBeInTheDocument();
+    expect(screen.getByText('t5')).toBeInTheDocument();
   });
 
   it('shows the error count in the tool call summary', () => {
     render(
       <MessagesPanelNew
         nodes={
-          createNodesWithToolCalls(['alpha', 'beta', 'gamma'], {
-            errorToolNames: ['beta', 'gamma'],
+          createNodesWithToolCalls(['t1', 't2', 't3', 't4', 't5'], {
+            errorToolNames: ['t2', 't4'],
           }) as any
         }
         selectedNodeId={null}
@@ -264,20 +263,20 @@ describe('MessagesPanelNew', () => {
       />
     );
 
-    expect(screen.getByText('3 tool calls')).toBeInTheDocument();
+    expect(screen.getByText('5 tool calls')).toBeInTheDocument();
     expect(screen.getByText('2 errors')).toBeInTheDocument();
   });
 
   it('expands the tool call group when one of its calls is selected', () => {
     render(
       <MessagesPanelNew
-        nodes={createNodesWithToolCalls(['alpha', 'beta', 'gamma']) as any}
+        nodes={createNodesWithToolCalls(['t1', 't2', 't3', 't4', 't5']) as any}
         selectedNodeId="tool-1"
         onSelectNode={mockOnSelectNode}
       />
     );
 
-    const details = screen.getByText('3 tool calls').closest('details');
+    const details = screen.getByText('5 tool calls').closest('details');
     expect(details).toHaveAttribute('open');
   });
 


### PR DESCRIPTION
Tool-heavy assistant turns filled the conversation transcript with long runs of individual tool-call rows, pushing the reasoning and text that explain what the agent actually did off the screen and making conversations hard to skim.

When a turn has a long run of tool calls (five or more), they now group behind a summary row showing the call count and, when any calls failed, an error count. The group is collapsed by default and expands on demand, so the transcript reads as a conversation while the per-call detail stays one click away. Shorter runs still render inline, and a group auto-expands when one of its calls is the currently selected span so deep links and timeline selections stay visible.

Expanding or collapsing a group emits a new `conversations.detail.expand-tool-calls` analytics event (with the resulting open/closed state) so we can see how often the collapsed detail is opened.

Refs TET-2631