### PR TITLE
ref(spans): Add `default` parameter to `attribute_value` helper

### DIFF
--- a/src/sentry/spans/consumers/process_segments/types.py
+++ b/src/sentry/spans/consumers/process_segments/types.py
@@ -37,10 +37,10 @@ class CompatibleSpan(SpanEvent, total=True):
     hash: NotRequired[str]
 
 
-def attribute_value(span: Mapping[str, Any], key: str) -> Any:
+def attribute_value(span: Mapping[str, Any], key: str, *, default: Any | None = None) -> Any:
     attributes = span.get("attributes") or {}
     attr: dict[str, Any] = attributes.get(key) or {}
-    return attr.get("value")
+    return attr.get("value", default)
 
 
 def is_gen_ai_span(span: SpanEvent) -> bool:


### PR DESCRIPTION
This is a small change to allow our `attribute_value` utility function (which we use to extract the actual attribute value from a span) to be provided a default value to return in case the attribute isn't found. (Right now, the helper always returns `None` in that case.) The new parameter is keyword-only, so that using it forces the caller to make it obvious what the otherwise-random third value means.