### PR TITLE
fix(analytics): Split integration-install flow into view value + variant param

### DIFF
--- a/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
@@ -219,7 +219,11 @@ export function ScmIntegrationConnect({
     </Stack>
   ) : (
     <Stack key="without-integration" gap="2xl" width="100%" maxWidth={maxWidth}>
-      <ScmProviderPills providers={scmProviders} onInstall={handleInstall} />
+      <ScmProviderPills
+        analyticsFlow={analyticsFlow}
+        providers={scmProviders}
+        onInstall={handleInstall}
+      />
     </Stack>
   );
 }

--- a/static/app/components/onboarding/scm/scmProviderPills.spec.tsx
+++ b/static/app/components/onboarding/scm/scmProviderPills.spec.tsx
@@ -4,6 +4,7 @@ import {GitLabIntegrationProviderFixture} from 'sentry-fixture/gitlabIntegration
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import * as pipelineModal from 'sentry/components/pipeline/modal';
+import * as integrationUtil from 'sentry/utils/integrationUtil';
 
 import {ScmProviderPills} from './scmProviderPills';
 
@@ -39,7 +40,13 @@ describe('ScmProviderPills', () => {
       bitbucketProvider,
     ];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.getByText('GitLab')).toBeInTheDocument();
@@ -54,7 +61,13 @@ describe('ScmProviderPills', () => {
       GitHubIntegrationProviderFixture(),
     ];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     const buttons = screen.getAllByRole('button');
     expect(buttons[0]).toHaveTextContent('GitHub');
@@ -72,7 +85,13 @@ describe('ScmProviderPills', () => {
       azureDevOpsProvider,
     ];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     // Primary providers are visible as buttons
     expect(screen.getByText('GitHub')).toBeInTheDocument();
@@ -100,7 +119,13 @@ describe('ScmProviderPills', () => {
 
     const providers = [GitHubIntegrationProviderFixture(), gitHubEnterpriseProvider];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     await userEvent.click(screen.getByRole('button', {name: 'More'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub Enterprise'}));
@@ -108,10 +133,62 @@ describe('ScmProviderPills', () => {
     expect(openPipelineModalSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('fires the install start with the project-creation view + scm variant', async () => {
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(() => {});
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+
+    const providers = [GitHubIntegrationProviderFixture(), gitHubEnterpriseProvider];
+
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub Enterprise'}));
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'integrations.installation_start',
+      expect.objectContaining({view: 'project_creation', variant: 'scm'})
+    );
+  });
+
+  it('fires the install start with the onboarding view + scm variant', async () => {
+    jest.spyOn(pipelineModal, 'openPipelineModal').mockImplementation(() => {});
+    const trackSpy = jest.spyOn(integrationUtil, 'trackIntegrationAnalytics');
+
+    const providers = [GitHubIntegrationProviderFixture(), gitHubEnterpriseProvider];
+
+    render(
+      <ScmProviderPills
+        analyticsFlow="onboarding"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'More'}));
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'GitHub Enterprise'}));
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      'integrations.installation_start',
+      expect.objectContaining({view: 'onboarding', variant: 'scm'})
+    );
+  });
+
   it('does not render "More" dropdown when all providers are primary', () => {
     const providers = [GitHubIntegrationProviderFixture()];
 
-    render(<ScmProviderPills providers={providers} onInstall={jest.fn()} />);
+    render(
+      <ScmProviderPills
+        analyticsFlow="project-creation"
+        providers={providers}
+        onInstall={jest.fn()}
+      />
+    );
 
     expect(screen.getByText('GitHub')).toBeInTheDocument();
     expect(screen.queryByText('More')).not.toBeInTheDocument();

--- a/static/app/components/onboarding/scm/scmProviderPills.tsx
+++ b/static/app/components/onboarding/scm/scmProviderPills.tsx
@@ -9,17 +9,31 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {IntegrationButton} from 'sentry/views/settings/organizationIntegrations/integrationButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {partitionScmProviders} from './scmProviderOrder';
 
+// The install view identifies the host surface. These providers only render in SCM
+// flows, so both install paths always set the variant to `scm`.
+const INSTALL_VIEW = {
+  onboarding: 'onboarding',
+  'project-creation': 'project_creation',
+} as const;
+
 interface ScmProviderPillsProps {
+  analyticsFlow: ScmAnalyticsFlow;
   onInstall: (data: Integration) => void;
   providers: IntegrationProvider[];
 }
 
-export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) {
+export function ScmProviderPills({
+  analyticsFlow,
+  providers,
+  onInstall,
+}: ScmProviderPillsProps) {
   const organization = useOrganization();
   const {startFlow} = useAddIntegration();
   const {primaryProviders, moreProviders} = partitionScmProviders(providers);
+  const view = INSTALL_VIEW[analyticsFlow];
   const gridItemCount = primaryProviders.length + (moreProviders.length > 0 ? 1 : 0);
 
   const columnsXs = `repeat(${Math.min(gridItemCount, 2)}, 1fr)`;
@@ -48,7 +62,8 @@ export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) 
               type: 'first_party',
               installStatus: 'Not Installed',
               analyticsParams: {
-                view: 'onboarding_scm',
+                view,
+                variant: 'scm',
                 already_installed: false,
               },
               suppressSuccessMessage: true,
@@ -79,7 +94,8 @@ export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) 
                   organization,
                   onInstall,
                   analyticsParams: {
-                    view: 'onboarding_scm',
+                    view,
+                    variant: 'scm',
                     already_installed: false,
                   },
                   suppressSuccessMessage: true,

--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -5,6 +5,9 @@ import type {PlatformEventParameters} from './platformAnalyticsEvents';
 import {platformEventMap} from './platformAnalyticsEvents';
 
 export type IntegrationView = {
+  // `view` identifies the flow or surface; `variant` identifies whether that flow
+  // uses the SCM or legacy experience.
+  variant?: 'scm' | 'legacy';
   view?:
     | MessagingIntegrationAnalyticsView
     | 'external_install'
@@ -16,7 +19,6 @@ export type IntegrationView = {
     | 'stacktrace_issue_details'
     | 'integration_configuration_detail'
     | 'onboarding'
-    | 'onboarding_scm'
     | 'project_creation'
     | 'developer_settings'
     | 'new_integration_modal'

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -20,13 +20,14 @@ export interface AddIntegrationParams {
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
       | 'onboarding'
-      | 'onboarding_scm'
       | 'project_creation'
       | 'seer_onboarding_github'
       | 'seer_onboarding_code_review'
       | 'test_analytics_onboarding'
       | 'test_analytics_org_selector';
     referrer?: string;
+    // Keep the experience variant separate from the flow-specific view value.
+    variant?: 'scm' | 'legacy';
   };
   /**
    * Overrides for the install modal's copy. Passed straight through to

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -11,13 +11,14 @@ type IntegrationContextProps = {
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
       | 'onboarding'
-      | 'onboarding_scm'
       | 'project_creation'
       | 'seer_onboarding_github'
       | 'seer_onboarding_code_review'
       | 'test_analytics_onboarding'
       | 'test_analytics_org_selector';
     referrer?: string;
+    // Keep the experience variant separate from the flow-specific view value.
+    variant?: 'scm' | 'legacy';
   };
   installStatus: string;
   provider: IntegrationProvider;


### PR DESCRIPTION
## TLDR

Integration installs started from the SCM flows now log `integrations.installation_start`/`installation_complete` with a `view` that names only the surface (`onboarding` / `project_creation`) plus a `variant: 'scm'` param — instead of baking the flow-and-variant together as `onboarding_scm`. Project-creation SCM installs are now distinguishable from onboarding installs (fixing the prior mislabel) without a bespoke `*_scm` view value.

## Details

Establishes the orthogonal-dimensions convention the rest of the VDY-133 stack follows. Frontend-only. Two independent dimensions, each with one carrier: the `view` value names the flow/surface, and a `variant: 'scm' | 'legacy'` param carries SCM-ness. This replaces the earlier idea of a dedicated `scm_project_creation` view value, which conflated the two.

`ScmProviderPills` renders the connect-a-provider UI inside `ScmIntegrationConnect`, shared by both new-org onboarding (`analyticsFlow="onboarding"`) and the SCM project-creation wizard (`analyticsFlow="project-creation"`). Both install paths in the component — the primary pill via `IntegrationContext.analyticsParams` and the "More" dropdown via `useAddIntegration().startFlow` — hardcoded `view: 'onboarding_scm'`, so a provider connected during project creation was indistinguishable from onboarding in Amplitude.

The fix threads the `analyticsFlow` that `ScmIntegrationConnect` already carries down into `ScmProviderPills` (its only caller) and derives the install `view` from a small `INSTALL_VIEW` map: `onboarding -> 'onboarding'`, `'project-creation' -> 'project_creation'`. Both fire sites additionally stamp `variant: 'scm'` (these pills only ever install SCM providers, in an SCM flow, so the variant is constant here — but it is set explicitly so the install events carry the same dimension the rest of the funnel uses). Threading the existing discriminant is preferable to reading the experiment inside the component: it stays flow-agnostic and reusable, and the label reflects the flow that hosted the install rather than experiment enrollment.

The baked `onboarding_scm` and `scm_project_creation` values are removed from the three `view` unions that must stay in sync — the two component-local `analyticsParams` declarations (`useAddIntegration.tsx`, `integrationContext.tsx`) and the canonical `IntegrationView` in `utils/analytics/integrations/index.ts` — and each gains an optional `variant: 'scm' | 'legacy'`. The type is declared inline (not imported from the setup-docs PR's `ProjectCreationVariant`) because this PR is the base of the stack and cannot depend on a symbol a later PR introduces.

The `scmProviderPills` spec gained the now-required `analyticsFlow` prop on every render plus assertions that the install fires with `view: 'project_creation'` + `variant: 'scm'` for project creation and `view: 'onboarding'` + `variant: 'scm'` for onboarding — the latter guards the onboarding path against regression.

Note for BI: this moves traffic between buckets. Any `integrations.installation_* where view == 'onboarding_scm'` segmentation drops at merge, since both SCM onboarding and SCM project-creation installs now use flow-only `view` values (`onboarding` / `project_creation`) discriminated by `variant`. Recover the SCM cohort with `variant == 'scm'`.

Refs VDY-133

