### PR TITLE
ref(scraps): Stabilize InfoText overflow handling

### DIFF
--- a/static/app/components/core/info/infoText.spec.tsx
+++ b/static/app/components/core/info/infoText.spec.tsx
@@ -33,6 +33,7 @@ describe('InfoText', () => {
 
     const text = screen.getByText('Text content');
     expect(text).toHaveAttribute('tabindex', '0');
+    expect(text).toHaveAttribute('aria-describedby');
     expect(
       getEmotionRules(text).some(
         rule =>
@@ -54,7 +55,17 @@ describe('InfoText', () => {
       </InfoText>
     );
 
-    await userEvent.hover(screen.getByText('Text content'));
+    const text = screen.getByText('Text content');
+    expect(text).not.toHaveAttribute('tabindex');
+    expect(text).not.toHaveAttribute('aria-describedby');
+
+    await userEvent.hover(text);
     expect(screen.queryByText('Tooltip content')).not.toBeInTheDocument();
+  });
+
+  it('keeps regular InfoText keyboard interactive', () => {
+    render(<InfoText title="Tooltip content">Text content</InfoText>);
+
+    expect(screen.getByText('Text content')).toHaveAttribute('tabindex', '0');
   });
 });

--- a/static/app/components/core/info/infoText.tsx
+++ b/static/app/components/core/info/infoText.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 import type {DistributedOmit} from 'type-fest';
 
@@ -25,6 +26,7 @@ export function InfoText<T extends 'span' | 'p' | 'label' | 'div' | 'time' = 'sp
   ...textProps
 }: InfoTextProps<T>) {
   const isOverflowOnly = mode === 'overflowOnly';
+  const [isOverflowing, setIsOverflowing] = useState(false);
   // Text's ellipsis props are mutually exclusive with display and wrap.
   const textPropsWithMode = {
     ...textProps,
@@ -40,12 +42,16 @@ export function InfoText<T extends 'span' | 'p' | 'label' | 'div' | 'time' = 'sp
       position={position}
       maxWidth={maxWidth}
       showOnlyOnOverflow={isOverflowOnly}
+      onOverflowChange={isOverflowOnly ? setIsOverflowing : undefined}
       skipWrapper
       isHoverable
       showUnderline={!isOverflowOnly}
       underlineColor={textProps.variant === 'inherit' ? undefined : textProps.variant}
     >
-      <StyledText {...textPropsWithMode} tabIndex={0}>
+      <StyledText
+        {...textPropsWithMode}
+        tabIndex={isOverflowOnly && !isOverflowing ? undefined : 0}
+      >
         {children}
       </StyledText>
     </Tooltip>

--- a/static/app/components/core/tooltip/tooltip.spec.tsx
+++ b/static/app/components/core/tooltip/tooltip.spec.tsx
@@ -1,8 +1,10 @@
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 describe('Tooltip', () => {
+  let originalResizeObserver: typeof window.ResizeObserver;
+
   function mockOverflow(width: number, containerWidth: number) {
     Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
       configurable: true,
@@ -15,6 +17,7 @@ describe('Tooltip', () => {
   }
 
   afterEach(() => {
+    window.ResizeObserver = originalResizeObserver;
     // @ts-expect-error cleanup previously mocked properties
     delete HTMLElement.prototype.scrollWidth;
     // @ts-expect-error cleanup previously mocked properties
@@ -23,6 +26,7 @@ describe('Tooltip', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    originalResizeObserver = window.ResizeObserver;
   });
 
   it('renders', async () => {
@@ -135,6 +139,38 @@ describe('Tooltip', () => {
     expect(screen.getByText('test')).toBeInTheDocument();
 
     await userEvent.unhover(screen.getByText('This text overflows'));
+  });
+
+  it('hides an open tooltip when the content stops overflowing', async () => {
+    let resizeCallback: ResizeObserverCallback | undefined;
+    window.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+      observe() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    mockOverflow(100, 50);
+    render(
+      <Tooltip title="test" showOnlyOnOverflow>
+        <div>This text changes size</div>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByText('This text changes size');
+    await userEvent.hover(trigger);
+    expect(screen.getByText('test')).toBeInTheDocument();
+
+    mockOverflow(50, 100);
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('test')).not.toBeInTheDocument();
+    });
+    expect(trigger).not.toHaveAttribute('aria-describedby');
   });
 
   it('does not display a tooltip if the content does not overflow with showOnlyOnOverflow', async () => {

--- a/static/app/utils/useHoverOverlay.spec.tsx
+++ b/static/app/utils/useHoverOverlay.spec.tsx
@@ -49,7 +49,11 @@ describe('useHoverOverlay', () => {
       return wrapTrigger(<InnerComponent ref={ref} />);
     };
 
-    render(<WrappedComponent />);
+    const {rerender} = render(<WrappedComponent />);
     expect(ref).toHaveBeenCalled();
+
+    const callsAfterMount = ref.mock.calls.length;
+    rerender(<WrappedComponent />);
+    expect(ref).toHaveBeenCalledTimes(callsAfterMount);
   });
 });

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -626,6 +626,12 @@ function useHoverOverlay({
     }
   }, [commitStatus, group]);
 
+  useEffect(() => {
+    if (showOnlyOnOverflow && !isOverflowing) {
+      reset();
+    }
+  }, [showOnlyOnOverflow, isOverflowing, reset]);
+
   const overlayProps = useMemo(() => {
     return {
       id: describeById,

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -14,10 +14,12 @@ import {
 import type {PopperProps} from 'react-popper';
 import {usePopper} from 'react-popper';
 import {useTheme} from '@emotion/react';
-import {mergeProps, mergeRefs} from '@react-aria/utils';
+import {mergeProps} from '@react-aria/utils';
 
 import {NODE_ENV} from 'sentry/constants/env';
 import type {Theme} from 'sentry/utils/theme';
+
+import {useStableMergeRef} from './useStableMergeRef';
 
 function makeDefaultPopperModifiers(arrowElement: HTMLElement | null, offset: number) {
   return [
@@ -200,6 +202,11 @@ interface UseHoverOverlayProps {
   onHover?: () => void;
 
   /**
+   * Called when the trigger changes between overflowing and fitting.
+   */
+  onOverflowChange?: (isOverflowing: boolean) => void;
+
+  /**
    * Position for the overlay.
    */
   position?: PopperProps<any>['placement'];
@@ -210,7 +217,7 @@ interface UseHoverOverlayProps {
   showOnlyOnOverflow?: boolean;
   /**
    * Whether to add a dotted underline to the trigger element, to indicate the
-   * presence of a overlay.
+   * presence of an overlay.
    */
   showUnderline?: boolean;
   /**
@@ -281,6 +288,7 @@ function useHoverOverlay({
   showUnderline,
   underlineColor,
   showOnlyOnOverflow,
+  onOverflowChange,
   skipWrapper,
   forceVisible,
   offset = 8,
@@ -383,8 +391,57 @@ function useHoverOverlay({
   }, [isOpen]);
 
   const [triggerElement, setTriggerElement] = useState<HTMLElement | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const isOverflowingRef = useRef(false);
   const [overlayElement, setOverlayElement] = useState<HTMLElement | null>(null);
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
+
+  const onOverflowChangeRef = useRef(onOverflowChange);
+  useLayoutEffect(() => {
+    onOverflowChangeRef.current = onOverflowChange;
+  });
+
+  const updateOverflow = useCallback((element: HTMLElement | null) => {
+    const nextIsOverflowing = element ? isOverflown(element) : false;
+    if (isOverflowingRef.current === nextIsOverflowing) {
+      return;
+    }
+
+    isOverflowingRef.current = nextIsOverflowing;
+    setIsOverflowing(nextIsOverflowing);
+    onOverflowChangeRef.current?.(nextIsOverflowing);
+  }, []);
+
+  const setTriggerElementRef = useCallback(
+    (element: HTMLElement | null) => {
+      setTriggerElement(element);
+      updateOverflow(showOnlyOnOverflow ? element : null);
+
+      if (!showOnlyOnOverflow || !element) {
+        return;
+      }
+
+      const resizeObserver = new ResizeObserver(() => updateOverflow(element));
+      resizeObserver.observe(element);
+
+      const mutationObserver = new MutationObserver(() => updateOverflow(element));
+      mutationObserver.observe(element, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+      });
+
+      return () => {
+        resizeObserver.disconnect();
+        mutationObserver.disconnect();
+        setTriggerElement(null);
+        updateOverflow(null);
+      };
+    },
+    [showOnlyOnOverflow, updateOverflow]
+  );
+
+  const mergeTriggerRef = useStableMergeRef(setTriggerElementRef);
 
   const modifiers = useMemo(
     () => makeDefaultPopperModifiers(arrowElement, offset),
@@ -477,10 +534,11 @@ function useHoverOverlay({
    */
   const wrapTrigger = useCallback(
     (triggerChildren: React.ReactNode) => {
+      const shouldInteract = !showOnlyOnOverflow || isOverflowing || forceVisible;
       const providedProps = {
-        // !!These props are always overriden!!
-        'aria-describedby': describeById,
-        ref: setTriggerElement,
+        // !!These props are always overridden!!
+        'aria-describedby': shouldInteract ? describeById : undefined,
+        ref: setTriggerElementRef,
         // The following props are composed from the componentProps trigger props
         onFocus: handleMouseEnter,
         onBlur: handleMouseLeave,
@@ -496,6 +554,10 @@ function useHoverOverlay({
         isValidElement(triggerChildren) &&
         (skipWrapper || typeof triggerChildren.type === 'string')
       ) {
+        const triggerRef = mergeTriggerRef(
+          (triggerChildren.props as any).ref as React.Ref<HTMLElement> | null | undefined
+        );
+
         if (showUnderline) {
           const triggerStyle = {
             ...(triggerChildren.props as any).style,
@@ -505,7 +567,7 @@ function useHoverOverlay({
           return cloneElement<any>(
             triggerChildren,
             Object.assign(mergeProps(triggerChildren.props as any, providedProps), {
-              ref: mergeRefs((triggerChildren.props as any).ref, setTriggerElement),
+              ref: triggerRef,
               style: triggerStyle,
             })
           );
@@ -515,7 +577,7 @@ function useHoverOverlay({
         return cloneElement<any>(
           triggerChildren,
           Object.assign(mergeProps(triggerChildren.props as any, providedProps), {
-            ref: mergeRefs((triggerChildren.props as any).ref, setTriggerElement),
+            ref: triggerRef,
             style: (triggerChildren.props as any).style,
           })
         );
@@ -541,11 +603,16 @@ function useHoverOverlay({
       handleMouseEnter,
       handleMouseLeave,
       showUnderline,
+      showOnlyOnOverflow,
       skipWrapper,
       describeById,
+      forceVisible,
       style,
       theme,
       underlineColor,
+      isOverflowing,
+      setTriggerElementRef,
+      mergeTriggerRef,
     ]
   );
 

--- a/static/app/utils/useStableMergeRef.spec.tsx
+++ b/static/app/utils/useStableMergeRef.spec.tsx
@@ -1,0 +1,40 @@
+import {renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {useStableMergeRef} from './useStableMergeRef';
+
+describe('useStableMergeRef', () => {
+  it('keeps merged refs stable for stable inputs', () => {
+    const stableRef = jest.fn();
+    const childRef = jest.fn();
+    const {result, rerender} = renderHook(() => useStableMergeRef(stableRef));
+
+    const firstMergedRef = result.current(childRef);
+    rerender();
+
+    expect(result.current(childRef)).toBe(firstMergedRef);
+  });
+
+  it('returns the stable ref when there is no child ref', () => {
+    const stableRef = jest.fn();
+    const {result} = renderHook(() => useStableMergeRef(stableRef));
+
+    expect(result.current(null)).toBe(stableRef);
+    expect(result.current(undefined)).toBe(stableRef);
+  });
+
+  it('resets merged refs when the stable ref changes', () => {
+    const firstStableRef = jest.fn();
+    const secondStableRef = jest.fn();
+    const childRef = jest.fn();
+    const {result, rerender} = renderHook(
+      ({stableRef}: {stableRef: React.Ref<HTMLDivElement>}) =>
+        useStableMergeRef(stableRef),
+      {initialProps: {stableRef: firstStableRef}}
+    );
+
+    const firstMergedRef = result.current(childRef);
+    rerender({stableRef: secondStableRef});
+
+    expect(result.current(childRef)).not.toBe(firstMergedRef);
+  });
+});

--- a/static/app/utils/useStableMergeRef.ts
+++ b/static/app/utils/useStableMergeRef.ts
@@ -1,0 +1,30 @@
+import {useMemo} from 'react';
+import {mergeRefs} from '@react-aria/utils';
+
+/**
+ * Returns a stable function for merging a dynamic child ref with a stable ref.
+ *
+ * Merged refs are cached by child ref identity so React does not detach and
+ * reattach callback refs on every render. Cleanup functions returned by either
+ * ref are preserved by `mergeRefs`.
+ */
+export function useStableMergeRef<T>(stableRef: React.Ref<T>) {
+  return useMemo(() => {
+    const cache = new WeakMap<NonNullable<React.Ref<T>>, React.Ref<T>>();
+
+    return (ref: React.Ref<T> | null | undefined) => {
+      if (ref === null || ref === undefined) {
+        return stableRef;
+      }
+
+      const cachedRef = cache.get(ref);
+      if (cachedRef !== undefined) {
+        return cachedRef;
+      }
+
+      const mergedRef = mergeRefs(ref, stableRef);
+      cache.set(ref, mergedRef);
+      return mergedRef;
+    };
+  }, [stableRef]);
+}

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -421,7 +421,7 @@ describe('GroupReplays', () => {
       });
 
       const mockReplayRecord = mockReplay?.getReplay();
-      MockApiClient.addMockResponse({
+      const mockReplayViewedApi = MockApiClient.addMockResponse({
         method: 'POST',
         url: `/projects/${organization.slug}/${mockReplayRecord?.project_id}/replays/${mockReplayRecord?.id}/viewed-by/`,
       });
@@ -486,6 +486,8 @@ describe('GroupReplays', () => {
 
       // Expect the second row to have the correct date
       expect(screen.getByText('7 days ago')).toBeInTheDocument();
+
+      await waitFor(() => expect(mockReplayViewedApi).toHaveBeenCalled());
     });
 
     it('Should render the replay player', async () => {
@@ -538,7 +540,7 @@ describe('GroupReplays', () => {
       });
 
       const mockReplayRecord = mockReplay?.getReplay();
-      MockApiClient.addMockResponse({
+      const mockReplayViewedApi = MockApiClient.addMockResponse({
         method: 'POST',
         url: `/projects/${organization.slug}/${mockReplayRecord?.project_id}/replays/${mockReplayRecord?.id}/viewed-by/`,
       });
@@ -549,6 +551,7 @@ describe('GroupReplays', () => {
       });
 
       expect(await screen.findByText('See Full Replay')).toBeInTheDocument();
+      await waitFor(() => expect(mockReplayViewedApi).toHaveBeenCalled());
       expect(mockReplayCountApi).toHaveBeenCalledWith(
         mockReplayCountUrl,
         expect.objectContaining({


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/119892

InfoText that only shows a tooltip when an ellipsis is rendered needs render-time information about text being cut off in order to set tabIndex conditionally.

This PR adds an `onOverflowChange` callback to `useHoverOverlay` so that consumers get informed when overflow changes between true/false. We’re setting up both a ResizeObserver (to check for size constraints changing) as well as a MutationObserver (to guard against text changes).