### PR TITLE
fix(data-browsing): Turn off Safari user selection on ECharts charts

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -871,6 +871,19 @@ const ChartContainer = styled('div')<{autoHeightResize: boolean}>`
     font-variant-numeric: tabular-nums !important;
   }
 
+  /*
+   * Desktop Safari runs heuristics to determine whether an incoming trackpad
+   action is going to be a drag or a select. An SVG that contains text like our
+   charts is _ambiguous_ so Safari will wait for 500ms before determining that a
+   pointer action is a drag, which stalls box selection on Heat Maps for half a
+   second, creating major jank. We need to turn off user selection manually.
+   ECharts already does this, but unprefixed, which is not supported in Safari.
+   */
+  .echarts-for-react svg {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
   ${p => getTooltipStyles(p)}
 `;
 


### PR DESCRIPTION
Closes [DAIN-1790](https://linear.app/getsentry/issue/DAIN-1790/heat-map-drag-to-select-in-safari-is-very-slow-and-inconsistent-when).

Here's the scoop.

* On Heat Map charts, dragging with a Macbook touchscreen had a weird delay (see video) where the square wouldn't appear for half a second of the drag
* Safari was *witholding* `pointermove` events because it's spending 500ms to determine whether the event is going to be a drag or a select
* Safari doesn't respect `user-select`, it's still prefixed there, so ECharts' own intervention doesn't work

This PR remendies the situation by turning off user select on all ECharts elements. This is already *mostly* the case (ECharts turns this off in Chrome when a brush is enabled), and user selection of text in a chart is never desirable (tooltips are omitted from this).

**Before:**

https://github.com/user-attachments/assets/b47419b2-657a-4b95-837e-5f0b2f3bb58d

**After:**

https://github.com/user-attachments/assets/ea380d24-f76f-42d1-b292-a91492f5de57