### PR TITLE
build(ui): Remove unused Node polyfill `buffer`

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -76,7 +76,6 @@ const config: KnipConfig = {
   ignoreDependencies: [
     'core-js',
     'tslib', // subdependency of many packages, declare the latest version
-    'buffer', // rspack.ProvidePlugin, needs better knip plugin
     'odiff-bin', // raw binary consumed by Python backend, not a JS import
     'run-on-changed', // CLI used by the eslint CI job (.github/workflows/frontend.yml), not a JS import
     '@swc-contrib/mut-cjs-exports', // used in jest config

--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "@types/webpack-env": "1.18.8",
     "ansi-to-react": "^6.1.6",
     "base64-arraybuffer": "^1.0.1",
-    "buffer": "^6.0.3",
     "cbor2": "^1.12.0",
     "classnames": "2.3.1",
     "color": "5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,9 +322,6 @@ importers:
       base64-arraybuffer:
         specifier: ^1.0.1
         version: 1.0.2
-      buffer:
-        specifier: ^6.0.3
-        version: 6.0.3
       cbor2:
         specifier: ^1.12.0
         version: 1.12.0

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -426,13 +426,6 @@ const appConfig: Configuration = {
     new rspack.ContextReplacementPlugin(/platformicons/, /\.svg$/),
 
     /**
-     * TODO(epurkhiser): Figure out if we still need these
-     */
-    new rspack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-    }),
-
-    /**
      * Extract CSS into separate files.
      * https://rspack.rs/plugins/rspack/css-extract-rspack-plugin
      */
@@ -527,8 +520,6 @@ const appConfig: Configuration = {
     fallback: {
       vm: false,
       stream: false,
-      // Node crypto is imported in @sentry-internal/global-search but not used here
-      crypto: false,
       // `pnpm why` says this is only needed in dev deps
       string_decoder: false,
     },


### PR DESCRIPTION
Removes the leftover Buffer `ProvidePlugin` and disabled crypto fallback.

These polyfills originally came from the Webpack 5 migration in #25004 to cover Node globals used by the old global-search bundle.

Also removes the direct `buffer` dependency and Knip exception, saving about 26.5 KiB uncompressed and 7.7 KiB gzipped