### PR TITLE
fix(trace): Avoid unnecessary trace metadata fallback

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -6,6 +6,7 @@ import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageStat
 
 import {
   getTraceMetaErrorCount,
+  getTraceMetaLogsCount,
   getTraceMetaMetricsCount,
   getTraceMetaSpanCount,
   useTraceMeta,
@@ -442,6 +443,56 @@ describe('useTraceMeta', () => {
     expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
     expect(mockSlug1_90d).not.toHaveBeenCalled();
     expect(getTraceMetaSpanCount(result.current.data)).toBe(1);
+  });
+
+  it('Does not retry when initial EAP response has logs only', async () => {
+    const org = OrganizationFixture({features: ['trace-spans-format']});
+    const tracesWithoutTimestamp: TraceMetaTrace[] = [
+      {traceSlug: 'slug1', timestamp: undefined},
+    ];
+
+    const mockSlug1_14d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '14d'})],
+      body: {
+        errorsCount: 0,
+        logsCount: 3,
+        metricsCount: 0,
+        performanceIssuesCount: 0,
+        spansCount: 0,
+        spansCountMap: {},
+        transactionChildCountMap: [],
+        uptimeCount: 0,
+      },
+    });
+
+    const mockSlug1_90d = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug1/',
+      match: [MockApiClient.matchData({statsPeriod: '90d'})],
+      body: {
+        errorsCount: 1,
+        logsCount: 4,
+        metricsCount: 0,
+        performanceIssuesCount: 0,
+        spansCount: 1,
+        spansCountMap: {},
+        transactionChildCountMap: [],
+        uptimeCount: 0,
+      },
+    });
+
+    const {result} = renderHookWithProviders(useTraceMeta, {
+      organization: org,
+      initialProps: tracesWithoutTimestamp,
+    });
+
+    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+
+    expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
+    expect(mockSlug1_90d).not.toHaveBeenCalled();
+    expect(getTraceMetaLogsCount(result.current.data)).toBe(3);
   });
 
   it('Does not retry when all traces have timestamps', async () => {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -6,7 +6,6 @@ import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageStat
 
 import {
   getTraceMetaErrorCount,
-  getTraceMetaLogsCount,
   getTraceMetaMetricsCount,
   getTraceMetaSpanCount,
   useTraceMeta,
@@ -395,105 +394,76 @@ describe('useTraceMeta', () => {
     expect(getTraceMetaErrorCount(result.current.data)).toBe(2);
   });
 
-  it('Does not retry when initial response has data', async () => {
-    const org = OrganizationFixture({features: ['trace-spans-format']});
-    const tracesWithoutTimestamp: TraceMetaTrace[] = [
-      {traceSlug: 'slug1', timestamp: undefined},
-    ];
+  it.each([
+    {traceType: 'EAP', countField: 'errorsCount'},
+    {traceType: 'EAP', countField: 'logsCount'},
+    {traceType: 'EAP', countField: 'metricsCount'},
+    {traceType: 'EAP', countField: 'performanceIssuesCount'},
+    {traceType: 'EAP', countField: 'spansCount'},
+    {traceType: 'EAP', countField: 'uptimeCount'},
+    {traceType: 'non-EAP', countField: 'errors'},
+    {traceType: 'non-EAP', countField: 'performance_issues'},
+    {traceType: 'non-EAP', countField: 'span_count'},
+    {traceType: 'non-EAP', countField: 'transactions'},
+  ] as const)(
+    'Does not retry when initial $traceType response has only $countField',
+    async ({traceType, countField}) => {
+      const isEAP = traceType === 'EAP';
+      const org = isEAP
+        ? OrganizationFixture({features: ['trace-spans-format']})
+        : organization;
+      const endpoint = isEAP ? 'trace-meta' : 'events-trace-meta';
+      const emptyBody = isEAP
+        ? {
+            errorsCount: 0,
+            logsCount: 0,
+            metricsCount: 0,
+            performanceIssuesCount: 0,
+            spansCount: 0,
+            spansCountMap: {},
+            transactionChildCountMap: [],
+            uptimeCount: 0,
+          }
+        : {
+            errors: 0,
+            performance_issues: 0,
+            projects: 0,
+            transactions: 0,
+            transaction_child_count_map: [],
+            span_count: 0,
+            span_count_map: {},
+          };
+      const initialBody = {...emptyBody, [countField]: 1};
+      const tracesWithoutTimestamp: TraceMetaTrace[] = [
+        {traceSlug: 'slug1', timestamp: undefined},
+      ];
 
-    const mockSlug1_14d = MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/trace-meta/slug1/',
-      match: [MockApiClient.matchData({statsPeriod: '14d'})],
-      body: {
-        errorsCount: 1,
-        logsCount: 1,
-        metricsCount: 0,
-        performanceIssuesCount: 1,
-        spansCount: 1,
-        spansCountMap: {op1: 1},
-        transactionChildCountMap: [],
-        uptimeCount: 0,
-      },
-    });
+      const mockSlug1_14d = MockApiClient.addMockResponse({
+        method: 'GET',
+        url: `/organizations/org-slug/${endpoint}/slug1/`,
+        match: [MockApiClient.matchData({statsPeriod: '14d'})],
+        body: initialBody,
+      });
 
-    const mockSlug1_90d = MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/trace-meta/slug1/',
-      match: [MockApiClient.matchData({statsPeriod: '90d'})],
-      body: {
-        errorsCount: 2,
-        logsCount: 2,
-        metricsCount: 0,
-        performanceIssuesCount: 2,
-        spansCount: 2,
-        spansCountMap: {},
-        transactionChildCountMap: [],
-        uptimeCount: 0,
-      },
-    });
+      const mockSlug1_90d = MockApiClient.addMockResponse({
+        method: 'GET',
+        url: `/organizations/org-slug/${endpoint}/slug1/`,
+        match: [MockApiClient.matchData({statsPeriod: '90d'})],
+        body: emptyBody,
+      });
 
-    const {result} = renderHookWithProviders(useTraceMeta, {
-      organization: org,
-      initialProps: tracesWithoutTimestamp,
-    });
+      const {result} = renderHookWithProviders(useTraceMeta, {
+        organization: org,
+        initialProps: tracesWithoutTimestamp,
+      });
 
-    await waitFor(() => expect(result.current.status === 'success').toBe(true));
+      await waitFor(() => expect(result.current.status === 'success').toBe(true));
 
-    expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
-    expect(mockSlug1_90d).not.toHaveBeenCalled();
-    expect(getTraceMetaSpanCount(result.current.data)).toBe(1);
-  });
-
-  it('Does not retry when initial EAP response has logs only', async () => {
-    const org = OrganizationFixture({features: ['trace-spans-format']});
-    const tracesWithoutTimestamp: TraceMetaTrace[] = [
-      {traceSlug: 'slug1', timestamp: undefined},
-    ];
-
-    const mockSlug1_14d = MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/trace-meta/slug1/',
-      match: [MockApiClient.matchData({statsPeriod: '14d'})],
-      body: {
-        errorsCount: 0,
-        logsCount: 3,
-        metricsCount: 0,
-        performanceIssuesCount: 0,
-        spansCount: 0,
-        spansCountMap: {},
-        transactionChildCountMap: [],
-        uptimeCount: 0,
-      },
-    });
-
-    const mockSlug1_90d = MockApiClient.addMockResponse({
-      method: 'GET',
-      url: '/organizations/org-slug/trace-meta/slug1/',
-      match: [MockApiClient.matchData({statsPeriod: '90d'})],
-      body: {
-        errorsCount: 1,
-        logsCount: 4,
-        metricsCount: 0,
-        performanceIssuesCount: 0,
-        spansCount: 1,
-        spansCountMap: {},
-        transactionChildCountMap: [],
-        uptimeCount: 0,
-      },
-    });
-
-    const {result} = renderHookWithProviders(useTraceMeta, {
-      organization: org,
-      initialProps: tracesWithoutTimestamp,
-    });
-
-    await waitFor(() => expect(result.current.status === 'success').toBe(true));
-
-    expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
-    expect(mockSlug1_90d).not.toHaveBeenCalled();
-    expect(getTraceMetaLogsCount(result.current.data)).toBe(3);
-  });
+      expect(mockSlug1_14d).toHaveBeenCalledTimes(1);
+      expect(mockSlug1_90d).not.toHaveBeenCalled();
+      expect(result.current.data).toEqual(expect.objectContaining({[countField]: 1}));
+    }
+  );
 
   it('Does not retry when all traces have timestamps', async () => {
     const org = OrganizationFixture({features: ['trace-spans-format']});

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -39,10 +39,23 @@ type TraceMetaQueryParams =
     };
 
 function isEmptyMeta(meta: TraceMeta | EAPTraceMeta): boolean {
+  if (isEAPTraceMeta(meta)) {
+    return (
+      meta.errorsCount === 0 &&
+      meta.logsCount === 0 &&
+      meta.metricsCount === 0 &&
+      meta.performanceIssuesCount === 0 &&
+      meta.spansCount === 0 &&
+      meta.uptimeCount === 0
+    );
+  }
+
   return (
-    getTraceMetaSpanCount(meta) === 0 &&
-    getTraceMetaErrorCount(meta) === 0 &&
-    getTraceMetaPerformanceIssueCount(meta) === 0
+    meta.errors === 0 &&
+    meta.performance_issues === 0 &&
+    meta.projects === 0 &&
+    meta.span_count === 0 &&
+    meta.transactions === 0
   );
 }
 

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -41,21 +41,20 @@ type TraceMetaQueryParams =
 function isEmptyMeta(meta: TraceMeta | EAPTraceMeta): boolean {
   if (isEAPTraceMeta(meta)) {
     return (
-      meta.errorsCount === 0 &&
-      meta.logsCount === 0 &&
-      meta.metricsCount === 0 &&
-      meta.performanceIssuesCount === 0 &&
-      meta.spansCount === 0 &&
-      meta.uptimeCount === 0
+      getTraceMetaErrorCount(meta) === 0 &&
+      getTraceMetaLogsCount(meta) === 0 &&
+      getTraceMetaMetricsCount(meta) === 0 &&
+      getTraceMetaPerformanceIssueCount(meta) === 0 &&
+      getTraceMetaSpanCount(meta) === 0 &&
+      getTraceMetaUptimeCount(meta) === 0
     );
   }
 
   return (
-    meta.errors === 0 &&
-    meta.performance_issues === 0 &&
-    meta.projects === 0 &&
-    meta.span_count === 0 &&
-    meta.transactions === 0
+    getTraceMetaErrorCount(meta) === 0 &&
+    getTraceMetaPerformanceIssueCount(meta) === 0 &&
+    getTraceMetaSpanCount(meta) === 0 &&
+    getTraceMetaTransactionCount(meta) === 0
   );
 }
 


### PR DESCRIPTION
The trace metadata fallback now considers all meaningful counts before deciding that a stats-period response is empty. Previously, EAP responses containing logs only—such as `logsCount: 3` with zero spans, errors, and performance issues—were incorrectly retried over 90 days. Legacy metadata also now accounts for project and transaction counts.

Adds regression coverage proving that a valid logs-only 14-day EAP response does not trigger the wider-window request.
