### PR TITLE
fix(inbound-filters): Rename custom filters tab URL segment

### DIFF
--- a/static/app/views/settings/project/projectFilters/index.spec.tsx
+++ b/static/app/views/settings/project/projectFilters/index.spec.tsx
@@ -47,7 +47,7 @@ describe('ProjectFilters', () => {
 
   const inboundFiltersRouterConfig = {
     location: {
-      pathname: `/settings/${organization.slug}/projects/${project.slug}/filters/inbound-filters/`,
+      pathname: `/settings/${organization.slug}/projects/${project.slug}/filters/custom-filters/`,
     },
     route: '/settings/:orgId/projects/:projectId/filters/:filterType/',
   };

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -60,9 +60,9 @@ export default function ProjectFilters() {
                   {t('Data Filters')}
                 </TabList.Item>
                 <TabList.Item
-                  key="inbound-filters"
+                  key="custom-filters"
                   hidden={!hasInboundFiltersV2}
-                  to={recreateRoute('inbound-filters/', {
+                  to={recreateRoute('custom-filters/', {
                     routes,
                     params,
                     stepBack: -1,
@@ -84,7 +84,7 @@ export default function ProjectFilters() {
 
         {filterType === 'discarded-groups' ? (
           <GroupTombstones project={project} />
-        ) : hasInboundFiltersV2 && filterType === 'inbound-filters' ? (
+        ) : hasInboundFiltersV2 && filterType === 'custom-filters' ? (
           <CustomFilters project={project} />
         ) : (
           <ProjectFiltersSettings project={project} params={params} />


### PR DESCRIPTION
- The new inbound filters v2 tab used `inbound-filters` as its `:filterType` URL segment, so the page lived at `/settings/projects/<project>/filters/inbound-filters/`
- Rename the segment to `custom-filters`, matching the tab's "Custom Filters" label
- No redirect for the old URL since the feature is still behind the `inbound-filters-v2` flag
- Updates the tab link, the `filterType` check, and the test pathname