### PR TITLE
fix(devserver): Wait for Rspack shutdown on interrupt

### DIFF
--- a/scripts/dev-ui-server.ts
+++ b/scripts/dev-ui-server.ts
@@ -31,6 +31,12 @@ function startServer(port: number): void {
     env: {...process.env, SENTRY_WEBPACK_PROXY_PORT: String(port)},
     stdio: 'inherit',
   });
+
+  // SIGINT is delivered to both this wrapper and rspack because they share a
+  // foreground process group. Keep the wrapper alive while rspack performs its
+  // graceful shutdown so the shell does not reclaim the terminal too early.
+  process.on('SIGINT', () => {});
+
   child.on('close', code => process.exit(code ?? 0));
 }
 


### PR DESCRIPTION
When `dev-ui` receives Ctrl+C, both the Node wrapper and Rspack receive SIGINT. The wrapper previously exited immediately while Rspack was still performing its graceful shutdown, returning control to the shell while the child continued using the terminal and causing terminal protocol responses to appear as input.

Keep the wrapper alive until Rspack exits so terminal control returns to the shell only after shutdown completes. Rspack still receives SIGINT directly, including a second Ctrl+C to force an immediate exit.