### PR TITLE
feat(seer): score smart-assignment predictions against ground truth

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -125,6 +125,9 @@ class ActivityManager(BaseManager["Activity"]):
     def create(self, **kwargs: Any) -> Activity:
         activity: Activity = super().create(**kwargs)
 
+        if not options.get("group_action_log.activity.double-write") and not in_test_environment():
+            return activity
+
         group_id = kwargs.get("group_id")
         if group_id is None:
             group = kwargs.get("group")
@@ -150,7 +153,8 @@ class ActivityManager(BaseManager["Activity"]):
 
     def bulk_create(self, *args: Any) -> list[Activity]:
         activities: list[Activity] = super().bulk_create(*args)
-
+        if not options.get("group_action_log.activity.double-write") and not in_test_environment():
+            return activities
         try:
             actions_with_activities = [
                 (activity_to_action(activity), activity) for activity in activities
@@ -300,3 +304,4 @@ class ActivityIntegration(Enum):
     MSTEAMS = IntegrationProviderSlug.MSTEAMS.value
     DISCORD = IntegrationProviderSlug.DISCORD.value
     SUSPECT_COMMITTER = "suspectCommitter"
+    SEER_SUGGESTED = "seerSuggested"

--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -26,6 +26,7 @@ SEER_FEATURE_ID = "smart_assignment"
 # Resolutions we treat as ground truth: a human resolving an issue is a signal for
 # who should have owned it.
 # SET_RESOLVED_BY_AGE is excluded (auto-resolve cron, no acting user, so no signal).
+# SET_RESOLVED_IN_PULL_REQUEST is excluded (it will trigger ASSIGNED in practice, which we already capture).
 # Other ground-truth activities include ASSIGNED and SEER_*_STARTED,
 # configured in workflow_activity_handlers.py
 RESOLUTION_ACTIVITIES = frozenset(
@@ -33,7 +34,6 @@ RESOLUTION_ACTIVITIES = frozenset(
         ActivityType.SET_RESOLVED,
         ActivityType.SET_RESOLVED_IN_RELEASE,
         ActivityType.SET_RESOLVED_IN_COMMIT,
-        ActivityType.SET_RESOLVED_IN_PULL_REQUEST,
     }
 )
 

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.db import router, transaction
+
+from sentry.models.activity import Activity, ActivityIntegration
+from sentry.models.group import Group
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.seer.models.run import SeerAgentRun
+from sentry.seer.smart_assignment.models import (
+    RESOLUTION_ACTIVITIES,
+    SEER_FEATURE_ID,
+    SmartAssignmentScore,
+)
+from sentry.types.activity import ActivityType
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+# How far down the ranked candidate list a correct name still earns a hit rank. The
+# agent delivers a short best-first list; a match past this is treated as a miss.
+HIT_RANK_LIMIT = 3
+
+
+def _get_run(group_id: int) -> SeerAgentRun | None:
+    """The canonical smart-assignment run mirror for a group (latest wins).
+
+    Dedup keeps this to one per group in practice; always picking the latest keeps the
+    prediction and ground-truth writers agreeing on the same row even in the rare case
+    a race dispatched more than one run, and matches the run Seer most recently
+    delivered against.
+    """
+    return (
+        SeerAgentRun.objects.filter(group_id=group_id, source=SEER_FEATURE_ID)
+        .select_related("run")
+        .order_by("-date_added")
+        .first()
+    )
+
+
+def record_prediction(group_id: int, predicted_assignee_user_ids: list[int | None]) -> None:
+    """Record the delivered ranked picks (best-first, each resolved to a user) on the
+    run mirror, then score if the ground truth already landed. A position we couldn't
+    map to an org user is stored as ``None`` so each candidate keeps its rank; an
+    empty list means the agent abstained. Stored so we don't re-treat the run as
+    undelivered, but never scored on its own -- scoring waits for ground truth."""
+    run = _get_run(group_id)
+    if run is None:
+        return
+    _apply(run.id, {"predicted_assignee_user_ids": predicted_assignee_user_ids})
+
+
+def record_ground_truth(
+    group: Group,
+    activity_type: ActivityType,
+    activity: Activity | None = None,
+) -> None:
+    """Record who the issue actually belonged to on the run mirror, then score.
+
+    No-op if no run was dispatched for the group, or the outcome carries no useful
+    signal: a Seer AI-step start, an automatic resolution with no acting user, or our
+    own auto-assignment (tagged with the ``SEER_SUGGESTED`` integration by
+    ProjectOwnership.handle_auto_assignment, which would score us against ourselves).
+    For an assignment we mirror the current assignee (user and/or team). For a
+    user-driven resolution we record the resolver as the assumed assignee only when no
+    explicit assignee has been recorded -- an assignment is better truth.
+    """
+    run = _get_run(group.id)
+    if run is None:
+        return
+
+    updates: dict[str, Any] = {}
+    if activity_type == ActivityType.ASSIGNED:
+        if (
+            activity is not None
+            and (activity.data or {}).get("integration") == ActivityIntegration.SEER_SUGGESTED.value
+        ):
+            return
+        assignee = GroupAssignee.objects.filter(group=group).first()
+        if assignee is None:
+            return
+        updates["actual_assignee_user_id"] = assignee.user_id
+        updates["actual_assignee_team_id"] = assignee.team_id
+    elif activity_type in RESOLUTION_ACTIVITIES:
+        if activity is None or activity.user_id is None:
+            return
+        if (run.extras or {}).get("actual_assignee_user_id") is not None:
+            # An explicit assignee is better ground truth than the resolver.
+            return
+        updates["actual_assignee_user_id"] = activity.user_id
+    else:
+        return
+
+    updates["ground_truth_source"] = activity_type.name
+    _apply(run.id, updates)
+    metrics.incr("smart_assignment.ground_truth.recorded", tags={"trigger": activity_type.name})
+
+
+def _apply(run_id: int, updates: dict[str, Any]) -> None:
+    """Merge `updates` into the run mirror's extras under a row lock and, if that
+    completes the (prediction, ground truth) pair, emit `smart_assignment.scored`
+    once. The lock serializes the prediction and ground-truth writers so neither a
+    lost update nor a double emit is possible."""
+    with transaction.atomic(using=router.db_for_write(SeerAgentRun)):
+        run = SeerAgentRun.objects.select_for_update().select_related("run").get(id=run_id)
+        extras = dict(run.extras or {})
+        if extras.get("result"):
+            # The row is a terminal snapshot once scored. Applying later prediction or
+            # ground-truth updates would drift the mirrored fields away from what we
+            # actually scored against, leaving `result`/`hit_rank` inconsistent.
+            return
+        extras.update(updates)
+        result, hit_rank = _score(run.run.organization_id, extras)
+        if result is not None:
+            extras["result"] = str(result)
+            extras["hit_rank"] = hit_rank
+        run.extras = extras
+        run.save(update_fields=["extras"])
+
+    if result is not None:
+        metrics.incr(
+            "smart_assignment.scored",
+            tags={"result": str(result), "hit_rank": hit_rank, "trigger": extras.get("trigger")},
+        )
+
+
+def _score(
+    organization_id: int, extras: dict[str, Any]
+) -> tuple[SmartAssignmentScore | None, int | None]:
+    """Grade the ranked predictions in `extras` against the ground truth, returning the
+    top pick's coarse outcome paired with the 1-based rank at which the actual assignee
+    appears (capped at `HIT_RANK_LIMIT`, None if they aren't among those top picks so a
+    correct-but-not-top name still counts for something). None if the pair isn't
+    complete yet or it's already been scored."""
+    if extras.get("result"):
+        return None, None
+    predicted_user_ids = extras.get("predicted_assignee_user_ids") or []
+    actual_user_id = extras.get("actual_assignee_user_id")
+    actual_team_id = extras.get("actual_assignee_team_id")
+    if not predicted_user_ids:
+        return None, None
+    if actual_user_id is None and actual_team_id is None:
+        return None, None
+
+    hit_rank: int | None = None
+    if actual_user_id is not None:
+        for rank, user_id in enumerate(predicted_user_ids[:HIT_RANK_LIMIT], start=1):
+            if user_id == actual_user_id:
+                hit_rank = rank
+                break
+
+    # A top pick we couldn't resolve to an org user (None) can't be EXACT or TEAM, so
+    # it's a miss -- but a lower-ranked candidate may still have named the assignee,
+    # which `hit_rank` records.
+    predicted_user_id = predicted_user_ids[0]
+    if predicted_user_id is not None:
+        if predicted_user_id == actual_user_id:
+            return SmartAssignmentScore.EXACT, hit_rank
+        if _is_team_match(organization_id, predicted_user_id, actual_user_id, actual_team_id):
+            return SmartAssignmentScore.TEAM, hit_rank
+    return SmartAssignmentScore.MISS, hit_rank
+
+
+def _user_team_ids(organization_id: int, user_id: int) -> set[int]:
+    return set(
+        OrganizationMemberTeam.objects.filter(
+            is_active=True,
+            organizationmember__organization_id=organization_id,
+            organizationmember__user_id=user_id,
+        ).values_list("team_id", flat=True)
+    )
+
+
+def _correct_team_ids(
+    organization_id: int, actual_user_id: int | None, actual_team_id: int | None
+) -> set[int]:
+    """The team(s) a correct prediction could belong to for this ground truth."""
+    if actual_team_id is not None:
+        return {actual_team_id}
+    if actual_user_id is not None:
+        return _user_team_ids(organization_id, actual_user_id)
+    return set()
+
+
+def _is_team_match(
+    organization_id: int,
+    predicted_user_id: int,
+    actual_user_id: int | None,
+    actual_team_id: int | None,
+) -> bool:
+    """Whether the predicted user is on a team the ground truth points at."""
+    correct_team_ids = _correct_team_ids(organization_id, actual_user_id, actual_team_id)
+    if not correct_team_ids:
+        return False
+    return bool(_user_team_ids(organization_id, predicted_user_id) & correct_team_ids)

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -15,6 +15,7 @@ from sentry.seer.smart_assignment.models import (
     SEER_FEATURE_ID,
     SmartAssignmentPayload,
 )
+from sentry.seer.smart_assignment.scoring import record_ground_truth
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 
@@ -31,15 +32,16 @@ def trigger_smart_assignment(
     activity_type: ActivityType,
     activity: Activity | None = None,
 ) -> None:
-    """Gate + dispatch a prediction for `group`.
+    """Gate + dispatch a prediction for `group`, and record ground truth.
 
-    Dispatches a Seer run the first time (deduped to one run per group, and subject
-    to per-org / global daily caps). `activity_type` is what triggered us (a Seer AI
-    step starting, an assignment, or a resolution); `activity` is the triggering
-    activity, stamped with a pointer to the run it kicked off. No-op unless the org
-    is flagged. Automatic resolutions (no acting user, e.g. resolved by age) are
-    skipped entirely -- we only treat a resolution as signal when a human resolved
-    the issue, since then they probably should have been the assignee.
+    to per-org / global daily caps); records the observed ground truth for assignment
+    and resolution activities either way. Note the caps only gate new dispatches --
+    ground truth is still recorded for already-predicted issues. `activity_type` is
+    what triggered us; `activity` is the triggering activity (stamped with a pointer
+    to the run, and for a resolution supplies the resolving user). No-op unless the
+    org is flagged. Automatic resolutions (no acting user, e.g. resolved by age) are
+    skipped entirely -- we only treat a resolution as signal when a human resolved the
+    issue, since then they probably should have been the assignee.
     """
     organization = group.organization
 
@@ -57,6 +59,8 @@ def trigger_smart_assignment(
     # is our durable record that a run was dispatched.
     if not _already_predicted(group) and not _dispatch_rate_limited(organization):
         _dispatch(group, activity_type, activity)
+
+    record_ground_truth(group, activity_type, activity)
 
 
 def _already_predicted(group: Group) -> bool:

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -1,0 +1,282 @@
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from sentry.models.activity import Activity, ActivityIntegration
+from sentry.models.group import Group
+from sentry.models.groupassignee import GroupAssignee
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
+from sentry.seer.smart_assignment.scoring import (
+    record_ground_truth,
+    record_prediction,
+)
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+METRICS_PATH = "sentry.seer.smart_assignment.scoring.metrics"
+
+# A representative dispatch trigger (a Seer AI-step start): its ActivityType name is
+# what gets seeded on the run mirror's `extras["trigger"]`.
+STARTED = ActivityType.SEER_RCA_STARTED
+
+
+class ScoringTestBase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+
+    def _run(
+        self, group: Group | None = None, trigger: str = STARTED.name, **extras
+    ) -> SeerAgentRun:
+        seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        return SeerAgentRun.objects.create(
+            run=seer_run,
+            source=SEER_FEATURE_ID,
+            group=group or self.group,
+            extras={"trigger": trigger, **extras},
+        )
+
+
+class RecordPredictionScoringTest(ScoringTestBase):
+    def _assert_result(
+        self, mock_metrics: MagicMock, expected: str, hit_rank: int | None = None
+    ) -> None:
+        mock_metrics.incr.assert_called_once_with(
+            "smart_assignment.scored",
+            tags={"result": expected, "hit_rank": hit_rank, "trigger": STARTED.name},
+        )
+
+    @patch(METRICS_PATH)
+    def test_exact_when_prediction_matches_user(self, mock_metrics: MagicMock) -> None:
+        user = self.create_user()
+        run = self._run(actual_assignee_user_id=user.id)
+        record_prediction(self.group.id, [user.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.EXACT, hit_rank=1)
+        run.refresh_from_db()
+        assert run.extras["result"] == SmartAssignmentScore.EXACT
+        assert run.extras["hit_rank"] == 1
+
+    @patch(METRICS_PATH)
+    def test_team_when_predicted_user_on_assigned_team(self, mock_metrics: MagicMock) -> None:
+        team = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team])
+        self._run(actual_assignee_team_id=team.id)
+        record_prediction(self.group.id, [alice.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.TEAM)
+
+    @patch(METRICS_PATH)
+    def test_team_when_predicted_shares_team_with_actual_user(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        team = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        bob = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team])
+        self.create_member(user=bob, organization=self.organization, teams=[team])
+        self._run(actual_assignee_user_id=bob.id)
+        record_prediction(self.group.id, [alice.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.TEAM)
+
+    @patch(METRICS_PATH)
+    def test_miss_when_no_team_overlap(self, mock_metrics: MagicMock) -> None:
+        team_a = self.create_team(organization=self.organization)
+        team_b = self.create_team(organization=self.organization)
+        alice = self.create_user()
+        bob = self.create_user()
+        self.create_member(user=alice, organization=self.organization, teams=[team_a])
+        self.create_member(user=bob, organization=self.organization, teams=[team_b])
+        self._run(actual_assignee_user_id=bob.id)
+        record_prediction(self.group.id, [alice.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS)
+
+    @patch(METRICS_PATH)
+    def test_hit_rank_when_actual_is_lower_candidate(self, mock_metrics: MagicMock) -> None:
+        # Top pick is wrong (and shares no team with the actual assignee, so it's a
+        # miss), but the actual assignee is the second-ranked candidate -- still a hit.
+        alice = self.create_user()
+        bob = self.create_user()
+        self._run(actual_assignee_user_id=bob.id)
+        record_prediction(self.group.id, [alice.id, bob.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=2)
+
+    @patch(METRICS_PATH)
+    def test_no_hit_rank_when_actual_absent_from_candidates(self, mock_metrics: MagicMock) -> None:
+        alice = self.create_user()
+        bob = self.create_user()
+        self._run(actual_assignee_user_id=bob.id)
+        record_prediction(self.group.id, [alice.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=None)
+
+    @patch(METRICS_PATH)
+    def test_unresolved_top_pick_is_miss_but_lower_candidate_still_hits(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # Top pick couldn't be mapped to an org user (None), so the coarse outcome is a
+        # miss, but the actual assignee is the rank-2 candidate -- still a hit.
+        bob = self.create_user()
+        self._run(actual_assignee_user_id=bob.id)
+        record_prediction(self.group.id, [None, bob.id])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=2)
+
+    @patch(METRICS_PATH)
+    def test_unresolved_top_pick_alone_is_miss(self, mock_metrics: MagicMock) -> None:
+        bob = self.create_user()
+        self._run(actual_assignee_user_id=bob.id)
+        record_prediction(self.group.id, [None])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=None)
+
+    @patch(METRICS_PATH)
+    def test_unresolved_top_pick_with_team_truth_is_miss(self, mock_metrics: MagicMock) -> None:
+        # Team-only ground truth with an unresolved top pick must not read as an EXACT
+        # match on the None == None comparison.
+        team = self.create_team(organization=self.organization)
+        self._run(actual_assignee_team_id=team.id)
+        record_prediction(self.group.id, [None])
+
+        self._assert_result(mock_metrics, SmartAssignmentScore.MISS, hit_rank=None)
+
+    @patch(METRICS_PATH)
+    def test_noop_without_both_sides(self, mock_metrics: MagicMock) -> None:
+        # Prediction but no ground truth yet.
+        self._run()
+        record_prediction(self.group.id, [7])
+        # Ground truth but no (resolvable) prediction (separate group).
+        other = self.create_group()
+        self._run(group=other, actual_assignee_user_id=9)
+        record_prediction(other.id, [])
+        mock_metrics.incr.assert_not_called()
+
+    @patch(METRICS_PATH)
+    def test_scores_only_once(self, mock_metrics: MagicMock) -> None:
+        user = self.create_user()
+        self._run(actual_assignee_user_id=user.id)
+        record_prediction(self.group.id, [user.id])
+        record_prediction(self.group.id, [user.id])
+        assert mock_metrics.incr.call_count == 1
+
+    @patch(METRICS_PATH)
+    def test_noop_without_run(self, mock_metrics: MagicMock) -> None:
+        record_prediction(self.group.id, [7])
+        mock_metrics.incr.assert_not_called()
+
+
+class RecordGroundTruthTest(ScoringTestBase):
+    def _resolved_activity(self, user_id: int | None = None) -> Activity:
+        return self.create_group_activity(
+            group=self.group, type=ActivityType.SET_RESOLVED.value, user_id=user_id
+        )
+
+    def test_noop_without_run(self) -> None:
+        record_ground_truth(
+            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(self.user.id)
+        )
+        assert not SeerAgentRun.objects.filter(
+            group_id=self.group.id, source=SEER_FEATURE_ID
+        ).exists()
+
+    def test_records_assignee_user(self) -> None:
+        run = self._run()
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        record_ground_truth(self.group, ActivityType.ASSIGNED)
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_user_id"] == assignee.id
+        assert run.extras["ground_truth_source"] == ActivityType.ASSIGNED.name
+
+    def test_resolution_keeps_existing_team_and_adds_resolver(self) -> None:
+        team = self.create_team(organization=self.organization)
+        run = self._run(actual_assignee_team_id=team.id)
+        resolver = self.create_user()
+        record_ground_truth(
+            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+        )
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_user_id"] == resolver.id
+        # A user-driven resolution shouldn't wipe a prior team assignee.
+        assert run.extras["actual_assignee_team_id"] == team.id
+
+    def test_automatic_resolution_is_noop(self) -> None:
+        run = self._run()
+        record_ground_truth(self.group, ActivityType.SET_RESOLVED, self._resolved_activity(None))
+
+        run.refresh_from_db()
+        assert "actual_assignee_user_id" not in run.extras
+        assert "ground_truth_source" not in run.extras
+
+    def test_seer_start_is_noop(self) -> None:
+        run = self._run()
+        record_ground_truth(self.group, ActivityType.SEER_RCA_STARTED)
+
+        run.refresh_from_db()
+        assert "ground_truth_source" not in run.extras
+
+    def test_our_auto_assignment_is_not_recorded(self) -> None:
+        run = self._run()
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={
+                "assignee": str(assignee.id),
+                "assigneeType": "user",
+                "integration": ActivityIntegration.SEER_SUGGESTED.value,
+            },
+        )
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert "actual_assignee_user_id" not in run.extras
+        assert "ground_truth_source" not in run.extras
+
+    @patch(METRICS_PATH)
+    def test_records_ground_truth_scores_existing_prediction(self, mock_metrics: MagicMock) -> None:
+        # Prediction already delivered; recording the matching assignment as ground
+        # truth completes the pair and scores it exact (tagged with the dispatch
+        # trigger, not the ground-truth event).
+        assignee = self.create_user()
+        self._run(predicted_assignee_user_ids=[assignee.id])
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        record_ground_truth(self.group, ActivityType.ASSIGNED)
+
+        mock_metrics.incr.assert_any_call(
+            "smart_assignment.scored",
+            tags={"result": SmartAssignmentScore.EXACT, "hit_rank": 1, "trigger": STARTED.name},
+        )
+
+    def test_resolution_does_not_overwrite_existing_assignee(self) -> None:
+        assignee = self.create_user()
+        run = self._run(
+            actual_assignee_user_id=assignee.id,
+            ground_truth_source=ActivityType.ASSIGNED.name,
+        )
+        resolver = self.create_user()
+        record_ground_truth(
+            self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+        )
+
+        run.refresh_from_db()
+        assert run.extras["actual_assignee_user_id"] == assignee.id
+        assert run.extras["ground_truth_source"] == ActivityType.ASSIGNED.name

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from django.utils import timezone
 
 from sentry.models.activity import Activity
+from sentry.models.groupassignee import GroupAssignee
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
 from sentry.seer.smart_assignment.trigger import trigger_smart_assignment
@@ -20,7 +21,7 @@ class TriggerSmartAssignmentTest(TestCase):
     def _wire_client(self, mock_client_cls: MagicMock) -> None:
         """Make start_feature_run create the SeerAgentRun mirror the real client
         would (source=SEER_FEATURE_ID, the group, and the seeded extras) and return the
-        SeerRun -- so dedup sees a realistic run."""
+        SeerRun -- so dedup and scoring see a realistic run."""
 
         def fake_start(**kwargs: object) -> SeerRun:
             run = SeerRun.objects.create(
@@ -85,6 +86,50 @@ class TriggerSmartAssignmentTest(TestCase):
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)
+    def test_assignment_dispatches_and_records_user(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(self.group, ActivityType.ASSIGNED)
+
+        mirrors = self._mirrors()
+        assert len(mirrors) == 1
+        extras = mirrors[0].extras
+        assert extras["trigger"] == ActivityType.ASSIGNED.name
+        assert extras["actual_assignee_user_id"] == assignee.id
+        assert extras["actual_assignee_team_id"] is None
+        assert extras["ground_truth_source"] == ActivityType.ASSIGNED.name
+
+    @patch(CLIENT_PATH)
+    def test_assignment_records_team(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        team = self.create_team(organization=self.organization)
+        GroupAssignee.objects.create(group=self.group, project=self.group.project, team=team)
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(self.group, ActivityType.ASSIGNED)
+
+        extras = self._mirrors()[0].extras
+        assert extras["actual_assignee_team_id"] == team.id
+        assert extras["actual_assignee_user_id"] is None
+
+    @patch(CLIENT_PATH)
+    def test_user_resolution_records_resolver_as_assignee(self, mock_client_cls: MagicMock) -> None:
+        self._wire_client(mock_client_cls)
+        resolver = self.create_user()
+        with self.feature("organizations:seer-smart-assignment-run"):
+            trigger_smart_assignment(
+                self.group, ActivityType.SET_RESOLVED, self._resolved_activity(resolver.id)
+            )
+
+        extras = self._mirrors()[0].extras
+        assert extras["trigger"] == ActivityType.SET_RESOLVED.name
+        assert extras["actual_assignee_user_id"] == resolver.id
+        assert extras["ground_truth_source"] == ActivityType.SET_RESOLVED.name
+
+    @patch(CLIENT_PATH)
     def test_dispatch_stamps_triggering_activity(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
         activity = self.create_group_activity(
@@ -124,6 +169,31 @@ class TriggerSmartAssignmentTest(TestCase):
             trigger_smart_assignment(self.group, ActivityType.SEER_RCA_STARTED)
 
         assert self._mirrors() == []
+        mock_client_cls.return_value.start_feature_run.assert_not_called()
+
+    @patch(CLIENT_PATH)
+    def test_rate_limit_still_records_ground_truth(self, mock_client_cls: MagicMock) -> None:
+        # An issue predicted earlier still gets ground truth even once caps are
+        # exhausted -- the caps only gate new dispatches.
+        self._mirror(trigger=ActivityType.SEER_RCA_STARTED.name)
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        with (
+            self.feature("organizations:seer-smart-assignment-run"),
+            self.options(
+                {
+                    "seer.smart_assignment.max_dispatches_per_org_per_day": 0,
+                    "seer.smart_assignment.max_dispatches_per_day": 0,
+                }
+            ),
+        ):
+            trigger_smart_assignment(self.group, ActivityType.ASSIGNED)
+
+        extras = self._mirrors()[0].extras
+        assert extras["actual_assignee_user_id"] == assignee.id
+        assert extras["ground_truth_source"] == ActivityType.ASSIGNED.name
         mock_client_cls.return_value.start_feature_run.assert_not_called()
 
     @patch(CLIENT_PATH)


### PR DESCRIPTION
## Summary
First of a 3-PR stack splitting the smart-assignment delivery/scoring work.

- Adds the scoring engine (`scoring.py`): mirrors delivered ranked predictions and observed ground truth onto the Seer run, and grades the top pick (EXACT / TEAM / MISS + hit-rank) once both sides land, under a row lock so there's no lost update or double emit.
- Records ground truth (assignment / user-driven resolution) from the smart-assignment trigger path.
- Stops treating `SET_RESOLVED_IN_PULL_REQUEST` as a resolution signal (it triggers `ASSIGNED` in practice, which we already capture).
- Adds `ActivityIntegration.SEER_SUGGESTED` so ground-truth capture can skip our own auto-assignment (used by the next PR).

## Stack
1. **this PR** — scoring (base: `master`)
2. suggested assignment (base: `sa-scoring`)
3. delivery (base: `sa-suggested-assignment`)

## Test plan
- [ ] `pytest tests/sentry/seer/smart_assignment/test_scoring.py tests/sentry/seer/smart_assignment/test_trigger.py`

Made with [Cursor](https://cursor.com)