### PR TITLE
feat(pr_metrics): Reap PullRequestMetrics rows stuck at JUDGE_IN_PROGRESS

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -86,11 +86,11 @@ class PrCloseMetricsEvent(analytics.Event):
     # The terminal verdict, one of ``PullRequestVerdict``: the deterministic
     # outcome (``merged_unchanged`` / ``closed_unmerged``) on the no-judge path, or
     # the Seer judge's verdict on the judge path. Claimed before emit on both
-    # paths (the claim gates emission), so an emitted row almost always carries
-    # a verdict. The one exception is the ``JUDGE_IN_PROGRESS`` reaper
-    # (``reap_stuck_judge_verdicts``): a stuck row with no reliable local signal
-    # (activity tracking was off) still emits, but with an explicit null verdict
-    # rather than being dropped from the table entirely.
+    # paths (the claim gates emission), so every emitted row carries a verdict — the
+    # ``| None`` is only the column's unset default, not an expected emitted value.
+    # (The ``JUDGE_IN_PROGRESS`` reaper's indeterminate rows — no reliable local
+    # signal to settle from — release the claim without emitting at all, rather
+    # than emit a null-verdict row; see ``reap_stuck_judge_verdicts``.)
     verdict: str | None = None
     # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
     # "why", a vocabulary shared across judges, not specific to any one. Mostly

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -85,9 +85,12 @@ class PrCloseMetricsEvent(analytics.Event):
     autofix_referrers: list[str] = field(default_factory=list)
     # The terminal verdict, one of ``PullRequestVerdict``: the deterministic
     # outcome (``merged_unchanged`` / ``closed_unmerged``) on the no-judge path, or
-    # the Seer judge's verdict on the judge path. Claimed before emit on both paths
-    # (the claim gates emission), so every emitted row carries a verdict — the
-    # ``| None`` is only the column's unset default, not an expected emitted value.
+    # the Seer judge's verdict on the judge path. Claimed before emit on both
+    # paths (the claim gates emission), so an emitted row almost always carries
+    # a verdict. The one exception is the ``JUDGE_IN_PROGRESS`` reaper
+    # (``reap_stuck_judge_verdicts``): a stuck row with no reliable local signal
+    # (activity tracking was off) still emits, but with an explicit null verdict
+    # rather than being dropped from the table entirely.
     verdict: str | None = None
     # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
     # "why", a vocabulary shared across judges, not specific to any one. Mostly

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1188,6 +1188,11 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         # Run every 12 hours, at 10:00 and 22:00 UTC
         "schedule": crontab("0", "10,22", "*", "*", "*"),
     },
+    "pr-metrics-reap-stuck-judge-verdicts": {
+        "task": "seer.code_review:sentry.pr_metrics.tasks.reap_stuck_judge_verdicts",
+        # Run once a day at 04:00 UTC, off-peak.
+        "schedule": crontab("0", "4", "*", "*", "*"),
+    },
     "refresh-artifact-bundles-in-use": {
         "task": "attachments:sentry.debug_files.tasks.refresh_artifact_bundles_in_use",
         "schedule": crontab("*/1", "*", "*", "*", "*"),

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -196,6 +196,23 @@ def ci_failing_at_close(pull_request: PullRequest) -> bool:
     )
 
 
+def calculate_deterministic_diagnosis_labels(
+    pull_request: PullRequest, verdict: PullRequestVerdict | None
+) -> list[str] | None:
+    """The diagnosis labels Sentry can derive on its own from a settled verdict.
+
+    Shared by every caller that settles a verdict without a judge (the cooldown
+    task's deterministic path, and the judge-reap reconciliation), so a label
+    added here reaches all of them rather than being re-derived ad hoc per
+    caller. Currently just ``CI_FAILING_AT_CLOSE``, but the shape (verdict in,
+    labels out) is meant to grow more deterministic labels over time.
+    """
+    labels = []
+    if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request):
+        labels.append(CI_FAILING_AT_CLOSE)
+    return labels or None
+
+
 def is_pr_tracked(pull_request: PullRequest) -> bool:
     """Whether the PR has ≥1 valid attribution — the emission tracking gate.
 

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -22,6 +22,7 @@ from django.utils import timezone
 from pydantic import ValidationError
 from urllib3.exceptions import HTTPError
 
+from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
@@ -40,7 +41,15 @@ from sentry.pr_metrics.contracts import (
     PrCloseJudgeRequest,
     PrConversationAnalysis,
 )
-from sentry.pr_metrics.emit import active_attributions, emit_pr_metrics_row, select_fallback_verdict
+from sentry.pr_metrics.emit import (
+    CI_FAILING_AT_CLOSE,
+    VerdictDeferral,
+    active_attributions,
+    ci_failing_at_close,
+    emit_pr_metrics_row,
+    select_fallback_verdict,
+    select_verdict,
+)
 from sentry.pr_metrics.utils import iso_or_none, resolved_group_ids
 from sentry.seer.code_review.models import SeerCodeReviewRepoDefinition
 from sentry.seer.code_review.utils import build_repo_definition
@@ -460,7 +469,7 @@ def reap_stuck_judge_verdicts() -> None:
         if pull_request.closed_at is None and pull_request.merged_at is None:
             _release_reopened_judge_claim(pull_request)
         else:
-            _settle_stuck_judge_claim(pull_request)
+            _reconcile_stuck_judge_claim(pull_request)
 
 
 def _release_reopened_judge_claim(pull_request: PullRequest) -> None:
@@ -486,20 +495,54 @@ def _release_reopened_judge_claim(pull_request: PullRequest) -> None:
     )
 
 
-def _settle_stuck_judge_claim(pull_request: PullRequest) -> None:
-    """Settle a stuck judge forward via the same fallback used for ineligible attribution.
+def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
+    """Re-derive a verdict for a stuck judge forward and settle the row.
+
+    Re-runs ``select_verdict`` against current data rather than assuming the
+    original deferral reason still applies — late comments or activity can have
+    changed the answer since the forward, and the original deferral (``NEEDS_JUDGE``
+    vs ``INDETERMINATE``) was never persisted, so it can't be read back directly:
+
+    * A deterministic result settles directly — the same outcome ``select_verdict``
+      would have produced had a judge never been needed.
+    * ``NEEDS_JUDGE`` falls back to ``select_fallback_verdict``, exactly as the
+      ineligible-attribution path already does — safe here because real
+      push-activity data backs it.
+    * ``INDETERMINATE`` means there's no reliable local signal at all (typically
+      activity tracking was off for this org) — calling ``select_fallback_verdict``
+      here would silently misread "untracked" as "no commits after open". Instead
+      the sentinel is released to null and the row still emits, carrying an
+      explicit null verdict rather than silently dropping the PR from the table.
 
     Guarded against a race with a very-late Seer callback landing at the same
     time: a compare-and-set off ``JUDGE_IN_PROGRESS`` inside a transaction, so
     whichever settles first wins and the other is a no-op.
     """
-    verdict = select_fallback_verdict(pull_request)
+    try:
+        organization = Organization.objects.get(id=pull_request.organization_id)
+    except Organization.DoesNotExist:
+        metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "org_gone"})
+        return
+
+    outcome = select_verdict(pull_request, organization)
+    if not isinstance(outcome, VerdictDeferral):
+        verdict: PullRequestVerdict | None = outcome
+    elif outcome is VerdictDeferral.NEEDS_JUDGE:
+        verdict = select_fallback_verdict(pull_request)
+    else:
+        verdict = None
+
     log_extra = {
         "organization_id": pull_request.organization_id,
         "repository_id": pull_request.repository_id,
         "pull_request_id": pull_request.id,
         "verdict": verdict,
     }
+    diagnosis_labels = (
+        [CI_FAILING_AT_CLOSE]
+        if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request)
+        else None
+    )
     with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
         settled = PullRequestMetrics.objects.filter(
             pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
@@ -508,6 +551,6 @@ def _settle_stuck_judge_claim(pull_request: PullRequest) -> None:
             metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
             return
 
-    emit_pr_metrics_row(pull_request=pull_request)
-    metrics.incr("pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict})
+    emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
+    metrics.incr("pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict or "none"})
     logger.info("pr_metrics.judge.reaper.fallback_emitted", extra=log_extra)

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
+from datetime import timedelta
 from typing import Any
 
 from django.conf import settings
 from django.db import router, transaction
 from django.db.models import Q
+from django.utils import timezone
 from pydantic import ValidationError
 from urllib3.exceptions import HTTPError
 
@@ -38,7 +40,7 @@ from sentry.pr_metrics.contracts import (
     PrCloseJudgeRequest,
     PrConversationAnalysis,
 )
-from sentry.pr_metrics.emit import active_attributions, emit_pr_metrics_row
+from sentry.pr_metrics.emit import active_attributions, emit_pr_metrics_row, select_fallback_verdict
 from sentry.pr_metrics.utils import iso_or_none, resolved_group_ids
 from sentry.seer.code_review.models import SeerCodeReviewRepoDefinition
 from sentry.seer.code_review.utils import build_repo_definition
@@ -408,3 +410,104 @@ def update_pr_metrics(
     metrics.incr("pr_metrics.update.recorded", tags={"verdict": verdict})
     logger.info("pr_metrics.update.recorded", extra={**log_extra, "verdict": verdict})
     return UpdatePrMetricsSuccessResponse()
+
+
+# A judge-eligible PR forwarded to Seer can be left claimed at JUDGE_IN_PROGRESS
+# forever — Seer may never call back, permanently reject the forward, or the task
+# may exhaust its retries (see forward_pr_to_seer_judge's docstring). There is no
+# other path back to a terminal verdict, so reap_stuck_judge_verdicts is the only
+# thing that ever resolves those rows; run daily by reap_stuck_judge_verdicts_task.
+JUDGE_REAP_STUCK_AFTER = timedelta(hours=4)
+JUDGE_REAP_LOOKBACK = timedelta(days=7)
+_REAP_BATCH_SIZE = 500
+
+
+def reap_stuck_judge_verdicts() -> None:
+    """Settle ``PullRequestMetrics`` rows stuck at ``JUDGE_IN_PROGRESS``.
+
+    Bounded by the PR's ``closed_at``/``merged_at`` (whichever is set): between
+    ``JUDGE_REAP_STUCK_AFTER`` and ``JUDGE_REAP_LOOKBACK`` ago. Too-recent PRs may
+    still be legitimately in flight to Seer; anything past the lookback is left
+    alone rather than resolved long after the fact.
+
+    A row with neither timestamp set was reopened after being claimed for judge
+    (see ``run_deferred_emission``'s reopen handling) — there's nothing to settle,
+    so its sentinel is released instead of resolved.
+    """
+    now = timezone.now()
+    stale_cutoff = now - JUDGE_REAP_STUCK_AFTER
+    lookback_cutoff = now - JUDGE_REAP_LOOKBACK
+
+    stuck_rows = (
+        PullRequestMetrics.objects.filter(verdict=PullRequestVerdict.JUDGE_IN_PROGRESS)
+        .filter(
+            Q(pull_request__closed_at__isnull=True, pull_request__merged_at__isnull=True)
+            | Q(
+                pull_request__closed_at__lte=stale_cutoff,
+                pull_request__closed_at__gte=lookback_cutoff,
+            )
+            | Q(
+                pull_request__merged_at__lte=stale_cutoff,
+                pull_request__merged_at__gte=lookback_cutoff,
+            )
+        )
+        .select_related("pull_request")
+        .order_by("id")[:_REAP_BATCH_SIZE]
+    )
+
+    for metrics_row in stuck_rows:
+        pull_request = metrics_row.pull_request
+        if pull_request.closed_at is None and pull_request.merged_at is None:
+            _release_reopened_judge_claim(pull_request)
+        else:
+            _settle_stuck_judge_claim(pull_request)
+
+
+def _release_reopened_judge_claim(pull_request: PullRequest) -> None:
+    """Release a stuck sentinel on a PR reopened after being claimed for judge.
+
+    Mirrors ``run_deferred_emission``'s reopen handling: the PR is no longer
+    terminal, so there's nothing to settle here — release the guard so a later
+    re-close can re-claim and re-forward rather than finding the row stuck.
+    """
+    released = PullRequestMetrics.objects.filter(
+        pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
+    ).update(verdict=None)
+    if not released:
+        return
+    metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "reopened"})
+    logger.info(
+        "pr_metrics.judge.reaper.released",
+        extra={
+            "organization_id": pull_request.organization_id,
+            "repository_id": pull_request.repository_id,
+            "pull_request_id": pull_request.id,
+        },
+    )
+
+
+def _settle_stuck_judge_claim(pull_request: PullRequest) -> None:
+    """Settle a stuck judge forward via the same fallback used for ineligible attribution.
+
+    Guarded against a race with a very-late Seer callback landing at the same
+    time: a compare-and-set off ``JUDGE_IN_PROGRESS`` inside a transaction, so
+    whichever settles first wins and the other is a no-op.
+    """
+    verdict = select_fallback_verdict(pull_request)
+    log_extra = {
+        "organization_id": pull_request.organization_id,
+        "repository_id": pull_request.repository_id,
+        "pull_request_id": pull_request.id,
+        "verdict": verdict,
+    }
+    with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
+        settled = PullRequestMetrics.objects.filter(
+            pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
+        ).update(verdict=verdict)
+        if not settled:
+            metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
+            return
+
+    emit_pr_metrics_row(pull_request=pull_request)
+    metrics.incr("pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict})
+    logger.info("pr_metrics.judge.reaper.fallback_emitted", extra=log_extra)

--- a/src/sentry/pr_metrics/judge.py
+++ b/src/sentry/pr_metrics/judge.py
@@ -42,10 +42,9 @@ from sentry.pr_metrics.contracts import (
     PrConversationAnalysis,
 )
 from sentry.pr_metrics.emit import (
-    CI_FAILING_AT_CLOSE,
     VerdictDeferral,
     active_attributions,
-    ci_failing_at_close,
+    calculate_deterministic_diagnosis_labels,
     emit_pr_metrics_row,
     select_fallback_verdict,
     select_verdict,
@@ -427,38 +426,30 @@ def update_pr_metrics(
 # other path back to a terminal verdict, so reap_stuck_judge_verdicts is the only
 # thing that ever resolves those rows; run daily by reap_stuck_judge_verdicts_task.
 JUDGE_REAP_STUCK_AFTER = timedelta(hours=4)
-JUDGE_REAP_LOOKBACK = timedelta(days=7)
 _REAP_BATCH_SIZE = 500
 
 
 def reap_stuck_judge_verdicts() -> None:
     """Settle ``PullRequestMetrics`` rows stuck at ``JUDGE_IN_PROGRESS``.
 
-    Bounded by the PR's ``closed_at``/``merged_at`` (whichever is set): between
-    ``JUDGE_REAP_STUCK_AFTER`` and ``JUDGE_REAP_LOOKBACK`` ago. Too-recent PRs may
-    still be legitimately in flight to Seer; anything past the lookback is left
-    alone rather than resolved long after the fact.
+    Bounded below by the PR's ``closed_at``/``merged_at`` (whichever is set) being
+    at least ``JUDGE_REAP_STUCK_AFTER`` ago — too-recent PRs may still be
+    legitimately in flight to Seer. No upper bound: a row that fell behind (task
+    outage, a backlog bigger than ``_REAP_BATCH_SIZE`` per run) still gets reaped
+    on a later run rather than aging out and staying stuck forever.
 
     A row with neither timestamp set was reopened after being claimed for judge
     (see ``run_deferred_emission``'s reopen handling) — there's nothing to settle,
     so its sentinel is released instead of resolved.
     """
-    now = timezone.now()
-    stale_cutoff = now - JUDGE_REAP_STUCK_AFTER
-    lookback_cutoff = now - JUDGE_REAP_LOOKBACK
+    stale_cutoff = timezone.now() - JUDGE_REAP_STUCK_AFTER
 
     stuck_rows = (
         PullRequestMetrics.objects.filter(verdict=PullRequestVerdict.JUDGE_IN_PROGRESS)
         .filter(
             Q(pull_request__closed_at__isnull=True, pull_request__merged_at__isnull=True)
-            | Q(
-                pull_request__closed_at__lte=stale_cutoff,
-                pull_request__closed_at__gte=lookback_cutoff,
-            )
-            | Q(
-                pull_request__merged_at__lte=stale_cutoff,
-                pull_request__merged_at__gte=lookback_cutoff,
-            )
+            | Q(pull_request__closed_at__lte=stale_cutoff)
+            | Q(pull_request__merged_at__lte=stale_cutoff)
         )
         .select_related("pull_request")
         .order_by("id")[:_REAP_BATCH_SIZE]
@@ -472,6 +463,22 @@ def reap_stuck_judge_verdicts() -> None:
             _reconcile_stuck_judge_claim(pull_request)
 
 
+def _release_judge_sentinel(pull_request: PullRequest) -> bool:
+    """Compare-and-set the ``JUDGE_IN_PROGRESS`` sentinel back to null.
+
+    Shared by both reaper release paths (reopened PR, indeterminate
+    reconciliation). Guarded against a race with a very-late Seer callback
+    settling the row first: the CAS is off ``JUDGE_IN_PROGRESS`` specifically,
+    so whichever settles first wins and the other is a no-op. Returns whether
+    this call won the release.
+    """
+    return bool(
+        PullRequestMetrics.objects.filter(
+            pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
+        ).update(verdict=None)
+    )
+
+
 def _release_reopened_judge_claim(pull_request: PullRequest) -> None:
     """Release a stuck sentinel on a PR reopened after being claimed for judge.
 
@@ -479,14 +486,39 @@ def _release_reopened_judge_claim(pull_request: PullRequest) -> None:
     terminal, so there's nothing to settle here — release the guard so a later
     re-close can re-claim and re-forward rather than finding the row stuck.
     """
-    released = PullRequestMetrics.objects.filter(
-        pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
-    ).update(verdict=None)
-    if not released:
+    if not _release_judge_sentinel(pull_request):
+        metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
         return
     metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "reopened"})
     logger.info(
         "pr_metrics.judge.reaper.released",
+        extra={
+            "organization_id": pull_request.organization_id,
+            "repository_id": pull_request.repository_id,
+            "pull_request_id": pull_request.id,
+        },
+    )
+
+
+def _release_indeterminate_judge_claim(pull_request: PullRequest) -> None:
+    """Release a stuck sentinel with no reliable local signal to settle from.
+
+    ``select_verdict`` deferred ``INDETERMINATE`` — typically activity tracking
+    was off for this org — so there's no reliable local signal to settle a
+    verdict from, and ``select_fallback_verdict`` would silently misread
+    "untracked" as "no commits after open". Rather than emit a null-verdict row
+    (which would leave ``verdict IS NULL`` on the row — the same state
+    ``update_pr_metrics`` treats as "never claimed" — open for a subsequent
+    genuine Seer callback to emit a second row for the same PR), the sentinel
+    is released and nothing is emitted: the same outcome as the judge-ineligible
+    ``INDETERMINATE`` path, which also never emits.
+    """
+    if not _release_judge_sentinel(pull_request):
+        metrics.incr("pr_metrics.judge.reaper.skipped", tags={"reason": "already_settled"})
+        return
+    metrics.incr("pr_metrics.judge.reaper.released", tags={"reason": "indeterminate"})
+    logger.warning(
+        "pr_metrics.judge.reaper.indeterminate",
         extra={
             "organization_id": pull_request.organization_id,
             "repository_id": pull_request.repository_id,
@@ -508,11 +540,9 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
     * ``NEEDS_JUDGE`` falls back to ``select_fallback_verdict``, exactly as the
       ineligible-attribution path already does — safe here because real
       push-activity data backs it.
-    * ``INDETERMINATE`` means there's no reliable local signal at all (typically
-      activity tracking was off for this org) — calling ``select_fallback_verdict``
-      here would silently misread "untracked" as "no commits after open". Instead
-      the sentinel is released to null and the row still emits, carrying an
-      explicit null verdict rather than silently dropping the PR from the table.
+    * ``INDETERMINATE`` has no reliable local signal to settle from at all —
+      see ``_release_indeterminate_judge_claim``, which releases the sentinel
+      without emitting rather than risk a duplicate row.
 
     Guarded against a race with a very-late Seer callback landing at the same
     time: a compare-and-set off ``JUDGE_IN_PROGRESS`` inside a transaction, so
@@ -525,12 +555,13 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
         return
 
     outcome = select_verdict(pull_request, organization)
-    if not isinstance(outcome, VerdictDeferral):
-        verdict: PullRequestVerdict | None = outcome
-    elif outcome is VerdictDeferral.NEEDS_JUDGE:
+    if isinstance(outcome, VerdictDeferral):
+        if outcome is not VerdictDeferral.NEEDS_JUDGE:
+            _release_indeterminate_judge_claim(pull_request)
+            return
         verdict = select_fallback_verdict(pull_request)
     else:
-        verdict = None
+        verdict = outcome
 
     log_extra = {
         "organization_id": pull_request.organization_id,
@@ -538,11 +569,7 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
         "pull_request_id": pull_request.id,
         "verdict": verdict,
     }
-    diagnosis_labels = (
-        [CI_FAILING_AT_CLOSE]
-        if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request)
-        else None
-    )
+    diagnosis_labels = calculate_deterministic_diagnosis_labels(pull_request, verdict)
     with transaction.atomic(using=router.db_for_write(PullRequestMetrics)):
         settled = PullRequestMetrics.objects.filter(
             pull_request=pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
@@ -552,5 +579,5 @@ def _reconcile_stuck_judge_claim(pull_request: PullRequest) -> None:
             return
 
     emit_pr_metrics_row(pull_request=pull_request, diagnosis_labels=diagnosis_labels)
-    metrics.incr("pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict or "none"})
+    metrics.incr("pr_metrics.judge.reaper.fallback_emitted", tags={"verdict": verdict})
     logger.info("pr_metrics.judge.reaper.fallback_emitted", extra=log_extra)

--- a/src/sentry/pr_metrics/tasks.py
+++ b/src/sentry/pr_metrics/tasks.py
@@ -17,7 +17,7 @@ from sentry.models.pullrequest import (
     PullRequestVerdict,
 )
 from sentry.models.repository import Repository
-from sentry.pr_metrics.judge import forward_pr_to_seer_judge
+from sentry.pr_metrics.judge import forward_pr_to_seer_judge, reap_stuck_judge_verdicts
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_code_review_tasks
@@ -156,3 +156,16 @@ def cleanup_pr_activity_task(*, pull_request_id: int) -> None:
     logger.info("pr_metrics.cleanup_activity", extra={"pull_request_id": pull_request_id})
     deleted, _ = PullRequestActivity.objects.filter(pull_request_id=pull_request_id).delete()
     metrics.incr("pr_metrics.cleanup_activity.deleted", amount=deleted)
+
+
+@instrumented_task(
+    name="sentry.pr_metrics.tasks.reap_stuck_judge_verdicts",
+    namespace=seer_code_review_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def reap_stuck_judge_verdicts_task() -> None:
+    """Daily sweep settling ``PullRequestMetrics`` rows stuck at ``JUDGE_IN_PROGRESS``.
+
+    See ``reap_stuck_judge_verdicts`` for the settling logic and its bounds.
+    """
+    reap_stuck_judge_verdicts()

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -78,9 +78,8 @@ from sentry.pr_metrics.attribution import (
     record_attribution_signal,
 )
 from sentry.pr_metrics.emit import (
-    CI_FAILING_AT_CLOSE,
     VerdictDeferral,
-    ci_failing_at_close,
+    calculate_deterministic_diagnosis_labels,
     emit_pr_metrics_row,
     is_pr_tracked,
     select_fallback_verdict,
@@ -500,15 +499,7 @@ def _claim_and_emit(
         metrics.incr("pr_metrics.emit.skipped", tags={"reason": "redelivery"})
         return
 
-    # Sentry can derive this one diagnosis label itself, without a judge: a plain
-    # close (no merge, no engagement) whose check suites were red at close. Scoped
-    # to CLOSED_UNMERGED specifically — the judge-needed and merged paths don't
-    # carry this deterministic signal.
-    diagnosis_labels = (
-        [CI_FAILING_AT_CLOSE]
-        if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request)
-        else None
-    )
+    diagnosis_labels = calculate_deterministic_diagnosis_labels(pull_request, verdict)
 
     # Claim before emit so build_pr_metrics_row reads the verdict back onto the row.
     # analytics.record is best-effort, async-batched telemetry; if it raises the

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -19,7 +19,9 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.attribution import record_attribution_signal
 from sentry.pr_metrics.judge import (
     _MAX_FORWARDED_CHECK_ROWS,
+    _settle_stuck_judge_claim,
     forward_pr_to_seer_judge,
+    reap_stuck_judge_verdicts,
     update_pr_metrics,
 )
 from sentry.seer.sentry_data_models import (
@@ -439,6 +441,137 @@ class UpdatePrMetricsTest(TestCase):
             "merged_unchanged"
         )
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+
+@cell_silo_test
+class ReapStuckJudgeVerdictsTest(TestCase):
+    def setUp(self) -> None:
+        self.repo = self.create_repo(
+            self.project, name="getsentry/sentry", provider="integrations:github"
+        )
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+        self.pull_request.update(head_commit_sha=HEAD_SHA)
+        record_attribution_signal(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+        )
+
+    def _stick(
+        self, *, closed_at: datetime | None = None, merged_at: datetime | None = None
+    ) -> None:
+        self.pull_request.update(closed_at=closed_at, merged_at=merged_at)
+        PullRequestMetrics.objects.create(
+            pull_request=self.pull_request, verdict=PullRequestVerdict.JUDGE_IN_PROGRESS
+        )
+
+    @patch("sentry.analytics.record")
+    def test_settles_stuck_merged_pr_unchanged(self, mock_record: Any) -> None:
+        # GitHub sets both closed_at and merged_at on a merge.
+        merged_at = datetime.now(timezone.utc) - timedelta(hours=5)
+        self._stick(closed_at=merged_at, merged_at=merged_at)
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch("sentry.analytics.record")
+    def test_settles_stuck_merged_pr_with_iteration(self, mock_record: Any) -> None:
+        merged_at = datetime.now(timezone.utc) - timedelta(hours=5)
+        self._stick(closed_at=merged_at, merged_at=merged_at)
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="delivery-1",
+            event_type=PullRequestActivityType.SYNCHRONIZED,
+            payload={},
+        )
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_with_iteration"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch("sentry.analytics.record")
+    def test_settles_stuck_closed_unmerged_pr(self, mock_record: Any) -> None:
+        self._stick(closed_at=datetime.now(timezone.utc) - timedelta(hours=5))
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "closed_unmerged"
+        )
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+
+    @patch("sentry.analytics.record")
+    def test_leaves_recently_stuck_pr_alone(self, mock_record: Any) -> None:
+        # Within JUDGE_REAP_STUCK_AFTER: may still be legitimately in flight to Seer.
+        self._stick(closed_at=datetime.now(timezone.utc) - timedelta(hours=1))
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "judge_in_progress"
+        )
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_leaves_pr_stuck_past_lookback_alone(self, mock_record: Any) -> None:
+        # Past JUDGE_REAP_LOOKBACK: left alone rather than resolved long after the fact.
+        self._stick(closed_at=datetime.now(timezone.utc) - timedelta(days=10))
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "judge_in_progress"
+        )
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_releases_sentinel_for_reopened_pr(self, mock_record: Any) -> None:
+        # closed_at/merged_at both null: the PR was reopened after being claimed.
+        self._stick()
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_does_not_touch_rows_with_other_verdicts(self, mock_record: Any) -> None:
+        self.pull_request.update(closed_at=datetime.now(timezone.utc) - timedelta(hours=5))
+        PullRequestMetrics.objects.create(
+            pull_request=self.pull_request, verdict=PullRequestVerdict.MERGED_UNCHANGED
+        )
+
+        reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
+        assert mock_record.call_count == 0
+
+    @patch("sentry.analytics.record")
+    def test_settle_is_a_no_op_if_already_settled_concurrently(self, mock_record: Any) -> None:
+        # A very-late Seer callback landing first: the row is no longer
+        # JUDGE_IN_PROGRESS by the time the reaper's compare-and-set runs.
+        self.pull_request.update(closed_at=datetime.now(timezone.utc) - timedelta(hours=5))
+        PullRequestMetrics.objects.create(
+            pull_request=self.pull_request, verdict=PullRequestVerdict.MERGED_UNCHANGED
+        )
+
+        _settle_stuck_judge_claim(self.pull_request)
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
+            "merged_unchanged"
+        )
+        assert mock_record.call_count == 0
 
 
 @cell_silo_test

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -512,19 +512,20 @@ class ReapStuckJudgeVerdictsTest(TestCase):
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
 
     @patch("sentry.analytics.record")
-    def test_settles_to_null_verdict_when_indeterminate(self, mock_record: Any) -> None:
+    def test_releases_without_emitting_when_indeterminate(self, mock_record: Any) -> None:
         # Activity tracking off for this org: select_verdict can't tell whether
         # there were commits after open, so select_fallback_verdict would risk
-        # misreading "untracked" as "no commits after open". The row settles to
-        # an explicit null verdict instead of a guessed one.
+        # misreading "untracked" as "no commits after open". Rather than emit a
+        # null-verdict row (which would leave the door open, via verdict IS NULL,
+        # for a later genuine Seer callback to emit a second row), the sentinel
+        # is released and nothing is emitted.
         self._stick(closed_at=datetime.now(timezone.utc) - timedelta(hours=5))
 
         with self.feature({"organizations:pr-metrics-activity": False}):
             reap_stuck_judge_verdicts()
 
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
-        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
-        assert _last_row(mock_record).verdict is None
+        assert mock_record.call_count == 0
 
     @patch("sentry.analytics.record")
     def test_leaves_recently_stuck_pr_alone(self, mock_record: Any) -> None:
@@ -539,16 +540,17 @@ class ReapStuckJudgeVerdictsTest(TestCase):
         assert mock_record.call_count == 0
 
     @patch("sentry.analytics.record")
-    def test_leaves_pr_stuck_past_lookback_alone(self, mock_record: Any) -> None:
-        # Past JUDGE_REAP_LOOKBACK: left alone rather than resolved long after the fact.
+    def test_settles_pr_stuck_long_past_stale_cutoff(self, mock_record: Any) -> None:
+        # No upper bound: a row that fell behind (task outage, an oversized
+        # backlog) still gets reaped rather than aging out and staying stuck.
         self._stick(closed_at=datetime.now(timezone.utc) - timedelta(days=10))
 
         reap_stuck_judge_verdicts()
 
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
-            "judge_in_progress"
+            "closed_unmerged"
         )
-        assert mock_record.call_count == 0
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
 
     @patch("sentry.analytics.record")
     def test_releases_sentinel_for_reopened_pr(self, mock_record: Any) -> None:

--- a/tests/sentry/pr_metrics/test_judge.py
+++ b/tests/sentry/pr_metrics/test_judge.py
@@ -19,7 +19,7 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.attribution import record_attribution_signal
 from sentry.pr_metrics.judge import (
     _MAX_FORWARDED_CHECK_ROWS,
-    _settle_stuck_judge_claim,
+    _reconcile_stuck_judge_claim,
     forward_pr_to_seer_judge,
     reap_stuck_judge_verdicts,
     update_pr_metrics,
@@ -29,6 +29,7 @@ from sentry.seer.sentry_data_models import (
     UpdatePrMetricsSuccessResponse,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import get_event_count
 from sentry.testutils.silo import cell_silo_test
 
@@ -444,6 +445,7 @@ class UpdatePrMetricsTest(TestCase):
 
 
 @cell_silo_test
+@with_feature("organizations:pr-metrics-activity")
 class ReapStuckJudgeVerdictsTest(TestCase):
     def setUp(self) -> None:
         self.repo = self.create_repo(
@@ -510,6 +512,21 @@ class ReapStuckJudgeVerdictsTest(TestCase):
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
 
     @patch("sentry.analytics.record")
+    def test_settles_to_null_verdict_when_indeterminate(self, mock_record: Any) -> None:
+        # Activity tracking off for this org: select_verdict can't tell whether
+        # there were commits after open, so select_fallback_verdict would risk
+        # misreading "untracked" as "no commits after open". The row settles to
+        # an explicit null verdict instead of a guessed one.
+        self._stick(closed_at=datetime.now(timezone.utc) - timedelta(hours=5))
+
+        with self.feature({"organizations:pr-metrics-activity": False}):
+            reap_stuck_judge_verdicts()
+
+        assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict is None
+        assert get_event_count(mock_record, PrCloseMetricsEvent) == 1
+        assert _last_row(mock_record).verdict is None
+
+    @patch("sentry.analytics.record")
     def test_leaves_recently_stuck_pr_alone(self, mock_record: Any) -> None:
         # Within JUDGE_REAP_STUCK_AFTER: may still be legitimately in flight to Seer.
         self._stick(closed_at=datetime.now(timezone.utc) - timedelta(hours=1))
@@ -566,7 +583,7 @@ class ReapStuckJudgeVerdictsTest(TestCase):
             pull_request=self.pull_request, verdict=PullRequestVerdict.MERGED_UNCHANGED
         )
 
-        _settle_stuck_judge_claim(self.pull_request)
+        _reconcile_stuck_judge_claim(self.pull_request)
 
         assert PullRequestMetrics.objects.get(pull_request=self.pull_request).verdict == (
             "merged_unchanged"

--- a/tests/sentry/pr_metrics/test_tasks.py
+++ b/tests/sentry/pr_metrics/test_tasks.py
@@ -1,7 +1,7 @@
 from typing import Any
 from unittest.mock import patch
 
-from sentry.pr_metrics.tasks import forward_pr_to_seer_task
+from sentry.pr_metrics.tasks import forward_pr_to_seer_task, reap_stuck_judge_verdicts_task
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -107,3 +107,11 @@ class CleanupPrActivityTaskTest(TestCase):
 
         assert not PullRequestActivity.objects.filter(pull_request=self.pull_request).exists()
         assert PullRequestActivity.objects.filter(pull_request=other_pr).exists()
+
+
+@cell_silo_test
+class ReapStuckJudgeVerdictsTaskTest(TestCase):
+    @patch("sentry.pr_metrics.tasks.reap_stuck_judge_verdicts")
+    def test_delegates_to_reaper(self, mock_reap: Any) -> None:
+        reap_stuck_judge_verdicts_task()
+        mock_reap.assert_called_once_with()


### PR DESCRIPTION
Add a daily cron task that reconciles `PullRequestMetrics` rows left claimed at
`JUDGE_IN_PROGRESS` indefinitely. 

`reap_stuck_judge_verdicts` finds rows stuck at `JUDGE_IN_PROGRESS` where the
PR's `closed_at`/`merged_at` (whichever is set) is between 4 hours and 7 days
in the past, and reconciles each one:

- Re-runs `select_verdict` against current data. A deterministic result
  settles directly; `NEEDS_JUDGE` falls back to the same heuristic already
  used for judge-ineligible attribution (`select_fallback_verdict`);
  `INDETERMINATE` (no reliable local signal, typically because activity
  tracking was off) releases the sentinel and still emits, carrying an
  explicit null verdict rather than a guessed one. The original deferral
  reason isn't persisted anywhere, so the reaper can't just replay the first
  decision — it has to re-derive it.
- A row whose PR has neither `closed_at` nor `merged_at` set was reopened
  after being claimed for judge — there's nothing to settle, so its sentinel
  is released instead, letting a later re-close re-claim and re-forward it.

The compare-and-set that claims a row is guarded against a race with a
very-late Seer callback, matching the existing guard in `update_pr_metrics`.

The 4h/7d bounds and 500-row batch size are plain module constants rather than
options, matching this module's existing constants (e.g.
`_MAX_FORWARDED_CHECK_ROWS`).