### PR TITLE
fix(nightshift): Fix all skips

### DIFF
--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -18,12 +18,19 @@ from sentry.snuba.referrer import Referrer
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
 from sentry.tasks.seer.night_shift.skip_cache import recently_skipped
 from sentry.types.group import PriorityLevel
+from sentry.utils.cursors import Cursor
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
 NIGHT_SHIFT_ISSUE_FETCH_LIMIT = 100
 # Scales the per-project fetch limit instead of using the flat limit above.
 NIGHT_SHIFT_PER_PROJECT_FETCH_MULTIPLIER = 3
+# Skipped issues can't be filtered at query time, so we page past them. At
+# defaults (2 runs/day x 10 candidates, skips expire after 7.5d) live skips
+# plateau at ~150 (~1.5 pages), so 10 pages leaves ample headroom.
+# The per-project path uses a smaller page (~30) but spreads skips across
+# projects, so its per-project window stays well clear too.
+NIGHT_SHIFT_MAX_SEARCH_PAGES = 10
 FIXABILITY_SCORE_THRESHOLD = FixabilityScoreThresholds.MEDIUM.value
 
 
@@ -70,51 +77,74 @@ def _fetch_and_score(
     Issues with a fixability score above the threshold are taken first (sorted by
     fixability), then backfilled with unscored issues in their original recommended
     sort order.
+
+    Recently-skipped issues can't be excluded at query time, so a single page of
+    results can be whittled well below fetch_limit. We page through additional
+    results (up to NIGHT_SHIFT_MAX_SEARCH_PAGES) until we've gathered a full
+    page's worth of non-skipped candidates or run out of issues.
     """
     # Default types + LowValueSpan
     type_ids = sorted(group_types_from([]) | {LowValueSpanConfigurationType.type_id})
-    result = search.backend.query(
-        projects=projects,
-        sort_by="recommended",
-        limit=fetch_limit,
-        search_filters=[
-            SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
-            SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
-            SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
-        ],
-        referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
-    )
-
-    skipped_ids = recently_skipped(g.id for g in result.results)
-
-    logger.info(
-        "night_shift.search_results",
-        extra={
-            "num_projects": len(projects),
-            "num_results": len(result.results),
-            "num_skip_filtered": len(skipped_ids),
-            "num_kept_after_skip_filter": len(result.results) - len(skipped_ids),
-        },
-    )
+    search_filters = [
+        SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
+        SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
+        SearchFilter(SearchKey("issue.type"), "=", SearchValue(type_ids)),
+    ]
 
     scored: list[ScoredCandidate] = []
     unscored: list[ScoredCandidate] = []
-    for group in result.results:
-        if group.id in skipped_ids:
-            continue
-        if not is_issue_category_eligible(group):
-            continue
+    kept = 0
+    cursor: Cursor | None = None
 
-        candidate = ScoredCandidate(
-            group=group,
-            fixability=group.seer_fixability_score,
-            times_seen=group.times_seen,
+    for page in range(NIGHT_SHIFT_MAX_SEARCH_PAGES):
+        result = search.backend.query(
+            projects=projects,
+            sort_by="recommended",
+            limit=fetch_limit,
+            cursor=cursor,
+            search_filters=search_filters,
+            referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value,
         )
 
-        if candidate.fixability is None:
-            unscored.append(candidate)
-        elif candidate.fixability >= FIXABILITY_SCORE_THRESHOLD:
-            scored.append(candidate)
+        skipped_ids = recently_skipped(g.id for g in result.results)
+        kept += len(result.results) - len(skipped_ids)
+
+        logger.info(
+            "night_shift.search_results",
+            extra={
+                "projects": [project.id for project in projects],
+                "num_projects": len(projects),
+                "page": page,
+                "num_results": len(result.results),
+                "num_skip_filtered": len(skipped_ids),
+                "num_kept_after_skip_filter": len(result.results) - len(skipped_ids),
+            },
+        )
+
+        for group in result.results:
+            if group.id in skipped_ids:
+                continue
+            if not is_issue_category_eligible(group):
+                continue
+
+            candidate = ScoredCandidate(
+                group=group,
+                fixability=group.seer_fixability_score,
+                times_seen=group.times_seen,
+            )
+
+            if candidate.fixability is None:
+                unscored.append(candidate)
+            elif candidate.fixability >= FIXABILITY_SCORE_THRESHOLD:
+                scored.append(candidate)
+
+        # We're aiming to collect a full page of non-skipped results.
+        # If that happens in a single query that's ideal - if not we
+        # continue till we've looked at NIGHT_SHIFT_MAX_SEARCH_PAGES.
+        if kept >= fetch_limit or not result.next:
+            break
+
+        cursor = result.next
 
     scored.sort(key=lambda c: c.fixability or 0.0, reverse=True)
     selected = (scored + unscored)[:max_candidates]

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -23,6 +23,8 @@ from sentry.tasks.seer.night_shift.cron import (
 )
 from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.simple_triage import (
+    NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
+    NIGHT_SHIFT_MAX_SEARCH_PAGES,
     ScoredCandidate,
     fixability_score_strategy,
     fixability_score_strategy_per_project,
@@ -34,7 +36,12 @@ from sentry.testutils.fixtures import Fixtures
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.utils.cursors import Cursor
 from sentry.utils.redis import redis_clusters
+
+
+def _cursor_result(results, has_next=False):
+    return Mock(results=results, next=Cursor(0, has_results=has_next))
 
 
 def _dispatched_feature_body(organization):
@@ -1008,7 +1015,7 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         with patch(
             "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
         ) as mock_query:
-            mock_query.return_value = Mock(results=[error_group, lvs_group])
+            mock_query.return_value = _cursor_result([error_group, lvs_group])
             result = fixability_score_strategy([project], max_candidates=10)
 
         assert {c.group.id for c in result} == {error_group.id, lvs_group.id}
@@ -1031,7 +1038,7 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         with patch(
             "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
         ) as mock_query:
-            mock_query.return_value = Mock(results=[])
+            mock_query.return_value = _cursor_result([])
             fixability_score_strategy_per_project([project], max_candidates=5)
 
         assert mock_query.call_args.kwargs["limit"] == 15
@@ -1042,10 +1049,91 @@ class TestFixabilityScoreStrategy(NightShiftFixtures, TestCase, SnubaTestCase):
         with patch(
             "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
         ) as mock_query:
-            mock_query.return_value = Mock(results=[])
+            mock_query.return_value = _cursor_result([])
             fixability_score_strategy_per_project([project], max_candidates=40)
 
         assert mock_query.call_args.kwargs["limit"] == 100
+
+    def test_paginates_when_first_page_mostly_skipped(self) -> None:
+        project = self.create_project()
+        page1 = [
+            self._store_event_and_update_group(project, f"p1-{i}", seer_fixability_score=None)
+            for i in range(3)
+        ]
+        page2 = [self._store_event_and_update_group(project, "p2-0", seer_fixability_score=None)]
+        mark_skipped(page1[1].id)
+        mark_skipped(page1[2].id)
+
+        with patch(
+            "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
+        ) as mock_query:
+            mock_query.side_effect = [
+                _cursor_result(page1, has_next=True),
+                _cursor_result(page2),
+            ]
+            result = fixability_score_strategy([project], max_candidates=3)
+
+        assert mock_query.call_count == 2
+        assert mock_query.call_args_list[0].kwargs["cursor"] is None
+        assert mock_query.call_args_list[1].kwargs["cursor"] is not None
+        assert {c.group.id for c in result} == {page1[0].id, page2[0].id}
+
+    def test_stops_paginating_once_a_page_worth_of_candidates(self) -> None:
+        project = self.create_project()
+        groups = [
+            Mock(id=i, seer_fixability_score=None, times_seen=1)
+            for i in range(NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
+        ]
+
+        with (
+            patch("sentry.tasks.seer.night_shift.simple_triage.search.backend.query") as mock_query,
+            patch(
+                "sentry.tasks.seer.night_shift.simple_triage.is_issue_category_eligible",
+                return_value=True,
+            ),
+        ):
+            mock_query.return_value = _cursor_result(groups, has_next=True)
+            result = fixability_score_strategy([project], max_candidates=10)
+
+        assert mock_query.call_count == 1
+        assert len(result) == 10
+
+    def test_stops_at_a_page_of_non_skipped_even_when_all_dropped(self) -> None:
+        # A full page of non-skipped results is enough to stop, even when scoring
+        # later drops every issue as below-threshold — we page past skips, not
+        # past low fixability.
+        project = self.create_project()
+        groups = [
+            Mock(id=i, seer_fixability_score=0.0, times_seen=1)
+            for i in range(NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
+        ]
+
+        with (
+            patch("sentry.tasks.seer.night_shift.simple_triage.search.backend.query") as mock_query,
+            patch(
+                "sentry.tasks.seer.night_shift.simple_triage.is_issue_category_eligible",
+                return_value=True,
+            ),
+        ):
+            mock_query.return_value = _cursor_result(groups, has_next=True)
+            result = fixability_score_strategy([project], max_candidates=10)
+
+        assert mock_query.call_count == 1
+        assert result == []
+
+    def test_pagination_is_bounded(self) -> None:
+        project = self.create_project()
+        skipped = self._store_event_and_update_group(project, "skip", seer_fixability_score=None)
+        mark_skipped(skipped.id)
+
+        with patch(
+            "sentry.tasks.seer.night_shift.simple_triage.search.backend.query"
+        ) as mock_query:
+            mock_query.return_value = _cursor_result([skipped], has_next=True)
+            result = fixability_score_strategy([project], max_candidates=5)
+
+        assert mock_query.call_count == NIGHT_SHIFT_MAX_SEARCH_PAGES
+        assert result == []
 
 
 class TestTriageActionFromFixabilityScore:


### PR DESCRIPTION
We're running into an issue where we end up not having enough eventual pre-candidates - because we've examined
them and skipped them all in previous runs.

For example in Sentry we we want to:
- Get the top 100 issues by some sort.
- Re-sort these 100 locally.
- Triage the top 15 of these with an LLM.

Currently we:
- Grab 100 issues.
- Filter those and discover 87 have been previously skipped.
- Now we only have 13 candidates - less than we wanted.
- Despite having plenty of issues we could triage.

This changes the process to:
- Grab 100 issues.
- If we have less than 100 non-skipped issues then grab 100 more.
- Continue till we have 100 pre-candidates or we've looked through 10 pages or we've run out of issues.
- Then take the top N pre-candidates and send them to the LLM for triage.

The math of this looks like (with the default settings):
- 2 runs/day x 10 candidates = 20 skips a day in the worst case
- skips expire after 7.5d
- so we plateau at 7.5 * 20 = ~150 (~1.5 pages) skipped issues

So in the worst case we should have to look at 3 pages in order to get 100 pre-candidates. 
