### PR TITLE
feat(external-mcp): Connect org level datadog integration to Seer

### DIFF
--- a/src/sentry/identity/datadog/provider.py
+++ b/src/sentry/identity/datadog/provider.py
@@ -430,6 +430,9 @@ class DatadogPatIdentityProvider(McpIdentityProvider, Provider):
 
     key = IntegrationProviderSlug.DATADOG_PAT
     name = "Datadog (Personal Access Token)"
+    # A PAT connection is a variant of the datadog integration, so it shares its family
+    # and a personal PAT suppresses the org-level datadog fallback.
+    monitoring_family = IntegrationProviderSlug.DATADOG.value
     create_organization_identity = True
 
     def get_pipeline_views(self) -> list[PipelineView[IdentityPipeline]]:

--- a/src/sentry/identity/mcp.py
+++ b/src/sentry/identity/mcp.py
@@ -6,6 +6,10 @@ from typing import Any
 class McpIdentityProvider:
     """Mixin for identity providers that back an MCP server."""
 
+    # Identity family used for org/personal fallback. Personal identities override
+    # org-level identities within the same family. Defaults to the provider's key.
+    monitoring_family: str | None = None
+
     def build_mcp_urls(self, identity_data: dict[str, Any]) -> list[str]:
         """Build MCP server URLs from the identity's stored ``data`` dict.
 

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections.abc import Mapping, MutableMapping
 from typing import Any, TypedDict, cast
 
@@ -10,6 +11,8 @@ from rest_framework.fields import CharField
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.identity.datadog.provider import DATADOG_VALID_SITES
+from sentry.constants import ObjectStatus
+from sentry.identity.datadog.provider import MCP_ENDPOINT_PATH, mcp_base_url_for_site
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -23,10 +26,19 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.organization import Organization
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps
+from sentry.seer.agent.monitoring_providers import (
+    OrgMonitoringProvider,
+    org_monitoring_provider_registry,
+)
+from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
+
+logger = logging.getLogger(__name__)
 
 DESCRIPTION = """
 Connect your Datadog organization so Seer can pull in infrastructure telemetry
@@ -197,3 +209,52 @@ class DatadogIntegrationProvider(IntegrationProvider):
         site = integration.metadata.get("site")
         if site:
             integration.update(debug_data={**(integration.debug_data or {}), "site": site})
+
+
+@org_monitoring_provider_registry.register(IntegrationProviderSlug.DATADOG.value)
+class DatadogOrgMonitoringProvider(OrgMonitoringProvider):
+    """Surfaces the org-level Datadog integration to Seer as a shared monitoring connection."""
+
+    provider_key = IntegrationProviderSlug.DATADOG.value
+
+    def build_connection(
+        self, organization: Organization
+    ) -> MonitoringProviderConnectionData | None:
+        integration = integration_service.get_integration(
+            organization_id=organization.id,
+            provider=self.provider_key,
+            status=ObjectStatus.ACTIVE,
+        )
+        if integration is None:
+            return None
+
+        metadata = integration.metadata or {}
+        api_key = metadata.get("api_key")
+        app_key = metadata.get("app_key")
+        base_url = mcp_base_url_for_site(metadata.get("site"))
+        if not (api_key and app_key and base_url):
+            logger.error(
+                "seer.monitoring_providers.datadog_integration_invalid",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                },
+            )
+            return None
+
+        encrypted_api_key = encrypt_access_token_for_seer(api_key)
+        encrypted_app_key = encrypt_access_token_for_seer(app_key)
+        if not (encrypted_api_key and encrypted_app_key):
+            return None
+
+        return MonitoringProviderConnectionData(
+            provider_key=self.provider_key,
+            url=f"{base_url}{MCP_ENDPOINT_PATH}",
+            encrypted_auth_headers={
+                "DD-API-KEY": encrypted_api_key,
+                "DD-APPLICATION-KEY": encrypted_app_key,
+            },
+            identity_id=None,
+            auth_method="api_key",
+            refreshable=False,
+        )

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -10,9 +10,12 @@ from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
-from sentry.identity.datadog.provider import DATADOG_VALID_SITES
 from sentry.constants import ObjectStatus
-from sentry.identity.datadog.provider import MCP_ENDPOINT_PATH, mcp_base_url_for_site
+from sentry.identity.datadog.provider import (
+    DATADOG_VALID_SITES,
+    MCP_ENDPOINT_PATH,
+    mcp_base_url_for_site,
+)
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -220,12 +220,17 @@ class DatadogOrgMonitoringProvider(OrgMonitoringProvider):
     def build_connection(
         self, organization: Organization
     ) -> MonitoringProviderConnectionData | None:
-        integration = integration_service.get_integration(
-            organization_id=organization.id,
-            provider=self.provider_key,
-            status=ObjectStatus.ACTIVE,
+        ctx = integration_service.organization_context(
+            organization_id=organization.id, provider=self.provider_key
         )
-        if integration is None:
+        integration = ctx.integration
+        org_integration = ctx.organization_integration
+        if (
+            integration is None
+            or org_integration is None
+            or integration.status != ObjectStatus.ACTIVE
+            or org_integration.status != ObjectStatus.ACTIVE
+        ):
             return None
 
         metadata = integration.metadata or {}

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -37,7 +37,6 @@ from sentry.receivers.outbox import maybe_process_tombstone
 from sentry.seer.agent.client import (
     _trigger_explorer_indexes_if_needed,
     get_available_monitoring_providers,
-    get_monitoring_provider_connections,
 )
 from sentry.seer.agent.client_utils import (
     AgentChatRequest,
@@ -45,6 +44,7 @@ from sentry.seer.agent.client_utils import (
     make_agent_chat_request,
     make_feature_run_request,
 )
+from sentry.seer.agent.monitoring_providers import get_monitoring_provider_connections
 from sentry.seer.models.run import SeerRun, SeerRunMirrorStatus, SeerRunType
 from sentry.seer.signed_seer_api import SearchAgentStartRequest, make_search_agent_start_request
 from sentry.sentry_apps.services.app.service import app_service

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -247,26 +247,27 @@ def handle_seer_run_create(object_identifier: int, payload: Any, **kwds: Any) ->
 
     match run_type:
         case SeerRunType.EXPLORER:
-            # Add connected and available monitoring providers for runs with user context.
-            if run.user_id is not None:
-                try:
-                    organization = Organization.objects.get_from_cache(id=run.organization_id)
-                    monitoring_provider_connections = get_monitoring_provider_connections(
-                        organization, run.user_id
-                    )
-                    if monitoring_provider_connections:
-                        body["monitoring_providers"] = monitoring_provider_connections
+            try:
+                organization = Organization.objects.get_from_cache(id=run.organization_id)
+                monitoring_provider_connections = get_monitoring_provider_connections(
+                    organization, run.user_id
+                )
+                if monitoring_provider_connections:
+                    body["monitoring_providers"] = [
+                        connection.dict() for connection in monitoring_provider_connections
+                    ]
 
+                if run.user_id is not None:
                     available_monitoring_providers = get_available_monitoring_providers(
                         organization, run.user_id
                     )
                     if available_monitoring_providers:
                         body["available_monitoring_providers"] = available_monitoring_providers
-                except Organization.DoesNotExist:
-                    logger.warning(
-                        "seer_run_create.organization_dne",
-                        extra={"organization_id": run.organization_id, "run_id": run.id},
-                    )
+            except Organization.DoesNotExist:
+                logger.warning(
+                    "seer_run_create.organization_dne",
+                    extra={"organization_id": run.organization_id, "run_id": run.id},
+                )
             response = make_agent_chat_request(
                 cast(AgentChatRequest, body), viewer_context=viewer_context
             )

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -46,6 +46,10 @@ from sentry.seer.agent.client_utils import (
 from sentry.seer.agent.coding_agent_handoff import launch_coding_agents
 from sentry.seer.agent.custom_tool_utils import AgentTool, extract_tool_schema
 from sentry.seer.agent.embed_widgets import get_embed_widgets
+from sentry.seer.agent.monitoring_providers import (
+    get_org_monitoring_connections,
+    provider_family,
+)
 from sentry.seer.agent.on_completion_hook import (
     AgentOnCompletionHook,
     extract_hook_definition,
@@ -53,6 +57,7 @@ from sentry.seer.agent.on_completion_hook import (
 from sentry.seer.models import SeerApiError, SeerPermissionError, SeerRepoDefinition
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
+from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.tasks.seer.context_engine_index import build_service_map, index_org_project_knowledge
@@ -114,14 +119,11 @@ def _has_context_engine(
     return True
 
 
-def get_monitoring_provider_connections(
+def _get_personal_monitoring_connections(
     organization: Organization, user_id: int
-) -> list[dict[str, Any]]:
-    """Fetch the user's monitoring provider identities and build connection dicts for Seer."""
-    if not features.has("organizations:seer-infra-telemetry", organization):
-        return []
-
-    connections: list[dict[str, Any]] = []
+) -> list[MonitoringProviderConnectionData]:
+    """Build connections from the user's connected monitoring-provider identities."""
+    connections: list[MonitoringProviderConnectionData] = []
     for provider_type in MONITORING_PROVIDERS:
         provider = identity_manager.get(provider_type)
         is_oauth_provider = isinstance(provider, OAuth2Provider)
@@ -159,16 +161,40 @@ def get_monitoring_provider_connections(
             auth_method = "oauth" if is_oauth_provider else "pat"
             for url in urls:
                 connections.append(
-                    {
-                        "provider_key": provider_type,
-                        "url": url,
-                        "encrypted_access_token": encrypted_access_token,
-                        "identity_id": identity.id,
-                        "auth_method": auth_method,
-                    }
+                    MonitoringProviderConnectionData(
+                        provider_key=provider_type,
+                        url=url,
+                        encrypted_access_token=encrypted_access_token,
+                        identity_id=identity.id,
+                        auth_method=auth_method,
+                    )
                 )
 
     return connections
+
+
+def get_monitoring_provider_connections(
+    organization: Organization, user_id: int | None
+) -> list[MonitoringProviderConnectionData]:
+    """Build monitoring-provider connections for Seer.
+
+    Combines the user's personal provider identities with org-level integrations.
+    Personal identities take priority over org level for the same provider.
+    """
+    if not features.has("organizations:seer-infra-telemetry", organization):
+        return []
+
+    personal_connections = (
+        _get_personal_monitoring_connections(organization, user_id) if user_id is not None else []
+    )
+    connected_families = {provider_family(c.provider_key) for c in personal_connections}
+    org_connections = [
+        connection
+        for connection in get_org_monitoring_connections(organization)
+        if provider_family(connection.provider_key) not in connected_families
+    ]
+
+    return personal_connections + org_connections
 
 
 def get_available_monitoring_providers(
@@ -751,7 +777,9 @@ class SeerAgentClient:
                 self.organization, self.user.id
             )
             if monitoring_provider_connections:
-                chat_body["monitoring_providers"] = monitoring_provider_connections
+                chat_body["monitoring_providers"] = [
+                    connection.dict() for connection in monitoring_provider_connections
+                ]
 
             available_monitoring_providers = get_available_monitoring_providers(
                 self.organization,

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -167,6 +167,7 @@ def _get_personal_monitoring_connections(
                         encrypted_access_token=encrypted_access_token,
                         identity_id=identity.id,
                         auth_method=auth_method,
+                        refreshable=is_oauth_provider,
                     )
                 )
 

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -17,11 +17,9 @@ from urllib3 import BaseHTTPResponse
 
 from sentry import features, options
 from sentry.constants import ENABLE_SEER_CODING_DEFAULT, ObjectStatus
-from sentry.hybridcloud.rpc.service import RpcException
 from sentry.identity import default_manager as identity_manager
 from sentry.identity.mcp import McpIdentityProvider
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.identity.services.identity import identity_service
 from sentry.integrations.types import MONITORING_PROVIDERS
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -46,10 +44,7 @@ from sentry.seer.agent.client_utils import (
 from sentry.seer.agent.coding_agent_handoff import launch_coding_agents
 from sentry.seer.agent.custom_tool_utils import AgentTool, extract_tool_schema
 from sentry.seer.agent.embed_widgets import get_embed_widgets
-from sentry.seer.agent.monitoring_providers import (
-    get_org_monitoring_connections,
-    provider_family,
-)
+from sentry.seer.agent.monitoring_providers import get_monitoring_provider_connections
 from sentry.seer.agent.on_completion_hook import (
     AgentOnCompletionHook,
     extract_hook_definition,
@@ -57,9 +52,7 @@ from sentry.seer.agent.on_completion_hook import (
 from sentry.seer.models import SeerApiError, SeerPermissionError, SeerRepoDefinition
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
 from sentry.seer.signed_seer_api import SeerViewerContext
-from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.tasks.seer.context_engine_index import build_service_map, index_org_project_knowledge
 from sentry.tasks.seer.explorer_index import dispatch_explorer_index_projects
 from sentry.users.models.user import User
@@ -117,85 +110,6 @@ def _has_context_engine(
     organization: Organization, user: User | RpcUser | AnonymousUser | None
 ) -> bool:
     return True
-
-
-def _get_personal_monitoring_connections(
-    organization: Organization, user_id: int
-) -> list[MonitoringProviderConnectionData]:
-    """Build connections from the user's connected monitoring-provider identities."""
-    connections: list[MonitoringProviderConnectionData] = []
-    for provider_type in MONITORING_PROVIDERS:
-        provider = identity_manager.get(provider_type)
-        is_oauth_provider = isinstance(provider, OAuth2Provider)
-        if not isinstance(provider, McpIdentityProvider):
-            continue
-
-        try:
-            identities = identity_service.get_org_user_identities_by_provider_type(
-                organization_id=organization.id, user_id=user_id, provider_type=provider_type
-            )
-        except RpcException:
-            # Monitoring providers are optional enrichment. A control-silo RPC failure
-            # shouldn't fail a run--just move on to the next provider.
-            logger.warning(
-                "seer.monitoring_providers.fetch_failed",
-                extra={
-                    "organization_id": organization.id,
-                    "user_id": user_id,
-                    "provider": provider_type,
-                },
-                exc_info=True,
-            )
-            continue
-
-        for identity in identities:
-            access_token = identity.data.get("access_token")
-            if not access_token:
-                continue
-            urls = provider.build_mcp_urls(identity.data)
-            if not urls:
-                continue
-            encrypted_access_token = encrypt_access_token_for_seer(access_token)
-            if not encrypted_access_token:
-                continue
-            auth_method = "oauth" if is_oauth_provider else "pat"
-            for url in urls:
-                connections.append(
-                    MonitoringProviderConnectionData(
-                        provider_key=provider_type,
-                        url=url,
-                        encrypted_access_token=encrypted_access_token,
-                        identity_id=identity.id,
-                        auth_method=auth_method,
-                        refreshable=is_oauth_provider,
-                    )
-                )
-
-    return connections
-
-
-def get_monitoring_provider_connections(
-    organization: Organization, user_id: int | None
-) -> list[MonitoringProviderConnectionData]:
-    """Build monitoring-provider connections for Seer.
-
-    Combines the user's personal provider identities with org-level integrations.
-    Personal identities take priority over org level for the same provider.
-    """
-    if not features.has("organizations:seer-infra-telemetry", organization):
-        return []
-
-    personal_connections = (
-        _get_personal_monitoring_connections(organization, user_id) if user_id is not None else []
-    )
-    connected_families = {provider_family(c.provider_key) for c in personal_connections}
-    org_connections = [
-        connection
-        for connection in get_org_monitoring_connections(organization)
-        if provider_family(connection.provider_key) not in connected_families
-    ]
-
-    return personal_connections + org_connections
 
 
 def get_available_monitoring_providers(
@@ -772,19 +686,23 @@ class SeerAgentClient:
         if ui_tools:
             chat_body["ui_tools"] = ui_tools
 
-        # Add connected and available monitoring providers for runs with user context.
-        if self.user and not isinstance(self.user, AnonymousUser):
-            monitoring_provider_connections = get_monitoring_provider_connections(
-                self.organization, self.user.id
-            )
-            if monitoring_provider_connections:
-                chat_body["monitoring_providers"] = [
-                    connection.dict() for connection in monitoring_provider_connections
-                ]
+        monitoring_user_id = (
+            self.user.id
+            if self.user and not isinstance(self.user, AnonymousUser) and self.user.id is not None
+            else None
+        )
+        monitoring_provider_connections = get_monitoring_provider_connections(
+            self.organization, monitoring_user_id
+        )
+        if monitoring_provider_connections:
+            chat_body["monitoring_providers"] = [
+                connection.dict() for connection in monitoring_provider_connections
+            ]
 
+        if monitoring_user_id is not None:
             available_monitoring_providers = get_available_monitoring_providers(
                 self.organization,
-                self.user.id,
+                monitoring_user_id,
             )
             if available_monitoring_providers:
                 chat_body["available_monitoring_providers"] = available_monitoring_providers

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 import abc
+import logging
 
+from sentry import features
+from sentry.hybridcloud.rpc.service import RpcException
 from sentry.identity import default_manager as identity_manager
 from sentry.identity.mcp import McpIdentityProvider
+from sentry.identity.oauth2 import OAuth2Provider
+from sentry.identity.services.identity import identity_service
+from sentry.integrations.types import MONITORING_PROVIDERS
 from sentry.models.organization import Organization
 from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.utils.registry import Registry
+
+logger = logging.getLogger(__name__)
 
 
 class OrgMonitoringProvider(abc.ABC):
@@ -42,6 +51,106 @@ def provider_family(provider_key: str) -> str:
 def get_org_monitoring_connections(
     organization: Organization,
 ) -> list[MonitoringProviderConnectionData]:
-    """Build connections from all registered org-level (shared) monitoring integrations."""
-    built = (provider.build_connection(organization) for provider in _org_monitoring_providers())
-    return [connection for connection in built if connection is not None]
+    """Build connections from all registered org-level (shared) monitoring integrations.
+
+    Monitoring providers are optional enrichment. Building a connection hits the control silo,
+    so a transient RPC failure must not propagate--it would fail (or, from the SEER_RUN_CREATE
+    outbox handler, stall) a Seer run. Log and skip that provider instead, mirroring the
+    per-user path in ``_get_personal_monitoring_connections``.
+    """
+    connections: list[MonitoringProviderConnectionData] = []
+    for provider in _org_monitoring_providers():
+        try:
+            connection = provider.build_connection(organization)
+        except RpcException:
+            logger.warning(
+                "seer.monitoring_providers.org_fetch_failed",
+                extra={
+                    "organization_id": organization.id,
+                    "provider": provider.provider_key,
+                },
+                exc_info=True,
+            )
+            continue
+        if connection is not None:
+            connections.append(connection)
+    return connections
+
+
+def _get_personal_monitoring_connections(
+    organization: Organization, user_id: int
+) -> list[MonitoringProviderConnectionData]:
+    """Build connections from the user's connected monitoring-provider identities."""
+    connections: list[MonitoringProviderConnectionData] = []
+    for provider_type in MONITORING_PROVIDERS:
+        provider = identity_manager.get(provider_type)
+        is_oauth_provider = isinstance(provider, OAuth2Provider)
+        if not isinstance(provider, McpIdentityProvider):
+            continue
+
+        try:
+            identities = identity_service.get_org_user_identities_by_provider_type(
+                organization_id=organization.id, user_id=user_id, provider_type=provider_type
+            )
+        except RpcException:
+            # Monitoring providers are optional enrichment. A control-silo RPC failure
+            # shouldn't fail a run--just move on to the next provider.
+            logger.warning(
+                "seer.monitoring_providers.fetch_failed",
+                extra={
+                    "organization_id": organization.id,
+                    "user_id": user_id,
+                    "provider": provider_type,
+                },
+                exc_info=True,
+            )
+            continue
+
+        for identity in identities:
+            access_token = identity.data.get("access_token")
+            if not access_token:
+                continue
+            urls = provider.build_mcp_urls(identity.data)
+            if not urls:
+                continue
+            encrypted_access_token = encrypt_access_token_for_seer(access_token)
+            if not encrypted_access_token:
+                continue
+            auth_method = "oauth" if is_oauth_provider else "pat"
+            for url in urls:
+                connections.append(
+                    MonitoringProviderConnectionData(
+                        provider_key=provider_type,
+                        url=url,
+                        encrypted_access_token=encrypted_access_token,
+                        identity_id=identity.id,
+                        auth_method=auth_method,
+                        refreshable=is_oauth_provider,
+                    )
+                )
+
+    return connections
+
+
+def get_monitoring_provider_connections(
+    organization: Organization, user_id: int | None
+) -> list[MonitoringProviderConnectionData]:
+    """Build monitoring-provider connections for Seer.
+
+    Combines the user's personal provider identities with org-level integrations.
+    Personal identities take priority over org level for the same provider.
+    """
+    if not features.has("organizations:seer-infra-telemetry", organization):
+        return []
+
+    personal_connections = (
+        _get_personal_monitoring_connections(organization, user_id) if user_id is not None else []
+    )
+    connected_families = {provider_family(c.provider_key) for c in personal_connections}
+    org_connections = [
+        connection
+        for connection in get_org_monitoring_connections(organization)
+        if provider_family(connection.provider_key) not in connected_families
+    ]
+
+    return personal_connections + org_connections

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import abc
+
+from sentry.identity import default_manager as identity_manager
+from sentry.identity.mcp import McpIdentityProvider
+from sentry.models.organization import Organization
+from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.utils.registry import Registry
+
+
+class OrgMonitoringProvider(abc.ABC):
+    """An org-level (shared) monitoring integration Seer can connect to."""
+
+    provider_key: str
+
+    @abc.abstractmethod
+    def build_connection(
+        self, organization: Organization
+    ) -> MonitoringProviderConnectionData | None:
+        """Build the Seer connection for this org's integration, or None if unconfigured."""
+
+
+org_monitoring_provider_registry = Registry[type[OrgMonitoringProvider]]()
+
+
+def _org_monitoring_providers() -> list[OrgMonitoringProvider]:
+    return [
+        provider_cls() for provider_cls in org_monitoring_provider_registry.registrations.values()
+    ]
+
+
+def provider_family(provider_key: str) -> str:
+    """Resolve a provider key to its monitoring family"""
+    if identity_manager.exists(provider_key):
+        provider = identity_manager.get(provider_key)
+        if isinstance(provider, McpIdentityProvider) and provider.monitoring_family:
+            return provider.monitoring_family
+    return provider_key
+
+
+def get_org_monitoring_connections(
+    organization: Organization,
+) -> list[MonitoringProviderConnectionData]:
+    """Build connections from all registered org-level (shared) monitoring integrations."""
+    built = (provider.build_connection(organization) for provider in _org_monitoring_providers())
+    return [connection for connection in built if connection is not None]

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -73,9 +73,6 @@ from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.spans.definitions import SPAN_DEFINITIONS
 from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.events.types import SnubaParams
-from sentry.seer.agent.client import (
-    get_monitoring_provider_connections as fetch_monitoring_provider_connections,
-)
 from sentry.seer.agent.context_engine_utils import get_instrumentation_types
 from sentry.seer.agent.custom_tool_utils import call_custom_tool
 from sentry.seer.agent.feature_delivery import DELIVERY_HANDLERS, FeatureRunStatus
@@ -84,6 +81,9 @@ from sentry.seer.agent.index_data import (
     rpc_get_profiles_for_trace,
     rpc_get_trace_for_transaction,
     rpc_get_transactions_for_project,
+)
+from sentry.seer.agent.monitoring_providers import (
+    get_monitoring_provider_connections as fetch_monitoring_provider_connections,
 )
 from sentry.seer.agent.on_completion_hook import call_on_completion_hook
 from sentry.seer.agent.tools import (

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -862,9 +862,11 @@ class ExecuteTimeseriesQueryErrorResponse(BaseModel):
 class MonitoringProviderConnectionData(BaseModel):
     provider_key: str
     url: str
-    encrypted_access_token: str
-    identity_id: int
+    encrypted_access_token: str | None = None
+    encrypted_auth_headers: dict[str, str] | None = None
+    identity_id: int | None = None
     auth_method: str
+    refreshable: bool = True
 
     def __getitem__(self, key: str) -> Any:
         return self.dict()[key]

--- a/tests/sentry/receivers/outbox/test_cell.py
+++ b/tests/sentry/receivers/outbox/test_cell.py
@@ -3,6 +3,8 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from cryptography.fernet import Fernet
+from django.test import override_settings
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
@@ -12,6 +14,8 @@ from sentry.seer.models.run import SeerRunMirrorStatus, SeerRunType
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
+
+TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
 
 
 class BackfillScmIntegrationConfigReceiverTest(TestCase):
@@ -144,6 +148,38 @@ class HandleSeerRunCreateTest(TestCase):
         run.refresh_from_db()
         assert run.seer_run_state_id == 99
         assert run.mirror_status == SeerRunMirrorStatus.LIVE
+
+    @override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)
+    @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
+    def test_explorer_serializes_monitoring_providers_as_dicts(self, mock_request: Mock) -> None:
+        mock_request.return_value = Mock(status=200, json=Mock(return_value={"run_id": 1}))
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                provider="datadog",
+                external_id="dd-org-uuid",
+                name="Datadog",
+                metadata={
+                    "api_key": "org-api-key",
+                    "app_key": "org-app-key",
+                    "site": "datadoghq.com",
+                },
+            )
+            org_integration = integration.add_organization(self.organization.id)
+            assert org_integration is not None
+        run = self.create_seer_run(type=SeerRunType.EXPLORER)
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            handle_seer_run_create(
+                object_identifier=run.id,
+                payload=self._make_payload(),
+                shard_identifier=run.id,
+            )
+
+        body = mock_request.call_args.args[0]
+        providers = body["monitoring_providers"]
+        assert providers, "expected an org monitoring connection in the body"
+        assert all(isinstance(provider, dict) for provider in providers)
+        assert providers[0]["provider_key"] == "datadog"
 
     @patch("sentry.receivers.outbox.cell.make_search_agent_start_request")
     def test_happy_path_assisted_query(self, mock_request: Mock) -> None:

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -7,6 +7,7 @@ from django.test import override_settings
 from django.utils import timezone
 from pydantic import BaseModel
 
+from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.outbox import CellOutbox
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.rpc.service import RpcException
@@ -1758,6 +1759,130 @@ class TestGetMonitoringProviderConnections(TestCase):
 
         assert len(result) == 3
         mock_encrypt.assert_called_once_with("gcp-token")
+
+    def _create_org_datadog_integration(self, site: str = "datadoghq.com") -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name=f"Datadog ({site})",
+            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": site},
+        )
+
+    def test_org_datadog_connection_when_user_has_no_personal(self) -> None:
+        self._create_org_datadog_integration()
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        conn = result[0]
+        assert conn["provider_key"] == "datadog"
+        assert conn["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        assert conn["identity_id"] is None
+        assert conn["auth_method"] == "api_key"
+        assert conn["refreshable"] is False
+        assert conn["encrypted_access_token"] is None
+
+        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+        headers = conn["encrypted_auth_headers"]
+        assert fernet.decrypt(headers["DD-API-KEY"].encode()).decode() == "org-api-key"
+        assert fernet.decrypt(headers["DD-APPLICATION-KEY"].encode()).decode() == "org-app-key"
+
+    def test_personal_datadog_overrides_org(self) -> None:
+        self._create_org_datadog_integration()
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "personal-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        conn = result[0]
+        assert conn["identity_id"] == identity.id
+        assert conn["auth_method"] == "oauth"
+        assert conn["encrypted_auth_headers"] is None
+
+    def test_personal_datadog_pat_overrides_org(self) -> None:
+        self._create_org_datadog_integration()
+        idp = self.create_identity_provider(type="datadog_pat", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-pat-user-1",
+            data={"access_token": "personal-pat-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        conn = result[0]
+        assert conn["identity_id"] == identity.id
+        assert conn["auth_method"] == "pat"
+        assert conn["encrypted_auth_headers"] is None
+
+    def test_org_datadog_kept_when_personal_is_different_family(self) -> None:
+        self._create_org_datadog_integration()
+        gcp_idp = self.create_identity_provider(type="gcp", external_id="")
+        gcp_identity = self.create_identity(
+            user=self.user,
+            identity_provider=gcp_idp,
+            external_id="gcp-user-1",
+            data={"access_token": "gcp-token"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=gcp_identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert {c["provider_key"] for c in result} == {"gcp", "datadog"}
+        dd_connections = [c for c in result if c["provider_key"] == "datadog"]
+        assert len(dd_connections) == 1
+        assert dd_connections[0]["identity_id"] is None
+
+    def test_org_datadog_connection_ignores_non_active_integration(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name="Datadog",
+            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
+            status=ObjectStatus.DISABLED,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_org_datadog_connection_for_no_user_run(self) -> None:
+        self._create_org_datadog_integration()
+
+        result = get_monitoring_provider_connections(self.organization, None)
+
+        assert len(result) == 1
+        assert result[0]["provider_key"] == "datadog"
+        assert result[0]["identity_id"] is None
+        assert result[0]["refreshable"] is False
+
+    def test_no_connections_for_no_user_run_without_org_integration(self) -> None:
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_org_integration_with_corrupt_metadata_is_skipped_and_logged(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name="Datadog",
+            metadata={"api_key": "org-api-key", "site": "datadoghq.com"},
+        )
+
+        with self.assertLogs("sentry.integrations.datadog.integration", level="ERROR") as logs:
+            result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert result == []
+        assert any("datadog_integration_invalid" in line for line in logs.output)
 
 
 @with_feature("organizations:seer-infra-telemetry")

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1806,6 +1806,7 @@ class TestGetMonitoringProviderConnections(TestCase):
         assert conn["identity_id"] == identity.id
         assert conn["auth_method"] == "oauth"
         assert conn["encrypted_auth_headers"] is None
+        assert conn["refreshable"] is True
 
     def test_personal_datadog_pat_overrides_org(self) -> None:
         self._create_org_datadog_integration()
@@ -1825,6 +1826,7 @@ class TestGetMonitoringProviderConnections(TestCase):
         assert conn["identity_id"] == identity.id
         assert conn["auth_method"] == "pat"
         assert conn["encrypted_auth_headers"] is None
+        assert conn["refreshable"] is False
 
     def test_org_datadog_kept_when_personal_is_different_family(self) -> None:
         self._create_org_datadog_integration()
@@ -1852,6 +1854,20 @@ class TestGetMonitoringProviderConnections(TestCase):
             name="Datadog",
             metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
             status=ObjectStatus.DISABLED,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_org_datadog_connection_ignores_uninstalled_org_integration(self) -> None:
+        # On uninstall the OrganizationIntegration goes PENDING_DELETION while the Integration can
+        # stay ACTIVE until async deletion runs -- creds must not leak during that window.
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name="Datadog",
+            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
+            oi_params={"status": ObjectStatus.PENDING_DELETION},
         )
 
         assert get_monitoring_provider_connections(self.organization, None) == []

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -2,20 +2,15 @@ from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from cryptography.fernet import Fernet
-from django.test import override_settings
 from django.utils import timezone
 from pydantic import BaseModel
 
-from sentry.constants import ObjectStatus
 from sentry.hybridcloud.models.outbox import CellOutbox
 from sentry.hybridcloud.outbox.category import OutboxCategory
-from sentry.hybridcloud.rpc.service import RpcException
 from sentry.models.promptsactivity import PromptsActivity
 from sentry.seer.agent.client import (
     SeerAgentClient,
     get_available_monitoring_providers,
-    get_monitoring_provider_connections,
 )
 from sentry.seer.agent.client_models import (
     AgentFilePatch,
@@ -27,12 +22,11 @@ from sentry.seer.agent.client_models import (
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
+from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options, with_feature
 from sentry.testutils.requests import make_request
 from sentry.utils.prompts import seer_monitoring_provider_dont_ask_feature
-
-TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
 
 
 class TestSeerAgentClient(TestCase):
@@ -440,6 +434,34 @@ class TestSeerAgentClient(TestCase):
         assert mock_post.called
         body = mock_post.call_args[0][0]
         assert "enable_frontend_code_search" not in body["agent_run_options"]
+
+    @patch("sentry.seer.agent.client.get_available_monitoring_providers")
+    @patch("sentry.seer.agent.client.get_monitoring_provider_connections")
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
+    @patch("sentry.seer.agent.client.make_agent_chat_request")
+    def test_continue_run_attaches_org_connections_without_user(
+        self, mock_post, mock_access, mock_conns, mock_available
+    ):
+        mock_access.return_value = (True, None)
+        mock_post.return_value = self._mock_run_response(run_id=1)
+        mock_conns.return_value = [
+            MonitoringProviderConnectionData(
+                provider_key="datadog",
+                url="https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+                encrypted_auth_headers={"DD-API-KEY": "x", "DD-APPLICATION-KEY": "y"},
+                identity_id=None,
+                auth_method="api_key",
+                refreshable=False,
+            )
+        ]
+
+        client = SeerAgentClient(self.organization, user=None)
+        client.continue_run(1, "Follow up")
+
+        mock_conns.assert_called_once_with(self.organization, None)
+        mock_available.assert_not_called()
+        body = mock_post.call_args[0][0]
+        assert body["monitoring_providers"][0]["provider_key"] == "datadog"
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
@@ -1484,421 +1506,6 @@ class TestStartFeatureRun(TestCase):
         assert outbox is not None and outbox.payload is not None
         body = outbox.payload["body"]
         assert body["agent_run_options"] == {}
-
-
-@override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)
-@with_feature("organizations:seer-infra-telemetry")
-class TestGetMonitoringProviderConnections(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.user = self.create_user()
-        self.organization = self.create_organization(owner=self.user)
-
-    def test_returns_empty_when_no_identities(self) -> None:
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    def test_returns_connection(self) -> None:
-        idp = self.create_identity_provider(type="datadog", external_id="org-uuid-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={
-                "access_token": "access-token",
-                "refresh_token": "refresh-token",
-                "client_id": "dd-client-id",
-                "client_secret": "dd-client-secret",
-                "site": "datadoghq.com",
-            },
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert result is not None
-        assert len(result) == 1
-        connection = result[0]
-        assert connection["provider_key"] == "datadog"
-        assert connection["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
-        assert connection["identity_id"] == identity.id
-        assert connection["auth_method"] == "oauth"
-        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
-        decrypted_access_token = fernet.decrypt(
-            connection["encrypted_access_token"].encode("utf-8")
-        ).decode("utf-8")
-        assert decrypted_access_token == "access-token"
-
-    def test_returns_multiple_connections(self) -> None:
-        for site, ext_id in [("datadoghq.com", "org-1"), ("datadoghq.eu", "org-2")]:
-            idp = self.create_identity_provider(type="datadog", external_id=ext_id)
-            identity = self.create_identity(
-                user=self.user,
-                identity_provider=idp,
-                external_id=f"user-{ext_id}",
-                data={"access_token": "access-token", "site": site},
-            )
-            self.create_organization_identity(
-                organization=self.organization,
-                identity=identity,
-            )
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert result is not None
-        assert len(result) == 2
-        urls = {c["url"] for c in result}
-        assert "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp" in urls
-        assert "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp" in urls
-
-    def test_cross_org_isolation(self) -> None:
-        org2 = self.create_organization(name="other-org", owner=self.user)
-
-        idp = self.create_identity_provider(type="datadog", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"access_token": "access-token", "site": "datadoghq.com"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        result_org1 = get_monitoring_provider_connections(self.organization, self.user.id)
-        assert len(result_org1) == 1
-        assert result_org1[0]["provider_key"] == "datadog"
-
-        result_org2 = get_monitoring_provider_connections(org2, self.user.id)
-        assert result_org2 == []
-
-    def test_skips_identity_missing_access_token(self) -> None:
-        idp = self.create_identity_provider(type="datadog", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"site": "datadoghq.com"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    def test_skips_identity_missing_site(self) -> None:
-        idp = self.create_identity_provider(type="datadog", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"access_token": "access-token"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    def test_ignores_non_monitoring_provider_identities(self) -> None:
-        idp = self.create_identity_provider(type="slack", external_id="slack-team")
-        self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="slack-user-1",
-            data={"access_token": "access-token"},
-        )
-
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    @override_settings(SEER_GHE_ENCRYPT_KEY=None)
-    def test_skips_identity_when_encryption_fails(self) -> None:
-        idp = self.create_identity_provider(type="datadog", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"access_token": "access-token", "site": "datadoghq.com"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    @with_feature({"organizations:seer-infra-telemetry": False})
-    def test_returns_empty_when_feature_disabled(self) -> None:
-        idp = self.create_identity_provider(type="datadog", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"access_token": "access-token", "site": "datadoghq.com"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    @patch(
-        "sentry.seer.agent.client.identity_service.get_org_user_identities_by_provider_type",
-        side_effect=RpcException("identity", "get_org_user_identities_by_provider_type", "boom"),
-    )
-    def test_degrades_when_identity_service_errors(self, mock_get: MagicMock) -> None:
-        # A control-silo RPC failure must not propagate (it would stall the outbox shard).
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    def test_returns_gcp_connections(self) -> None:
-        idp = self.create_identity_provider(type="gcp", external_id="")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="gcp-user-1",
-            data={
-                "access_token": "gcp-access-token",
-                "refresh_token": "gcp-refresh-token",
-            },
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 3
-        urls = {c["url"] for c in result}
-        assert urls == {
-            "https://logging.googleapis.com/mcp",
-            "https://monitoring.googleapis.com/mcp",
-            "https://cloudtrace.googleapis.com/mcp",
-        }
-        for connection in result:
-            assert connection["provider_key"] == "gcp"
-            assert connection["identity_id"] == identity.id
-            assert connection["auth_method"] == "oauth"
-            fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
-            decrypted = fernet.decrypt(connection["encrypted_access_token"].encode("utf-8")).decode(
-                "utf-8"
-            )
-            assert decrypted == "gcp-access-token"
-
-    def test_gcp_and_datadog_connections_together(self) -> None:
-        gcp_idp = self.create_identity_provider(type="gcp", external_id="")
-        gcp_identity = self.create_identity(
-            user=self.user,
-            identity_provider=gcp_idp,
-            external_id="gcp-user-1",
-            data={"access_token": "gcp-token"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=gcp_identity,
-        )
-
-        dd_idp = self.create_identity_provider(type="datadog", external_id="dd-org-1")
-        dd_identity = self.create_identity(
-            user=self.user,
-            identity_provider=dd_idp,
-            external_id="dd-user-1",
-            data={"access_token": "dd-token", "site": "datadoghq.com"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=dd_identity,
-        )
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 4
-        gcp_connections = [c for c in result if c["provider_key"] == "gcp"]
-        dd_connections = [c for c in result if c["provider_key"] == "datadog"]
-        assert len(gcp_connections) == 3
-        assert len(dd_connections) == 1
-
-    def test_gcp_skips_identity_missing_access_token(self) -> None:
-        idp = self.create_identity_provider(type="gcp", external_id="")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="gcp-user-1",
-            data={"refresh_token": "refresh-only"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
-
-    @patch("sentry.seer.agent.client.encrypt_access_token_for_seer")
-    def test_gcp_token_encrypted_once(self, mock_encrypt: MagicMock) -> None:
-        mock_encrypt.return_value = "encrypted-token"
-
-        idp = self.create_identity_provider(type="gcp", external_id="")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="gcp-user-1",
-            data={"access_token": "gcp-token"},
-        )
-        self.create_organization_identity(
-            organization=self.organization,
-            identity=identity,
-        )
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 3
-        mock_encrypt.assert_called_once_with("gcp-token")
-
-    def _create_org_datadog_integration(self, site: str = "datadoghq.com") -> None:
-        self.create_integration(
-            organization=self.organization,
-            provider="datadog",
-            external_id="dd-org-uuid",
-            name=f"Datadog ({site})",
-            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": site},
-        )
-
-    def test_org_datadog_connection_when_user_has_no_personal(self) -> None:
-        self._create_org_datadog_integration()
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 1
-        conn = result[0]
-        assert conn["provider_key"] == "datadog"
-        assert conn["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
-        assert conn["identity_id"] is None
-        assert conn["auth_method"] == "api_key"
-        assert conn["refreshable"] is False
-        assert conn["encrypted_access_token"] is None
-
-        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
-        headers = conn["encrypted_auth_headers"]
-        assert fernet.decrypt(headers["DD-API-KEY"].encode()).decode() == "org-api-key"
-        assert fernet.decrypt(headers["DD-APPLICATION-KEY"].encode()).decode() == "org-app-key"
-
-    def test_personal_datadog_overrides_org(self) -> None:
-        self._create_org_datadog_integration()
-        idp = self.create_identity_provider(type="datadog", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-user-1",
-            data={"access_token": "personal-token", "site": "datadoghq.com"},
-        )
-        self.create_organization_identity(organization=self.organization, identity=identity)
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 1
-        conn = result[0]
-        assert conn["identity_id"] == identity.id
-        assert conn["auth_method"] == "oauth"
-        assert conn["encrypted_auth_headers"] is None
-        assert conn["refreshable"] is True
-
-    def test_personal_datadog_pat_overrides_org(self) -> None:
-        self._create_org_datadog_integration()
-        idp = self.create_identity_provider(type="datadog_pat", external_id="org-1")
-        identity = self.create_identity(
-            user=self.user,
-            identity_provider=idp,
-            external_id="dd-pat-user-1",
-            data={"access_token": "personal-pat-token", "site": "datadoghq.com"},
-        )
-        self.create_organization_identity(organization=self.organization, identity=identity)
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert len(result) == 1
-        conn = result[0]
-        assert conn["identity_id"] == identity.id
-        assert conn["auth_method"] == "pat"
-        assert conn["encrypted_auth_headers"] is None
-        assert conn["refreshable"] is False
-
-    def test_org_datadog_kept_when_personal_is_different_family(self) -> None:
-        self._create_org_datadog_integration()
-        gcp_idp = self.create_identity_provider(type="gcp", external_id="")
-        gcp_identity = self.create_identity(
-            user=self.user,
-            identity_provider=gcp_idp,
-            external_id="gcp-user-1",
-            data={"access_token": "gcp-token"},
-        )
-        self.create_organization_identity(organization=self.organization, identity=gcp_identity)
-
-        result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert {c["provider_key"] for c in result} == {"gcp", "datadog"}
-        dd_connections = [c for c in result if c["provider_key"] == "datadog"]
-        assert len(dd_connections) == 1
-        assert dd_connections[0]["identity_id"] is None
-
-    def test_org_datadog_connection_ignores_non_active_integration(self) -> None:
-        self.create_integration(
-            organization=self.organization,
-            provider="datadog",
-            external_id="dd-org-uuid",
-            name="Datadog",
-            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
-            status=ObjectStatus.DISABLED,
-        )
-
-        assert get_monitoring_provider_connections(self.organization, None) == []
-
-    def test_org_datadog_connection_ignores_uninstalled_org_integration(self) -> None:
-        # On uninstall the OrganizationIntegration goes PENDING_DELETION while the Integration can
-        # stay ACTIVE until async deletion runs -- creds must not leak during that window.
-        self.create_integration(
-            organization=self.organization,
-            provider="datadog",
-            external_id="dd-org-uuid",
-            name="Datadog",
-            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
-            oi_params={"status": ObjectStatus.PENDING_DELETION},
-        )
-
-        assert get_monitoring_provider_connections(self.organization, None) == []
-
-    def test_org_datadog_connection_for_no_user_run(self) -> None:
-        self._create_org_datadog_integration()
-
-        result = get_monitoring_provider_connections(self.organization, None)
-
-        assert len(result) == 1
-        assert result[0]["provider_key"] == "datadog"
-        assert result[0]["identity_id"] is None
-        assert result[0]["refreshable"] is False
-
-    def test_no_connections_for_no_user_run_without_org_integration(self) -> None:
-        assert get_monitoring_provider_connections(self.organization, None) == []
-
-    def test_org_integration_with_corrupt_metadata_is_skipped_and_logged(self) -> None:
-        self.create_integration(
-            organization=self.organization,
-            provider="datadog",
-            external_id="dd-org-uuid",
-            name="Datadog",
-            metadata={"api_key": "org-api-key", "site": "datadoghq.com"},
-        )
-
-        with self.assertLogs("sentry.integrations.datadog.integration", level="ERROR") as logs:
-            result = get_monitoring_provider_connections(self.organization, self.user.id)
-
-        assert result == []
-        assert any("datadog_integration_invalid" in line for line in logs.output)
 
 
 @with_feature("organizations:seer-infra-telemetry")

--- a/tests/sentry/seer/agent/test_monitoring_providers.py
+++ b/tests/sentry/seer/agent/test_monitoring_providers.py
@@ -1,0 +1,434 @@
+from unittest.mock import MagicMock, patch
+
+from cryptography.fernet import Fernet
+from django.test import override_settings
+
+from sentry.constants import ObjectStatus
+from sentry.hybridcloud.rpc.service import RpcException
+from sentry.seer.agent.monitoring_providers import get_monitoring_provider_connections
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers import with_feature
+
+TEST_FERNET_KEY = Fernet.generate_key().decode("utf-8")
+
+
+@override_settings(SEER_GHE_ENCRYPT_KEY=TEST_FERNET_KEY)
+@with_feature("organizations:seer-infra-telemetry")
+class TestGetMonitoringProviderConnections(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+
+    def test_returns_empty_when_no_identities(self) -> None:
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    def test_returns_connection(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="org-uuid-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "client_id": "dd-client-id",
+                "client_secret": "dd-client-secret",
+                "site": "datadoghq.com",
+            },
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert result is not None
+        assert len(result) == 1
+        connection = result[0]
+        assert connection["provider_key"] == "datadog"
+        assert connection["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        assert connection["identity_id"] == identity.id
+        assert connection["auth_method"] == "oauth"
+        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+        decrypted_access_token = fernet.decrypt(
+            connection["encrypted_access_token"].encode("utf-8")
+        ).decode("utf-8")
+        assert decrypted_access_token == "access-token"
+
+    def test_returns_multiple_connections(self) -> None:
+        for site, ext_id in [("datadoghq.com", "org-1"), ("datadoghq.eu", "org-2")]:
+            idp = self.create_identity_provider(type="datadog", external_id=ext_id)
+            identity = self.create_identity(
+                user=self.user,
+                identity_provider=idp,
+                external_id=f"user-{ext_id}",
+                data={"access_token": "access-token", "site": site},
+            )
+            self.create_organization_identity(
+                organization=self.organization,
+                identity=identity,
+            )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert result is not None
+        assert len(result) == 2
+        urls = {c["url"] for c in result}
+        assert "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp" in urls
+        assert "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp" in urls
+
+    def test_cross_org_isolation(self) -> None:
+        org2 = self.create_organization(name="other-org", owner=self.user)
+
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "access-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        result_org1 = get_monitoring_provider_connections(self.organization, self.user.id)
+        assert len(result_org1) == 1
+        assert result_org1[0]["provider_key"] == "datadog"
+
+        result_org2 = get_monitoring_provider_connections(org2, self.user.id)
+        assert result_org2 == []
+
+    def test_skips_identity_missing_access_token(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"site": "datadoghq.com"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    def test_skips_identity_missing_site(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "access-token"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    def test_ignores_non_monitoring_provider_identities(self) -> None:
+        idp = self.create_identity_provider(type="slack", external_id="slack-team")
+        self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="slack-user-1",
+            data={"access_token": "access-token"},
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    @override_settings(SEER_GHE_ENCRYPT_KEY=None)
+    def test_skips_identity_when_encryption_fails(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "access-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    @with_feature({"organizations:seer-infra-telemetry": False})
+    def test_returns_empty_when_feature_disabled(self) -> None:
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "access-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    @patch(
+        "sentry.seer.agent.monitoring_providers.identity_service.get_org_user_identities_by_provider_type",
+        side_effect=RpcException("identity", "get_org_user_identities_by_provider_type", "boom"),
+    )
+    def test_degrades_when_identity_service_errors(self, mock_get: MagicMock) -> None:
+        # A control-silo RPC failure must not propagate (it would stall the outbox shard).
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    def test_returns_gcp_connections(self) -> None:
+        idp = self.create_identity_provider(type="gcp", external_id="")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="gcp-user-1",
+            data={
+                "access_token": "gcp-access-token",
+                "refresh_token": "gcp-refresh-token",
+            },
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 3
+        urls = {c["url"] for c in result}
+        assert urls == {
+            "https://logging.googleapis.com/mcp",
+            "https://monitoring.googleapis.com/mcp",
+            "https://cloudtrace.googleapis.com/mcp",
+        }
+        for connection in result:
+            assert connection["provider_key"] == "gcp"
+            assert connection["identity_id"] == identity.id
+            assert connection["auth_method"] == "oauth"
+            fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+            decrypted = fernet.decrypt(connection["encrypted_access_token"].encode("utf-8")).decode(
+                "utf-8"
+            )
+            assert decrypted == "gcp-access-token"
+
+    def test_gcp_and_datadog_connections_together(self) -> None:
+        gcp_idp = self.create_identity_provider(type="gcp", external_id="")
+        gcp_identity = self.create_identity(
+            user=self.user,
+            identity_provider=gcp_idp,
+            external_id="gcp-user-1",
+            data={"access_token": "gcp-token"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=gcp_identity,
+        )
+
+        dd_idp = self.create_identity_provider(type="datadog", external_id="dd-org-1")
+        dd_identity = self.create_identity(
+            user=self.user,
+            identity_provider=dd_idp,
+            external_id="dd-user-1",
+            data={"access_token": "dd-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=dd_identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 4
+        gcp_connections = [c for c in result if c["provider_key"] == "gcp"]
+        dd_connections = [c for c in result if c["provider_key"] == "datadog"]
+        assert len(gcp_connections) == 3
+        assert len(dd_connections) == 1
+
+    def test_gcp_skips_identity_missing_access_token(self) -> None:
+        idp = self.create_identity_provider(type="gcp", external_id="")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="gcp-user-1",
+            data={"refresh_token": "refresh-only"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, self.user.id) == []
+
+    @patch("sentry.seer.agent.monitoring_providers.encrypt_access_token_for_seer")
+    def test_gcp_token_encrypted_once(self, mock_encrypt: MagicMock) -> None:
+        mock_encrypt.return_value = "encrypted-token"
+
+        idp = self.create_identity_provider(type="gcp", external_id="")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="gcp-user-1",
+            data={"access_token": "gcp-token"},
+        )
+        self.create_organization_identity(
+            organization=self.organization,
+            identity=identity,
+        )
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 3
+        mock_encrypt.assert_called_once_with("gcp-token")
+
+    def _create_org_datadog_integration(self, site: str = "datadoghq.com") -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name=f"Datadog ({site})",
+            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": site},
+        )
+
+    def test_org_datadog_connection_when_user_has_no_personal(self) -> None:
+        self._create_org_datadog_integration()
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        conn = result[0]
+        assert conn["provider_key"] == "datadog"
+        assert conn["url"] == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+        assert conn["identity_id"] is None
+        assert conn["auth_method"] == "api_key"
+        assert conn["refreshable"] is False
+        assert conn["encrypted_access_token"] is None
+
+        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+        headers = conn["encrypted_auth_headers"]
+        assert fernet.decrypt(headers["DD-API-KEY"].encode()).decode() == "org-api-key"
+        assert fernet.decrypt(headers["DD-APPLICATION-KEY"].encode()).decode() == "org-app-key"
+
+    def test_personal_datadog_overrides_org(self) -> None:
+        self._create_org_datadog_integration()
+        idp = self.create_identity_provider(type="datadog", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-user-1",
+            data={"access_token": "personal-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        conn = result[0]
+        assert conn["identity_id"] == identity.id
+        assert conn["auth_method"] == "oauth"
+        assert conn["encrypted_auth_headers"] is None
+        assert conn["refreshable"] is True
+
+    def test_personal_datadog_pat_overrides_org(self) -> None:
+        self._create_org_datadog_integration()
+        idp = self.create_identity_provider(type="datadog_pat", external_id="org-1")
+        identity = self.create_identity(
+            user=self.user,
+            identity_provider=idp,
+            external_id="dd-pat-user-1",
+            data={"access_token": "personal-pat-token", "site": "datadoghq.com"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert len(result) == 1
+        conn = result[0]
+        assert conn["identity_id"] == identity.id
+        assert conn["auth_method"] == "pat"
+        assert conn["encrypted_auth_headers"] is None
+        assert conn["refreshable"] is False
+
+    def test_org_datadog_kept_when_personal_is_different_family(self) -> None:
+        self._create_org_datadog_integration()
+        gcp_idp = self.create_identity_provider(type="gcp", external_id="")
+        gcp_identity = self.create_identity(
+            user=self.user,
+            identity_provider=gcp_idp,
+            external_id="gcp-user-1",
+            data={"access_token": "gcp-token"},
+        )
+        self.create_organization_identity(organization=self.organization, identity=gcp_identity)
+
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert {c["provider_key"] for c in result} == {"gcp", "datadog"}
+        dd_connections = [c for c in result if c["provider_key"] == "datadog"]
+        assert len(dd_connections) == 1
+        assert dd_connections[0]["identity_id"] is None
+
+    def test_org_datadog_connection_ignores_non_active_integration(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name="Datadog",
+            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
+            status=ObjectStatus.DISABLED,
+        )
+
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_org_datadog_connection_ignores_uninstalled_org_integration(self) -> None:
+        # On uninstall the OrganizationIntegration goes PENDING_DELETION while the Integration can
+        # stay ACTIVE until async deletion runs -- creds must not leak during that window.
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name="Datadog",
+            metadata={"api_key": "org-api-key", "app_key": "org-app-key", "site": "datadoghq.com"},
+            oi_params={"status": ObjectStatus.PENDING_DELETION},
+        )
+
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_org_datadog_connection_for_no_user_run(self) -> None:
+        self._create_org_datadog_integration()
+
+        result = get_monitoring_provider_connections(self.organization, None)
+
+        assert len(result) == 1
+        assert result[0]["provider_key"] == "datadog"
+        assert result[0]["identity_id"] is None
+        assert result[0]["refreshable"] is False
+
+    @patch(
+        "sentry.integrations.datadog.integration.integration_service.organization_context",
+        side_effect=RpcException("integration", "organization_context", "boom"),
+    )
+    def test_degrades_when_org_integration_rpc_errors(self, mock_ctx: MagicMock) -> None:
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_no_connections_for_no_user_run_without_org_integration(self) -> None:
+        assert get_monitoring_provider_connections(self.organization, None) == []
+
+    def test_org_integration_with_corrupt_metadata_is_skipped_and_logged(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="datadog",
+            external_id="dd-org-uuid",
+            name="Datadog",
+            metadata={"api_key": "org-api-key", "site": "datadoghq.com"},
+        )
+
+        with self.assertLogs("sentry.integrations.datadog.integration", level="ERROR") as logs:
+            result = get_monitoring_provider_connections(self.organization, self.user.id)
+
+        assert result == []
+        assert any("datadog_integration_invalid" in line for line in logs.output)

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -895,6 +895,7 @@ class TestGetMonitoringProviderConnections(APITestCase):
         assert connection.url == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection.identity_id == identity.id
         assert connection.auth_method == "oauth"
+        assert connection.encrypted_access_token is not None
         decrypted = Fernet(TEST_FERNET_KEY.encode("utf-8")).decrypt(
             connection.encrypted_access_token.encode("utf-8")
         )


### PR DESCRIPTION
This starts sending org level datadog external mcp info to Seer. We also add an abstraction to handle this generically for other providers like this.

User level identities for the same provider take precedence over the org level ones, if both are set up.

<!-- Describe your PR here. -->