### PR TITLE
chore(dashboards): remove `data-browsing-heat-map-widget` flag usage

### DIFF
--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -246,7 +246,7 @@ describe('MetricPanel', () => {
 
     const equationOrg = {
       ...organization,
-      features: [...organization.features, 'data-browsing-heat-map-widget'],
+      features: [...organization.features],
     };
 
     render(
@@ -289,7 +289,7 @@ describe('MetricPanel', () => {
 
     const heatMapOrg = {
       ...organization,
-      features: [...organization.features, 'data-browsing-heat-map-widget'],
+      features: [...organization.features],
     };
 
     render(

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -41,8 +41,5 @@ export const canUseMetricsPiiScrubbingUI = (organization: Organization) => {
 };
 
 export const canUseMetricsHeatMap = (organization: Organization) => {
-  return (
-    canUseMetricsUI(organization) &&
-    organization.features.includes('data-browsing-heat-map-widget')
-  );
+  return canUseMetricsUI(organization);
 };


### PR DESCRIPTION
Frontend removal of `organizations:data-browsing-heat-map-widget`. We're still gating Heat Map visualizations behind having access to Application Metrics, since ... well, that's the only dataset that supports it.

## Related
- Backend PR: getsentry/sentry#119854
- Flagpole removal: [getsentry/sentry-options-automator#8697](https://github.com/getsentry/sentry-options-automator/pull/8697)