### PR TITLE
feat(copilot): Add agent session URL to autofix panel

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -117,7 +117,7 @@ class GithubCopilotAgentClient(CodingAgentClient):
             provider=CodingAgentProviderType.GITHUB_COPILOT_AGENT,
             name=f"{owner}/{repo}: GitHub Copilot",
             started_at=started_at,
-            agent_url=None,
+            agent_url=task.html_url,
         )
 
     def get_task_status(self, owner: str, repo: str, task_id: str) -> GithubCopilotTask:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -265,6 +265,7 @@ def poll_github_copilot_agents(
                     agent_id=agent_id,
                     organization_id=organization_id,
                     status=new_status,
+                    agent_url=task_status.html_url,
                     result=result,
                 )
 

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -124,6 +124,7 @@ class GithubCopilotAgentClientTest(TestCase):
             "id": "task-123",
             "state": "in_progress",
             "created_at": "2024-06-01T12:00:00Z",
+            "html_url": "https://github.com/getsentry/sentry/copilot/tasks/task-123",
         }
         mock_response.status_code = 200
         mock_post.return_value = mock_response
@@ -137,6 +138,7 @@ class GithubCopilotAgentClientTest(TestCase):
         assert result.status == CodingAgentStatus.RUNNING
         assert result.provider == CodingAgentProviderType.GITHUB_COPILOT_AGENT
         assert result.started_at == datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC)
+        assert result.agent_url == "https://github.com/getsentry/sentry/copilot/tasks/task-123"
 
     @patch.object(GithubCopilotAgentClient, "post")
     def test_launch_with_missing_created_at(self, mock_post: Mock) -> None:

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -178,6 +178,7 @@ class TestPollGithubCopilotAgents(TestCase):
             task_status=GithubCopilotTask(
                 id="task-123",
                 state="completed",
+                html_url="https://github.com/getsentry/sentry/copilot/tasks/task-123",
                 artifacts=[
                     GithubCopilotArtifact(
                         provider="github",
@@ -215,6 +216,9 @@ class TestPollGithubCopilotAgents(TestCase):
         assert call_kwargs["agent_id"] == "getsentry:sentry:task-123"
         assert call_kwargs["organization_id"] == self.organization.id
         assert call_kwargs["status"] == CodingAgentStatus.COMPLETED
+        assert (
+            call_kwargs["agent_url"] == "https://github.com/getsentry/sentry/copilot/tasks/task-123"
+        )
         assert call_kwargs["result"].pr_url == "https://github.com/getsentry/sentry/pull/12345"
         assert call_kwargs["result"].description == "Fix the bug"
         assert call_kwargs["result"].repo_full_name == "getsentry/sentry"
@@ -452,6 +456,7 @@ class TestPollGithubCopilotAgents(TestCase):
             agent_id="getsentry:sentry:task-123",
             organization_id=self.organization.id,
             status=CodingAgentStatus.FAILED,
+            agent_url=None,
             result=None,
         )
 


### PR DESCRIPTION
## Summary
- Populate `agent_url` for GitHub Copilot coding agent tasks so the autofix panel shows an "Open in GitHub Copilot" link, matching existing Claude and Cursor behavior.
- The `html_url` from the Copilot API response is passed through at both launch time and during polling updates. The frontend already renders this link generically for any provider when `agent_url` is present.

## Test plan
- [x] Existing tests updated to verify `agent_url` flows through from `html_url`
- [ ] Trigger a GitHub Copilot autofix task and verify the "Open in GitHub Copilot" button appears in the autofix panel once the task completes

Fixes AIML-3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)