### PR TITLE
ref(native): Remove compatibility code

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -645,25 +645,6 @@ def get_native_symbolication_functions(
     return functions
 
 
-def get_native_symbolication_function(
-    data: Mapping[str, Any], stacktraces: list[StacktraceInfo]
-) -> SymbolicatorFunction | None:
-    """
-    Returns the appropriate symbolication function (or `None`) that will process
-    the event, based on the Event `data`, and the supplied `stacktraces`.
-
-    This is a **legacy** function used for old tasks.
-    """
-    if is_minidump_event(data):
-        return SymbolicatorFunction.minidump
-    elif is_applecrashreport_event(data):
-        return SymbolicatorFunction.applecrashreport
-    elif is_native_event(data, stacktraces):
-        return SymbolicatorFunction.native
-    else:
-        return None
-
-
 def get_required_attachment_types(data) -> set[str]:
     if is_minidump_event(data):
         return {MINIDUMP_ATTACHMENT_TYPE}

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -50,20 +50,6 @@ class SymbolicatorFunction(Enum):
     def __call__(self, symbolicator: Symbolicator, data: Any) -> Any:
         return self.function()(symbolicator, data)
 
-    def platform_name(self) -> str:
-        """Lossy conversion to a legacy platform"""
-        match self:
-            case SymbolicatorFunction.native:
-                return "native"
-            case SymbolicatorFunction.js:
-                return "js"
-            case SymbolicatorFunction.jvm:
-                return "jvm"
-            case SymbolicatorFunction.minidump:
-                return "native"
-            case SymbolicatorFunction.applecrashreport:
-                return "native"
-
     def function(self) -> Callable[[Symbolicator, Any], Any]:
         from sentry.lang.java.processing import process_jvm_stacktraces
         from sentry.lang.javascript.processing import process_js_stacktraces

--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -8,7 +8,6 @@ from django.conf import settings
 
 from sentry.killswitches import killswitch_matches_context
 from sentry.lang.native.processing import (
-    get_native_symbolication_function,
     get_native_symbolication_functions,
 )
 from sentry.lang.native.symbolicator import (
@@ -21,7 +20,7 @@ from sentry.models.project import Project
 from sentry.services.eventstore import processing
 from sentry.services.eventstore.processing.base import Event
 from sentry.silo.base import SiloMode
-from sentry.stacktraces.processing import StacktraceInfo, find_stacktraces_in_data
+from sentry.stacktraces.processing import StacktraceInfo
 from sentry.tasks import store
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import symbolication_tasks
@@ -31,20 +30,6 @@ from sentry.utils.tracing import set_span_data, start_span
 
 error_logger = logging.getLogger("sentry.errors.events")
 info_logger = logging.getLogger("sentry.symbolication")
-
-
-def derive_native_function(
-    data: Mapping[str, Any],
-    stacktraces: list[StacktraceInfo],
-) -> SymbolicatorFunction:
-    """Returns the symbolication function for a native event based on
-    and event data. This is a **legacy** function used for old tasks."""
-
-    symbolication_function = get_native_symbolication_function(data, stacktraces)
-    # get_native_symbolication_function already returned something in
-    # get_symbolication_platforms
-    assert symbolication_function is not None
-    return symbolication_function
 
 
 def get_symbolication_functions(
@@ -80,7 +65,6 @@ def _do_symbolicate_event(
     event_id: str | None,
     data: Event | None = None,
     has_attachments: bool = False,
-    derive_native: bool = False,
     symbolicate_functions: list[SymbolicatorFunction] | None = None,
 ) -> None:
     if data is None:
@@ -127,16 +111,7 @@ def _do_symbolicate_event(
             has_attachments=has_attachments,
         )
 
-    if derive_native:
-        # Happens when a new task worker picks up an old task.
-        try:
-            stacktraces = find_stacktraces_in_data(data)
-            symbolication_function = derive_native_function(data, stacktraces)
-        except AssertionError:
-            symbolication_function = None
-    else:
-        # New behavior
-        symbolication_function = task_kind.function
+    symbolication_function = task_kind.function
     symbolication_function_name = (
         None
         if symbolication_function is None
@@ -265,19 +240,12 @@ def submit_symbolicate(
     symbolicate_function_names = (
         None if symbolicate_functions is None else [p.name for p in symbolicate_functions]
     )
-    # Keep platform names around as well, just in case an old worker picks up the task.
-    symbolicate_platform_names = (
-        None
-        if symbolicate_functions is None
-        else [p.platform_name() for p in symbolicate_functions]
-    )
 
     task_fn.delay(
         cache_key=cache_key,
         start_time=start_time,
         event_id=event_id,
         has_attachments=has_attachments,
-        symbolicate_platforms=symbolicate_platform_names,
         symbolicate_functions=symbolicate_function_names,
     )
 
@@ -305,7 +273,6 @@ def make_task_fn(name: str, queue: str, task_kind: SymbolicatorTaskKind) -> Symb
         event_id: str | None = None,
         data: Event | None = None,
         has_attachments: bool = False,
-        symbolicate_platforms: list[str] | None = None,  # legacy
         symbolicate_functions: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -318,21 +285,12 @@ def make_task_fn(name: str, queue: str, task_kind: SymbolicatorTaskKind) -> Symb
         """
 
         symbolicate_function_values: list[SymbolicatorFunction] | None = None
-        derive_native = False
         if symbolicate_functions is not None:
             # Turn symbolicate_functions back into proper enum values
             symbolicate_function_values = (
                 None
                 if symbolicate_functions is None
                 else [SymbolicatorFunction(p) for p in symbolicate_functions]
-            )
-        elif symbolicate_platforms is not None:
-            # [legacy] Turn symbolicate_platforms back into the next best function
-            derive_native = task_kind.function == SymbolicatorFunction.native
-            symbolicate_function_values = (
-                None
-                if symbolicate_platforms is None
-                else [SymbolicatorFunction(p) for p in symbolicate_platforms]
             )
 
         return _do_symbolicate_event(
@@ -342,7 +300,6 @@ def make_task_fn(name: str, queue: str, task_kind: SymbolicatorTaskKind) -> Symb
             event_id=event_id,
             data=data,
             has_attachments=has_attachments,
-            derive_native=derive_native,
             symbolicate_functions=symbolicate_function_values,
         )
 

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -5,7 +5,7 @@ import pytest
 
 from sentry.lang.native.symbolicator import Symbolicator, SymbolicatorFunction
 from sentry.tasks.store import preprocess_event
-from sentry.tasks.symbolication import symbolicate_event, symbolicate_js_event
+from sentry.tasks.symbolication import symbolicate_event
 from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -229,59 +229,3 @@ def test_symbolicate_minidump_and_native_stacktrace(
     native_frames = exceptions[1]["stacktrace"]["frames"]
     assert [f["function"] for f in native_frames] == ["worker_thread"]
     assert [f["data"]["symbolicator_status"] for f in native_frames] == ["symbolicated"]
-
-
-@django_db_all
-def test_symbolicate_event_with_legacy_symbolicate_platforms(
-    default_project,
-    mock_event_processing_store,
-    mock_process_event,
-    mock_save_event,
-):
-    """
-    Tasks that were enqueued before the switch from `symbolicate_platforms` to
-    `symbolicate_functions` still carry the legacy `symbolicate_platforms`
-    kwarg (a list of `SymbolicatorPlatform` names). Such in-flight tasks must
-    still run through all remaining symbolication rounds and hand the event
-    over to processing.
-    """
-    data = {
-        "platform": "javascript",
-        "project": default_project.id,
-        "event_id": EVENT_ID,
-        "exception": {
-            "values": [
-                {"stacktrace": {"frames": [{"platform": "native", "instruction_addr": "0x2a2a3d"}]}}
-            ]
-        },
-    }
-    mock_event_processing_store.get.return_value = data
-
-    # `autospec=True` so that the enum member itself is recorded as the first
-    # call argument.
-    with (
-        mock.patch.object(
-            SymbolicatorFunction, "__call__", autospec=True, return_value=None
-        ) as mock_symbolication_function,
-        TaskRunner(),
-    ):
-        # An event with both a JS and a native stacktrace was submitted by the
-        # old code: the js platform was popped and submitted to
-        # `symbolicate_js_event`, with the native platform remaining in
-        # `symbolicate_platforms`.
-        symbolicate_js_event.delay(
-            cache_key="e:1",
-            start_time=1,
-            event_id=EVENT_ID,
-            symbolicate_platforms=["native"],
-        )
-
-    # Both symbolication rounds ran: js first, then the remaining native round.
-    invoked_functions = [call.args[0] for call in mock_symbolication_function.call_args_list]
-    assert invoked_functions == [SymbolicatorFunction.js, SymbolicatorFunction.native]
-
-    # The event was never flagged with a processing error and moved on to
-    # processing.
-    assert mock_event_processing_store.store.call_count == 0
-    assert mock_process_event.delay.call_count == 1
-    assert mock_save_event.delay.call_count == 0


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/119780: Some compatibility code was necessary for forward and backward compatibility during the transition. It can now be removed.

ref: RELAY-256