### PR TITLE
feat(logs): Add Copy and View in Explore actions to log row details

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -151,7 +151,7 @@ export function OurlogsDrawer({
             </Flex>
             {exploreUrl && (
               <LinkButton size="sm" to={exploreUrl} openInNewTab>
-                {t('Open in explore')}
+                {t('View in Explore')}
               </LinkButton>
             )}
           </Flex>

--- a/static/app/utils/analytics/logsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/logsAnalyticsEvent.tsx
@@ -84,6 +84,10 @@ export type LogsAnalyticsEventParameters = {
     save_type: 'save_new_query' | 'rename_query';
     ui_source: 'toolbar' | 'table';
   };
+  'logs.table.row_copied': {
+    log_id: string;
+    organization: Organization;
+  };
   'logs.table.row_copied_as_json': {
     log_id: string;
     organization: Organization;
@@ -93,6 +97,10 @@ export type LogsAnalyticsEventParameters = {
     page_source: LogsAnalyticsPageSource;
   };
   'logs.table.row_link_copied': {
+    log_id: string;
+    organization: Organization;
+  };
+  'logs.table.row_view_in_explore_clicked': {
     log_id: string;
     organization: Organization;
   };
@@ -140,6 +148,8 @@ export const logsAnalyticsEventMap: Record<LogsAnalyticsEventKey, string | null>
   'logs.save_query_modal': 'Logs Save Query Modal',
   'logs.onboarding_platform_docs_viewed':
     'Logs Explore Empty State (Onboarding) - Platform Docs Viewed',
+  'logs.table.row_copied': 'Logs Row Copied',
   'logs.table.row_copied_as_json': 'Logs Row Copied as JSON',
   'logs.table.row_link_copied': 'Logs Row Link Copied',
+  'logs.table.row_view_in_explore_clicked': 'Logs Row View in Explore Clicked',
 };

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -698,6 +698,90 @@ describe('logsTableRow', () => {
     expect(parsedData).not.toHaveProperty('sentry.item_id');
   });
 
+  it.isKnownFlake('copies the message when the Copy button is clicked', async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+    });
+
+    render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.click(logTableRow);
+
+    await waitFor(() => {
+      expect(rowDetailsMock).toHaveBeenCalledTimes(1);
+    });
+
+    const copyButton = await screen.findByRole('button', {name: 'Copy'});
+    await userEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith('test log body');
+  });
+
+  it('does not render a View in Explore button in the standalone logs view', async () => {
+    render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.click(logTableRow);
+
+    expect(await screen.findByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'View in Explore'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a View in Explore button linking to the log when embedded', async () => {
+    render(
+      <LogRowContent
+        dataRow={rowData}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowData)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+        embedded
+      />,
+      {organization, initialRouterConfig, additionalWrapper: FrozenProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.click(logTableRow);
+
+    const viewInExplore = await screen.findByRole('button', {name: 'View in Explore'});
+    expect(viewInExplore).toHaveAttribute(
+      'href',
+      expect.stringContaining('logsQuery=id%3A1')
+    );
+  });
+
   it.isKnownFlake('copies link to log when Copy link menu item is clicked', async () => {
     const mockWriteText = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, 'clipboard', {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -16,7 +16,9 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {
   IconAdd,
+  IconCopy,
   IconJson,
+  IconOpen,
   IconPin,
   IconSubtract,
   IconTerminal,
@@ -111,6 +113,7 @@ import {
   getLogRowItem,
   getLogRowTimestampMillis,
   getLogSeverityLevel,
+  getLogsUrl,
   isPseudoLogResponseItem,
   isRegularLogResponseItem,
   ourlogToJson,
@@ -800,6 +803,7 @@ function LogRowDetails({
           }}
         >
           <LogRowDetailsActions
+            embedded={embedded}
             fullLogDataResult={fullLogDataResult}
             projectSlug={projectSlug}
             tableDataRow={dataRow}
@@ -846,10 +850,12 @@ function LogRowDetailsFilterActions({filter}: {filter: MessageFilter}) {
 }
 
 function LogRowDetailsActions({
+  embedded,
   fullLogDataResult,
   projectSlug,
   tableDataRow,
 }: {
+  embedded: boolean;
   fullLogDataResult: UseQueryResult<TraceItemDetailsResponse>;
   projectSlug: string;
   tableDataRow: OurLogsResponseItem;
@@ -857,6 +863,7 @@ function LogRowDetailsActions({
   const {data, isPending, isError} = fullLogDataResult;
   const isFrozen = useLogsFrozenIsFrozen();
   const organization = useOrganization();
+  const {selection} = usePageFilters();
   const user = useUser();
   const showFilterButtons = !isFrozen;
   const message = String(
@@ -870,6 +877,15 @@ function LogRowDetailsActions({
     message
   );
 
+  const logId = String(tableDataRow[OurLogKnownFieldKey.ID] ?? '');
+
+  // Embedded log tables (trace, replay, issues) are a low-fidelity view; send the
+  // user to the full Explore Logs experience focused on this specific log.
+  const viewInExploreUrl =
+    embedded && logId
+      ? getLogsUrl({organization, selection, query: `id:${logId}`})
+      : null;
+
   const {copy} = useCopyToClipboard();
 
   // Memoize in case we are attempting to copy large JSON objects.
@@ -877,7 +893,6 @@ function LogRowDetailsActions({
   let logDebugEndpoint: string | undefined;
 
   if (user.isSuperuser && projectSlug && isRegularLogResponseItem(tableDataRow)) {
-    const logId = tableDataRow[OurLogKnownFieldKey.ID] ?? '';
     const traceId = tableDataRow[OurLogKnownFieldKey.TRACE_ID] ?? '';
 
     if (logId && traceId) {
@@ -912,7 +927,19 @@ function LogRowDetailsActions({
       errorMessage: t('Failed to copy'),
     }).then(() => {
       trackAnalytics('logs.table.row_copied_as_json', {
-        log_id: String(tableDataRow[OurLogKnownFieldKey.ID]),
+        log_id: logId,
+        organization,
+      });
+    });
+  };
+
+  const copyMessage = () => {
+    copy(message, {
+      successMessage: t('Copied!'),
+      errorMessage: t('Failed to copy'),
+    }).then(() => {
+      trackAnalytics('logs.table.row_copied', {
+        log_id: logId,
         organization,
       });
     });
@@ -926,6 +953,31 @@ function LogRowDetailsActions({
         <span />
       )}
       <LogDetailTableActionsButtonBar>
+        {viewInExploreUrl ? (
+          <LinkButton
+            variant="transparent"
+            size="sm"
+            icon={<IconOpen />}
+            to={viewInExploreUrl}
+            onClick={() => {
+              trackAnalytics('logs.table.row_view_in_explore_clicked', {
+                log_id: logId,
+                organization,
+              });
+            }}
+          >
+            {t('View in Explore')}
+          </LinkButton>
+        ) : null}
+        <Button
+          variant="transparent"
+          size="sm"
+          icon={<IconCopy />}
+          onClick={copyMessage}
+          disabled={isPending || isError || !message}
+        >
+          {t('Copy')}
+        </Button>
         <Button
           variant="transparent"
           size="sm"

--- a/static/app/views/explore/replays/detail/ourlogs/openInLogsButton.spec.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/openInLogsButton.spec.tsx
@@ -53,7 +53,7 @@ describe('OpenInLogsButton', () => {
       {organization}
     );
 
-    expect(screen.getByRole('button', {name: 'Open in Logs'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'View in Explore'})).toBeInTheDocument();
   });
 
   it('appends replay_id to the URL when replayId is provided', () => {
@@ -68,7 +68,7 @@ describe('OpenInLogsButton', () => {
       {organization}
     );
 
-    const link = screen.getByRole('button', {name: 'Open in Logs'});
+    const link = screen.getByRole('button', {name: 'View in Explore'});
     expect(link).toHaveAttribute('href', expect.stringContaining('replay_id%3Adeadbeef'));
   });
 
@@ -84,7 +84,7 @@ describe('OpenInLogsButton', () => {
       {organization}
     );
 
-    const link = screen.getByRole('button', {name: 'Open in Logs'});
+    const link = screen.getByRole('button', {name: 'View in Explore'});
     expect(link).toHaveAttribute(
       'href',
       expect.stringMatching(/logsQuery=.*replay_id%3Adeadbeef/)

--- a/static/app/views/explore/replays/detail/ourlogs/openInLogsButton.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/openInLogsButton.tsx
@@ -34,7 +34,7 @@ export function OpenInLogsButton({replayId}: Props) {
 
   return (
     <LinkButton size="md" to={url} openInNewTab>
-      {t('Open in Logs')}
+      {t('View in Explore')}
     </LinkButton>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOurlogs.tsx
@@ -83,7 +83,7 @@ function LogsSectionContent() {
           {...tracesItemSearchQueryBuilderProps}
           placeholder={t('Search logs for this event')}
         />
-        <LinkButton to={logsUrl}>{t('Open in Logs')}</LinkButton>
+        <LinkButton to={logsUrl}>{t('View in Explore')}</LinkButton>
       </Flex>
       <TableContainer>
         <LogsInfiniteTable


### PR DESCRIPTION
Adds two new actions to the expanded log row detail panel in issues:

* 

Also standardizes on _View in Explore_ as the text, rather than _Open in Logs_ or _Open in explore_.

Closes LOGS-524
