### PR TITLE
fix(conversations): Preserve reasoning for reasoning-only assistant turns

### DIFF
--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -971,6 +971,21 @@ describe('conversationMessages utilities', () => {
       const assistant = turnsToMessages(turns).find(m => m.role === 'assistant');
       expect(assistant?.reasoning).toBe('Let me think step by step...');
     });
+
+    it('creates an assistant message for reasoning-only turns without content or tool calls', () => {
+      const turns = [
+        makeTurn({
+          userContent: 'Question',
+          reasoning: 'Thinking only...',
+        }),
+      ];
+
+      const messages = turnsToMessages(turns);
+      const assistant = messages.find(m => m.role === 'assistant');
+      expect(assistant).toBeDefined();
+      expect(assistant?.content).toBe('');
+      expect(assistant?.reasoning).toBe('Thinking only...');
+    });
   });
 
   describe('extractMessagesFromNodes (integration)', () => {
@@ -1247,6 +1262,27 @@ describe('conversationMessages utilities', () => {
         id: 'node-1',
         attributes: {
           [SpanFields.GEN_AI_OUTPUT_MESSAGES]: messages,
+        },
+      });
+      const result = parseAssistantContent(node as any);
+      expect(result.content).toBeNull();
+      expect(result.reasoning).toBe('Thinking only...');
+    });
+
+    it('does not fall through to gen_ai.response.object for reasoning-only output', () => {
+      const messages = JSON.stringify([
+        {role: 'assistant', parts: [{type: 'reasoning', content: 'Thinking only...'}]},
+      ]);
+      const node = createMockNode({
+        id: 'node-1',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: messages,
+          [SpanFields.GEN_AI_RESPONSE_OBJECT]: JSON.stringify([
+            {
+              role: 'assistant',
+              parts: [{type: 'reasoning', content: 'Thinking only...'}],
+            },
+          ]),
         },
       });
       const result = parseAssistantContent(node as any);

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -225,7 +225,7 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
         !seenAssistantContent.has(turn.assistantContent));
     const hasToolCalls = turn.toolCalls.length > 0;
 
-    if (hasAssistantContent || hasToolCalls) {
+    if (hasAssistantContent || hasToolCalls || turn.reasoning) {
       if (turn.assistantContent) {
         seenAssistantContent.add(turn.assistantContent);
       }
@@ -362,9 +362,10 @@ export function parseAssistantContent(node: AITraceSpanNode): {
         reasoning: extracted.reasoningText,
       };
     }
-    // If tool calls were found but no text, don't fall through to response
-    // attributes — tool calls are rendered separately as badges
-    if (extracted.toolCalls) {
+    // If tool calls or reasoning were found but no text, don't fall through to
+    // response attributes — tool calls are rendered separately as badges and
+    // reasoning is rendered in its own collapsible section.
+    if (extracted.toolCalls || extracted.reasoningText) {
       return {content: null, reasoning: extracted.reasoningText};
     }
   }


### PR DESCRIPTION
We had a bug when the only message in `gen_ai.output.messages` was a thinking message, we would show it is a JSON object instead of nicely parsing it. 

Before:
<img width="262" height="182" alt="image" src="https://github.com/user-attachments/assets/4d781e96-2a2f-4946-9734-f26035969807" />

After the fix:
<img width="1030" height="59" alt="image" src="https://github.com/user-attachments/assets/a7288b17-cafb-47e8-9548-10eacac035ac" />
