### PR TITLE
ref(weekly-reports): Remove weekly-report-project-exclusions backend flag

### DIFF
--- a/src/sentry/api/endpoints/organization_weekly_report_project_exclusion_details.py
+++ b/src/sentry/api/endpoints/organization_weekly_report_project_exclusion_details.py
@@ -2,7 +2,6 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -30,11 +29,6 @@ class OrganizationWeeklyReportProjectExclusionDetailsEndpoint(OrganizationEndpoi
         self, request: Request, organization: Organization, project_id_or_slug: str
     ) -> Response:
         assert request.user and request.user.id
-
-        if not features.has(
-            "organizations:weekly-report-project-exclusions", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
 
         parsed = parse_id_or_slug_params([project_id_or_slug])
         if any(pid <= 0 for pid in parsed.ids):

--- a/src/sentry/api/endpoints/organization_weekly_report_project_exclusions.py
+++ b/src/sentry/api/endpoints/organization_weekly_report_project_exclusions.py
@@ -3,7 +3,6 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -33,11 +32,6 @@ class OrganizationWeeklyReportProjectExclusionsEndpoint(OrganizationEndpoint):
     def get(self, request: Request, organization: Organization) -> Response:
         assert request.user and request.user.id
 
-        if not features.has(
-            "organizations:weekly-report-project-exclusions", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
-
         queryset = WeeklyReportProjectExclusion.objects.filter(
             user_id=request.user.id,
             project__organization_id=organization.id,
@@ -53,11 +47,6 @@ class OrganizationWeeklyReportProjectExclusionsEndpoint(OrganizationEndpoint):
 
     def put(self, request: Request, organization: Organization) -> Response:
         assert request.user and request.user.id
-
-        if not features.has(
-            "organizations:weekly-report-project-exclusions", organization, actor=request.user
-        ):
-            return Response(status=status.HTTP_404_NOT_FOUND)
 
         project_ids = request.data.get("projectIds", [])
         if not isinstance(project_ids, list) or not all(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -393,8 +393,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     # Show combined resolved "past issues" section instead of separate key errors / performance issues
     manager.add("organizations:weekly-report-past-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Allow users to exclude specific projects from their weekly email reports
-    manager.add("organizations:weekly-report-project-exclusions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable week-over-week percentage change metric in weekly email reports
     manager.add("organizations:weekly-report-week-over-week-metric", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable logging to debug workflow engine process workflows

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -920,9 +920,7 @@ def prepare_template_context(
 ) -> list[Mapping[str, Any]] | list:
     exclusions_by_user: dict[int, set[int]] = {}
     valid_user_ids = [uid for uid in user_ids if uid is not None]
-    if valid_user_ids and features.has(
-        "organizations:weekly-report-project-exclusions", ctx.organization
-    ):
+    if valid_user_ids:
         for exc_user_id, exc_project_id in WeeklyReportProjectExclusion.objects.filter(
             user_id__in=valid_user_ids,
             project__organization_id=ctx.organization.id,

--- a/tests/sentry/api/endpoints/test_organization_weekly_report_project_exclusion_details.py
+++ b/tests/sentry/api/endpoints/test_organization_weekly_report_project_exclusion_details.py
@@ -11,8 +11,7 @@ class DeleteOrganizationWeeklyReportProjectExclusionDetailsTest(APITestCase):
 
     def test_delete_by_slug(self) -> None:
         self.create_weekly_report_project_exclusion(project=self.project, user_id=self.user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(self.organization.slug, self.project.slug)
+        response = self.get_response(self.organization.slug, self.project.slug)
         assert response.status_code == 204
         assert not WeeklyReportProjectExclusion.objects.filter(
             project=self.project, user_id=self.user.id
@@ -20,16 +19,10 @@ class DeleteOrganizationWeeklyReportProjectExclusionDetailsTest(APITestCase):
 
     def test_delete_by_id(self) -> None:
         self.create_weekly_report_project_exclusion(project=self.project, user_id=self.user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(self.organization.slug, self.project.id)
+        response = self.get_response(self.organization.slug, self.project.id)
         assert response.status_code == 204
 
     def test_not_found_when_no_exclusion(self) -> None:
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(self.organization.slug, self.project.slug)
-        assert response.status_code == 404
-
-    def test_feature_flag_required(self) -> None:
         response = self.get_response(self.organization.slug, self.project.slug)
         assert response.status_code == 404
 
@@ -40,13 +33,11 @@ class DeleteOrganizationWeeklyReportProjectExclusionDetailsTest(APITestCase):
         self.create_member(organization=org, user=user, role="member", teams=[team])
         non_member_project = self.create_project(organization=org)
         self.login_as(user=user)
-        with self.feature({"organizations:weekly-report-project-exclusions": True}):
-            response = self.get_response(org.slug, non_member_project.slug)
+        response = self.get_response(org.slug, non_member_project.slug)
         assert response.status_code == 403
 
     def test_project_in_other_org(self) -> None:
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(self.organization.slug, other_project.slug)
+        response = self.get_response(self.organization.slug, other_project.slug)
         assert response.status_code == 403

--- a/tests/sentry/api/endpoints/test_organization_weekly_report_project_exclusions.py
+++ b/tests/sentry/api/endpoints/test_organization_weekly_report_project_exclusions.py
@@ -10,8 +10,7 @@ class GetOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
         self.login_as(user=self.user)
 
     def test_empty(self) -> None:
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         assert response.data == []
 
     def test_returns_exclusions(self) -> None:
@@ -21,8 +20,7 @@ class GetOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
         )
         exc2 = self.create_weekly_report_project_exclusion(project=project2, user_id=self.user.id)
 
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
         assert len(response.data) == 2
         returned_ids = {item["id"] for item in response.data}
@@ -31,21 +29,15 @@ class GetOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
     def test_does_not_return_other_users_exclusions(self) -> None:
         other_user = self.create_user()
         self.create_weekly_report_project_exclusion(project=self.project, user_id=other_user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         assert response.data == []
 
     def test_does_not_return_other_org_exclusions(self) -> None:
         other_org = self.create_organization(owner=self.user)
         other_project = self.create_project(organization=other_org)
         self.create_weekly_report_project_exclusion(project=other_project, user_id=self.user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
         assert response.data == []
-
-    def test_feature_flag_required(self) -> None:
-        response = self.get_response(self.organization.slug)
-        assert response.status_code == 404
 
 
 class PutOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
@@ -57,22 +49,20 @@ class PutOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
 
     def test_set_exclusions(self) -> None:
         project2 = self.create_project(organization=self.organization)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(
-                self.organization.slug,
-                projectIds=[self.project.id, project2.id],
-            )
+        response = self.get_response(
+            self.organization.slug,
+            projectIds=[self.project.id, project2.id],
+        )
         assert response.status_code == 204
         assert WeeklyReportProjectExclusion.objects.filter(user_id=self.user.id).count() == 2
 
     def test_replace_exclusions(self) -> None:
         project2 = self.create_project(organization=self.organization)
         self.create_weekly_report_project_exclusion(project=self.project, user_id=self.user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(
-                self.organization.slug,
-                projectIds=[project2.id],
-            )
+        response = self.get_response(
+            self.organization.slug,
+            projectIds=[project2.id],
+        )
         assert response.status_code == 204
         exclusions = list(
             WeeklyReportProjectExclusion.objects.filter(user_id=self.user.id).values_list(
@@ -83,45 +73,34 @@ class PutOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
 
     def test_clear_exclusions(self) -> None:
         self.create_weekly_report_project_exclusion(project=self.project, user_id=self.user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(
-                self.organization.slug,
-                projectIds=[],
-            )
+        response = self.get_response(
+            self.organization.slug,
+            projectIds=[],
+        )
         assert response.status_code == 204
         assert WeeklyReportProjectExclusion.objects.filter(user_id=self.user.id).count() == 0
 
     def test_does_not_affect_other_users(self) -> None:
         other_user = self.create_user()
         self.create_weekly_report_project_exclusion(project=self.project, user_id=other_user.id)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            self.get_response(
-                self.organization.slug,
-                projectIds=[self.project.id],
-            )
-        assert WeeklyReportProjectExclusion.objects.filter(user_id=other_user.id).count() == 1
-
-    def test_feature_flag_required(self) -> None:
-        response = self.get_response(
+        self.get_response(
             self.organization.slug,
             projectIds=[self.project.id],
         )
-        assert response.status_code == 404
+        assert WeeklyReportProjectExclusion.objects.filter(user_id=other_user.id).count() == 1
 
     def test_invalid_project_ids_not_a_list(self) -> None:
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(
-                self.organization.slug,
-                projectIds="not-a-list",
-            )
+        response = self.get_response(
+            self.organization.slug,
+            projectIds="not-a-list",
+        )
         assert response.status_code == 400
 
     def test_invalid_project_ids_non_integers(self) -> None:
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(
-                self.organization.slug,
-                projectIds=["not-a-number"],
-            )
+        response = self.get_response(
+            self.organization.slug,
+            projectIds=["not-a-number"],
+        )
         assert response.status_code == 400
 
     def test_project_user_not_member_of(self) -> None:
@@ -132,19 +111,17 @@ class PutOrganizationWeeklyReportProjectExclusionsTest(APITestCase):
         member_project = self.create_project(organization=org, teams=[team])
         non_member_project = self.create_project(organization=org)
         self.login_as(user=user)
-        with self.feature({"organizations:weekly-report-project-exclusions": True}):
-            response = self.get_response(
-                org.slug,
-                projectIds=[member_project.id, non_member_project.id],
-            )
+        response = self.get_response(
+            org.slug,
+            projectIds=[member_project.id, non_member_project.id],
+        )
         assert response.status_code == 403
 
     def test_project_in_other_org(self) -> None:
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
-        with self.feature("organizations:weekly-report-project-exclusions"):
-            response = self.get_response(
-                self.organization.slug,
-                projectIds=[other_project.id],
-            )
+        response = self.get_response(
+            self.organization.slug,
+            projectIds=[other_project.id],
+        )
         assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Remove the `organizations:weekly-report-project-exclusions` flag registration from `temporary.py` (flag is at 100% GA)
- Remove `features.has()` gates in the exclusion list and detail endpoints
- Remove the feature check in the `weekly_reports` task so exclusions are always queried
- Remove `with self.feature(...)` wrappers and `test_feature_flag_required` tests

## Note
This PR depends on #119851 (frontend) landing first. Removing the flag registration before the frontend stops checking it would disable the project exclusion UI.

## Test plan
- [x] Backend tests pass (`pytest test_organization_weekly_report_project_exclusion_details.py test_organization_weekly_report_project_exclusions.py`)
- [x] prek lint checks pass