### PR TITLE
feat(seer): deliver smart-assignment verdicts from Seer

### DIFF
--- a/src/sentry/seer/agent/feature_delivery.py
+++ b/src/sentry/seer/agent/feature_delivery.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.night_shift.delivery import deliver_night_shift_result
+from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
 
 __all__ = ["DELIVERY_HANDLERS", "FeatureDeliveryFn", "FeatureRunStatus"]
 
@@ -23,4 +24,5 @@ class FeatureDeliveryFn(Protocol):
 
 DELIVERY_HANDLERS: dict[str, FeatureDeliveryFn] = {
     "night_shift": deliver_night_shift_result,
+    "smart_assignment": deliver_smart_assignment_result,
 }

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -1,0 +1,162 @@
+"""Delivery handler for smart_assignment feature results from Seer.
+
+Seer pushes the `AssigneeVerdict` artifact back via the `deliver_feature_result`
+RPC, routed here by feature_id (see `sentry.seer.agent.feature_delivery`). Seer is
+the system of record for the verdict itself; here we resolve the ranked candidates to
+Sentry users and record a `SMART_ASSIGNMENT_COMPLETED` activity (pointing back at the
+run) carrying those resolved picks, then emit a delivery outcome metric. Acting on
+the verdict -- scoring it and auto-assigning -- happens independently off that activity
+(see `completion`), so this handler stays a thin resolve-and-record step.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.organizations.services.organization import organization_service
+from sentry.seer.agent.types import FeatureRunStatus
+from sentry.seer.models.run import SeerAgentRun
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, AssigneeVerdict
+from sentry.types.activity import ActivityType
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_identifier_to_user_id(
+    organization_id: int, identifier: str | None, kind: str | None
+) -> int | None:
+    """Map an agent-produced `identifier` to a Sentry user id in the org.
+
+    The agent tags each pick with `identifier_kind` (see the `RankedCandidate`
+    contract on the Seer side) so we resolve deterministically instead of inferring
+    the type from the string:
+      - "email":    verified org email (the RPC already scopes to the org).
+      - "username": unique username, confirmed to be an org member so a global match
+                    can't attribute a prediction to someone outside the org.
+    `kind` is a validated Literal by the time it gets here, so this doesn't guess.
+    Returns None when the agent named no one or the identifier maps to no org user.
+    """
+    if not identifier:
+        return None
+
+    value = identifier.strip()
+    if not value:
+        return None
+
+    if kind == "email":
+        users = user_service.get_many_by_email(
+            emails=[value], organization_id=organization_id, is_verified=True
+        )
+        return users[0].id if users else None
+
+    if kind == "username":
+        users = user_service.get_by_username(username=value)
+        if not users:
+            return None
+        user_id = users[0].id
+        member = organization_service.check_membership_by_id(
+            organization_id=organization_id, user_id=user_id
+        )
+        return user_id if member is not None else None
+
+    return None
+
+
+def deliver_smart_assignment_result(
+    organization_id: int,
+    run_uuid: str,
+    status: FeatureRunStatus,
+    result: dict[str, Any] | None,
+    error: str | None,
+) -> None:
+    """Resolve a delivered smart_assignment verdict's ranked picks and record them.
+
+    Emits a single `smart_assignment.delivery` counter tagged with the outcome so we
+    can track success vs failure, how often the agent abstains, and how often it
+    names someone we can't link to a Sentry user in the org:
+      - `missing_run`   -- delivery arrived with no matching run mirror (orphaned run)
+      - `error`         -- Seer run failed or returned no artifact
+      - `missing_group` -- run isn't tied to a group, or the group was deleted before
+                           delivery, so there's nothing to record the prediction against
+      - `abstain`       -- completed, but the agent named no one
+      - `unlinked`      -- named someone we couldn't map to an org user
+      - `resolved`      -- named someone we mapped to a Sentry user
+    """
+    agent_run = (
+        SeerAgentRun.objects.filter(
+            run__uuid=run_uuid, run__organization_id=organization_id, source=SEER_FEATURE_ID
+        )
+        .select_related("run")
+        .first()
+    )
+    if agent_run is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_run"})
+        logger.warning(
+            "smart_assignment.delivery.missing_run",
+            extra={"organization_id": organization_id, "run_uuid": run_uuid},
+        )
+        return
+
+    group_id = agent_run.group_id
+    log_extra = {"organization_id": organization_id, "group_id": group_id, "run_uuid": run_uuid}
+
+    if status == "error" or result is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
+        logger.warning(
+            "smart_assignment.delivery.no_result",
+            extra={**log_extra, "status": status, "error": error},
+        )
+        return
+
+    try:
+        verdict = AssigneeVerdict.parse_obj(result)
+    except Exception:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
+        logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)
+        return
+
+    # Resolve every ranked candidate (best-first) to a Sentry user id so scoring can
+    # grade the top pick and also see where the eventual assignee placed in the list
+    # (its hit_rank). None marks a position we couldn't map to an org user, preserving
+    # each candidate's rank; the raw verdict itself is still queryable on the Seer run.
+    predicted_assignee_user_ids = [
+        _resolve_identifier_to_user_id(
+            organization_id, candidate.identifier, candidate.identifier_kind
+        )
+        for candidate in verdict.candidates
+    ]
+
+    # Do nothing if the group was deleted before delivery, or if the run isn't tied to a group.
+    group = Group.objects.filter(id=group_id).first() if group_id is not None else None
+    if group is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_group"})
+        logger.warning("smart_assignment.delivery.missing_group", extra=log_extra)
+        return
+
+    # Hand the resolved verdict off to the completion path via an activity that points
+    # back at this run. Creating it invokes the workflow activity handlers, which score
+    # the prediction (completing the pair now if ground truth already landed) and
+    # auto-assign as needed -- kept out of this RPC handler on purpose.
+    Activity.objects.create_group_activity(
+        group,
+        ActivityType.SMART_ASSIGNMENT_COMPLETED,
+        data={
+            "run_id": agent_run.id,
+            "run_uuid": run_uuid,
+            "predicted_assignee_user_ids": predicted_assignee_user_ids,
+        },
+        send_notification=False,
+    )
+
+    if not predicted_assignee_user_ids:
+        outcome = "abstain"
+    elif predicted_assignee_user_ids[0] is None:
+        outcome = "unlinked"
+    else:
+        outcome = "resolved"
+    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome})

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -1,0 +1,219 @@
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from sentry.models.activity import Activity
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
+from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+METRICS_PATH = "sentry.seer.smart_assignment.delivery.metrics"
+
+
+class DeliverSmartAssignmentResultTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        # The run mirror the client would have created at dispatch.
+        self.mirror = SeerAgentRun.objects.create(
+            run=self.seer_run,
+            source=SEER_FEATURE_ID,
+            group=self.group,
+            extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
+        )
+
+    def _extras(self) -> dict:
+        self.mirror.refresh_from_db()
+        return self.mirror.extras
+
+    def _deliver(self, result: dict | None, status: str = "completed", error: str | None = None):
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), status, result, error
+        )
+
+    def _assert_outcome(self, mock_metrics: MagicMock, expected: str) -> None:
+        mock_metrics.incr.assert_called_once_with(
+            "smart_assignment.delivery", tags={"outcome": expected}
+        )
+
+    def _completion_activity(self) -> Activity:
+        return Activity.objects.get(
+            group=self.group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        )
+
+    @patch(METRICS_PATH)
+    def test_records_top_pick_resolved_to_user(self, mock_metrics: MagicMock) -> None:
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "suspect commit",
+                    "confidence": "high",
+                },
+                {
+                    "identifier": "bob",
+                    "identifier_kind": "username",
+                    "reason": "code owner",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        # Every candidate resolved (best-first) and cached on the run mirror: alice is
+        # an org member; "bob" maps to no org user, so its rank is held with None. The
+        # full verdict itself lives on the Seer run, not here.
+        assert self._extras()["predicted_assignee_user_ids"] == [alice.id, None]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_creates_completion_activity_referencing_run(self, mock_metrics: MagicMock) -> None:
+        # The delivered verdict is handed off via a SMART_ASSIGNMENT_COMPLETED
+        # activity that points back at the Seer run and carries the resolved picks.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self._deliver(
+            {
+                "candidates": [
+                    {"identifier": "alice", "identifier_kind": "username"},
+                ]
+            }
+        )
+
+        data = self._completion_activity().data
+        assert data["run_id"] == self.mirror.id
+        assert data["run_uuid"] == str(self.seer_run.uuid)
+        assert data["predicted_assignee_user_ids"] == [alice.id]
+
+    @patch(METRICS_PATH)
+    def test_email_kind_resolves_by_verified_email(self, mock_metrics: MagicMock) -> None:
+        # An email-kind pick (unlinked commit author) resolves by verified org email,
+        # even when the address happens to also be someone's username-shaped handle.
+        carol = self.create_user(email="carol@example.com")
+        self.create_member(user=carol, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "carol@example.com",
+                    "identifier_kind": "email",
+                    "reason": "unlinked commit author",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [carol.id]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_unresolvable_identifier_records_no_user(self, mock_metrics: MagicMock) -> None:
+        result = {
+            "candidates": [
+                {
+                    "identifier": "nobody-here",
+                    "identifier_kind": "username",
+                    "reason": "guess",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [None]
+        self._assert_outcome(mock_metrics, "unlinked")
+
+    @patch(METRICS_PATH)
+    def test_empty_candidates_is_abstain(self, mock_metrics: MagicMock) -> None:
+        self._deliver({"candidates": []})
+        assert self._extras()["predicted_assignee_user_ids"] == []
+        self._assert_outcome(mock_metrics, "abstain")
+
+    @patch(METRICS_PATH)
+    def test_error_status_records_nothing(self, mock_metrics: MagicMock) -> None:
+        self._deliver(None, status="error", error="boom")
+        # No prediction recorded on error; the Seer run holds the failure.
+        assert "predicted_assignee_user_ids" not in self._extras()
+        self._assert_outcome(mock_metrics, "error")
+
+    @patch("sentry.seer.smart_assignment.scoring.metrics")
+    def test_scores_when_ground_truth_already_present(
+        self, mock_scoring_metrics: MagicMock
+    ) -> None:
+        # Assignment landed before Seer finished: ground truth is already on the run
+        # mirror, so delivering the prediction completes the pair and scores it.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self.mirror.extras = {**self.mirror.extras, "actual_assignee_user_id": alice.id}
+        self.mirror.save(update_fields=["extras"])
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "x",
+                    "confidence": "high",
+                }
+            ]
+        }
+        self._deliver(result)
+
+        mock_scoring_metrics.incr.assert_called_once_with(
+            "smart_assignment.scored",
+            tags={
+                "result": SmartAssignmentScore.EXACT,
+                "hit_rank": 1,
+                "trigger": ActivityType.SEER_RCA_STARTED.name,
+            },
+        )
+
+    @patch(METRICS_PATH)
+    def test_untied_run_is_missing_group(self, mock_metrics: MagicMock) -> None:
+        # Run mirror was never tied to a group (group_id is NULL): there's nothing to
+        # record the prediction against, so it must not count as a delivery success.
+        self.mirror.group = None
+        self.mirror.save(update_fields=["group"])
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self._deliver({"candidates": [{"identifier": "alice", "identifier_kind": "username"}]})
+
+        assert not Activity.objects.filter(
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        ).exists()
+        self._assert_outcome(mock_metrics, "missing_group")
+
+    @patch(METRICS_PATH)
+    def test_deleted_group_is_missing_group(self, mock_metrics: MagicMock) -> None:
+        # Group deleted between dispatch and delivery (stale, dangling group_id): the
+        # activity can't be created, so this is reported distinctly, not as a success.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self.group.delete()
+        self._deliver({"candidates": [{"identifier": "alice", "identifier_kind": "username"}]})
+
+        assert not Activity.objects.filter(
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        ).exists()
+        self._assert_outcome(mock_metrics, "missing_group")
+
+    @patch(METRICS_PATH)
+    def test_missing_run_is_noop(self, mock_metrics: MagicMock) -> None:
+        # Unknown run uuid: should not raise.
+        deliver_smart_assignment_result(
+            self.organization.id,
+            "00000000-0000-0000-0000-000000000000",
+            "completed",
+            {"candidates": []},
+            None,
+        )
+        self._assert_outcome(mock_metrics, "missing_run")


### PR DESCRIPTION
## Summary
Third of a 3-PR stack. **Stacked on #119932 — review that first.**

- Adds `delivery.py`, the handler Seer routes `AssigneeVerdict` artifacts to via `deliver_feature_result` (registered in `feature_delivery.py`).
- Resolves each ranked candidate (best-first) to a Sentry user in the org — by verified email or org-scoped username, keyed off the agent's `identifier_kind`.
- Records a `SMART_ASSIGNMENT_COMPLETED` activity carrying the resolved picks and pointing back at the run, which hands off to scoring + auto-assignment (previous PRs).
- Emits a single `smart_assignment.delivery` outcome metric (missing_run / error / missing_group / abstain / unlinked / resolved).

## Stack
1. scoring (#119931)
2. suggested assignment (#119932)
3. **this PR** — delivery (base: `sa-suggested-assignment`)

This PR's tip is byte-identical to the original squashed commit.

## Test plan
- [ ] `pytest tests/sentry/seer/smart_assignment/test_delivery.py`

Made with [Cursor](https://cursor.com)