### PR TITLE
feat(issues): add 'Open in Explore' as Logs fold action

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -1,5 +1,4 @@
 import {useMemo} from 'react';
-import moment from 'moment-timezone';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {LinkButton} from '@sentry/scraps/button';
@@ -14,29 +13,25 @@ import {
   NavigationCrumbs,
   ShortId,
 } from 'sentry/components/events/eventDrawer';
+import {useEventLogsUrl} from 'sentry/components/events/ourlogs/useEventLogsUrl';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
-import {getUtcDateString} from 'sentry/utils/dates';
 import {getShortEventId} from 'sentry/utils/events';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
 } from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {useLogItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
-import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
-import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {
   useQueryParamsSearch,
   useSetQueryParamsQuery,
 } from 'sentry/views/explore/queryParams/context';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {getEventEnvironment} from 'sentry/views/issueDetails/utils';
 
 interface LogIssueDrawerProps {
   event: Event;
@@ -58,7 +53,6 @@ export function OurlogsDrawer({
   embeddedOptions,
   additionalData: propAdditionalData,
 }: LogIssueDrawerProps) {
-  const organization = useOrganization();
   const setLogsQuery = useSetQueryParamsQuery();
   const logsSearch = useQueryParamsSearch();
 
@@ -93,37 +87,7 @@ export function OurlogsDrawer({
     [event, propAdditionalData?.scrollToDisabled]
   );
 
-  const exploreUrl = useMemo(() => {
-    const traceId = event.contexts.trace?.trace_id;
-    if (!traceId) {
-      return null;
-    }
-
-    const eventTimestamp = event.dateCreated || event.dateReceived;
-    if (!eventTimestamp) {
-      return null;
-    }
-
-    const eventMoment = moment(eventTimestamp);
-    const start = getUtcDateString(eventMoment.clone().subtract(1, 'day'));
-    const end = getUtcDateString(eventMoment.clone().add(1, 'day'));
-    const environment = getEventEnvironment(event);
-
-    return getLogsUrl({
-      organization,
-      selection: {
-        projects: [parseInt(project.id, 10)],
-        environments: environment ? [environment] : [],
-        datetime: {
-          start,
-          end,
-          period: null,
-          utc: null,
-        },
-      },
-      query: `${OurLogKnownFieldKey.TRACE_ID}:${traceId}`,
-    });
-  }, [event, organization, project.id]);
+  const exploreUrl = useEventLogsUrl(event, project);
 
   return (
     <SearchQueryBuilderProvider {...searchQueryBuilderProps}>
@@ -151,7 +115,7 @@ export function OurlogsDrawer({
             </Flex>
             {exploreUrl && (
               <LinkButton size="sm" to={exploreUrl} openInNewTab>
-                {t('Open in explore')}
+                {t('Open in Explore')}
               </LinkButton>
             )}
           </Flex>

--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -409,7 +409,7 @@ describe('OurlogsSection', () => {
     expect(mockRequest).not.toHaveBeenCalled();
   });
 
-  it('renders Open in explore button with correct URL when trace_id exists', async () => {
+  it('renders Open in Explore button with correct URL when trace_id exists', async () => {
     render(<OurlogsSection event={event} project={project} group={group} />, {
       organization: OrganizationFixture({
         features: ['ourlogs-enabled', 'visibility-explore-view'],
@@ -434,7 +434,7 @@ describe('OurlogsSection', () => {
     expect(aside).toBeInTheDocument();
 
     const openInExploreButton = within(aside).getByRole('button', {
-      name: 'Open in explore',
+      name: 'Open in Explore',
     });
     expect(openInExploreButton).toBeInTheDocument();
     expect(openInExploreButton).toHaveAttribute('target', '_blank');

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -2,12 +2,13 @@ import {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
-import {Stack} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 
 import {ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS} from 'sentry/components/events/issueDetailsLazyRender';
 import {OurlogsDrawer} from 'sentry/components/events/ourlogs/ourlogsDrawer';
+import {useEventLogsUrl} from 'sentry/components/events/ourlogs/useEventLogsUrl';
 import {LazyRender} from 'sentry/components/lazyRender';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -143,6 +144,7 @@ function OurlogsSectionContent({
   const {openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const logsUrl = useEventLogsUrl(event, project);
 
   const onOpenLogsDrawer = useCallback(
     (e: React.MouseEvent, expandedLogId?: string) => {
@@ -236,7 +238,25 @@ function OurlogsSectionContent({
     return null;
   }
   return (
-    <FoldSection sectionKey={SectionKey.LOGS} title={t('Logs')}>
+    <FoldSection
+      actions={
+        logsUrl && (
+          <Grid flow="column" align="center" gap="md">
+            <LinkButton
+              analyticsEventKey="issue_details.logs_open_in_explore_action_button_clicked"
+              analyticsEventName="Issue Details: Logs Open in Explore Action Button Clicked"
+              openInNewTab
+              size="xs"
+              to={logsUrl}
+            >
+              {t('Open in Explore')}
+            </LinkButton>
+          </Grid>
+        )
+      }
+      sectionKey={SectionKey.LOGS}
+      title={t('Logs')}
+    >
       <Stack>
         <SmallTable>
           <TableBody>

--- a/static/app/components/events/ourlogs/useEventLogsUrl.spec.tsx
+++ b/static/app/components/events/ourlogs/useEventLogsUrl.spec.tsx
@@ -1,0 +1,77 @@
+import {EventFixture} from 'sentry-fixture/event';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useEventLogsUrl} from 'sentry/components/events/ourlogs/useEventLogsUrl';
+
+const project = ProjectFixture();
+
+describe('useEventLogsUrl', () => {
+  it('returns null when there is no context trace_id', () => {
+    const event = EventFixture({
+      contexts: {},
+      dateCreated: '12-21-2024',
+    });
+
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when there is no dateCreated or dateReceived', () => {
+    const event = EventFixture({
+      contexts: {
+        trace: {
+          trace_id: 'trace-abc-123',
+        },
+      },
+      dateCreated: null,
+      dateReceived: null,
+    });
+
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns the logs url with empty environment when the environment does not exist', () => {
+    const event = EventFixture({
+      contexts: {
+        trace: {
+          trace_id: 'trace-abc-123',
+        },
+      },
+      dateCreated: '12-21-2024',
+    });
+
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+
+    expect(result.current).toMatchInlineSnapshot(
+      `"/organizations/org-slug/explore/logs/?end=2024-12-22T05%3A00%3A00&logsQuery=trace%3Atrace-abc-123&project=2&start=2024-12-20T05%3A00%3A00"`
+    );
+  });
+
+  it('returns the logs url with an environment when the environment exists', () => {
+    const event = EventFixture({
+      contexts: {
+        trace: {
+          trace_id: 'trace-abc-123',
+        },
+      },
+      dateCreated: '12-21-2024',
+      tags: [
+        {
+          key: 'environment',
+          value: 'environment-abc-123',
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+
+    expect(result.current).toMatchInlineSnapshot(
+      `"/organizations/org-slug/explore/logs/?end=2024-12-22T05%3A00%3A00&environment=environment-abc-123&logsQuery=trace%3Atrace-abc-123&project=2&start=2024-12-20T05%3A00%3A00"`
+    );
+  });
+});

--- a/static/app/components/events/ourlogs/useEventLogsUrl.tsx
+++ b/static/app/components/events/ourlogs/useEventLogsUrl.tsx
@@ -1,0 +1,42 @@
+import moment from 'moment-timezone';
+
+import type {Event} from 'sentry/types/event';
+import type {Project} from 'sentry/types/project';
+import {getUtcDateString} from 'sentry/utils/dates';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import {getLogsUrl} from 'sentry/views/explore/logs/utils';
+import {getEventEnvironment} from 'sentry/views/issueDetails/utils';
+
+export function useEventLogsUrl(event: Event, project: Project) {
+  const organization = useOrganization();
+  const traceId = event.contexts.trace?.trace_id;
+  if (!traceId) {
+    return null;
+  }
+
+  const eventTimestamp = event.dateCreated || event.dateReceived;
+  if (!eventTimestamp) {
+    return null;
+  }
+
+  const eventMoment = moment(eventTimestamp);
+  const start = getUtcDateString(eventMoment.clone().subtract(1, 'day'));
+  const end = getUtcDateString(eventMoment.clone().add(1, 'day'));
+  const environment = getEventEnvironment(event);
+
+  return getLogsUrl({
+    organization,
+    selection: {
+      projects: [parseInt(project.id, 10)],
+      environments: environment ? [environment] : [],
+      datetime: {
+        start,
+        end,
+        period: null,
+        utc: null,
+      },
+    },
+    query: `${OurLogKnownFieldKey.TRACE_ID}:${traceId}`,
+  });
+}


### PR DESCRIPTION
Not all of the Issues fold sections have a fold action. This adds _Open in Explore_ to fill in the Logs one, which addresses the root _"we want more info on these logs"_ user need from LOGS-524.

The drawer already has a button to do this, so this PR extracts out a shared `useEventLogsUrl` to get the same existing URL. Also aligns the existing _View in explore_ (note the casing) from inside the drawer to the much-more-app-standard _Open in Explore_.

Example from https://sentry.sentry.io/issues/7521426076:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="936" height="376" alt="Screenshot 2026-07-17 at 9 38 15 AM" src="https://github.com/user-attachments/assets/28931d7e-0ed4-429b-8b1d-73034117d8fb" />
</td>
<td>
<img width="936" height="376" alt="Screenshot 2026-07-17 at 9 38 21 AM" src="https://github.com/user-attachments/assets/b797c75f-9e5e-4433-a80c-1bbb432dfd19" />
</td>
</tr>
</tbody>
</table>

Closes LOGS-524