### PR TITLE
feat(taskbroker): Add Application Argument to Task Sender

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -387,6 +387,13 @@ def run_taskworker(
     default=None,
 )
 @click.option(
+    "--application",
+    "activation_application",
+    type=str,
+    help="Override the application field on generated task activations",
+    default=None,
+)
+@click.option(
     "--extra-arg-bytes",
     type=int,
     help="Generater random args of specified size in bytes",
@@ -402,6 +409,7 @@ def taskbroker_send_tasks(
     bootstrap_servers: str,
     kafka_topic: str,
     namespace: str,
+    application: str | None,
     extra_arg_bytes: int | None,
 ) -> None:
     from taskbroker_client.canary import CANARY_TASK_NAME
@@ -435,6 +443,9 @@ def taskbroker_send_tasks(
             [chr(ord("a") + random.randint(0, ord("z") - ord("a"))) for _ in range(extra_arg_bytes)]
         )
         task_args.append(extra_padding_arg)
+
+    if application is not None:
+        func.namespace.application = application
 
     if not infinite:
         checkmarks = {int(repeat * (i / 10)) for i in range(1, 10)}

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -388,7 +388,6 @@ def run_taskworker(
 )
 @click.option(
     "--application",
-    "activation_application",
     type=str,
     help="Override the application field on generated task activations",
     default=None,


### PR DESCRIPTION
## Linear
Refs [STREAM-969](https://linear.app/getsentry/issue/STREAM-969/create-seer-alloydb-pushalloydb-pool)

## Description
We can't use the task sender in its current state for Seer and Launchpad because the `application` field will be `sentry`. Let's add an `--application` argument that overrides the application field with whatever the user provides (like `seer` or `launchpad`).