### PR TITLE
fix(profiling): Cap span query limit to API max of 100

### DIFF
--- a/static/app/utils/profiling/hooks/useTransactionAsSpans.tsx
+++ b/static/app/utils/profiling/hooks/useTransactionAsSpans.tsx
@@ -46,7 +46,7 @@ export function useTransactionAsSpans({
   const result = useSpans(
     {
       search,
-      limit: 1000,
+      limit: 100,
       fields: [
         SpanFields.TRACE,
         SpanFields.SPAN_ID,


### PR DESCRIPTION
## Summary

The continuous profile flamegraph page shows "No associated transaction found" in the Trace section. The `useTransactionAsSpans` hook was requesting `limit: 1000` spans, but the events API caps `per_page` at 100 for the spans dataset. This returned a 400 error, which surfaced as `isError=true` → "No associated transaction found."

Fix: `limit: 1000` → `limit: 100`.

Regression introduced in #112975 (Apr 28, 2026) — broken from day one.

### Before

<img width="2940" height="1776" alt="image" src="https://github.com/user-attachments/assets/e70962ad-ea5c-4da4-9fdd-5dfd6f9bd3d4" />

### After

<img width="1246" height="783" alt="Google Chrome 2026-07-20 10 34 40" src="https://github.com/user-attachments/assets/e906cda0-310c-4750-b160-8f9c922e8e7f" />


## Test plan

- [ ] Open a trace with a continuous profile (e.g. Android)
- [ ] Click through to the profile flamegraph from the Profiles tab
- [ ] Verify the Trace section shows the transaction spans instead of "No associated transaction found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)