### PR TITLE
feat(activity): Register templates for assigned/unassigned/note notifications

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/base.py
+++ b/src/sentry/notifications/notification_action/activity_registry/base.py
@@ -11,10 +11,12 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.notification_action.registry import activity_handler_registry
+from sentry.notifications.notifications.activity.assigned import get_assignee_str
 from sentry.notifications.platform.service import NotificationService
 from sentry.notifications.platform.templates.activity import (
     ACTIVITY_TYPE_TO_SOURCE,
     ActivityNotificationData,
+    AssignedNotificationData,
     SetResolvedInCommitNotificationData,
     SetResolvedInReleaseNotificationData,
 )
@@ -133,6 +135,17 @@ def build_activity_notification_data(
                     query=urlencode({"project": project.id}),
                 )
             return SetResolvedInReleaseNotificationData(**action_data, release_url=release_url)
+
+        case ActivityType.ASSIGNED.value:
+            assignee_label = get_assignee_str(activity=activity, organization=organization)
+            assignee_email = activity.data.get("assigneeEmail")
+            assignee_url = None
+            # TODO(Leander): If a team is assigned, maybe link to the team page?
+            if assignee_email:
+                assignee_url = f"mailto:{assignee_email}"
+            return AssignedNotificationData(
+                **action_data, assignee_label=assignee_label, assignee_url=assignee_url
+            )
         case _:
             return ActivityNotificationData(**action_data)
 

--- a/src/sentry/notifications/platform/templates/activity/__init__.py
+++ b/src/sentry/notifications/platform/templates/activity/__init__.py
@@ -1,9 +1,11 @@
+from .assigned import AssignedActivityTemplate
 from .base import (
     ACTIVITY_TYPE_TO_SOURCE,
     ActivityNotificationData,
     SetResolvedInCommitNotificationData,
     SetResolvedInReleaseNotificationData,
 )
+from .note import NoteActivityTemplate
 from .seer.coding_completed import SeerCodingCompletedActivityTemplate
 from .seer.coding_started import SeerCodingStartedActivityTemplate
 from .seer.iteration_completed import SeerIterationCompletedActivityTemplate
@@ -21,6 +23,7 @@ from .status_change.set_resolved_by_age import SetResolvedByAgeActivityTemplate
 from .status_change.set_resolved_in_commit import SetResolvedInCommitActivityTemplate
 from .status_change.set_resolved_in_release import SetResolvedInReleaseActivityTemplate
 from .status_change.set_unresolved import SetUnresolvedActivityTemplate
+from .unassigned import UnassignedActivityTemplate
 
 __all__ = (
     "ACTIVITY_TYPE_TO_SOURCE",
@@ -44,4 +47,7 @@ __all__ = (
     "SetIgnoredActivityTemplate",
     "SetRegressionActivityTemplate",
     "SetUnresolvedActivityTemplate",
+    "AssignedActivityTemplate",
+    "UnassignedActivityTemplate",
+    "NoteActivityTemplate",
 )

--- a/src/sentry/notifications/platform/templates/activity/__init__.py
+++ b/src/sentry/notifications/platform/templates/activity/__init__.py
@@ -2,6 +2,7 @@ from .assigned import AssignedActivityTemplate
 from .base import (
     ACTIVITY_TYPE_TO_SOURCE,
     ActivityNotificationData,
+    AssignedNotificationData,
     SetResolvedInCommitNotificationData,
     SetResolvedInReleaseNotificationData,
 )
@@ -30,6 +31,7 @@ __all__ = (
     "ActivityNotificationData",
     "SetResolvedInCommitNotificationData",
     "SetResolvedInReleaseNotificationData",
+    "AssignedNotificationData",
     "SeerRcaStartedActivityTemplate",
     "SeerRcaCompletedActivityTemplate",
     "SeerSolutionStartedActivityTemplate",

--- a/src/sentry/notifications/platform/templates/activity/assigned.py
+++ b/src/sentry/notifications/platform/templates/activity/assigned.py
@@ -32,11 +32,11 @@ def get_assignee_text(data: AssignedNotificationData) -> str:
 
 
 def get_assigned_subject(data: AssignedNotificationData) -> list[NotificationTextBlock]:
-    blocks: list[NotificationTextBlock] = []
     assignee_text = get_assignee_text(data)
-    if data.issue_short_id:
-        blocks.append(CodeTextBlock(text=data.issue_short_id))
-    blocks.append(PlainTextBlock(text=f"was assigned to {assignee_text}"))
+    blocks: list[NotificationTextBlock] = [
+        CodeTextBlock(text=data.issue_short_id if data.issue_short_id else "An Issue"),
+        PlainTextBlock(text=f"was assigned to {assignee_text}"),
+    ]
     if data.activity_user_name:
         blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
     return blocks
@@ -59,7 +59,7 @@ def get_assigned_body_blocks(data: AssignedNotificationData) -> list[Notificatio
     return body_blocks
 
 
-def create_set_resolved_in_release_example() -> AssignedNotificationData:
+def create_assigned_example() -> AssignedNotificationData:
     action_data = create_activity_notification_example(
         ActivityType.ASSIGNED,
         activity_data={
@@ -78,7 +78,7 @@ def create_set_resolved_in_release_example() -> AssignedNotificationData:
 @template_registry.register(NotificationSource.ACTIVITY_ASSIGNED)
 class AssignedActivityTemplate(NotificationTemplate[AssignedNotificationData]):
     category = NotificationCategory.ACTIVITY
-    example_data = create_set_resolved_in_release_example()
+    example_data = create_assigned_example()
 
     def render(self, data: AssignedNotificationData) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(

--- a/src/sentry/notifications/platform/templates/activity/assigned.py
+++ b/src/sentry/notifications/platform/templates/activity/assigned.py
@@ -1,0 +1,91 @@
+from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.templates.activity.base import (
+    AssignedNotificationData,
+    build_footer,
+    build_issue_link,
+    create_activity_notification_example,
+    get_issue_description,
+)
+from sentry.notifications.platform.types import (
+    CodeTextBlock,
+    LinkTextBlock,
+    NotificationCategory,
+    NotificationRenderedTemplate,
+    NotificationSource,
+    NotificationTemplate,
+    NotificationTextBlock,
+    ParagraphSection,
+    PlainTextBlock,
+)
+from sentry.types.activity import ActivityType
+
+
+def get_assignee_text(data: AssignedNotificationData) -> str:
+    if not data.activity_data:
+        return "someone"
+
+    assignee_type = data.activity_data.get("assigneeType")
+    if assignee_type == "team":
+        return f"the #{data.assignee_label} team" if data.assignee_label else "a team"
+    else:
+        return data.assignee_label if data.assignee_label else "someone"
+
+
+def get_assigned_subject(data: AssignedNotificationData) -> list[NotificationTextBlock]:
+    blocks: list[NotificationTextBlock] = []
+    assignee_text = get_assignee_text(data)
+    if data.issue_short_id:
+        blocks.append(CodeTextBlock(text=data.issue_short_id))
+    blocks.append(PlainTextBlock(text=f"was assigned to {assignee_text}"))
+    if data.activity_user_name:
+        blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
+    return blocks
+
+
+def get_assigned_body_blocks(data: AssignedNotificationData) -> list[NotificationTextBlock]:
+    assignee_text = get_assignee_text(data)
+    body_blocks: list[NotificationTextBlock] = [
+        build_issue_link(data.issue_short_id, data.issue_url)
+    ]
+    if data.assignee_url:
+        body_blocks.extend(
+            [
+                PlainTextBlock(text="has been assigned to"),
+                LinkTextBlock(text=assignee_text, url=data.assignee_url),
+            ]
+        )
+    else:
+        body_blocks.append(PlainTextBlock(text=f"has been assigned to {assignee_text}."))
+    return body_blocks
+
+
+def create_set_resolved_in_release_example() -> AssignedNotificationData:
+    action_data = create_activity_notification_example(
+        ActivityType.ASSIGNED,
+        activity_data={
+            "assignee": "123",
+            "assigneeEmail": "john@example.com",
+            "assigneeType": "user",
+        },
+    )
+    return AssignedNotificationData(
+        **action_data.dict(),
+        assignee_label="themselves",
+        assignee_url="mailto:example@sentry.io",
+    )
+
+
+@template_registry.register(NotificationSource.ACTIVITY_ASSIGNED)
+class AssignedActivityTemplate(NotificationTemplate[AssignedNotificationData]):
+    category = NotificationCategory.ACTIVITY
+    example_data = create_set_resolved_in_release_example()
+
+    def render(self, data: AssignedNotificationData) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject=get_assigned_subject(data),
+            body=[
+                ParagraphSection(blocks=get_assigned_body_blocks(data=data)),
+                *get_issue_description(data=data),
+            ],
+            footer=build_footer(data=data),
+        )

--- a/src/sentry/notifications/platform/templates/activity/assigned.py
+++ b/src/sentry/notifications/platform/templates/activity/assigned.py
@@ -20,22 +20,10 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
-def get_assignee_text(data: AssignedNotificationData) -> str:
-    if not data.activity_data:
-        return "someone"
-
-    assignee_type = data.activity_data.get("assigneeType")
-    if assignee_type == "team":
-        return f"the #{data.assignee_label} team" if data.assignee_label else "a team"
-    else:
-        return data.assignee_label if data.assignee_label else "someone"
-
-
 def get_assigned_subject(data: AssignedNotificationData) -> list[NotificationTextBlock]:
-    assignee_text = get_assignee_text(data)
     blocks: list[NotificationTextBlock] = [
         CodeTextBlock(text=data.issue_short_id if data.issue_short_id else "An Issue"),
-        PlainTextBlock(text=f"was assigned to {assignee_text}"),
+        PlainTextBlock(text=f"was assigned to {data.assignee_label}"),
     ]
     if data.activity_user_name:
         blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
@@ -43,7 +31,6 @@ def get_assigned_subject(data: AssignedNotificationData) -> list[NotificationTex
 
 
 def get_assigned_body_blocks(data: AssignedNotificationData) -> list[NotificationTextBlock]:
-    assignee_text = get_assignee_text(data)
     body_blocks: list[NotificationTextBlock] = [
         build_issue_link(data.issue_short_id, data.issue_url)
     ]
@@ -51,11 +38,11 @@ def get_assigned_body_blocks(data: AssignedNotificationData) -> list[Notificatio
         body_blocks.extend(
             [
                 PlainTextBlock(text="has been assigned to"),
-                LinkTextBlock(text=assignee_text, url=data.assignee_url),
+                LinkTextBlock(text=data.assignee_label, url=data.assignee_url),
             ]
         )
     else:
-        body_blocks.append(PlainTextBlock(text=f"has been assigned to {assignee_text}."))
+        body_blocks.append(PlainTextBlock(text=f"has been assigned to {data.assignee_label}."))
     return body_blocks
 
 

--- a/src/sentry/notifications/platform/templates/activity/assigned.py
+++ b/src/sentry/notifications/platform/templates/activity/assigned.py
@@ -20,13 +20,26 @@ from sentry.notifications.platform.types import (
 from sentry.types.activity import ActivityType
 
 
+def get_assignee_label(data: AssignedNotificationData) -> str:
+    return (
+        data.activity_user_name or "a user"
+        if data.assignee_label == "themselves"
+        else data.assignee_label
+    )
+
+
 def get_assigned_subject(data: AssignedNotificationData) -> list[NotificationTextBlock]:
-    blocks: list[NotificationTextBlock] = [
-        CodeTextBlock(text=data.issue_short_id if data.issue_short_id else "An Issue"),
-        PlainTextBlock(text=f"was assigned to {data.assignee_label}"),
-    ]
-    if data.activity_user_name:
-        blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
+    blocks: list[NotificationTextBlock] = []
+    if data.issue_short_id:
+        blocks.append(CodeTextBlock(text=data.issue_short_id))
+    else:
+        blocks.append(PlainTextBlock(text="An Issue"))
+    blocks.append(PlainTextBlock(text=f"was assigned to {get_assignee_label(data)}"))
+    by_display = (
+        data.assignee_label if data.assignee_label == "themselves" else data.activity_user_name
+    )
+    if by_display:
+        blocks.append(PlainTextBlock(text=f"by {by_display}"))
     return blocks
 
 
@@ -38,11 +51,11 @@ def get_assigned_body_blocks(data: AssignedNotificationData) -> list[Notificatio
         body_blocks.extend(
             [
                 PlainTextBlock(text="has been assigned to"),
-                LinkTextBlock(text=data.assignee_label, url=data.assignee_url),
+                LinkTextBlock(text=get_assignee_label(data), url=data.assignee_url),
             ]
         )
     else:
-        body_blocks.append(PlainTextBlock(text=f"has been assigned to {data.assignee_label}."))
+        body_blocks.append(PlainTextBlock(text=f"has been assigned to {get_assignee_label(data)}."))
     return body_blocks
 
 

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -97,7 +97,7 @@ class SetResolvedInReleaseNotificationData(ActivityNotificationData):
 
 
 class AssignedNotificationData(ActivityNotificationData):
-    assignee_label: str | None = None
+    assignee_label: str
     assignee_url: str | None = None
 
 

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -31,6 +31,9 @@ ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
     ActivityType.SET_ESCALATING.value: NotificationSource.ACTIVITY_SET_ESCALATING,
     ActivityType.SET_IGNORED.value: NotificationSource.ACTIVITY_SET_IGNORED,
     ActivityType.SET_UNRESOLVED.value: NotificationSource.ACTIVITY_SET_UNRESOLVED,
+    ActivityType.NOTE.value: NotificationSource.ACTIVITY_NOTE,
+    ActivityType.ASSIGNED.value: NotificationSource.ACTIVITY_ASSIGNED,
+    ActivityType.UNASSIGNED.value: NotificationSource.ACTIVITY_UNASSIGNED,
 }
 
 EXAMPLE_PROJECT_URL = "https://sentry.io/organizations/acme/issues/?project=123"
@@ -91,6 +94,11 @@ class SetResolvedInCommitNotificationData(ActivityNotificationData):
 
 class SetResolvedInReleaseNotificationData(ActivityNotificationData):
     release_url: str | None = None
+
+
+class AssignedNotificationData(ActivityNotificationData):
+    assignee_label: str | None = None
+    assignee_url: str | None = None
 
 
 def build_footer(data: ActivityNotificationData) -> list[NotificationTextBlock]:

--- a/src/sentry/notifications/platform/templates/activity/note.py
+++ b/src/sentry/notifications/platform/templates/activity/note.py
@@ -1,0 +1,67 @@
+from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.templates.activity.base import (
+    ActivityNotificationData,
+    build_footer,
+    build_issue_link,
+    create_activity_notification_example,
+    get_issue_description,
+)
+from sentry.notifications.platform.types import (
+    BlockQuoteSection,
+    CodeTextBlock,
+    NotificationCategory,
+    NotificationRenderedTemplate,
+    NotificationSection,
+    NotificationSource,
+    NotificationTemplate,
+    NotificationTextBlock,
+    ParagraphSection,
+    PlainTextBlock,
+)
+from sentry.types.activity import ActivityType
+
+
+def get_note_subject(data: ActivityNotificationData) -> list[NotificationTextBlock]:
+    blocks: list[NotificationTextBlock] = []
+    blocks.append(PlainTextBlock(text="New comment on"))
+    if data.issue_short_id:
+        blocks.append(CodeTextBlock(text=data.issue_short_id))
+    else:
+        blocks.append(PlainTextBlock(text="a Sentry Issue"))
+    if data.activity_user_name:
+        blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
+    return blocks
+
+
+def get_note_body(data: ActivityNotificationData) -> list[NotificationSection]:
+    if not data.activity_data:
+        return []
+    text = data.activity_data.get("text")
+    if not text:
+        return []
+    return [BlockQuoteSection(blocks=[PlainTextBlock(text=str(text))])]
+
+
+@template_registry.register(NotificationSource.ACTIVITY_NOTE)
+class NoteActivityTemplate(NotificationTemplate[ActivityNotificationData]):
+    category = NotificationCategory.ACTIVITY
+    example_data = create_activity_notification_example(
+        ActivityType.NOTE,
+        activity_data={"text": "This looks like it might be related to the auth migration."},
+    )
+
+    def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject=get_note_subject(data),
+            body=[
+                ParagraphSection(
+                    blocks=[
+                        build_issue_link(data.issue_short_id, data.issue_url),
+                        PlainTextBlock(text="has a new comment."),
+                    ]
+                ),
+                *get_note_body(data),
+                *get_issue_description(data=data),
+            ],
+            footer=build_footer(data=data),
+        )

--- a/src/sentry/notifications/platform/templates/activity/unassigned.py
+++ b/src/sentry/notifications/platform/templates/activity/unassigned.py
@@ -1,0 +1,50 @@
+from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.templates.activity.base import (
+    ActivityNotificationData,
+    build_footer,
+    build_issue_link,
+    create_activity_notification_example,
+    get_issue_description,
+)
+from sentry.notifications.platform.types import (
+    CodeTextBlock,
+    NotificationCategory,
+    NotificationRenderedTemplate,
+    NotificationSource,
+    NotificationTemplate,
+    NotificationTextBlock,
+    ParagraphSection,
+    PlainTextBlock,
+)
+from sentry.types.activity import ActivityType
+
+
+def get_unassigned_subject(data: ActivityNotificationData) -> list[NotificationTextBlock]:
+    blocks: list[NotificationTextBlock] = []
+    if data.issue_short_id:
+        blocks.append(CodeTextBlock(text=data.issue_short_id))
+    blocks.append(PlainTextBlock(text="was unassigned"))
+    if data.activity_user_name:
+        blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
+    return blocks
+
+
+@template_registry.register(NotificationSource.ACTIVITY_UNASSIGNED)
+class UnassignedActivityTemplate(NotificationTemplate[ActivityNotificationData]):
+    category = NotificationCategory.ACTIVITY
+    example_data = create_activity_notification_example(ActivityType.UNASSIGNED)
+
+    def render(self, data: ActivityNotificationData) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject=get_unassigned_subject(data),
+            body=[
+                ParagraphSection(
+                    blocks=[
+                        build_issue_link(data.issue_short_id, data.issue_url),
+                        PlainTextBlock(text="is no longer assigned to anyone."),
+                    ]
+                ),
+                *get_issue_description(data=data),
+            ],
+            footer=build_footer(data=data),
+        )

--- a/src/sentry/notifications/platform/templates/activity/unassigned.py
+++ b/src/sentry/notifications/platform/templates/activity/unassigned.py
@@ -20,10 +20,12 @@ from sentry.types.activity import ActivityType
 
 
 def get_unassigned_subject(data: ActivityNotificationData) -> list[NotificationTextBlock]:
-    blocks: list[NotificationTextBlock] = [
-        CodeTextBlock(text=data.issue_short_id if data.issue_short_id else "An Issue"),
-        PlainTextBlock(text="was unassigned"),
-    ]
+    blocks: list[NotificationTextBlock] = []
+    if data.issue_short_id:
+        blocks.append(CodeTextBlock(text=data.issue_short_id))
+    else:
+        blocks.append(PlainTextBlock(text="An Issue"))
+    blocks.append(PlainTextBlock(text="was unassigned"))
     if data.activity_user_name:
         blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
     return blocks

--- a/src/sentry/notifications/platform/templates/activity/unassigned.py
+++ b/src/sentry/notifications/platform/templates/activity/unassigned.py
@@ -20,10 +20,10 @@ from sentry.types.activity import ActivityType
 
 
 def get_unassigned_subject(data: ActivityNotificationData) -> list[NotificationTextBlock]:
-    blocks: list[NotificationTextBlock] = []
-    if data.issue_short_id:
-        blocks.append(CodeTextBlock(text=data.issue_short_id))
-    blocks.append(PlainTextBlock(text="was unassigned"))
+    blocks: list[NotificationTextBlock] = [
+        CodeTextBlock(text=data.issue_short_id if data.issue_short_id else "An Issue"),
+        PlainTextBlock(text="was unassigned"),
+    ]
     if data.activity_user_name:
         blocks.append(PlainTextBlock(text=f"by {data.activity_user_name}"))
     return blocks

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -91,6 +91,9 @@ class NotificationSource(StrEnum):
     ACTIVITY_SET_ESCALATING = "activity-set-escalating"
     ACTIVITY_SET_UNRESOLVED = "activity-set-unresolved"
     ACTIVITY_SET_IGNORED = "activity-set-ignored"
+    ACTIVITY_NOTE = "activity-note"
+    ACTIVITY_ASSIGNED = "activity-assigned"
+    ACTIVITY_UNASSIGNED = "activity-unassigned"
 
 
 NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = {

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -150,6 +150,9 @@ NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = 
         NotificationSource.ACTIVITY_SET_ESCALATING,
         NotificationSource.ACTIVITY_SET_UNRESOLVED,
         NotificationSource.ACTIVITY_SET_IGNORED,
+        NotificationSource.ACTIVITY_NOTE,
+        NotificationSource.ACTIVITY_ASSIGNED,
+        NotificationSource.ACTIVITY_UNASSIGNED,
     ],
 }
 


### PR DESCRIPTION
Implements a few more activity notifications, the last deploy one is quite a bit more complicated so im doing that in its own PR

**some previews:**

<img width="777" height="604" alt="image" src="https://github.com/user-attachments/assets/c5ec4d78-92ac-4213-a71c-295b95eb6331" />
<img width="744" height="310" alt="image" src="https://github.com/user-attachments/assets/641316a7-237c-464f-a159-dc13671fa079" />
<img width="767" height="278" alt="image" src="https://github.com/user-attachments/assets/eeecb44b-cb8b-42fe-9883-8fcd4a426e2b" />
