### PR TITLE
[DNM] test(ci): add dummy endpoint to validate FE+BE warning filter fix

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_dummy_junior_test_endpoint.py
+++ b/src/sentry/workflow_engine/endpoints/organization_dummy_junior_test_endpoint.py
@@ -1,0 +1,35 @@
+"""
+DO NOT MERGE — dummy endpoint added by Junior to test CI behavior.
+
+This endpoint exists solely to trigger the `api-url-typescript` job in
+backend.yml (which fires whenever a urls.py changes). That job runs
+`python3 -m tools.api_urls_to_typescript` and commits the updated
+`knownSentryApiUrls.generated.ts` back to the PR branch. The test PR
+targeting `fix/fe-be-warning-exclude-generated-files` validates that
+the new `frontend_non_generated` filter prevents that bot commit from
+triggering the spurious "FE+BE changes" warning.
+
+See: https://github.com/getsentry/sentry/pull/118795
+"""
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.models.organization import Organization
+
+
+@cell_silo_endpoint
+class OrganizationDummyJuniorTestEndpoint(OrganizationEndpoint):
+    """Dummy endpoint — DO NOT MERGE."""
+
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ISSUES
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        return Response({"ok": True})

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -9,6 +9,7 @@ from .organization_detector_count import OrganizationDetectorCountEndpoint
 from .organization_detector_details import OrganizationDetectorDetailsEndpoint
 from .organization_detector_index import OrganizationDetectorIndexEndpoint
 from .organization_detector_types import OrganizationDetectorTypeIndexEndpoint
+from .organization_dummy_junior_test_endpoint import OrganizationDummyJuniorTestEndpoint
 from .organization_incident_groupopenperiod_index import (
     OrganizationIncidentGroupOpenPeriodIndexEndpoint,
 )
@@ -105,5 +106,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/incident-groupopenperiod/$",
         OrganizationIncidentGroupOpenPeriodIndexEndpoint.as_view(),
         name="sentry-api-0-organization-incident-groupopenperiod-index",
+    ),
+    # DO NOT MERGE — dummy endpoint to test CI filter behavior (see PR #118795)
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/junior-test-dummy/$",
+        OrganizationDummyJuniorTestEndpoint.as_view(),
+        name="sentry-api-0-organization-junior-test-dummy",
     ),
 ]

--- a/static/app/components/core/button/button.tsx
+++ b/static/app/components/core/button/button.tsx
@@ -16,6 +16,7 @@ import {useButtonFunctionality} from './useButtonFunctionality';
 
 export type {ButtonProps};
 
+// test comment to trigger PR labeler check
 export function Button({
   disabled,
   type = 'button',

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -236,6 +236,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/issues/$issueId/user-feedback/'
   | '/organizations/$organizationIdOrSlug/issues/$issueId/user-reports/'
   | '/organizations/$organizationIdOrSlug/join-request/'
+  | '/organizations/$organizationIdOrSlug/junior-test-dummy/'
   | '/organizations/$organizationIdOrSlug/key-transactions-list/'
   | '/organizations/$organizationIdOrSlug/key-transactions/'
   | '/organizations/$organizationIdOrSlug/legacy-webhooks/'


### PR DESCRIPTION
DO NOT MERGE — this PR exists to exercise the fix from PR #118795.

Adding a URL entry in urls.py triggers the `api-url-typescript` job in backend.yml, which runs `tools.api_urls_to_typescript` and commits an update to `knownSentryApiUrls.generated.ts`. Since this PR targets the fix branch, label-pullrequest.yml uses the new `frontend_non_generated` filter for the FE+BE warning check, which correctly excludes `*.generated.ts` files and suppresses the spurious warning.

Refs #118795

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
