### PR TITLE
feat(billing): Sample success logs via trace_log_sample_rate

### DIFF
--- a/src/sentry/billing/platform/core/README.md
+++ b/src/sentry/billing/platform/core/README.md
@@ -6,7 +6,7 @@ Base classes and decorators for billing services. No application-specific code.
 
 Provides automatic observability for service methods:
 
-**Datadog metrics emitted** (via `metrics.incr` / `metrics.timing`):
+**Metrics emitted:**
 
 - `billing.service.method.called` - Method invocations
 - `billing.service.method.success` - Successful completions
@@ -15,11 +15,6 @@ Provides automatic observability for service methods:
 
 All metrics include `service` and `method` tags.
 
-**Sentry Metrics** (via `sentry_sdk.metrics.count`, 100% sampled):
-
-- `billing.service.method.success` - Successful completions
-- `billing.service.method.error` - Failures (tagged with error_type)
-
 **Validation:**
 
 - Input must be a protobuf Message
@@ -27,7 +22,10 @@ All metrics include `service` and `method` tags.
 
 **Logging:**
 
-Structured error logs with service name, method name, duration, and error details. Success paths do not emit a structured log (use Sentry Metrics instead).
+Structured success and error logs with service name, method name, and duration.
+Error logs are always emitted. Success logs are sampled via
+`trace_log_sample_rate` (default `0.001` / 0.1%). Pass
+`trace_log_sample_rate=1.0` when validating a new service method.
 
 ## Example
 
@@ -39,6 +37,10 @@ from sentry_protos.billing.v1.services.contract import GetContractRequest, GetCo
 class ContractService(BillingService):
     @service_method
     def get_contract(self, request: GetContractRequest) -> GetContractResponse:
+        return GetContractResponse(contract_id=f"contract_{request.organization_id}")
+
+    @service_method(trace_log_sample_rate=1.0)
+    def experimental_method(self, request: GetContractRequest) -> GetContractResponse:
         return GetContractResponse(contract_id=f"contract_{request.organization_id}")
 ```
 

--- a/src/sentry/billing/platform/core/README.md
+++ b/src/sentry/billing/platform/core/README.md
@@ -6,7 +6,7 @@ Base classes and decorators for billing services. No application-specific code.
 
 Provides automatic observability for service methods:
 
-**Metrics emitted:**
+**Datadog metrics emitted** (via `metrics.incr` / `metrics.timing`):
 
 - `billing.service.method.called` - Method invocations
 - `billing.service.method.success` - Successful completions
@@ -15,6 +15,11 @@ Provides automatic observability for service methods:
 
 All metrics include `service` and `method` tags.
 
+**Sentry Metrics** (via `sentry_sdk.metrics.count`, 100% sampled):
+
+- `billing.service.method.success` - Successful completions
+- `billing.service.method.error` - Failures (tagged with error_type)
+
 **Validation:**
 
 - Input must be a protobuf Message
@@ -22,7 +27,7 @@ All metrics include `service` and `method` tags.
 
 **Logging:**
 
-Structured logs at start, success, and error with service name, method name, and duration.
+Structured error logs with service name, method name, duration, and error details. Success paths do not emit a structured log (use Sentry Metrics instead).
 
 ## Example
 

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -126,16 +126,9 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
             metrics.timing(
                 "billing.service.method.duration", duration_ms, tags=metric_tags, sample_rate=1.0
             )
-            metrics.incr(
-                "billing.service.method.error",
-                tags={**metric_tags, "error_type": type(e).__name__},
-                sample_rate=1.0,
-            )
-            sentry_sdk.metrics.count(
-                "billing.service.method.error",
-                1,
-                attributes={**metric_tags, "error_type": type(e).__name__},
-            )
+            tags = {**metric_tags, "error_type": type(e).__name__}
+            metrics.incr("billing.service.method.error", tags=tags, sample_rate=1.0)
+            sentry_sdk.metrics.count("billing.service.method.error", 1, attributes=tags)
 
             logger.info(
                 "billing.service.method.error",

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -4,9 +4,9 @@ import functools
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TypeVar
+from random import random
+from typing import Any, TypeVar, overload
 
-import sentry_sdk
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import Message
 
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=Message)
 R = TypeVar("R", bound=Message)
+
+# Sample success structured logs by default; dial to 1.0 when debugging a new method.
+DEFAULT_TRACE_LOG_SAMPLE_RATE = 0.001
 
 
 class BillingService:
@@ -52,7 +55,22 @@ class BillingService:
         pass
 
 
-def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
+@overload
+def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]: ...
+
+
+@overload
+def service_method(
+    *,
+    trace_log_sample_rate: float = DEFAULT_TRACE_LOG_SAMPLE_RATE,
+) -> Callable[[Callable[[Any, T], R]], Callable[[Any, T], R]]: ...
+
+
+def service_method(
+    func: Callable[[Any, T], R] | None = None,
+    *,
+    trace_log_sample_rate: float = DEFAULT_TRACE_LOG_SAMPLE_RATE,
+) -> Callable[[Any, T], R] | Callable[[Callable[[Any, T], R]], Callable[[Any, T], R]]:
     """
     Decorator for billing service methods.
 
@@ -62,83 +80,115 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
     - Error handling
     - Request/response validation
 
+    Success structured logs are sampled via ``trace_log_sample_rate`` (default
+    0.1%). Pass ``trace_log_sample_rate=1.0`` when validating a new method.
+    Error logs are always emitted. Datadog metrics are always emitted.
+
     The decorated method should accept a protobuf request and return a protobuf response.
 
     Example:
         @service_method
         def get_contract(self, request: GetContractRequest) -> GetContractResponse:
             pass
+
+        @service_method(trace_log_sample_rate=1.0)
+        def experimental_method(self, request: ...) -> ...:
+            pass
     """
 
-    @functools.wraps(func)
-    def wrapper(self: BillingService, request: T) -> R:
-        service_name = self.__class__.__name__
-        method_name = func.__name__
-        metric_tags = {"service": service_name, "method": method_name}
+    def decorator(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
+        @functools.wraps(func)
+        def wrapper(self: BillingService, request: T) -> R:
+            service_name = self.__class__.__name__
+            method_name = func.__name__
+            metric_tags = {"service": service_name, "method": method_name}
 
-        # Validate input is a protobuf message
-        if not isinstance(request, Message):
-            raise TypeError(
-                f"{service_name}.{method_name} expects a protobuf Message, "
-                f"got {type(request).__name__}"
-            )
-
-        start_time = time.time()
-
-        metrics.incr("billing.service.method.called", tags=metric_tags, sample_rate=1.0)
-        extras = {
-            "service": service_name,
-            "method": method_name,
-            "request_type": type(request).__name__,
-            "request": MessageToDict(request),
-        }
-        if organization_id := getattr(request, "organization_id", None):
-            extras["organization_id"] = organization_id
-        if contract_id := getattr(request, "contract_id", None):
-            extras["contract_id"] = contract_id
-
-        try:
-            with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
-                for k, v in extras.items():
-                    set_span_data(cur_span, k, v)
-                result = func(self, request)
-
-            # Validate output is a protobuf message
-            if not isinstance(result, Message):
+            # Validate input is a protobuf message
+            if not isinstance(request, Message):
                 raise TypeError(
-                    f"{service_name}.{method_name} must return a protobuf Message, "
-                    f"returned {type(result).__name__}"
+                    f"{service_name}.{method_name} expects a protobuf Message, "
+                    f"got {type(request).__name__}"
                 )
 
-            duration_ms = (time.time() - start_time) * 1000
+            start_time = time.time()
 
-            metrics.timing(
-                "billing.service.method.duration", duration_ms, tags=metric_tags, sample_rate=1.0
-            )
-            metrics.incr("billing.service.method.success", tags=metric_tags, sample_rate=1.0)
-            sentry_sdk.metrics.count("billing.service.method.success", 1, attributes=metric_tags)
+            metrics.incr("billing.service.method.called", tags=metric_tags, sample_rate=1.0)
+            extras = {
+                "service": service_name,
+                "method": method_name,
+                "request_type": type(request).__name__,
+                "request": MessageToDict(request),
+            }
+            if organization_id := getattr(request, "organization_id", None):
+                extras["organization_id"] = organization_id
+            if contract_id := getattr(request, "contract_id", None):
+                extras["contract_id"] = contract_id
 
-            return result
+            try:
+                with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
+                    for k, v in extras.items():
+                        set_span_data(cur_span, k, v)
+                    result = func(self, request)
 
-        except Exception as e:
-            duration_ms = (time.time() - start_time) * 1000
+                # Validate output is a protobuf message
+                if not isinstance(result, Message):
+                    raise TypeError(
+                        f"{service_name}.{method_name} must return a protobuf Message, "
+                        f"returned {type(result).__name__}"
+                    )
 
-            metrics.timing(
-                "billing.service.method.duration", duration_ms, tags=metric_tags, sample_rate=1.0
-            )
-            tags = {**metric_tags, "error_type": type(e).__name__}
-            metrics.incr("billing.service.method.error", tags=tags, sample_rate=1.0)
-            sentry_sdk.metrics.count("billing.service.method.error", 1, attributes=tags)
+                duration_ms = (time.time() - start_time) * 1000
 
-            logger.info(
-                "billing.service.method.error",
-                extra={
-                    "duration_ms": duration_ms,
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                    **extras,
-                },
-            )
-            raise
+                metrics.timing(
+                    "billing.service.method.duration",
+                    duration_ms,
+                    tags=metric_tags,
+                    sample_rate=1.0,
+                )
+                metrics.incr("billing.service.method.success", tags=metric_tags, sample_rate=1.0)
 
-    return wrapper
+                if _should_emit_trace_log(trace_log_sample_rate):
+                    logger.info(
+                        "billing.service.method.success",
+                        extra={
+                            "duration_ms": duration_ms,
+                            "response_type": type(result).__name__,
+                            "response": MessageToDict(result),
+                            **extras,
+                        },
+                    )
+
+                return result
+
+            except Exception as e:
+                duration_ms = (time.time() - start_time) * 1000
+
+                metrics.timing(
+                    "billing.service.method.duration",
+                    duration_ms,
+                    tags=metric_tags,
+                    sample_rate=1.0,
+                )
+                tags = {**metric_tags, "error_type": type(e).__name__}
+                metrics.incr("billing.service.method.error", tags=tags, sample_rate=1.0)
+
+                logger.info(
+                    "billing.service.method.error",
+                    extra={
+                        "duration_ms": duration_ms,
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                        **extras,
+                    },
+                )
+                raise
+
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    return decorator
+
+
+def _should_emit_trace_log(sample_rate: float) -> bool:
+    return sample_rate >= 1.0 or (sample_rate > 0.0 and random() < sample_rate)

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Callable
 from typing import Any, TypeVar
 
+import sentry_sdk
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import Message
 
@@ -115,16 +116,7 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
                 "billing.service.method.duration", duration_ms, tags=metric_tags, sample_rate=1.0
             )
             metrics.incr("billing.service.method.success", tags=metric_tags, sample_rate=1.0)
-
-            logger.info(
-                "billing.service.method.success",
-                extra={
-                    "duration_ms": duration_ms,
-                    "response_type": type(result).__name__,
-                    "response": MessageToDict(result),
-                    **extras,
-                },
-            )
+            sentry_sdk.metrics.count("billing.service.method.success", 1, attributes=metric_tags)
 
             return result
 
@@ -138,6 +130,11 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
                 "billing.service.method.error",
                 tags={**metric_tags, "error_type": type(e).__name__},
                 sample_rate=1.0,
+            )
+            sentry_sdk.metrics.count(
+                "billing.service.method.error",
+                1,
+                attributes={**metric_tags, "error_type": type(e).__name__},
             )
 
             logger.info(

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -52,14 +52,13 @@ class TestBillingService:
         with pytest.raises(TypeError, match="must return a protobuf Message"):
             service.bad_return(StringValue(value="test"))
 
-    @mock.patch("sentry.billing.platform.core.service.sentry_sdk.metrics.count")
     @mock.patch("sentry.billing.platform.core.service.metrics")
     @mock.patch("sentry.billing.platform.core.service.logger")
-    def test_service_method_observability(self, mock_logger, mock_metrics, mock_sentry_count):
-        """Service methods emit Datadog and Sentry metrics; no success log."""
+    def test_service_method_observability_with_full_sample_rate(self, mock_logger, mock_metrics):
+        """With trace_log_sample_rate=1.0, success metrics and logs are emitted."""
 
         class TestService(BillingService):
-            @service_method
+            @service_method(trace_log_sample_rate=1.0)
             def test_method(self, request: StringValue) -> StringValue:
                 return StringValue(value="ok")
 
@@ -80,22 +79,69 @@ class TestBillingService:
         )
         mock_metrics.timing.assert_called()
 
-        mock_sentry_count.assert_called_once_with(
-            "billing.service.method.success",
-            1,
-            attributes=metric_tags,
-        )
+        mock_logger.info.assert_called_once()
+        assert mock_logger.info.call_args[0][0] == "billing.service.method.success"
 
-        mock_logger.info.assert_not_called()
-
-    @mock.patch("sentry.billing.platform.core.service.sentry_sdk.metrics.count")
+    @mock.patch("sentry.billing.platform.core.service.random", return_value=0.5)
     @mock.patch("sentry.billing.platform.core.service.metrics")
     @mock.patch("sentry.billing.platform.core.service.logger")
-    def test_service_method_error_handling(self, mock_logger, mock_metrics, mock_sentry_count):
-        """Service methods propagate exceptions and emit error metrics/logs."""
+    def test_service_method_success_log_sampled_out(self, mock_logger, mock_metrics, mock_random):
+        """Default sample rate skips success logs when the draw is above the rate."""
 
         class TestService(BillingService):
             @service_method
+            def test_method(self, request: StringValue) -> StringValue:
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.test_method(StringValue(value="test"))
+
+        mock_metrics.incr.assert_any_call(
+            "billing.service.method.success",
+            tags={"service": "TestService", "method": "test_method"},
+            sample_rate=1.0,
+        )
+        mock_logger.info.assert_not_called()
+
+    @mock.patch("sentry.billing.platform.core.service.random", return_value=0.0005)
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    @mock.patch("sentry.billing.platform.core.service.logger")
+    def test_service_method_success_log_sampled_in(self, mock_logger, mock_metrics, mock_random):
+        """Default sample rate emits success logs when the draw is below the rate."""
+
+        class TestService(BillingService):
+            @service_method
+            def test_method(self, request: StringValue) -> StringValue:
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.test_method(StringValue(value="test"))
+
+        mock_logger.info.assert_called_once()
+        assert mock_logger.info.call_args[0][0] == "billing.service.method.success"
+
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    @mock.patch("sentry.billing.platform.core.service.logger")
+    def test_service_method_zero_sample_rate_skips_success_log(self, mock_logger, mock_metrics):
+        """trace_log_sample_rate=0 never emits success logs."""
+
+        class TestService(BillingService):
+            @service_method(trace_log_sample_rate=0.0)
+            def test_method(self, request: StringValue) -> StringValue:
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.test_method(StringValue(value="test"))
+
+        mock_logger.info.assert_not_called()
+
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    @mock.patch("sentry.billing.platform.core.service.logger")
+    def test_service_method_error_handling(self, mock_logger, mock_metrics):
+        """Errors always emit metrics and logs regardless of sample rate."""
+
+        class TestService(BillingService):
+            @service_method(trace_log_sample_rate=0.0)
             def failing_method(self, request: StringValue) -> StringValue:
                 raise ValueError("Something went wrong")
 
@@ -104,22 +150,14 @@ class TestBillingService:
         with pytest.raises(ValueError, match="Something went wrong"):
             service.failing_method(StringValue(value="test"))
 
-        error_tags = {
-            "service": "TestService",
-            "method": "failing_method",
-            "error_type": "ValueError",
-        }
-
         mock_metrics.incr.assert_any_call(
             "billing.service.method.error",
-            tags=error_tags,
+            tags={
+                "service": "TestService",
+                "method": "failing_method",
+                "error_type": "ValueError",
+            },
             sample_rate=1.0,
-        )
-
-        mock_sentry_count.assert_called_once_with(
-            "billing.service.method.error",
-            1,
-            attributes=error_tags,
         )
 
         mock_logger.info.assert_called_once()

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -52,10 +52,11 @@ class TestBillingService:
         with pytest.raises(TypeError, match="must return a protobuf Message"):
             service.bad_return(StringValue(value="test"))
 
+    @mock.patch("sentry.billing.platform.core.service.sentry_sdk.metrics.count")
     @mock.patch("sentry.billing.platform.core.service.metrics")
     @mock.patch("sentry.billing.platform.core.service.logger")
-    def test_service_method_observability(self, mock_logger, mock_metrics):
-        """Service methods emit metrics and logs."""
+    def test_service_method_observability(self, mock_logger, mock_metrics, mock_sentry_count):
+        """Service methods emit Datadog and Sentry metrics; no success log."""
 
         class TestService(BillingService):
             @service_method
@@ -65,25 +66,33 @@ class TestBillingService:
         service = TestService()
         service.test_method(StringValue(value="test"))
 
-        # Verify metrics were called
+        metric_tags = {"service": "TestService", "method": "test_method"}
+
         mock_metrics.incr.assert_any_call(
             "billing.service.method.called",
-            tags={"service": "TestService", "method": "test_method"},
+            tags=metric_tags,
             sample_rate=1.0,
         )
         mock_metrics.incr.assert_any_call(
             "billing.service.method.success",
-            tags={"service": "TestService", "method": "test_method"},
+            tags=metric_tags,
             sample_rate=1.0,
         )
         mock_metrics.timing.assert_called()
 
-        # Verify logging
-        assert mock_logger.info.call_count == 1
+        mock_sentry_count.assert_called_once_with(
+            "billing.service.method.success",
+            1,
+            attributes=metric_tags,
+        )
 
+        mock_logger.info.assert_not_called()
+
+    @mock.patch("sentry.billing.platform.core.service.sentry_sdk.metrics.count")
     @mock.patch("sentry.billing.platform.core.service.metrics")
-    def test_service_method_error_handling(self, mock_metrics):
-        """Service methods propagate exceptions and emit error metrics."""
+    @mock.patch("sentry.billing.platform.core.service.logger")
+    def test_service_method_error_handling(self, mock_logger, mock_metrics, mock_sentry_count):
+        """Service methods propagate exceptions and emit error metrics/logs."""
 
         class TestService(BillingService):
             @service_method
@@ -95,16 +104,26 @@ class TestBillingService:
         with pytest.raises(ValueError, match="Something went wrong"):
             service.failing_method(StringValue(value="test"))
 
-        # Verify error metrics
+        error_tags = {
+            "service": "TestService",
+            "method": "failing_method",
+            "error_type": "ValueError",
+        }
+
         mock_metrics.incr.assert_any_call(
             "billing.service.method.error",
-            tags={
-                "service": "TestService",
-                "method": "failing_method",
-                "error_type": "ValueError",
-            },
+            tags=error_tags,
             sample_rate=1.0,
         )
+
+        mock_sentry_count.assert_called_once_with(
+            "billing.service.method.error",
+            1,
+            attributes=error_tags,
+        )
+
+        mock_logger.info.assert_called_once()
+        assert mock_logger.info.call_args[0][0] == "billing.service.method.error"
 
     def test_multiple_methods_on_same_service(self) -> None:
         """A service can have multiple service methods."""


### PR DESCRIPTION
`@service_method` now samples success structured logs via `trace_log_sample_rate` (default `0.001` / 0.1%) instead of logging every successful call. Pass `trace_log_sample_rate=1.0` while validating a new method, then leave the default in place for steady state.

Error logs and Datadog metrics (`called` / `success` / `error` / `duration`) are unchanged and always emitted. Existing `@service_method` usages keep working without changes.
