### PR TITLE
ref(weekly-reports): Remove weekly-report-project-exclusions frontend flag check

### DIFF
--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.spec.tsx
@@ -24,13 +24,6 @@ describe('WeeklyReportProjectExclusions', () => {
       ...ConfigStore.get('customerDomain')!,
       subdomain: organization.slug,
     });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/`,
-      body: OrganizationFixture({
-        ...organization,
-        features: ['weekly-report-project-exclusions'],
-      }),
-    });
   });
 
   afterEach(() => {
@@ -352,32 +345,6 @@ describe('WeeklyReportProjectExclusions', () => {
     await selectEvent.select(await screen.findByText('Off'), 'On');
 
     expect(handleRemove).toHaveBeenCalledWith('42');
-  });
-
-  it('does not show project toggles when feature flag is disabled', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/`,
-      body: OrganizationFixture({...organization, features: []}),
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/projects/`,
-      body: [projectA],
-    });
-
-    render(
-      <WeeklyReportProjectExclusions
-        organizations={[organization]}
-        {...defaultNotificationProps}
-      />
-    );
-
-    expect(await screen.findByText('On')).toBeInTheDocument();
-
-    expect(
-      screen.queryByRole('checkbox', {
-        name: 'Toggle weekly report for project-a',
-      })
-    ).not.toBeInTheDocument();
   });
 
   describe('pagination', () => {

--- a/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
+++ b/static/app/views/settings/account/notifications/weeklyReportProjectExclusions.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useEffect, useState} from 'react';
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import {skipToken, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 
@@ -20,7 +19,7 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {Organization, OrganizationSummary} from 'sentry/types/organization';
+import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
@@ -88,18 +87,6 @@ export function WeeklyReportProjectExclusions({
     setCurrentPage(0);
   }, [organization?.id]);
 
-  const {data: orgDetails, isPending: orgDetailsPending} = useQuery({
-    ...apiOptions.as<Organization>()('/organizations/$organizationIdOrSlug/', {
-      path: organization ? {organizationIdOrSlug: organization.slug} : skipToken,
-      host: organization?.links?.regionUrl,
-      query: {include_feature_flags: 1},
-      staleTime: 30_000,
-    }),
-  });
-
-  const featureEnabled =
-    orgDetails?.features.includes('weekly-report-project-exclusions') ?? false;
-
   const {
     data: projects,
     isPending: projectsPending,
@@ -118,7 +105,7 @@ export function WeeklyReportProjectExclusions({
   });
 
   const exclusionsOpts = exclusionsApiOptions(
-    orgDetails && featureEnabled ? (organization?.slug ?? skipToken) : skipToken,
+    organization?.slug ?? skipToken,
     organization?.links?.regionUrl
   );
 
@@ -223,9 +210,8 @@ export function WeeklyReportProjectExclusions({
     }
   };
 
-  const isPending =
-    orgDetailsPending || projectsPending || (featureEnabled && exclusionsPending);
-  const isError = projectsError || (featureEnabled && exclusionsError);
+  const isPending = projectsPending || exclusionsPending;
+  const isError = projectsError || exclusionsError;
 
   const sortedProjects = [...(projects ?? [])]
     .filter(project => project.isMember)
@@ -282,12 +268,12 @@ export function WeeklyReportProjectExclusions({
                     <LoadingError onRetry={refetchProjects} />
                   </PanelBody>
                 )}
-                {featureEnabled && isPending && !projectsPending && (
+                {isPending && !projectsPending && (
                   <PanelBody>
                     <LoadingIndicator />
                   </PanelBody>
                 )}
-                {featureEnabled && isError && !projectsError && (
+                {isError && !projectsError && (
                   <PanelBody>
                     <LoadingError
                       onRetry={() => {
@@ -299,46 +285,37 @@ export function WeeklyReportProjectExclusions({
                 )}
                 {!isPending && !isError && !projectsPending && !projectsError && (
                   <Fragment>
-                    {featureEnabled && allExcluded && (
+                    {allExcluded && (
                       <StyledAlert variant="warning">
                         {t(
                           "You won't receive a weekly report for this organization if all projects are excluded."
                         )}
                       </StyledAlert>
                     )}
-                    <DisabledOverlay disabled={!featureEnabled}>
-                      <StyledPanelBody>
-                        {sortedProjects.length === 0 ? (
-                          <EmptyStateWarning withIcon={false}>
-                            {t('No projects found')}
-                          </EmptyStateWarning>
-                        ) : (
-                          paginatedProjects.map(project => (
-                            <Item key={project.id}>
-                              <IdBadge
-                                project={project}
-                                avatarSize={20}
-                                avatarProps={{consistentWidth: true}}
-                                disableLink
-                              />
-                              <Switch
-                                size="lg"
-                                checked={
-                                  !featureEnabled ||
-                                  !excludedProjectIds.has(String(project.id))
-                                }
-                                disabled={!featureEnabled}
-                                onChange={() => handleToggle(String(project.id))}
-                                aria-label={t(
-                                  'Toggle weekly report for %s',
-                                  project.slug
-                                )}
-                              />
-                            </Item>
-                          ))
-                        )}
-                      </StyledPanelBody>
-                    </DisabledOverlay>
+                    <StyledPanelBody>
+                      {sortedProjects.length === 0 ? (
+                        <EmptyStateWarning withIcon={false}>
+                          {t('No projects found')}
+                        </EmptyStateWarning>
+                      ) : (
+                        paginatedProjects.map(project => (
+                          <Item key={project.id}>
+                            <IdBadge
+                              project={project}
+                              avatarSize={20}
+                              avatarProps={{consistentWidth: true}}
+                              disableLink
+                            />
+                            <Switch
+                              size="lg"
+                              checked={!excludedProjectIds.has(String(project.id))}
+                              onChange={() => handleToggle(String(project.id))}
+                              aria-label={t('Toggle weekly report for %s', project.slug)}
+                            />
+                          </Item>
+                        ))
+                      )}
+                    </StyledPanelBody>
                     {showPagination && (
                       <Flex justify="end" align="center" margin="lg xl">
                         <PaginationCaption>
@@ -403,15 +380,6 @@ const StyledPanelHeader = styled(PanelHeader)`
     font-weight: ${p => p.theme.font.weight.sans.regular};
     text-transform: none;
   }
-`;
-
-const DisabledOverlay = styled('div')<{disabled: boolean}>`
-  ${p =>
-    p.disabled &&
-    css`
-      opacity: 0.6;
-      pointer-events: none;
-    `}
 `;
 
 const StyledPanelBody = styled(PanelBody)`


### PR DESCRIPTION
## Summary
- Remove the `organizations:weekly-report-project-exclusions` feature flag check from the frontend (flag is at 100% GA)
- Remove the org details fetch that existed only for the feature check
- Remove the `DisabledOverlay` wrapper and `featureEnabled` gating throughout the component
- Remove the feature-flag-disabled test case

## Note
This PR should land **before** the backend PR that removes the flag registration and server-side gates.

## Test plan
- [x] Frontend tests pass (`pnpm test-ci weeklyReportProjectExclusions.spec.tsx`)
- [x] ESLint/TypeScript checks pass