### PR TITLE
feat(pr_metrics): Include group_ids in delegated agent attribution

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -1314,6 +1314,7 @@ def _send_seer_delegated_agent_match(
             agent_id=match.agent_id,
             pr_url=request_body.pr_url,
             run_id=match.run_id,
+            group_ids=request_body.group_ids,
         ).dict(),
     )
     _record_delegated_candidate(provider_hint, "sync_matched")

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -145,6 +145,7 @@ def poll_github_copilot_agents(
     coding_agents: dict[str, Any] | None = None,
     organization_id: int = 0,
     run_id: int | None = None,
+    group_id: int | None = None,
 ) -> None:
     agents = coding_agents or (autofix_state.coding_agents if autofix_state else None)
     if not agents:
@@ -156,6 +157,11 @@ def poll_github_copilot_agents(
         autofix_state.request.organization_id if autofix_state else 0
     )
     run_id = run_id if run_id is not None else (autofix_state.run_id if autofix_state else None)
+    group_id = (
+        group_id
+        if group_id is not None
+        else (autofix_state.request.issue["id"] if autofix_state else None)
+    )
 
     user_access_token: str | None = None
 
@@ -278,6 +284,7 @@ def poll_github_copilot_agents(
                             pr_url=pr_url,
                             agent_id=agent_id,
                             run_id=run_id,
+                            group_ids=[group_id] if group_id is not None else None,
                         )
                     except Exception:
                         logger.exception(
@@ -308,6 +315,7 @@ def poll_claude_code_agents(
     organization_id: int | None = None,
     coding_agents: dict[str, Any] | None = None,
     run_id: int | None = None,
+    group_id: int | None = None,
 ) -> None:
     """
     Poll Claude Code Agent sessions for status updates.
@@ -332,13 +340,23 @@ def poll_claude_code_agents(
     clients: dict[int, Any] = {}
 
     run_id = run_id if run_id is not None else (autofix_state.run_id if autofix_state else None)
+    group_id = (
+        group_id
+        if group_id is not None
+        else (autofix_state.request.issue["id"] if autofix_state else None)
+    )
 
     for agent_id, agent_state in agents.items():
-        poll_claude_agent(clients, agent_id, org_id, agent_state, run_id=run_id)
+        poll_claude_agent(clients, agent_id, org_id, agent_state, run_id=run_id, group_id=group_id)
 
 
 def poll_claude_agent(
-    clients, agent_id, org_id, agent_state: CodingAgentState, run_id: int | None = None
+    clients,
+    agent_id,
+    org_id,
+    agent_state: CodingAgentState,
+    run_id: int | None = None,
+    group_id: int | None = None,
 ) -> None:
     if agent_state.provider != CodingAgentProviderType.CLAUDE_CODE_AGENT:
         return
@@ -387,6 +405,7 @@ def poll_claude_agent(
                         pr_url=result.pr_url,
                         agent_id=agent_id,
                         run_id=run_id,
+                        group_ids=[group_id] if group_id is not None else None,
                     )
                 except Exception:
                     logger.exception(

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -480,12 +480,14 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     user_id=request.user.id,
                     organization_id=group.organization.id,
                     run_id=state.run_id,
+                    group_id=group.id,
                 )
             if CodingAgentProviderType.CLAUDE_CODE_AGENT in agent_providers:
                 poll_claude_code_agents(
                     coding_agents=state.coding_agents,
                     organization_id=group.organization.id,
                     run_id=state.run_id,
+                    group_id=group.id,
                 )
 
         run = get_seer_run(state.run_id, group.organization)

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -272,6 +272,21 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
             "group_ids": [self.group.id],
         }
 
+    def test_includes_multiple_group_ids_in_signal_details(self) -> None:
+        self._attribute(
+            pr_url="https://github.com/getsentry/sentry/pull/88",
+            group_ids=[555],
+        )
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="88")
+        attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
+        assert attribution.signal_details == {
+            "agent_id": "agent-1",
+            "pr_url": "https://github.com/getsentry/sentry/pull/88",
+            "run_id": None,
+            "group_ids": [555],
+        }
+
     def test_noop_when_feature_disabled(self) -> None:
         self._attribute(has_feature=False)
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2411,7 +2411,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             "agent_id": "agent-1",
             "pr_url": "https://github.com/org/repo/pull/42",
             "run_id": 123,
-            "group_ids": [],
+            "group_ids": [self.group.id],
         }
         assert self._candidate_outcome(mock_incr) == {
             "provider": "claude_code",

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -370,6 +370,7 @@ class TestPollGithubCopilotAgents(TestCase):
             pr_url="https://github.com/getsentry/sentry/pull/12345",
             agent_id="getsentry:sentry:task-123",
             run_id=self.run_id,
+            group_ids=[1],
         )
 
         call_kwargs = mock_sync_status.call_args.kwargs
@@ -925,6 +926,7 @@ class TestPollClaudeCodeAgents(TestCase):
             pr_url="https://github.com/getsentry/sentry/pull/999",
             agent_id="claude-session-123",
             run_id=self.run_id,
+            group_ids=[1],
         )
 
         call_kwargs = mock_sync_status.call_args.kwargs


### PR DESCRIPTION
I want this because I recently moved the HEX dashboard to look for missing matches based on group_id match. It's harder for delegated agents cause we don't include those in the attribution.

---

Adds a `group_ids` field to `DelegatedAgentSignalDetails` and populates it on the two write paths where the resolved group ids were already available but previously discarded:

- The synchronous Seer match response (`_send_seer_delegated_agent_match`) already sends `group_ids` to Seer on the outbound `MatchDelegatedAgentPrRequest`; those same ids are now carried into the stored `signal_details`.
- The GitHub Copilot / Claude Code autofix pollers now thread `group_id` from the originating `Group` (via `GroupAutofixEndpoint.get`) down through `poll_github_copilot_agents` / `poll_claude_code_agents` into the attribution write.

The Cursor webhook path and the async `record_pr_attribution` RPC callback are left unchanged — neither has group context readily available without new plumbing on the Seer side, and can be addressed separately.