### PR TITLE
chore(dashboards): Remove `data-browsing-heat-map-widget` backend flag usage

### DIFF
--- a/src/sentry/api/endpoints/organization_events_heatmap.py
+++ b/src/sentry/api/endpoints/organization_events_heatmap.py
@@ -6,7 +6,6 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
@@ -99,10 +98,6 @@ class OrganizationEventsHeatmapEndpoint(OrganizationEventsEndpointBase):
         """
         Retrieves explore data for a given organization as a heatmap.
         """
-        if not features.has(
-            "organizations:data-browsing-heat-map-widget", organization, actor=request.user
-        ):
-            return Response(status=404)
         with start_span(op="discover.endpoint", name="filter_params") as span:
             set_span_data(span, "organization", organization)
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -170,9 +170,8 @@ DATASET_CONFIG: dict[int, DatasetConfig] = {
                 DashboardWidgetDisplayTypes.BAR_CHART,
                 DashboardWidgetDisplayTypes.BIG_NUMBER,
                 DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART,
-                # HEATMAP is additionally gated behind the
-                # ``data-browsing-heat-map-widget`` feature flag in
-                # ``validate_display_type``.
+                # HEATMAP is additionally gated behind the application metrics
+                # (``tracemetrics-enabled``) feature in ``validate_display_type``.
                 DashboardWidgetDisplayTypes.HEATMAP,
             }
         )
@@ -406,10 +405,11 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     def validate_display_type(self, display_type):
         display_type_id = DashboardWidgetDisplayTypes.get_id_for_type_name(display_type)
 
-        # Heat map widgets are only available to organizations with the feature
-        # flag. Without it, creating or updating a heat map widget is rejected.
+        # Heat maps are a metrics-only visualization, so they're only available
+        # to organizations with the application metrics feature. Without it,
+        # creating or updating a heat map widget is rejected.
         if display_type_id == DashboardWidgetDisplayTypes.HEATMAP and not features.has(
-            "organizations:data-browsing-heat-map-widget", self.context["organization"]
+            "organizations:tracemetrics-enabled", self.context["organization"]
         ):
             raise serializers.ValidationError(
                 f"Display type '{display_type}' is not available for this organization."

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -170,8 +170,8 @@ DATASET_CONFIG: dict[int, DatasetConfig] = {
                 DashboardWidgetDisplayTypes.BAR_CHART,
                 DashboardWidgetDisplayTypes.BIG_NUMBER,
                 DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART,
-                # HEATMAP is additionally gated behind the application metrics
-                # (``tracemetrics-enabled``) feature in ``validate_display_type``.
+                # HEATMAP is a metrics-only visualization; it's supported here for
+                # trace metrics widgets and rejected for other widget types.
                 DashboardWidgetDisplayTypes.HEATMAP,
             }
         )
@@ -404,16 +404,6 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
 
     def validate_display_type(self, display_type):
         display_type_id = DashboardWidgetDisplayTypes.get_id_for_type_name(display_type)
-
-        # Heat maps are a metrics-only visualization, so they're only available
-        # to organizations with the application metrics feature. Without it,
-        # creating or updating a heat map widget is rejected.
-        if display_type_id == DashboardWidgetDisplayTypes.HEATMAP and not features.has(
-            "organizations:tracemetrics-enabled", self.context["organization"]
-        ):
-            raise serializers.ValidationError(
-                f"Display type '{display_type}' is not available for this organization."
-            )
 
         widget_type_name = self.context.get("widget_type")
         if widget_type_name is not None and display_type_id is not None:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -170,8 +170,6 @@ DATASET_CONFIG: dict[int, DatasetConfig] = {
                 DashboardWidgetDisplayTypes.BAR_CHART,
                 DashboardWidgetDisplayTypes.BIG_NUMBER,
                 DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART,
-                # HEATMAP is a metrics-only visualization; it's supported here for
-                # trace metrics widgets and rejected for other widget types.
                 DashboardWidgetDisplayTypes.HEATMAP,
             }
         )

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -348,8 +348,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make Insights overview pages use EAP instead of transactions (because eap is not on AM1)
     manager.add("organizations:insights-modules-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable data browsing heat map widget
-    manager.add("organizations:data-browsing-heat-map-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable attribute context in data browsing
     manager.add("organizations:data-browsing-attribute-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable public RPC endpoint for local seer development

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -348,6 +348,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Make Insights overview pages use EAP instead of transactions (because eap is not on AM1)
     manager.add("organizations:insights-modules-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable data browsing heat map widget
+    manager.add("organizations:data-browsing-heat-map-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable attribute context in data browsing
     manager.add("organizations:data-browsing-attribute-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable public RPC endpoint for local seer development

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -587,10 +587,12 @@ def _unfurl_explore(
             continue
 
         if display_type == "heatmap":
-            # Heat maps are a metrics-only visualization, so chartType 3 only ever
-            # comes from metrics URLs — traces/logs never offer it. This branch
-            # therefore assumes the trace metrics dataset (events-heatmap with
-            # metric-style axes); it is not reached for other Explore datasets.
+            # Heat maps are a metrics-only visualization (events-heatmap with
+            # metric-style axes). Traces/logs never offer chartType 3 in the UI,
+            # but guard against hand-built URLs by skipping any non-metrics dataset.
+            if explore_dataset != SupportedTraceItemType.TRACEMETRICS:
+                continue
+
             style = ChartType.SLACK_HEATMAP
             heatmap_params = _build_heatmap_query(params)
             api_params: dict[str, str | list[str]] = {

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -555,12 +555,6 @@ def _unfurl_explore(
         if features.has("organizations:visibility-explore-view", org, actor=user)
     }
 
-    heatmap_enabled_orgs = {
-        slug: org
-        for slug, org in orgs_by_slug.items()
-        if features.has("organizations:data-browsing-heat-map-widget", org, actor=user)
-    }
-
     if not enabled_orgs:
         return {}
 
@@ -597,10 +591,6 @@ def _unfurl_explore(
             # comes from metrics URLs — traces/logs never offer it. This branch
             # therefore assumes the trace metrics dataset (events-heatmap with
             # metric-style axes); it is not reached for other Explore datasets.
-            heatmap_org = heatmap_enabled_orgs.get(org_slug)
-            if not heatmap_org:
-                continue
-
             style = ChartType.SLACK_HEATMAP
             heatmap_params = _build_heatmap_query(params)
             api_params: dict[str, str | list[str]] = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1485,18 +1485,20 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
-    def test_widget_type_tracemetrics_heatmap_requires_metrics_feature(self) -> None:
+    def test_heatmap_rejected_for_non_tracemetrics_widget(self) -> None:
+        # Heat maps are only a supported display type for trace metrics widgets;
+        # requesting one for another dataset is rejected on the display type.
         data = {
-            "title": "Test Metrics Heat Map",
-            "widgetType": "tracemetrics",
+            "title": "Test Heat Map",
+            "widgetType": "spans",
             "displayType": "heatmap",
             "queries": [
                 {
                     "name": "",
-                    "conditions": "metric.name:foo",
-                    "fields": ["sum(value)"],
+                    "conditions": "",
+                    "fields": ["count()"],
                     "columns": [],
-                    "aggregates": ["sum(value)"],
+                    "aggregates": ["count()"],
                 },
             ],
         }
@@ -1509,7 +1511,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
 
-    def test_widget_type_tracemetrics_heatmap_with_metrics_feature(self) -> None:
+    def test_widget_type_tracemetrics_heatmap(self) -> None:
         data = {
             "title": "Test Metrics Heat Map",
             "widgetType": "tracemetrics",
@@ -1525,12 +1527,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 200, response.data
 
     def test_heatmap_rejects_equation_aggregate(self) -> None:
@@ -1549,12 +1550,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert response.data["queries"] == ["Heatmap widgets don't support equations."], (
             response.data
@@ -1583,12 +1583,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert response.data["queries"] == ["Heatmap widgets cannot have multiple queries"], (
             response.data
@@ -1616,12 +1615,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert (
             response.data["queries"][0]["selectedAggregate"]
@@ -1651,12 +1649,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 200, response.data
 
     def test_heatmap_rejects_second_of_multiple_aggregates_when_invalid(self) -> None:
@@ -1682,12 +1679,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert (
             response.data["queries"][0]["aggregates"]
@@ -1710,12 +1706,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert (
             response.data["queries"][0]["aggregates"]
@@ -1738,12 +1733,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert (
             response.data["queries"][0]["aggregates"]
@@ -1766,12 +1760,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert (
             response.data["queries"][0]["columns"]
@@ -1794,12 +1787,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert (
             response.data["queries"][0]["columns"]
@@ -1829,12 +1821,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:tracemetrics-enabled"):
-            response = self.do_request(
-                "post",
-                self.url(),
-                data=data,
-            )
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert response.data["thresholds"] == ["Heatmap widgets do not support thresholds."], (
             response.data

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1485,7 +1485,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 200, response.data
 
-    def test_widget_type_tracemetrics_heatmap_requires_flag(self) -> None:
+    def test_widget_type_tracemetrics_heatmap_requires_metrics_feature(self) -> None:
         data = {
             "title": "Test Metrics Heat Map",
             "widgetType": "tracemetrics",
@@ -1509,7 +1509,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
 
-    def test_widget_type_tracemetrics_heatmap_with_flag(self) -> None:
+    def test_widget_type_tracemetrics_heatmap_with_metrics_feature(self) -> None:
         data = {
             "title": "Test Metrics Heat Map",
             "widgetType": "tracemetrics",
@@ -1525,7 +1525,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1549,7 +1549,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1583,7 +1583,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1616,7 +1616,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1651,7 +1651,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1682,7 +1682,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1710,7 +1710,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1738,7 +1738,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1766,7 +1766,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1794,7 +1794,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),
@@ -1829,7 +1829,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             ],
         }
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
+        with self.feature("organizations:tracemetrics-enabled"):
             response = self.do_request(
                 "post",
                 self.url(),

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1211,8 +1211,7 @@ class UnfurlTest(TestCase):
 
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert len(unfurls) == 1
         assert mock_client_get.call_args[1]["path"].endswith("/events-heatmap/")
@@ -1257,8 +1256,7 @@ class UnfurlTest(TestCase):
 
         links = [UnfurlableUrl(url=url, args=args)]
 
-        with self.feature("organizations:data-browsing-heat-map-widget"):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+        unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
 
         assert unfurls == {}
         assert mock_generate_chart.mock_calls == []

--- a/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_heatmap_trace_metrics.py
@@ -22,7 +22,6 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
         )
         self.end = self.start + timedelta(hours=6)
         self.two_days_ago = self.day_ago - timedelta(days=1)
-        self.features = {"organizations:data-browsing-heat-map-widget": True}
 
         self.url = reverse(
             self.endpoint,
@@ -30,8 +29,7 @@ class OrganizationEventsHeatmapTraceMetricsEndpointTest(OrganizationEventsEndpoi
         )
 
     def _do_request(self, data, url=None, features=None):
-        with self.feature(self.features):
-            return self.client.get(self.url if url is None else url, data=data, format="json")
+        return self.client.get(self.url if url is None else url, data=data, format="json")
 
     def test_simple(self) -> None:
         metric_values = [6, 0, 6, 3, 0, 3]


### PR DESCRIPTION
Flag's rolled out! From now on, people are free to try to use the endpoint (though it's still not public) and it'll alert them if they're trying to make a heat map for a dataset that's not allowed.

## Related
- Frontend PR: getsentry/sentry#119855
- Flagpole removal: getsentry/sentry-options-automator#8697
- Declaration removal (land last): getsentry/sentry#119913