### PR TITLE
chore(event formatter): use formatter for copy to markdown

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -227,6 +227,7 @@ export interface ExplorerAutofixState {
  */
 export interface ExplorerAutofixResponse {
   autofix: ExplorerAutofixState | null;
+  formatted?: {content: string; format: string};
 }
 
 /**
@@ -247,7 +248,7 @@ function explorerAutofixApiOptions(orgSlug: string, groupId: string) {
     '/organizations/$organizationIdOrSlug/issues/$issueId/autofix/',
     {
       path: {organizationIdOrSlug: orgSlug, issueId: groupId},
-      query: {mode: 'explorer'},
+      query: {mode: 'explorer', llmFormat: 'markdown'},
       staleTime: 0,
     }
   );
@@ -956,6 +957,10 @@ export function useExplorerAutofix(
      * Current autofix run state, or null if no run exists.
      */
     runState,
+    /**
+     * Formatted markdown for LLM prompts
+     */
+    autofixFormatted: apiData?.formatted?.content ?? null,
     /**
      * Whether we're fetching without an existing run to display.
      * This includes background refetches of a cached null response so callers do not

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -109,6 +109,7 @@ function makePR(overrides: Partial<RepoPRState> = {}): RepoPRState {
 
 const mockAutofix: ReturnType<typeof useExplorerAutofix> = {
   runState: null,
+  autofixFormatted: null,
   isLoading: false,
   isPolling: false,
   startStep: jest.fn(),

--- a/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
@@ -125,6 +125,7 @@ function makeAutofix(
 
   return {
     runState,
+    autofixFormatted: null,
     isLoading: false,
     isPolling: false,
     // Async no-ops — none of these are invoked by the static examples below.

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -20,6 +20,7 @@ function makeAutofix(
 ): ReturnType<typeof useExplorerAutofix> {
   const base: ReturnType<typeof useExplorerAutofix> = {
     runState: {run_id: 1} as any,
+    autofixFormatted: null,
     startStep: jest.fn(),
     createPR: jest.fn(),
     reset: jest.fn(),

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -13,6 +13,7 @@ function makeAutofix(
 ): ReturnType<typeof useExplorerAutofix> {
   return {
     runState: {run_id: 1, blocks: []} as any,
+    autofixFormatted: null,
     startStep: jest.fn().mockResolvedValue(undefined),
     createPR: jest.fn(),
     reset: jest.fn(),

--- a/static/app/components/events/autofix/v3/useAutoTriggerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/v3/useAutoTriggerAutofix.spec.tsx
@@ -10,6 +10,7 @@ function makeAutofix(
 ): ReturnType<typeof useExplorerAutofix> {
   const base: ReturnType<typeof useExplorerAutofix> = {
     runState: null,
+    autofixFormatted: null,
     startStep: jest.fn(),
     createPR: jest.fn(),
     reset: jest.fn(),

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -11,6 +11,7 @@ function makeAutofix(
 ): ReturnType<typeof useExplorerAutofix> {
   const base: ReturnType<typeof useExplorerAutofix> = {
     runState: null,
+    autofixFormatted: null,
     startStep: jest.fn(),
     createPR: jest.fn(),
     reset: jest.fn(),

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -765,6 +765,7 @@ interface EventBase {
   dateCreated?: string;
   device?: Record<string, any>;
   endTimestamp?: number;
+  formatted?: {content: string; format: string};
   groupID?: string;
   groupingConfig?: {
     enhancements: string;

--- a/static/app/views/issueDetails/eventNavigation/index.tsx
+++ b/static/app/views/issueDetails/eventNavigation/index.tsx
@@ -116,7 +116,9 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
   const activeThreadId = useActiveThreadId();
 
   // Get data for markdown copy functionality
-  const {runState: autofixData} = useExplorerAutofix(group, {enabled: false});
+  const {runState: autofixData, autofixFormatted} = useExplorerAutofix(group, {
+    enabled: false,
+  });
 
   const handleCopyMarkdown = useCallback(() => {
     const markdownText = issueAndEventToMarkdown({
@@ -125,6 +127,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
       autofixData,
       activeThreadId,
       organization,
+      autofixFormatted,
     });
 
     trackAnalytics('issue_details.copy_issue_details_as_markdown', {
@@ -135,7 +138,7 @@ export function IssueEventNavigation({event, group}: IssueEventNavigationProps) 
     });
 
     return markdownText;
-  }, [activeThreadId, event, group, autofixData, organization]);
+  }, [activeThreadId, event, group, autofixData, organization, autofixFormatted]);
 
   return (
     <EventNavigationWrapper role="navigation" ref={navigationRef}>

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.spec.tsx
@@ -105,6 +105,37 @@ describe('useCopyIssueDetails', () => {
       expect(result).toContain(`**Project:** ${group.project?.slug}`);
     });
 
+    it('uses the server-rendered body and does not add a second date', () => {
+      const user = UserFixture();
+      user.options.timezone = 'America/New_York';
+      ConfigStore.set('user', user);
+
+      const formattedEvent = EventFixture({
+        id: '123456',
+        dateCreated: '2023-01-01T00:00:00Z',
+        formatted: {
+          format: 'markdown',
+          content: '## Title\nboom\n**Date:** 2023-01-01 00:00:00 UTC',
+        },
+      });
+
+      try {
+        const result = issueAndEventToMarkdown({
+          group,
+          event: formattedEvent,
+          organization,
+        });
+
+        expect(result).toContain(`**Issue ID:** ${group.id}`);
+        expect(result).toContain('**Date:** 2023-01-01 00:00:00 UTC');
+        // the server body carries the only date; the header must not add a local-time one
+        expect(result.match(/\*\*Date:\*\*/g)).toHaveLength(1);
+        expect(result).not.toContain('EST');
+      } finally {
+        ConfigStore.set('user', UserFixture());
+      }
+    });
+
     it("renders the date in the user's timezone and clock preference", () => {
       const user = UserFixture();
       user.options.timezone = 'America/New_York';

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -276,9 +276,8 @@ export const issueAndEventToMarkdown = ({
     if (group.project?.slug) {
       llmMarkdown += `**Project:** ${group.project.slug}\n`;
     }
-    if (typeof event?.dateCreated === 'string') {
-      llmMarkdown += `**Date:** ${new Date(event.dateCreated).toLocaleString()}\n`;
-    }
+    // no date here: the server-rendered body already opens with a `Date` field in UTC, and a
+    // second one formatted in the viewer's timezone would just disagree with it
     llmMarkdown += `\n${formatted}`;
     if (autofixFormatted) {
       llmMarkdown += `\n\n${autofixFormatted}`;

--- a/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/hooks/useCopyIssueDetails.tsx
@@ -258,6 +258,7 @@ interface IssueAndEventToMarkdownOptions {
   organization: Organization;
   activeThreadId?: number;
   autofixData?: ExplorerAutofixState | null;
+  autofixFormatted?: string | null;
   event?: Event | null;
 }
 
@@ -267,7 +268,24 @@ export const issueAndEventToMarkdown = ({
   autofixData,
   activeThreadId,
   organization,
+  autofixFormatted,
 }: IssueAndEventToMarkdownOptions): string => {
+  const formatted = event?.formatted?.content;
+  if (formatted) {
+    let llmMarkdown = `**Issue ID:** ${group.id}\n`;
+    if (group.project?.slug) {
+      llmMarkdown += `**Project:** ${group.project.slug}\n`;
+    }
+    if (typeof event?.dateCreated === 'string') {
+      llmMarkdown += `**Date:** ${new Date(event.dateCreated).toLocaleString()}\n`;
+    }
+    llmMarkdown += `\n${formatted}`;
+    if (autofixFormatted) {
+      llmMarkdown += `\n\n${autofixFormatted}`;
+    }
+    return llmMarkdown;
+  }
+
   // Format the basic issue information
   let markdownText = `# ${group.title}\n\n`;
   markdownText += `**Issue ID:** ${group.id}\n`;
@@ -340,7 +358,9 @@ export const issueAndEventToMarkdown = ({
 export const useCopyIssueDetails = (group: Group, event?: Event) => {
   const organization = useOrganization();
 
-  const {runState: autofixData} = useExplorerAutofix(group, {enabled: false});
+  const {runState: autofixData, autofixFormatted} = useExplorerAutofix(group, {
+    enabled: false,
+  });
   const activeThreadId = useActiveThreadId();
 
   const text = useMemo(() => {
@@ -350,8 +370,9 @@ export const useCopyIssueDetails = (group: Group, event?: Event) => {
       autofixData,
       activeThreadId,
       organization,
+      autofixFormatted,
     });
-  }, [group, event, autofixData, activeThreadId, organization]);
+  }, [group, event, autofixData, activeThreadId, organization, autofixFormatted]);
 
   const {copy} = useCopyToClipboard();
 

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -212,6 +212,7 @@ function getGroupEventDetailsQueryData({
 }): Record<string, string | string[]> {
   const params: Record<string, string | string[]> = {
     collapse: ['fullRelease'],
+    llmFormat: 'markdown',
   };
 
   if (query) {

--- a/tests/js/fixtures/autofix.ts
+++ b/tests/js/fixtures/autofix.ts
@@ -10,6 +10,7 @@ export function ExplorerAutofixFixture(
 ): ReturnType<typeof useExplorerAutofix> {
   return {
     runState: ExplorerAutofixStateFixture(),
+    autofixFormatted: null,
     startStep: jest.fn(),
     createPR: jest.fn(),
     reset: jest.fn(),


### PR DESCRIPTION
to be merged after #119545

Wires the issue-details "Copy to Markdown" action to the shared formatter. The event-details and autofix queries now request `?llmFormat=markdown`, and when the API returns a formatted payload the copy output is built from that server-rendered markdown (issue ID / project / date header + the formatted event body, plus the autofix markdown when present). When formatted is absent, it falls back to the existing client-side markdown builder.

No behavioral change on merge. behind the `issues.standardized-markdown-for-llm` option. Rollout will happen gradually via feature flag.