### PR TITLE
build(ui): Remove process browser polyfill

### DIFF
--- a/config/build-chartcuterie.ts
+++ b/config/build-chartcuterie.ts
@@ -70,7 +70,6 @@ async function runEsbuild(commitHash: string): Promise<void> {
       'process.env.EXPERIMENTAL_SPA': JSON.stringify(false),
       'process.env.IS_ACCEPTANCE_TEST': JSON.stringify(false),
       'process.env.USE_TANSTACK_DEVTOOL': JSON.stringify(false),
-      'process.env.UI_DEV_ENABLE_PROFILING': JSON.stringify(false),
       'process.env.SPA_DSN': JSON.stringify(''),
       'process.env.SENTRY_RELEASE_VERSION': JSON.stringify(''),
     },

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -77,7 +77,6 @@ const config: KnipConfig = {
     'core-js',
     'tslib', // subdependency of many packages, declare the latest version
     'buffer', // rspack.ProvidePlugin, needs better knip plugin
-    'process', // rspack.ProvidePlugin, needs better knip plugin
     'odiff-bin', // raw binary consumed by Python backend, not a JS import
     'run-on-changed', // CLI used by the eslint CI job (.github/workflows/frontend.yml), not a JS import
     '@swc-contrib/mut-cjs-exports', // used in jest config

--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
     "platformicons": "^9.5.0",
     "po-catalog-loader": "2.1.0",
     "prismjs": "^1.30.0",
-    "process": "^0.11.10",
     "qrcode.react": "^3.1.0",
     "query-string": "7.0.1",
     "react": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,9 +457,6 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
-      process:
-        specifier: ^0.11.10
-        version: 0.11.10
       qrcode.react:
         specifier: ^3.1.0
         version: 3.1.0(react@19.2.3)

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -429,7 +429,6 @@ const appConfig: Configuration = {
      * TODO(epurkhiser): Figure out if we still need these
      */
     new rspack.ProvidePlugin({
-      process: 'process/browser',
       Buffer: ['buffer', 'Buffer'],
     }),
 
@@ -532,8 +531,6 @@ const appConfig: Configuration = {
       crypto: false,
       // `pnpm why` says this is only needed in dev deps
       string_decoder: false,
-      // For framer motion v6, might be able to remove on v11
-      'process/browser': require.resolve('process/browser'),
     },
 
     // Prefers local modules over node_modules

--- a/static/app/bootstrap/commonInitialization.tsx
+++ b/static/app/bootstrap/commonInitialization.tsx
@@ -1,6 +1,6 @@
 import {MotionGlobalConfig} from 'framer-motion';
 
-import {IS_ACCEPTANCE_TEST, NODE_ENV, UI_DEV_ENABLE_PROFILING} from 'sentry/constants';
+import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'sentry/constants';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 
@@ -11,9 +11,6 @@ if (IS_ACCEPTANCE_TEST || NODE_ENV === 'test') {
 export function commonInitialization(config: Config) {
   if (NODE_ENV === 'development') {
     import(/* webpackMode: "eager" */ 'sentry/utils/silence-react-unsafe-warnings');
-    if (UI_DEV_ENABLE_PROFILING) {
-      config.sentryConfig.profileSessionSampleRate = 1;
-    }
   }
 
   ConfigStore.loadInitialData(config);

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -717,7 +717,6 @@ export const SPAN_PROPS_DOCS_URL =
   'https://docs.sentry.io/concepts/search/searchable-properties/spans/';
 
 export {IS_ACCEPTANCE_TEST, NODE_ENV} from './env';
-export const UI_DEV_ENABLE_PROFILING = process.env.UI_DEV_ENABLE_PROFILING;
 export const USE_TANSTACK_DEVTOOL = process.env.USE_TANSTACK_DEVTOOL;
 
 export const DEFAULT_ERROR_JSON = {


### PR DESCRIPTION
Removes the old browser `process` shim and direct dependency now that Framer Motion no longer needs it.

Also removes the always-disabled UI profiling flag, which was the last runtime `process` access and caused dev-ui startup to fail once the shim was gone.