### PR TITLE
fix(nightshift): Fetch limit 100 -> 250

### DIFF
--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -21,7 +21,7 @@ from sentry.types.group import PriorityLevel
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
-NIGHT_SHIFT_ISSUE_FETCH_LIMIT = 100
+NIGHT_SHIFT_ISSUE_FETCH_LIMIT = 250
 # Scales the per-project fetch limit instead of using the flat limit above.
 NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER = 3
 FIXABILITY_SCORE_THRESHOLD = FixabilityScoreThresholds.MEDIUM.value


### PR DESCRIPTION
We're running into an issue where we end up not having enough eventual candidates - because we've examined them and skipped them.

For example in Sentry we:
- Grab 100 issues.
- Filter those and discover 87 have been skipped.
- Now we only have 13 candidates - less than we wanted.
- Dispite having plenty of issues we could triage. 

Bumping this limit is a very short term work around. A medium term solution is to keep querying until we get enough issues (and ideally the long term solution would be to be able to query on skipped - but that might be quite hard).