### PR TITLE
fix(relocation) Avoid integrity errors on self-hosted import pt2

### DIFF
--- a/src/sentry/users/models/user.py
+++ b/src/sentry/users/models/user.py
@@ -248,7 +248,7 @@ class User(Model, AbstractBaseUser):
                     if self.pk is None and not is_relocated_user:
                         # new users should set email_unique
                         self.email_unique = self.email
-                    elif self.pk is None and is_relocated_user and self.email_unique:
+                    elif self.pk is None and is_relocated_user:
                         # If the user is new, relocated and has email_unique blank email_unique
                         # to dodge integrity errors.
                         self.email_unique = None

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -2236,7 +2236,58 @@ class CollisionTests(ImportTestCase):
             tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
             with open(tmp_path, "rb") as tmp_file:
                 # Create a user with a colliding username & email address,
-                # and set email_unique again.
+                # and set email_unique to trigger a conflict.
+                colliding_owner = self.create_exhaustive_user(
+                    username="owner", email="importing@example.com"
+                )
+                colliding_owner.email_unique = colliding_owner.email
+                with assume_test_silo_mode(SiloMode.CONTROL):
+                    colliding_owner.save()
+
+                org = self.create_organization("other-org", owner=colliding_owner)
+
+                import_in_organization_scope(
+                    tmp_file,
+                    flags=ImportFlags(merge_users=False),
+                    printer=NOOP_PRINTER,
+                )
+
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                colliding_owner.refresh_from_db()
+                imported_user = User.objects.get(username__icontains="owner-")
+
+                # The colliding_owner should retain its original attributes.
+                assert colliding_owner.email == "importing@example.com"
+                assert colliding_owner.email_unique == "importing@example.com"
+
+                # The imported user should not have email_unique defined as it would conflict
+                assert imported_user.email == "importing@example.com"
+                assert imported_user.email_unique is None
+
+                assert User.objects.count() == 2
+                assert UserEmail.objects.count() == 2
+
+            with open(tmp_path, "rb") as tmp_file:
+                verify_models_in_output(expected_models, orjson.loads(tmp_file.read()))
+
+    @expect_models(COLLISION_TESTED, Organization, OrganizationMember, User, UserEmail)
+    def test_colliding_user_email_unique_existing_user_no_merge(
+        self, expected_models: list[type[Model]]
+    ):
+        # Create an owner, and ensure that email_unique is None
+        owner = self.create_exhaustive_user(username="owner", email="importing@example.com")
+        assert owner.email_unique is None
+
+        org = self.create_organization("some-org", owner=owner)
+        old_org_membership = OrganizationMember.objects.get(organization=org)
+        old_org_membership.regenerate_token()
+        old_org_membership.save()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = self.export_to_tmp_file_and_clear_database(tmp_dir)
+            with open(tmp_path, "rb") as tmp_file:
+                # Create a user with a colliding username & email address,
+                # and set email_unique to trigger a conflict.
                 colliding_owner = self.create_exhaustive_user(
                     username="owner", email="importing@example.com"
                 )


### PR DESCRIPTION
A part continuation of #118579 this fix avoids the inverse scenario, where a user record exists in the database with `email_unique` set, but the import data has `email_unique=null`. Falling through the `else` results in integrity errors which break imports

Refs SENTRY-5NJV