### PR TITLE
fix(pr-metrics): Resolve run_id/group_id locally for Cursor attribution

### DIFF
--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -234,7 +234,7 @@ class CursorWebhookEndpoint(Endpoint):
             branch_name=branch_name,
         )
 
-        known_to_seer = sync_coding_agent_status(
+        sync_result = sync_coding_agent_status(
             agent_id=agent_id,
             organization_id=self.organization_id,
             status=status,
@@ -242,7 +242,7 @@ class CursorWebhookEndpoint(Endpoint):
             result=result,
         )
 
-        if known_to_seer and status == CodingAgentStatus.COMPLETED and pr_url:
+        if sync_result.known_to_seer and status == CodingAgentStatus.COMPLETED and pr_url:
             try:
                 attribute_delegated_agent_pull_request(
                     organization_id=self.organization_id,
@@ -251,6 +251,10 @@ class CursorWebhookEndpoint(Endpoint):
                     repo_provider=repo_provider,
                     pr_url=pr_url,
                     agent_id=agent_id,
+                    run_id=sync_result.run_id,
+                    group_ids=(
+                        [sync_result.group_id] if sync_result.group_id is not None else None
+                    ),
                 )
             except Exception:
                 logger.exception(
@@ -268,7 +272,7 @@ class CursorWebhookEndpoint(Endpoint):
                     "agent_id": agent_id,
                     "pr_url": pr_url,
                     "repo_full_name": repo_full_name,
-                    "known_to_seer": known_to_seer,
+                    "known_to_seer": sync_result.known_to_seer,
                     "has_pr_url": bool(pr_url),
                 },
             )

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -62,6 +62,7 @@ class DelegatedAgentSignalDetails(BaseModel):
     agent_id: str | None = None
     pr_url: str
     run_id: int | None = None
+    group_ids: list[int] = []
 
 
 # Signal types that use DelegatedAgentSignalDetails for their signal_details.
@@ -312,6 +313,7 @@ def attribute_delegated_agent_pull_request(
     pr_url: str,
     agent_id: str | None = None,
     run_id: int | None = None,
+    group_ids: Sequence[int] | None = None,
 ) -> None:
     """Attribute a PR opened by a Seer-delegated coding agent (Cursor/Copilot/Claude).
 
@@ -360,6 +362,7 @@ def attribute_delegated_agent_pull_request(
             agent_id=agent_id,
             pr_url=pr_url,
             run_id=run_id,
+            group_ids=list(group_ids) if group_ids else [],
         ).dict(),
         log_context=log_context,
     )

--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -323,6 +323,11 @@ def attribute_delegated_agent_pull_request(
     point. Callers pass the ``SEER_DELEGATED_*`` signal type for the authoring
     agent; unlike Seer-native PRs we never attribute these to ``SENTRY_APP``.
 
+    ``run_id``/``group_ids`` are optional and left sparse (``None``/``[]``) when
+    a caller can't resolve them locally; ``group_ids`` is the issue(s) the
+    delegated run was launched against, mirroring the field already on
+    ``SentryAppSignalDetails``.
+
     Gated behind ``organizations:pr-metrics-attribution``. Best-effort: callers run
     this inside the polling/webhook flow, so any failure is logged and swallowed
     rather than allowed to interrupt that flow.

--- a/src/sentry/seer/autofix/coding_agent_handoffs.py
+++ b/src/sentry/seer/autofix/coding_agent_handoffs.py
@@ -6,6 +6,7 @@ outcome.
 from __future__ import annotations
 
 import logging
+from typing import NamedTuple
 
 from sentry.models.organization import Organization
 from sentry.seer.autofix.constants import CodingAgentStatus
@@ -16,9 +17,27 @@ from sentry.seer.autofix.utils import (
     update_coding_agent_state,
 )
 from sentry.seer.endpoints.utils import get_seer_run
-from sentry.seer.models.run import SeerRunCodingAgentHandoff, SeerRunCodingAgentHandoffExtras
+from sentry.seer.models.run import (
+    SeerAgentRun,
+    SeerRunCodingAgentHandoff,
+    SeerRunCodingAgentHandoffExtras,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class CodingAgentSyncResult(NamedTuple):
+    """Result of :func:`sync_coding_agent_status`.
+
+    ``run_id``/``group_id`` are resolved locally from the handoff's ``seer_run``
+    (and its ``SeerAgentRun`` sibling, populated when the run was launched
+    against an issue) — no Seer round trip needed. Both are ``None`` when no
+    matching handoff row exists locally.
+    """
+
+    known_to_seer: bool
+    run_id: int | None
+    group_id: int | None
 
 
 def create_seer_run_coding_agent_handoff(
@@ -53,16 +72,20 @@ def sync_coding_agent_status(
     status: CodingAgentStatus,
     agent_url: str | None = None,
     result: CodingAgentResult | None = None,
-) -> bool:
+) -> CodingAgentSyncResult:
     """Update Sentry's own SeerRunCodingAgentHandoff, then Seer's coding agent state.
 
-    Returns whether Seer recognized this ``agent_id`` (mirrors
-    ``update_coding_agent_state``'s return value, e.g. for gating PR attribution).
+    ``known_to_seer`` mirrors ``update_coding_agent_state``'s return value (e.g.
+    for gating PR attribution). ``run_id``/``group_id`` are populated whenever a
+    matching handoff row exists locally.
     """
     log_context = {"agent_id": agent_id, "organization_id": organization_id}
 
+    run_id: int | None = None
+    group_id: int | None = None
+
     try:
-        handoff = SeerRunCodingAgentHandoff.objects.select_related("seer_run").get(
+        handoff = SeerRunCodingAgentHandoff.objects.select_related("seer_run__agent").get(
             agent_id=agent_id, seer_run__organization_id=organization_id
         )
     except SeerRunCodingAgentHandoff.DoesNotExist:
@@ -70,6 +93,12 @@ def sync_coding_agent_status(
         logger.info("seer.coding_agent_handoff.not_found", extra=log_context)
 
     if handoff is not None:
+        run_id = handoff.seer_run.seer_run_state_id
+        try:
+            group_id = handoff.seer_run.agent.group_id
+        except SeerAgentRun.DoesNotExist:
+            group_id = None
+
         try:
             handoff.status = status.value
             update_fields = ["status", "date_updated"]
@@ -84,8 +113,9 @@ def sync_coding_agent_status(
         except Exception:
             logger.exception("seer.coding_agent_handoff.update_failed", extra=log_context)
             if handoff.provider != CodingAgentProviderType.CURSOR_BACKGROUND_AGENT.value:
-                return False
+                return CodingAgentSyncResult(known_to_seer=False, run_id=run_id, group_id=group_id)
 
-    return update_coding_agent_state(
+    known_to_seer = update_coding_agent_state(
         agent_id=agent_id, status=status, agent_url=agent_url, result=result
     )
+    return CodingAgentSyncResult(known_to_seer=known_to_seer, run_id=run_id, group_id=group_id)

--- a/src/sentry/seer/autofix/coding_agent_handoffs.py
+++ b/src/sentry/seer/autofix/coding_agent_handoffs.py
@@ -33,6 +33,9 @@ class CodingAgentSyncResult(NamedTuple):
     (and its ``SeerAgentRun`` sibling, populated when the run was launched
     against an issue) — no Seer round trip needed. Both are ``None`` when no
     matching handoff row exists locally.
+
+    Being a tuple, this is always truthy — check ``.known_to_seer`` explicitly
+    rather than the result object itself.
     """
 
     known_to_seer: bool

--- a/tests/sentry/integrations/cursor/test_webhook.py
+++ b/tests/sentry/integrations/cursor/test_webhook.py
@@ -13,6 +13,7 @@ from sentry.models.pullrequest import (
     PullRequestAttributionSignalType,
     PullRequestAttributionSource,
 )
+from sentry.seer.autofix.coding_agent_handoffs import CodingAgentSyncResult
 from sentry.testutils.cases import APITestCase
 
 
@@ -83,7 +84,9 @@ class TestCursorWebhook(APITestCase):
 
     @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
     def test_happy_path_finished(self, mock_update_state):
-        mock_update_state.return_value = True
+        mock_update_state.return_value = CodingAgentSyncResult(
+            known_to_seer=True, run_id=None, group_id=None
+        )
         payload = self._build_status_payload(status="FINISHED")
         body = orjson.dumps(payload)
         headers = self._signed_headers(body)
@@ -116,7 +119,9 @@ class TestCursorWebhook(APITestCase):
 
     @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
     def test_finished_records_pr_attribution(self, mock_update_state):
-        mock_update_state.return_value = True
+        mock_update_state.return_value = CodingAgentSyncResult(
+            known_to_seer=True, run_id=123, group_id=456
+        )
         repo = self.create_repo(
             self.project, name="testorg/testrepo", provider="integrations:github"
         )
@@ -132,6 +137,11 @@ class TestCursorWebhook(APITestCase):
         assert attribution.source == PullRequestAttributionSource.SEER_DATA
         assert attribution.pull_request.repository_id == repo.id
         assert attribution.pull_request.key == "1"
+        # run_id/group_ids are resolved locally (via SeerRunCodingAgentHandoff ->
+        # SeerRun -> SeerAgentRun) rather than left sparse as they were before.
+        assert attribution.signal_details is not None
+        assert attribution.signal_details["run_id"] == 123
+        assert attribution.signal_details["group_ids"] == [456]
 
     @patch("sentry.seer.autofix.coding_agent_handoffs.update_coding_agent_state")
     def test_finished_updates_seer_run_coding_agent_handoff(self, mock_update_state):
@@ -156,7 +166,9 @@ class TestCursorWebhook(APITestCase):
     def test_unknown_agent_records_no_attribution(self, mock_update_state):
         # Seer returns False (e.g. 404) for agent_ids it doesn't know about —
         # these are Cursor sessions not delegated by Seer, and must not be attributed.
-        mock_update_state.return_value = False
+        mock_update_state.return_value = CodingAgentSyncResult(
+            known_to_seer=False, run_id=None, group_id=None
+        )
         self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
         body = orjson.dumps(self._build_status_payload(status="FINISHED"))
         headers = self._signed_headers(body)
@@ -201,7 +213,9 @@ class TestCursorWebhook(APITestCase):
         self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
 
         # Seer didn't recognize the agent: known_to_seer=False, but a PR is present.
-        mock_update_state.return_value = False
+        mock_update_state.return_value = CodingAgentSyncResult(
+            known_to_seer=False, run_id=None, group_id=None
+        )
         body = orjson.dumps(self._build_status_payload(status="FINISHED"))
         with self.feature("organizations:pr-metrics-attribution"):
             assert self._post_with_headers(body, self._signed_headers(body)).status_code == 204
@@ -211,7 +225,9 @@ class TestCursorWebhook(APITestCase):
 
         # Seer knew the agent but there's no PR to attribute: known_to_seer=True, pr_url absent.
         mock_logger.reset_mock()
-        mock_update_state.return_value = True
+        mock_update_state.return_value = CodingAgentSyncResult(
+            known_to_seer=True, run_id=None, group_id=None
+        )
         body = orjson.dumps(self._build_status_payload(status="FINISHED", pr_url=None))
         with self.feature("organizations:pr-metrics-attribution"):
             assert self._post_with_headers(body, self._signed_headers(body)).status_code == 204
@@ -352,7 +368,9 @@ class TestCursorWebhook(APITestCase):
     @patch("sentry.integrations.cursor.webhooks.handler.sync_coding_agent_status")
     def test_invalid_pr_url_is_dropped(self, mock_update_state):
         # Non-https scheme must be rejected — the pr_url is nulled out so no attribution fires.
-        mock_update_state.return_value = True
+        mock_update_state.return_value = CodingAgentSyncResult(
+            known_to_seer=True, run_id=None, group_id=None
+        )
         self.create_repo(self.project, name="testorg/testrepo", provider="integrations:github")
 
         for bad_url in [

--- a/tests/sentry/pr_metrics/test_attribution.py
+++ b/tests/sentry/pr_metrics/test_attribution.py
@@ -199,6 +199,7 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
         pr_url: str = "https://github.com/getsentry/sentry/pull/42",
         agent_id: str | None = "agent-1",
         run_id: int | None = None,
+        group_ids: list[int] | None = None,
         organization_id: int | None = None,
         has_feature: bool = True,
     ) -> None:
@@ -213,6 +214,7 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
                 pr_url=pr_url,
                 agent_id=agent_id,
                 run_id=run_id,
+                group_ids=group_ids,
             )
 
     def test_records_the_given_signal_type(self) -> None:
@@ -236,6 +238,7 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
                 "agent_id": "agent-1",
                 "pr_url": f"https://github.com/getsentry/sentry/pull/{pr_number}",
                 "run_id": None,
+                "group_ids": [],
             }
 
     def test_includes_run_id_in_signal_details(self) -> None:
@@ -250,6 +253,23 @@ class AttributeDelegatedAgentPullRequestTest(TestCase):
             "agent_id": "agent-1",
             "pr_url": "https://github.com/getsentry/sentry/pull/77",
             "run_id": 9999,
+            "group_ids": [],
+        }
+
+    def test_includes_group_ids_in_signal_details(self) -> None:
+        self._attribute(
+            pr_url="https://github.com/getsentry/sentry/pull/78",
+            run_id=9999,
+            group_ids=[self.group.id],
+        )
+
+        pull_request = PullRequest.objects.get(repository_id=self.repo.id, key="78")
+        attribution = PullRequestAttribution.objects.get(pull_request=pull_request)
+        assert attribution.signal_details == {
+            "agent_id": "agent-1",
+            "pr_url": "https://github.com/getsentry/sentry/pull/78",
+            "run_id": 9999,
+            "group_ids": [self.group.id],
         }
 
     def test_noop_when_feature_disabled(self) -> None:

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -2411,6 +2411,7 @@ class HandleDelegatedAgentDetectionTest(TestCase):
             "agent_id": "agent-1",
             "pr_url": "https://github.com/org/repo/pull/42",
             "run_id": 123,
+            "group_ids": [],
         }
         assert self._candidate_outcome(mock_incr) == {
             "provider": "claude_code",

--- a/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
+++ b/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
@@ -82,7 +82,7 @@ class SyncCodingAgentStatusTest(TestCase):
     def test_updates_seer_and_returns_known_to_seer(self, mock_update_state: Mock) -> None:
         mock_update_state.return_value = True
 
-        known_to_seer = sync_coding_agent_status(
+        result = sync_coding_agent_status(
             agent_id="agent-1",
             organization_id=self.organization.id,
             status=CodingAgentStatus.COMPLETED,
@@ -95,11 +95,28 @@ class SyncCodingAgentStatusTest(TestCase):
             agent_url="https://github.com/copilot/agents/agent-1",
             result=None,
         )
-        assert known_to_seer is True
+        assert result.known_to_seer is True
+        assert result.run_id == RUN_STATE_ID
+        assert result.group_id is None
 
         self.handoff.refresh_from_db()
         assert self.handoff.status == "completed"
         assert self.handoff.extras["agent_url"] == "https://github.com/copilot/agents/agent-1"
+
+    @patch(MOCK_UPDATE_STATE_PATH)
+    def test_resolves_group_id_from_seer_agent_run(self, mock_update_state: Mock) -> None:
+        mock_update_state.return_value = True
+        group = self.create_group()
+        self.create_seer_agent_run(self.seer_run, group=group)
+
+        result = sync_coding_agent_status(
+            agent_id="agent-1",
+            organization_id=self.organization.id,
+            status=CodingAgentStatus.COMPLETED,
+        )
+
+        assert result.run_id == RUN_STATE_ID
+        assert result.group_id == group.id
 
     @patch(MOCK_UPDATE_STATE_PATH)
     def test_returns_false_when_seer_does_not_recognize_agent(
@@ -107,13 +124,13 @@ class SyncCodingAgentStatusTest(TestCase):
     ) -> None:
         mock_update_state.return_value = False
 
-        known_to_seer = sync_coding_agent_status(
+        result = sync_coding_agent_status(
             agent_id="agent-1",
             organization_id=self.organization.id,
             status=CodingAgentStatus.COMPLETED,
         )
 
-        assert known_to_seer is False
+        assert result.known_to_seer is False
         # The Sentry-side row still updates even if Seer didn't recognize the agent --
         # the two systems are independent, so the return value is informational only.
         self.handoff.refresh_from_db()
@@ -122,13 +139,13 @@ class SyncCodingAgentStatusTest(TestCase):
     @patch(MOCK_UPDATE_STATE_PATH)
     def test_skips_seer_call_when_local_save_fails(self, mock_update_state: Mock) -> None:
         with patch.object(SeerRunCodingAgentHandoff, "save", side_effect=Exception("db blip")):
-            known_to_seer = sync_coding_agent_status(
+            result = sync_coding_agent_status(
                 agent_id="agent-1",
                 organization_id=self.organization.id,
                 status=CodingAgentStatus.COMPLETED,
             )
 
-        assert known_to_seer is False
+        assert result.known_to_seer is False
         mock_update_state.assert_not_called()
         self.handoff.refresh_from_db()
         assert self.handoff.status == "pending"
@@ -143,13 +160,13 @@ class SyncCodingAgentStatusTest(TestCase):
         mock_update_state.return_value = True
 
         with patch.object(SeerRunCodingAgentHandoff, "save", side_effect=Exception("db blip")):
-            known_to_seer = sync_coding_agent_status(
+            result = sync_coding_agent_status(
                 agent_id="agent-cursor",
                 organization_id=self.organization.id,
                 status=CodingAgentStatus.COMPLETED,
             )
 
-        assert known_to_seer is True
+        assert result.known_to_seer is True
         mock_update_state.assert_called_once_with(
             agent_id="agent-cursor",
             status=CodingAgentStatus.COMPLETED,
@@ -164,13 +181,15 @@ class SyncCodingAgentStatusTest(TestCase):
     def test_noop_when_agent_id_not_found(self, mock_update_state: Mock, mock_logger: Mock) -> None:
         mock_update_state.return_value = True
 
-        known_to_seer = sync_coding_agent_status(
+        result = sync_coding_agent_status(
             agent_id="does-not-exist",
             organization_id=self.organization.id,
             status=CodingAgentStatus.COMPLETED,
         )
 
-        assert known_to_seer is True
+        assert result.known_to_seer is True
+        assert result.run_id is None
+        assert result.group_id is None
         mock_logger.info.assert_called_once_with(
             "seer.coding_agent_handoff.not_found",
             extra={"agent_id": "does-not-exist", "organization_id": self.organization.id},

--- a/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
+++ b/tests/sentry/seer/autofix/test_coding_agent_handoffs.py
@@ -146,6 +146,10 @@ class SyncCodingAgentStatusTest(TestCase):
             )
 
         assert result.known_to_seer is False
+        # run_id/group_id are resolved before the local save is attempted, so a
+        # save failure doesn't leave the caller without this data too.
+        assert result.run_id == RUN_STATE_ID
+        assert result.group_id is None
         mock_update_state.assert_not_called()
         self.handoff.refresh_from_db()
         assert self.handoff.status == "pending"

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1111,6 +1111,7 @@ class TestRecordPrAttribution(APITestCase):
             "agent_id": "agent-abc-123",
             "pr_url": self._DEFAULT_PR_URL,
             "run_id": 42,
+            "group_ids": [],
         }
 
     def test_delegated_signal_details_defaults_nullable_fields(self) -> None:
@@ -1121,6 +1122,7 @@ class TestRecordPrAttribution(APITestCase):
             "agent_id": None,
             "pr_url": self._DEFAULT_PR_URL,
             "run_id": None,
+            "group_ids": [],
         }
 
     def test_invalid_delegated_signal_details_raises(self) -> None:


### PR DESCRIPTION
Enhance the signal_details for Cursor delegated agent attribution. Brings it to parity with other delegated agents rows.

---

The Cursor delegated-agent webhook wrote `SEER_DELEGATED_CURSOR` attribution rows with `run_id` always null and no group linkage, unlike the GitHub Copilot and Claude Code polling paths, which both pass `run_id` explicitly.

`sync_coding_agent_status` already looks up the `SeerRunCodingAgentHandoff` row for the incoming `agent_id` to update its status — that same row's `seer_run` gives us the `run_id`, and the run's `SeerAgentRun` sibling (populated whenever the run was launched against an issue) gives us the originating `group_id`. Both are resolvable locally, with no additional Seer round trip.

This threads that data through:
- `sync_coding_agent_status` now returns a `CodingAgentSyncResult` (`known_to_seer`, `run_id`, `group_id`) instead of a bare bool.
- The Cursor webhook handler passes `run_id`/`group_ids` into `attribute_delegated_agent_pull_request`.
- `DelegatedAgentSignalDetails` gains a `group_ids` field, mirroring the one `SentryAppSignalDetails` already has.

Considered instead calling Seer's existing `/v1/pr-metrics/delegated-agent-match` sync endpoint, but that's keyed on `group_ids` (used to match an anonymous PR back to a run) — the wrong shape here, since Cursor's webhook already tells us unambiguously which agent/PR this is; we just weren't threading the run/group we already had.