### PR TITLE
fix(spans): Handle missing span descriptions in MN + 1 detector

### DIFF
--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -249,13 +249,15 @@ class ContinuingMNPlusOne(MNPlusOneState):
             metrics.incr("mn_plus_one_db_span_detector.no_db_span")
             return None
 
+        db_span_description = db_span.get("description") or ""
+
         db_span_ids = [span["span_id"] for span in offender_db_spans]
         offender_span_ids = [span["span_id"] for span in offender_spans]
 
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),
             op="db",
-            desc=db_span["description"],
+            desc=db_span_description,
             type=PerformanceNPlusOneGroupType,
             parent_span_ids=[common_parent_span["span_id"]],
             cause_span_ids=db_span_ids,
@@ -280,7 +282,7 @@ class ContinuingMNPlusOne(MNPlusOneState):
                     name="Offending Spans",
                     value=get_notification_attachment_body(
                         "db",
-                        db_span["description"],
+                        db_span_description,
                     ),
                     # Has to be marked important to be displayed in the notifications
                     important=True,

--- a/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
+++ b/src/sentry/issue_detection/detectors/mn_plus_one_db_span_detector.py
@@ -4,6 +4,7 @@ import hashlib
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Sequence
+from random import randint
 from typing import Any
 
 from sentry.issue_detection.base import DetectorType, PerformanceDetector
@@ -20,6 +21,7 @@ from sentry.issues.grouptype import (
 )
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.utils import metrics
+from sentry.utils.sdk import sdk_logger
 
 
 class MNPlusOneState(ABC):
@@ -253,6 +255,27 @@ class ContinuingMNPlusOne(MNPlusOneState):
 
         db_span_ids = [span["span_id"] for span in offender_db_spans]
         offender_span_ids = [span["span_id"] for span in offender_spans]
+
+        # TODO: Temporary debugging log
+        if not db_span_description and randint(1, 100) == 1:
+            sdk_logger.info(
+                "db_span_missing_description",
+                attributes={
+                    "db_spans": [
+                        {
+                            "id": span["span_id"],
+                            "op": span["op"],
+                            "db": (span.get("data") or {}).get("db.system"),
+                        }
+                        for span in offender_db_spans
+                    ],
+                    "offender_span_ids": offender_span_ids,
+                    "trace_id": db_span.get("trace_id"),
+                    "project_id": db_span.get("project_id"),
+                    "org_id": db_span.get("organization_id"),
+                    "sdk": (db_span.get("data") or {}).get("sdk.name"),
+                },
+            )
 
         return PerformanceProblem(
             fingerprint=self._fingerprint(db_span["hash"], common_parent_span),


### PR DESCRIPTION
Newstyle spans (spans from the span buffer) don't always have a `description` field, which is causing our existing MN + 1 detector (which is running experimentally during segment processing) to fail. This fixes that by switching description access from using bracket notation to using `.get()`. 

With this change, spans from transactions (which do always have a description) will continue to behave as they always have, while newstyle spans missing a description will get a placeholder. This prevents the crash, but doesn't fully solve the problem - in the long run, it'd be nice to have real data there. To get better visibility into these cases, this PR also adds a sampled log tracking hopefully enough metadata to let us figure out what these cases look like and how best to handle them.

Fixes https://sentry.sentry.io/issues/7574056686.