### PR TITLE
feat(control): Drop unconsumed check_run webhook actions at the parser

### DIFF
--- a/src/sentry/integrations/github/webhook_types.py
+++ b/src/sentry/integrations/github/webhook_types.py
@@ -33,6 +33,18 @@ CELL_PROCESSED_GITHUB_EVENTS = frozenset(
     t.value for t in GithubWebhookType if t not in _CONTROL_ONLY_EVENTS
 )
 
+# Every action GitHub sends for check_run events; used to bound metric tag cardinality.
+GITHUB_CHECK_RUN_ACTIONS = frozenset({"completed", "created", "requested_action", "rerequested"})
+
+# check_run actions that a cell-side processor actually consumes
+# (see CheckRunEventWebhook.WEBHOOK_EVENT_PROCESSORS):
+#   completed        -> sentry.pr_metrics.webhooks.handle_check_run
+#   requested_action -> sentry.preprod.vcs.webhooks.github_check_run
+#   rerequested      -> sentry.seer.code_review.webhooks.check_run
+# The control parser drops the other actions (notably "created") before forwarding,
+# so a new consumer must add its action here to receive those events.
+CELL_PROCESSED_CHECK_RUN_ACTIONS = frozenset({"completed", "requested_action", "rerequested"})
+
 
 class GitHubInstallationRepo(TypedDict):
     id: int

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -16,8 +16,11 @@ from sentry.integrations.github.webhook import (
 )
 from sentry.integrations.github.webhook_types import (
     _CONTROL_ONLY_EVENTS,
+    CELL_PROCESSED_CHECK_RUN_ACTIONS,
     CELL_PROCESSED_GITHUB_EVENTS,
+    GITHUB_CHECK_RUN_ACTIONS,
     GITHUB_WEBHOOK_TYPE_HEADER,
+    GithubWebhookType,
 )
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
@@ -138,6 +141,28 @@ class GithubRequestParser(BaseRequestParser):
                 tags={"event_type": github_event or "unknown"},
             )
             return HttpResponse(status=202)
+
+        # check_run is by far the highest-volume event type and only some actions
+        # have a cell-side consumer (see CELL_PROCESSED_CHECK_RUN_ACTIONS); drop the
+        # rest, most notably "created" which is roughly half of all deliveries.
+        if github_event == GithubWebhookType.CHECK_RUN:
+            action = event.get("action")
+            if not (isinstance(action, str) and action in CELL_PROCESSED_CHECK_RUN_ACTIONS):
+                # The body is not signature-verified until it reaches the cell, so
+                # only known check_run actions may be tagged verbatim to keep tag
+                # cardinality bounded.
+                metrics.incr(
+                    "github.webhook.drop_unprocessed_event",
+                    tags={
+                        "event_type": github_event,
+                        "action": (
+                            action
+                            if isinstance(action, str) and action in GITHUB_CHECK_RUN_ACTIONS
+                            else "unknown"
+                        ),
+                    },
+                )
+                return HttpResponse(status=202)
 
         response = self.get_response_from_webhookpayload(
             cells=cells,

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 import responses
+from django.core.handlers.wsgi import WSGIRequest
 from django.db import router, transaction
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, override_settings
@@ -531,6 +532,143 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
             request=request,
             mailbox_name=f"github:{integration.id}",
             cell_names=[cell.name],
+        )
+
+    def _post_check_run(self, action: object) -> WSGIRequest:
+        data: dict[str, object] = {"installation": {"id": "1"}, "repository": {"id": 123}}
+        if action is not None:
+            data["action"] = action
+        return self.factory.post(
+            self.path,
+            data=data,
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.CHECK_RUN.value},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @patch("sentry.middleware.integrations.parsers.github.metrics")
+    def test_drops_check_run_created(self, mock_metrics: Mock) -> None:
+        """check_run action=created has no cell-side consumer and is dropped."""
+        self.get_integration()
+        request = self._post_check_run(action="created")
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+        mock_metrics.incr.assert_any_call(
+            "github.webhook.drop_unprocessed_event",
+            tags={"event_type": "check_run", "action": "created"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    def test_forwards_check_run_completed(self) -> None:
+        integration = self.get_integration()
+        request = self._post_check_run(action="completed")
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            cell_names=[cell.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    def test_forwards_check_run_rerequested(self) -> None:
+        integration = self.get_integration()
+        request = self._post_check_run(action="rerequested")
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            cell_names=[cell.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    def test_forwards_check_run_requested_action(self) -> None:
+        integration = self.get_integration()
+        request = self._post_check_run(action="requested_action")
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            cell_names=[cell.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @patch("sentry.middleware.integrations.parsers.github.metrics")
+    def test_drops_check_run_bogus_action(self, mock_metrics: Mock) -> None:
+        """Unrecognized actions are dropped with a bounded 'unknown' metric tag."""
+        self.get_integration()
+        request = self._post_check_run(action="attacker-controlled-junk")
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+        mock_metrics.incr.assert_any_call(
+            "github.webhook.drop_unprocessed_event",
+            tags={"event_type": "check_run", "action": "unknown"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @patch("sentry.middleware.integrations.parsers.github.metrics")
+    def test_drops_check_run_missing_action(self, mock_metrics: Mock) -> None:
+        self.get_integration()
+        request = self._post_check_run(action=None)
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+        mock_metrics.incr.assert_any_call(
+            "github.webhook.drop_unprocessed_event",
+            tags={"event_type": "check_run", "action": "unknown"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_cells(cell_config)
+    @responses.activate
+    @patch("sentry.middleware.integrations.parsers.github.metrics")
+    def test_drops_check_run_non_string_action(self, mock_metrics: Mock) -> None:
+        """A non-string (unhashable) action must not raise; it is dropped as 'unknown'."""
+        self.get_integration()
+        request = self._post_check_run(action={"nested": "junk"})
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+        mock_metrics.incr.assert_any_call(
+            "github.webhook.drop_unprocessed_event",
+            tags={"event_type": "check_run", "action": "unknown"},
         )
 
 


### PR DESCRIPTION
## Problem

The GitHub App now subscribes to `check_run` events, which immediately became the highest-volume GitHub event type forwarded from the control silo to region cells — contributing to webhook delivery backlogs. Roughly half of that volume is `action=created`, which **no cell-side processor consumes**:

| Consumer | Actions consumed |
|---|---|
| pr_metrics (`sentry.pr_metrics.webhooks.handle_check_run`) | `completed` only |
| Seer code review (`sentry.seer.code_review.webhooks.check_run`) | `rerequested` only |
| preprod (`sentry.preprod.vcs.webhooks.github_check_run`) | `requested_action` only |

Also verified: the SCM event stream's only registered `check_run` listener is a no-op placeholder, and the generic `GitHubWebhook` base does nothing action-specific. GHE uses the same processors and its request parser inherits `get_response`, so the drop applies there too (desired).

## Approach

Drop `check_run` events whose action has no consumer at the control parser — right beside the existing unprocessed-event-type drop, so it only runs after integration/cell resolution. Dropped events get a 202 and a `github.webhook.drop_unprocessed_event` metric with an `action` tag. The tag is only emitted verbatim for known GitHub check_run actions (otherwise `unknown`): the body is not signature-verified until it reaches the cell, so raw values must not become metric tags.

`CELL_PROCESSED_CHECK_RUN_ACTIONS` lives next to the event-type allowlist in `webhook_types.py` with the consumer→action mapping documented — a new consumer must add its action there to receive those events.

## Testing

- 7 new parser tests: `created` → dropped (202, no WebhookPayload rows, metric); `completed`/`rerequested`/`requested_action` → forwarded unchanged; bogus/missing/non-string actions → dropped with bounded `unknown` tag.
- Full parser test modules pass (49/49), prek/mypy clean.