### PR TITLE
ref(billing): Add trace_log_sample_rate to service_method decorator

### DIFF
--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import functools
 import hashlib
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Any, TypeVar, overload
 
 from google.protobuf.json_format import MessageToDict
@@ -53,18 +55,50 @@ class BillingService:
         pass
 
 
-def _should_log_trace(trace_log_sample_rate: float) -> bool:
-    """
-    Determine whether to log based on a hash of the current trace ID.
+_effective_sample_rate: contextvars.ContextVar[float] = contextvars.ContextVar(
+    "_effective_sample_rate"
+)
 
-    Uses a deterministic hash so all calls within the same trace are consistently
-    logged or not.
+
+@contextlib.contextmanager
+def _propagate_sample_rate(rate: float) -> Generator[None]:
+    """Set the effective sample rate for this scope and restore it on exit.
+
+    The effective rate is ``max(rate, parent_rate)`` so that if a parent
+    service method is being logged, all children in the same call tree
+    will be logged too.  The previous value is restored when the context
+    manager exits, preventing siblings from inheriting each other's rates.
     """
+    effective = max(rate, _effective_sample_rate.get(0.0))
+    token = _effective_sample_rate.set(effective)
+    try:
+        yield
+    finally:
+        _effective_sample_rate.reset(token)
+
+
+def _get_trace_hash() -> int | None:
+    """Return a deterministic hash value for the current trace ID, or None if unavailable."""
     trace_id = get_trace_id()
     if trace_id is None:
+        return None
+    return int(hashlib.md5(str(trace_id).encode()).hexdigest(), 16) % 10000
+
+
+def _should_log_trace() -> bool:
+    """
+    Determine whether to log based on a hash of the current trace ID and the
+    effective sample rate from the ContextVar.
+
+    The effective rate is set by ``_propagate_sample_rate`` as
+    ``max(own_rate, parent_rate)``, so if a parent decided to log, all children
+    in the same call tree will too.
+    """
+    effective_rate = _effective_sample_rate.get(0.0)
+    trace_hash = _get_trace_hash()
+    if trace_hash is None:
         return False
-    hash_value = int(hashlib.md5(str(trace_id).encode()).hexdigest(), 16)
-    return (hash_value % 10000) < int(trace_log_sample_rate * 10000)
+    return trace_hash < int(effective_rate * 10000)
 
 
 @overload
@@ -122,81 +156,86 @@ def service_method(
                     f"got {type(request).__name__}"
                 )
 
-            start_time = time.time()
+            with _propagate_sample_rate(trace_log_sample_rate):
+                start_time = time.time()
 
-            metrics.incr("billing.service.method.called", tags=metric_tags, sample_rate=1.0)
-            extras = {
-                "service": service_name,
-                "method": method_name,
-                "request_type": type(request).__name__,
-                "request": MessageToDict(request),
-            }
-            if organization_id := getattr(request, "organization_id", None):
-                extras["organization_id"] = organization_id
-            if contract_id := getattr(request, "contract_id", None):
-                extras["contract_id"] = contract_id
+                metrics.incr("billing.service.method.called", tags=metric_tags, sample_rate=1.0)
+                extras = {
+                    "service": service_name,
+                    "method": method_name,
+                    "request_type": type(request).__name__,
+                    "request": MessageToDict(request),
+                }
+                if organization_id := getattr(request, "organization_id", None):
+                    extras["organization_id"] = organization_id
+                if contract_id := getattr(request, "contract_id", None):
+                    extras["contract_id"] = contract_id
 
-            try:
-                with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
-                    for k, v in extras.items():
-                        set_span_data(cur_span, k, v)
-                    result = func(self, request)
+                try:
+                    with start_span(
+                        op="function", name=f"{service_name}.{method_name}"
+                    ) as cur_span:
+                        for k, v in extras.items():
+                            set_span_data(cur_span, k, v)
+                        result = func(self, request)
 
-                # Validate output is a protobuf message
-                if not isinstance(result, Message):
-                    raise TypeError(
-                        f"{service_name}.{method_name} must return a protobuf Message, "
-                        f"returned {type(result).__name__}"
+                    # Validate output is a protobuf message
+                    if not isinstance(result, Message):
+                        raise TypeError(
+                            f"{service_name}.{method_name} must return a protobuf Message, "
+                            f"returned {type(result).__name__}"
+                        )
+
+                    duration_ms = (time.time() - start_time) * 1000
+
+                    metrics.timing(
+                        "billing.service.method.duration",
+                        duration_ms,
+                        tags=metric_tags,
+                        sample_rate=1.0,
+                    )
+                    metrics.incr(
+                        "billing.service.method.success", tags=metric_tags, sample_rate=1.0
                     )
 
-                duration_ms = (time.time() - start_time) * 1000
+                    if _should_log_trace():
+                        logger.info(
+                            "billing.service.method.success",
+                            extra={
+                                "duration_ms": duration_ms,
+                                "response_type": type(result).__name__,
+                                "response": MessageToDict(result),
+                                **extras,
+                            },
+                        )
 
-                metrics.timing(
-                    "billing.service.method.duration",
-                    duration_ms,
-                    tags=metric_tags,
-                    sample_rate=1.0,
-                )
-                metrics.incr("billing.service.method.success", tags=metric_tags, sample_rate=1.0)
+                    return result
 
-                if _should_log_trace(trace_log_sample_rate):
+                except Exception as e:
+                    duration_ms = (time.time() - start_time) * 1000
+
+                    metrics.timing(
+                        "billing.service.method.duration",
+                        duration_ms,
+                        tags=metric_tags,
+                        sample_rate=1.0,
+                    )
+                    metrics.incr(
+                        "billing.service.method.error",
+                        tags={**metric_tags, "error_type": type(e).__name__},
+                        sample_rate=1.0,
+                    )
+
                     logger.info(
-                        "billing.service.method.success",
+                        "billing.service.method.error",
                         extra={
                             "duration_ms": duration_ms,
-                            "response_type": type(result).__name__,
-                            "response": MessageToDict(result),
+                            "error": str(e),
+                            "error_type": type(e).__name__,
                             **extras,
                         },
                     )
-
-                return result
-
-            except Exception as e:
-                duration_ms = (time.time() - start_time) * 1000
-
-                metrics.timing(
-                    "billing.service.method.duration",
-                    duration_ms,
-                    tags=metric_tags,
-                    sample_rate=1.0,
-                )
-                metrics.incr(
-                    "billing.service.method.error",
-                    tags={**metric_tags, "error_type": type(e).__name__},
-                    sample_rate=1.0,
-                )
-
-                logger.info(
-                    "billing.service.method.error",
-                    extra={
-                        "duration_ms": duration_ms,
-                        "error": str(e),
-                        "error_type": type(e).__name__,
-                        **extras,
-                    },
-                )
-                raise
+                    raise
 
         return wrapper
 

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -130,8 +130,14 @@ def service_method(
     Args:
         trace_log_sample_rate: Rate at which to log successful calls, based on
             a hash of the trace ID. Defaults to 0.001 (0.1%). Error logs are
-            always emitted.
+            always emitted. The behavior is such that in a call tree of service methods,
+            the effective sample rate for any node is max(self.trace_log_sample_rate, parent.trace_log_sample_rate)
 
+            Example:
+                Service.method_1(trace_log_sample_rate=0.1) # effective rate = 0.1
+                    -> Service.method_2(trace_log_sample_rate=0.5) # effective_rate = 0.5
+                        -> Service.method_3(trace_log_sample_rate=0.001) # effective_rate = 0.5 (because parent is higher)
+                    -> Service.method_4(trace_log_sample_rate=0.2) # effective_rate = 0.2
     Example:
         @service_method
         def get_contract(self, request: GetContractRequest) -> GetContractResponse:

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -5,7 +5,7 @@ import hashlib
 import logging
 import time
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import Message
@@ -65,6 +65,16 @@ def _should_log_trace(trace_log_sample_rate: float) -> bool:
         return False
     hash_value = int(hashlib.md5(str(trace_id).encode()).hexdigest(), 16)
     return (hash_value % 10000) < int(trace_log_sample_rate * 10000)
+
+
+@overload
+def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]: ...
+
+
+@overload
+def service_method(
+    *, trace_log_sample_rate: float = ...
+) -> Callable[[Callable[[Any, T], R]], Callable[[Any, T], R]]: ...
 
 
 def service_method(

--- a/src/sentry/billing/platform/core/service.py
+++ b/src/sentry/billing/platform/core/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import hashlib
 import logging
 import time
 from collections.abc import Callable
@@ -10,6 +11,7 @@ from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import Message
 
 from sentry.utils import metrics
+from sentry.utils.sdk import get_trace_id
 from sentry.utils.tracing import set_span_data, start_span
 
 logger = logging.getLogger(__name__)
@@ -51,7 +53,25 @@ class BillingService:
         pass
 
 
-def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
+def _should_log_trace(trace_log_sample_rate: float) -> bool:
+    """
+    Determine whether to log based on a hash of the current trace ID.
+
+    Uses a deterministic hash so all calls within the same trace are consistently
+    logged or not.
+    """
+    trace_id = get_trace_id()
+    if trace_id is None:
+        return False
+    hash_value = int(hashlib.md5(str(trace_id).encode()).hexdigest(), 16)
+    return (hash_value % 10000) < int(trace_log_sample_rate * 10000)
+
+
+def service_method(
+    func: Callable[[Any, T], R] | None = None,
+    *,
+    trace_log_sample_rate: float = 0.001,
+) -> Callable[[Any, T], R] | Callable[[Callable[[Any, T], R]], Callable[[Any, T], R]]:
     """
     Decorator for billing service methods.
 
@@ -63,92 +83,113 @@ def service_method(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
 
     The decorated method should accept a protobuf request and return a protobuf response.
 
+    Args:
+        trace_log_sample_rate: Rate at which to log successful calls, based on
+            a hash of the trace ID. Defaults to 0.001 (0.1%). Error logs are
+            always emitted.
+
     Example:
         @service_method
         def get_contract(self, request: GetContractRequest) -> GetContractResponse:
             pass
+
+        @service_method(trace_log_sample_rate=0.01)
+        def high_volume_method(self, request: Request) -> Response:
+            pass
     """
 
-    @functools.wraps(func)
-    def wrapper(self: BillingService, request: T) -> R:
-        service_name = self.__class__.__name__
-        method_name = func.__name__
-        metric_tags = {"service": service_name, "method": method_name}
+    def decorator(func: Callable[[Any, T], R]) -> Callable[[Any, T], R]:
+        @functools.wraps(func)
+        def wrapper(self: BillingService, request: T) -> R:
+            service_name = self.__class__.__name__
+            method_name = func.__name__
+            metric_tags = {"service": service_name, "method": method_name}
 
-        # Validate input is a protobuf message
-        if not isinstance(request, Message):
-            raise TypeError(
-                f"{service_name}.{method_name} expects a protobuf Message, "
-                f"got {type(request).__name__}"
-            )
-
-        start_time = time.time()
-
-        metrics.incr("billing.service.method.called", tags=metric_tags, sample_rate=1.0)
-        extras = {
-            "service": service_name,
-            "method": method_name,
-            "request_type": type(request).__name__,
-            "request": MessageToDict(request),
-        }
-        if organization_id := getattr(request, "organization_id", None):
-            extras["organization_id"] = organization_id
-        if contract_id := getattr(request, "contract_id", None):
-            extras["contract_id"] = contract_id
-
-        try:
-            with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
-                for k, v in extras.items():
-                    set_span_data(cur_span, k, v)
-                result = func(self, request)
-
-            # Validate output is a protobuf message
-            if not isinstance(result, Message):
+            # Validate input is a protobuf message
+            if not isinstance(request, Message):
                 raise TypeError(
-                    f"{service_name}.{method_name} must return a protobuf Message, "
-                    f"returned {type(result).__name__}"
+                    f"{service_name}.{method_name} expects a protobuf Message, "
+                    f"got {type(request).__name__}"
                 )
 
-            duration_ms = (time.time() - start_time) * 1000
+            start_time = time.time()
 
-            metrics.timing(
-                "billing.service.method.duration", duration_ms, tags=metric_tags, sample_rate=1.0
-            )
-            metrics.incr("billing.service.method.success", tags=metric_tags, sample_rate=1.0)
+            metrics.incr("billing.service.method.called", tags=metric_tags, sample_rate=1.0)
+            extras = {
+                "service": service_name,
+                "method": method_name,
+                "request_type": type(request).__name__,
+                "request": MessageToDict(request),
+            }
+            if organization_id := getattr(request, "organization_id", None):
+                extras["organization_id"] = organization_id
+            if contract_id := getattr(request, "contract_id", None):
+                extras["contract_id"] = contract_id
 
-            logger.info(
-                "billing.service.method.success",
-                extra={
-                    "duration_ms": duration_ms,
-                    "response_type": type(result).__name__,
-                    "response": MessageToDict(result),
-                    **extras,
-                },
-            )
+            try:
+                with start_span(op="function", name=f"{service_name}.{method_name}") as cur_span:
+                    for k, v in extras.items():
+                        set_span_data(cur_span, k, v)
+                    result = func(self, request)
 
-            return result
+                # Validate output is a protobuf message
+                if not isinstance(result, Message):
+                    raise TypeError(
+                        f"{service_name}.{method_name} must return a protobuf Message, "
+                        f"returned {type(result).__name__}"
+                    )
 
-        except Exception as e:
-            duration_ms = (time.time() - start_time) * 1000
+                duration_ms = (time.time() - start_time) * 1000
 
-            metrics.timing(
-                "billing.service.method.duration", duration_ms, tags=metric_tags, sample_rate=1.0
-            )
-            metrics.incr(
-                "billing.service.method.error",
-                tags={**metric_tags, "error_type": type(e).__name__},
-                sample_rate=1.0,
-            )
+                metrics.timing(
+                    "billing.service.method.duration",
+                    duration_ms,
+                    tags=metric_tags,
+                    sample_rate=1.0,
+                )
+                metrics.incr("billing.service.method.success", tags=metric_tags, sample_rate=1.0)
 
-            logger.info(
-                "billing.service.method.error",
-                extra={
-                    "duration_ms": duration_ms,
-                    "error": str(e),
-                    "error_type": type(e).__name__,
-                    **extras,
-                },
-            )
-            raise
+                if _should_log_trace(trace_log_sample_rate):
+                    logger.info(
+                        "billing.service.method.success",
+                        extra={
+                            "duration_ms": duration_ms,
+                            "response_type": type(result).__name__,
+                            "response": MessageToDict(result),
+                            **extras,
+                        },
+                    )
 
-    return wrapper
+                return result
+
+            except Exception as e:
+                duration_ms = (time.time() - start_time) * 1000
+
+                metrics.timing(
+                    "billing.service.method.duration",
+                    duration_ms,
+                    tags=metric_tags,
+                    sample_rate=1.0,
+                )
+                metrics.incr(
+                    "billing.service.method.error",
+                    tags={**metric_tags, "error_type": type(e).__name__},
+                    sample_rate=1.0,
+                )
+
+                logger.info(
+                    "billing.service.method.error",
+                    extra={
+                        "duration_ms": duration_ms,
+                        "error": str(e),
+                        "error_type": type(e).__name__,
+                        **extras,
+                    },
+                )
+                raise
+
+        return wrapper
+
+    if func is not None:
+        return decorator(func)
+    return decorator

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -54,7 +54,8 @@ class TestBillingService:
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
     @mock.patch("sentry.billing.platform.core.service.logger")
-    def test_service_method_observability(self, mock_logger, mock_metrics):
+    @mock.patch("sentry.billing.platform.core.service._should_log_trace", return_value=True)
+    def test_service_method_observability(self, mock_should_log, mock_logger, mock_metrics):
         """Service methods emit metrics and logs."""
 
         class TestService(BillingService):
@@ -79,6 +80,49 @@ class TestBillingService:
         mock_metrics.timing.assert_called()
 
         # Verify logging
+        assert mock_logger.info.call_count == 1
+
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    @mock.patch("sentry.billing.platform.core.service.logger")
+    @mock.patch("sentry.billing.platform.core.service._should_log_trace", return_value=False)
+    def test_service_method_skips_success_log_when_not_sampled(
+        self, mock_should_log, mock_logger, mock_metrics
+    ):
+        """Success logs are skipped when trace is not sampled."""
+
+        class TestService(BillingService):
+            @service_method
+            def test_method(self, request: StringValue) -> StringValue:
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.test_method(StringValue(value="test"))
+
+        # Metrics are still emitted
+        mock_metrics.incr.assert_any_call(
+            "billing.service.method.success",
+            tags={"service": "TestService", "method": "test_method"},
+            sample_rate=1.0,
+        )
+
+        # But no success log
+        mock_logger.info.assert_not_called()
+
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    @mock.patch("sentry.billing.platform.core.service.logger")
+    @mock.patch("sentry.billing.platform.core.service._should_log_trace", return_value=True)
+    def test_service_method_custom_sample_rate(self, mock_should_log, mock_logger, mock_metrics):
+        """Service methods accept a custom trace_log_sample_rate."""
+
+        class TestService(BillingService):
+            @service_method(trace_log_sample_rate=0.5)
+            def test_method(self, request: StringValue) -> StringValue:
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.test_method(StringValue(value="test"))
+
+        mock_should_log.assert_called_with(0.5)
         assert mock_logger.info.call_count == 1
 
     @mock.patch("sentry.billing.platform.core.service.metrics")

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -6,7 +6,11 @@ import pytest
 from google.protobuf.wrappers_pb2 import Int32Value, StringValue
 
 from sentry.billing.platform.core import BillingService, service_method
-from sentry.billing.platform.core.service import _effective_sample_rate, _should_log_trace
+from sentry.billing.platform.core.service import (
+    _effective_sample_rate,
+    _propagate_sample_rate,
+    _should_log_trace,
+)
 
 
 class TestBillingService:
@@ -85,14 +89,11 @@ class TestBillingService:
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
     @mock.patch("sentry.billing.platform.core.service.logger")
-    @mock.patch("sentry.billing.platform.core.service._should_log_trace", return_value=False)
-    def test_service_method_skips_success_log_when_not_sampled(
-        self, mock_should_log, mock_logger, mock_metrics
-    ):
+    def test_service_method_skips_success_log_when_not_sampled(self, mock_logger, mock_metrics):
         """Success logs are skipped when trace is not sampled."""
 
         class TestService(BillingService):
-            @service_method
+            @service_method(trace_log_sample_rate=0)
             def test_method(self, request: StringValue) -> StringValue:
                 return StringValue(value="ok")
 
@@ -108,20 +109,6 @@ class TestBillingService:
 
         # But no success log
         mock_logger.info.assert_not_called()
-
-    @mock.patch("sentry.billing.platform.core.service.metrics")
-    def test_service_method_custom_sample_rate_sets_effective_rate(self, mock_metrics):
-        """A custom trace_log_sample_rate is propagated via the ContextVar."""
-
-        class TestService(BillingService):
-            @service_method(trace_log_sample_rate=0.5)
-            def test_method(self, request: StringValue) -> StringValue:
-                # Inside the method, the effective rate should be set
-                assert _effective_sample_rate.get(0.0) == 0.5
-                return StringValue(value="ok")
-
-        service = TestService()
-        service.test_method(StringValue(value="test"))
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
     def test_service_method_error_handling(self, mock_metrics):
@@ -171,28 +158,22 @@ class TestShouldLogTrace:
 
     @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=None)
     def test_returns_false_when_no_trace_id(self, mock_hash):
-        _effective_sample_rate.set(1.0)
-        assert _should_log_trace() is False
+        with _propagate_sample_rate(1.0):
+            assert _should_log_trace() is False
 
     @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=50)
     def test_logs_when_hash_below_threshold(self, mock_hash):
-        _effective_sample_rate.set(0.01)  # threshold = 100
-        assert _should_log_trace() is True
+        with _propagate_sample_rate(0.01):  # threshold = 100
+            assert _should_log_trace() is True
 
     @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=500)
     def test_skips_when_hash_above_threshold(self, mock_hash):
-        _effective_sample_rate.set(0.01)  # threshold = 100
-        assert _should_log_trace() is False
+        with _propagate_sample_rate(0.01):  # threshold = 100
+            assert _should_log_trace() is False
 
 
 class TestEffectiveSampleRatePropagation:
     """Tests for ContextVar-based sample rate propagation across nested service methods."""
-
-    @pytest.fixture(autouse=True)
-    def _reset_effective_sample_rate(self):
-        token = _effective_sample_rate.set(0.0)
-        yield
-        _effective_sample_rate.reset(token)
 
     @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=9999)
     @mock.patch("sentry.billing.platform.core.service.metrics")

--- a/tests/sentry/billing/platform/core/test_service.py
+++ b/tests/sentry/billing/platform/core/test_service.py
@@ -6,6 +6,7 @@ import pytest
 from google.protobuf.wrappers_pb2 import Int32Value, StringValue
 
 from sentry.billing.platform.core import BillingService, service_method
+from sentry.billing.platform.core.service import _effective_sample_rate, _should_log_trace
 
 
 class TestBillingService:
@@ -109,21 +110,18 @@ class TestBillingService:
         mock_logger.info.assert_not_called()
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
-    @mock.patch("sentry.billing.platform.core.service.logger")
-    @mock.patch("sentry.billing.platform.core.service._should_log_trace", return_value=True)
-    def test_service_method_custom_sample_rate(self, mock_should_log, mock_logger, mock_metrics):
-        """Service methods accept a custom trace_log_sample_rate."""
+    def test_service_method_custom_sample_rate_sets_effective_rate(self, mock_metrics):
+        """A custom trace_log_sample_rate is propagated via the ContextVar."""
 
         class TestService(BillingService):
             @service_method(trace_log_sample_rate=0.5)
             def test_method(self, request: StringValue) -> StringValue:
+                # Inside the method, the effective rate should be set
+                assert _effective_sample_rate.get(0.0) == 0.5
                 return StringValue(value="ok")
 
         service = TestService()
         service.test_method(StringValue(value="test"))
-
-        mock_should_log.assert_called_with(0.5)
-        assert mock_logger.info.call_count == 1
 
     @mock.patch("sentry.billing.platform.core.service.metrics")
     def test_service_method_error_handling(self, mock_metrics):
@@ -166,3 +164,111 @@ class TestBillingService:
 
         assert service.get_user_name(Int32Value(value=123)).value == "User 123"
         assert service.get_user_count(StringValue(value="org_1")).value == 42
+
+
+class TestShouldLogTrace:
+    """Tests for the _should_log_trace sampling logic."""
+
+    @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=None)
+    def test_returns_false_when_no_trace_id(self, mock_hash):
+        _effective_sample_rate.set(1.0)
+        assert _should_log_trace() is False
+
+    @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=50)
+    def test_logs_when_hash_below_threshold(self, mock_hash):
+        _effective_sample_rate.set(0.01)  # threshold = 100
+        assert _should_log_trace() is True
+
+    @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=500)
+    def test_skips_when_hash_above_threshold(self, mock_hash):
+        _effective_sample_rate.set(0.01)  # threshold = 100
+        assert _should_log_trace() is False
+
+
+class TestEffectiveSampleRatePropagation:
+    """Tests for ContextVar-based sample rate propagation across nested service methods."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_effective_sample_rate(self):
+        token = _effective_sample_rate.set(0.0)
+        yield
+        _effective_sample_rate.reset(token)
+
+    @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=9999)
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    def test_parent_rate_propagates_to_child(self, mock_metrics, mock_hash):
+        """A child method inherits the parent's higher effective sample rate."""
+        captured_rates: list[float] = []
+
+        class TestService(BillingService):
+            @service_method(trace_log_sample_rate=0.01)
+            def parent_method(self, request: StringValue) -> StringValue:
+                captured_rates.append(_effective_sample_rate.get(0.0))
+                return self.child_method(request)
+
+            @service_method(trace_log_sample_rate=0.001)
+            def child_method(self, request: StringValue) -> StringValue:
+                captured_rates.append(_effective_sample_rate.get(0.0))
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.parent_method(StringValue(value="test"))
+
+        assert captured_rates[0] == 0.01  # parent's own rate
+        assert captured_rates[1] == 0.01  # child inherited parent's higher rate
+
+    @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=9999)
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    def test_child_higher_rate_takes_precedence(self, mock_metrics, mock_hash):
+        """A child with a higher rate than the parent uses its own rate."""
+        captured_rates: list[float] = []
+
+        class TestService(BillingService):
+            @service_method(trace_log_sample_rate=0.001)
+            def parent_method(self, request: StringValue) -> StringValue:
+                captured_rates.append(_effective_sample_rate.get(0.0))
+                return self.child_method(request)
+
+            @service_method(trace_log_sample_rate=0.01)
+            def child_method(self, request: StringValue) -> StringValue:
+                captured_rates.append(_effective_sample_rate.get(0.0))
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.parent_method(StringValue(value="test"))
+
+        assert captured_rates[0] == 0.001  # parent's own rate
+        assert captured_rates[1] == 0.01  # child's higher rate wins
+
+    @mock.patch("sentry.billing.platform.core.service._get_trace_hash", return_value=9999)
+    @mock.patch("sentry.billing.platform.core.service.metrics")
+    def test_effective_rate_resets_after_method_returns(self, mock_metrics, mock_hash):
+        """The effective rate is restored after a method returns, so siblings
+        don't inherit each other's rates."""
+        captured_rates: list[float] = []
+
+        class TestService(BillingService):
+            @service_method(trace_log_sample_rate=0.001)
+            def parent_method(self, request: StringValue) -> StringValue:
+                self.high_rate_child(request)
+                # After high_rate_child returns, rate should be restored
+                captured_rates.append(_effective_sample_rate.get(0.0))
+                self.low_rate_sibling(request)
+                return StringValue(value="ok")
+
+            @service_method(trace_log_sample_rate=0.1)
+            def high_rate_child(self, request: StringValue) -> StringValue:
+                return StringValue(value="ok")
+
+            @service_method(trace_log_sample_rate=0.0001)
+            def low_rate_sibling(self, request: StringValue) -> StringValue:
+                captured_rates.append(_effective_sample_rate.get(0.0))
+                return StringValue(value="ok")
+
+        service = TestService()
+        service.parent_method(StringValue(value="test"))
+
+        # After high_rate_child returns, parent's rate should be restored
+        assert captured_rates[0] == 0.001
+        # low_rate_sibling should use parent's rate (0.001) since it's higher
+        assert captured_rates[1] == 0.001


### PR DESCRIPTION
## Summary

- Add `trace_log_sample_rate` parameter to `@service_method` decorator (default `0.001`) to reduce excessive success log volume
- Success logs are deterministically sampled using a hash of the trace ID, so all calls within a trace are consistently logged or skipped
- Error logs and all metrics are unaffected — always emitted
- Supports both `@service_method` and `@service_method(trace_log_sample_rate=0.01)` syntax