### PR TITLE
fix(analytics): Split SCM project-creation install view from onboarding

### DIFF
--- a/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
@@ -219,7 +219,11 @@ export function ScmIntegrationConnect({
     </Stack>
   ) : (
     <Stack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>
-      <ScmProviderPills providers={scmProviders} onInstall={handleInstall} />
+      <ScmProviderPills
+        analyticsFlow={analyticsFlow}
+        providers={scmProviders}
+        onInstall={handleInstall}
+      />
     </Stack>
   );
 }

--- a/static/app/components/onboarding/scm/scmProviderPills.spec.tsx
+++ b/static/app/components/onboarding/scm/scmProviderPills.spec.tsx
@@ -4,6 +4,7 @@ import {GitLabIntegrationProviderFixture} from 'sentry-fixture/gitlabIntegration
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as pipelineModal from 'sentry/components/pipeline/modal';
+import * as integrationUtil from 'sentry/utils/integrationUtil';
 
 import {ScmProviderPills} from './scmProviderPills';
 
@@ -39,7 +40,13 @@ describe('ScmProviderPills', () => {
       bitbucketProvider,
     ];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.getByText('GitLab')).toBeInTheDocument();
@@ -54,7 +61,13 @@ describe('ScmProviderPills', () => {
       GitHubIntegrationProviderFixture(),
     ];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     const buttons = screen.getAllByRole('button');
     expect(buttons[0]).toHaveTextContent('GitHub');
@@ -72,7 +85,13 @@ describe('ScmProviderPills', () => {
       azureDevOpsProvider,
     ];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     // Primary providers are visible as buttons
     expect(screen.getByText('GitHub')).toBeInTheDocument();
@@ -100,7 +119,13 @@ describe('ScmProviderPills', () => {
 
     const providers = [GitHubIntegrationProviderFixture(), gitHubEnterpriseProvider];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     await userEvent.click(screen.getByRole('button', {name: 'More'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub Enterprise'}));
@@ -108,10 +133,62 @@ describe('ScmProviderPills', () => {
     expect(openPipelineModalSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('fires the install start with the SCM project-creation view', async () => {
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(() => {});
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+
+    const providers = [GitHubIntegrationProviderFixture(), gitHubEnterpriseProvider];
+
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub Enterprise'}));
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'integrations.installation_start',
+      expect.objectContaining({view: 'scm_project_creation'})
+    );
+  });
+
+  it('fires the install start with the onboarding SCM view', async () => {
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(() => {});
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+
+    const providers = [GitHubIntegrationProviderFixture(), gitHubEnterpriseProvider];
+
+    render(
+      <ScmProviderPills
+        analyticsFlow="onboarding"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub Enterprise'}));
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'integrations.installation_start',
+      expect.objectContaining({view: 'onboarding_scm'})
+    );
+  });
+
   it('does not render "More" dropdown when all providers are primary', () => {
     const providers = [GitHubIntegrationProviderFixture()];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.queryByText('More')).not.toBeInTheDocument();

--- a/static/app/components/onboarding/scm/scmProviderPills.tsx
+++ b/static/app/components/onboarding/scm/scmProviderPills.tsx
@@ -9,17 +9,33 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {IntegrationButton} from 'sentry/views/settings/organizationIntegrations/integrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {partitionScmProviders} from './scmProviderOrder';
 
+// Which install `view` the SCM provider install fires under, per host flow. Keeps
+// onboarding installs on `onboarding_scm` while splitting project-creation SCM
+// installs into their own `scm_project_creation` bucket (was mislabeled as
+// `onboarding_scm`).
+const INSTALL_VIEW = {
+  onboarding: 'onboarding_scm',
+  'project-creation': 'scm_project_creation',
+} as const;
+
 interface ScmProviderPillsProps {
+  analyticsFlow: ScmAnalyticsFlow;
   onInstall: (data: Integration) => void;
   providers: IntegrationProvider[];
 }
 
-export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) {
+export function ScmProviderPills({
+  analyticsFlow,
+  providers,
+  onInstall,
+}: ScmProviderPillsProps) {
   const organization = useOrganization();
   const {startFlow} = useAddIntegration();
   const {primaryProviders, moreProviders} = partitionScmProviders(providers);
+  const view = INSTALL_VIEW[analyticsFlow];
   const gridItemCount = primaryProviders.length + (moreProviders.length > 0 ? 1 : 0);
 
   const columnsXs = `repeat(${Math.min(gridItemCount, 2)}, 1fr)`;
@@ -48,7 +64,7 @@ export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) 
               type: 'first_party',
               installStatus: 'Not Installed',
               analyticsParams: {
-                view: 'onboarding_scm',
+                view,
                 already_installed: false,
               },
               suppressSuccessMessage: true,
@@ -79,7 +95,7 @@ export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) 
                   organization,
                   onInstall,
                   analyticsParams: {
-                    view: 'onboarding_scm',
+                    view,
                     already_installed: false,
                   },
                   suppressSuccessMessage: true,

--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -18,6 +18,7 @@ export type IntegrationView = {
     | 'onboarding'
     | 'onboarding_scm'
     | 'project_creation'
+    | 'scm_project_creation'
     | 'developer_settings'
     | 'new_integration_modal'
     | 'seer_onboarding_github'

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -22,6 +22,7 @@ export interface AddIntegrationParams {
       | 'onboarding'
       | 'onboarding_scm'
       | 'project_creation'
+      | 'scm_project_creation'
       | 'seer_onboarding_github'
       | 'seer_onboarding_code_review'
       | 'test_analytics_onboarding'

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -13,6 +13,7 @@ type IntegrationContextProps = {
       | 'onboarding'
       | 'onboarding_scm'
       | 'project_creation'
+      | 'scm_project_creation'
       | 'seer_onboarding_github'
       | 'seer_onboarding_code_review'
       | 'test_analytics_onboarding'


### PR DESCRIPTION
## TLDR

SCM provider installs (GitHub/GitLab/etc.) started from the project-creation flow now log `integrations.installation_start`/`installation_complete` under `view: 'scm_project_creation'` instead of `onboarding_scm`, so project-creation installs cannot contaminate new-org onboarding install metrics.

## Details

First PR in the VDY-133 stack, scoped to a single relabel bug — it deliberately does not touch the messaging-integration install `view` or add any new registry events; those land in later PRs.

`ScmProviderPills` renders the connect-a-provider UI inside `ScmIntegrationConnect`, which is shared by both new-org onboarding (`views/onboarding/scmConnect.tsx`, `analyticsFlow="onboarding"`) and the SCM project-creation wizard (`views/projectInstall/scmCreateProject.tsx`, `analyticsFlow="project-creation"`). Both install paths in the component — the primary pill via `IntegrationContext.analyticsParams` and the "More" dropdown via `useAddIntegration().startFlow` — hardcoded `view: 'onboarding_scm'`. So connecting a provider during project creation was indistinguishable from onboarding in Amplitude, and there was no per-flow SCM-install funnel.

The fix threads the `analyticsFlow` that `ScmIntegrationConnect` already carries down into `ScmProviderPills` (its only caller) and derives the install `view` once via a small `INSTALL_VIEW` map: `onboarding -> 'onboarding_scm'` (unchanged) and `'project-creation' -> 'scm_project_creation'`. Threading the existing discriminant is preferable to reading the experiment inside the component — the component stays flow-agnostic and reusable, and the label reflects the flow that actually hosted the install rather than experiment enrollment.

`scm_project_creation` is added to the three `view` unions that must stay in sync: the two local `analyticsParams` declarations (`useAddIntegration.tsx`, `integrationContext.tsx`) and the canonical `IntegrationView` in `utils/analytics/integrations/index.ts`. The last was required for typecheck — the two component-local unions structurally duplicate `IntegrationView`, and `trackIntegrationAnalytics` validates against the canonical one.

The `scmProviderPills` spec gained the now-required `analyticsFlow` prop on every render plus two assertions that the install fires with `scm_project_creation` for the project-creation flow and `onboarding_scm` for onboarding — the latter guards the onboarding path against regression.

Note for BI: this moves traffic between buckets, so any `integrations.installation_* where view == 'onboarding_scm'` segmentation steps down at merge as SCM project-creation installs move to `scm_project_creation`.

Refs VDY-133
