### PR TITLE
ref(sentry-apps): Stop capturing external-request errors from the issue form

### DIFF
--- a/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppExternalForm.tsx
@@ -1035,17 +1035,6 @@ export function SentryAppExternalForm({
       if (!(error instanceof RequestError)) {
         addErrorMessage(t('Unable to %s %s issue.', action, appName));
       }
-      Sentry.captureException(error, {
-        tags: {
-          sentry_app: appName,
-          form_element: element,
-          form_action: action,
-        },
-        extra: {
-          sentryAppInstallationUuid,
-          configUri: config.uri,
-        },
-      });
     },
   });
 


### PR DESCRIPTION
We already capture these errors in the backend, so we are getting more events than needed in Sentry.