### PR TITLE
feat(seer): Render embed tags as Slack Block Kit elements

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -11,7 +11,6 @@ from slack_sdk.models.blocks import (
     ContextBlock,
     InteractiveElement,
     LinkButtonElement,
-    MarkdownBlock,
     MarkdownTextObject,
     PlainTextObject,
     RichTextBlock,
@@ -254,8 +253,9 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
     def _render_agent_response(cls, data: SeerAgentResponse) -> SlackRenderable:
         from sentry import features
         from sentry.models.organization import Organization
+        from sentry.seer.entrypoints.slack.embed_renderer import render_agent_summary
 
-        blocks: list[Block] = [MarkdownBlock(text=data.summary)]
+        blocks: list[Block] = render_agent_summary(data.summary)
         try:
             organization = Organization.objects.get_from_cache(id=data.organization_id)
         except Organization.DoesNotExist:

--- a/src/sentry/seer/agent/embed_parser.py
+++ b/src/sentry/seer/agent/embed_parser.py
@@ -1,0 +1,106 @@
+"""Parse Seer embed tags from agent response markdown.
+
+Uses mistune for markdown-aware tokenization — code fences, paragraph
+boundaries, and heading detection come from the parser, not hand-rolled
+regex. A custom plugin adds ``{% tag %}`` awareness at both block and
+inline levels, mirroring the frontend tokenizer grammar in
+``static/app/utils/marked/extensions/tag.ts``.
+
+This module is provider-agnostic. It produces a token stream that
+platform-specific renderers (Slack, email, Discord, etc.) consume to
+build native output.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import mistune
+from mistune.core import BlockState
+
+from sentry.utils import json
+
+_ATTRS_PAT = r'(?:\s+[\w-]+="[^"]*")*'
+_BLOCK_TAG = (
+    rf"\{{%\s+(?P<bt_name>[\w-]+)(?P<bt_attrs>{_ATTRS_PAT})"
+    rf"\s+%\}}(?P<bt_body>[\s\S]*?)\{{%\s+/(?P=bt_name)\s+%\}}"
+)
+_SELF_CLOSING_TAG = rf"\{{%\s+(?P<sc_name>[\w-]+)(?P<sc_attrs>{_ATTRS_PAT})\s+/%\}}"
+_ATTR_RE = re.compile(r'([\w-]+)="([^"]*)"')
+
+_BLOCK_PATTERN = rf"^ {{0,3}}(?:{_BLOCK_TAG}|{_SELF_CLOSING_TAG}) *(?:\n|$)"
+_INLINE_PATTERN = rf"(?:{_BLOCK_TAG}|{_SELF_CLOSING_TAG})"
+
+
+def _parse_attrs(raw: str) -> dict[str, str]:
+    return dict(_ATTR_RE.findall(raw or ""))
+
+
+def _parse_body(body: str | None) -> Any:
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return body.strip() or None
+
+
+def _extract_tag_fields(m: re.Match[str]) -> dict[str, Any]:
+    name = m.group("bt_name") or m.group("sc_name")
+    attr_str = m.group("bt_attrs") or m.group("sc_attrs") or ""
+    body = m.group("bt_body") if m.group("bt_name") else None
+    return {"name": name, "attrs": _parse_attrs(attr_str), "data": _parse_body(body)}
+
+
+def _handle_block_tag(block: mistune.BlockParser, m: re.Match[str], state: BlockState) -> int:
+    fields = _extract_tag_fields(m)
+    state.append_token(
+        {"type": "seer_tag", "raw": m.group(0), "attrs": {**fields, "level": "block"}}
+    )
+    return m.end()
+
+
+def _handle_inline_tag(inline: mistune.InlineParser, m: re.Match[str], state: Any) -> int:
+    fields = _extract_tag_fields(m)
+    state.append_token(
+        {"type": "seer_tag", "raw": m.group(0), "attrs": {**fields, "level": "inline"}}
+    )
+    return m.end()
+
+
+def _build_parsers() -> tuple[mistune.BlockParser, mistune.InlineParser]:
+    bp = mistune.BlockParser()
+    ip = mistune.InlineParser()
+    bp.register("seer_tag", _BLOCK_PATTERN, _handle_block_tag, before="paragraph")
+    ip.register("seer_tag", _INLINE_PATTERN, _handle_inline_tag, before="linebreak")
+    return bp, ip
+
+
+def tokenize(text: str) -> list[dict[str, Any]]:
+    """Parse *text* into block-level tokens with inline tag splitting.
+
+    Returns a list of mistune tokens. Paragraphs that contain embed tags
+    are emitted as ``paragraph_with_tags`` with a ``children`` list of
+    inline tokens (text and ``seer_tag`` alternating). All other token
+    types pass through unchanged from mistune's block parser.
+    """
+    bp, ip = _build_parsers()
+
+    state = BlockState()
+    state.process(text)
+    bp.parse(state)
+
+    result: list[dict[str, Any]] = []
+    for tok in state.tokens:
+        if tok["type"] == "paragraph" and "{%" in tok.get("text", ""):
+            children = ip(tok["text"].strip(), state.env)
+            result.append({"type": "paragraph_with_tags", "raw": tok["text"], "children": children})
+        else:
+            result.append(tok)
+    return result
+
+
+def has_embed_tags(tokens: list[dict[str, Any]]) -> bool:
+    """Return whether any tokens contain Seer embed tags."""
+    return any(tok["type"] in ("seer_tag", "paragraph_with_tags") for tok in tokens)

--- a/src/sentry/seer/entrypoints/slack/embed_renderer.py
+++ b/src/sentry/seer/entrypoints/slack/embed_renderer.py
@@ -1,24 +1,16 @@
-"""Convert Seer agent response markdown (with embed tags) to Slack Block Kit blocks.
+"""Slack-specific rendering of Seer embed tags as Block Kit elements.
 
-Uses mistune for markdown-aware tokenization — code fences, paragraph boundaries,
-and heading detection come from the parser, not hand-rolled regex. A custom plugin
-adds ``{% tag %}`` awareness at both block and inline levels, mirroring the
-frontend tokenizer grammar in ``static/app/utils/marked/extensions/tag.ts``.
-
-The output is a list of Slack Block Kit blocks ready for ``SlackRenderable``:
-- Plain markdown paragraphs → ``MarkdownBlock``
-- Paragraphs with inline embeds (timestamp, docs) → ``RichTextBlock``
-- Block-level embeds (thinking, tool-use) → ``PlanBlock`` / ``TaskCardBlock``
+Consumes the provider-agnostic token stream from
+``sentry.seer.agent.embed_parser`` and converts it to Slack Block Kit
+blocks: ``MarkdownBlock`` for plain markdown, ``RichTextBlock`` for
+paragraphs with inline embeds (native Slack ``Date``/``Link`` parts).
 """
 
 from __future__ import annotations
 
-import re
 from datetime import datetime, timezone
 from typing import Any
 
-import mistune
-from mistune.core import BlockState
 from slack_sdk.models.blocks import (
     Block,
     MarkdownBlock,
@@ -28,90 +20,7 @@ from slack_sdk.models.blocks import (
 )
 from slack_sdk.models.blocks.block_elements import RichTextElement
 
-from sentry.utils import json
-
-# ---------------------------------------------------------------------------
-# Mistune plugin: Seer embed tag grammar
-# ---------------------------------------------------------------------------
-
-_ATTRS_PAT = r'(?:\s+[\w-]+="[^"]*")*'
-_BLOCK_TAG = (
-    rf"\{{%\s+(?P<bt_name>[\w-]+)(?P<bt_attrs>{_ATTRS_PAT})"
-    rf"\s+%\}}(?P<bt_body>[\s\S]*?)\{{%\s+/(?P=bt_name)\s+%\}}"
-)
-_SELF_CLOSING_TAG = rf"\{{%\s+(?P<sc_name>[\w-]+)(?P<sc_attrs>{_ATTRS_PAT})\s+/%\}}"
-_ATTR_RE = re.compile(r'([\w-]+)="([^"]*)"')
-
-_BLOCK_PATTERN = rf"^ {{0,3}}(?:{_BLOCK_TAG}|{_SELF_CLOSING_TAG}) *(?:\n|$)"
-_INLINE_PATTERN = rf"(?:{_BLOCK_TAG}|{_SELF_CLOSING_TAG})"
-
-
-def _parse_attrs(raw: str) -> dict[str, str]:
-    return dict(_ATTR_RE.findall(raw or ""))
-
-
-def _parse_body(body: str | None) -> Any:
-    if not body:
-        return None
-    try:
-        return json.loads(body)
-    except (json.JSONDecodeError, TypeError):
-        return body.strip() or None
-
-
-def _extract_tag_fields(m: re.Match[str]) -> dict[str, Any]:
-    name = m.group("bt_name") or m.group("sc_name")
-    attr_str = m.group("bt_attrs") or m.group("sc_attrs") or ""
-    body = m.group("bt_body") if m.group("bt_name") else None
-    return {"name": name, "attrs": _parse_attrs(attr_str), "data": _parse_body(body)}
-
-
-def _handle_block_tag(block: mistune.BlockParser, m: re.Match[str], state: BlockState) -> int:
-    fields = _extract_tag_fields(m)
-    state.append_token(
-        {"type": "seer_tag", "raw": m.group(0), "attrs": {**fields, "level": "block"}}
-    )
-    return m.end()
-
-
-def _handle_inline_tag(inline: mistune.InlineParser, m: re.Match[str], state: Any) -> int:
-    fields = _extract_tag_fields(m)
-    state.append_token(
-        {"type": "seer_tag", "raw": m.group(0), "attrs": {**fields, "level": "inline"}}
-    )
-    return m.end()
-
-
-def _build_parsers() -> tuple[mistune.BlockParser, mistune.InlineParser]:
-    bp = mistune.BlockParser()
-    ip = mistune.InlineParser()
-    bp.register("seer_tag", _BLOCK_PATTERN, _handle_block_tag, before="paragraph")
-    ip.register("seer_tag", _INLINE_PATTERN, _handle_inline_tag, before="linebreak")
-    return bp, ip
-
-
-# ---------------------------------------------------------------------------
-# Tokenizer
-# ---------------------------------------------------------------------------
-
-
-def _tokenize(text: str) -> list[dict[str, Any]]:
-    """Parse *text* into block-level tokens with inline tag splitting."""
-    bp, ip = _build_parsers()
-
-    state = BlockState()
-    state.process(text)
-    bp.parse(state)
-
-    result: list[dict[str, Any]] = []
-    for tok in state.tokens:
-        if tok["type"] == "paragraph" and "{%" in tok.get("text", ""):
-            children = ip(tok["text"].strip(), state.env)
-            result.append({"type": "paragraph_with_tags", "raw": tok["text"], "children": children})
-        else:
-            result.append(tok)
-    return result
-
+from sentry.seer.agent.embed_parser import has_embed_tags, tokenize
 
 # ---------------------------------------------------------------------------
 # Inline tag → RichText element converters
@@ -152,10 +61,7 @@ def _fallback_elements(attrs: dict[str, str], _data: Any) -> list[RichTextElemen
     return []
 
 
-_INLINE_CONVERTERS: dict[
-    str,
-    Any,
-] = {
+_INLINE_CONVERTERS: dict[str, Any] = {
     "timestamp": _timestamp_elements,
     "docs": _docs_elements,
 }
@@ -184,25 +90,20 @@ def _build_rich_text_block(children: list[dict[str, Any]]) -> RichTextBlock:
     return RichTextBlock(elements=[RichTextSectionElement(elements=elements)])
 
 
-def _rebuild_paragraph_markdown(raw: str) -> str:
-    """Reconstruct a paragraph's raw text, stripping only the tag syntax."""
-    return raw
-
-
 def render_agent_summary(summary: str) -> list[Block]:
     """Convert an agent response summary to Slack Block Kit blocks.
 
-    Paragraphs without tags pass through as ``MarkdownBlock``. Paragraphs with
-    inline embeds become ``RichTextBlock`` with native Slack elements (localized
-    dates, clickable links). Block-level tags (thinking, tool-use) will map to
-    ``PlanBlock`` in the future — for now they're stripped.
+    Paragraphs without tags pass through as ``MarkdownBlock``. Paragraphs
+    with inline embeds become ``RichTextBlock`` with native Slack elements
+    (localized dates, clickable links). Block-level tags (thinking,
+    tool-use) will map to ``PlanBlock`` in the future — for now they're
+    stripped.
 
-    Falls back to a single ``MarkdownBlock`` when no tags are present at all.
+    Falls back to a single ``MarkdownBlock`` when no tags are present.
     """
-    tokens = _tokenize(summary)
+    tokens = tokenize(summary)
 
-    has_any_tags = any(tok["type"] in ("seer_tag", "paragraph_with_tags") for tok in tokens)
-    if not has_any_tags:
+    if not has_embed_tags(tokens):
         return [MarkdownBlock(text=summary)]
 
     blocks: list[Block] = []
@@ -220,8 +121,6 @@ def render_agent_summary(summary: str) -> list[Block]:
                 blocks.append(_build_rich_text_block(tok["children"]))
 
             case "seer_tag":
-                # Block-level tags (thinking, tool-use, summary) — PlanBlock
-                # support will go here. For now, strip them.
                 pass
 
             case "paragraph":

--- a/src/sentry/seer/entrypoints/slack/embed_renderer.py
+++ b/src/sentry/seer/entrypoints/slack/embed_renderer.py
@@ -1,0 +1,259 @@
+"""Convert Seer agent response markdown (with embed tags) to Slack Block Kit blocks.
+
+Uses mistune for markdown-aware tokenization — code fences, paragraph boundaries,
+and heading detection come from the parser, not hand-rolled regex. A custom plugin
+adds ``{% tag %}`` awareness at both block and inline levels, mirroring the
+frontend tokenizer grammar in ``static/app/utils/marked/extensions/tag.ts``.
+
+The output is a list of Slack Block Kit blocks ready for ``SlackRenderable``:
+- Plain markdown paragraphs → ``MarkdownBlock``
+- Paragraphs with inline embeds (timestamp, docs) → ``RichTextBlock``
+- Block-level embeds (thinking, tool-use) → ``PlanBlock`` / ``TaskCardBlock``
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+import mistune
+from mistune.core import BlockState
+from slack_sdk.models.blocks import (
+    Block,
+    MarkdownBlock,
+    RichTextBlock,
+    RichTextElementParts,
+    RichTextSectionElement,
+)
+from slack_sdk.models.blocks.block_elements import RichTextElement
+
+from sentry.utils import json
+
+# ---------------------------------------------------------------------------
+# Mistune plugin: Seer embed tag grammar
+# ---------------------------------------------------------------------------
+
+_ATTRS_PAT = r'(?:\s+[\w-]+="[^"]*")*'
+_BLOCK_TAG = (
+    rf"\{{%\s+(?P<bt_name>[\w-]+)(?P<bt_attrs>{_ATTRS_PAT})"
+    rf"\s+%\}}(?P<bt_body>[\s\S]*?)\{{%\s+/(?P=bt_name)\s+%\}}"
+)
+_SELF_CLOSING_TAG = rf"\{{%\s+(?P<sc_name>[\w-]+)(?P<sc_attrs>{_ATTRS_PAT})\s+/%\}}"
+_ATTR_RE = re.compile(r'([\w-]+)="([^"]*)"')
+
+_BLOCK_PATTERN = rf"^ {{0,3}}(?:{_BLOCK_TAG}|{_SELF_CLOSING_TAG}) *(?:\n|$)"
+_INLINE_PATTERN = rf"(?:{_BLOCK_TAG}|{_SELF_CLOSING_TAG})"
+
+
+def _parse_attrs(raw: str) -> dict[str, str]:
+    return dict(_ATTR_RE.findall(raw or ""))
+
+
+def _parse_body(body: str | None) -> Any:
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return body.strip() or None
+
+
+def _extract_tag_fields(m: re.Match[str]) -> dict[str, Any]:
+    name = m.group("bt_name") or m.group("sc_name")
+    attr_str = m.group("bt_attrs") or m.group("sc_attrs") or ""
+    body = m.group("bt_body") if m.group("bt_name") else None
+    return {"name": name, "attrs": _parse_attrs(attr_str), "data": _parse_body(body)}
+
+
+def _handle_block_tag(block: mistune.BlockParser, m: re.Match[str], state: BlockState) -> int:
+    fields = _extract_tag_fields(m)
+    state.append_token(
+        {"type": "seer_tag", "raw": m.group(0), "attrs": {**fields, "level": "block"}}
+    )
+    return m.end()
+
+
+def _handle_inline_tag(inline: mistune.InlineParser, m: re.Match[str], state: Any) -> int:
+    fields = _extract_tag_fields(m)
+    state.append_token(
+        {"type": "seer_tag", "raw": m.group(0), "attrs": {**fields, "level": "inline"}}
+    )
+    return m.end()
+
+
+def _build_parsers() -> tuple[mistune.BlockParser, mistune.InlineParser]:
+    bp = mistune.BlockParser()
+    ip = mistune.InlineParser()
+    bp.register("seer_tag", _BLOCK_PATTERN, _handle_block_tag, before="paragraph")
+    ip.register("seer_tag", _INLINE_PATTERN, _handle_inline_tag, before="linebreak")
+    return bp, ip
+
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+def _tokenize(text: str) -> list[dict[str, Any]]:
+    """Parse *text* into block-level tokens with inline tag splitting."""
+    bp, ip = _build_parsers()
+
+    state = BlockState()
+    state.process(text)
+    bp.parse(state)
+
+    result: list[dict[str, Any]] = []
+    for tok in state.tokens:
+        if tok["type"] == "paragraph" and "{%" in tok.get("text", ""):
+            children = ip(tok["text"].strip(), state.env)
+            result.append({"type": "paragraph_with_tags", "raw": tok["text"], "children": children})
+        else:
+            result.append(tok)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Inline tag → RichText element converters
+# ---------------------------------------------------------------------------
+
+
+def _timestamp_elements(attrs: dict[str, str], _data: Any) -> list[RichTextElement]:
+    value = attrs.get("value", "")
+    fmt = attrs.get("format", "absolute")
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return [RichTextElementParts.Text(text=value or "(invalid date)")]
+
+    unix_ts = int(dt.replace(tzinfo=dt.tzinfo or timezone.utc).timestamp())
+    if fmt == "relative":
+        return [RichTextElementParts.Date(timestamp=unix_ts, format="{ago}", fallback=value)]
+    fallback = dt.strftime("%b %d, %Y at %I:%M %p")
+    return [
+        RichTextElementParts.Date(
+            timestamp=unix_ts, format="{date_short} at {time}", fallback=fallback
+        )
+    ]
+
+
+def _docs_elements(attrs: dict[str, str], _data: Any) -> list[RichTextElement]:
+    href = attrs.get("href", "")
+    title = attrs.get("title", href)
+    if href:
+        return [RichTextElementParts.Link(url=href, text=title)]
+    return [RichTextElementParts.Text(text=title)]
+
+
+def _fallback_elements(attrs: dict[str, str], _data: Any) -> list[RichTextElement]:
+    for key in ("value", "title", "href"):
+        if key in attrs:
+            return [RichTextElementParts.Text(text=attrs[key])]
+    return []
+
+
+_INLINE_CONVERTERS: dict[
+    str,
+    Any,
+] = {
+    "timestamp": _timestamp_elements,
+    "docs": _docs_elements,
+}
+
+
+def _tag_to_rich_text_elements(tag_attrs: dict[str, Any]) -> list[RichTextElement]:
+    name = tag_attrs["name"]
+    converter = _INLINE_CONVERTERS.get(name, _fallback_elements)
+    return converter(tag_attrs["attrs"], tag_attrs.get("data"))
+
+
+# ---------------------------------------------------------------------------
+# Token stream → Block Kit blocks
+# ---------------------------------------------------------------------------
+
+
+def _build_rich_text_block(children: list[dict[str, Any]]) -> RichTextBlock:
+    elements: list[RichTextElement] = []
+    for child in children:
+        if child["type"] == "seer_tag":
+            elements.extend(_tag_to_rich_text_elements(child["attrs"]))
+        else:
+            raw = child.get("raw", "")
+            if raw:
+                elements.append(RichTextElementParts.Text(text=raw))
+    return RichTextBlock(elements=[RichTextSectionElement(elements=elements)])
+
+
+def _rebuild_paragraph_markdown(raw: str) -> str:
+    """Reconstruct a paragraph's raw text, stripping only the tag syntax."""
+    return raw
+
+
+def render_agent_summary(summary: str) -> list[Block]:
+    """Convert an agent response summary to Slack Block Kit blocks.
+
+    Paragraphs without tags pass through as ``MarkdownBlock``. Paragraphs with
+    inline embeds become ``RichTextBlock`` with native Slack elements (localized
+    dates, clickable links). Block-level tags (thinking, tool-use) will map to
+    ``PlanBlock`` in the future — for now they're stripped.
+
+    Falls back to a single ``MarkdownBlock`` when no tags are present at all.
+    """
+    tokens = _tokenize(summary)
+
+    has_any_tags = any(tok["type"] in ("seer_tag", "paragraph_with_tags") for tok in tokens)
+    if not has_any_tags:
+        return [MarkdownBlock(text=summary)]
+
+    blocks: list[Block] = []
+    md_buffer: list[str] = []
+
+    def flush_md() -> None:
+        if md_buffer:
+            blocks.append(MarkdownBlock(text="\n\n".join(md_buffer)))
+            md_buffer.clear()
+
+    for tok in tokens:
+        match tok["type"]:
+            case "paragraph_with_tags":
+                flush_md()
+                blocks.append(_build_rich_text_block(tok["children"]))
+
+            case "seer_tag":
+                # Block-level tags (thinking, tool-use, summary) — PlanBlock
+                # support will go here. For now, strip them.
+                pass
+
+            case "paragraph":
+                md_buffer.append(tok.get("text", "").strip())
+
+            case "heading":
+                level = tok.get("attrs", {}).get("level", 2)
+                prefix = "#" * level
+                md_buffer.append(f"{prefix} {tok.get('text', '')}")
+
+            case "block_code":
+                info = tok.get("attrs", {}).get("info", "")
+                lang = info.split()[0] if info else ""
+                code = tok.get("raw", tok.get("text", ""))
+                md_buffer.append(f"```{lang}\n{code}```")
+
+            case "list":
+                md_buffer.append(tok.get("raw", tok.get("text", "")))
+
+            case "block_quote":
+                md_buffer.append(tok.get("raw", tok.get("text", "")))
+
+            case "thematic_break":
+                md_buffer.append("---")
+
+            case "blank_line":
+                pass
+
+            case _:
+                raw = tok.get("raw", tok.get("text", ""))
+                if raw and raw.strip():
+                    md_buffer.append(raw.strip())
+
+    flush_md()
+    return blocks

--- a/tests/sentry/seer/agent/test_embed_parser.py
+++ b/tests/sentry/seer/agent/test_embed_parser.py
@@ -1,0 +1,67 @@
+from sentry.seer.agent.embed_parser import has_embed_tags, tokenize
+
+
+class TestTokenize:
+    def test_plain_markdown(self):
+        tokens = tokenize("Hello **world**.")
+        assert not has_embed_tags(tokens)
+        types = [t["type"] for t in tokens if t["type"] != "blank_line"]
+        assert "paragraph" in types
+
+    def test_block_level_tag(self):
+        text = '{% thinking %}{"content": "analyzing"}{% /thinking %}'
+        tokens = tokenize(text)
+        assert has_embed_tags(tokens)
+        tag = next(t for t in tokens if t["type"] == "seer_tag")
+        assert tag["attrs"]["name"] == "thinking"
+        assert tag["attrs"]["level"] == "block"
+        assert tag["attrs"]["data"] == {"content": "analyzing"}
+
+    def test_inline_tag_in_paragraph(self):
+        text = 'Seen {% timestamp value="2026-07-15T14:30:00Z" format="relative" /%} ago.'
+        tokens = tokenize(text)
+        assert has_embed_tags(tokens)
+        para = next(t for t in tokens if t["type"] == "paragraph_with_tags")
+        tag_children = [c for c in para["children"] if c["type"] == "seer_tag"]
+        assert len(tag_children) == 1
+        assert tag_children[0]["attrs"]["name"] == "timestamp"
+        assert tag_children[0]["attrs"]["attrs"]["format"] == "relative"
+
+    def test_self_closing_tag(self):
+        text = '{% docs href="https://docs.sentry.io/" title="Docs" /%}'
+        tokens = tokenize(text)
+        tag = next(t for t in tokens if t["type"] == "seer_tag")
+        assert tag["attrs"]["name"] == "docs"
+        assert tag["attrs"]["attrs"]["href"] == "https://docs.sentry.io/"
+
+    def test_code_fence_not_parsed(self):
+        text = '```\n{% timestamp value="2026-01-01" /%}\n```'
+        tokens = tokenize(text)
+        assert not has_embed_tags(tokens)
+
+    def test_mixed_content(self):
+        text = (
+            "## Title\n\n"
+            "Plain paragraph.\n\n"
+            '{% thinking %}{"step": 1}{% /thinking %}\n\n'
+            'Last seen {% timestamp value="2026-07-15" format="relative" /%}.\n'
+        )
+        tokens = tokenize(text)
+        assert has_embed_tags(tokens)
+        types = {t["type"] for t in tokens}
+        assert "heading" in types
+        assert "paragraph" in types
+        assert "seer_tag" in types
+        assert "paragraph_with_tags" in types
+
+    def test_json_body_parsing(self):
+        text = '{% widget %}{"key": [1, 2, 3]}{% /widget %}'
+        tokens = tokenize(text)
+        tag = next(t for t in tokens if t["type"] == "seer_tag")
+        assert tag["attrs"]["data"] == {"key": [1, 2, 3]}
+
+    def test_non_json_body_returned_as_string(self):
+        text = "{% widget %}plain text body{% /widget %}"
+        tokens = tokenize(text)
+        tag = next(t for t in tokens if t["type"] == "seer_tag")
+        assert tag["attrs"]["data"] == "plain text body"

--- a/tests/sentry/seer/entrypoints/slack/test_embed_renderer.py
+++ b/tests/sentry/seer/entrypoints/slack/test_embed_renderer.py
@@ -1,0 +1,102 @@
+from sentry.seer.entrypoints.slack.embed_renderer import render_agent_summary
+
+
+class TestRenderAgentSummary:
+    def test_plain_markdown_passthrough(self):
+        summary = "Here is a normal response with **no** embeds."
+        blocks = render_agent_summary(summary)
+        assert len(blocks) == 1
+        assert blocks[0].to_dict()["type"] == "markdown"
+        assert blocks[0].to_dict()["text"] == summary
+
+    def test_inline_timestamp_absolute(self):
+        summary = 'The error appeared {% timestamp value="2026-07-15T14:30:00Z" format="absolute" /%} in production.'
+        blocks = render_agent_summary(summary)
+        assert len(blocks) == 1
+        block = blocks[0].to_dict()
+        assert block["type"] == "rich_text"
+        elements = block["elements"][0]["elements"]
+        assert elements[0] == {"type": "text", "text": "The error appeared "}
+        date_el = elements[1]
+        assert date_el["type"] == "date"
+        assert date_el["format"] == "{date_short} at {time}"
+        assert date_el["timestamp"] == 1784125800
+        assert elements[2] == {"type": "text", "text": " in production."}
+
+    def test_inline_timestamp_relative(self):
+        summary = 'Last seen {% timestamp value="2026-07-15T14:30:00Z" format="relative" /%}.'
+        blocks = render_agent_summary(summary)
+        block = blocks[0].to_dict()
+        date_el = block["elements"][0]["elements"][1]
+        assert date_el["format"] == "{ago}"
+
+    def test_inline_docs_link(self):
+        summary = (
+            'See {% docs href="https://docs.sentry.io/product/issues/" title="Issues" /%} for more.'
+        )
+        blocks = render_agent_summary(summary)
+        block = blocks[0].to_dict()
+        elements = block["elements"][0]["elements"]
+        link = elements[1]
+        assert link["type"] == "link"
+        assert link["url"] == "https://docs.sentry.io/product/issues/"
+        assert link["text"] == "Issues"
+
+    def test_mixed_tags_and_markdown(self):
+        summary = (
+            "## Analysis\n\n"
+            "Plain paragraph here.\n\n"
+            'First seen {% timestamp value="2026-07-15T14:30:00Z" format="relative" /%}.\n\n'
+            "### Details\n\n"
+            "- Item 1\n- Item 2\n"
+        )
+        blocks = render_agent_summary(summary)
+        types = [b.to_dict()["type"] for b in blocks]
+        assert "markdown" in types
+        assert "rich_text" in types
+        md_texts = [b.to_dict()["text"] for b in blocks if b.to_dict()["type"] == "markdown"]
+        combined = "\n\n".join(md_texts)
+        assert "## Analysis" in combined
+        assert "Plain paragraph here." in combined
+        assert "### Details" in combined
+
+    def test_block_level_tag_stripped(self):
+        summary = 'Before.\n\n{% thinking %}{"content": "analyzing..."}{% /thinking %}\n\nAfter.'
+        blocks = render_agent_summary(summary)
+        types = [b.to_dict()["type"] for b in blocks]
+        assert all(t == "markdown" for t in types)
+        combined = " ".join(b.to_dict()["text"] for b in blocks)
+        assert "Before." in combined
+        assert "After." in combined
+        assert "thinking" not in combined
+
+    def test_code_fence_not_parsed(self):
+        summary = (
+            "Normal text.\n\n"
+            '```python\n# {% timestamp value="2026-01-01" /%}\ndef foo(): pass\n```\n'
+        )
+        blocks = render_agent_summary(summary)
+        types = [b.to_dict()["type"] for b in blocks]
+        assert all(t == "markdown" for t in types)
+        combined = "\n\n".join(b.to_dict()["text"] for b in blocks)
+        assert "{% timestamp" in combined
+
+    def test_unknown_tag_fallback(self):
+        summary = 'Found {% unknown-widget value="something" /%} here.'
+        blocks = render_agent_summary(summary)
+        block = blocks[0].to_dict()
+        elements = block["elements"][0]["elements"]
+        texts = [e["text"] for e in elements if e["type"] == "text"]
+        assert "something" in texts
+
+    def test_multiple_inline_tags(self):
+        summary = (
+            'Started {% timestamp value="2026-07-15T14:30:00Z" format="relative" /%}'
+            ', see {% docs href="https://docs.sentry.io/" title="Docs" /%}.'
+        )
+        blocks = render_agent_summary(summary)
+        block = blocks[0].to_dict()
+        elements = block["elements"][0]["elements"]
+        types = [e["type"] for e in elements]
+        assert "date" in types
+        assert "link" in types


### PR DESCRIPTION
- Add `embed_parser` module (`sentry.seer.agent`) that uses mistune to tokenize agent response markdown with embed tag awareness (`{% tag %}` syntax). Provider-agnostic — shared across notification providers.
- Add Slack-specific `embed_renderer` that converts the token stream to Block Kit blocks: `MarkdownBlock` for plain paragraphs, `RichTextBlock` with native `Date`/`Link` elements for paragraphs with inline embeds (timestamps, doc links).
- Wire `render_agent_summary()` into `SeerSlackRenderer._render_agent_response()` in place of the raw `MarkdownBlock` passthrough.

Inline embeds that need Slack-native elements (e.g. `{% timestamp %}` → localized `Date` part with `{ago}` for relative) get `RichTextBlock`. Everything else stays as `MarkdownBlock` (full markdown support). Block-level tags (thinking, tool-use) are stripped for now — `PlanBlock`/`TaskCardBlock` support is planned for codemode's thinking state embeds.

Re-enabling `enable_embeds=True` for Slack runs will be a follow-up once this lands.