### PR TITLE
feat(pr-metrics): Add repo provider and visibility to scm.pr.closed

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -16,6 +16,14 @@ class PrCloseMetricsEvent(analytics.Event):
 
     organization_id: int
     repository_id: int
+    # Normalized SCM slug (e.g. "github", "gitlab"), read off Repository.provider
+    # at emit time. Null when the Repository row is gone or its provider is unset.
+    repository_provider: str | None = None
+    # Whether the repo was public at PR-open time. Sourced from the "opened"
+    # webhook payload's repository.private (Repository never persists visibility),
+    # so it's null for PRs opened before this field existed or with activity
+    # tracking off.
+    repository_is_public: bool | None = None
     pull_request_id: int
     # The PR number as stored on ``PullRequest.key`` (e.g. "5131" on GitHub).
     pr_key: str

--- a/src/sentry/models/pullrequest.py
+++ b/src/sentry/models/pullrequest.py
@@ -117,7 +117,7 @@ def parse_pull_request_number(url: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def _normalize_scm_provider(provider: str | None) -> str | None:
+def normalize_scm_provider(provider: str | None) -> str | None:
     """Normalize a reported SCM provider to Sentry's unprefixed form, or None if unusable.
 
     Returns None for the ``"unknown"`` sentinel (the source couldn't resolve the repo) and
@@ -189,7 +189,7 @@ class PullRequestManager(BaseManager["PullRequest"]):
         """
         from sentry.models.repository import Repository
 
-        normalized_provider = _normalize_scm_provider(provider)
+        normalized_provider = normalize_scm_provider(provider)
         provider_unmappable = (
             normalized_provider is not None and normalized_provider not in _KNOWN_SCM_PROVIDERS
         )

--- a/src/sentry/pr_metrics/activity_types.py
+++ b/src/sentry/pr_metrics/activity_types.py
@@ -42,6 +42,10 @@ class OpenedPayload(BaseActivityPayload, SenderMixin):
     commits: int = 0
     head_sha: str | None = None
     base_sha: str | None = None
+    # Visibility of the repo the webhook fired for, straight off the payload's
+    # top-level ``repository.private`` — the only point in the PR's lifecycle
+    # where Sentry observes this, since ``Repository`` never persists it.
+    is_private: bool | None = None
 
 
 @dataclass

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -19,7 +19,6 @@ from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
-    PullRequestActivityLog,
     PullRequestActivityType,
     PullRequestAttribution,
     PullRequestMetrics,
@@ -363,11 +362,8 @@ def _repo_is_public(pull_request: PullRequest) -> bool | None:
     ``pr_metrics.webhooks``), so the document is checked first and the legacy
     row is a fallback for PRs still on the old store.
     """
-    doc = (
-        PullRequestActivityLog.objects.filter(pull_request=pull_request)
-        .values_list("data", flat=True)
-        .first()
-    )
+    # Use the standard helper that correctly handles empty documents and orphaned rows
+    doc = load_activity_document(pull_request)
     if doc:
         opened_entry = next(
             (e for e in doc.get("events", []) if e["event_type"] == PullRequestActivityType.OPENED),
@@ -377,6 +373,7 @@ def _repo_is_public(pull_request: PullRequest) -> bool | None:
             is_private = opened_entry["payload"].get("is_private")
             return None if is_private is None else not is_private
 
+    # Fallback to legacy store when no document exists
     is_private = (
         PullRequestActivity.objects.filter(
             pull_request=pull_request, event_type=PullRequestActivityType.OPENED

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -19,11 +19,14 @@ from sentry.models.organization import Organization
 from sentry.models.pullrequest import (
     PullRequest,
     PullRequestActivity,
+    PullRequestActivityLog,
     PullRequestActivityType,
     PullRequestAttribution,
     PullRequestMetrics,
     PullRequestVerdict,
+    normalize_scm_provider,
 )
+from sentry.models.repository import Repository
 from sentry.pr_metrics import activity_doc
 from sentry.pr_metrics.attribution import SIGNAL_TYPE_CONFIDENCE
 from sentry.pr_metrics.contracts import (
@@ -350,6 +353,51 @@ def _conversation_analysis_fields(
     }
 
 
+def _repo_is_public(pull_request: PullRequest) -> bool | None:
+    """Whether the repo was public at PR-open time, or ``None`` if unknown.
+
+    Repository never persists visibility, so this is read back from the
+    "opened" activity payload's ``is_private`` (set at webhook-ingestion time
+    from the GitHub payload's ``repository.private``). A PR's activity can live
+    in either store depending on its ``_use_activity_document`` routing (see
+    ``pr_metrics.webhooks``), so the document is checked first and the legacy
+    row is a fallback for PRs still on the old store.
+    """
+    doc = (
+        PullRequestActivityLog.objects.filter(pull_request=pull_request)
+        .values_list("data", flat=True)
+        .first()
+    )
+    if doc:
+        opened_entry = next(
+            (e for e in doc.get("events", []) if e["event_type"] == PullRequestActivityType.OPENED),
+            None,
+        )
+        if opened_entry is not None:
+            is_private = opened_entry["payload"].get("is_private")
+            return None if is_private is None else not is_private
+
+    is_private = (
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request, event_type=PullRequestActivityType.OPENED
+        )
+        .values_list("payload__is_private", flat=True)
+        .first()
+    )
+    return None if is_private is None else not is_private
+
+
+def _repo_provider(pull_request: PullRequest) -> str | None:
+    """Normalized SCM slug for the PR's repo (e.g. "github"), or ``None`` if the
+    ``Repository`` row is gone or its provider is unset."""
+    provider = (
+        Repository.objects.filter(id=pull_request.repository_id)
+        .values_list("provider", flat=True)
+        .first()
+    )
+    return normalize_scm_provider(provider)
+
+
 def build_pr_metrics_row(
     *,
     pull_request: PullRequest,
@@ -390,6 +438,8 @@ def build_pr_metrics_row(
     return PrCloseMetricsEvent(
         organization_id=pull_request.organization_id,
         repository_id=pull_request.repository_id,
+        repository_provider=_repo_provider(pull_request),
+        repository_is_public=_repo_is_public(pull_request),
         pull_request_id=pull_request.id,
         pr_key=pull_request.key,
         group_ids=group_ids,

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -1555,6 +1555,7 @@ def _build_activity_payload(
 
     match action:
         case "opened":
+            repository_payload = event.get("repository") or {}
             return asdict(
                 OpenedPayload(
                     **sender_kw,
@@ -1564,6 +1565,7 @@ def _build_activity_payload(
                     deletions=pull_request.get("deletions", 0),
                     changed_files=pull_request.get("changed_files", 0),
                     commits=pull_request.get("commits", 0),
+                    is_private=repository_payload.get("private"),
                 )
             )
         case "synchronize":

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -415,6 +415,50 @@ class PrMetricsEmissionTest(TestCase):
         )
         assert row.repository_is_public is True
 
+    def test_build_row_repository_is_public_empty_document_fallback_to_legacy(self) -> None:
+        # Edge case: PullRequestActivityLog exists but has empty data {}
+        # Should fall back to legacy store instead of treating as document
+        PullRequestActivityLog.objects.create(
+            pull_request=self.pull_request,
+            data={},  # Empty document - no version field
+        )
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="opened-1",
+            event_type=PullRequestActivityType.OPENED,
+            payload={"is_private": False},
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        # Should read from legacy store, not fail due to empty document
+        assert row.repository_is_public is True
+
+    def test_build_row_repository_is_public_no_version_document_fallback_to_legacy(self) -> None:
+        # Edge case: PullRequestActivityLog exists but has no version field
+        # Should fall back to legacy store (orphaned document from failed fold)
+        PullRequestActivityLog.objects.create(
+            pull_request=self.pull_request,
+            data={"events": []},  # Document without version - treated as orphaned
+        )
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="opened-1",
+            event_type=PullRequestActivityType.OPENED,
+            payload={"is_private": False},
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        # Should read from legacy store, not fail due to versionless document
+        assert row.repository_is_public is True
+
     def test_build_row_counters_default_to_zero_when_metrics_row_absent(self) -> None:
         # A PR Sentry never saw active has no PullRequestMetrics row; emit
         # coalesces every counter to its zero/false default.

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -8,6 +8,7 @@ from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import (
     PullRequestActivity,
+    PullRequestActivityLog,
     PullRequestActivityType,
     PullRequestAttribution,
     PullRequestAttributionSignalType,
@@ -328,6 +329,92 @@ class PrMetricsEmissionTest(TestCase):
         assert row.review_comments_count == 6
         assert row.is_assigned is True
 
+    def test_build_row_carries_repository_provider(self) -> None:
+        # setUp's repo is created with the prefixed "integrations:github" form —
+        # the row carries the normalized slug.
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.repository_provider == "github"
+
+    def test_build_row_repository_provider_null_when_repository_deleted(self) -> None:
+        self.repo.delete()
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.repository_provider is None
+
+    def test_build_row_repository_is_public_null_when_no_opened_activity(self) -> None:
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.repository_is_public is None
+
+    def test_build_row_repository_is_public_from_legacy_activity_row(self) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="opened-1",
+            event_type=PullRequestActivityType.OPENED,
+            payload={"is_private": False},
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.repository_is_public is True
+
+    def test_build_row_repository_is_public_false_for_private_repo(self) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id="opened-1",
+            event_type=PullRequestActivityType.OPENED,
+            payload={"is_private": True},
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.repository_is_public is False
+
+    def test_build_row_repository_is_public_from_activity_document(self) -> None:
+        # The doc-routed store takes priority over (and here, is the only)
+        # source — mirrors the webhook side's per-PR routing.
+        PullRequestActivityLog.objects.create(
+            pull_request=self.pull_request,
+            data={
+                "version": 1,
+                "events": [
+                    {
+                        "event_type": PullRequestActivityType.OPENED,
+                        "ts": "2020-06-04T09:00:00Z",
+                        "event_at": None,
+                        "webhook_id": "opened-1",
+                        "payload": {"is_private": False},
+                    }
+                ],
+            },
+        )
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.repository_is_public is True
+
     def test_build_row_counters_default_to_zero_when_metrics_row_absent(self) -> None:
         # A PR Sentry never saw active has no PullRequestMetrics row; emit
         # coalesces every counter to its zero/false default.
@@ -646,6 +733,7 @@ class PrMetricsEmissionTest(TestCase):
             PrCloseMetricsEvent(
                 organization_id=self.organization.id,
                 repository_id=self.repo.id,
+                repository_provider="github",
                 pull_request_id=self.pull_request.id,
                 pr_key="42",
                 group_ids=[],

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -974,6 +974,24 @@ class HandleWebhookForPrMetricsActivityTest(TestCase):
         assert activity.payload["changed_files"] == 4
         assert activity.payload["commits"] == 3
 
+    def test_opened_payload_captures_repo_visibility(self) -> None:
+        self._call(action="opened", extra_event={"repository": {"private": True}})
+
+        activity = PullRequestActivity.objects.get(pull_request=self.pr)
+        assert activity.payload["is_private"] is True
+
+    def test_opened_payload_captures_public_repo_visibility(self) -> None:
+        self._call(action="opened", extra_event={"repository": {"private": False}})
+
+        activity = PullRequestActivity.objects.get(pull_request=self.pr)
+        assert activity.payload["is_private"] is False
+
+    def test_opened_payload_visibility_null_when_repository_key_absent(self) -> None:
+        self._call(action="opened")
+
+        activity = PullRequestActivity.objects.get(pull_request=self.pr)
+        assert activity.payload["is_private"] is None
+
     def test_synchronize_writes_synchronized_activity(self) -> None:
         self._call(action="synchronize", before="old-sha", after="new-sha")
 

--- a/tests/sentry/pr_metrics/test_webhooks_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_webhooks_activity_doc.py
@@ -278,6 +278,12 @@ class ActivityDocumentWritePathTest(TestCase):
         assert doc is not None
         assert [e["event_type"] for e in doc["events"]] == [PullRequestActivityType.OPENED]
 
+    def test_opened_captures_repo_visibility_in_document(self) -> None:
+        with self.feature(DOC_FLAG):
+            self._activity(action="opened", repository={"private": True})
+        opened_entry = self._doc()["events"][0]
+        assert opened_entry["payload"]["is_private"] is True
+
     def test_flag_on_existing_legacy_rows_stay_on_legacy(self) -> None:
         # A PR that already has legacy rows keeps writing them (self-drains later).
         PullRequestActivity.objects.create(


### PR DESCRIPTION
Adds `repository_provider` (normalized SCM slug, e.g. "github") and
`repository_is_public` to the `scm.pr.closed` analytics event, so PR-metrics
rows can be broken down by which SCM a repo is on and whether it's public or
private.

`repository_provider` is read straight off the `Repository` row at emit time
via a newly-public `normalize_scm_provider()` helper (promoted from a private
helper already used elsewhere in `models/pullrequest.py`).

`repository_is_public` has no existing persisted source — `Repository` never
stores visibility (confirmed by an audit of the model, its `config` JSON keys
per provider, related models, caches, and serializers). It's captured from the
GitHub `opened` webhook payload's `repository.private` (a new
`OpenedPayload.is_private` field) and read back at emit time from whichever
store the PR's activity is routed to (the `PullRequestActivityLog` document or
the legacy `PullRequestActivity` row). This mirrors an existing pattern
elsewhere in the codebase (`seer/code_review/utils.py`) that reads visibility
transiently off webhook payloads without persisting it on `Repository`.

Both fields are `None` when the underlying fact was never observed
(pre-existing PRs, activity tracking off, or a deleted repo) rather than
erroring.

Closes CORE-288