### PR TITLE
feat(seer): suggest and auto-assign from smart-assignment verdicts

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -251,8 +251,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Run the Seer smart assignment feature (predictions + ground truth) on issues
     manager.add("organizations:seer-smart-assignment-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Send notifications for Seer smart assignment predictions
-    manager.add("organizations:seer-smart-assignment-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Auto-assign the top Seer smart assignment pick when a verdict is delivered
+    manager.add("organizations:seer-smart-assignment-auto-assign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display nightshift settings
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Roll out structured LLM page context on STRUCTURED_CONTEXT_ROUTES to all orgs
@@ -424,6 +424,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable alerting on trace metrics
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable equations for trace metrics in alerts
+    manager.add("organizations:tracemetrics-equations-in-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable equations in trace metrics explore
+    manager.add("organizations:tracemetrics-equations-in-explore", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable equations for trace metrics in dashboards
+    manager.add("organizations:tracemetrics-equations-in-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics product to be ingested via Relay
     manager.add("organizations:tracemetrics-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics multi-metric selection in dashboards
@@ -491,9 +497,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:relay-minidump-uploads", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables the uploading of playstation attachments to the objectstore.
     manager.add("projects:relay-playstation-uploads", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enables uploading streams to objectstore via multipart uploads.
-    # See <https://getsentry.github.io/objectstore/rust/objectstore_service/multipart/>.
-    manager.add("projects:relay-upload-multipart", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Allows sending additional stack traces with minidumps.
+    manager.add("projects:minidump-multi-exception", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     # Enable lightweight RCA clustering write path (generate embeddings on new issues)
     manager.add("organizations:supergroups-lightweight-rca-clustering-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -35,6 +35,7 @@ class GroupOwnerType(Enum):
     SUSPECT_COMMIT = 0
     OWNERSHIP_RULE = 1
     CODEOWNERS = 2
+    SEER_SUGGESTED = 3
 
 
 class OwnerRuleType(Enum):
@@ -46,6 +47,7 @@ GROUP_OWNER_TYPE = {
     GroupOwnerType.SUSPECT_COMMIT: "suspectCommit",
     GroupOwnerType.OWNERSHIP_RULE: "ownershipRule",
     GroupOwnerType.CODEOWNERS: "codeowners",
+    GroupOwnerType.SEER_SUGGESTED: "seerSuggested",
 }
 
 

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -251,7 +251,11 @@ class ProjectOwnership(Model):
 
         if ownership.auto_assignment:
             autoassignment_types.extend(
-                [GroupOwnerType.OWNERSHIP_RULE.value, GroupOwnerType.CODEOWNERS.value]
+                [
+                    GroupOwnerType.OWNERSHIP_RULE.value,
+                    GroupOwnerType.CODEOWNERS.value,
+                    GroupOwnerType.SEER_SUGGESTED.value,
+                ]
             )
         return autoassignment_types
 
@@ -330,6 +334,8 @@ class ProjectOwnership(Model):
             elif issue_owner.type == GroupOwnerType.OWNERSHIP_RULE.value:
                 activity_details["integration"] = ActivityIntegration.PROJECT_OWNERSHIP.value
                 activity_details["rule"] = (issue_owner.context or {}).get("rule", "")
+            elif issue_owner.type == GroupOwnerType.SEER_SUGGESTED.value:
+                activity_details["integration"] = ActivityIntegration.SEER_SUGGESTED.value
             else:
                 activity_details["integration"] = ActivityIntegration.CODEOWNERS.value
                 activity_details["rule"] = (issue_owner.context or {}).get("rule", "")

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+
+from django.utils import timezone
+
+from sentry import features
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.projectownership import ProjectOwnership
+from sentry.seer.smart_assignment.scoring import record_prediction
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+AUTO_ASSIGN_FEATURE_FLAG = "organizations:seer-smart-assignment-auto-assign"
+
+
+def process_smart_assignment_completion(group: Group, activity: Activity) -> None:
+    """Score and act on the delivered prediction.
+
+    Reads the ranked, org-resolved candidate user ids (best-first, `None` for a rank we
+    couldn't map to an org user) that delivery stashed on the activity. Scoring is
+    internal bookkeeping and always runs (it no-ops until ground truth lands); acting on
+    the verdict is a single user-facing step gated behind the feature flag.
+    """
+    data = activity.data or {}
+    predicted_assignee_user_ids: list[int | None] = data.get("predicted_assignee_user_ids") or []
+
+    # Mirror the ranked predictions onto the run; scores immediately if ground truth
+    # already landed (assignment before Seer finished), otherwise waits for it. This is
+    # not user-facing, so it runs regardless of the feature flag.
+    record_prediction(group.id, predicted_assignee_user_ids)
+
+    _apply_prediction(group, predicted_assignee_user_ids, run_uuid=data.get("run_uuid"))
+
+
+def _apply_prediction(
+    group: Group,
+    predicted_assignee_user_ids: list[int | None],
+    run_uuid: str | None,
+) -> None:
+    """Record the top pick as a suggested owner and let the project decide if it assigns.
+    No-op when the org isn't flagged in, the agent abstained, or the top pick doesn't
+    resolve to an org user. Runs synchronously during activity creation, so the owner
+    (and any assignment) exists before any workflow notification fires off this completion.
+    """
+    if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
+        return
+
+    top_user_id = predicted_assignee_user_ids[0] if predicted_assignee_user_ids else None
+    if top_user_id is None:
+        # Agent abstained or named someone we couldn't map to an org user.
+        metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "no_candidate"})
+        return
+
+    if user_service.get_user(user_id=top_user_id) is None:
+        metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "user_missing"})
+        return
+
+    # Persist the pick as a suggested owner (idempotent upsert).
+    context: dict[str, object] = {"run_uuid": run_uuid} if run_uuid else {}
+    GroupOwner.objects.update_or_create_and_preserve_context(
+        lookup_kwargs={
+            "group_id": group.id,
+            "type": GroupOwnerType.SEER_SUGGESTED.value,
+            "user_id": top_user_id,
+            "project_id": group.project_id,
+            "organization_id": group.organization.id,
+        },
+        defaults={"date_added": timezone.now()},
+        context_defaults=context,
+    )
+
+    # Promote the suggestion to an assignment iff the project auto-assigns to owners.
+    # The ASSIGNED activity written is tagged with ActivityIntegration.SEER_SUGGESTED so
+    # ground-truth capture skips our own assignment (see scoring.record_ground_truth).
+    ProjectOwnership.handle_auto_assignment(project_id=group.project_id, group=group)
+
+    metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "applied"})
+    logger.info(
+        "smart_assignment.apply_prediction.applied",
+        extra={"group_id": group.id, "user_id": top_user_id},
+    )

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -50,6 +50,11 @@ class ActivityType(Enum):
     PULL_REQUEST_MERGED = 40
     PULL_REQUEST_UNLINKED = 41
 
+    # A smart-assignment run finished and delivered its verdict. Not part of the
+    # SEER_* autofix progress lifecycle -- it's an internal signal that drives
+    # scoring/auto-assignment, so it deliberately omits the SEER_ prefix.
+    SMART_ASSIGNMENT_COMPLETED = 42
+
 
 # Warning: This must remain in this EXACT order.
 CHOICES = tuple(
@@ -96,6 +101,7 @@ CHOICES = tuple(
         ActivityType.PULL_REQUEST_REOPENED,  # 39
         ActivityType.PULL_REQUEST_MERGED,  # 40
         ActivityType.PULL_REQUEST_UNLINKED,  # 41
+        ActivityType.SMART_ASSIGNMENT_COMPLETED,  # 42
     ]
 )
 

--- a/src/sentry/utils/action_log/activity_translator.py
+++ b/src/sentry/utils/action_log/activity_translator.py
@@ -56,6 +56,9 @@ ACTIVITY_TYPES_WITH_NO_ACTION: frozenset[int] = frozenset(
     (
         ActivityType.FIRST_SEEN.value,
         ActivityType.RELEASE.value,
+        # Internal signal that drives smart-assignment scoring/auto-assign off a
+        # workflow activity handler; not a user-facing group action.
+        ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
     )
 )
 

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,11 +1,13 @@
 from .workflow_activity_handlers import (
     activity_handler,
     seer_activity_handler,
-    smart_assignment_activity_handler,
+    smart_assignment_completed_handler,
+    smart_assignment_trigger_handler,
 )
 
 __all__ = [
     "activity_handler",
     "seer_activity_handler",
-    "smart_assignment_activity_handler",
+    "smart_assignment_completed_handler",
+    "smart_assignment_trigger_handler",
 ]

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -101,8 +101,8 @@ def seer_activity_handler(
     logger.info("workflow_engine.seer_activity_handler.complete", extra=logging_ctx)
 
 
-@workflow_activity_registry.register("smart_assignment")
-def smart_assignment_activity_handler(
+@workflow_activity_registry.register("smart_assignment_trigger")
+def smart_assignment_trigger_handler(
     group: Group,
     activity: Activity,
     detector_id: DetectorId | None = None,
@@ -126,6 +126,33 @@ def smart_assignment_activity_handler(
     from sentry.seer.smart_assignment.trigger import trigger_smart_assignment
 
     trigger_smart_assignment(group, activity_type, activity)
+
+
+@workflow_activity_registry.register("smart_assignment_completed")
+def smart_assignment_completed_handler(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId | None = None,
+) -> None:
+    """Act on a delivered smart-assignment verdict.
+
+    Fires off the SMART_ASSIGNMENT_COMPLETED activity that delivery records when Seer
+    returns a result (the activity references the originating Seer run). Invoked
+    unconditionally for every group activity, so it self-filters and delegates scoring
+    and auto-assignment to process_smart_assignment_completion -- decoupled from the
+    dispatch/ground-truth path that reacts to the *triggering* activities.
+    """
+    try:
+        activity_type = ActivityType(activity.type)
+    except ValueError:
+        return
+
+    if activity_type != ActivityType.SMART_ASSIGNMENT_COMPLETED:
+        return
+
+    from sentry.seer.smart_assignment.completion import process_smart_assignment_completion
+
+    process_smart_assignment_completion(group, activity)
 
 
 @workflow_activity_registry.register("generic_activity")

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -34,6 +34,7 @@ const suggestedReasonTable: Record<SuggestedOwnerReason, string> = {
   suspectCommit: t('Suspect Commit'),
   ownershipRule: t('Ownership Rule'),
   projectOwnership: t('Ownership Rule'),
+  seerSuggested: t('Suggested by Seer'),
   // TODO: codeowners may no longer exist
   codeowners: t('Codeowners'),
 };
@@ -128,6 +129,7 @@ function AssigneeAvatar({
     }),
     ownershipRule: t('Matching Issue Owners Rule'),
     projectOwnership: t('Matching Issue Owners Rule'),
+    seerSuggested: t('Suggested by Seer'),
     codeowners: t('Matching Codeowners Rule'),
   };
   const assignedToSuggestion = suggestedActors.find(actor => actor.id === assignedTo?.id);

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -550,6 +550,7 @@ export type SuggestedOwnerReason =
   | 'suspectCommit'
   | 'ownershipRule'
   | 'projectOwnership'
+  | 'seerSuggested'
   // TODO: codeowners may no longer exist
   | 'codeowners';
 

--- a/tests/sentry/notifications/platform/strategies/test_issue_owners.py
+++ b/tests/sentry/notifications/platform/strategies/test_issue_owners.py
@@ -123,6 +123,38 @@ class TestIssueOwnersActivityAlertStrategy(TestCase):
         emails = [t.resource_id for t in targets]
         assert emails.count(self.user.email) == 1
 
+    def test_seer_suggested_owner_notified_when_no_assignee(self) -> None:
+        seer_user = self.create_user(email="seer-pick@example.com")
+        self.create_member(organization=self.organization, user=seer_user)
+        self.create_group_owner(
+            group=self.group,
+            type=GroupOwnerType.SEER_SUGGESTED.value,
+            user_id=seer_user.id,
+        )
+
+        strategy = IssueOwnersActivityAlertStrategy(group=self.group)
+        targets = strategy.get_targets()
+
+        assert len(targets) == 1
+        assert targets[0].resource_id == "seer-pick@example.com"
+
+    def test_assignee_supersedes_seer_suggested_owner(self) -> None:
+        seer_user = self.create_user(email="seer-pick@example.com")
+        self.create_member(organization=self.organization, user=seer_user)
+        self.create_group_owner(
+            group=self.group,
+            type=GroupOwnerType.SEER_SUGGESTED.value,
+            user_id=seer_user.id,
+        )
+        GroupAssignee.objects.assign(self.group, self.user)
+
+        strategy = IssueOwnersActivityAlertStrategy(group=self.group)
+        targets = strategy.get_targets()
+
+        emails = {t.resource_id for t in targets}
+        assert self.user.email in emails
+        assert "seer-pick@example.com" not in emails
+
     def test_no_assignee_no_owners_returns_empty(self) -> None:
         strategy = IssueOwnersActivityAlertStrategy(group=self.group)
         assert strategy.get_targets() == []

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -1,0 +1,154 @@
+from django.utils import timezone
+
+from sentry.models.activity import Activity, ActivityIntegration
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.projectownership import ProjectOwnership
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
+from sentry.seer.smart_assignment.completion import process_smart_assignment_completion
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+AUTO_ASSIGN_FLAG = "organizations:seer-smart-assignment-auto-assign"
+
+
+class ProcessSmartAssignmentCompletionTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        self.mirror = SeerAgentRun.objects.create(
+            run=self.seer_run,
+            source=SEER_FEATURE_ID,
+            group=self.group,
+            extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
+        )
+
+    def _activity(self, predicted_assignee_user_ids: list[int | None]) -> Activity:
+        return Activity.objects.create_without_group_action(
+            project_id=self.group.project_id,
+            group=self.group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+            data={
+                "run_id": self.mirror.id,
+                "run_uuid": str(self.seer_run.uuid),
+                "predicted_assignee_user_ids": predicted_assignee_user_ids,
+            },
+        )
+
+    def _extras(self) -> dict:
+        self.mirror.refresh_from_db()
+        return self.mirror.extras
+
+    def _member(self, username: str = "alice"):
+        user = self.create_user(username=username)
+        self.create_member(user=user, organization=self.organization)
+        return user
+
+    def _set_project_auto_assignment(self, enabled: bool) -> None:
+        # The post_save signal keeps get_ownership_cached in sync with this row.
+        ProjectOwnership.objects.create(
+            project_id=self.group.project_id,
+            auto_assignment=enabled,
+            suspect_committer_auto_assignment=False,
+        )
+
+    def _suggested_owners(self) -> list[GroupOwner]:
+        return list(
+            GroupOwner.objects.filter(group=self.group, type=GroupOwnerType.SEER_SUGGESTED.value)
+        )
+
+    def test_records_prediction_regardless_of_flag(self) -> None:
+        # Scoring bookkeeping is internal, not user-facing, so it runs without the flag.
+        alice = self._member()
+        process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        assert self._extras()["predicted_assignee_user_ids"] == [alice.id]
+
+    def test_handles_missing_payload(self) -> None:
+        activity = Activity.objects.create_without_group_action(
+            project_id=self.group.project_id,
+            group=self.group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+            data={},
+        )
+        process_smart_assignment_completion(self.group, activity)
+        assert self._extras()["predicted_assignee_user_ids"] == []
+
+    def test_no_writes_without_flag(self) -> None:
+        alice = self._member()
+        process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        # Everything user-facing is behind the flag: no suggested owner, no assignment.
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_suggests_without_assigning_when_project_auto_assign_off(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id, None]))
+
+        owners = self._suggested_owners()
+        assert len(owners) == 1
+        assert owners[0].user_id == alice.id
+        assert owners[0].context == {"run_uuid": str(self.seer_run.uuid)}
+        # Project doesn't auto-assign to owners -> the pick stays a suggestion.
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_promotes_suggestion_to_assignment_when_project_auto_assigns(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(True)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        # Suggested owner is always written...
+        assert len(self._suggested_owners()) == 1
+        # ...and promoted to a real assignment via the existing auto-assign machinery.
+        assignee = GroupAssignee.objects.get(group=self.group)
+        assert assignee.user_id == alice.id
+        # The ASSIGNED activity is tagged so ground-truth capture skips our own work.
+        assigned = Activity.objects.filter(
+            group=self.group, type=ActivityType.ASSIGNED.value
+        ).latest("datetime")
+        assert assigned.data["integration"] == ActivityIntegration.SEER_SUGGESTED.value
+
+    def test_does_not_override_existing_assignee(self) -> None:
+        existing = self.create_user()
+        alice = self._member()
+        GroupAssignee.objects.assign(self.group, existing)
+        self._set_project_auto_assignment(True)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        # We record the suggestion but never override a manual assignment.
+        assert len(self._suggested_owners()) == 1
+        assert GroupAssignee.objects.get(group=self.group).user_id == existing.id
+
+    def test_no_writes_when_top_pick_unlinked(self) -> None:
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([None]))
+
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_no_writes_on_abstain(self) -> None:
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([]))
+
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_suggested_owner_is_idempotent(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        assert len(self._suggested_owners()) == 1

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -10,7 +10,8 @@ from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import 
     SUPPORTED_ACTIVITIES,
     activity_handler,
     seer_activity_handler,
-    smart_assignment_activity_handler,
+    smart_assignment_completed_handler,
+    smart_assignment_trigger_handler,
 )
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.registry import workflow_activity_registry
@@ -21,8 +22,9 @@ class WorkflowActivityRegistryTest(TestCase):
     def test_registrants(self) -> None:
         assert "seer_activity" in workflow_activity_registry.registrations
         assert "generic_activity" in workflow_activity_registry.registrations
-        assert "smart_assignment" in workflow_activity_registry.registrations
-        assert len(workflow_activity_registry.registrations) == 3
+        assert "smart_assignment_trigger" in workflow_activity_registry.registrations
+        assert "smart_assignment_completed" in workflow_activity_registry.registrations
+        assert len(workflow_activity_registry.registrations) == 4
 
 
 class SmartAssignmentActivityHandlerTest(TestCase):
@@ -47,7 +49,7 @@ class SmartAssignmentActivityHandlerTest(TestCase):
             activity = self.create_group_activity(
                 group=self.group, type=activity_type.value, data=data
             )
-            smart_assignment_activity_handler(self.group, activity, None)
+            smart_assignment_trigger_handler(self.group, activity, None)
             mock_trigger.assert_called_once_with(self.group, activity_type, activity)
 
     @mock.patch(TRIGGER)
@@ -63,8 +65,41 @@ class SmartAssignmentActivityHandlerTest(TestCase):
             ActivityType.NOTE,
         ):
             activity = self.create_group_activity(group=self.group, type=activity_type.value)
-            smart_assignment_activity_handler(self.group, activity, None)
+            smart_assignment_trigger_handler(self.group, activity, None)
         mock_trigger.assert_not_called()
+
+
+class SmartAssignmentCompletedHandlerTest(TestCase):
+    COMPLETION = "sentry.seer.smart_assignment.completion.process_smart_assignment_completion"
+
+    def setUp(self) -> None:
+        self.group = self.create_group()
+
+    @mock.patch(COMPLETION)
+    def test_delegates_for_completed_activity(self, mock_completion: MagicMock) -> None:
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+        )
+        # create_group_activity invokes the registered handlers itself, so the delegate
+        # is already called once for the real activity; assert on a direct call to keep
+        # this focused on the handler's own filtering + delegation.
+        mock_completion.reset_mock()
+        smart_assignment_completed_handler(self.group, activity, None)
+        mock_completion.assert_called_once_with(self.group, activity)
+
+    @mock.patch(COMPLETION)
+    def test_skips_unrelated_activities(self, mock_completion: MagicMock) -> None:
+        for activity_type in (
+            ActivityType.SEER_RCA_STARTED,
+            ActivityType.SEER_PR_CREATED,
+            ActivityType.SET_RESOLVED,
+            ActivityType.NOTE,
+        ):
+            activity = self.create_group_activity(group=self.group, type=activity_type.value)
+            mock_completion.reset_mock()
+            smart_assignment_completed_handler(self.group, activity, None)
+            mock_completion.assert_not_called()
 
 
 class SeerActivityHandlerTest(TestCase):


### PR DESCRIPTION
## Summary
Second of a 3-PR stack. **Stacked on #119931 — review that first.**

- Adds `completion.py`: turns a delivered verdict into a `SEER_SUGGESTED` group owner (idempotent upsert) and, when the project auto-assigns to owners, promotes it to a real assignment via the existing auto-assign machinery (tagged `ActivityIntegration.SEER_SUGGESTED` so ground-truth capture skips our own work).
- Gated behind the new `seer-smart-assignment-auto-assign` flag; scoring bookkeeping still runs regardless.
- Adds the `SMART_ASSIGNMENT_COMPLETED` activity type + the `smart_assignment_completed` workflow handler that drives completion, and splits the old `smart_assignment` handler into `smart_assignment_trigger`.
- Adds the `SEER_SUGGESTED` group-owner type + auto-assignment wiring, and the "Suggested by Seer" owner reason in the assignee selector UI.

## Stack
1. scoring (#119931)
2. **this PR** — suggested assignment (base: `sa-scoring`)
3. delivery (base: `sa-suggested-assignment`)

## Test plan
- [ ] `pytest tests/sentry/seer/smart_assignment/test_completion.py tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py tests/sentry/notifications/platform/strategies/test_issue_owners.py`

Made with [Cursor](https://cursor.com)