### PR TITLE
chore(event formatter): add new event formatter to rpc

### DIFF
--- a/src/sentry/issues/formatting/limits.py
+++ b/src/sentry/issues/formatting/limits.py
@@ -43,13 +43,3 @@ LIMITS_LOW = Limits(
     max_contexts_chars=2_000,
     max_evidence_chars=2_000,
 )
-
-# tighter caps for token-constrained callers; mirrors Seer's EVENT_FORMAT_LIMITS_LOW
-LIMITS_LOW = Limits(
-    max_exceptions_chars=50_000,
-    max_stacktrace_chars=10_000,
-    max_breadcrumbs_chars=5_000,
-    max_single_breadcrumb_chars=500,
-    max_request_chars=2_000,
-    max_spans_chars=5_000,
-)

--- a/src/sentry/issues/formatting/limits.py
+++ b/src/sentry/issues/formatting/limits.py
@@ -43,3 +43,13 @@ LIMITS_LOW = Limits(
     max_contexts_chars=2_000,
     max_evidence_chars=2_000,
 )
+
+# tighter caps for token-constrained callers; mirrors Seer's EVENT_FORMAT_LIMITS_LOW
+LIMITS_LOW = Limits(
+    max_exceptions_chars=50_000,
+    max_stacktrace_chars=10_000,
+    max_breadcrumbs_chars=5_000,
+    max_single_breadcrumb_chars=500,
+    max_request_chars=2_000,
+    max_spans_chars=5_000,
+)

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2,7 +2,7 @@ import logging
 import time
 import uuid
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any, Literal, TypedDict, cast, get_args
+from typing import Any, Literal, TypedDict, cast
 
 from django.core.exceptions import BadRequest
 from django.db import models
@@ -26,7 +26,7 @@ from sentry.constants import ALL_ACCESS_PROJECT_ID, ObjectStatus
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.formatting.formatter import Format
 from sentry.issues.formatting.limits import LIMITS_DEFAULT, LIMITS_LOW
-from sentry.issues.formatting.mixin import FORMATTER_FEATURE
+from sentry.issues.formatting.mixin import FORMATTER_FEATURE, VALID_FORMATS
 from sentry.issues.formatting.sections import (
     EVENT_SECTIONS,
     breadcrumbs_section,
@@ -2021,7 +2021,7 @@ def get_event_details(
 
     # `format` arrives as an unvalidated RPC argument. Reject unknown values alongside the other
     # argument checks, so a bad request is a 400 whatever the lookup finds or the rollout says.
-    if format is not None and format not in get_args(Format):
+    if format is not None and format not in VALID_FORMATS:
         raise ParseError(f"Unsupported format: {format!r}")
 
     organization = Organization.objects.get(id=organization_id)

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2,7 +2,7 @@ import logging
 import time
 import uuid
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any, Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast, get_args
 
 from django.core.exceptions import BadRequest
 from django.db import models
@@ -2111,14 +2111,11 @@ def get_event_details(
             if include_breadcrumbs
             else [section for section in EVENT_SECTIONS if section is not breadcrumbs_section]
         )
-        # `format` arrives as an unvalidated RPC argument, so an unknown value would otherwise
-        # escape as a ValueError and surface as a 500 on the internal endpoint
-        try:
-            formatted = format_issue(
-                serialized_event, format=format, sections=sections, limits=limits
-            )
-        except ValueError as e:
-            raise ParseError(str(e)) from e
+        # `format` arrives as an unvalidated RPC argument; reject unknown values here so they
+        # surface as a 400 rather than escaping get_formatter as a ValueError -> 500
+        if format not in get_args(Format):
+            raise ParseError(f"Unsupported format: {format!r}")
+        formatted = format_issue(serialized_event, format=format, sections=sections, limits=limits)
 
     return EventDetailsResponse(
         event=serialized_event,

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2111,7 +2111,14 @@ def get_event_details(
             if include_breadcrumbs
             else [section for section in EVENT_SECTIONS if section is not breadcrumbs_section]
         )
-        formatted = format_issue(serialized_event, format=format, sections=sections, limits=limits)
+        # `format` arrives as an unvalidated RPC argument, so an unknown value would otherwise
+        # escape as a ValueError and surface as a 500 on the internal endpoint
+        try:
+            formatted = format_issue(
+                serialized_event, format=format, sections=sections, limits=limits
+            )
+        except ValueError as e:
+            raise ParseError(str(e)) from e
 
     return EventDetailsResponse(
         event=serialized_event,

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2019,6 +2019,11 @@ def get_event_details(
     if bool(event_id) == bool(issue_id):
         raise BadRequest("Either event_id or issue_id must be provided, but not both.")
 
+    # `format` arrives as an unvalidated RPC argument. Reject unknown values alongside the other
+    # argument checks, so a bad request is a 400 whatever the lookup finds or the rollout says.
+    if format is not None and format not in get_args(Format):
+        raise ParseError(f"Unsupported format: {format!r}")
+
     organization = Organization.objects.get(id=organization_id)
 
     event: Event | GroupEvent | None
@@ -2100,11 +2105,6 @@ def get_event_details(
 
     serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
     serialized_event.update(_get_event_troubleshooting_context(event))
-
-    # `format` arrives as an unvalidated RPC argument, so reject unknown values before the
-    # feature check: a bad request stays a 400 whether or not the org has the rollout
-    if format is not None and format not in get_args(Format):
-        raise ParseError(f"Unsupported format: {format!r}")
 
     # Opt-in shared-formatter output for Seer, gated behind the rollout feature so it can be
     # ramped gradually; when the feature is off, callers fall back to their own formatter.

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -24,6 +24,13 @@ from sentry.api.serializers.models.group import GroupSerializer
 from sentry.api.utils import MAX_STATS_PERIOD, default_start_end_dates, get_date_range_from_params
 from sentry.constants import ALL_ACCESS_PROJECT_ID, ObjectStatus
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
+from sentry.issues.formatting.formatter import Format
+from sentry.issues.formatting.limits import LIMITS_DEFAULT, LIMITS_LOW
+from sentry.issues.formatting.sections import (
+    EVENT_SECTIONS,
+    breadcrumbs_section,
+    format_issue,
+)
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
@@ -1984,6 +1991,9 @@ def get_event_details(
     start: str | None = None,
     end: str | None = None,
     project_slug: str | None = None,
+    format: Format | None = None,
+    format_limits: str = "default",
+    include_breadcrumbs: bool = True,
 ) -> EventDetailsResponse | None:
     """
     Get event details by event ID, or get the recommended event for an issue, optionally scoped by time range.
@@ -2085,12 +2095,24 @@ def get_event_details(
     serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
     serialized_event.update(_get_event_troubleshooting_context(event))
 
+    # Opt-in shared-formatter output for Seer (so it drops its own EventDetails.format_event).
+    formatted: str | None = None
+    if format is not None:
+        limits = LIMITS_LOW if format_limits == "low" else LIMITS_DEFAULT
+        sections = (
+            EVENT_SECTIONS
+            if include_breadcrumbs
+            else [section for section in EVENT_SECTIONS if section is not breadcrumbs_section]
+        )
+        formatted = format_issue(serialized_event, format=format, sections=sections, limits=limits)
+
     return EventDetailsResponse(
         event=serialized_event,
         event_id=event.event_id,
         event_trace_id=event.trace_id,
         project_id=event.project_id,
         project_slug=event.project.slug,
+        formatted=formatted,
     )
 
 

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -31,6 +31,7 @@ from sentry.issues.formatting.sections import (
     EVENT_SECTIONS,
     breadcrumbs_section,
     format_issue,
+    user_section,
 )
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
@@ -2106,11 +2107,11 @@ def get_event_details(
     formatted: str | None = None
     if format is not None and features.has(FORMATTER_FEATURE, organization):
         limits = LIMITS_LOW if format_limits == "low" else LIMITS_DEFAULT
-        sections = (
-            EVENT_SECTIONS
-            if include_breadcrumbs
-            else [section for section in EVENT_SECTIONS if section is not breadcrumbs_section]
-        )
+        # Seer's own formatter never rendered user identifiers into its prompts; keep that
+        # true here so switching to the shared formatter doesn't send email/IP to the model.
+        sections = [section for section in EVENT_SECTIONS if section is not user_section]
+        if not include_breadcrumbs:
+            sections = [section for section in sections if section is not breadcrumbs_section]
         # `format` arrives as an unvalidated RPC argument; reject unknown values here so they
         # surface as a 400 rather than escaping get_formatter as a ValueError -> 500
         if format not in get_args(Format):

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2,7 +2,7 @@ import logging
 import time
 import uuid
 from datetime import UTC, datetime, timedelta, timezone
-from typing import Any, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
 from django.core.exceptions import BadRequest
 from django.db import models
@@ -1993,7 +1993,7 @@ def get_event_details(
     end: str | None = None,
     project_slug: str | None = None,
     format: Format | None = None,
-    format_limits: str = "default",
+    format_limits: Literal["default", "low"] = "default",
     include_breadcrumbs: bool = True,
 ) -> EventDetailsResponse | None:
     """
@@ -2007,9 +2007,14 @@ def get_event_details(
         start: ISO timestamp for the start of the time range to get recommended event for (optional).
         end: ISO timestamp for the end of the time range to get recommended event for (optional).
         project_slug: The slug of the project (optional).
+        format: When set (markdown | xml), also render the event through the shared formatter into
+            the ``formatted`` field. Requires the ``issues.standardized-markdown-for-llm`` option.
+        format_limits: Truncation profile for the rendered output ("default" or "low").
+        include_breadcrumbs: Drop the breadcrumbs section from the rendered output when False.
 
     Returns:
-        Dict with serialized event, event_id, event_trace_id, project_id, project_slug, or None if not found.
+        Dict with serialized event, event_id, event_trace_id, project_id, project_slug, and
+        formatted (rendered text when a ``format`` is requested, else None), or None if not found.
     """
     if bool(event_id) == bool(issue_id):
         raise BadRequest("Either event_id or issue_id must be provided, but not both.")

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -31,7 +31,6 @@ from sentry.issues.formatting.sections import (
     EVENT_SECTIONS,
     breadcrumbs_section,
     format_issue,
-    user_section,
 )
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
@@ -2107,11 +2106,13 @@ def get_event_details(
     formatted: str | None = None
     if format is not None and features.has(FORMATTER_FEATURE, organization):
         limits = LIMITS_LOW if format_limits == "low" else LIMITS_DEFAULT
-        # Seer's own formatter never rendered user identifiers into its prompts; keep that
-        # true here so switching to the shared formatter doesn't send email/IP to the model.
-        sections = [section for section in EVENT_SECTIONS if section is not user_section]
-        if not include_breadcrumbs:
-            sections = [section for section in sections if section is not breadcrumbs_section]
+        # EVENT_SECTIONS already holds back user identifiers, which Seer's own formatter never
+        # rendered into its prompts either
+        sections = (
+            EVENT_SECTIONS
+            if include_breadcrumbs
+            else [section for section in EVENT_SECTIONS if section is not breadcrumbs_section]
+        )
         # `format` arrives as an unvalidated RPC argument; reject unknown values here so they
         # surface as a 400 rather than escaping get_formatter as a ValueError -> 500
         if format not in get_args(Format):

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
-from sentry import eventstore, features, options
+from sentry import eventstore, features
 from sentry.api import client
 from sentry.api.endpoints.organization_events_timeseries import TOP_EVENTS_DATASETS
 from sentry.api.event_search import parse_search_query
@@ -26,7 +26,7 @@ from sentry.constants import ALL_ACCESS_PROJECT_ID, ObjectStatus
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.formatting.formatter import Format
 from sentry.issues.formatting.limits import LIMITS_DEFAULT, LIMITS_LOW
-from sentry.issues.formatting.mixin import FORMATTER_OPTION
+from sentry.issues.formatting.mixin import FORMATTER_FEATURE
 from sentry.issues.formatting.sections import (
     EVENT_SECTIONS,
     breadcrumbs_section,
@@ -2008,7 +2008,7 @@ def get_event_details(
         end: ISO timestamp for the end of the time range to get recommended event for (optional).
         project_slug: The slug of the project (optional).
         format: When set (markdown | xml), also render the event through the shared formatter into
-            the ``formatted`` field. Requires the ``issues.standardized-markdown-for-llm`` option.
+            the ``formatted`` field. Requires the ``organizations:issue-standardized-markdown-for-llm`` feature.
         format_limits: Truncation profile for the rendered output ("default" or "low").
         include_breadcrumbs: Drop the breadcrumbs section from the rendered output when False.
 
@@ -2101,10 +2101,10 @@ def get_event_details(
     serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
     serialized_event.update(_get_event_troubleshooting_context(event))
 
-    # Opt-in shared-formatter output for Seer, gated behind the rollout option so it can be
-    # ramped gradually; when the option is off, callers fall back to their own formatter.
+    # Opt-in shared-formatter output for Seer, gated behind the rollout feature so it can be
+    # ramped gradually; when the feature is off, callers fall back to their own formatter.
     formatted: str | None = None
-    if format is not None and options.get(FORMATTER_OPTION):
+    if format is not None and features.has(FORMATTER_FEATURE, organization):
         limits = LIMITS_LOW if format_limits == "low" else LIMITS_DEFAULT
         sections = (
             EVENT_SECTIONS

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -11,7 +11,7 @@ from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from snuba_sdk import Column, Condition, Entity, Function, Limit, Op, Query, Request
 
-from sentry import eventstore, features
+from sentry import eventstore, features, options
 from sentry.api import client
 from sentry.api.endpoints.organization_events_timeseries import TOP_EVENTS_DATASETS
 from sentry.api.event_search import parse_search_query
@@ -26,6 +26,7 @@ from sentry.constants import ALL_ACCESS_PROJECT_ID, ObjectStatus
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
 from sentry.issues.formatting.formatter import Format
 from sentry.issues.formatting.limits import LIMITS_DEFAULT, LIMITS_LOW
+from sentry.issues.formatting.mixin import FORMATTER_OPTION
 from sentry.issues.formatting.sections import (
     EVENT_SECTIONS,
     breadcrumbs_section,
@@ -2095,9 +2096,10 @@ def get_event_details(
     serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
     serialized_event.update(_get_event_troubleshooting_context(event))
 
-    # Opt-in shared-formatter output for Seer (so it drops its own EventDetails.format_event).
+    # Opt-in shared-formatter output for Seer, gated behind the rollout option so it can be
+    # ramped gradually; when the option is off, callers fall back to their own formatter.
     formatted: str | None = None
-    if format is not None:
+    if format is not None and options.get(FORMATTER_OPTION):
         limits = LIMITS_LOW if format_limits == "low" else LIMITS_DEFAULT
         sections = (
             EVENT_SECTIONS

--- a/src/sentry/seer/agent/tools.py
+++ b/src/sentry/seer/agent/tools.py
@@ -2101,22 +2101,22 @@ def get_event_details(
     serialized_event = dict(serialize(event, user=None, serializer=EventSerializer()))
     serialized_event.update(_get_event_troubleshooting_context(event))
 
+    # `format` arrives as an unvalidated RPC argument, so reject unknown values before the
+    # feature check: a bad request stays a 400 whether or not the org has the rollout
+    if format is not None and format not in get_args(Format):
+        raise ParseError(f"Unsupported format: {format!r}")
+
     # Opt-in shared-formatter output for Seer, gated behind the rollout feature so it can be
     # ramped gradually; when the feature is off, callers fall back to their own formatter.
     formatted: str | None = None
     if format is not None and features.has(FORMATTER_FEATURE, organization):
         limits = LIMITS_LOW if format_limits == "low" else LIMITS_DEFAULT
-        # EVENT_SECTIONS already holds back user identifiers, which Seer's own formatter never
-        # rendered into its prompts either
+        # EVENT_SECTIONS holds back user identifiers, which Seer's prompts never carried
         sections = (
             EVENT_SECTIONS
             if include_breadcrumbs
             else [section for section in EVENT_SECTIONS if section is not breadcrumbs_section]
         )
-        # `format` arrives as an unvalidated RPC argument; reject unknown values here so they
-        # surface as a 400 rather than escaping get_formatter as a ValueError -> 500
-        if format not in get_args(Format):
-            raise ParseError(f"Unsupported format: {format!r}")
         formatted = format_issue(serialized_event, format=format, sections=sections, limits=limits)
 
     return EventDetailsResponse(

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -471,7 +471,7 @@ class EventDetailsResponse(_DictProxyMixin):
     event_trace_id: str | None
     project_id: int
     project_slug: str
-    # shared-formatter text, present when the RPC is called with a `format`
+    # shared-formatter text; populated when the RPC is called with a `format`, else None
     formatted: str | None = None
 
 

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -471,6 +471,8 @@ class EventDetailsResponse(_DictProxyMixin):
     event_trace_id: str | None
     project_id: int
     project_slug: str
+    # shared-formatter text, present when the RPC is called with a `format`
+    formatted: str | None = None
 
 
 class IssueDetailsResponse(_DictProxyMixin):

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -61,7 +61,6 @@ from sentry.testutils.cases import (
     SpanTestCase,
     TraceMetricsTestCase,
 )
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.activity import ActivityType
 from sentry.utils.dates import parse_stats_period
@@ -2068,7 +2067,7 @@ class TestGetEventDetails(
     def test_format_returns_shared_formatter_output(self) -> None:
         event = self._make_error_event()
 
-        with override_options({"issues.standardized-markdown-for-llm": True}):
+        with self.feature("organizations:issue-standardized-markdown-for-llm"):
             result = get_event_details(
                 organization_id=self.organization.id,
                 event_id=event.event_id,
@@ -2114,7 +2113,7 @@ class TestGetEventDetails(
         }
         event = self.store_event(data=data, project_id=self.project.id)
 
-        with override_options({"issues.standardized-markdown-for-llm": True}):
+        with self.feature("organizations:issue-standardized-markdown-for-llm"):
             with_crumbs = get_event_details(
                 organization_id=self.organization.id,
                 event_id=event.event_id,

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2107,6 +2107,33 @@ class TestGetEventDetails(
         assert result is not None
         assert result["formatted"] is None
 
+    def test_include_breadcrumbs_false_drops_section(self) -> None:
+        data = load_data("python", timestamp=before_now(minutes=5))
+        data["breadcrumbs"] = {
+            "values": [{"category": "auth", "message": "login", "level": "info"}]
+        }
+        event = self.store_event(data=data, project_id=self.project.id)
+
+        with override_options({"issues.standardized-markdown-for-llm": True}):
+            with_crumbs = get_event_details(
+                organization_id=self.organization.id,
+                event_id=event.event_id,
+                project_slug=self.project.slug,
+                format="markdown",
+            )
+            without_crumbs = get_event_details(
+                organization_id=self.organization.id,
+                event_id=event.event_id,
+                project_slug=self.project.slug,
+                format="markdown",
+                include_breadcrumbs=False,
+            )
+
+        assert with_crumbs is not None and with_crumbs["formatted"] is not None
+        assert "## Breadcrumbs" in with_crumbs["formatted"]
+        assert without_crumbs is not None and without_crumbs["formatted"] is not None
+        assert "## Breadcrumbs" not in without_crumbs["formatted"]
+
     def test_by_event_id_multi_project(self) -> None:
         """Fetching by event_id without project_slug hits the multi-project code path."""
         self.create_project(organization=self.organization)  # second project → multi-project path

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2064,6 +2064,33 @@ class TestGetEventDetails(
 
         self._assert_event_response_shape(result, expected_event_id=event.event_id)
 
+    def test_format_returns_shared_formatter_output(self) -> None:
+        event = self._make_error_event()
+
+        result = get_event_details(
+            organization_id=self.organization.id,
+            event_id=event.event_id,
+            project_slug=self.project.slug,
+            format="markdown",
+        )
+
+        assert result is not None
+        assert result["formatted"] is not None
+        assert "## Title" in result["formatted"]
+        assert "## Exception" in result["formatted"]
+
+    def test_no_format_omits_formatted(self) -> None:
+        event = self._make_error_event()
+
+        result = get_event_details(
+            organization_id=self.organization.id,
+            event_id=event.event_id,
+            project_slug=self.project.slug,
+        )
+
+        assert result is not None
+        assert result["formatted"] is None
+
     def test_by_event_id_multi_project(self) -> None:
         """Fetching by event_id without project_slug hits the multi-project code path."""
         self.create_project(organization=self.organization)  # second project → multi-project path

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -61,6 +61,7 @@ from sentry.testutils.cases import (
     SpanTestCase,
     TraceMetricsTestCase,
 )
+from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.activity import ActivityType
 from sentry.utils.dates import parse_stats_period
@@ -2067,6 +2068,23 @@ class TestGetEventDetails(
     def test_format_returns_shared_formatter_output(self) -> None:
         event = self._make_error_event()
 
+        with override_options({"issues.standardized-markdown-for-llm": True}):
+            result = get_event_details(
+                organization_id=self.organization.id,
+                event_id=event.event_id,
+                project_slug=self.project.slug,
+                format="markdown",
+            )
+
+        assert result is not None
+        assert result["formatted"] is not None
+        assert "## Title" in result["formatted"]
+        assert "## Exception" in result["formatted"]
+
+    def test_format_omitted_when_option_disabled(self) -> None:
+        # format requested, but the rollout option is off -> no formatted (caller falls back)
+        event = self._make_error_event()
+
         result = get_event_details(
             organization_id=self.organization.id,
             event_id=event.event_id,
@@ -2075,9 +2093,7 @@ class TestGetEventDetails(
         )
 
         assert result is not None
-        assert result["formatted"] is not None
-        assert "## Title" in result["formatted"]
-        assert "## Exception" in result["formatted"]
+        assert result["formatted"] is None
 
     def test_no_format_omits_formatted(self) -> None:
         event = self._make_error_event()

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2108,17 +2108,19 @@ class TestGetEventDetails(
         assert result["formatted"] is None
 
     def test_invalid_format_raises_parse_error(self) -> None:
-        # `format` is an unvalidated RPC argument; an unknown value must be a 400, not a 500
+        # `format` is an unvalidated RPC argument; an unknown value must be a 400, not a 500,
+        # and the answer can't depend on whether the org has the rollout yet
         event = self._make_error_event()
 
-        with self.feature("organizations:issue-standardized-markdown-for-llm"):
-            with pytest.raises(ParseError):
-                get_event_details(
-                    organization_id=self.organization.id,
-                    event_id=event.event_id,
-                    project_slug=self.project.slug,
-                    format="yaml",  # type: ignore[arg-type]
-                )
+        for features in ([], ["organizations:issue-standardized-markdown-for-llm"]):
+            with self.subTest(features=features), self.feature(features):
+                with pytest.raises(ParseError):
+                    get_event_details(
+                        organization_id=self.organization.id,
+                        event_id=event.event_id,
+                        project_slug=self.project.slug,
+                        format="yaml",  # type: ignore[arg-type]
+                    )
 
     def test_include_breadcrumbs_false_drops_section(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=5))

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -7,6 +7,7 @@ import pytest
 from django.core.cache import cache
 from django.core.exceptions import BadRequest, ObjectDoesNotExist
 from pydantic import BaseModel
+from rest_framework.exceptions import ParseError
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.api import client
@@ -2105,6 +2106,19 @@ class TestGetEventDetails(
 
         assert result is not None
         assert result["formatted"] is None
+
+    def test_invalid_format_raises_parse_error(self) -> None:
+        # `format` is an unvalidated RPC argument; an unknown value must be a 400, not a 500
+        event = self._make_error_event()
+
+        with self.feature("organizations:issue-standardized-markdown-for-llm"):
+            with pytest.raises(ParseError):
+                get_event_details(
+                    organization_id=self.organization.id,
+                    event_id=event.event_id,
+                    project_slug=self.project.slug,
+                    format="yaml",  # type: ignore[arg-type]
+                )
 
     def test_include_breadcrumbs_false_drops_section(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=5))

--- a/tests/sentry/seer/agent/test_tools.py
+++ b/tests/sentry/seer/agent/test_tools.py
@@ -2122,6 +2122,16 @@ class TestGetEventDetails(
                         format="yaml",  # type: ignore[arg-type]
                     )
 
+        # ...and it can't depend on the lookup succeeding either: a bad argument is a bad
+        # argument, not a "not found"
+        with pytest.raises(ParseError):
+            get_event_details(
+                organization_id=self.organization.id,
+                event_id=uuid.uuid4().hex,
+                project_slug=self.project.slug,
+                format="yaml",  # type: ignore[arg-type]
+            )
+
     def test_include_breadcrumbs_false_drops_section(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=5))
         data["breadcrumbs"] = {

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -5,9 +5,12 @@ from django.urls import reverse
 from sentry.models.apitoken import ApiToken
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
+from sentry.utils.samples import load_data
 
 
 class TestOrganizationSeerRpcEndpoint(APITestCase):
@@ -388,3 +391,50 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
 
         assert response.status_code == 200
         assert response.data == {"has_code_mappings": False, "project_slug_to_id": {}}
+
+
+class TestOrganizationSeerRpcGetEventDetailsWire(APITestCase, SnubaTestCase):
+    """End-to-end wire check: get_event_details' `formatted` field survives serialization
+    through the RPC endpoint and comes back in the JSON body."""
+
+    endpoint = "sentry-api-0-organization-seer-rpc"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.login_as(self.user)
+
+    def _get_path(self, method_name: str) -> str:
+        return reverse(
+            self.endpoint,
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "method_name": method_name,
+            },
+        )
+
+    @with_feature("organizations:seer-public-rpc")
+    @override_options({"issues.standardized-markdown-for-llm": True})
+    def test_formatted_survives_the_wire(self) -> None:
+        data = load_data("python", timestamp=before_now(minutes=5))
+        data["exception"] = {"values": [{"type": "Exception", "value": "boom"}]}
+        event = self.store_event(data=data, project_id=self.project.id)
+
+        path = self._get_path("get_event_details")
+        response = self.client.post(
+            path,
+            data={
+                "args": {
+                    "event_id": event.event_id,
+                    "project_slug": self.project.slug,
+                    "format": "markdown",
+                }
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body["formatted"], str)
+        assert "## Exception" in body["formatted"]

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -6,7 +6,6 @@ from sentry.models.apitoken import ApiToken
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, SnubaTestCase
-from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
@@ -415,7 +414,7 @@ class TestOrganizationSeerRpcGetEventDetailsWire(APITestCase, SnubaTestCase):
         )
 
     @with_feature("organizations:seer-public-rpc")
-    @override_options({"issues.standardized-markdown-for-llm": True})
+    @with_feature("organizations:issue-standardized-markdown-for-llm")
     def test_formatted_survives_the_wire(self) -> None:
         data = load_data("python", timestamp=before_now(minutes=5))
         data["exception"] = {"values": [{"type": "Exception", "value": "boom"}]}


### PR DESCRIPTION
to be merged after #119862

Extends the existing get_event_details Seer RPC (src/sentry/seer/agent/tools.py) to optionally return shared-formatter output, so Seer can drop its own EventDetails.format_event. Adds three optional params:
- format (markdown | xml | None) — when set, the RPC renders the serialized event through the shared formatter.
- format_limits ("default" | "low") — selects the truncation limits (adds LIMITS_LOW to mirror Seer's low-limit profile).
- include_breadcrumbs (default True) — drops the breadcrumbs section when False.

The rendered text comes back in a new optional formatted field on EventDetailsResponse.

No behavioral change on merge. behind the `issues.standardized-markdown-for-llm` option. Rollout will happen gradually via feature flag.