### PR TITLE
chore(GAL): shift activity double-write to feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -117,6 +117,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-issues-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Allows GroupActionLogEntries to be written from Activity creation.
+    manager.add("organizations:group_action_log.activity.double-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable LLM-generated title and description for external issue details
     manager.add("organizations:external-issues-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:inbound-filters-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -12,7 +12,7 @@ from django.db.models import F
 from django.db.models.signals import post_save
 from django.utils import timezone
 
-from sentry import options
+from sentry import features, options
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import (
     BoundedPositiveIntegerField,
@@ -125,7 +125,14 @@ class ActivityManager(BaseManager["Activity"]):
     def create(self, **kwargs: Any) -> Activity:
         activity: Activity = super().create(**kwargs)
 
-        if not options.get("group_action_log.activity.double-write") and not in_test_environment():
+        double_write_enabled = False
+        p = activity.project
+        if p is not None:
+            o = p.organization
+            double_write_enabled = features.has(
+                "organizations:group_action_log.activity.double-write", o
+            )
+        if not double_write_enabled and not in_test_environment():
             return activity
 
         group_id = kwargs.get("group_id")
@@ -153,7 +160,17 @@ class ActivityManager(BaseManager["Activity"]):
 
     def bulk_create(self, *args: Any) -> list[Activity]:
         activities: list[Activity] = super().bulk_create(*args)
-        if not options.get("group_action_log.activity.double-write") and not in_test_environment():
+        if len(activities) == 0:
+            return activities
+
+        double_write_enabled = False
+        p = activities[0].project
+        if p is not None:
+            o = p.organization
+            double_write_enabled = features.has(
+                "organizations:group_action_log.activity.double-write", o
+            )
+        if not double_write_enabled and not in_test_environment():
             return activities
         try:
             actions_with_activities = [

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3928,11 +3928,3 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-
-# Allows GroupActionLogEntries to be written from Activity creation.
-register(
-    "group_action_log.activity.double-write",
-    default=False,
-    type=Bool,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)


### PR DESCRIPTION
set this up as an option while juggling failures yesterday, but I think that a feature flag would be more appropriate
