### PR TITLE
feat(dashboards): add starred dashboards to dashboards sidebar

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -161,7 +161,7 @@ export async function updateDashboardFavorite(
       {
         method: 'PUT',
         data: {
-          isFavorited,
+          shouldFavorite: isFavorited,
         },
       }
     );

--- a/static/app/utils/dashboards/dashboardsApiOptions.tsx
+++ b/static/app/utils/dashboards/dashboardsApiOptions.tsx
@@ -3,6 +3,16 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {QueryParamValue} from 'sentry/utils/useLocation';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
+export function starredDashboardsApiOptions(organization: Organization) {
+  return apiOptions.as<DashboardListItem[]>()(
+    '/organizations/$organizationIdOrSlug/dashboards/starred/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      staleTime: Infinity,
+    }
+  );
+}
+
 export function dashboardsApiOptions(
   organization: Organization,
   options?: {

--- a/static/app/utils/dashboards/dashboardsApiOptions.tsx
+++ b/static/app/utils/dashboards/dashboardsApiOptions.tsx
@@ -3,11 +3,14 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {QueryParamValue} from 'sentry/utils/useLocation';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
+export const MAX_STARRED_DASHBOARDS_IN_NAV = 20;
+
 export function starredDashboardsApiOptions(organization: Organization) {
   return apiOptions.as<DashboardListItem[]>()(
     '/organizations/$organizationIdOrSlug/dashboards/starred/',
     {
       path: {organizationIdOrSlug: organization.slug},
+      query: {per_page: MAX_STARRED_DASHBOARDS_IN_NAV},
       staleTime: Infinity,
     }
   );

--- a/static/app/utils/dashboards/dashboardsApiOptions.tsx
+++ b/static/app/utils/dashboards/dashboardsApiOptions.tsx
@@ -3,7 +3,7 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {QueryParamValue} from 'sentry/utils/useLocation';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 
-export const MAX_STARRED_DASHBOARDS_IN_NAV = 20;
+const MAX_STARRED_DASHBOARDS_IN_NAV = 20;
 
 export function starredDashboardsApiOptions(organization: Organization) {
   return apiOptions.as<DashboardListItem[]>()(

--- a/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useGetStarredDashboards.tsx
@@ -1,11 +1,17 @@
 import {useQuery} from '@tanstack/react-query';
 
 import type {Organization} from 'sentry/types/organization';
-import {dashboardsApiOptions} from 'sentry/utils/dashboards/dashboardsApiOptions';
+import {
+  dashboardsApiOptions,
+  starredDashboardsApiOptions,
+} from 'sentry/utils/dashboards/dashboardsApiOptions';
 import {useHasProjectAccess} from 'sentry/utils/useHasProjectAccess';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function getStarredDashboardsQueryKey(organization: Organization) {
+  if (organization.features.includes('dashboards-starred')) {
+    return starredDashboardsApiOptions(organization).queryKey;
+  }
   return dashboardsApiOptions(organization, {
     query: {filter: 'onlyFavorites'},
   }).queryKey;
@@ -15,10 +21,14 @@ export function useGetStarredDashboards() {
   const organization = useOrganization();
   const {hasProjectAccess, projectsLoaded} = useHasProjectAccess();
 
+  const usesStarredEndpoint = organization.features.includes('dashboards-starred');
+
   return useQuery({
-    ...dashboardsApiOptions(organization, {
-      query: {filter: 'onlyFavorites'},
-    }),
+    ...(usesStarredEndpoint
+      ? starredDashboardsApiOptions(organization)
+      : dashboardsApiOptions(organization, {
+          query: {filter: 'onlyFavorites'},
+        })),
     staleTime: Infinity,
     enabled: hasProjectAccess || !projectsLoaded,
   });

--- a/static/app/views/dashboards/hooks/useReorderStarredDashboards.spec.tsx
+++ b/static/app/views/dashboards/hooks/useReorderStarredDashboards.spec.tsx
@@ -1,0 +1,35 @@
+import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useReorderStarredDashboards} from 'sentry/views/dashboards/hooks/useReorderStarredDashboards';
+
+describe('useReorderStarredDashboards', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('sends the reordered dashboard ids to the starred order endpoint', async () => {
+    const reorderMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/starred/order/',
+      method: 'PUT',
+      match: [MockApiClient.matchData({dashboard_ids: ['2', '1']})],
+    });
+
+    const {result} = renderHookWithProviders(() => useReorderStarredDashboards(), {
+      organization,
+    });
+
+    act(() => {
+      result.current([
+        DashboardListItemFixture({id: '2', title: 'Dashboard 2'}),
+        DashboardListItemFixture({id: '1', title: 'Dashboard 1'}),
+      ]);
+    });
+
+    await waitFor(() => expect(reorderMock).toHaveBeenCalled());
+  });
+});

--- a/static/app/views/dashboards/hooks/useReorderStarredDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useReorderStarredDashboards.tsx
@@ -1,0 +1,33 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getStarredDashboardsQueryKey} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+
+export function useReorderStarredDashboards() {
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const queryKey = getStarredDashboardsQueryKey(organization);
+
+  const {mutate} = useMutation({
+    mutationFn: (dashboards: DashboardListItem[]) =>
+      fetchMutation({
+        url: `/organizations/${organization.slug}/dashboards/starred/order/`,
+        method: 'PUT',
+        data: {
+          dashboard_ids: dashboards.map(dashboard => dashboard.id),
+        },
+      }),
+    onMutate: dashboards => {
+      queryClient.setQueryData(queryKey, prev =>
+        prev ? {...prev, json: dashboards} : prev
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({queryKey});
+    },
+  });
+
+  return mutate;
+}

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.spec.tsx
@@ -1,0 +1,25 @@
+import {DashboardListItemFixture} from 'sentry-fixture/dashboard';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
+import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
+
+describe('DashboardsNavigationItems', () => {
+  it('renders a reorderable list of starred dashboards', () => {
+    render(
+      <SecondaryNavigationContextProvider>
+        <DashboardsNavigationItems
+          dashboards={[
+            DashboardListItemFixture({id: '1', title: 'Dashboard 1'}),
+            DashboardListItemFixture({id: '2', title: 'Dashboard 2'}),
+          ]}
+        />
+      </SecondaryNavigationContextProvider>
+    );
+
+    expect(screen.getByText('Dashboard 1')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard 2')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', {name: 'Drag to reorder'})).toHaveLength(2);
+  });
+});

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.tsx
@@ -1,12 +1,9 @@
-import * as Sentry from '@sentry/react';
-
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useUser} from 'sentry/utils/useUser';
 import {useReorderStarredDashboards} from 'sentry/views/dashboards/hooks/useReorderStarredDashboards';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
@@ -17,7 +14,6 @@ type DashboardsNavigationItemsProps = {
 
 export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItemsProps) {
   const organization = useOrganization();
-  const user = useUser();
   const {projects} = useProjects();
 
   const reorderStarredDashboards = useReorderStarredDashboards();
@@ -30,14 +26,7 @@ export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItem
       }}
     >
       {dashboard => {
-        const dashboardProjects = new Set((dashboard?.projects ?? []).map(String));
-        if (!defined(dashboard?.projects)) {
-          logUndefinedDashboardValue(dashboard, {
-            organizationId: organization.id,
-            userId: user.id,
-          });
-        }
-
+        const dashboardProjects = new Set(dashboard.projects.map(String));
         const dashboardProjectPlatforms = projects
           .filter(p => dashboardProjects.has(p.id))
           .map(p => p.platform)
@@ -51,7 +40,7 @@ export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItem
               <SecondaryNavigation.ProjectIcon
                 projectPlatforms={dashboardProjectPlatforms}
                 allProjects={
-                  dashboard.projects?.length === 1 && dashboard.projects[0] === -1
+                  dashboard.projects.length === 1 && dashboard.projects[0] === -1
                 }
               />
             }
@@ -71,16 +60,4 @@ export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItem
       }}
     </SecondaryNavigation.ReorderableList>
   );
-}
-
-function logUndefinedDashboardValue(
-  dashboard: DashboardListItem,
-  {organizationId, userId}: {organizationId: string; userId: string}
-) {
-  Sentry.setTag('organization', organizationId);
-  Sentry.setTag('dashboard.id', dashboard.id);
-  Sentry.setTag('user.id', userId);
-  Sentry.captureMessage('dashboard.projects is undefined in starred sidebar', {
-    level: 'warning',
-  });
 }

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.tsx
@@ -1,0 +1,86 @@
+import * as Sentry from '@sentry/react';
+
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {defined} from 'sentry/utils/defined';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {useUser} from 'sentry/utils/useUser';
+import {useReorderStarredDashboards} from 'sentry/views/dashboards/hooks/useReorderStarredDashboards';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
+
+type DashboardsNavigationItemsProps = {
+  dashboards: DashboardListItem[];
+};
+
+export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItemsProps) {
+  const organization = useOrganization();
+  const user = useUser();
+  const {projects} = useProjects();
+
+  const reorderStarredDashboards = useReorderStarredDashboards();
+
+  return (
+    <SecondaryNavigation.ReorderableList
+      items={dashboards}
+      onDragEnd={newDashboards => {
+        reorderStarredDashboards(newDashboards);
+      }}
+    >
+      {dashboard => {
+        const dashboardProjects = new Set((dashboard?.projects ?? []).map(String));
+        if (!defined(dashboard?.projects)) {
+          logUndefinedDashboardValue(dashboard, {
+            organizationId: organization.id,
+            userId: user.id,
+          });
+        }
+
+        const dashboardProjectPlatforms = projects
+          .filter(p => dashboardProjects.has(p.id))
+          .map(p => p.platform)
+          .filter(defined);
+
+        return (
+          <SecondaryNavigation.ReorderableLink
+            to={`/organizations/${organization.slug}/dashboard/${dashboard.id}/`}
+            analyticsItemName="dashboard_starred_item"
+            icon={
+              <SecondaryNavigation.ProjectIcon
+                projectPlatforms={dashboardProjectPlatforms}
+                allProjects={
+                  dashboard.projects?.length === 1 && dashboard.projects[0] === -1
+                }
+              />
+            }
+          >
+            <Tooltip
+              title={dashboard.title}
+              position="top"
+              showOnlyOnOverflow
+              skipWrapper
+            >
+              <Text ellipsis variant="inherit">
+                {dashboard.title}
+              </Text>
+            </Tooltip>
+          </SecondaryNavigation.ReorderableLink>
+        );
+      }}
+    </SecondaryNavigation.ReorderableList>
+  );
+}
+
+function logUndefinedDashboardValue(
+  dashboard: DashboardListItem,
+  {organizationId, userId}: {organizationId: string; userId: string}
+) {
+  Sentry.setTag('organization', organizationId);
+  Sentry.setTag('dashboard.id', dashboard.id);
+  Sentry.setTag('user.id', userId);
+  Sentry.captureMessage('dashboard.projects is undefined in starred sidebar', {
+    level: 'warning',
+  });
+}

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems.tsx
@@ -26,7 +26,8 @@ export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItem
       }}
     >
       {dashboard => {
-        const dashboardProjects = new Set(dashboard.projects.map(String));
+        const dashboardProjectIds = dashboard.projects ?? [];
+        const dashboardProjects = new Set(dashboardProjectIds.map(String));
         const dashboardProjectPlatforms = projects
           .filter(p => dashboardProjects.has(p.id))
           .map(p => p.platform)
@@ -40,7 +41,7 @@ export function DashboardsNavigationItems({dashboards}: DashboardsNavigationItem
               <SecondaryNavigation.ProjectIcon
                 projectPlatforms={dashboardProjectPlatforms}
                 allProjects={
-                  dashboard.projects.length === 1 && dashboard.projects[0] === -1
+                  dashboardProjectIds.length === 1 && dashboardProjectIds[0] === -1
                 }
               />
             }

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.spec.tsx
@@ -54,4 +54,29 @@ describe('DashboardsSecondaryNavigation', () => {
       'Dashboard 1',
     ]);
   });
+
+  it('renders a reorderable starred list when dashboards-starred is enabled', async () => {
+    const starredOrganization = OrganizationFixture({
+      features: ['dashboards-prebuilt-insights-dashboards', 'dashboards-starred'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${starredOrganization.slug}/dashboards/starred/`,
+      body: [
+        DashboardListItemFixture({id: '9999', title: 'Dashboard 9999'}),
+        DashboardListItemFixture({id: '1', title: 'Dashboard 1'}),
+      ],
+    });
+
+    render(
+      <SecondaryNavigationContextProvider>
+        <DashboardsSecondaryNavigation />
+      </SecondaryNavigationContextProvider>,
+      {organization: starredOrganization}
+    );
+
+    expect(await screen.findByText('Dashboard 9999')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard 1')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', {name: 'Drag to reorder'})).toHaveLength(2);
+  });
 });

--- a/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation.tsx
@@ -18,6 +18,7 @@ import {DashboardFilter, PREBUILT_DASHBOARD_LABEL} from 'sentry/views/dashboards
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
 import {isPrimaryNavigationLinkActive} from 'sentry/views/navigation/primary/components';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components';
+import {DashboardsNavigationItems} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsNavigationItems';
 
 export function DashboardsSecondaryNavigation() {
   const organization = useOrganization();
@@ -94,13 +95,17 @@ export function DashboardsSecondaryNavigation() {
               title={t('Starred Dashboards')}
             >
               <ErrorBoundary mini>
-                <StarredDashboardItems
-                  dashboards={starredDashboards}
-                  projects={projects}
-                  organizationSlug={organization.slug}
-                  organizationId={organization.id}
-                  userId={user.id}
-                />
+                {organization.features.includes('dashboards-starred') ? (
+                  <DashboardsNavigationItems dashboards={starredDashboards} />
+                ) : (
+                  <StarredDashboardItems
+                    dashboards={starredDashboards}
+                    projects={projects}
+                    organizationSlug={organization.slug}
+                    organizationId={organization.id}
+                    userId={user.id}
+                  />
+                )}
               </ErrorBoundary>
             </SecondaryNavigation.Section>
           </Fragment>


### PR DESCRIPTION
This PR is one of many to bring the "starred dashboards" sidebar to parity with Explore's "starred queries" sidebar.

This PR brings the "Starred Dashboards" sidebar to parity with the "Starred Queries" in Explore. This is the FE ticket after all backend changes, all feature flagged. 

This PR adjusts the current `useGetStarredDashboards ` hook to ping the new `/dashboards/starred/` endpoint if feature flagged (the previous logic will be removed once it GAs), and creates a new component and hook, `DashboardsNavigationItems`, `useReorderStarredDashboards`, which renders a reorderable list. Also, renaming the FE parameter from `isFavorited` to `shouldFavorite` to adhere by the changes suggested in [this comment](https://github.com/getsentry/sentry/pull/119784#discussion_r3597681364). Added tests for these as well.

*Changes are local, will turn the FF after PR is in to see it broadly in production.

https://github.com/user-attachments/assets/e375677c-f833-42ae-9b51-d5c29e237bd6

Closes BROWSE-613