### PR TITLE
feat(search): Add Ask Seer regenerate action

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -181,7 +181,7 @@ describe('AskSeerComboBox', () => {
     expect(screen.getByRole('button', {name: 'Give Feedback'})).toBeInTheDocument();
   });
 
-  it('regenerates the displayed mutation results', async () => {
+  it('regenerates results when feedback is unavailable', async () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const queryRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-explorer-ai/query/',
@@ -201,7 +201,7 @@ describe('AskSeerComboBox', () => {
           applySeerSearchQuery={() => {}}
         />
       </SearchQueryBuilderProvider>,
-      {organization: reworkedOrganization, additionalWrapper: FeedbackProvider}
+      {organization: reworkedOrganization}
     );
 
     await userEvent.type(
@@ -210,6 +210,7 @@ describe('AskSeerComboBox', () => {
     );
     await userEvent.click(await screen.findByRole('button', {name: 'Generate again'}));
 
+    expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
     await waitFor(() => expect(queryRequest).toHaveBeenCalledTimes(2));
     expect(trackAnalyticsSpy).toHaveBeenCalledWith('ai_query.regenerated', {
       organization: reworkedOrganization,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -1,15 +1,23 @@
+import {useEffect} from 'react';
 import {destroyAnnouncer} from '@react-aria/live-announcer';
 import {mutationOptions} from '@tanstack/react-query';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import type {FeedbackIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilderAI,
 } from 'sentry/components/searchQueryBuilder/context';
+import * as analytics from 'sentry/utils/analytics';
 import {fetchMutation} from 'sentry/utils/queryClient';
+import {GlobalFeedbackForm} from 'sentry/utils/useFeedbackForm';
+import {
+  AsyncSDKIntegrationContextProvider,
+  useAsyncSDKIntegrationStore,
+} from 'sentry/views/app/asyncSDKIntegrationProvider';
 
 const defaultProps = {
   enableAISearch: true,
@@ -36,6 +44,29 @@ const askSeerMutationOptions = mutationOptions({
 const {organization} = initializeOrg({
   organization: {features: ['gen-ai-features'], hideAiFeatures: false},
 });
+
+const feedbackIntegration = {
+  createForm: jest.fn(),
+} as unknown as FeedbackIntegration;
+
+function FeedbackProvider({children}: {children: React.ReactNode}) {
+  return (
+    <AsyncSDKIntegrationContextProvider>
+      <InstallFeedbackIntegration />
+      <GlobalFeedbackForm>{children}</GlobalFeedbackForm>
+    </AsyncSDKIntegrationContextProvider>
+  );
+}
+
+function InstallFeedbackIntegration() {
+  const {setState} = useAsyncSDKIntegrationStore();
+
+  useEffect(() => {
+    setState({Feedback: feedbackIntegration});
+  }, [setState]);
+
+  return null;
+}
 
 describe('AskSeerComboBox', () => {
   beforeEach(() => {
@@ -112,6 +143,79 @@ describe('AskSeerComboBox', () => {
 
     const header = await screen.findByText(/Describe what you're looking for./);
     expect(header).toBeInTheDocument();
+  });
+
+  it('only shows the reworked footer after results are displayed', async () => {
+    const reworkedOrganization = {
+      ...organization,
+      features: [...organization.features, 'gen-ai-ask-seer-ux-rework'],
+    };
+
+    render(
+      <SearchQueryBuilderProvider {...defaultProps}>
+        <AskSeerComboBox
+          initialQuery=""
+          askSeerMutationOptions={askSeerMutationOptions}
+          applySeerSearchQuery={() => {}}
+        />
+      </SearchQueryBuilderProvider>,
+      {organization: reworkedOrganization, additionalWrapper: FeedbackProvider}
+    );
+
+    expect(
+      await screen.findByText(/Describe what you're looking for./)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Generate again'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
+
+    const input = screen.getByRole('combobox', {
+      name: 'Ask Seer with Natural Language',
+    });
+    await userEvent.type(input, 'test{Enter}');
+
+    expect(
+      await screen.findByRole('button', {name: 'Generate again'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Give Feedback'})).toBeInTheDocument();
+  });
+
+  it('regenerates the displayed mutation results', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const queryRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-explorer-ai/query/',
+      method: 'POST',
+      body: {status: 'ok', queries: [{query: 'span.duration:>30s'}]},
+    });
+    const reworkedOrganization = {
+      ...organization,
+      features: [...organization.features, 'gen-ai-ask-seer-ux-rework'],
+    };
+
+    render(
+      <SearchQueryBuilderProvider {...defaultProps}>
+        <AskSeerComboBox
+          initialQuery=""
+          askSeerMutationOptions={askSeerMutationOptions}
+          applySeerSearchQuery={() => {}}
+        />
+      </SearchQueryBuilderProvider>,
+      {organization: reworkedOrganization, additionalWrapper: FeedbackProvider}
+    );
+
+    await userEvent.type(
+      await screen.findByRole('combobox', {name: 'Ask Seer with Natural Language'}),
+      'test{Enter}'
+    );
+    await userEvent.click(await screen.findByRole('button', {name: 'Generate again'}));
+
+    await waitFor(() => expect(queryRequest).toHaveBeenCalledTimes(2));
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith('ai_query.regenerated', {
+      organization: reworkedOrganization,
+      area: '',
+      natural_language_query: 'test',
+    });
   });
 
   it('closes seer search when close button is clicked', async () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -175,10 +175,15 @@ describe('AskSeerComboBox', () => {
     });
     await userEvent.type(input, 'test{Enter}');
 
-    expect(
-      await screen.findByRole('button', {name: 'Generate again'})
-    ).toBeInTheDocument();
+    const regenerateButton = await screen.findByRole('button', {
+      name: 'Generate again',
+    });
+    expect(regenerateButton).toBeEnabled();
     expect(screen.getByRole('button', {name: 'Give Feedback'})).toBeInTheDocument();
+
+    await userEvent.clear(input);
+
+    expect(regenerateButton).toBeEnabled();
   });
 
   it('regenerates results when feedback is unavailable', async () => {
@@ -204,10 +209,11 @@ describe('AskSeerComboBox', () => {
       {organization: reworkedOrganization}
     );
 
-    await userEvent.type(
-      await screen.findByRole('combobox', {name: 'Ask Seer with Natural Language'}),
-      'test{Enter}'
-    );
+    const input = await screen.findByRole('combobox', {
+      name: 'Ask Seer with Natural Language',
+    });
+    await userEvent.type(input, 'test{Enter}');
+    await userEvent.clear(input);
     await userEvent.click(await screen.findByRole('button', {name: 'Generate again'}));
 
     expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -9,7 +9,7 @@ import type {MutationOptions} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -30,7 +30,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/tokens/useSearchTokenCombobox';
-import {IconClose, IconMegaphone, IconSearch} from 'sentry/icons';
+import {IconClose, IconMegaphone, IconSearch, IconSync} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {RequestError} from 'sentry/utils/requestError/requestError';
@@ -114,6 +114,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
   const isInitialRender = useRef(true);
   const inputRef = useRef<HTMLInputElement>(null);
   const organization = useOrganization();
+  const hasAskSeerUxRework = organization.features.includes('gen-ai-ask-seer-ux-rework');
   const {projects} = useProjects();
 
   const [searchQuery, setSearchQuery] = useState(() =>
@@ -423,6 +424,9 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
     return null;
   }
 
+  const hasResults = (data?.queries?.length ?? 0) > 0;
+  const isDisplayingResults = !isPending && !isError && hasResults;
+
   return (
     <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
       <PositionedSearchIconContainer>
@@ -495,10 +499,41 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               <AskSeerSearchHeader title={t("Describe what you're looking for.")} />
             </Stack>
           )}
-          {openForm && (
-            <SeerFooter onMouseDown={e => e.preventDefault()}>
+          {openForm && (!hasAskSeerUxRework || isDisplayingResults) ? (
+            <Flex
+              justify={hasAskSeerUxRework ? 'between' : 'end'}
+              borderTop="primary"
+              paddingTop="sm"
+              paddingBottom="sm"
+              paddingLeft="md"
+              paddingRight="md"
+              background={hasAskSeerUxRework ? 'secondary' : 'primary'}
+              onMouseDown={e => e.preventDefault()}
+            >
+              {hasAskSeerUxRework ? (
+                <Button
+                  icon={<IconSync />}
+                  size="zero"
+                  onClick={() => {
+                    if (!searchQuery.trim()) {
+                      setAutoSubmitFromCurrentQuery(false);
+                      setAutoSubmitSeer(false);
+                      return;
+                    }
+
+                    trackAnalytics('ai_query.regenerated', {
+                      organization,
+                      area: analyticsArea,
+                      natural_language_query: searchQuery.trim(),
+                    });
+                    submitQuery(searchQuery.trim());
+                  }}
+                >
+                  {t('Generate again')}
+                </Button>
+              ) : null}
               <Button
-                size="xs"
+                size={hasAskSeerUxRework ? 'zero' : 'xs'}
                 icon={<IconMegaphone />}
                 onClick={() =>
                   openForm({
@@ -512,8 +547,8 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               >
                 {t('Give Feedback')}
               </Button>
-            </SeerFooter>
-          )}
+            </Flex>
+          ) : null}
         </AskSeerSearchPopover>
       ) : null}
     </Wrapper>
@@ -590,12 +625,4 @@ const ButtonsWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${p => p.theme.space.xs};
-`;
-
-const SeerFooter = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-  padding: ${p => p.theme.space.md};
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => p.theme.tokens.background.primary};
 `;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -499,7 +499,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               <AskSeerSearchHeader title={t("Describe what you're looking for.")} />
             </Stack>
           )}
-          {openForm && (!hasAskSeerUxRework || isDisplayingResults) ? (
+          {!hasAskSeerUxRework || isDisplayingResults ? (
             <Flex
               justify={hasAskSeerUxRework ? 'between' : 'end'}
               borderTop="primary"
@@ -532,21 +532,25 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
                   {t('Generate again')}
                 </Button>
               ) : null}
-              <Button
-                size={hasAskSeerUxRework ? 'zero' : 'xs'}
-                icon={<IconMegaphone />}
-                onClick={() =>
-                  openForm({
-                    messagePlaceholder: t('How can we make Seer search better for you?'),
-                    tags: {
-                      ['feedback.source']: `ai_query.${analyticsArea}`,
-                      ['feedback.owner']: 'ml-ai',
-                    },
-                  })
-                }
-              >
-                {t('Give Feedback')}
-              </Button>
+              {openForm ? (
+                <Button
+                  size={hasAskSeerUxRework ? 'zero' : 'xs'}
+                  icon={<IconMegaphone />}
+                  onClick={() =>
+                    openForm({
+                      messagePlaceholder: t(
+                        'How can we make Seer search better for you?'
+                      ),
+                      tags: {
+                        ['feedback.source']: `ai_query.${analyticsArea}`,
+                        ['feedback.owner']: 'ml-ai',
+                      },
+                    })
+                  }
+                >
+                  {t('Give Feedback')}
+                </Button>
+              ) : null}
             </Flex>
           ) : null}
         </AskSeerSearchPopover>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -515,18 +515,17 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
                   icon={<IconSync />}
                   size="zero"
                   onClick={() => {
-                    if (!searchQuery.trim()) {
-                      setAutoSubmitFromCurrentQuery(false);
-                      setAutoSubmitSeer(false);
+                    const query = searchQuery.trim() || askSeerNLQueryRef.current?.trim();
+                    if (!query) {
                       return;
                     }
 
                     trackAnalytics('ai_query.regenerated', {
                       organization,
                       area: analyticsArea,
-                      natural_language_query: searchQuery.trim(),
+                      natural_language_query: query,
                     });
-                    submitQuery(searchQuery.trim());
+                    submitQuery(query);
                   }}
                 >
                   {t('Generate again')}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -499,7 +499,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               <AskSeerSearchHeader title={t("Describe what you're looking for.")} />
             </Stack>
           )}
-          {!hasAskSeerUxRework || isDisplayingResults ? (
+          {(hasAskSeerUxRework ? isDisplayingResults : openForm) ? (
             <Flex
               justify={hasAskSeerUxRework ? 'between' : 'end'}
               borderTop="primary"

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
@@ -7,6 +7,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import type {FeedbackIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import * as analytics from 'sentry/utils/analytics';
 import {GlobalFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {
   AsyncSDKIntegrationContextProvider,
@@ -60,6 +61,8 @@ function renderPollingComboBox(features: string[]) {
     </SearchQueryBuilderProvider>,
     {organization, additionalWrapper: FeedbackProvider}
   );
+
+  return {organization};
 }
 
 async function submitQuery() {
@@ -96,5 +99,46 @@ describe('AskSeerPollingComboBox loading state', () => {
     expect(await screen.findByRole('status')).toHaveTextContent("I'm on it...");
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
+  });
+});
+
+describe('AskSeerPollingComboBox results', () => {
+  beforeEach(() => {
+    destroyAnnouncer();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows the reworked footer for results and starts a new run when regenerated', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const startRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/search-agent/start/',
+      method: 'POST',
+      body: {run_id: 123},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/search-agent/state/123/',
+      body: {
+        session: {
+          status: 'completed',
+          current_step: null,
+          completed_steps: [],
+          final_response: {query: 'span.duration:>30s'},
+        },
+      },
+    });
+    const {organization} = renderPollingComboBox([
+      'gen-ai-features',
+      'gen-ai-ask-seer-ux-rework',
+    ]);
+
+    await submitQuery();
+    await userEvent.click(await screen.findByRole('button', {name: 'Generate again'}));
+
+    expect(startRequest).toHaveBeenCalledTimes(2);
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith('ai_query.regenerated', {
+      organization,
+      area: '',
+      natural_language_query: 'find slow spans',
+    });
   });
 });

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
@@ -45,7 +45,7 @@ function InstallFeedbackIntegration() {
   return null;
 }
 
-function renderPollingComboBox(features: string[]) {
+function renderPollingComboBox(features: string[], withFeedback = true) {
   const {organization} = initializeOrg({
     organization: {features, hideAiFeatures: false},
   });
@@ -59,7 +59,7 @@ function renderPollingComboBox(features: string[]) {
         applySeerSearchQuery={() => {}}
       />
     </SearchQueryBuilderProvider>,
-    {organization, additionalWrapper: FeedbackProvider}
+    withFeedback ? {organization, additionalWrapper: FeedbackProvider} : {organization}
   );
 
   return {organization};
@@ -108,7 +108,7 @@ describe('AskSeerPollingComboBox results', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('shows the reworked footer for results and starts a new run when regenerated', async () => {
+  it('regenerates results when feedback is unavailable', async () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const startRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/search-agent/start/',
@@ -126,14 +126,15 @@ describe('AskSeerPollingComboBox results', () => {
         },
       },
     });
-    const {organization} = renderPollingComboBox([
-      'gen-ai-features',
-      'gen-ai-ask-seer-ux-rework',
-    ]);
+    const {organization} = renderPollingComboBox(
+      ['gen-ai-features', 'gen-ai-ask-seer-ux-rework'],
+      false
+    );
 
     await submitQuery();
     await userEvent.click(await screen.findByRole('button', {name: 'Generate again'}));
 
+    expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
     expect(startRequest).toHaveBeenCalledTimes(2);
     expect(trackAnalyticsSpy).toHaveBeenCalledWith('ai_query.regenerated', {
       organization,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
@@ -132,7 +132,18 @@ describe('AskSeerPollingComboBox results', () => {
     );
 
     await submitQuery();
-    await userEvent.click(await screen.findByRole('button', {name: 'Generate again'}));
+    const regenerateButton = await screen.findByRole('button', {
+      name: 'Generate again',
+    });
+    expect(regenerateButton).toBeEnabled();
+
+    const input = screen.getByRole('combobox', {
+      name: 'Ask Seer with Natural Language',
+    });
+    await userEvent.clear(input);
+    expect(regenerateButton).toBeEnabled();
+
+    await userEvent.click(regenerateButton);
 
     expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
     expect(startRequest).toHaveBeenCalledTimes(2);

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -633,7 +633,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             state={state}
             onMouseLeave={onMouseLeave}
           />
-          {!hasAskSeerUxRework || isDisplayingResults ? (
+          {(hasAskSeerUxRework ? isDisplayingResults : openForm) ? (
             <Flex
               justify={hasAskSeerUxRework ? 'between' : 'end'}
               borderTop="primary"

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -10,6 +10,7 @@ import type {UseMutationOptions} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -34,7 +35,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/utils';
 import {useSearchQueryBuilderAI} from 'sentry/components/searchQueryBuilder/context';
 import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/tokens/useSearchTokenCombobox';
-import {IconClose, IconMegaphone, IconSearch} from 'sentry/icons';
+import {IconClose, IconMegaphone, IconSearch, IconSync} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {RequestError} from 'sentry/utils/requestError/requestError';
@@ -576,6 +577,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
 
   const showLoading = isSessionPending || isPolling;
   const hasResults = queries.length > 0;
+  const isDisplayingResults = !showLoading && !isSessionError && hasResults;
 
   return (
     <Wrapper ref={containerRef} isDropdownOpen={state.isOpen}>
@@ -631,10 +633,42 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             state={state}
             onMouseLeave={onMouseLeave}
           />
-          {openForm && !hasAskSeerUxRework ? (
-            <SeerFooter onMouseDown={e => e.preventDefault()}>
+          {openForm && (!hasAskSeerUxRework || isDisplayingResults) ? (
+            <Flex
+              justify={hasAskSeerUxRework ? 'between' : 'end'}
+              borderTop="primary"
+              paddingTop="sm"
+              paddingBottom="sm"
+              paddingLeft="md"
+              paddingRight="md"
+              background={hasAskSeerUxRework ? 'secondary' : 'primary'}
+              onMouseDown={e => e.preventDefault()}
+            >
+              {hasAskSeerUxRework ? (
+                <Button
+                  icon={<IconSync />}
+                  size="zero"
+                  onClick={() => {
+                    if (!searchQuery.trim()) {
+                      setAutoSubmitFromCurrentQuery(false);
+                      setAutoSubmitSeer(false);
+                      return;
+                    }
+
+                    trackAnalytics('ai_query.regenerated', {
+                      organization,
+                      area: analyticsArea,
+                      natural_language_query: searchQuery.trim(),
+                    });
+                    reset();
+                    submitQuery(searchQuery.trim());
+                  }}
+                >
+                  {t('Generate again')}
+                </Button>
+              ) : null}
               <Button
-                size="xs"
+                size={hasAskSeerUxRework ? 'zero' : 'xs'}
                 icon={<IconMegaphone />}
                 onClick={() =>
                   openForm({
@@ -648,7 +682,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
               >
                 {t('Give Feedback')}
               </Button>
-            </SeerFooter>
+            </Flex>
           ) : null}
         </AskSeerSearchPopover>
       ) : null}
@@ -726,14 +760,6 @@ const ButtonsWrapper = styled('div')`
   display: flex;
   align-items: center;
   gap: ${p => p.theme.space.xs};
-`;
-
-const SeerFooter = styled('div')`
-  display: flex;
-  justify-content: flex-end;
-  padding: ${p => p.theme.space.md};
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => p.theme.tokens.background.primary};
 `;
 
 const SeerContent = styled('div')`

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -633,7 +633,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
             state={state}
             onMouseLeave={onMouseLeave}
           />
-          {openForm && (!hasAskSeerUxRework || isDisplayingResults) ? (
+          {!hasAskSeerUxRework || isDisplayingResults ? (
             <Flex
               justify={hasAskSeerUxRework ? 'between' : 'end'}
               borderTop="primary"
@@ -667,21 +667,25 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
                   {t('Generate again')}
                 </Button>
               ) : null}
-              <Button
-                size={hasAskSeerUxRework ? 'zero' : 'xs'}
-                icon={<IconMegaphone />}
-                onClick={() =>
-                  openForm({
-                    messagePlaceholder: t('How can we make Seer search better for you?'),
-                    tags: {
-                      ['feedback.source']: `ai_query.${analyticsArea}`,
-                      ['feedback.owner']: 'ml-ai',
-                    },
-                  })
-                }
-              >
-                {t('Give Feedback')}
-              </Button>
+              {openForm ? (
+                <Button
+                  size={hasAskSeerUxRework ? 'zero' : 'xs'}
+                  icon={<IconMegaphone />}
+                  onClick={() =>
+                    openForm({
+                      messagePlaceholder: t(
+                        'How can we make Seer search better for you?'
+                      ),
+                      tags: {
+                        ['feedback.source']: `ai_query.${analyticsArea}`,
+                        ['feedback.owner']: 'ml-ai',
+                      },
+                    })
+                  }
+                >
+                  {t('Give Feedback')}
+                </Button>
+              ) : null}
             </Flex>
           ) : null}
         </AskSeerSearchPopover>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -649,19 +649,18 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
                   icon={<IconSync />}
                   size="zero"
                   onClick={() => {
-                    if (!searchQuery.trim()) {
-                      setAutoSubmitFromCurrentQuery(false);
-                      setAutoSubmitSeer(false);
+                    const query = searchQuery.trim() || askSeerNLQueryRef.current?.trim();
+                    if (!query) {
                       return;
                     }
 
                     trackAnalytics('ai_query.regenerated', {
                       organization,
                       area: analyticsArea,
-                      natural_language_query: searchQuery.trim(),
+                      natural_language_query: query,
                     });
                     reset();
-                    submitQuery(searchQuery.trim());
+                    submitQuery(query);
                   }}
                 >
                   {t('Generate again')}

--- a/static/app/utils/analytics/seerAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/seerAnalyticsEvents.tsx
@@ -32,6 +32,10 @@ export type SeerAnalyticsEventsParameters = {
     action: 'opened' | 'closed' | 'consent_accepted';
     area: string;
   };
+  'ai_query.regenerated': {
+    area: string;
+    natural_language_query: string;
+  };
   'ai_query.rejected': {
     area: string;
     natural_language_query: string;
@@ -178,6 +182,7 @@ export const seerAnalyticsEventsMap: Record<SeerAnalyticsEventKey, string | null
   'ai_query.applied': 'AI Query: Applied',
   'ai_query.error': 'AI Query: Error',
   'ai_query.interface': 'AI Query: Interface',
+  'ai_query.regenerated': 'AI Query: Regenerated',
   'ai_query.rejected': 'AI Query: Rejected',
   'ai_query.submitted': 'AI Query: Submitted',
   'ai_query.feedback': 'AI Query: Feedback',


### PR DESCRIPTION
Ask Seer results now include a feature-flagged “Generate again” action alongside feedback in both mutation- and polling-based comboboxes. The reworked footer appears only after successful results, while the existing footer behavior remains unchanged when the UX rework is disabled.

Regenerating reuses the current natural-language query and records a dedicated analytics event. The polling flow resets the completed run before starting a replacement so the new request is not blocked by the previous run state.

Closes BROWSE-619

Example:

<img width="870" height="227" alt="Screenshot 2026-07-17 at 11 09 38" src="https://github.com/user-attachments/assets/14dea4e7-fee3-41fe-abc2-111f84c91777" />