### PR TITLE
feat(activity): Register status_change activities on notification platform

### DIFF
--- a/src/sentry/notifications/platform/templates/activity/__init__.py
+++ b/src/sentry/notifications/platform/templates/activity/__init__.py
@@ -13,10 +13,14 @@ from .seer.rca_completed import SeerRcaCompletedActivityTemplate
 from .seer.rca_started import SeerRcaStartedActivityTemplate
 from .seer.solution_completed import SeerSolutionCompletedActivityTemplate
 from .seer.solution_started import SeerSolutionStartedActivityTemplate
+from .status_change.set_escalating import SetEscalatingActivityTemplate
+from .status_change.set_ignored import SetIgnoredActivityTemplate
+from .status_change.set_regression import SetRegressionActivityTemplate
 from .status_change.set_resolved import SetResolvedActivityTemplate
 from .status_change.set_resolved_by_age import SetResolvedByAgeActivityTemplate
 from .status_change.set_resolved_in_commit import SetResolvedInCommitActivityTemplate
 from .status_change.set_resolved_in_release import SetResolvedInReleaseActivityTemplate
+from .status_change.set_unresolved import SetUnresolvedActivityTemplate
 
 __all__ = (
     "ACTIVITY_TYPE_TO_SOURCE",
@@ -36,4 +40,8 @@ __all__ = (
     "SetResolvedInReleaseActivityTemplate",
     "SetResolvedByAgeActivityTemplate",
     "SetResolvedInCommitActivityTemplate",
+    "SetEscalatingActivityTemplate",
+    "SetIgnoredActivityTemplate",
+    "SetRegressionActivityTemplate",
+    "SetUnresolvedActivityTemplate",
 )

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -27,6 +27,8 @@ ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
     ActivityType.SET_RESOLVED_IN_RELEASE.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_RELEASE,
     ActivityType.SET_RESOLVED_BY_AGE.value: NotificationSource.ACTIVITY_SET_RESOLVED_BY_AGE,
     ActivityType.SET_RESOLVED_IN_COMMIT.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_COMMIT,
+    ActivityType.SET_REGRESSION.value: NotificationSource.ACTIVITY_SET_REGRESSION,
+    ActivityType.SET_ESCALATING.value: NotificationSource.ACTIVITY_SET_ESCALATING,
 }
 
 EXAMPLE_PROJECT_URL = "https://sentry.io/organizations/acme/issues/?project=123"

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -29,6 +29,8 @@ ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
     ActivityType.SET_RESOLVED_IN_COMMIT.value: NotificationSource.ACTIVITY_SET_RESOLVED_IN_COMMIT,
     ActivityType.SET_REGRESSION.value: NotificationSource.ACTIVITY_SET_REGRESSION,
     ActivityType.SET_ESCALATING.value: NotificationSource.ACTIVITY_SET_ESCALATING,
+    ActivityType.SET_IGNORED.value: NotificationSource.ACTIVITY_SET_IGNORED,
+    ActivityType.SET_UNRESOLVED.value: NotificationSource.ACTIVITY_SET_UNRESOLVED,
 }
 
 EXAMPLE_PROJECT_URL = "https://sentry.io/organizations/acme/issues/?project=123"

--- a/src/sentry/notifications/platform/templates/activity/status_change/base.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/base.py
@@ -6,18 +6,39 @@ from sentry.notifications.platform.types import (
     NotificationTextBlock,
     PlainTextBlock,
 )
+from sentry.types.activity import ActivityType
 
 
-def get_resolution_subject(data: ActivityNotificationData) -> list[NotificationTextBlock]:
+def get_status_change_subject(data: ActivityNotificationData) -> list[NotificationTextBlock]:
     blocks: list[NotificationTextBlock] = []
-    if data.issue_short_id:
-        blocks.extend(
-            [CodeTextBlock(text=data.issue_short_id), PlainTextBlock(text="was resolved")]
-        )
-    else:
-        blocks.append(PlainTextBlock(text="A Sentry Issue was resolved"))
+    activity_type = ActivityType(data.activity_type)
 
-    if data.activity_user_name:
+    match activity_type:
+        case (
+            ActivityType.SET_RESOLVED
+            | ActivityType.SET_RESOLVED_BY_AGE
+            | ActivityType.SET_RESOLVED_IN_COMMIT
+            | ActivityType.SET_RESOLVED_IN_RELEASE
+        ):
+            action = "was resolved"
+        case ActivityType.SET_REGRESSION:
+            action = "has regressed"
+        case ActivityType.SET_ESCALATING:
+            action = "is escalating"
+        case ActivityType.SET_IGNORED:
+            action = "has been archived"
+        case ActivityType.SET_UNRESOLVED:
+            action = "was unresolved"
+        case _:
+            raise ValueError("Unsupported activity, can only be used for status changes.")
+
+    if data.issue_short_id:
+        blocks.extend([CodeTextBlock(text=data.issue_short_id), PlainTextBlock(text=action)])
+    else:
+        blocks.append(PlainTextBlock(text=f"A Sentry Issue {action}"))
+
+    # Escalating is not attributable, even if we have an author for some reason
+    if data.activity_user_name and not activity_type == ActivityType.SET_ESCALATING:
         blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
 
     return blocks

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_escalating.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_escalating.py
@@ -20,10 +20,10 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
-@template_registry.register(NotificationSource.ACTIVITY_SET_RESOLVED)
-class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]):
+@template_registry.register(NotificationSource.ACTIVITY_SET_ESCALATING)
+class SetEscalatingActivityTemplate(NotificationTemplate[ActivityNotificationData]):
     category = NotificationCategory.ACTIVITY
-    example_data = create_activity_notification_example(ActivityType.SET_RESOLVED)
+    example_data = create_activity_notification_example(ActivityType.SET_ESCALATING)
 
     def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -32,7 +32,7 @@ class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="had its status changed to resolved."),
+                        PlainTextBlock(text="is escalating."),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_escalating.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_escalating.py
@@ -20,6 +20,16 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
+def get_escalating_explanation(data: ActivityNotificationData) -> str:
+    if data.activity_data:
+        if forecast := int(data.activity_data.get("forecast", 0)):
+            event_word = "event" if forecast == 1 else "events"
+            return f"has been flagged as escalating because over {forecast} {event_word} happened in an hour."
+        if data.activity_data.get("expired_snooze"):
+            return "has been flagged as escalating because your archive condition has expired."
+    return "has been flagged as escalating."
+
+
 @template_registry.register(NotificationSource.ACTIVITY_SET_ESCALATING)
 class SetEscalatingActivityTemplate(NotificationTemplate[ActivityNotificationData]):
     category = NotificationCategory.ACTIVITY
@@ -32,7 +42,7 @@ class SetEscalatingActivityTemplate(NotificationTemplate[ActivityNotificationDat
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="is escalating."),
+                        PlainTextBlock(text=get_escalating_explanation(data)),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
@@ -18,7 +18,7 @@ from sentry.notifications.platform.types import (
     PlainTextBlock,
 )
 from sentry.types.activity import ActivityType
-from sentry.utils.dates import format_duration
+from sentry.utils.dates import format_duration, parse_timestamp
 
 
 def get_archive_explanation(data: ActivityNotificationData) -> str:
@@ -55,7 +55,11 @@ def get_archive_explanation(data: ActivityNotificationData) -> str:
 
     ignore_until = data.activity_data.get("ignoreUntil")
     if ignore_until:
-        return f"has been archived until {ignore_until}."
+        # TODO(Leander): This should probably be derived from the recipient's user preferences
+        # but we'd have to extend the NotificationData type, so we can do that later.
+        dt = parse_timestamp(ignore_until)
+        formatted = dt.strftime("%b %-d, %Y, %-I:%M %p UTC") if dt else ignore_until
+        return f"has been archived until {formatted}."
 
     ignore_until_escalating = data.activity_data.get("ignoreUntilEscalating")
     if ignore_until_escalating:

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
@@ -18,6 +18,50 @@ from sentry.notifications.platform.types import (
     PlainTextBlock,
 )
 from sentry.types.activity import ActivityType
+from sentry.utils.dates import format_duration
+
+
+def get_archive_explanation(data: ActivityNotificationData) -> str:
+    """
+    Matches getIgnoredMessage from groupActivityItem.tsx.
+    """
+
+    if not data.activity_data:
+        return "has been archived forever."
+
+    ignore_duration = data.activity_data.get("ignore_duration")
+
+    if ignore_duration:
+        duration = format_duration(int(ignore_duration))
+        return f"has been archived for {duration}."
+
+    ignore_count = data.activity_data.get("ignore_count")
+    ignore_window = data.activity_data.get("ignore_window")
+    if ignore_count and ignore_window:
+        window = format_duration(int(ignore_window))
+        return f"has been archived until it happens {ignore_count} time(s) in {window}."
+
+    if ignore_count:
+        return f"has been archived until it happens {ignore_count} time(s)."
+
+    ignore_user_count = data.activity_data.get("ignore_user_count")
+    ignore_user_window = data.activity_data.get("ignore_user_window")
+    if ignore_user_count and ignore_user_window:
+        window = format_duration(int(ignore_user_window))
+        return f"has been archived until it affects {ignore_user_count} user(s) in {window}."
+
+    if ignore_user_count:
+        return f"has been archived until it affects {ignore_user_count} user(s)."
+
+    ignore_until = data.activity_data.get("ignore_until")
+    if ignore_until:
+        return f"has been archived until {ignore_until}."
+
+    ignore_until_escalating = data.activity_data.get("ignore_until_escalating")
+    if ignore_until_escalating:
+        return "has been archived until it escalates."
+
+    return "has been archived forever."
 
 
 @template_registry.register(NotificationSource.ACTIVITY_SET_IGNORED)
@@ -32,7 +76,7 @@ class SetIgnoredActivityTemplate(NotificationTemplate[ActivityNotificationData])
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="has been archived."),
+                        PlainTextBlock(text=get_archive_explanation(data)),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
@@ -29,14 +29,14 @@ def get_archive_explanation(data: ActivityNotificationData) -> str:
     if not data.activity_data:
         return "has been archived forever."
 
-    ignore_duration = data.activity_data.get("ignore_duration")
+    ignore_duration = data.activity_data.get("ignoreDuration")
 
     if ignore_duration:
         duration = format_duration(int(ignore_duration))
         return f"has been archived for {duration}."
 
-    ignore_count = data.activity_data.get("ignore_count")
-    ignore_window = data.activity_data.get("ignore_window")
+    ignore_count = data.activity_data.get("ignoreCount")
+    ignore_window = data.activity_data.get("ignoreWindow")
     if ignore_count and ignore_window:
         window = format_duration(int(ignore_window))
         return f"has been archived until it happens {ignore_count} time(s) in {window}."
@@ -44,8 +44,8 @@ def get_archive_explanation(data: ActivityNotificationData) -> str:
     if ignore_count:
         return f"has been archived until it happens {ignore_count} time(s)."
 
-    ignore_user_count = data.activity_data.get("ignore_user_count")
-    ignore_user_window = data.activity_data.get("ignore_user_window")
+    ignore_user_count = data.activity_data.get("ignoreUserCount")
+    ignore_user_window = data.activity_data.get("ignoreUserWindow")
     if ignore_user_count and ignore_user_window:
         window = format_duration(int(ignore_user_window))
         return f"has been archived until it affects {ignore_user_count} user(s) in {window}."
@@ -53,11 +53,11 @@ def get_archive_explanation(data: ActivityNotificationData) -> str:
     if ignore_user_count:
         return f"has been archived until it affects {ignore_user_count} user(s)."
 
-    ignore_until = data.activity_data.get("ignore_until")
+    ignore_until = data.activity_data.get("ignoreUntil")
     if ignore_until:
         return f"has been archived until {ignore_until}."
 
-    ignore_until_escalating = data.activity_data.get("ignore_until_escalating")
+    ignore_until_escalating = data.activity_data.get("ignoreUntilEscalating")
     if ignore_until_escalating:
         return "has been archived until it escalates."
 

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_ignored.py
@@ -20,10 +20,10 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
-@template_registry.register(NotificationSource.ACTIVITY_SET_RESOLVED)
-class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]):
+@template_registry.register(NotificationSource.ACTIVITY_SET_IGNORED)
+class SetIgnoredActivityTemplate(NotificationTemplate[ActivityNotificationData]):
     category = NotificationCategory.ACTIVITY
-    example_data = create_activity_notification_example(ActivityType.SET_RESOLVED)
+    example_data = create_activity_notification_example(ActivityType.SET_IGNORED)
 
     def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -32,7 +32,7 @@ class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="had its status changed to resolved."),
+                        PlainTextBlock(text="has been archived."),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_regression.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_regression.py
@@ -29,8 +29,7 @@ def get_regression_blocks(data: ActivityNotificationData) -> list[NotificationTe
         raw_version = data.activity_data["version"]
         readable_version = parse_release(raw_version, json_loads=orjson.loads)["description"]
         return [
-            PlainTextBlock(text="has regressed in release"),
-            PlainTextBlock(text=f"{readable_version or raw_version}."),
+            PlainTextBlock(text=f"has regressed in release {readable_version}."),
         ]
     return [PlainTextBlock(text="has regressed.")]
 

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_regression.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_regression.py
@@ -20,10 +20,10 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
-@template_registry.register(NotificationSource.ACTIVITY_SET_RESOLVED)
-class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]):
+@template_registry.register(NotificationSource.ACTIVITY_SET_REGRESSION)
+class SetRegressionActivityTemplate(NotificationTemplate[ActivityNotificationData]):
     category = NotificationCategory.ACTIVITY
-    example_data = create_activity_notification_example(ActivityType.SET_RESOLVED)
+    example_data = create_activity_notification_example(ActivityType.SET_REGRESSION)
 
     def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -32,7 +32,7 @@ class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="had its status changed to resolved."),
+                        PlainTextBlock(text="has been marked as a regression."),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_regression.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_regression.py
@@ -1,3 +1,6 @@
+import orjson
+from sentry_relay.processing import parse_release
+
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.templates.activity.base import (
     ActivityNotificationData,
@@ -14,16 +17,31 @@ from sentry.notifications.platform.types import (
     NotificationRenderedTemplate,
     NotificationSource,
     NotificationTemplate,
+    NotificationTextBlock,
     ParagraphSection,
     PlainTextBlock,
 )
 from sentry.types.activity import ActivityType
 
 
+def get_regression_blocks(data: ActivityNotificationData) -> list[NotificationTextBlock]:
+    if data.activity_data and data.activity_data.get("version"):
+        raw_version = data.activity_data["version"]
+        readable_version = parse_release(raw_version, json_loads=orjson.loads)["description"]
+        return [
+            PlainTextBlock(text="has regressed in release"),
+            PlainTextBlock(text=f"{readable_version or raw_version}."),
+        ]
+    return [PlainTextBlock(text="has regressed.")]
+
+
 @template_registry.register(NotificationSource.ACTIVITY_SET_REGRESSION)
 class SetRegressionActivityTemplate(NotificationTemplate[ActivityNotificationData]):
     category = NotificationCategory.ACTIVITY
-    example_data = create_activity_notification_example(ActivityType.SET_REGRESSION)
+    example_data = create_activity_notification_example(
+        ActivityType.SET_REGRESSION,
+        activity_data={"version": "example-project@1.0.0"},
+    )
 
     def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -32,7 +50,7 @@ class SetRegressionActivityTemplate(NotificationTemplate[ActivityNotificationDat
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="has been marked as a regression."),
+                        *get_regression_blocks(data),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_resolved_by_age.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_resolved_by_age.py
@@ -7,7 +7,7 @@ from sentry.notifications.platform.templates.activity.base import (
     get_issue_description,
 )
 from sentry.notifications.platform.templates.activity.status_change.base import (
-    get_resolution_subject,
+    get_status_change_subject,
 )
 from sentry.notifications.platform.types import (
     NotificationCategory,
@@ -38,7 +38,7 @@ class SetResolvedByAgeActivityTemplate(NotificationTemplate[ActivityNotification
             resolution_text = f"was resolved automatically after {duration} of inactivity."
 
         return NotificationRenderedTemplate(
-            subject=get_resolution_subject(data),
+            subject=get_status_change_subject(data),
             body=[
                 ParagraphSection(
                     blocks=[

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_resolved_in_commit.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_resolved_in_commit.py
@@ -7,7 +7,7 @@ from sentry.notifications.platform.templates.activity.base import (
     get_issue_description,
 )
 from sentry.notifications.platform.templates.activity.status_change.base import (
-    get_resolution_subject,
+    get_status_change_subject,
 )
 from sentry.notifications.platform.types import (
     BlockQuoteSection,
@@ -56,7 +56,7 @@ class SetResolvedInCommitActivityTemplate(
                 )
 
         return NotificationRenderedTemplate(
-            subject=get_resolution_subject(data),
+            subject=get_status_change_subject(data),
             body=[
                 ParagraphSection(
                     blocks=[

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_resolved_in_release.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_resolved_in_release.py
@@ -10,7 +10,7 @@ from sentry.notifications.platform.templates.activity.base import (
     get_issue_description,
 )
 from sentry.notifications.platform.templates.activity.status_change.base import (
-    get_resolution_subject,
+    get_status_change_subject,
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
@@ -60,7 +60,7 @@ class SetResolvedInReleaseActivityTemplate(
                 ]
 
         return NotificationRenderedTemplate(
-            subject=get_resolution_subject(data),
+            subject=get_status_change_subject(data),
             body=[
                 ParagraphSection(
                     blocks=[

--- a/src/sentry/notifications/platform/templates/activity/status_change/set_unresolved.py
+++ b/src/sentry/notifications/platform/templates/activity/status_change/set_unresolved.py
@@ -20,10 +20,10 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
-@template_registry.register(NotificationSource.ACTIVITY_SET_RESOLVED)
-class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]):
+@template_registry.register(NotificationSource.ACTIVITY_SET_UNRESOLVED)
+class SetUnresolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]):
     category = NotificationCategory.ACTIVITY
-    example_data = create_activity_notification_example(ActivityType.SET_RESOLVED)
+    example_data = create_activity_notification_example(ActivityType.SET_UNRESOLVED)
 
     def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(
@@ -32,7 +32,7 @@ class SetResolvedActivityTemplate(NotificationTemplate[ActivityNotificationData]
                 ParagraphSection(
                     blocks=[
                         build_issue_link(data.issue_short_id, data.issue_url),
-                        PlainTextBlock(text="had its status changed to resolved."),
+                        PlainTextBlock(text="has been unresolved."),
                     ]
                 ),
                 *get_issue_description(data=data),

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -87,6 +87,10 @@ class NotificationSource(StrEnum):
     ACTIVITY_SET_RESOLVED_IN_RELEASE = "activity-set-resolved-in-release"
     ACTIVITY_SET_RESOLVED_BY_AGE = "activity-set-resolved-by-age"
     ACTIVITY_SET_RESOLVED_IN_COMMIT = "activity-set-resolved-in-commit"
+    ACTIVITY_SET_REGRESSION = "activity-set-regression"
+    ACTIVITY_SET_ESCALATING = "activity-set-escalating"
+    ACTIVITY_SET_UNRESOLVED = "activity-set-unresolved"
+    ACTIVITY_SET_IGNORED = "activity-set-ignored"
 
 
 NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = {

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -143,6 +143,10 @@ NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = 
         NotificationSource.ACTIVITY_SET_RESOLVED_IN_RELEASE,
         NotificationSource.ACTIVITY_SET_RESOLVED_BY_AGE,
         NotificationSource.ACTIVITY_SET_RESOLVED_IN_COMMIT,
+        NotificationSource.ACTIVITY_SET_REGRESSION,
+        NotificationSource.ACTIVITY_SET_ESCALATING,
+        NotificationSource.ACTIVITY_SET_UNRESOLVED,
+        NotificationSource.ACTIVITY_SET_IGNORED,
     ],
 }
 

--- a/tests/sentry/notifications/platform/templates/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/test_activity.py
@@ -15,7 +15,7 @@ from sentry.notifications.platform.templates.activity.seer.base import (
     get_subject,
 )
 from sentry.notifications.platform.templates.activity.status_change.base import (
-    get_resolution_subject,
+    get_status_change_subject,
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
@@ -125,24 +125,24 @@ class ActivitySeerAlertBaseTest(TestCase):
 
 
 class ActivitySetResolvedAlertBaseTest(TestCase):
-    def test_get_resolution_subject_with_short_id(self) -> None:
+    def test_get_status_change_subject_with_short_id(self) -> None:
         data = create_activity_notification_example(ActivityType.SET_RESOLVED)
-        subject = get_resolution_subject(data)
+        subject = get_status_change_subject(data)
         assert subject[0].type == NotificationTextBlockType.CODE
         assert subject[0].text == "JAVASCRIPT-1"
         assert "was resolved" in subject[1].text
 
-    def test_get_resolution_subject_without_short_id(self) -> None:
+    def test_get_status_change_subject_without_short_id(self) -> None:
         data = create_activity_notification_example(ActivityType.SET_RESOLVED).copy(
             update={"issue_short_id": None, "activity_user_name": None}
         )
-        subject = get_resolution_subject(data)
+        subject = get_status_change_subject(data)
         assert len(subject) == 1
         assert "A Sentry Issue was resolved" in subject[0].text
 
-    def test_get_resolution_subject_with_user(self) -> None:
+    def test_get_status_change_subject_with_user(self) -> None:
         data = create_activity_notification_example(ActivityType.SET_RESOLVED)
-        subject = get_resolution_subject(data)
+        subject = get_status_change_subject(data)
         assert any(
             "by Jane Doe" in b.text
             for b in subject


### PR DESCRIPTION
Register new notifications for a few status changes that weren't covered:
- archived
- escalating
- unresolved
- regression

The appearance and content match the UI and legacy notifications (if applicable)