### PR TITLE
ref(tests): add types to most {}-typed fixture params

### DIFF
--- a/static/app/components/pageFilters/actions.spec.tsx
+++ b/static/app/components/pageFilters/actions.spec.tsx
@@ -1,3 +1,4 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
@@ -153,7 +154,7 @@ describe('PageFilters ActionCreators', () => {
     it('does not change dates with no query params or defaultSelection', () => {
       initializeUrlState({
         organization,
-        location: {...router.location, query: {project: '1'}},
+        location: LocationFixture({...router.location, query: {project: '1'}}),
         memberProjects: projects,
         nonMemberProjects: [],
         navigate,
@@ -174,7 +175,7 @@ describe('PageFilters ActionCreators', () => {
     it('does changes to default dates with defaultSelection and no query params', () => {
       initializeUrlState({
         organization,
-        location: {...router.location, query: {project: '1'}},
+        location: LocationFixture({...router.location, query: {project: '1'}}),
         memberProjects: projects,
         nonMemberProjects: [],
         defaultSelection: {
@@ -203,7 +204,10 @@ describe('PageFilters ActionCreators', () => {
     it('uses query params statsPeriod over defaults', () => {
       initializeUrlState({
         organization,
-        location: {...router.location, query: {statsPeriod: '1h', project: '1'}},
+        location: LocationFixture({
+          ...router.location,
+          query: {statsPeriod: '1h', project: '1'},
+        }),
         memberProjects: projects,
         nonMemberProjects: [],
         defaultSelection: {
@@ -229,10 +233,10 @@ describe('PageFilters ActionCreators', () => {
     it('uses absolute dates over defaults', () => {
       initializeUrlState({
         organization,
-        location: {
+        location: LocationFixture({
           ...router.location,
           query: {start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38', project: '1'},
-        },
+        }),
         memberProjects: projects,
         nonMemberProjects: [],
         defaultSelection: {
@@ -261,7 +265,7 @@ describe('PageFilters ActionCreators', () => {
     it('does not load from local storage when there are query params', () => {
       initializeUrlState({
         organization,
-        location: {...router.location, query: {project: '1'}},
+        location: LocationFixture({...router.location, query: {project: '1'}}),
         memberProjects: projects,
         nonMemberProjects: [],
         navigate,
@@ -285,7 +289,7 @@ describe('PageFilters ActionCreators', () => {
     it('does not invalidate all projects from query params', () => {
       initializeUrlState({
         organization,
-        location: {...router.location, query: {project: '-1'}},
+        location: LocationFixture({...router.location, query: {project: '-1'}}),
         memberProjects: projects,
         nonMemberProjects: [],
         navigate,
@@ -640,7 +644,7 @@ describe('PageFilters ActionCreators', () => {
     it('updates history when queries are different', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {project: '2'}},
+        location: LocationFixture({pathname: '/test/', query: {project: '2'}}),
       }).location;
       // this can be passed w/ `project` as an array (e.g. multiple projects being selected)
       // however react-router will treat it as a string if there is only one param
@@ -654,7 +658,7 @@ describe('PageFilters ActionCreators', () => {
     it('does not update history when queries are the same', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {project: '1'}},
+        location: LocationFixture({pathname: '/test/', query: {project: '1'}}),
       }).location;
       // this can be passed w/ `project` as an array (e.g. multiple projects
       // being selected) however react-router will treat it as a string if
@@ -667,7 +671,7 @@ describe('PageFilters ActionCreators', () => {
     it('updates history when queries are different with replace', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {project: '2'}},
+        location: LocationFixture({pathname: '/test/', query: {project: '2'}}),
       }).location;
       updateProjects([1], location, nav, {replace: true});
 
@@ -680,7 +684,7 @@ describe('PageFilters ActionCreators', () => {
     it('does not update history when queries are the same with replace', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {project: '1'}},
+        location: LocationFixture({pathname: '/test/', query: {project: '1'}}),
       }).location;
       updateProjects([1], location, nav, {replace: true});
 
@@ -690,10 +694,10 @@ describe('PageFilters ActionCreators', () => {
     it('does not override an absolute date selection', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {
+        location: LocationFixture({
           pathname: '/test/',
           query: {project: '1', start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},
-        },
+        }),
       }).location;
       updateProjects([2], location, nav, {replace: true});
 
@@ -715,7 +719,7 @@ describe('PageFilters ActionCreators', () => {
     it('updates single', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {environment: 'test'}},
+        location: LocationFixture({pathname: '/test/', query: {environment: 'test'}}),
       }).location;
       updateEnvironments(['new-env'], location, nav);
 
@@ -728,7 +732,7 @@ describe('PageFilters ActionCreators', () => {
     it('updates multiple', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {environment: 'test'}},
+        location: LocationFixture({pathname: '/test/', query: {environment: 'test'}}),
       }).location;
       updateEnvironments(['new-env', 'another-env'], location, nav);
 
@@ -741,7 +745,7 @@ describe('PageFilters ActionCreators', () => {
     it('removes environment', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {environment: 'test'}},
+        location: LocationFixture({pathname: '/test/', query: {environment: 'test'}}),
       }).location;
       updateEnvironments(null, location, nav);
       expect(nav).toHaveBeenCalledWith(
@@ -753,14 +757,14 @@ describe('PageFilters ActionCreators', () => {
     it('does not override an absolute date selection', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {
+        location: LocationFixture({
           pathname: '/test/',
           query: {
             environment: 'test',
             start: '2020-03-22T00:53:38',
             end: '2020-04-21T00:53:38',
           },
-        },
+        }),
       }).location;
       updateEnvironments(['new-env'], location, nav, {replace: true});
 
@@ -782,7 +786,7 @@ describe('PageFilters ActionCreators', () => {
     it('updates statsPeriod when there is no existing stats period', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {}},
+        location: LocationFixture({pathname: '/test/', query: {}}),
       }).location;
       updateDateTime({period: '24h'}, location, nav);
 
@@ -795,7 +799,7 @@ describe('PageFilters ActionCreators', () => {
     it('updates statsPeriod when there is an existing stats period', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {statsPeriod: '14d'}},
+        location: LocationFixture({pathname: '/test/', query: {statsPeriod: '14d'}}),
       }).location;
       updateDateTime({period: '24h'}, location, nav);
 
@@ -808,7 +812,7 @@ describe('PageFilters ActionCreators', () => {
     it('changes to absolute date', () => {
       const nav = jest.fn();
       const location = RouterFixture({
-        location: {pathname: '/test/', query: {statsPeriod: '24h'}},
+        location: LocationFixture({pathname: '/test/', query: {statsPeriod: '24h'}}),
       }).location;
       updateDateTime(
         {start: '2020-03-22T00:53:38', end: '2020-04-21T00:53:38'},

--- a/static/app/components/pageFilters/persistence.tsx
+++ b/static/app/components/pageFilters/persistence.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import type {PageFiltersState} from 'sentry/components/pageFilters/types';
 import type {PinnedPageFilter} from 'sentry/types/core';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
@@ -98,10 +99,18 @@ export function setPageFiltersStorage(
   }
 }
 
+export interface PageFilterStorage {
+  pinnedFilters: Set<PinnedPageFilter>;
+  state: PageFiltersState;
+}
+
 /**
  * Retrieves the page filters from local storage
  */
-export function getPageFilterStorage(orgSlug: string, storageNamespace = '') {
+export function getPageFilterStorage(
+  orgSlug: string,
+  storageNamespace = ''
+): PageFilterStorage {
   const globalSelectionValue = decodePageFilter(orgSlug);
   const storageNamespaceValue = decodePageFilter(`${storageNamespace}:${orgSlug}`);
 

--- a/static/app/views/admin/installWizard/index.spec.tsx
+++ b/static/app/views/admin/installWizard/index.spec.tsx
@@ -28,8 +28,8 @@ describe('InstallWizard', () => {
       body: InstallWizardFixture({
         'beacon.anonymous': {
           field: {
-            disabledReason: null,
-            default: false,
+            key: '',
+            label: '',
             required: true,
             disabled: false,
             allowEmpty: true,
@@ -59,8 +59,8 @@ describe('InstallWizard', () => {
       body: InstallWizardFixture({
         'beacon.anonymous': {
           field: {
-            disabledReason: null,
-            default: false,
+            key: '',
+            label: '',
             required: true,
             disabled: false,
             allowEmpty: true,

--- a/tests/js/fixtures/debugFile.ts
+++ b/tests/js/fixtures/debugFile.ts
@@ -1,7 +1,7 @@
 import type {DebugFile} from 'sentry/types/debugFiles';
 import {DebugFileFeature, DebugFileType} from 'sentry/types/debugFiles';
 
-export function DebugFileFixture(params = {}): DebugFile {
+export function DebugFileFixture(params: Partial<DebugFile> = {}): DebugFile {
   return {
     objectName: 'libS.so',
     symbolType: 'elf',

--- a/tests/js/fixtures/discover.ts
+++ b/tests/js/fixtures/discover.ts
@@ -1,7 +1,7 @@
 import type {SavedQuery} from 'sentry/types/organization';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 
-export function DiscoverSavedQueryFixture(params = {}): SavedQuery {
+export function DiscoverSavedQueryFixture(params: Partial<SavedQuery> = {}): SavedQuery {
   return {
     id: '1',
     name: 'Saved query #1',

--- a/tests/js/fixtures/docIntegration.ts
+++ b/tests/js/fixtures/docIntegration.ts
@@ -1,6 +1,8 @@
 import type {DocIntegration} from 'sentry/types/integrations';
 
-export function DocIntegrationFixture(params = {}): DocIntegration {
+export function DocIntegrationFixture(
+  params: Partial<DocIntegration> = {}
+): DocIntegration {
   return {
     name: 'Sample Doc',
     slug: 'sample-doc',

--- a/tests/js/fixtures/eventStacktraceFrame.ts
+++ b/tests/js/fixtures/eventStacktraceFrame.ts
@@ -1,6 +1,6 @@
 import type {Frame} from 'sentry/types/event';
 
-export function EventStacktraceFrameFixture(params = {}): Frame {
+export function EventStacktraceFrameFixture(params: Partial<Frame> = {}): Frame {
   return {
     filename: 'raven/base.py',
     absPath: '/home/ubuntu/.virtualenvs/getsentry/src/raven/raven/base.py',

--- a/tests/js/fixtures/events.ts
+++ b/tests/js/fixtures/events.ts
@@ -1,7 +1,7 @@
 import {EventOrGroupType, type Event} from 'sentry/types/event';
 import type {EventsStats} from 'sentry/types/organization';
 
-export function EventsStatsFixture(params = {}): EventsStats {
+export function EventsStatsFixture(params: Partial<EventsStats> = {}): EventsStats {
   return {
     data: [
       [Date.now(), [{count: 321}, {count: 79}]],

--- a/tests/js/fixtures/installWizard.ts
+++ b/tests/js/fixtures/installWizard.ts
@@ -1,6 +1,8 @@
 import type {InstallWizardOptions} from 'sentry/views/admin/installWizard/index';
 
-export function InstallWizardFixture(params = {}): InstallWizardOptions {
+export function InstallWizardFixture(
+  params: Partial<InstallWizardOptions> = {}
+): InstallWizardOptions {
   return {
     'mail.use-tls': {
       field: {

--- a/tests/js/fixtures/pageFilters.ts
+++ b/tests/js/fixtures/pageFilters.ts
@@ -1,3 +1,4 @@
+import type {PageFilterStorage} from 'sentry/components/pageFilters/persistence';
 import type {PageFiltersState} from 'sentry/components/pageFilters/store';
 import type {PageFilters, PinnedPageFilter} from 'sentry/types/core';
 
@@ -15,7 +16,9 @@ export function PageFiltersFixture(params: Partial<PageFilters> = {}): PageFilte
   };
 }
 
-export function PageFiltersStorageFixture(params = {}) {
+export function PageFiltersStorageFixture(
+  params: Partial<PageFilterStorage> = {}
+): PageFilterStorage {
   return {
     pinnedFilters: new Set<PinnedPageFilter>(['projects']),
     state: {


### PR DESCRIPTION
I noticed in #119905 that some fixtures don't properly type their `params`, so they're just `{}` (allow anything, almost like an `any`):

```ts
function ExampleFixture(params = {}): Example {
  //                    ^? {}
  return { ...defaults, ...params };
}
```

This fills in most of them. I left out a couple that were super convoluted (`Events`, `InjectedRouter`).