### PR TITLE
ref(api): type org member user as always present and nullable

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -74,8 +74,8 @@ class OrganizationMemberResponse(TypedDict):
     id: str
     email: str
     name: str
-    # User may be optional b/c invites don't have users yet
-    user: NotRequired[UserSerializerResponse]
+    # Null for invited members (no account yet) and unresolvable users.
+    user: UserSerializerResponse | None
     orgRole: str
     pending: bool
     expired: bool

--- a/src/sentry/apidocs/examples/organization_member_examples.py
+++ b/src/sentry/apidocs/examples/organization_member_examples.py
@@ -51,6 +51,7 @@ INVITED_ORGANIZATION_MEMBER = {
     "id": "57377908165",
     "email": "rockhopper@antarcticarocks.com",
     "name": "Rockhopper",
+    "user": None,
     "orgRole": "member",
     "pending": True,
     "expired": False,


### PR DESCRIPTION
Slight typing change — the member serializer always emits the user key, so this type should be `| None` rather than `NotRequired`