### PR TITLE
feat(search): Refine Ask Seer empty-state heading

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -166,7 +166,7 @@ function AskSeerPollingPopoverContent({
 
   return (
     <SeerContent onMouseLeave={onMouseLeave}>
-      <AskSeerSearchHeader title={t("Describe what you're looking for.")} />
+      <AskSeerSearchHeader title={t("Describe what you're looking for")} />
     </SeerContent>
   );
 }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchHeader.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchHeader.tsx
@@ -4,6 +4,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {IconSeer} from 'sentry/icons';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface SeerSearchHeaderProps {
   title: string;
@@ -11,10 +12,14 @@ interface SeerSearchHeaderProps {
 }
 
 export function AskSeerSearchHeader({title, loading = false}: SeerSearchHeaderProps) {
+  const hasAskSeerRework = useOrganization().features.includes(
+    'gen-ai-ask-seer-ux-rework'
+  );
+
   return (
     <Flex align="center" padding="lg xl" gap="md" width="100%">
       <StyledIconSeer animation={loading ? 'loading' : undefined} />
-      <Text>{title}</Text>
+      <Text monospace={hasAskSeerRework}>{title}</Text>
     </Flex>
   );
 }


### PR DESCRIPTION
The Ask Seer search heading now uses monospace typography when the Ask Seer UX rework feature is enabled, while preserving the existing typography for organizations outside the rollout. The reworked empty-state prompt also drops its trailing period.

Closes BROWSE-626

**Example:**

<img width="1131" height="112" alt="Screenshot 2026-07-16 at 10 03 25" src="https://github.com/user-attachments/assets/95a736bc-6feb-47d4-bf89-336eeb9c1d63" />