### PR TITLE
fix(action_log): Include stack info in our missing context error

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -183,6 +183,7 @@ def publish_action_from_context(
         logger.error(
             "publish_action_from_context called without ActionContext",
             extra={"action": action.get_type().name.lower(), "group_id": str(group_id)},
+            stack_info=True,
         )
         source: str = ActionSource.UNKNOWN
         actor = SYSTEM_ACTOR
@@ -222,6 +223,7 @@ def publish_actions_from_context_bulk(
             extra={
                 "actions": [ap[0].get_type().name.lower() for ap in actions],
             },
+            stack_info=True,
         )
         source: str = ActionSource.UNKNOWN
         actor = SYSTEM_ACTOR


### PR DESCRIPTION
Each case of missing context is different, so it'd be nice to identify them easily and have them bucketed individually in Sentry.
