### PR TITLE
feat(action-log): Serialize derived data on the returned group

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import features, tagstore
+from sentry import tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.constants import LOG_LEVELS
@@ -204,31 +204,6 @@ def _make_group_project_response(project: Project) -> GroupProjectResponse:
     }
 
 
-def _get_derived_data_by_group_id(
-    item_list: Sequence[Group], user: User | RpcUser | AnonymousUser
-) -> dict[int, GroupDerivedDataResponse]:
-    unique_projects = list({item.project for item in item_list})
-    feature_results = features.batch_has(
-        ["projects:issue-stream-derived-progress"],
-        actor=user,
-        projects=unique_projects,
-        skip_experiment_exposure=True,
-    )
-    if not feature_results:
-        return {}
-
-    enabled_project_ids = {
-        project.id
-        for project in unique_projects
-        if feature_results.get(f"project:{project.id}", {}).get(
-            "projects:issue-stream-derived-progress"
-        )
-    }
-    return get_bulk_group_derived_data(
-        {item.id for item in item_list if item.project_id in enabled_project_ids}
-    )
-
-
 GroupStatusStr = Literal[
     "resolved",
     "ignored",
@@ -392,7 +367,11 @@ class GroupSerializerBase(Serializer, ABC):
 
         snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
-        derived_data_by_group_id = _get_derived_data_by_group_id(item_list, user)
+        derived_data_by_group_id = (
+            get_bulk_group_derived_data({item.id for item in item_list})
+            if self._expand("derivedData")
+            else {}
+        )
 
         result = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -12,13 +12,17 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import tagstore
+from sentry import features, tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.constants import LOG_LEVELS
 from sentry.eventtypes import EventTypeStr
 from sentry.integrations.mixins.issues import IssueBasicIntegration
 from sentry.integrations.services.integration import integration_service
+from sentry.issues.derived.serialization import (
+    GroupDerivedDataResponse,
+    get_bulk_group_derived_data,
+)
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.commit import Commit
 from sentry.models.environment import Environment
@@ -114,6 +118,7 @@ class BaseGroupResponseOptional(TypedDict, total=False):
     userCount: int
     firstSeen: datetime | None
     lastSeen: datetime | None
+    derivedData: GroupDerivedDataResponse
 
 
 class BaseGroupSerializerResponse(BaseGroupResponseOptional):
@@ -197,6 +202,31 @@ def _make_group_project_response(project: Project) -> GroupProjectResponse:
         "slug": project.slug,
         "platform": project.platform,
     }
+
+
+def _get_derived_data_by_group_id(
+    item_list: Sequence[Group], user: User | RpcUser | AnonymousUser
+) -> dict[int, GroupDerivedDataResponse]:
+    unique_projects = list({item.project for item in item_list})
+    feature_results = features.batch_has(
+        ["projects:issue-stream-derived-progress"],
+        actor=user,
+        projects=unique_projects,
+        skip_experiment_exposure=True,
+    )
+    if not feature_results:
+        return {}
+
+    enabled_project_ids = {
+        project.id
+        for project in unique_projects
+        if feature_results.get(f"project:{project.id}", {}).get(
+            "projects:issue-stream-derived-progress"
+        )
+    }
+    return get_bulk_group_derived_data(
+        {item.id for item in item_list if item.project_id in enabled_project_ids}
+    )
 
 
 GroupStatusStr = Literal[
@@ -362,6 +392,8 @@ class GroupSerializerBase(Serializer, ABC):
 
         snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
+        derived_data_by_group_id = _get_derived_data_by_group_id(item_list, user)
+
         result = {}
         for item in item_list:
             active_date = item.active_at or item.first_seen
@@ -395,6 +427,9 @@ class GroupSerializerBase(Serializer, ABC):
             }
             if snuba_stats is not None:
                 result[item]["is_unhandled"] = bool(snuba_stats.get(item.id, {}).get("unhandled"))
+
+            if item.id in derived_data_by_group_id:
+                result[item]["derived_data"] = derived_data_by_group_id[item.id]
 
             if seen_stats:
                 result[item].update(seen_stats.get(item, {}))
@@ -450,6 +485,8 @@ class GroupSerializerBase(Serializer, ABC):
         # This attribute is currently feature gated
         if "is_unhandled" in attrs:
             group_dict["isUnhandled"] = attrs["is_unhandled"]
+        if "derived_data" in attrs:
+            group_dict["derivedData"] = attrs["derived_data"]
         if is_seen_stats(attrs):
             group_dict.update(self._convert_seen_stats(attrs))
         return group_dict

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -29,6 +29,7 @@ from sentry.constants import StatsPeriod
 from sentry.eventtypes import EventTypeStr
 from sentry.integrations.api.serializers.models.external_issue import ExternalIssueSerializer
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.issues.derived.serialization import GroupDerivedDataResponse
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.environment import Environment
 from sentry.models.eventattachment import EventAttachment
@@ -283,6 +284,7 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     userCount: NotRequired[int]
     firstSeen: NotRequired[datetime | None]
     lastSeen: NotRequired[datetime | None]
+    derivedData: NotRequired[GroupDerivedDataResponse]
 
     # from the serializer itself
     stats: NotRequired[dict[str, Any]]

--- a/src/sentry/apidocs/examples/issue_examples.py
+++ b/src/sentry/apidocs/examples/issue_examples.py
@@ -93,6 +93,15 @@ SIMPLE_ISSUE: StreamGroupSerializerSnubaResponse = {
     "latestEventHasAttachments": False,
     "matchingEventId": None,
     "matchingEventEnvironment": None,
+    "derivedData": {
+        "progress": "fix_applied",
+        "status": "open",
+        "viewCount": 42,
+        "hasOpenFixPr": False,
+        "isAssigned": True,
+        "hasRootCause": True,
+        "lastProgressedAt": datetime.fromisoformat("2018-12-06T21:19:55Z"),
+    },
 }
 
 MUTATE_ISSUE_RESULT: MutateIssueResponse = {

--- a/src/sentry/issues/derived/serialization.py
+++ b/src/sentry/issues/derived/serialization.py
@@ -1,0 +1,65 @@
+"""
+API serialization for derived issue data.
+
+Reads the materialized ``GroupDerivedData`` for a set of groups and produces the
+camelCase response shape consumed by the group serializer. Read-only: this never
+triggers pipeline processing, so callers see whatever the last processing pass
+materialized (possibly stale), mirroring every other derived-data consumer.
+"""
+
+import logging
+from datetime import datetime
+from typing import TypedDict
+
+from sentry.issues.derived.features import (
+    HAS_OPEN_FIX_PR,
+    HAS_ROOT_CAUSE,
+    IS_ASSIGNED,
+    LAST_PROGRESSED_AT,
+    PROGRESS,
+    STATUS,
+    VIEW_COUNT,
+)
+from sentry.issues.derived.processing import PIPELINE
+from sentry.issues.derived.store import GroupDerivedDataStore
+from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.issues.progress_state import IssueProgressState
+
+logger = logging.getLogger(__name__)
+
+
+class GroupDerivedDataResponse(TypedDict):
+    progress: str
+    status: str
+    viewCount: int
+    hasOpenFixPr: bool
+    isAssigned: bool
+    hasRootCause: bool
+    lastProgressedAt: datetime | None
+
+
+def get_bulk_group_derived_data(group_ids: set[int]) -> dict[int, GroupDerivedDataResponse]:
+    """Bulk-load derived action log data for a set of groups, keyed by group id."""
+    if not group_ids:
+        return {}
+
+    result: dict[int, GroupDerivedDataResponse] = {}
+    for derived in GroupDerivedData.objects.filter(group_id__in=group_ids):
+        try:
+            state = GroupDerivedDataStore.load(PIPELINE, derived)
+            progress = state[PROGRESS]
+            result[derived.group_id] = GroupDerivedDataResponse(
+                progress=(progress or IssueProgressState.FIX_APPLIED).value,
+                status=state[STATUS].value,
+                viewCount=state[VIEW_COUNT],
+                hasOpenFixPr=state[HAS_OPEN_FIX_PR],
+                isAssigned=state[IS_ASSIGNED],
+                hasRootCause=state[HAS_ROOT_CAUSE],
+                lastProgressedAt=state[LAST_PROGRESSED_AT],
+            )
+        except (TypeError, ValueError):
+            logger.exception(
+                "Failed to serialize group derived data",
+                extra={"group_id": derived.group_id},
+            )
+    return result

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -204,7 +204,9 @@ class GroupDetailsEndpoint(GroupEndpoint):
             # WARNING: the rest of this endpoint relies on this serializer
             # populating the cache SO don't move this :)
             data: GroupDetailsResponse = serialize(
-                group, request.user, GroupSerializerSnuba(environment_ids=environment_ids)
+                group,
+                request.user,
+                GroupSerializerSnuba(environment_ids=environment_ids, expand=expand),
             )
 
             # TODO: these probably should be another endpoint

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.group import SimpleGroupSerializer
+from sentry.api.serializers.models.group import GroupSerializer, SimpleGroupSerializer
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.issues.grouptype import FeedbackGroup
@@ -506,8 +506,7 @@ class GroupSerializerDerivedDataTest(TestCase):
             },
         )
 
-        with self.feature("projects:issue-stream-derived-progress"):
-            result = serialize(group, self.user)
+        result = serialize(group, self.user, GroupSerializer(expand=["derivedData"]))
 
         assert result["derivedData"] == {
             "progress": "diagnosed",
@@ -527,8 +526,7 @@ class GroupSerializerDerivedDataTest(TestCase):
             data={"status": "closed"},
         )
 
-        with self.feature("projects:issue-stream-derived-progress"):
-            result = serialize(group, self.user)
+        result = serialize(group, self.user, GroupSerializer(expand=["derivedData"]))
 
         assert result["derivedData"]["progress"] == IssueProgressState.FIX_APPLIED.value
         assert result["derivedData"]["status"] == "closed"
@@ -536,17 +534,15 @@ class GroupSerializerDerivedDataTest(TestCase):
     def test_derived_data_omitted_without_row(self) -> None:
         group = self.create_group()
 
-        with self.feature("projects:issue-stream-derived-progress"):
-            result = serialize(group, self.user)
+        result = serialize(group, self.user, GroupSerializer(expand=["derivedData"]))
 
         assert "derivedData" not in result
 
-    def test_derived_data_omitted_without_feature(self) -> None:
+    def test_derived_data_omitted_without_expand(self) -> None:
         group = self.create_group()
         self.create_group_derived_data(group=group, progress=IssueProgressState.DIAGNOSED.value)
 
-        with self.feature({"projects:issue-stream-derived-progress": False}):
-            result = serialize(group, self.user)
+        result = serialize(group, self.user)
 
         assert "derivedData" not in result
 
@@ -559,8 +555,9 @@ class GroupSerializerDerivedDataTest(TestCase):
             progress=IssueProgressState.DIAGNOSED.value,
         )
 
-        with self.feature("projects:issue-stream-derived-progress"):
-            malformed_result, valid_result = serialize([malformed_group, valid_group], self.user)
+        malformed_result, valid_result = serialize(
+            [malformed_group, valid_group], self.user, GroupSerializer(expand=["derivedData"])
+        )
 
         assert "derivedData" not in malformed_result
         assert valid_result["derivedData"]["progress"] == "diagnosed"

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -8,6 +8,7 @@ from sentry.api.serializers.models.group import SimpleGroupSerializer
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.integrations.types import ExternalProviderEnum
 from sentry.issues.grouptype import FeedbackGroup
+from sentry.issues.progress_state import IssueProgressState
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouplink import GroupLink
 from sentry.models.groupresolution import GroupResolution
@@ -486,6 +487,83 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         result = serialize(group, user)
         assert result["seerAutofixLastTriggered"] == old_time
         assert result["seerExplorerAutofixLastTriggered"] == new_time
+
+
+class GroupSerializerDerivedDataTest(TestCase):
+    def test_derived_data_included(self) -> None:
+        group = self.create_group()
+        last_progressed_at = timezone.now()
+        self.create_group_derived_data(
+            group=group,
+            view_count=7,
+            progress=IssueProgressState.DIAGNOSED.value,
+            last_progressed_at=last_progressed_at,
+            data={
+                "status": "open",
+                "is_assigned": True,
+                "has_root_cause": True,
+                "has_open_fix_pr": False,
+            },
+        )
+
+        with self.feature("projects:issue-stream-derived-progress"):
+            result = serialize(group, self.user)
+
+        assert result["derivedData"] == {
+            "progress": "diagnosed",
+            "status": "open",
+            "viewCount": 7,
+            "hasOpenFixPr": False,
+            "isAssigned": True,
+            "hasRootCause": True,
+            "lastProgressedAt": last_progressed_at,
+        }
+
+    def test_derived_data_fix_applied_progress_for_closed_issue(self) -> None:
+        group = self.create_group()
+        self.create_group_derived_data(
+            group=group,
+            progress=None,
+            data={"status": "closed"},
+        )
+
+        with self.feature("projects:issue-stream-derived-progress"):
+            result = serialize(group, self.user)
+
+        assert result["derivedData"]["progress"] == IssueProgressState.FIX_APPLIED.value
+        assert result["derivedData"]["status"] == "closed"
+
+    def test_derived_data_omitted_without_row(self) -> None:
+        group = self.create_group()
+
+        with self.feature("projects:issue-stream-derived-progress"):
+            result = serialize(group, self.user)
+
+        assert "derivedData" not in result
+
+    def test_derived_data_omitted_without_feature(self) -> None:
+        group = self.create_group()
+        self.create_group_derived_data(group=group, progress=IssueProgressState.DIAGNOSED.value)
+
+        with self.feature({"projects:issue-stream-derived-progress": False}):
+            result = serialize(group, self.user)
+
+        assert "derivedData" not in result
+
+    def test_malformed_derived_data_does_not_fail_bulk_serialization(self) -> None:
+        malformed_group = self.create_group()
+        self.create_group_derived_data(group=malformed_group, progress="invalid")
+        valid_group = self.create_group(project=malformed_group.project)
+        self.create_group_derived_data(
+            group=valid_group,
+            progress=IssueProgressState.DIAGNOSED.value,
+        )
+
+        with self.feature("projects:issue-stream-derived-progress"):
+            malformed_result, valid_result = serialize([malformed_group, valid_group], self.user)
+
+        assert "derivedData" not in malformed_result
+        assert valid_result["derivedData"]["progress"] == "diagnosed"
 
 
 class SimpleGroupSerializerTest(TestCase):


### PR DESCRIPTION
This adds a new property to the default Group serializer:

```
{
  ...groupProperties
  derivedData: {
    progress: 'fix_applied',
    status: 'open',
    lastProgressedAt: '2026-01-01T00:00:00',
  }
```

This will allow us to easily use derived data on the issue stream and details pages. It will only add the property if you pass the query param `expand=derivedData`.