### PR TITLE
fix(search): Prevent Ask Seer overflow and bleed-through

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -562,19 +562,18 @@ const InvisibleInput = styled('input')`
   margin-bottom: -1px;
   background: transparent;
 
-  padding-top: ${p => p.theme.space.sm};
-  padding-bottom: ${p => p.theme.space.sm};
-  padding-left: ${p => p.theme.space['3xl']};
-  padding-right: ${p => p.theme.space.sm};
+  padding-top: calc(${p => p.theme.space.xs} + 1px);
+  padding-bottom: calc(${p => p.theme.space.xs} + 1px);
+  padding-left: calc(${p => p.theme.space['3xl']} + ${p => p.theme.space.xs});
+  padding-right: calc(${p => p.theme.space['3xl']} + ${p => p.theme.space.xs});
 
   &::selection {
     background: rgba(0, 0, 0, 0.2);
   }
 
-  :placeholder-shown {
+  &:not(:focus) {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   [disabled] {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -698,19 +698,18 @@ const InvisibleInput = styled('input')`
   margin-bottom: -1px;
   background: transparent;
 
-  padding-top: ${p => p.theme.space.sm};
-  padding-bottom: ${p => p.theme.space.sm};
-  padding-left: ${p => p.theme.space['3xl']};
-  padding-right: ${p => p.theme.space.sm};
+  padding-top: calc(${p => p.theme.space.xs} + 1px);
+  padding-bottom: calc(${p => p.theme.space.xs} + 1px);
+  padding-left: calc(${p => p.theme.space['3xl']} + ${p => p.theme.space.xs});
+  padding-right: calc(${p => p.theme.space['3xl']} + ${p => p.theme.space.xs});
 
   &::selection {
     background: rgba(0, 0, 0, 0.2);
   }
 
-  :placeholder-shown {
+  &:not(:focus) {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   [disabled] {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchPopover.tsx
@@ -47,11 +47,9 @@ export function AskSeerSearchPopover(props: PopoverProps) {
           };
         }}
       >
-        {hasAskSeerUxRework ? (
-          children
-        ) : (
-          <BackgroundColorWrapper>{children}</BackgroundColorWrapper>
-        )}
+        <BackgroundColorWrapper $hasAskSeerUxRework={hasAskSeerUxRework}>
+          {children}
+        </BackgroundColorWrapper>
       </ListBoxOverlay>
     </StyledPositionWrapper>
   );
@@ -65,8 +63,11 @@ const ListBoxOverlay = styled(Overlay)`
   border-top-right-radius: 0;
 `;
 
-const BackgroundColorWrapper = styled('div')`
-  background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+const BackgroundColorWrapper = styled('div')<{$hasAskSeerUxRework: boolean}>`
+  background-color: ${p =>
+    p.$hasAskSeerUxRework
+      ? p.theme.tokens.background.primary
+      : p.theme.tokens.background.transparent.accent.muted};
 `;
 
 const StyledPositionWrapper = styled('div')<{visible?: boolean}>`

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -351,6 +351,7 @@ const Wrapper = styled(Input.withComponent('div'))`
   height: auto;
   width: 100%;
   position: relative;
+  contain: inline-size;
   font-size: ${p => p.theme.font.size.md};
   cursor: text;
 `;


### PR DESCRIPTION
Long Ask Seer queries now stay within the available search-bar width in both polling and non-polling flows. The input reserves space for its icon and close control, remains horizontally scrollable while focused, and truncates when unfocused.

The reworked popover also uses an opaque primary background so removing the feedback footer does not expose the sticky search controls beneath it. The legacy popover keeps its existing muted accent background.

Closes BROWSE-627

**Examples:**

Ask seer overflowing:

<img width="867" height="107" alt="Screenshot 2026-07-17 at 09 47 49" src="https://github.com/user-attachments/assets/707e2558-b030-4b52-85f3-e6ee4a537b23" />

Ask seer constrained:

<img width="869" height="105" alt="Screenshot 2026-07-17 at 09 48 02" src="https://github.com/user-attachments/assets/c92eba02-be4a-4744-9b88-20b723d54b01" />

---

Search query builder expanding:

<img width="1253" height="71" alt="Screenshot 2026-07-17 at 09 50 33" src="https://github.com/user-attachments/assets/b0f03600-edc4-43d9-aabc-38f094b94dbb" />

Search query builder constrained:

<img width="1252" height="66" alt="Screenshot 2026-07-17 at 09 50 43" src="https://github.com/user-attachments/assets/f89f5a42-486e-4d2c-8947-ec904cd790a9" />