### PR TITLE
fix(replays): See All Replays button shouldn't replace

### DIFF
--- a/static/app/components/events/eventReplay/replayClipSection.tsx
+++ b/static/app/components/events/eventReplay/replayClipSection.tsx
@@ -50,7 +50,6 @@ export function ReplayClipSection({event, group, replayId}: Props) {
       to={{
         pathname: `${baseUrl}${TabPaths[Tab.REPLAYS]}`,
       }}
-      replace
       analyticsEventKey="issue_details.replay_player.clicked_see_all_replays"
       analyticsEventName="Issue Details: Replay Player Clicked See All Replays"
     >


### PR DESCRIPTION
The **See All Replays** button on the issue details page currently doesn't add to the history stack, so you can't back button out of it. This works differently than every other pane switch: the [dropdown to do so](https://github.com/getsentry/sentry/blob/master/static/app/views/issueDetails/eventNavigation/index.tsx), the [View All Attachments](https://github.com/getsentry/sentry/blob/8c0622cd91ba393157641b4123f04bdbd20767ec/static/app/components/events/eventAttachments.tsx#L53-L61) button, the [screenshot button](https://github.com/getsentry/sentry/blob/8c0622cd91ba393157641b4123f04bdbd20767ec/static/app/components/events/eventTagsAndScreenshot/screenshot/screenshotDataSection.tsx#L107-L110) all add to the history stack; this is the only button that works differently and it's annoying 😄 