### PR TITLE
feat(spans): Count segments with gen_ai conversation ids

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -92,6 +92,9 @@ def _process_segment(
     if segment_span is None:
         return spans
 
+    if any(attribute_value(s, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID) for s in spans):
+        metrics.incr("spans.consumers.process_segments.gen_ai_conversation")
+
     try:
         with metrics.timer("spans.consumers.process_segments.get_project"):
             project = Project.objects.get_from_cache(id=segment_span["project_id"])

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -89,11 +89,12 @@ def _process_segment(
             return [make_compatible(span) for span in unprocessed_spans]
 
     segment_span, spans = _enrich_spans(unprocessed_spans)
-    if segment_span is None:
-        return spans
 
     if any(attribute_value(s, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID) for s in spans):
         metrics.incr("spans.consumers.process_segments.gen_ai_conversation")
+
+    if segment_span is None:
+        return spans
 
     try:
         with metrics.timer("spans.consumers.process_segments.get_project"):

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -80,6 +80,9 @@ def _process_segment(
 ) -> list[CompatibleSpan]:
     _verify_compatibility(unprocessed_spans)
 
+    if any(attribute_value(s, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID) for s in unprocessed_spans):
+        metrics.incr("spans.consumers.process_segments.gen_ai_conversation")
+
     if skip_enrichment:
         return [make_compatible(span) for span in unprocessed_spans]
 
@@ -89,10 +92,6 @@ def _process_segment(
             return [make_compatible(span) for span in unprocessed_spans]
 
     segment_span, spans = _enrich_spans(unprocessed_spans)
-
-    if any(attribute_value(s, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID) for s in spans):
-        metrics.incr("spans.consumers.process_segments.gen_ai_conversation")
-
     if segment_span is None:
         return spans
 

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -278,6 +278,40 @@ class TestSpansTask(TestCase):
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_agent_monitoring"]
 
+    @mock.patch("sentry.spans.consumers.process_segments.message.metrics.incr")
+    def test_gen_ai_conversation_metric(self, mock_incr: mock.MagicMock) -> None:
+        """Count once per segment when any span has gen_ai.conversation.id."""
+        metric_name = "spans.consumers.process_segments.gen_ai_conversation"
+
+        def conversation_calls() -> int:
+            return sum(1 for call in mock_incr.call_args_list if call == mock.call(metric_name))
+
+        child_span, segment_span = self.generate_basic_spans()
+        process_segment([child_span, segment_span])
+        assert conversation_calls() == 0
+
+        mock_incr.reset_mock()
+        child_span, segment_span = self.generate_basic_spans()
+        child_span["attributes"]["gen_ai.conversation.id"] = {
+            "type": "string",
+            "value": "conv-123",
+        }
+        process_segment([child_span, segment_span])
+        assert conversation_calls() == 1
+
+        mock_incr.reset_mock()
+        child_span, segment_span = self.generate_basic_spans()
+        child_span["attributes"]["gen_ai.conversation.id"] = {
+            "type": "string",
+            "value": "conv-123",
+        }
+        segment_span["attributes"]["gen_ai.conversation.id"] = {
+            "type": "string",
+            "value": "conv-123",
+        }
+        process_segment([child_span, segment_span])
+        assert conversation_calls() == 1
+
     def test_segment_name_propagation(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         assert (

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -312,6 +312,15 @@ class TestSpansTask(TestCase):
         process_segment([child_span, segment_span])
         assert conversation_calls() == 1
 
+        mock_incr.reset_mock()
+        child_span, segment_span = self.generate_basic_spans()
+        child_span["attributes"]["gen_ai.conversation.id"] = {
+            "type": "string",
+            "value": "conv-123",
+        }
+        process_segment([child_span, segment_span], skip_enrichment=True)
+        assert conversation_calls() == 1
+
     def test_segment_name_propagation(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         assert (


### PR DESCRIPTION
The process-segments consumer now increments `spans.consumers.process_segments.gen_ai_conversation` once per segment when any span carries `gen_ai.conversation.id`. This gives a volume signal for conversation-linked spans without counting every attribute occurrence.

The check runs right after enrichment with a short-circuiting scan so enrichment stays free of product telemetry.

This is a preparation for generating conversation title in async tasks, but before that, we should know what kind of volume we expect to begin with.
