### PR TITLE
feat(seer): Register todos markdown embed flag and widget schema

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -265,6 +265,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-ui-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer to generate rich component embeds from an adjusted prompt
     manager.add("organizations:seer-explorer-embeds", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Emit Seer Explorer todos as {% todos %} markdown embeds instead of the block.todos sidecar
+    manager.add("organizations:seer-explorer-todos-markdown", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable thinking + tool-call summaries in Seer Agent
     manager.add("organizations:seer-explorer-thinking-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:seer-explorer-stream", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -19,5 +19,36 @@
       "required": ["value", "format"],
       "additionalProperties": false
     }
+  },
+  {
+    "name": "todos",
+    "description": "Your todo checklist. The todo_write tool emits this tag automatically — NEVER write a {% todos %} tag yourself and never restate the todo list in prose. The latest occurrence in the conversation replaces all earlier ones.",
+    "level": ["block"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "content": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string",
+                "enum": ["pending", "in_progress", "completed"]
+              }
+            },
+            "required": ["content", "status"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["items"],
+      "additionalProperties": false
+    },
+    "featureFlag": "organizations:seer-explorer-todos-markdown"
   }
 ]

--- a/tests/sentry/seer/agent/test_embed_widgets.py
+++ b/tests/sentry/seer/agent/test_embed_widgets.py
@@ -1,0 +1,22 @@
+from sentry.seer.agent.embed_widgets import get_embed_widgets
+from sentry.testutils.cases import TestCase
+
+
+class GetEmbedWidgetsTest(TestCase):
+    def test_unflagged_widgets_always_included(self) -> None:
+        names = {w["name"] for w in get_embed_widgets(self.organization)}
+        assert "timestamp" in names
+
+    def test_flagged_widget_excluded_without_flag(self) -> None:
+        names = {w["name"] for w in get_embed_widgets(self.organization)}
+        assert "todos" not in names
+
+    def test_flagged_widget_included_with_flag(self) -> None:
+        with self.feature("organizations:seer-explorer-todos-markdown"):
+            names = {w["name"] for w in get_embed_widgets(self.organization)}
+        assert "todos" in names
+
+    def test_flagged_widget_excluded_without_organization(self) -> None:
+        names = {w["name"] for w in get_embed_widgets(None)}
+        assert "timestamp" in names
+        assert "todos" not in names


### PR DESCRIPTION
Registers `organizations:seer-explorer-todos-markdown` and regenerates `embed_widgets.generated.json` (via `pnpm gen:embed-widgets`) to include the flag-gated `todos` widget. The widget's source schema lives in the frontend embed registry — getsentry/sentry#119830.

With the flag off, `get_embed_widgets` filters the widget out of the list sent to Seer and nothing changes anywhere. With it on, Seer runs receive the widget definition, which both documents the tag in the agent's prompt and switches Seer's `todo_write` from the `block.todos` sidecar to `{% todos %}` markdown emission (getsentry/seer PR to follow).

Pilot widget for the Seer Explorer markdown-wire migration. Ships inert; the Flagpole ramp is the rollout — no deploy ordering between this, the frontend PR, and the Seer PR matters, so long as all three are deployed before the flag flips.