### PR TITLE
fix(issue-search): Run native progress path when date_to is now

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1312,8 +1312,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         # in-memory path degrades to a plain last_seen sort.
         #
         # Skip when Snuba is needed for correctness: an environment scope (env-scoped values
-        # live in Snuba) or a past upper bound (native_upper_bound_ok). Both are constant
-        # across a search's pages, so cursors stay comparable.
+        # live in Snuba) or a past upper bound (see native_upper_bound_ok).
         if (
             strategy.native_order_by is not None
             and not has_snuba_filters
@@ -1495,6 +1494,8 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         # The native path bounds only by Group.last_seen (a global max, never in the future),
         # so it's correct for any upper bound at/after now. The endpoint always sends
         # date_to=now, so gate on "not in the past" (within clock fuzz), not "no bound at all".
+        # (A caller pinning an absolute end near now could flip this across pages as now
+        # advances; the default stream recomputes end=now each request, so it stays stable.)
         native_upper_bound_ok = end is None or end >= now - ALLOWED_FUTURE_DELTA
 
         allow_postgres_only_search = False

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1279,7 +1279,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         actor: Any | None,
         start: datetime,
         end: datetime,
-        allow_postgres_only_search: bool,
+        native_upper_bound_ok: bool,
         aggregate_kwargs: TrendsSortWeights | None = None,
         *,
         referrer: str,
@@ -1311,19 +1311,14 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         # memory. Lifts the max-candidates cap for the common issue-stream case, past which the
         # in-memory path degrades to a plain last_seen sort.
         #
-        # Gated to queries Snuba isn't needed to answer correctly:
-        # - no environment scoping: env filtering and env-scoped values live in Snuba; the
-        #   Postgres queryset only has lifetime GroupEnvironment membership, not window scoping.
-        # - no explicit upper time bound (allow_postgres_only_search): Group.last_seen is the
-        #   issue's global max event time, not its max within [start, end], so a Postgres-only
-        #   window bound would wrongly drop issues with events both inside and after `end`.
-        # These gate on query filters (constant across a search's pages), so every page of a
-        # given search consistently uses one path — cursors stay comparable.
+        # Skip when Snuba is needed for correctness: an environment scope (env-scoped values
+        # live in Snuba) or a past upper bound (native_upper_bound_ok). Both are constant
+        # across a search's pages, so cursors stay comparable.
         if (
             strategy.native_order_by is not None
             and not has_snuba_filters
             and not environments
-            and allow_postgres_only_search
+            and native_upper_bound_ok
             and _has_derived_progress(actor, projects)
         ):
             with start_span(
@@ -1497,6 +1492,11 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         if end_params:
             end = min(end_params)
 
+        # The native path bounds only by Group.last_seen (a global max, never in the future),
+        # so it's correct for any upper bound at/after now. The endpoint always sends
+        # date_to=now, so gate on "not in the past" (within clock fuzz), not "no bound at all".
+        native_upper_bound_ok = end is None or end >= now - ALLOWED_FUTURE_DELTA
+
         allow_postgres_only_search = False
         if not end:
             end = now + ALLOWED_FUTURE_DELTA
@@ -1547,7 +1547,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 actor=actor,
                 start=start,
                 end=end,
-                allow_postgres_only_search=allow_postgres_only_search,
+                native_upper_bound_ok=native_upper_bound_ok,
                 aggregate_kwargs=aggregate_kwargs,
                 referrer=referrer,
             )

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -212,6 +212,34 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
             response = self.get_success_response(sort="progress", query="is:unresolved")
         assert [item["id"] for item in response.data] == [str(group_2.id), str(group_1.id)]
 
+    def test_sort_by_progress_over_cap_uses_native_ordering(self) -> None:
+        # End-to-end guard for the native (cap-free) progress path. Reproduces the prod request
+        # exactly: real endpoint (which always sends date_to=now), derived-progress flag on, and
+        # over the candidate cap. Must rank by progress, not fall back to recency.
+        group_1 = self.store_event(
+            data={"timestamp": before_now(seconds=1).isoformat(), "fingerprint": ["group-1"]},
+            project_id=self.project.id,
+        ).group
+        group_2 = self.store_event(
+            data={"timestamp": before_now(hours=1).isoformat(), "fingerprint": ["group-2"]},
+            project_id=self.project.id,
+        ).group
+        # group_2 is older (loses recency) but fix_applied (wins progress).
+        self.create_group_derived_data(group=group_2, progress="fix_applied")
+        self.login_as(user=self.user)
+
+        with (
+            self.options({"snuba.search.max-pre-snuba-candidates": 0}),
+            self.feature(
+                [
+                    "organizations:issue-stream-progress-sort",
+                    "projects:issue-stream-derived-progress",
+                ]
+            ),
+        ):
+            response = self.get_success_response(sort="progress", query="is:unresolved")
+        assert [item["id"] for item in response.data] == [str(group_2.id), str(group_1.id)]
+
     def test_recommended_sort_serves_v2_with_experimental_flag(self) -> None:
         # group_1 has the newer event, so it wins the base recommended score (recency);
         # group_2 is regressed, which only the v2 scorer boosts.

--- a/tests/snuba/search/test_postgres_sort_framework.py
+++ b/tests/snuba/search/test_postgres_sort_framework.py
@@ -350,7 +350,7 @@ class TestFallbackBehavior(PostgresSortTestBase):
                 actor=None,
                 start=before_now(days=90),
                 end=timezone.now(),
-                allow_postgres_only_search=False,
+                native_upper_bound_ok=True,
                 referrer=Referrer.TESTING_TEST.value,
             )
             assert result is None
@@ -679,6 +679,17 @@ class TestProgressSort(PostgresSortTestBase):
         )
         assert self.groups[2] not in set(results)
         assert set(results) == {self.groups[0], self.groups[1]}
+
+    @with_feature("projects:issue-stream-derived-progress")
+    @override_options({"snuba.search.max-pre-snuba-candidates": 0})
+    def test_date_to_now_uses_native_path(self):
+        # The issue-stream endpoint always sends date_to=now. That is not a restrictive bound
+        # (last_seen can't exceed now), so the native path must still run and rank by progress
+        # rather than falling back to recency.
+        self.create_group_derived_data(group=self.groups[0], progress="fix_applied")
+        results = list(self.make_query(sort_by="progress", date_to=timezone.now()))
+        # Progress order: groups[0] (fix_applied) first, then identified by recency.
+        assert results == [self.groups[0], self.groups[2], self.groups[1]]
 
     @override_options({"snuba.search.max-pre-snuba-candidates": 0})
     def test_snuba_filter_over_cap_does_not_use_native_ordering(self):


### PR DESCRIPTION
Sorting the issue stream by Progress silently returned issues in Last Seen (recency) order once a project exceeded the pre-Snuba candidate cap, instead of ranking by fix-cycle progress. This fix makes the native cap-free progress ordering actually run for the default stream.

## Root cause

The native path was gated on `allow_postgres_only_search`, which is only true when a request carries no upper time bound at all. The issue-stream endpoint always sends `date_to=now`, so the gate was never satisfied in production — over the candidate cap, progress fell through to the `last_seen` sort.

`date_to=now` is not a restrictive bound: `Group.last_seen` can never exceed now, so the Postgres-only ordering excludes nothing Snuba would keep. The gate now allows the native path whenever the upper bound is not in the past (`end >= now - ALLOWED_FUTURE_DELTA`). A genuinely past `date_to` still routes to Snuba, which scopes the event window correctly.

## Regression coverage

`test_sort_by_progress_over_cap_uses_native_ordering` exercises the real endpoint with both flags enabled, over the candidate cap, and no date params — the production request shape that the previous tests missed by calling the search backend with `date_to=None` directly. It asserts progress ordering rather than recency, and fails against the previous gate.
