### PR TITLE
feat(seer-explorer): Add todos markdown embed widget

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/todos.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/todos.spec.tsx
@@ -60,6 +60,18 @@ describe('Todos embed', () => {
     expect(screen.getAllByRole('checkbox')).toHaveLength(2);
   });
 
+  it('ignores tags inside code fences when deriving the latest', () => {
+    // A tag quoted in a code fence is code, not an embed — the fold must see
+    // exactly what the renderer's lexer sees.
+    renderConversation([
+      block('a', FIRST_TAG),
+      block('b', `Example syntax:\n\n\`\`\`\n${LATEST_TAG}\n\`\`\``),
+    ]);
+
+    expect(screen.getByText('Check error rates')).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+  });
+
   it('renders standalone when no provider is present (stories/previews)', () => {
     render(<SeerMarkdown raw={LATEST_TAG} />);
     expect(screen.getByText('Write summary')).toBeInTheDocument();

--- a/static/app/components/seer/markdown/embeds/components/todos.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/todos.spec.tsx
@@ -1,10 +1,7 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
-import {
-  findLatestTodosBlockId,
-  SeerTodosProvider,
-} from 'sentry/components/seer/markdown/embeds/components/todos';
+import {SeerConversationProvider} from 'sentry/components/seer/markdown/embeds/conversation';
 import {SeerEmbedBlockContext} from 'sentry/components/seer/markdown/embeds/registry';
 
 const todosTag = (items: Array<{content: string; status: string}>) =>
@@ -20,63 +17,47 @@ const LATEST_TAG = todosTag([
   {content: 'Write summary', status: 'pending'},
 ]);
 
-describe('findLatestTodosBlockId', () => {
-  it('returns the last block containing a valid todos tag', () => {
-    expect(
-      findLatestTodosBlockId([
-        {id: 'a', content: FIRST_TAG},
-        {id: 'b', content: 'plain prose'},
-        {id: 'c', content: `intro\n\n${LATEST_TAG}`},
-        {id: 'd', content: 'trailing prose'},
-      ])
-    ).toBe('c');
-  });
+const block = (id: string, content: string | null) => ({id, message: {content}});
 
-  it('skips tags with invalid JSON or invalid shape', () => {
-    expect(
-      findLatestTodosBlockId([
-        {id: 'a', content: FIRST_TAG},
-        {id: 'b', content: '{% todos %}not json{% /todos %}'},
-        {
-          id: 'c',
-          content: '{% todos %}{"items":[{"content":"x","status":"bogus"}]}{% /todos %}',
-        },
-      ])
-    ).toBe('a');
-  });
-
-  it('returns null when no block has a todos tag', () => {
-    expect(
-      findLatestTodosBlockId([
-        {id: 'a', content: 'prose'},
-        {id: 'b', content: null},
-      ])
-    ).toBeNull();
-  });
-});
+function renderConversation(
+  blocks: Array<{id: string; message: {content: string | null}}>
+) {
+  render(
+    <SeerConversationProvider blocks={blocks}>
+      {blocks.map(b => (
+        <SeerEmbedBlockContext key={b.id} value={b.id}>
+          <SeerMarkdown raw={b.message.content ?? ''} />
+        </SeerEmbedBlockContext>
+      ))}
+    </SeerConversationProvider>
+  );
+}
 
 describe('Todos embed', () => {
   it('renders the checklist only for the latest todos block', () => {
-    const blocks = [
-      {id: 'a', content: FIRST_TAG},
-      {id: 'b', content: LATEST_TAG},
-    ];
-    render(
-      <SeerTodosProvider blocks={blocks}>
-        <SeerEmbedBlockContext value="a">
-          <SeerMarkdown raw={FIRST_TAG} />
-        </SeerEmbedBlockContext>
-        <SeerEmbedBlockContext value="b">
-          <SeerMarkdown raw={LATEST_TAG} />
-        </SeerEmbedBlockContext>
-      </SeerTodosProvider>
-    );
+    renderConversation([
+      block('a', FIRST_TAG),
+      block('b', 'plain prose'),
+      block('c', `intro\n\n${LATEST_TAG}`),
+    ]);
 
     // Only the latest snapshot's items render — 'Write summary' is unique to it.
     expect(screen.getByText('Write summary')).toBeInTheDocument();
     // Items shared by both snapshots appear exactly once (older embed renders null).
     expect(screen.getAllByText('Investigate spans')).toHaveLength(1);
     expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+  });
+
+  it('skips tags with invalid JSON or invalid shape when deriving the latest', () => {
+    renderConversation([
+      block('a', FIRST_TAG),
+      block('b', '{% todos %}not json{% /todos %}'),
+      block('c', '{% todos %}{"items":[{"content":"x","status":"bogus"}]}{% /todos %}'),
+    ]);
+
+    // 'a' holds the last valid snapshot, so its two items render.
+    expect(screen.getByText('Check error rates')).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
   });
 
   it('renders standalone when no provider is present (stories/previews)', () => {

--- a/static/app/components/seer/markdown/embeds/components/todos.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/todos.spec.tsx
@@ -1,0 +1,94 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {
+  findLatestTodosBlockId,
+  SeerTodosProvider,
+} from 'sentry/components/seer/markdown/embeds/components/todos';
+import {SeerEmbedBlockContext} from 'sentry/components/seer/markdown/embeds/registry';
+
+const todosTag = (items: Array<{content: string; status: string}>) =>
+  `{% todos %}${JSON.stringify({items})}{% /todos %}`;
+
+const FIRST_TAG = todosTag([
+  {content: 'Investigate spans', status: 'completed'},
+  {content: 'Check error rates', status: 'in_progress'},
+]);
+const LATEST_TAG = todosTag([
+  {content: 'Investigate spans', status: 'completed'},
+  {content: 'Check error rates', status: 'completed'},
+  {content: 'Write summary', status: 'pending'},
+]);
+
+describe('findLatestTodosBlockId', () => {
+  it('returns the last block containing a valid todos tag', () => {
+    expect(
+      findLatestTodosBlockId([
+        {id: 'a', content: FIRST_TAG},
+        {id: 'b', content: 'plain prose'},
+        {id: 'c', content: `intro\n\n${LATEST_TAG}`},
+        {id: 'd', content: 'trailing prose'},
+      ])
+    ).toBe('c');
+  });
+
+  it('skips tags with invalid JSON or invalid shape', () => {
+    expect(
+      findLatestTodosBlockId([
+        {id: 'a', content: FIRST_TAG},
+        {id: 'b', content: '{% todos %}not json{% /todos %}'},
+        {
+          id: 'c',
+          content: '{% todos %}{"items":[{"content":"x","status":"bogus"}]}{% /todos %}',
+        },
+      ])
+    ).toBe('a');
+  });
+
+  it('returns null when no block has a todos tag', () => {
+    expect(
+      findLatestTodosBlockId([
+        {id: 'a', content: 'prose'},
+        {id: 'b', content: null},
+      ])
+    ).toBeNull();
+  });
+});
+
+describe('Todos embed', () => {
+  it('renders the checklist only for the latest todos block', () => {
+    const blocks = [
+      {id: 'a', content: FIRST_TAG},
+      {id: 'b', content: LATEST_TAG},
+    ];
+    render(
+      <SeerTodosProvider blocks={blocks}>
+        <SeerEmbedBlockContext value="a">
+          <SeerMarkdown raw={FIRST_TAG} />
+        </SeerEmbedBlockContext>
+        <SeerEmbedBlockContext value="b">
+          <SeerMarkdown raw={LATEST_TAG} />
+        </SeerEmbedBlockContext>
+      </SeerTodosProvider>
+    );
+
+    // Only the latest snapshot's items render — 'Write summary' is unique to it.
+    expect(screen.getByText('Write summary')).toBeInTheDocument();
+    // Items shared by both snapshots appear exactly once (older embed renders null).
+    expect(screen.getAllByText('Investigate spans')).toHaveLength(1);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+  });
+
+  it('renders standalone when no provider is present (stories/previews)', () => {
+    render(<SeerMarkdown raw={LATEST_TAG} />);
+    expect(screen.getByText('Write summary')).toBeInTheDocument();
+  });
+
+  it('marks completed items as checked', () => {
+    render(<SeerMarkdown raw={LATEST_TAG} />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+  });
+});

--- a/static/app/components/seer/markdown/embeds/components/todos.tsx
+++ b/static/app/components/seer/markdown/embeds/components/todos.tsx
@@ -1,77 +1,32 @@
-import type {ReactNode} from 'react';
-import {createContext, useContext, useMemo} from 'react';
+import {useContext} from 'react';
 
+import {
+  registerEmbedFold,
+  useEmbedFoldState,
+} from 'sentry/components/seer/markdown/embeds/conversation';
 import {SeerEmbedBlockContext} from 'sentry/components/seer/markdown/embeds/registry';
-import {SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
 import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 import {TodoList, type TodoListItem} from 'sentry/components/seer/todoList';
 
-const TODOS_TAG_RE = /\{%\s+todos\s+%\}([\s\S]*?)\{%\s+\/todos\s+%\}/g;
-
-interface TodosSourceBlock {
-  content: string | null | undefined;
-  id: string;
-}
-
 /**
- * Returns the id of the last block whose content contains a valid
- * `{% todos %}` tag. The conversation's todo state is a complete-replacement
- * snapshot, so only the latest occurrence is current.
+ * Todo snapshots are complete replacements, so the conversation's todo state
+ * is simply the block holding the last valid `{% todos %}` occurrence.
  */
-export function findLatestTodosBlockId(blocks: TodosSourceBlock[]): string | null {
-  for (let i = blocks.length - 1; i >= 0; i--) {
-    const content = blocks[i]!.content;
-    if (!content) {
-      continue;
-    }
-    const matches = [...content.matchAll(TODOS_TAG_RE)];
-    for (let j = matches.length - 1; j >= 0; j--) {
-      let data: unknown;
-      try {
-        data = JSON.parse(matches[j]![1]!);
-      } catch {
-        continue;
-      }
-      if (SEER_EMBED_SCHEMAS.todos.schema.safeParse(data).success) {
-        return blocks[i]!.id;
-      }
-    }
-  }
-  return null;
-}
-
-const SeerTodosContext = createContext<{latestTodosBlockId: string | null} | undefined>(
-  undefined
-);
-
-/**
- * Conversation-scoped todo state, derived from block data (not the render
- * tree): the latest valid `{% todos %}` occurrence wins. Wrap the rendered
- * conversation and pass the blocks' `{id, content}` pairs.
- */
-export function SeerTodosProvider({
-  blocks,
-  children,
-}: {
-  blocks: TodosSourceBlock[];
-  children: ReactNode;
-}) {
-  const value = useMemo(
-    () => ({latestTodosBlockId: findLatestTodosBlockId(blocks)}),
-    [blocks]
-  );
-  return <SeerTodosContext value={value}>{children}</SeerTodosContext>;
-}
+const todosFold = registerEmbedFold({
+  tag: 'todos',
+  init: null as string | null,
+  reduce: (_latest, occurrence) => occurrence.blockId,
+});
 
 function TodosEmbed({items}: {items: TodoListItem[]}) {
-  const todosState = useContext(SeerTodosContext);
+  const latestTodosBlockId = useEmbedFoldState(todosFold);
   const blockId = useContext(SeerEmbedBlockContext);
 
   // Outside a conversation (stories, previews) there is no provider — render.
   // Inside one, render only from the latest todos-bearing block.
   const isLatest =
-    todosState === undefined ||
-    (todosState.latestTodosBlockId !== null && todosState.latestTodosBlockId === blockId);
+    latestTodosBlockId === undefined ||
+    (latestTodosBlockId !== null && latestTodosBlockId === blockId);
 
   if (!isLatest) {
     return null;

--- a/static/app/components/seer/markdown/embeds/components/todos.tsx
+++ b/static/app/components/seer/markdown/embeds/components/todos.tsx
@@ -1,0 +1,87 @@
+import type {ReactNode} from 'react';
+import {createContext, useContext, useMemo} from 'react';
+
+import {SeerEmbedBlockContext} from 'sentry/components/seer/markdown/embeds/registry';
+import {SEER_EMBED_SCHEMAS} from 'sentry/components/seer/markdown/embeds/schemas';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
+import {TodoList, type TodoListItem} from 'sentry/components/seer/todoList';
+
+const TODOS_TAG_RE = /\{%\s+todos\s+%\}([\s\S]*?)\{%\s+\/todos\s+%\}/g;
+
+interface TodosSourceBlock {
+  content: string | null | undefined;
+  id: string;
+}
+
+/**
+ * Returns the id of the last block whose content contains a valid
+ * `{% todos %}` tag. The conversation's todo state is a complete-replacement
+ * snapshot, so only the latest occurrence is current.
+ */
+export function findLatestTodosBlockId(blocks: TodosSourceBlock[]): string | null {
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const content = blocks[i]!.content;
+    if (!content) {
+      continue;
+    }
+    const matches = [...content.matchAll(TODOS_TAG_RE)];
+    for (let j = matches.length - 1; j >= 0; j--) {
+      let data: unknown;
+      try {
+        data = JSON.parse(matches[j]![1]!);
+      } catch {
+        continue;
+      }
+      if (SEER_EMBED_SCHEMAS.todos.schema.safeParse(data).success) {
+        return blocks[i]!.id;
+      }
+    }
+  }
+  return null;
+}
+
+const SeerTodosContext = createContext<{latestTodosBlockId: string | null} | undefined>(
+  undefined
+);
+
+/**
+ * Conversation-scoped todo state, derived from block data (not the render
+ * tree): the latest valid `{% todos %}` occurrence wins. Wrap the rendered
+ * conversation and pass the blocks' `{id, content}` pairs.
+ */
+export function SeerTodosProvider({
+  blocks,
+  children,
+}: {
+  blocks: TodosSourceBlock[];
+  children: ReactNode;
+}) {
+  const value = useMemo(
+    () => ({latestTodosBlockId: findLatestTodosBlockId(blocks)}),
+    [blocks]
+  );
+  return <SeerTodosContext value={value}>{children}</SeerTodosContext>;
+}
+
+function TodosEmbed({items}: {items: TodoListItem[]}) {
+  const todosState = useContext(SeerTodosContext);
+  const blockId = useContext(SeerEmbedBlockContext);
+
+  // Outside a conversation (stories, previews) there is no provider — render.
+  // Inside one, render only from the latest todos-bearing block.
+  const isLatest =
+    todosState === undefined ||
+    (todosState.latestTodosBlockId !== null && todosState.latestTodosBlockId === blockId);
+
+  if (!isLatest) {
+    return null;
+  }
+  return <TodoList todos={items} />;
+}
+
+export const Todos = defineSeerEmbed({
+  name: 'todos',
+  render({items}) {
+    return <TodosEmbed items={items} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/conversation.tsx
+++ b/static/app/components/seer/markdown/embeds/conversation.tsx
@@ -1,0 +1,132 @@
+import type {ReactNode} from 'react';
+import {createContext, useContext, useMemo} from 'react';
+import type {z} from 'zod';
+
+import {
+  SEER_EMBED_SCHEMAS,
+  type SeerEmbedName,
+} from 'sentry/components/seer/markdown/embeds/schemas';
+
+/**
+ * Conversation-derived embed state ("the fold").
+ *
+ * Many embeds are stateful across the conversation — the latest `{% todos %}`
+ * snapshot wins, PR-state embeds accumulate per repo, an interaction request
+ * is "active" only until a later turn resolves it. Rather than one provider
+ * per capability, a single `SeerConversationProvider` scans block contents
+ * once and feeds every embed occurrence, in conversation order, to the folds
+ * registered here. Each capability derives its state as a pure reduction over
+ * the conversation; nothing is stored outside the blocks themselves.
+ *
+ * To add a capability: call `registerEmbedFold` in your embed's module (it is
+ * imported via ./index.ts like the embed component itself) and read the state
+ * with `useEmbedFoldState(yourFold)`.
+ */
+
+/**
+ * Minimal structural view of a conversation block. The Explorer `Block` type
+ * satisfies this as-is — pass `blocks` straight in, no mapping needed.
+ */
+export interface EmbedSourceBlock {
+  id: string;
+  message: {content: string | null};
+}
+
+export interface EmbedOccurrence<N extends SeerEmbedName> {
+  blockId: string;
+  blockIndex: number;
+  data: z.output<(typeof SEER_EMBED_SCHEMAS)[N]['schema']>;
+}
+
+interface EmbedFold<N extends SeerEmbedName, S> {
+  /** Initial state. `reduce` must be pure — return new state, don't mutate. */
+  init: S;
+  reduce: (state: S, occurrence: EmbedOccurrence<N>) => S;
+  tag: N;
+}
+
+const foldRegistry = new Map<string, EmbedFold<SeerEmbedName, unknown>>();
+
+export function registerEmbedFold<N extends SeerEmbedName, S>(
+  fold: EmbedFold<N, S>
+): EmbedFold<N, S> {
+  foldRegistry.set(fold.tag, fold as EmbedFold<SeerEmbedName, unknown>);
+  return fold;
+}
+
+// Matches complete `{% name %}<body>{% /name %}` tags for any tag name;
+// occurrences whose name has no registered fold are skipped. Mirrors the
+// BLOCK_RE grammar in utils/marked/extensions/tag.ts.
+const EMBED_TAG_RE = /\{%\s+([\w-]+)\s+%\}([\s\S]*?)\{%\s+\/\1\s+%\}/g;
+
+function runEmbedFolds(blocks: readonly EmbedSourceBlock[]): Map<string, unknown> {
+  const state = new Map<string, unknown>();
+  for (const fold of foldRegistry.values()) {
+    state.set(fold.tag, fold.init);
+  }
+  blocks.forEach((block, blockIndex) => {
+    const content = block.message.content;
+    if (!content) {
+      return;
+    }
+    for (const match of content.matchAll(EMBED_TAG_RE)) {
+      const fold = foldRegistry.get(match[1]!);
+      if (!fold) {
+        continue;
+      }
+      let body: unknown;
+      try {
+        body = JSON.parse(match[2]!);
+      } catch {
+        continue;
+      }
+      const parsed = SEER_EMBED_SCHEMAS[fold.tag].schema.safeParse(body);
+      if (!parsed.success) {
+        continue;
+      }
+      state.set(
+        fold.tag,
+        fold.reduce(state.get(fold.tag), {
+          blockId: block.id,
+          blockIndex,
+          data: parsed.data,
+        })
+      );
+    }
+  });
+  return state;
+}
+
+const SeerConversationContext = createContext<ReadonlyMap<string, unknown> | undefined>(
+  undefined
+);
+
+/**
+ * Wrap the rendered conversation once; every registered fold derives its
+ * state from the same single pass over `blocks`.
+ */
+export function SeerConversationProvider({
+  blocks,
+  children,
+}: {
+  blocks: readonly EmbedSourceBlock[];
+  children: ReactNode;
+}) {
+  const state = useMemo(() => runEmbedFolds(blocks), [blocks]);
+  return <SeerConversationContext value={state}>{children}</SeerConversationContext>;
+}
+
+/**
+ * Read a fold's derived state. Returns `undefined` when rendering outside a
+ * conversation (no provider — e.g. stories/previews), letting embeds choose a
+ * standalone rendering.
+ */
+export function useEmbedFoldState<N extends SeerEmbedName, S>(
+  fold: EmbedFold<N, S>
+): S | undefined {
+  const state = useContext(SeerConversationContext);
+  if (state === undefined) {
+    return undefined;
+  }
+  return state.get(fold.tag) as S;
+}

--- a/static/app/components/seer/markdown/embeds/conversation.tsx
+++ b/static/app/components/seer/markdown/embeds/conversation.tsx
@@ -6,6 +6,7 @@ import {
   SEER_EMBED_SCHEMAS,
   type SeerEmbedName,
 } from 'sentry/components/seer/markdown/embeds/schemas';
+import {MarkedLexer, type ExtendedToken, type Token} from 'sentry/utils/marked/marked';
 
 /**
  * Conversation-derived embed state ("the fold").
@@ -33,6 +34,7 @@ export interface EmbedSourceBlock {
 }
 
 export interface EmbedOccurrence<N extends SeerEmbedName> {
+  attrs: Record<string, string>;
   blockId: string;
   blockIndex: number;
   data: z.output<(typeof SEER_EMBED_SCHEMAS)[N]['schema']>;
@@ -54,10 +56,25 @@ export function registerEmbedFold<N extends SeerEmbedName, S>(
   return fold;
 }
 
-// Matches complete `{% name %}<body>{% /name %}` tags for any tag name;
-// occurrences whose name has no registered fold are skipped. Mirrors the
-// BLOCK_RE grammar in utils/marked/extensions/tag.ts.
-const EMBED_TAG_RE = /\{%\s+([\w-]+)\s+%\}([\s\S]*?)\{%\s+\/\1\s+%\}/g;
+// The same lexer the renderer uses produces the tag tokens (with attrs and a
+// JSON-parsed body) — folds see exactly what renders, nothing more. Tags
+// inside code fences, partial tags mid-stream, etc. are correctly not tags.
+function visitTagTokens(
+  tokens: readonly Token[],
+  visit: (token: Extract<ExtendedToken, {type: 'tag'}>) => void
+): void {
+  for (const token of tokens) {
+    if (token.type === 'tag') {
+      visit(token as Extract<ExtendedToken, {type: 'tag'}>);
+    }
+    if ('tokens' in token && token.tokens) {
+      visitTagTokens(token.tokens, visit);
+    }
+    if ('items' in token && token.items) {
+      visitTagTokens(token.items, visit);
+    }
+  }
+}
 
 function runEmbedFolds(blocks: readonly EmbedSourceBlock[]): Map<string, unknown> {
   const state = new Map<string, unknown>();
@@ -69,30 +86,25 @@ function runEmbedFolds(blocks: readonly EmbedSourceBlock[]): Map<string, unknown
     if (!content) {
       return;
     }
-    for (const match of content.matchAll(EMBED_TAG_RE)) {
-      const fold = foldRegistry.get(match[1]!);
+    visitTagTokens(MarkedLexer.lex(content), token => {
+      const fold = foldRegistry.get(token.name);
       if (!fold) {
-        continue;
+        return;
       }
-      let body: unknown;
-      try {
-        body = JSON.parse(match[2]!);
-      } catch {
-        continue;
-      }
-      const parsed = SEER_EMBED_SCHEMAS[fold.tag].schema.safeParse(body);
+      const parsed = SEER_EMBED_SCHEMAS[fold.tag].schema.safeParse(token.data);
       if (!parsed.success) {
-        continue;
+        return;
       }
       state.set(
         fold.tag,
         fold.reduce(state.get(fold.tag), {
+          attrs: token.attrs,
           blockId: block.id,
           blockIndex,
           data: parsed.data,
         })
       );
-    }
+    });
   });
   return state;
 }

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -1,8 +1,9 @@
 // When adding a new embed, just drop a file in ./components/ and import it here
 import {Timestamp} from './components/timestamp';
+import {Todos} from './components/todos';
 import {SeerEmbedRegistry} from './registry';
 
-const embeds = [Timestamp];
+const embeds = [Timestamp, Todos];
 for (const embed of embeds) {
   SeerEmbedRegistry.register(embed.displayName, embed);
 }

--- a/static/app/components/seer/markdown/embeds/registry.tsx
+++ b/static/app/components/seer/markdown/embeds/registry.tsx
@@ -1,4 +1,15 @@
 import type {ReactNode} from 'react';
+import {createContext} from 'react';
+
+/**
+ * Identifies the conversation block whose content is currently being rendered.
+ * Provided by the surface rendering the conversation (e.g. the Explorer chat's
+ * BlockComponent) so embeds can locate themselves in the conversation — e.g.
+ * the `todos` embed renders only when it lives in the latest todos-bearing
+ * block. Undefined when markdown renders outside a conversation (stories,
+ * previews).
+ */
+export const SeerEmbedBlockContext = createContext<string | undefined>(undefined);
 
 /**
  * Generic props every Seer embed receives from the markdown Tag renderer.

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -18,6 +18,20 @@ export const SEER_EMBED_SCHEMAS = {
       format: z.enum(['absolute', 'relative']).default('absolute'),
     }),
   },
+  todos: {
+    description:
+      'Your todo checklist. The todo_write tool emits this tag automatically — NEVER write a {% todos %} tag yourself and never restate the todo list in prose. The latest occurrence in the conversation replaces all earlier ones.',
+    level: ['block'],
+    featureFlag: 'organizations:seer-explorer-todos-markdown',
+    schema: z.object({
+      items: z.array(
+        z.object({
+          content: z.string(),
+          status: z.enum(['pending', 'in_progress', 'completed']),
+        })
+      ),
+    }),
+  },
 } as const satisfies Record<string, SeerEmbedSchema>;
 
 export type SeerEmbedName = keyof typeof SEER_EMBED_SCHEMAS;

--- a/static/app/components/seer/todoList.tsx
+++ b/static/app/components/seer/todoList.tsx
@@ -1,0 +1,30 @@
+import {Checkbox} from '@sentry/scraps/checkbox';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+export interface TodoListItem {
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+/**
+ * Read-only todo checklist shared by the legacy `block.todos` sidecar path and
+ * the `{% todos %}` markdown embed.
+ */
+export function TodoList({todos}: {todos: TodoListItem[]}) {
+  return (
+    <Stack as="ul" gap="sm" padding="0">
+      {todos.map(todo => {
+        const checked = todo.status === 'completed';
+        return (
+          <Flex key={todo.content} as="li" gap="sm" align="center">
+            <Checkbox size="xs" checked={checked} readOnly />
+            <Text size="xs" monospace strikethrough={checked} variant="muted">
+              {todo.content}
+            </Text>
+          </Flex>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/static/app/views/seerExplorer/components/chat/index.tsx
+++ b/static/app/views/seerExplorer/components/chat/index.tsx
@@ -2,6 +2,7 @@ import {motion} from 'framer-motion';
 
 import {Container} from '@sentry/scraps/layout';
 
+import {SeerEmbedBlockContext} from 'sentry/components/seer/markdown/embeds/registry';
 import {unreachable} from 'sentry/utils/unreachable';
 import type {Block, SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 
@@ -33,7 +34,9 @@ export function BlockComponent({onClick, ref, ...props}: BlockProps) {
       onClick={onClick}
     >
       <motion.div initial={{opacity: 0, x: 10}} animate={{opacity: 1, x: 0}}>
-        <BlockVariant {...props} />
+        <SeerEmbedBlockContext value={props.block.id}>
+          <BlockVariant {...props} />
+        </SeerEmbedBlockContext>
       </motion.div>
     </Container>
   );

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Checkbox} from '@sentry/scraps/checkbox';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
@@ -9,6 +8,7 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {TodoList} from 'sentry/components/seer/todoList';
 import {IconCheckmark, IconClose, IconLink, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -229,24 +229,6 @@ function ToolCallRow({
         )}
       </Flex>
       {todos && <TodoList todos={todos} />}
-    </Stack>
-  );
-}
-
-function TodoList({todos}: {todos: TodoItem[]}) {
-  return (
-    <Stack as="ul" gap="sm" padding="0">
-      {todos.map(todo => {
-        const checked = todo.status === 'completed';
-        return (
-          <Flex key={todo.content} as="li" gap="sm" align="center">
-            <Checkbox size="xs" checked={checked} readOnly />
-            <Text size="xs" monospace strikethrough={checked} variant="muted">
-              {todo.content}
-            </Text>
-          </Flex>
-        );
-      })}
     </Stack>
   );
 }

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -7,6 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {usePictureInPicture} from '@sentry/scraps/pictureInPicture';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {SeerTodosProvider} from 'sentry/components/seer/markdown/embeds/components/todos';
 import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -211,6 +212,12 @@ export function SeerExplorerContent({
     sessionData.owner_user_id.toString() !== user.id;
 
   const blocks = useMemo(() => sessionData?.blocks || [], [sessionData?.blocks]);
+
+  // Feeds the conversation-scoped todo state (latest {% todos %} embed wins).
+  const todosSourceBlocks = useMemo(
+    () => blocks.map(block => ({id: block.id, content: block.message.content})),
+    [blocks]
+  );
   const isAwaitingUserInput = sessionData?.status === 'awaiting_user_input';
   const pendingInput = sessionData?.pending_user_input ?? null;
   const isEmptyState = blocks.length === 0 && !(isAwaitingUserInput && pendingInput);
@@ -565,74 +572,76 @@ export function SeerExplorerContent({
       {needsSlackUpgrade && (
         <UpdateSlackAlert num_configurations={activeSlackIntegrations.length} />
       )}
-      <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
-        {isEmptyState ? (
-          <EmptyState
-            isLoading={isPolling}
-            isError={isError}
-            errorStatusCode={errorStatusCode}
-            runId={runId}
-            displaySlackAgentReminder={hasSlackIntegration && !needsSlackUpgrade}
-            onSuggestionClick={readOnly ? undefined : sendMessage}
-          />
-        ) : (
-          <Fragment>
-            {blocks.map((block: Block, index: number) => {
-              // For slide-in animation that runs on mount. Avoid running this twice on user blocks when blocks are hydrated.
-              const key = block.message.role === 'user' ? `user-${index}` : block.id;
+      <SeerTodosProvider blocks={todosSourceBlocks}>
+        <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
+          {isEmptyState ? (
+            <EmptyState
+              isLoading={isPolling}
+              isError={isError}
+              errorStatusCode={errorStatusCode}
+              runId={runId}
+              displaySlackAgentReminder={hasSlackIntegration && !needsSlackUpgrade}
+              onSuggestionClick={readOnly ? undefined : sendMessage}
+            />
+          ) : (
+            <Fragment>
+              {blocks.map((block: Block, index: number) => {
+                // For slide-in animation that runs on mount. Avoid running this twice on user blocks when blocks are hydrated.
+                const key = block.message.role === 'user' ? `user-${index}` : block.id;
 
-              return (
-                <BlockComponent
-                  key={key}
-                  ref={el => {
-                    blockRefs.current[index] = el;
-                  }}
-                  block={block}
-                  blockIndex={index}
-                  blocks={blocks}
-                  runId={runId ?? undefined}
-                  getPageReferrer={getPageReferrer}
-                  interactionPending={
-                    isFileApprovalPending || isQuestionPending || showReauth
-                  }
-                  readOnly={readOnly}
-                  showThinking={showThinking}
-                />
-              );
-            })}
-            {!readOnly &&
-              isFileApprovalPending &&
-              fileApprovalIndex < fileApprovalTotalPatches && (
-                <FileChangeApprovalBlock
-                  currentIndex={fileApprovalIndex}
-                  pendingInput={pendingInput}
+                return (
+                  <BlockComponent
+                    key={key}
+                    ref={el => {
+                      blockRefs.current[index] = el;
+                    }}
+                    block={block}
+                    blockIndex={index}
+                    blocks={blocks}
+                    runId={runId ?? undefined}
+                    getPageReferrer={getPageReferrer}
+                    interactionPending={
+                      isFileApprovalPending || isQuestionPending || showReauth
+                    }
+                    readOnly={readOnly}
+                    showThinking={showThinking}
+                  />
+                );
+              })}
+              {!readOnly &&
+                isFileApprovalPending &&
+                fileApprovalIndex < fileApprovalTotalPatches && (
+                  <FileChangeApprovalBlock
+                    currentIndex={fileApprovalIndex}
+                    pendingInput={pendingInput}
+                  />
+                )}
+              {!readOnly && isQuestionPending && currentQuestion && (
+                <AskUserQuestionBlock
+                  currentQuestion={currentQuestion}
+                  customText={customText}
+                  isOtherSelected={isOtherSelected}
+                  onCustomTextChange={handleQuestionCustomTextChange}
+                  onSelectOption={handleQuestionSelectOption}
+                  questionIndex={questionIndex}
+                  selectedOption={selectedOption}
                 />
               )}
-            {!readOnly && isQuestionPending && currentQuestion && (
-              <AskUserQuestionBlock
-                currentQuestion={currentQuestion}
-                customText={customText}
-                isOtherSelected={isOtherSelected}
-                onCustomTextChange={handleQuestionCustomTextChange}
-                onSelectOption={handleQuestionSelectOption}
-                questionIndex={questionIndex}
-                selectedOption={selectedOption}
-              />
-            )}
-            {!readOnly && showReauth && reauthData && (
-              <ReauthMonitoringProviderBlock
-                data={reauthData}
-                onComplete={handleReauthComplete}
-                returnUrl={
-                  runId === null
-                    ? undefined
-                    : getRelativeExplorerUrl(runId, {resume: true})
-                }
-              />
-            )}
-          </Fragment>
-        )}
-      </BlocksContainer>
+              {!readOnly && showReauth && reauthData && (
+                <ReauthMonitoringProviderBlock
+                  data={reauthData}
+                  onComplete={handleReauthComplete}
+                  returnUrl={
+                    runId === null
+                      ? undefined
+                      : getRelativeExplorerUrl(runId, {resume: true})
+                  }
+                />
+              )}
+            </Fragment>
+          )}
+        </BlocksContainer>
+      </SeerTodosProvider>
       <InputSection
         blocks={blocks}
         enabled={!readOnly}

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -7,7 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {usePictureInPicture} from '@sentry/scraps/pictureInPicture';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
-import {SeerTodosProvider} from 'sentry/components/seer/markdown/embeds/components/todos';
+import {SeerConversationProvider} from 'sentry/components/seer/markdown/embeds/conversation';
 import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -212,12 +212,6 @@ export function SeerExplorerContent({
     sessionData.owner_user_id.toString() !== user.id;
 
   const blocks = useMemo(() => sessionData?.blocks || [], [sessionData?.blocks]);
-
-  // Feeds the conversation-scoped todo state (latest {% todos %} embed wins).
-  const todosSourceBlocks = useMemo(
-    () => blocks.map(block => ({id: block.id, content: block.message.content})),
-    [blocks]
-  );
   const isAwaitingUserInput = sessionData?.status === 'awaiting_user_input';
   const pendingInput = sessionData?.pending_user_input ?? null;
   const isEmptyState = blocks.length === 0 && !(isAwaitingUserInput && pendingInput);
@@ -572,7 +566,7 @@ export function SeerExplorerContent({
       {needsSlackUpgrade && (
         <UpdateSlackAlert num_configurations={activeSlackIntegrations.length} />
       )}
-      <SeerTodosProvider blocks={todosSourceBlocks}>
+      <SeerConversationProvider blocks={blocks}>
         <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
           {isEmptyState ? (
             <EmptyState
@@ -641,7 +635,7 @@ export function SeerExplorerContent({
             </Fragment>
           )}
         </BlocksContainer>
-      </SeerTodosProvider>
+      </SeerConversationProvider>
       <InputSection
         blocks={blocks}
         enabled={!readOnly}


### PR DESCRIPTION
Adds the `{% todos %}` markdown embed to the Seer Explorer chat: a flag-gated schema in the embed registry, the rendering component, and a conversation-scoped provider that derives the latest snapshot from block content so only the most recent checklist renders. The `TodoList` presentational component is extracted from the tool rail so the legacy `block.todos` sidecar path and the embed render identically — legacy behavior is unchanged.

This is the pilot widget for moving Explorer's structured block sidecars into markdown-with-embeds. Todos were chosen because they're stateful (latest-wins), display-only, and a true 1:1 cutover: with `organizations:seer-explorer-todos-markdown` enabled, todos travel *only* as `{% todos %}` tags in content; with it off, behavior is byte-for-byte today's.

Ships inert — no tag exists until Seer emits one, and unknown tags already render as nothing. Companions: getsentry/sentry#119831 (flag + generated widget schema), getsentry/seer#7381 (todo_write projection switch).