### PR TITLE
ref(slack): Increase nudge frequency to 30% and remove weekly limit

### DIFF
--- a/src/sentry/integrations/slack/utils/nudge.py
+++ b/src/sentry/integrations/slack/utils/nudge.py
@@ -1,12 +1,10 @@
 import random
-from datetime import datetime, timezone
 
 import sentry_sdk
 
 from sentry import features
 from sentry.models.organization import Organization
 from sentry.utils import metrics
-from sentry.utils.cache import cache
 
 SLACK_NUDGE_METRIC = "slack.alert_nudge"
 
@@ -29,28 +27,10 @@ def should_send_nudge_block(
     if not features.has("organizations:slack-reinstall-nudge-on-issue-alert", organization):
         return False
 
-    # only 10% of the alerts should have the nudge blocks
-    if random.random() >= 0.1:
+    # only 30% of the alerts should have the nudge blocks
+    if random.random() >= 0.3:
         record_nudge_metric("skipped_random_check")
         return False
-
-    iso_year, iso_week, _ = datetime.now(timezone.utc).isocalendar()
-    cache_key = f"slack:alert_nudge:{channel_id}:{iso_year}:{iso_week}"
-
-    count = cache.get(cache_key, 0)
-    if count >= 4:
-        record_nudge_metric("skipped_weekly_limit")
-        return False
-
-    if count == 0:
-        cache.set(cache_key, 1, timeout=7 * 24 * 60 * 60)
-    else:
-        try:
-            cache.incr(cache_key)
-        except ValueError:
-            # The key may have been evicted/expired between the get and the
-            # incr; incr raises ValueError on a missing key, so fall back to set.
-            cache.set(cache_key, count + 1, timeout=7 * 24 * 60 * 60)
 
     # The "sent" metric is emitted at render time
     return True

--- a/tests/sentry/integrations/slack/utils/test_nudge.py
+++ b/tests/sentry/integrations/slack/utils/test_nudge.py
@@ -1,17 +1,10 @@
-from datetime import datetime, timezone
 from unittest.mock import patch
 
 from sentry.integrations.slack.utils.nudge import should_send_nudge_block
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.utils.cache import cache
 
 FEATURE_FLAG = "organizations:slack-reinstall-nudge-on-issue-alert"
-
-
-def cache_key(channel_id: str) -> str:
-    iso_year, iso_week, _ = datetime.now(timezone.utc).isocalendar()
-    return f"slack:alert_nudge:{channel_id}:{iso_year}:{iso_week}"
 
 
 class ShouldSendNudgeBlockTest(TestCase):
@@ -19,21 +12,17 @@ class ShouldSendNudgeBlockTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # By default make the 10% random gate pass; individual tests override this.
+        # By default make the 30% random gate pass; individual tests override this.
         patcher = patch("sentry.integrations.slack.utils.nudge.random.random", return_value=0.0)
         patcher.start()
         self.addCleanup(patcher.stop)
 
     def test_no_feature_flag(self) -> None:
-        # Feature flag off: never post, even though the random gate passes and the
-        # cache has plenty of room.
-        assert cache.get(cache_key(self.channel_id)) is None
+        # Feature flag off: never post, even though the random gate passes.
         assert (
             should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
             is False
         )
-        # We bailed before touching the cache.
-        assert cache.get(cache_key(self.channel_id)) is None
 
     @with_feature(FEATURE_FLAG)
     def test_random_gate_fails(self) -> None:
@@ -42,55 +31,10 @@ class ShouldSendNudgeBlockTest(TestCase):
                 should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
                 is False
             )
-        assert cache.get(cache_key(self.channel_id)) is None
-
-    @with_feature(FEATURE_FLAG)
-    def test_cache_limit_reached(self) -> None:
-        # Already posted the max number of times for this channel this week.
-        cache.set(cache_key(self.channel_id), 4, timeout=7 * 24 * 60 * 60)
-        assert (
-            should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
-            is False
-        )
-        # Count is untouched (not incremented past the limit).
-        assert cache.get(cache_key(self.channel_id)) == 4
 
     @with_feature(FEATURE_FLAG)
     def test_posts_block(self) -> None:
-        assert cache.get(cache_key(self.channel_id)) is None
         assert (
             should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
             is True
         )
-        # Posting seeds the per-channel weekly counter.
-        assert cache.get(cache_key(self.channel_id)) == 1
-
-    @with_feature(FEATURE_FLAG)
-    def test_key_evicted_between_get_and_incr(self) -> None:
-        # The cached count says we've posted before (so we take the incr branch),
-        # but the key is evicted/expired before the incr runs. incr raises
-        # ValueError on a missing key; we must fall back to set rather than
-        # letting it propagate and drop the alert.
-        cache.set(cache_key(self.channel_id), 2, timeout=7 * 24 * 60 * 60)
-        with patch.object(cache, "incr", side_effect=ValueError("Key not found")):
-            assert (
-                should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
-                is True
-            )
-        # The fallback re-seeded the counter at count + 1.
-        assert cache.get(cache_key(self.channel_id)) == 3
-
-    @with_feature(FEATURE_FLAG)
-    def test_limit_is_per_channel(self) -> None:
-        # A different channel has hit the limit this week...
-        other_channel_id = "C9999999999"
-        cache.set(cache_key(other_channel_id), 4, timeout=7 * 24 * 60 * 60)
-
-        # ...but that must not block our channel (limit is per channel, not per org).
-        assert (
-            should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
-            is True
-        )
-        assert cache.get(cache_key(self.channel_id)) == 1
-        # The other channel's counter is unaffected.
-        assert cache.get(cache_key(other_channel_id)) == 4


### PR DESCRIPTION
We'd like to increase the number of slack nudges, as those channels that gets sent a lot of alerts will run out of quota really quickly, and we haven't seen the increase in slack app updates as much as we'd like to see.

So we've changed so 30% of alerts have nudges, and have removed the weekly limits.