### PR TITLE
feat(ourlogs): clarify rate limit error (429) message

### DIFF
--- a/src/sentry/web/frontend/signup_email_verification.py
+++ b/src/sentry/web/frontend/signup_email_verification.py
@@ -65,14 +65,14 @@ class BaseSignupVerificationView(BaseView):
         if ratelimiter.backend.is_limited(f"signup-verify:ip:{ip_address}", limit=5, window=60):
             return self._render_error(
                 title="Too many attempts",
-                message="Please wait a few minutes and try again.",
+                message="Please wait a moment and try again.",
             )
         if ratelimiter.backend.is_limited(
             f"signup-verify:ip:daily:{ip_address}", limit=50, window=86400
         ):
             return self._render_error(
                 title="Too many attempts",
-                message="Please wait a few minutes and try again.",
+                message="Please wait a moment and try again.",
             )
 
         try:

--- a/src/sentry/web/frontend/signup_email_verification.py
+++ b/src/sentry/web/frontend/signup_email_verification.py
@@ -65,14 +65,14 @@ class BaseSignupVerificationView(BaseView):
         if ratelimiter.backend.is_limited(f"signup-verify:ip:{ip_address}", limit=5, window=60):
             return self._render_error(
                 title="Too many attempts",
-                message="Please wait a moment and try again.",
+                message="Please wait a few minutes and try again.",
             )
         if ratelimiter.backend.is_limited(
             f"signup-verify:ip:daily:{ip_address}", limit=50, window=86400
         ):
             return self._render_error(
                 title="Too many attempts",
-                message="Please wait a moment and try again.",
+                message="Please wait a few minutes and try again.",
             )
 
         try:

--- a/static/app/components/replays/alerts/replayRequestsThrottledAlert.tsx
+++ b/static/app/components/replays/alerts/replayRequestsThrottledAlert.tsx
@@ -7,7 +7,7 @@ export function ReplayRequestsThrottledAlert() {
     <Alert.Container>
       <Alert variant="info" data-test-id="replay-throttled">
         {t(
-          'API requests have been temporarily rate-limited. Please wait a moment and try again.'
+          'API requests have been temporarily rate-limited. Please wait a few minutes and try again.'
         )}
       </Alert>
     </Alert.Container>

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -7,7 +7,7 @@ import {ReplayRequestsThrottledAlert} from 'sentry/components/replays/alerts/rep
 import {ReplayProcessingError} from 'sentry/components/replays/replayProcessingError';
 import type {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
 import type {ReplayReader} from 'sentry/utils/replays/replayReader';
-import {RequestError} from 'sentry/utils/requestError/requestError';
+import {isRateLimitError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 type ReplayReaderResult = ReturnType<typeof useLoadReplayReader>;
@@ -34,11 +34,8 @@ export function ReplayLoadingState({
   const organization = useOrganization();
 
   const throttledErrorExists =
-    (readerResult.fetchError instanceof RequestError &&
-      readerResult.fetchError.status === 429) ||
-    readerResult.attachmentError?.find(
-      error => error instanceof RequestError && error.status === 429
-    );
+    isRateLimitError(readerResult.fetchError) ||
+    readerResult.attachmentError?.find(isRateLimitError);
 
   if (throttledErrorExists) {
     return renderThrottled ? (

--- a/static/app/utils/requestError/getRequestErrorUserMessage.spec.tsx
+++ b/static/app/utils/requestError/getRequestErrorUserMessage.spec.tsx
@@ -25,7 +25,7 @@ describe('getRequestErrorUserMessage', () => {
       status: 429,
     } as ResponseMeta);
     expect(getRequestErrorUserMessage(err)).toBe(
-      'API requests have been temporarily rate-limited. Please wait a moment and try again.'
+      'API requests have been temporarily rate-limited. Please wait a few minutes and try again.'
     );
   });
 

--- a/static/app/utils/requestError/getRequestErrorUserMessage.tsx
+++ b/static/app/utils/requestError/getRequestErrorUserMessage.tsx
@@ -33,7 +33,7 @@ export function getRequestErrorUserMessage(
   switch (err.status) {
     case 429:
       return t(
-        'API requests have been temporarily rate-limited. Please wait a moment and try again.'
+        'API requests have been temporarily rate-limited. Please wait a few minutes and try again.'
       );
     case 401:
       return t('Authentication is required to load this data.');

--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -94,3 +94,11 @@ export class RequestError extends Error {
     }
   }
 }
+
+export interface RateLimitError extends RequestError {
+  status: 429;
+}
+
+export function isRateLimitError(error: unknown): error is RateLimitError {
+  return error instanceof RequestError && error.status === 429;
+}

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -138,7 +138,7 @@ describe('LogsAggregateTable', () => {
 
     expect(
       screen.getByText(
-        'Your organization has had a lot of activity. Please wait a moment and then try again.'
+        'Your organization has had a lot of activity. Wait a few seconds and then try again.'
       )
     ).toBeInTheDocument();
     expect(screen.queryByLabelText('Aggregates')).not.toBeInTheDocument();

--- a/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.spec.tsx
@@ -121,6 +121,33 @@ describe('LogsAggregateTable', () => {
     expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
   });
 
+  it('renders a rate limit message and retry button when rate limited', async () => {
+    const rateLimitError = new RequestError('GET', '/', new Error('rate limited'));
+    rateLimitError.status = 429;
+    const refetch = jest.fn();
+
+    render(
+      <LogsAggregateTableWithParamsProvider
+        aggregatesTableResult={createAggregatesTableResult({
+          error: rateLimitError,
+          refetch,
+        })}
+      />,
+      {initialRouterConfig}
+    );
+
+    expect(
+      screen.getByText(
+        'Your organization has had a lot of activity. Please wait a moment and then try again.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('Aggregates')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
   it('renders data rows', () => {
     render(
       <LogsAggregateTableWithParamsProvider

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -91,6 +91,14 @@ export function LogsAggregateTable({
   const organization = useOrganization();
   const {projects} = useProjects();
 
+  if (isRateLimitError(error)) {
+    return (
+      <Flex justify="center" align="center" padding="3xl" minHeight="200px">
+        <LogsRateLimitError onRetry={refetch} />
+      </Flex>
+    );
+  }
+
   const allFields: string[] = [];
   allFields.push(
     ...groupBys.filter(Boolean),
@@ -100,14 +108,6 @@ export function LogsAggregateTable({
   const numberOfRowsNeedingColor = Math.min(data?.data?.length ?? 0, topEventsLimit ?? 0);
 
   const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 1);
-
-  if (isRateLimitError(error)) {
-    return (
-      <Flex justify="center" align="center" padding="3xl" minHeight="200px">
-        <LogsRateLimitError onRetry={refetch} />
-      </Flex>
-    );
-  }
 
   return (
     <Stack>

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -2,7 +2,7 @@ import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -16,6 +16,7 @@ import {defined} from 'sentry/utils/defined';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {FieldValueType, prettifyTagKey} from 'sentry/utils/fields';
+import {isRateLimitError} from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -28,6 +29,7 @@ import {LogFieldRenderer} from 'sentry/views/explore/logs/fieldRenderers';
 import {getTargetWithReadableQueryParams} from 'sentry/views/explore/logs/logsQueryParams';
 import {getLogColors} from 'sentry/views/explore/logs/styles';
 import {addValidatedFieldTypesToLogsMeta} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
+import {LogsRateLimitError} from 'sentry/views/explore/logs/tables/logsRateLimitError';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {type LogsAggregatesTableResult} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 import {
@@ -54,7 +56,7 @@ export function LogsAggregateTable({
   aggregatesTableResult: LogsAggregatesTableResult;
   validatedFieldTypes?: Partial<Record<string, FieldValueType>>;
 }) {
-  const {data, pageLinks, isLoading, error, eventView} = aggregatesTableResult;
+  const {data, pageLinks, isLoading, error, refetch, eventView} = aggregatesTableResult;
   const meta = useMemo(
     () =>
       addValidatedFieldTypesToLogsMeta({
@@ -98,6 +100,14 @@ export function LogsAggregateTable({
   const numberOfRowsNeedingColor = Math.min(data?.data?.length ?? 0, topEventsLimit ?? 0);
 
   const palette = theme.chart.getColorPalette(numberOfRowsNeedingColor - 1);
+
+  if (isRateLimitError(error)) {
+    return (
+      <Flex justify="center" align="center" padding="3xl" minHeight="200px">
+        <LogsRateLimitError onRetry={refetch} />
+      </Flex>
+    );
+  }
 
   return (
     <Stack>

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -399,7 +399,7 @@ describe('LogsInfiniteTable', () => {
 
     expect(
       await screen.findByText(
-        'Your organization has had a lot of activity. Please wait a moment and then try again.'
+        'Your organization has had a lot of activity. Wait a few seconds and then try again.'
       )
     ).toBeInTheDocument();
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -385,6 +385,31 @@ describe('LogsInfiniteTable', () => {
     });
   });
 
+  it('shows a rate limit message and retry button when the query is rate limited', async () => {
+    MockApiClient.clearMockResponses();
+    const mockResponse = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      statusCode: 429,
+    });
+
+    renderWithProviders(
+      <LogsInfiniteTable analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS} />
+    );
+
+    expect(
+      await screen.findByText(
+        'Your organization has had a lot of activity. Please wait a moment and then try again.'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+
+    await waitFor(() => {
+      expect(mockResponse).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('quantizes log timestamps for replay links', async () => {
     const replayId = 'abc123def456';
     const replayId2 = 'abc123eef457';

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -33,6 +33,7 @@ import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import type {ColumnType} from 'sentry/utils/discover/fields';
 import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {isRateLimitError} from 'sentry/utils/requestError/requestError';
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useElementOffset} from 'sentry/utils/useElementOffset';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -69,6 +70,7 @@ import {
 } from 'sentry/views/explore/logs/styles';
 import {calculateLogsTableMinWidth} from 'sentry/views/explore/logs/tables/calculateLogsTableMinWidth';
 import {LogsEmptyResults} from 'sentry/views/explore/logs/tables/logsEmptyResults';
+import {LogsRateLimitError} from 'sentry/views/explore/logs/tables/logsRateLimitError';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {useLogsTableColumnWidths} from 'sentry/views/explore/logs/tables/useLogsTableColumnWidths';
 import {
@@ -154,6 +156,8 @@ export function LogsInfiniteTable({
     meta: rawMeta,
     data: originalData,
     isError,
+    error,
+    refetch,
     fetchNextPage,
     fetchPreviousPage,
     isFetchingNextPage,
@@ -559,7 +563,7 @@ export function LogsInfiniteTable({
       <Fragment>
         <Flex justify="center" align="center" height="100%" minHeight="200px">
           {isPending && <LoadingRenderer />}
-          {isError && <ErrorRenderer />}
+          {isError && <ErrorRenderer error={error} onRetry={refetch} />}
           {isEmpty &&
             (emptyRenderer ? (
               emptyRenderer()
@@ -628,7 +632,7 @@ export function LogsInfiniteTable({
               totalPayloadBytes={totalPayloadBytes}
             />
           )}
-          {!hasReplay && isError && <ErrorRenderer />}
+          {!hasReplay && isError && <ErrorRenderer error={error} onRetry={refetch} />}
           {!hasReplay &&
             isEmpty &&
             (emptyRenderer ? (
@@ -832,10 +836,14 @@ function LogsTableHeader({
   );
 }
 
-function ErrorRenderer() {
+function ErrorRenderer({error, onRetry}: {error?: unknown; onRetry?: () => void}) {
   return (
     <TableStatus>
-      <IconWarning variant="muted" size="lg" />
+      {isRateLimitError(error) ? (
+        <LogsRateLimitError onRetry={onRetry} />
+      ) : (
+        <IconWarning variant="muted" size="lg" />
+      )}
     </TableStatus>
   );
 }

--- a/static/app/views/explore/logs/tables/logsRateLimitError.tsx
+++ b/static/app/views/explore/logs/tables/logsRateLimitError.tsx
@@ -11,7 +11,7 @@ export function LogsRateLimitError({onRetry}: {onRetry?: () => void}) {
       <IconWarning variant="muted" size="lg" />
       <EmptyStateText size="md" textAlign="center">
         {t(
-          'Your organization has had a lot of activity. Please wait a moment and then try again.'
+          'Your organization has had a lot of activity. Wait a few seconds and then try again.'
         )}
       </EmptyStateText>
       {onRetry && (

--- a/static/app/views/explore/logs/tables/logsRateLimitError.tsx
+++ b/static/app/views/explore/logs/tables/logsRateLimitError.tsx
@@ -1,0 +1,24 @@
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+
+import {IconRefresh, IconWarning} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {EmptyStateText} from 'sentry/views/explore/tables/tracesTable/styles';
+
+export function LogsRateLimitError({onRetry}: {onRetry?: () => void}) {
+  return (
+    <Stack align="center" gap="xl">
+      <IconWarning variant="muted" size="lg" />
+      <EmptyStateText size="md" textAlign="center">
+        {t(
+          'Your organization has had a lot of activity. Please wait a moment and then try again.'
+        )}
+      </EmptyStateText>
+      {onRetry && (
+        <Button size="sm" icon={<IconRefresh />} onClick={onRetry}>
+          {t('Retry')}
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/static/app/views/explore/logs/useLogsAggregatesTable.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.tsx
@@ -79,6 +79,7 @@ export function useLogsAggregatesTable({
     isPending: result.isPending,
     isError: result.isError,
     error: result.error,
+    refetch: result.refetch,
     pageLinks,
     eventView,
   };


### PR DESCRIPTION
Even with all the work we did to prevent 429s, they still happen once in a while. So this gives a friendly indicator and a retry button (since folks tend to just refresh the page instead).

I also noticed there were a bunch of places that do the same `error instanceof RequestError && error.status === 429` check. So I extracted a shared `isRateLimitError` util.

<img width="944" height="376" alt="Screenshot 2026-07-16 at 11 57 21 AM" src="https://github.com/user-attachments/assets/5a540c5f-8e6e-429e-9d28-d84c2d95844a" />

Tip: to simulate a 429 error, I typically override the response in the browser devtools. Or set this in `LogsInfiniteTable` & switch the big destructured `const` to `let`:

```ts
  error = new RequestError("GET", "/something", new Error("Oh no!"))
  isError = true;
  originalData = []
```

Closes LOGS-560.
