### PR TITLE
fix(hybridcloud): Honor skip-on-failure in parallel webhook drains

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -481,20 +481,29 @@ def _handle_parallel_delivery_result(
 
 
 def _run_parallel_delivery_batch(
-    payload: WebhookPayload, worker_threads: int
-) -> tuple[int, bool, bool]:
+    mailbox_name: str, start_id: int, worker_threads: int
+) -> tuple[int, bool, int | None]:
     """
     Run one batch of parallel deliveries for the mailbox.
-    Returns (delivered_count, request_failed, no_more_messages).
+
+    Returns (delivered_count, request_failed, next_start_id).
+    `next_start_id` is one past the highest id attempted in this batch so callers
+    can advance past failed rows when continuing (e.g. skip-on-failure providers).
+    Returns `next_start_id=None` when the mailbox has no rows at/after `start_id`.
     """
-    query = WebhookPayload.objects.filter(
-        id__gte=payload.id, mailbox_name=payload.mailbox_name
-    ).order_by("id")
+    records = list(
+        WebhookPayload.objects.filter(id__gte=start_id, mailbox_name=mailbox_name).order_by("id")[
+            :worker_threads
+        ]
+    )
+    if not records:
+        return (0, False, None)
+
+    # Capture before delivery — successful deletes clear pk on the in-memory instance.
+    next_start_id = records[-1].id + 1
 
     with ContextPropagatingThreadPoolExecutor(max_workers=worker_threads) as threadpool:
-        futures = {
-            threadpool.submit(deliver_message_parallel, record) for record in query[:worker_threads]
-        }
+        futures = {threadpool.submit(deliver_message_parallel, record) for record in records}
         delivered = 0
         request_failed = False
         for future in as_completed(futures):
@@ -507,8 +516,7 @@ def _run_parallel_delivery_batch(
                 raise err
             if err is None:
                 delivered += 1
-        no_more_messages = len(futures) < 1
-    return (delivered, request_failed, no_more_messages)
+    return (delivered, request_failed, next_start_id)
 
 
 @instrumented_task(
@@ -526,10 +534,10 @@ def drain_mailbox_parallel(payload_id: int, mailbox_name: str | None = None) -> 
     Because of the sequential delivery in a mailbox we can't get higher throughput
     by scheduling batches in parallel.
 
-    Messages will be delivered in small batches until one fails, the batch
-    delay timeout is reached, or a message with a schedule_for greater than
-    the current time is encountered. A message with a higher schedule_for value
-    indicates that we have hit the start of another batch that has been scheduled.
+    Messages will be delivered in small batches until a non-skippable failure
+    occurs or the batch delay timeout is reached. Providers in
+    `hybridcloud.webhookpayload.skip_on_failure_providers` (e.g. github) continue
+    past retryable failures in the same way as sequential `drain_mailbox`.
 
     `mailbox_name` is passed when the drain was push-triggered so the lock can be
     released on completion (mirroring `drain_mailbox`). Scheduler-triggered calls
@@ -549,9 +557,15 @@ def drain_mailbox_parallel(payload_id: int, mailbox_name: str | None = None) -> 
     _set_webhook_delivery_sentry_context(payload)
     _discard_stale_mailbox_payloads(payload)
 
+    skip_on_failure_providers = frozenset(
+        options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
+    )
+    skip_on_failure = payload.provider in skip_on_failure_providers
+
     worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
     deadline = timezone.now() + BATCH_SCHEDULE_OFFSET
     delivered = 0
+    current_id = payload.id
     extra = {**payload.as_dict(), "delivered": delivered}
     try:
         while True:
@@ -564,17 +578,23 @@ def drain_mailbox_parallel(payload_id: int, mailbox_name: str | None = None) -> 
                 )
                 break
 
-            delivered_batch, request_failed, no_more_messages = _run_parallel_delivery_batch(
-                payload, worker_threads
+            delivered_batch, request_failed, next_id = _run_parallel_delivery_batch(
+                payload.mailbox_name, current_id, worker_threads
             )
             delivered += delivered_batch
             extra["delivered"] = delivered
 
-            if no_more_messages:
+            if next_id is None:
                 logger.info("deliver_webhook_parallel.task_complete", extra=extra)
                 break
 
-            if request_failed:
+            # Advance past this batch so failed rows (left with a future
+            # schedule_for) are not immediately re-attempted when we continue.
+            current_id = next_id
+
+            if request_failed and not skip_on_failure:
+                # For providers that require stricter mailbox behavior, stop on
+                # the first batch that had a retryable failure.
                 logger.info("deliver_webhook_parallel.delivery_request_failed", extra=extra)
                 return
     finally:

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -272,9 +272,7 @@ class ScheduleWebhooksTest(TestCase):
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:
     # Keep path aligned with provider so responses mocks aren't misleading.
-    request_path = (
-        f"/extensions/{provider}/webhook/" if provider else "/extensions/github/webhook/"
-    )
+    request_path = f"/extensions/{provider}/webhook/" if provider else "/extensions/github/webhook/"
     created = []
     for _ in range(0, num):
         hook = Factories.create_webhook_payload(

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -271,12 +271,17 @@ class ScheduleWebhooksTest(TestCase):
 
 
 def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:
+    # Keep path aligned with provider so responses mocks aren't misleading.
+    request_path = (
+        f"/extensions/{provider}/webhook/" if provider else "/extensions/github/webhook/"
+    )
     created = []
     for _ in range(0, num):
         hook = Factories.create_webhook_payload(
             mailbox_name=mailbox,
             cell_name="us",
             provider=provider,
+            request_path=request_path,
         )
         created.append(hook)
     return created
@@ -327,7 +332,7 @@ class DrainMailboxTest(TestCase):
     @responses.activate
     @override_cells(cell_config)
     def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:
-        url = "http://us.testserver/extensions/github/webhook/"
+        url = "http://us.testserver/extensions/jira/webhook/"
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")
@@ -666,7 +671,7 @@ class DrainMailboxParallelTest(TestCase):
     @responses.activate
     @override_cells(cell_config)
     def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:
-        url = "http://us.testserver/extensions/github/webhook/"
+        url = "http://us.testserver/extensions/jira/webhook/"
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=500, body="")
         records = create_payloads(5, "jira:123", provider="jira")

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -622,17 +622,62 @@ class DrainMailboxParallelTest(TestCase):
             status=500,
             body="",
         )
+        # provider=None is not in the skip-on-failure allowlist.
         records = create_payloads(5, "github:123")
         drain_mailbox_parallel(records[0].id)
 
         worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
-        # We'll attempt one thread batch, but the second+ will fail
+        # We'll attempt one thread batch, but the second+ will fail and stop the drain.
         assert len(responses.calls) == worker_threads
 
         # Mailbox should have 4 records left
         assert WebhookPayload.objects.count() == 4
 
         # Remaining record should be scheduled to run later.
+        first = WebhookPayload.objects.order_by("id").first()
+        assert first
+        assert first.attempts == 1
+        assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_skip_on_failure_for_allowlisted_provider(self) -> None:
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=500, body="")
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=200, body="")
+        records = create_payloads(5, "github:123", provider="github")
+        drain_mailbox_parallel(records[0].id)
+
+        # github is in the skip-on-failure allowlist: failed messages are skipped
+        # and processing continues across parallel batches.
+        assert len(responses.calls) == 5
+
+        # Only the failed message remains in the mailbox.
+        assert WebhookPayload.objects.count() == 1
+
+        first = WebhookPayload.objects.order_by("id").first()
+        assert first
+        assert first.attempts == 1
+        assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_cells(cell_config)
+    def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=500, body="")
+        records = create_payloads(5, "jira:123", provider="jira")
+        drain_mailbox_parallel(records[0].id)
+
+        worker_threads = options.get("hybridcloud.webhookpayload.worker_threads")
+        # jira is not in the allowlist: processing stops after the first batch
+        # that encounters a retryable failure.
+        assert len(responses.calls) == worker_threads
+        assert WebhookPayload.objects.count() == 4
+
         first = WebhookPayload.objects.order_by("id").first()
         assert first
         assert first.attempts == 1


### PR DESCRIPTION
the idea is to not bail on the parallel drain when we hit a skippable failure:
- when we're draining in parallel we've already accepted that we're willing to drain out of order
- we're already ok with skipping webhooks that failed to deliver in the sequential path

so let's just skip failed webhooks in the parallel path as well, so at the very least we continue to make progress on the webhooks that come after the one in the batch that failed

part of this is to help alleviate backed up webhook queues since i noticed that often the earliest item in the queue is blocking since it failed to deliver, which means that we end up waiting a bunch of time to continue delivering webhooks for that mailbox