### PR TITLE
feat(derived data): Add Pipeline.pipeline_hash

### DIFF
--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -425,6 +425,20 @@ def resolve[E: HasType](
     return [agg for agg in all_aggs if agg.name in needed]
 
 
+def _ensure_no_aliasing(features: Iterable[Feature[Any]]) -> tuple[Feature[Any], ...]:
+    """Return the unique features, raising if the same name maps to different instances."""
+    seen: dict[str, Feature[Any]] = {}
+    for f in features:
+        existing = seen.get(f.name)
+        if existing is not None and existing is not f:
+            raise ValueError(
+                f"Feature {f.name!r} has multiple distinct instances in the pipeline; "
+                f"use the same Feature object everywhere"
+            )
+        seen[f.name] = f
+    return tuple(seen.values())
+
+
 def _validate_and_sort[E: HasType](
     aggregators: tuple[Aggregator[E], ...],
 ) -> tuple[tuple[Aggregator[E], ...], tuple[Feature[Any], ...]]:
@@ -473,9 +487,6 @@ def _validate_and_sort[E: HasType](
         remaining = {a.name for a in aggregators} - {a.name for a in order}
         raise ValueError(f"Cycle detected among aggregators: {remaining}")
 
-    all_features: dict[str, Feature[Any]] = {}
-    for agg in aggregators:
-        for f in (*agg.deps, *agg.outputs):
-            all_features[f.name] = f
+    all_features = _ensure_no_aliasing(f for agg in aggregators for f in (*agg.deps, *agg.outputs))
 
-    return tuple(order), tuple(all_features.values())
+    return tuple(order), all_features

--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -3,7 +3,9 @@ Core framework for the derived-data pipeline.
 No Django dependencies — pure Python, fully testable in isolation.
 """
 
+import base64
 import copy
+import hashlib
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
@@ -102,6 +104,9 @@ class Feature[T]:
     The ``codec`` handles conversion to/from storage representations.
     JSON-blob features use ``to_json`` / ``from_json``; column-backed
     features use ``to_column`` / ``from_column``.
+
+    Increment ``version`` whenever the feature's aggregation logic changes
+    meaningfully so that stale derived data can be detected.
     """
 
     def __init__(
@@ -111,14 +116,21 @@ class Feature[T]:
         default: Any = _MISSING,
         default_factory: Callable[[], Any] | None = None,
         codec: Codec[T] | None = None,
+        version: int = 0,
     ) -> None:
         if default is _MISSING and default_factory is None:
             raise ValueError("Must provide default or default_factory")
         self.name = name
+        self.version = version
         self._default = default
         self._default_factory = default_factory
         self._codec = codec or IDENTITY_CODEC
         self._hash = hash(name)
+
+    @property
+    def content_id(self) -> str:
+        """Versioned identifier for this feature, e.g. ``"view_count:0"``."""
+        return f"{self.name}:{self.version}"
 
     def initial_value(self) -> T:
         if self._default_factory is not None:
@@ -344,6 +356,12 @@ class Pipeline[E: HasType]:
     @property
     def features(self) -> tuple[Feature[Any], ...]:
         return self._features
+
+    def get_feature_hash(self) -> str:
+        """Return a short digest capturing the set of features and their versions."""
+        payload = ",".join(sorted(f.content_id for f in self._features))
+        digest = hashlib.blake2b(payload.encode(), digest_size=8).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 
     def initial_state(self) -> State:
         return State({f: f.initial_value() for f in self._features})

--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum, StrEnum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, ClassVar, Final, Protocol, runtime_checkable
 
 _MISSING = object()
 
@@ -120,8 +120,8 @@ class Feature[T]:
     ) -> None:
         if default is _MISSING and default_factory is None:
             raise ValueError("Must provide default or default_factory")
-        self.name = name
-        self.version = version
+        self.name: Final[str] = name
+        self._version: Final[int] = version
         self._default = default
         self._default_factory = default_factory
         self._codec = codec or IDENTITY_CODEC
@@ -130,7 +130,7 @@ class Feature[T]:
     @property
     def content_id(self) -> str:
         """Versioned identifier for this feature, e.g. ``"view_count:0"``."""
-        return f"{self.name}:{self.version}"
+        return f"{self.name}:{self._version}"
 
     def initial_value(self) -> T:
         if self._default_factory is not None:
@@ -153,8 +153,8 @@ class Feature[T]:
         return (self, val)
 
     def __repr__(self) -> str:
-        if self.version:
-            return f"Feature({self.name!r}, v={self.version})"
+        if self._version:
+            return f"Feature({self.name!r}, v={self._version})"
         return f"Feature({self.name!r})"
 
     def __hash__(self) -> int:
@@ -162,7 +162,7 @@ class Feature[T]:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Feature):
-            return self.name == other.name and self.version == other.version
+            return self.name == other.name and self._version == other._version
         return NotImplemented
 
 
@@ -331,9 +331,10 @@ def aggregator[E: HasType](
 class Pipeline[E: HasType]:
     """Applies a set of Aggregators to a State for each event in a sequence, producing a new State."""
 
-    # Increment to change the pipeline hash when the feature set is
-    # unchanged but pipeline behaviour has changed meaningfully.
-    version: int = 0
+    # Bump this manually when pipeline behaviour changes in ways that affect
+    # results but the feature set itself is unchanged (e.g. changing
+    # aggregator execution order). This value is an input to pipeline_hash.
+    _version: ClassVar[int] = 0
 
     def __init__(
         self,
@@ -348,7 +349,7 @@ class Pipeline[E: HasType]:
             (agg, frozenset({*agg.deps, *agg.outputs}), frozenset(agg.outputs))
             for agg in self._aggregators
         )
-        payload = f"{self.version}:" + ",".join(sorted(f.content_id for f in self._features))
+        payload = f"{self._version}:" + ",".join(sorted(f.content_id for f in self._features))
         digest = hashlib.blake2b(payload.encode(), digest_size=8).digest()
         self._pipeline_hash = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 

--- a/src/sentry/issues/derived/framework.py
+++ b/src/sentry/issues/derived/framework.py
@@ -125,7 +125,7 @@ class Feature[T]:
         self._default = default
         self._default_factory = default_factory
         self._codec = codec or IDENTITY_CODEC
-        self._hash = hash(name)
+        self._hash = hash((name, version))
 
     @property
     def content_id(self) -> str:
@@ -153,6 +153,8 @@ class Feature[T]:
         return (self, val)
 
     def __repr__(self) -> str:
+        if self.version:
+            return f"Feature({self.name!r}, v={self.version})"
         return f"Feature({self.name!r})"
 
     def __hash__(self) -> int:
@@ -160,7 +162,7 @@ class Feature[T]:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Feature):
-            return self.name == other.name
+            return self.name == other.name and self.version == other.version
         return NotImplemented
 
 
@@ -329,14 +331,16 @@ def aggregator[E: HasType](
 class Pipeline[E: HasType]:
     """Applies a set of Aggregators to a State for each event in a sequence, producing a new State."""
 
+    # Increment to change the pipeline hash when the feature set is
+    # unchanged but pipeline behaviour has changed meaningfully.
+    version: int = 0
+
     def __init__(
         self,
         aggregators: Iterable[Aggregator[E]],
         *,
-        version: int,
         check_mutations: bool = False,
     ) -> None:
-        self._version = version
         self._check_mutations = check_mutations
         aggregators = tuple(aggregators)
         self._aggregators, self._features = _validate_and_sort(aggregators)
@@ -344,10 +348,9 @@ class Pipeline[E: HasType]:
             (agg, frozenset({*agg.deps, *agg.outputs}), frozenset(agg.outputs))
             for agg in self._aggregators
         )
-
-    @property
-    def version(self) -> int:
-        return self._version
+        payload = f"{self.version}:" + ",".join(sorted(f.content_id for f in self._features))
+        digest = hashlib.blake2b(payload.encode(), digest_size=8).digest()
+        self._pipeline_hash = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
 
     @property
     def aggregators(self) -> tuple[Aggregator[E], ...]:
@@ -357,11 +360,10 @@ class Pipeline[E: HasType]:
     def features(self) -> tuple[Feature[Any], ...]:
         return self._features
 
-    def get_feature_hash(self) -> str:
-        """Return a short digest capturing the set of features and their versions."""
-        payload = ",".join(sorted(f.content_id for f in self._features))
-        digest = hashlib.blake2b(payload.encode(), digest_size=8).digest()
-        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    @property
+    def pipeline_hash(self) -> str:
+        """Short digest capturing the pipeline version, feature set, and feature versions."""
+        return self._pipeline_hash
 
     def initial_state(self) -> State:
         return State({f: f.initial_value() for f in self._features})

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -18,11 +18,7 @@ from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
-# Pipeline with current aggregators. Versioned because in principle
-# we may want to change it in place and correlate that to existing derived data
-# for invalidation purposes.
-# TODO: Shouldn't it be versioned by a feature set hash? To be sorted out later.
-PIPELINE: Pipeline[GroupActionLogEntry] = Pipeline(AGGREGATORS, version=1)
+PIPELINE: Pipeline[GroupActionLogEntry] = Pipeline(AGGREGATORS)
 
 DEFAULT_BATCH_SIZE = 1000
 INLINE_BATCH_SIZE = 100

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -1047,6 +1047,22 @@ def test_duplicate_output_rejected() -> None:
         Pipeline([agg1, agg2])
 
 
+def test_duplicate_name_different_versions_rejected() -> None:
+    A_v0 = Feature[int]("x", default=0, version=0)
+    A_v1 = Feature[int]("x", default=0, version=1)
+
+    @aggregator((A_v0,))
+    def agg1(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    @aggregator((A_v1,))
+    def agg2(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    with pytest.raises(ValueError, match="output by both"):
+        Pipeline([agg1, agg2])
+
+
 def test_missing_dependency_rejected() -> None:
     A = Feature[int]("a", default=0)
     B = Feature[int]("b", default=0)
@@ -1073,6 +1089,23 @@ def test_cycle_rejected() -> None:
 
     with pytest.raises(ValueError, match="Cycle detected"):
         Pipeline([agg1, agg2])
+
+
+def test_distinct_feature_instances_same_name_rejected() -> None:
+    A_output = Feature[int]("a", default=0)
+    A_dep = Feature[int]("a", default=0)  # different instance, same name
+    B = Feature[int]("b", default=0)
+
+    @aggregator((A_output,))
+    def produce_a(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    @aggregator((B,), deps=(A_dep,))
+    def use_a(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    with pytest.raises(ValueError, match="multiple distinct instances"):
+        Pipeline([produce_a, use_a])
 
 
 def test_full_pipeline_constructs() -> None:

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -1109,3 +1109,81 @@ def test_full_pipeline_mixed_events() -> None:
     )
     assert state[STATUS] == IssueStatus.CLOSED
     assert state[VIEW_COUNT] == 1
+
+
+# ---------------------------------------------------------------------------
+# Feature.content_id and Pipeline.get_feature_hash
+# ---------------------------------------------------------------------------
+
+
+def test_feature_content_id_default_version() -> None:
+    f = Feature[int]("foo", default=0)
+    assert f.content_id == "foo:0"
+
+
+def test_feature_content_id_explicit_version() -> None:
+    f = Feature[int]("foo", default=0, version=3)
+    assert f.content_id == "foo:3"
+
+
+def test_get_feature_hash_deterministic() -> None:
+    p = _pipeline()
+    assert p.get_feature_hash() == p.get_feature_hash()
+
+
+def test_get_feature_hash_changes_with_version() -> None:
+    A = Feature[int]("a", default=0)
+    B = Feature[int]("b", default=0)
+
+    @aggregator((A,))
+    def agg_a(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    @aggregator((B,))
+    def agg_b(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    p1 = Pipeline([agg_a, agg_b], version=1)
+
+    A_v2 = Feature[int]("a", default=0, version=1)
+
+    @aggregator((A_v2,))
+    def agg_a2(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    p2 = Pipeline([agg_a2, agg_b], version=1)
+
+    assert p1.get_feature_hash() != p2.get_feature_hash()
+
+
+def test_get_feature_hash_is_order_independent() -> None:
+    A = Feature[int]("a", default=0)
+    B = Feature[int]("b", default=0)
+
+    @aggregator((A,))
+    def agg_a(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    @aggregator((B,))
+    def agg_b(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    @aggregator((B,))
+    def agg_b2(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    @aggregator((A,))
+    def agg_a2(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    p1 = Pipeline([agg_a, agg_b], version=1)
+    p2 = Pipeline([agg_a2, agg_b2], version=1)
+
+    assert p1.get_feature_hash() == p2.get_feature_hash()
+
+
+def test_get_feature_hash_is_unpadded_base64() -> None:
+    p = _pipeline()
+    h = p.get_feature_hash()
+    assert "=" not in h
+    assert len(h) == 11  # 8 bytes -> 11 base64 chars (no padding)

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -1197,10 +1197,10 @@ def test_pipeline_hash_changes_with_pipeline_version() -> None:
         return None
 
     class V0(Pipeline[Any]):
-        version = 0
+        _version = 0
 
     class V1(Pipeline[Any]):
-        version = 1
+        _version = 1
 
     assert V0([agg_a]).pipeline_hash != V1([agg_a]).pipeline_hash
 

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -47,7 +47,7 @@ def _pipeline(
     aggs = aggregators if aggregators is not None else AGGREGATORS
     if targets is not None:
         aggs = resolve(targets, aggs)
-    return Pipeline(aggs, version=1, check_mutations=True)
+    return Pipeline(aggs, check_mutations=True)
 
 
 def _run_for_feature[T](feature: Feature[T], entries: list[FakeEntry]) -> T:
@@ -1044,7 +1044,7 @@ def test_duplicate_output_rejected() -> None:
         return None
 
     with pytest.raises(ValueError, match="output by both"):
-        Pipeline([agg1, agg2], version=1)
+        Pipeline([agg1, agg2])
 
 
 def test_missing_dependency_rejected() -> None:
@@ -1056,7 +1056,7 @@ def test_missing_dependency_rejected() -> None:
         return None
 
     with pytest.raises(ValueError, match="not output by any aggregator"):
-        Pipeline([agg], version=1)
+        Pipeline([agg])
 
 
 def test_cycle_rejected() -> None:
@@ -1072,7 +1072,7 @@ def test_cycle_rejected() -> None:
         return None
 
     with pytest.raises(ValueError, match="Cycle detected"):
-        Pipeline([agg1, agg2], version=1)
+        Pipeline([agg1, agg2])
 
 
 def test_full_pipeline_constructs() -> None:
@@ -1112,7 +1112,7 @@ def test_full_pipeline_mixed_events() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Feature.content_id and Pipeline.get_feature_hash
+# Feature.content_id and Pipeline.pipeline_hash
 # ---------------------------------------------------------------------------
 
 
@@ -1126,12 +1126,12 @@ def test_feature_content_id_explicit_version() -> None:
     assert f.content_id == "foo:3"
 
 
-def test_get_feature_hash_deterministic() -> None:
+def test_pipeline_hash_deterministic() -> None:
     p = _pipeline()
-    assert p.get_feature_hash() == p.get_feature_hash()
+    assert p.pipeline_hash == p.pipeline_hash
 
 
-def test_get_feature_hash_changes_with_version() -> None:
+def test_pipeline_hash_changes_with_feature_version() -> None:
     A = Feature[int]("a", default=0)
     B = Feature[int]("b", default=0)
 
@@ -1143,7 +1143,7 @@ def test_get_feature_hash_changes_with_version() -> None:
     def agg_b(state: StateView, entry: object) -> AggregatorResult:
         return None
 
-    p1 = Pipeline([agg_a, agg_b], version=1)
+    p1 = Pipeline([agg_a, agg_b])
 
     A_v2 = Feature[int]("a", default=0, version=1)
 
@@ -1151,12 +1151,28 @@ def test_get_feature_hash_changes_with_version() -> None:
     def agg_a2(state: StateView, entry: object) -> AggregatorResult:
         return None
 
-    p2 = Pipeline([agg_a2, agg_b], version=1)
+    p2 = Pipeline([agg_a2, agg_b])
 
-    assert p1.get_feature_hash() != p2.get_feature_hash()
+    assert p1.pipeline_hash != p2.pipeline_hash
 
 
-def test_get_feature_hash_is_order_independent() -> None:
+def test_pipeline_hash_changes_with_pipeline_version() -> None:
+    A = Feature[int]("a", default=0)
+
+    @aggregator((A,))
+    def agg_a(state: StateView, entry: object) -> AggregatorResult:
+        return None
+
+    class V0(Pipeline[Any]):
+        version = 0
+
+    class V1(Pipeline[Any]):
+        version = 1
+
+    assert V0([agg_a]).pipeline_hash != V1([agg_a]).pipeline_hash
+
+
+def test_pipeline_hash_is_order_independent() -> None:
     A = Feature[int]("a", default=0)
     B = Feature[int]("b", default=0)
 
@@ -1176,14 +1192,14 @@ def test_get_feature_hash_is_order_independent() -> None:
     def agg_a2(state: StateView, entry: object) -> AggregatorResult:
         return None
 
-    p1 = Pipeline([agg_a, agg_b], version=1)
-    p2 = Pipeline([agg_a2, agg_b2], version=1)
+    p1 = Pipeline([agg_a, agg_b])
+    p2 = Pipeline([agg_a2, agg_b2])
 
-    assert p1.get_feature_hash() == p2.get_feature_hash()
+    assert p1.pipeline_hash == p2.pipeline_hash
 
 
-def test_get_feature_hash_is_unpadded_base64() -> None:
+def test_pipeline_hash_is_unpadded_base64() -> None:
     p = _pipeline()
-    h = p.get_feature_hash()
+    h = p.pipeline_hash
     assert "=" not in h
     assert len(h) == 11  # 8 bytes -> 11 base64 chars (no padding)

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -77,9 +77,7 @@ class ProcessGroupLogTest(TestCase):
         super().setUp()
         # Enable mutation checking so aggregators that modify state in place fail.
         self._original_pipeline = processing.PIPELINE
-        processing.PIPELINE = Pipeline(
-            AGGREGATORS, version=processing.PIPELINE.version, check_mutations=True
-        )
+        processing.PIPELINE = Pipeline(AGGREGATORS, check_mutations=True)
 
     def tearDown(self) -> None:
         processing.PIPELINE = self._original_pipeline
@@ -361,7 +359,7 @@ def test_mutation_checking_catches_in_place_mutation() -> None:
         state[ITEMS].append("oops")
         return None
 
-    p = Pipeline([bad_mutator], version=1, check_mutations=True)
+    p = Pipeline([bad_mutator], check_mutations=True)
     state = p.initial_state()
 
     class FakeEntry:
@@ -392,7 +390,7 @@ def test_build_update_json_blob_includes_all_json_features() -> None:
     def compute(state: StateView, entry: object) -> AggregatorResult:
         return None
 
-    pipeline = Pipeline([compute], version=1)
+    pipeline = Pipeline([compute])
     state = pipeline.initial_state()
 
     # Update only A — blob should still contain both A and B


### PR DESCRIPTION
The pipeline knows how to compute a particular group of features the way they are currently implemented.
`pipeline_hash` provides a compact hash that captures the full set of feature (including their versions) and how we use them.

This means that we can identify derived data (specifically GroupDerivedData in a follow-up) by pipeline hash and schedule any that are based on old pipeline data for reprocessing.

This also includes adding a 'version' to Features; the intended workflow here is that when a feature's implementation is changed meaningfully, we increment the version, and once deployed we can simply trigger regeneration (potentially automatically) to ensure the changes are applied.
If a feature has changed enough that it isn't reasonable to use on older data anymore, it should just be a new feature; version should be understood to be for tracking "minor releases".
