### PR TITLE
feat(seer): Smart Assignment delivery

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -28,7 +28,12 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.issues.action_log import publish_action_from_context, publish_actions_from_context_bulk
 from sentry.issues.grouptype import get_group_type_by_type_id
 from sentry.tasks import activity
-from sentry.types.activity import CHOICES, STATUS_CHANGE_ACTIVITY_TYPES, ActivityType
+from sentry.types.activity import (
+    CHOICES,
+    HIDDEN_ACTIVITY_TYPES,
+    STATUS_CHANGE_ACTIVITY_TYPES,
+    ActivityType,
+)
 from sentry.types.group import PriorityLevel
 from sentry.utils.action_log.activity_translator import (
     activity_action_idempotency_key,
@@ -50,7 +55,13 @@ _default_logger = logging.getLogger(__name__)
 class ActivityManager(BaseManager["Activity"]):
     def get_activities_for_group(self, group: Group, num: int) -> Sequence[Activity]:
         activities = []
-        activity_qs = self.filter(group=group).order_by("-datetime")
+        # Internal-signal activities (e.g. SMART_ASSIGNMENT_COMPLETED) exist only to drive
+        # workflow handlers; they have no frontend rendering and must be kept out of the feed.
+        activity_qs = (
+            self.filter(group=group)
+            .exclude(type__in=[t.value for t in HIDDEN_ACTIVITY_TYPES])
+            .order_by("-datetime")
+        )
 
         initial_priority_value = group.get_event_metadata().get("initial_priority")
         initial_priority = (

--- a/src/sentry/seer/agent/feature_delivery.py
+++ b/src/sentry/seer/agent/feature_delivery.py
@@ -6,6 +6,7 @@ from typing import Any, Protocol
 
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.night_shift.delivery import deliver_night_shift_result
+from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
 
 __all__ = ["DELIVERY_HANDLERS", "FeatureDeliveryFn", "FeatureRunStatus"]
 
@@ -23,4 +24,5 @@ class FeatureDeliveryFn(Protocol):
 
 DELIVERY_HANDLERS: dict[str, FeatureDeliveryFn] = {
     "night_shift": deliver_night_shift_result,
+    "smart_assignment": deliver_smart_assignment_result,
 }

--- a/src/sentry/seer/agent/feature_delivery.py
+++ b/src/sentry/seer/agent/feature_delivery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Protocol
+from uuid import UUID
 
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.night_shift.delivery import deliver_night_shift_result
@@ -15,7 +16,7 @@ class FeatureDeliveryFn(Protocol):
     def __call__(
         self,
         organization_id: int,
-        run_uuid: str,
+        run_uuid: UUID,
         status: FeatureRunStatus,
         result: dict[str, Any] | None,
         error: str | None,

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -829,7 +829,7 @@ def deliver_feature_result(
         )
         return
 
-    handler(organization_id, run_uuid, status, result, error)
+    handler(organization_id, uuid.UUID(run_uuid), status, result, error)
 
 
 def get_monitoring_provider_connections(

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -829,7 +829,12 @@ def deliver_feature_result(
         )
         return
 
-    handler(organization_id, uuid.UUID(run_uuid), status, result, error)
+    try:
+        parsed_run_uuid = uuid.UUID(run_uuid)
+    except (TypeError, ValueError):
+        raise ParseError("Invalid run uuid")
+
+    handler(organization_id, parsed_run_uuid, status, result, error)
 
 
 def get_monitoring_provider_connections(

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from typing import Any
+from uuid import UUID
 
 import sentry_sdk
 
@@ -40,7 +41,7 @@ REASON_MAX_CHARS = 2048
 
 def deliver_night_shift_result(
     organization_id: int,
-    run_uuid: str,
+    run_uuid: UUID,
     status: FeatureRunStatus,
     result: dict[str, Any] | None,
     error: str | None,

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any
+from uuid import UUID
 
 from sentry.models.activity import Activity
 from sentry.models.group import Group
@@ -54,7 +55,7 @@ def _resolve_identifier_to_user_id(
 
 def deliver_smart_assignment_result(
     organization_id: int,
-    run_uuid: str,
+    run_uuid: UUID,
     status: FeatureRunStatus,
     result: dict[str, Any] | None,
     error: str | None,
@@ -151,7 +152,7 @@ def deliver_smart_assignment_result(
         ActivityType.SMART_ASSIGNMENT_COMPLETED,
         data={
             "run_id": agent_run.run_id,
-            "run_uuid": run_uuid,
+            "run_uuid": str(run_uuid),
             "predicted_assignee_user_ids": predicted_assignee_user_ids,
         },
         send_notification=False,

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -55,7 +55,11 @@ def _resolve_identifier_to_user_id(
         return users[0].id if users else None
 
     if kind == "username":
-        users = user_service.get_by_username(username=value)
+        # with_valid_password=False: this is identity resolution, not authentication.
+        # The default excludes users whose password is "!" (SSO-only / no-password
+        # accounts), which would silently drop valid org members and mislabel the
+        # prediction as "unlinked". Org scoping is enforced by the membership check below.
+        users = user_service.get_by_username(username=value, with_valid_password=False)
         if not users:
             return None
         user_id = users[0].id
@@ -83,6 +87,8 @@ def deliver_smart_assignment_result(
       - `error`         -- Seer run failed or returned no artifact
       - `missing_group` -- run isn't tied to a group, or the group was deleted before
                            delivery, so there's nothing to record the prediction against
+      - `duplicate`     -- a completion activity already exists for this run (Seer retry
+                           or redelivery), so we skip re-recording it
       - `abstain`       -- completed, but the agent named no one
       - `unlinked`      -- named someone we couldn't map to an org user
       - `resolved`      -- named someone we mapped to a Sentry user
@@ -136,6 +142,25 @@ def deliver_smart_assignment_result(
     if group is None:
         metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_group"})
         logger.warning("smart_assignment.delivery.missing_group", extra=log_extra)
+        return
+
+    # A Seer retry or redelivery re-invokes this handler for the same run. The completion
+    # activity is this feature's system of record, and creating it re-runs scoring/
+    # auto-assignment via the workflow handlers, so skip if we already recorded one for
+    # this run. Activity carries no unique constraint, so this is a best-effort pre-check
+    # keyed on the run (like night_shift's recorded-rows check) rather than a DB guard;
+    # it covers sequential redelivery but not a concurrent-redelivery race. `data` is a
+    # text-backed JSON field (not queryable via a JSON path), so match run_id in Python
+    # over the handful of completion activities a group can accumulate.
+    already_recorded = any(
+        (activity.data or {}).get("run_id") == agent_run.id
+        for activity in Activity.objects.filter(
+            group=group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        )
+    )
+    if already_recorded:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "duplicate"})
+        logger.info("smart_assignment.delivery.duplicate", extra=log_extra)
         return
 
     # Hand the resolved verdict off to the completion path via an activity that points

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -116,7 +116,11 @@ def deliver_smart_assignment_result(
     ]
 
     # Do nothing if the group was deleted before delivery, or if the run isn't tied to a group.
-    group = Group.objects.filter(id=group_id).first() if group_id is not None else None
+    group = (
+        Group.objects.filter(id=group_id, project__organization_id=organization_id).first()
+        if group_id is not None
+        else None
+    )
     if group is None:
         metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_group"})
         logger.warning("smart_assignment.delivery.missing_group", extra=log_extra)

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -59,7 +59,9 @@ def _resolve_identifier_to_user_id(
         # The default excludes users whose password is "!" (SSO-only / no-password
         # accounts), which would silently drop valid org members and mislabel the
         # prediction as "unlinked". Org scoping is enforced by the membership check below.
-        users = user_service.get_by_username(username=value, with_valid_password=False)
+        users = user_service.get_by_username(
+            username=value, with_valid_password=False, is_active=True
+        )
         if not users:
             return None
         user_id = users[0].id

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -22,7 +22,7 @@ class _DeliveryAborted(Exception):
 
 
 def _incr(outcome: str) -> None:
-    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome})
+    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome}, sample_rate=1.0)
 
 
 def _validate_run(

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -153,11 +153,12 @@ def _record_result(
     recorded one for this run. Activity carries no unique constraint, so this is a
     best-effort pre-check; it covers sequential redelivery but not a concurrent race.
     """
-    already_recorded = Activity.objects.filter(
-        group=group,
-        type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
-        data__run_id=seer_run_id,
-    ).exists()
+    already_recorded = any(
+        (activity.data or {}).get("run_id") == seer_run_id
+        for activity in Activity.objects.filter(
+            group=group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        )
+    )
     if already_recorded:
         _incr("duplicate")
         logger.info("smart_assignment.delivery.duplicate", extra=log_extra)

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -1,14 +1,3 @@
-"""Delivery handler for smart_assignment feature results from Seer.
-
-Seer pushes the `AssigneeVerdict` artifact back via the `deliver_feature_result`
-RPC, routed here by feature_id (see `sentry.seer.agent.feature_delivery`). Seer is
-the system of record for the verdict itself; here we resolve the ranked candidates to
-Sentry users and record a `SMART_ASSIGNMENT_COMPLETED` activity (pointing back at the
-run) carrying those resolved picks, then emit a delivery outcome metric. Acting on
-the verdict -- scoring it and auto-assigning -- happens independently off that activity
-(see `completion`), so this handler stays a thin resolve-and-record step.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -32,13 +21,6 @@ def _resolve_identifier_to_user_id(
 ) -> int | None:
     """Map an agent-produced `identifier` to a Sentry user id in the org.
 
-    The agent tags each pick with `identifier_kind` (see the `RankedCandidate`
-    contract on the Seer side) so we resolve deterministically instead of inferring
-    the type from the string:
-      - "email":    verified org email (the RPC already scopes to the org).
-      - "username": unique username, confirmed to be an org member so a global match
-                    can't attribute a prediction to someone outside the org.
-    `kind` is a validated Literal by the time it gets here, so this doesn't guess.
     Returns None when the agent named no one or the identifier maps to no org user.
     """
     if not identifier:
@@ -55,10 +37,7 @@ def _resolve_identifier_to_user_id(
         return users[0].id if users else None
 
     if kind == "username":
-        # with_valid_password=False: this is identity resolution, not authentication.
-        # The default excludes users whose password is "!" (SSO-only / no-password
-        # accounts), which would silently drop valid org members and mislabel the
-        # prediction as "unlinked". Org scoping is enforced by the membership check below.
+        # use with_value_password=False to include SSO-only users
         users = user_service.get_by_username(
             username=value, with_valid_password=False, is_active=True
         )
@@ -128,10 +107,7 @@ def deliver_smart_assignment_result(
         logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)
         return
 
-    # Resolve every ranked candidate (best-first) to a Sentry user id so scoring can
-    # grade the top pick and also see where the eventual assignee placed in the list
-    # (its hit_rank). None marks a position we couldn't map to an org user, preserving
-    # each candidate's rank; the raw verdict itself is still queryable on the Seer run.
+    # Resolve every ranked candidate to a Sentry user, best-first.
     predicted_assignee_user_ids = [
         _resolve_identifier_to_user_id(
             organization_id, candidate.identifier, candidate.identifier_kind
@@ -149,11 +125,8 @@ def deliver_smart_assignment_result(
     # A Seer retry or redelivery re-invokes this handler for the same run. The completion
     # activity is this feature's system of record, and creating it re-runs scoring/
     # auto-assignment via the workflow handlers, so skip if we already recorded one for
-    # this run. Activity carries no unique constraint, so this is a best-effort pre-check
-    # keyed on the run (like night_shift's recorded-rows check) rather than a DB guard;
-    # it covers sequential redelivery but not a concurrent-redelivery race. `data` is a
-    # text-backed JSON field (not queryable via a JSON path), so match run_id in Python
-    # over the handful of completion activities a group can accumulate.
+    # this run. Activity carries no unique constraint, so this is a best-effort pre-check;
+    # it covers sequential redelivery but not a concurrent-redelivery race.
     already_recorded = any(
         (activity.data or {}).get("run_id") == agent_run.id
         for activity in Activity.objects.filter(
@@ -168,7 +141,7 @@ def deliver_smart_assignment_result(
     # Hand the resolved verdict off to the completion path via an activity that points
     # back at this run. Creating it invokes the workflow activity handlers, which score
     # the prediction (completing the pair now if ground truth already landed) and
-    # auto-assign as needed -- kept out of this RPC handler on purpose.
+    # auto-assign as needed.
     Activity.objects.create_group_activity(
         group,
         ActivityType.SMART_ASSIGNMENT_COMPLETED,

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -132,7 +132,7 @@ def deliver_smart_assignment_result(
     # this run. Activity carries no unique constraint, so this is a best-effort pre-check;
     # it covers sequential redelivery but not a concurrent-redelivery race.
     already_recorded = any(
-        (activity.data or {}).get("run_id") == agent_run.id
+        (activity.data or {}).get("run_id") == agent_run.run_id
         for activity in Activity.objects.filter(
             group=group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
         )
@@ -150,7 +150,7 @@ def deliver_smart_assignment_result(
         group,
         ActivityType.SMART_ASSIGNMENT_COMPLETED,
         data={
-            "run_id": agent_run.id,
+            "run_id": agent_run.run_id,
             "run_uuid": run_uuid,
             "predicted_assignee_user_ids": predicted_assignee_user_ids,
         },

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -17,40 +17,177 @@ from sentry.utils import metrics
 logger = logging.getLogger(__name__)
 
 
-def _resolve_identifier_to_user_id(
-    organization_id: int, identifier: str | None, kind: str | None
-) -> int | None:
-    """Map an agent-produced `identifier` to a Sentry user id in the org.
+class _DeliveryAborted(Exception):
+    """Control-flow signal: a step is stopping delivery early"""
 
-    Returns None when the agent named no one or the identifier maps to no org user.
+
+def _incr(outcome: str) -> None:
+    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome})
+
+
+def _validate_run(
+    organization_id: int,
+    run_uuid: UUID,
+    status: FeatureRunStatus,
+    result: dict[str, Any] | None,
+    error: str | None,
+) -> int:
+    """Load the run mirror and confirm the delivery carries a usable result.
+
+    Returns the SeerRun id, or emits the tagged outcome and aborts for an orphaned run
+    (`missing_run`) or a failed/empty delivery (`error`).
     """
-    if not identifier:
-        return None
-
-    value = identifier.strip()
-    if not value:
-        return None
-
-    if kind == "email":
-        users = user_service.get_many_by_email(
-            emails=[value], organization_id=organization_id, is_verified=True
+    agent_run = (
+        SeerAgentRun.objects.filter(
+            run__uuid=run_uuid, run__organization_id=organization_id, source=SEER_FEATURE_ID
         )
-        return users[0].id if users else None
-
-    if kind == "username":
-        # use with_value_password=False to include SSO-only users
-        users = user_service.get_by_username(
-            username=value, with_valid_password=False, is_active=True
+        .select_related("run")
+        .first()
+    )
+    if agent_run is None:
+        _incr("missing_run")
+        logger.warning(
+            "smart_assignment.delivery.missing_run",
+            extra={"organization_id": organization_id, "run_uuid": run_uuid},
         )
-        if not users:
-            return None
-        user_id = users[0].id
-        member = organization_service.check_membership_by_id(
-            organization_id=organization_id, user_id=user_id
-        )
-        return user_id if member is not None else None
+        raise _DeliveryAborted
 
-    return None
+    if status == "error" or result is None:
+        _incr("error")
+        logger.warning(
+            "smart_assignment.delivery.no_result",
+            extra={
+                "organization_id": organization_id,
+                "group_id": agent_run.group_id,
+                "run_uuid": run_uuid,
+                "status": status,
+                "error": error,
+            },
+        )
+        raise _DeliveryAborted
+
+    return agent_run.run_id
+
+
+def _validate_group(organization_id: int, run_uuid: UUID) -> Group:
+    """Load the live group the run is tied to, to record the prediction against.
+
+    Reaches the group through the run mirror in a single query. Emits `missing_group` and
+    aborts when the run isn't tied to a group, or the group was deleted before delivery.
+    """
+    group = Group.objects.filter(
+        seeragentrun__run__uuid=run_uuid,
+        seeragentrun__source=SEER_FEATURE_ID,
+        project__organization_id=organization_id,
+    ).first()
+    if group is None:
+        _incr("missing_group")
+        logger.warning(
+            "smart_assignment.delivery.missing_group",
+            extra={"organization_id": organization_id, "run_uuid": run_uuid},
+        )
+        raise _DeliveryAborted
+
+    return group
+
+
+def _validate_resolve_verdict(
+    organization_id: int, result: dict[str, Any] | None, log_extra: dict[str, Any]
+) -> list[int | None]:
+    """Parse the delivered artifact and resolve each ranked candidate to a Sentry user id.
+
+    Returns the resolved ids best-first, where a slot is None when that candidate names
+    no resolvable org user (blank identifier, an email with no verified org user, or a
+    username outside this org). Emits `error` and aborts when the artifact doesn't parse.
+    """
+    try:
+        verdict = AssigneeVerdict.parse_obj(result)
+    except Exception:
+        _incr("error")
+        logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)
+        raise _DeliveryAborted from None
+
+    resolved: list[int | None] = []
+    for candidate in verdict.candidates:
+        value = (candidate.identifier or "").strip()
+        if not value:
+            resolved.append(None)
+            continue
+
+        if candidate.identifier_kind == "email":
+            users = user_service.get_many_by_email(
+                emails=[value], organization_id=organization_id, is_verified=True
+            )
+            resolved.append(users[0].id if users else None)
+            continue
+
+        if candidate.identifier_kind == "username":
+            # with_valid_password=False so SSO-only users are included.
+            users = user_service.get_by_username(
+                username=value, with_valid_password=False, is_active=True
+            )
+            member = (
+                organization_service.check_membership_by_id(
+                    organization_id=organization_id, user_id=users[0].id
+                )
+                if users
+                else None
+            )
+            resolved.append(users[0].id if member is not None else None)
+            continue
+
+        resolved.append(None)
+
+    return resolved
+
+
+def _record_result(
+    group: Group,
+    seer_run_id: int,
+    run_uuid: UUID,
+    predicted_assignee_user_ids: list[int | None],
+    log_extra: dict[str, Any],
+) -> None:
+    """Record the resolved verdict as a completion activity and emit the delivery outcome.
+
+    A Seer retry or redelivery re-invokes this handler for the same run. The completion
+    activity is this feature's system of record, and creating it re-runs scoring/
+    auto-assignment via the workflow handlers, so skip (as `duplicate`) if we already
+    recorded one for this run. Activity carries no unique constraint, so this is a
+    best-effort pre-check; it covers sequential redelivery but not a concurrent race.
+    """
+    already_recorded = Activity.objects.filter(
+        group=group,
+        type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+        data__run_id=seer_run_id,
+    ).exists()
+    if already_recorded:
+        _incr("duplicate")
+        logger.info("smart_assignment.delivery.duplicate", extra=log_extra)
+        raise _DeliveryAborted
+
+    # Hand the resolved verdict off to the completion path via an activity that points
+    # back at this run. Creating it invokes the workflow activity handlers, which score
+    # the prediction (completing the pair now if ground truth already landed) and
+    # auto-assign as needed.
+    Activity.objects.create_group_activity(
+        group,
+        ActivityType.SMART_ASSIGNMENT_COMPLETED,
+        data={
+            "run_id": seer_run_id,
+            "run_uuid": str(run_uuid),
+            "predicted_assignee_user_ids": predicted_assignee_user_ids,
+        },
+        send_notification=False,
+    )
+
+    if not predicted_assignee_user_ids:
+        outcome = "abstain"
+    elif predicted_assignee_user_ids[0] is None:
+        outcome = "unlinked"
+    else:
+        outcome = "resolved"
+    _incr(outcome)
 
 
 def deliver_smart_assignment_result(
@@ -75,92 +212,15 @@ def deliver_smart_assignment_result(
       - `unlinked`      -- named someone we couldn't map to an org user
       - `resolved`      -- named someone we mapped to a Sentry user
     """
-    agent_run = (
-        SeerAgentRun.objects.filter(
-            run__uuid=run_uuid, run__organization_id=organization_id, source=SEER_FEATURE_ID
-        )
-        .select_related("run")
-        .first()
-    )
-    if agent_run is None:
-        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_run"})
-        logger.warning(
-            "smart_assignment.delivery.missing_run",
-            extra={"organization_id": organization_id, "run_uuid": run_uuid},
-        )
-        return
-
-    group_id = agent_run.group_id
-    log_extra = {"organization_id": organization_id, "group_id": group_id, "run_uuid": run_uuid}
-
-    if status == "error" or result is None:
-        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
-        logger.warning(
-            "smart_assignment.delivery.no_result",
-            extra={**log_extra, "status": status, "error": error},
-        )
-        return
-
     try:
-        verdict = AssigneeVerdict.parse_obj(result)
-    except Exception:
-        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
-        logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)
+        seer_run_id = _validate_run(organization_id, run_uuid, status, result, error)
+        group = _validate_group(organization_id, run_uuid)
+        log_extra = {
+            "organization_id": organization_id,
+            "group_id": group.id,
+            "run_uuid": run_uuid,
+        }
+        predicted_assignee_user_ids = _validate_resolve_verdict(organization_id, result, log_extra)
+        _record_result(group, seer_run_id, run_uuid, predicted_assignee_user_ids, log_extra)
+    except _DeliveryAborted:
         return
-
-    # Resolve every ranked candidate to a Sentry user, best-first.
-    predicted_assignee_user_ids = [
-        _resolve_identifier_to_user_id(
-            organization_id, candidate.identifier, candidate.identifier_kind
-        )
-        for candidate in verdict.candidates
-    ]
-
-    # Do nothing if the group was deleted before delivery, or if the run isn't tied to a group.
-    group = (
-        Group.objects.filter(id=group_id, project__organization_id=organization_id).first()
-        if group_id is not None
-        else None
-    )
-    if group is None:
-        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_group"})
-        logger.warning("smart_assignment.delivery.missing_group", extra=log_extra)
-        return
-
-    # A Seer retry or redelivery re-invokes this handler for the same run. The completion
-    # activity is this feature's system of record, and creating it re-runs scoring/
-    # auto-assignment via the workflow handlers, so skip if we already recorded one for
-    # this run. Activity carries no unique constraint, so this is a best-effort pre-check;
-    # it covers sequential redelivery but not a concurrent-redelivery race.
-    already_recorded = Activity.objects.filter(
-        group=group,
-        type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
-        data__run_id=agent_run.run_id,
-    ).exists()
-    if already_recorded:
-        metrics.incr("smart_assignment.delivery", tags={"outcome": "duplicate"})
-        logger.info("smart_assignment.delivery.duplicate", extra=log_extra)
-        return
-
-    # Hand the resolved verdict off to the completion path via an activity that points
-    # back at this run. Creating it invokes the workflow activity handlers, which score
-    # the prediction (completing the pair now if ground truth already landed) and
-    # auto-assign as needed.
-    Activity.objects.create_group_activity(
-        group,
-        ActivityType.SMART_ASSIGNMENT_COMPLETED,
-        data={
-            "run_id": agent_run.run_id,
-            "run_uuid": str(run_uuid),
-            "predicted_assignee_user_ids": predicted_assignee_user_ids,
-        },
-        send_notification=False,
-    )
-
-    if not predicted_assignee_user_ids:
-        outcome = "abstain"
-    elif predicted_assignee_user_ids[0] is None:
-        outcome = "unlinked"
-    else:
-        outcome = "resolved"
-    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome})

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -134,9 +134,6 @@ def _validate_resolve_verdict(
                 else None
             )
             resolved.append(users[0].id if member is not None else None)
-            continue
-
-        resolved.append(None)
 
     return resolved
 

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -1,0 +1,162 @@
+"""Delivery handler for smart_assignment feature results from Seer.
+
+Seer pushes the `AssigneeVerdict` artifact back via the `deliver_feature_result`
+RPC, routed here by feature_id (see `sentry.seer.agent.feature_delivery`). Seer is
+the system of record for the verdict itself; here we resolve the ranked candidates to
+Sentry users and record a `SMART_ASSIGNMENT_COMPLETED` activity (pointing back at the
+run) carrying those resolved picks, then emit a delivery outcome metric. Acting on
+the verdict -- scoring it and auto-assigning -- happens independently off that activity
+(see `completion`), so this handler stays a thin resolve-and-record step.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.organizations.services.organization import organization_service
+from sentry.seer.agent.types import FeatureRunStatus
+from sentry.seer.models.run import SeerAgentRun
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, AssigneeVerdict
+from sentry.types.activity import ActivityType
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_identifier_to_user_id(
+    organization_id: int, identifier: str | None, kind: str | None
+) -> int | None:
+    """Map an agent-produced `identifier` to a Sentry user id in the org.
+
+    The agent tags each pick with `identifier_kind` (see the `RankedCandidate`
+    contract on the Seer side) so we resolve deterministically instead of inferring
+    the type from the string:
+      - "email":    verified org email (the RPC already scopes to the org).
+      - "username": unique username, confirmed to be an org member so a global match
+                    can't attribute a prediction to someone outside the org.
+    `kind` is a validated Literal by the time it gets here, so this doesn't guess.
+    Returns None when the agent named no one or the identifier maps to no org user.
+    """
+    if not identifier:
+        return None
+
+    value = identifier.strip()
+    if not value:
+        return None
+
+    if kind == "email":
+        users = user_service.get_many_by_email(
+            emails=[value], organization_id=organization_id, is_verified=True
+        )
+        return users[0].id if users else None
+
+    if kind == "username":
+        users = user_service.get_by_username(username=value)
+        if not users:
+            return None
+        user_id = users[0].id
+        member = organization_service.check_membership_by_id(
+            organization_id=organization_id, user_id=user_id
+        )
+        return user_id if member is not None else None
+
+    return None
+
+
+def deliver_smart_assignment_result(
+    organization_id: int,
+    run_uuid: str,
+    status: FeatureRunStatus,
+    result: dict[str, Any] | None,
+    error: str | None,
+) -> None:
+    """Resolve a delivered smart_assignment verdict's ranked picks and record them.
+
+    Emits a single `smart_assignment.delivery` counter tagged with the outcome so we
+    can track success vs failure, how often the agent abstains, and how often it
+    names someone we can't link to a Sentry user in the org:
+      - `missing_run`   -- delivery arrived with no matching run mirror (orphaned run)
+      - `error`         -- Seer run failed or returned no artifact
+      - `missing_group` -- run isn't tied to a group, or the group was deleted before
+                           delivery, so there's nothing to record the prediction against
+      - `abstain`       -- completed, but the agent named no one
+      - `unlinked`      -- named someone we couldn't map to an org user
+      - `resolved`      -- named someone we mapped to a Sentry user
+    """
+    agent_run = (
+        SeerAgentRun.objects.filter(
+            run__uuid=run_uuid, run__organization_id=organization_id, source=SEER_FEATURE_ID
+        )
+        .select_related("run")
+        .first()
+    )
+    if agent_run is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_run"})
+        logger.warning(
+            "smart_assignment.delivery.missing_run",
+            extra={"organization_id": organization_id, "run_uuid": run_uuid},
+        )
+        return
+
+    group_id = agent_run.group_id
+    log_extra = {"organization_id": organization_id, "group_id": group_id, "run_uuid": run_uuid}
+
+    if status == "error" or result is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
+        logger.warning(
+            "smart_assignment.delivery.no_result",
+            extra={**log_extra, "status": status, "error": error},
+        )
+        return
+
+    try:
+        verdict = AssigneeVerdict.parse_obj(result)
+    except Exception:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "error"})
+        logger.warning("smart_assignment.delivery.invalid_result", extra=log_extra)
+        return
+
+    # Resolve every ranked candidate (best-first) to a Sentry user id so scoring can
+    # grade the top pick and also see where the eventual assignee placed in the list
+    # (its hit_rank). None marks a position we couldn't map to an org user, preserving
+    # each candidate's rank; the raw verdict itself is still queryable on the Seer run.
+    predicted_assignee_user_ids = [
+        _resolve_identifier_to_user_id(
+            organization_id, candidate.identifier, candidate.identifier_kind
+        )
+        for candidate in verdict.candidates
+    ]
+
+    # Do nothing if the group was deleted before delivery, or if the run isn't tied to a group.
+    group = Group.objects.filter(id=group_id).first() if group_id is not None else None
+    if group is None:
+        metrics.incr("smart_assignment.delivery", tags={"outcome": "missing_group"})
+        logger.warning("smart_assignment.delivery.missing_group", extra=log_extra)
+        return
+
+    # Hand the resolved verdict off to the completion path via an activity that points
+    # back at this run. Creating it invokes the workflow activity handlers, which score
+    # the prediction (completing the pair now if ground truth already landed) and
+    # auto-assign as needed -- kept out of this RPC handler on purpose.
+    Activity.objects.create_group_activity(
+        group,
+        ActivityType.SMART_ASSIGNMENT_COMPLETED,
+        data={
+            "run_id": agent_run.id,
+            "run_uuid": run_uuid,
+            "predicted_assignee_user_ids": predicted_assignee_user_ids,
+        },
+        send_notification=False,
+    )
+
+    if not predicted_assignee_user_ids:
+        outcome = "abstain"
+    elif predicted_assignee_user_ids[0] is None:
+        outcome = "unlinked"
+    else:
+        outcome = "resolved"
+    metrics.incr("smart_assignment.delivery", tags={"outcome": outcome})

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -132,12 +132,11 @@ def deliver_smart_assignment_result(
     # auto-assignment via the workflow handlers, so skip if we already recorded one for
     # this run. Activity carries no unique constraint, so this is a best-effort pre-check;
     # it covers sequential redelivery but not a concurrent-redelivery race.
-    already_recorded = any(
-        (activity.data or {}).get("run_id") == agent_run.run_id
-        for activity in Activity.objects.filter(
-            group=group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
-        )
-    )
+    already_recorded = Activity.objects.filter(
+        group=group,
+        type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+        data__run_id=agent_run.run_id,
+    ).exists()
     if already_recorded:
         metrics.incr("smart_assignment.delivery", tags={"outcome": "duplicate"})
         logger.info("smart_assignment.delivery.duplicate", extra=log_extra)

--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -26,6 +26,7 @@ SEER_FEATURE_ID = "smart_assignment"
 # Resolutions we treat as ground truth: a human resolving an issue is a signal for
 # who should have owned it.
 # SET_RESOLVED_BY_AGE is excluded (auto-resolve cron, no acting user, so no signal).
+# SET_RESOLVED_IN_PULL_REQUEST is excluded (it will trigger ASSIGNED in practice, which we already capture).
 # Other ground-truth activities include ASSIGNED and SEER_*_STARTED,
 # configured in workflow_activity_handlers.py
 RESOLUTION_ACTIVITIES = frozenset(
@@ -33,7 +34,6 @@ RESOLUTION_ACTIVITIES = frozenset(
         ActivityType.SET_RESOLVED,
         ActivityType.SET_RESOLVED_IN_RELEASE,
         ActivityType.SET_RESOLVED_IN_COMMIT,
-        ActivityType.SET_RESOLVED_IN_PULL_REQUEST,
     }
 )
 

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -107,6 +107,12 @@ CHOICES = tuple(
     ]
 )
 
+# Activity types created purely as internal signals (e.g. to drive workflow handlers
+# such as scoring/auto-assignment) that must never surface in the user-facing issue
+# activity feed. The frontend has no GroupActivityType entry for these, so leaking one
+# renders a blank feed item and fires an "Unknown group activity type" Sentry message.
+HIDDEN_ACTIVITY_TYPES = (ActivityType.SMART_ASSIGNMENT_COMPLETED,)
+
 SEER_ACTIVITY_TYPES = (
     ActivityType.SEER_RCA_STARTED,
     ActivityType.SEER_RCA_COMPLETED,

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -51,9 +51,7 @@ class ActivityType(Enum):
     PULL_REQUEST_UNLINKED = 41
     TRIGGER_AUTOFIX = 42
 
-    # A smart-assignment run finished and delivered its verdict. Not part of the
-    # SEER_* autofix progress lifecycle -- it's an internal signal that drives
-    # scoring/auto-assignment, so it deliberately omits the SEER_ prefix.
+    # A smart-assignment run finished and delivered its verdict.
     SMART_ASSIGNMENT_COMPLETED = 43
 
 

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -51,6 +51,11 @@ class ActivityType(Enum):
     PULL_REQUEST_UNLINKED = 41
     TRIGGER_AUTOFIX = 42
 
+    # A smart-assignment run finished and delivered its verdict. Not part of the
+    # SEER_* autofix progress lifecycle -- it's an internal signal that drives
+    # scoring/auto-assignment, so it deliberately omits the SEER_ prefix.
+    SMART_ASSIGNMENT_COMPLETED = 43
+
 
 # Warning: This must remain in this EXACT order.
 CHOICES = tuple(
@@ -98,6 +103,7 @@ CHOICES = tuple(
         ActivityType.PULL_REQUEST_MERGED,  # 40
         ActivityType.PULL_REQUEST_UNLINKED,  # 41
         ActivityType.TRIGGER_AUTOFIX,  # 42
+        ActivityType.SMART_ASSIGNMENT_COMPLETED,  # 43
     ]
 )
 

--- a/src/sentry/utils/action_log/activity_translator.py
+++ b/src/sentry/utils/action_log/activity_translator.py
@@ -57,6 +57,9 @@ ACTIVITY_TYPES_WITH_NO_ACTION: frozenset[int] = frozenset(
     (
         ActivityType.FIRST_SEEN.value,
         ActivityType.RELEASE.value,
+        # Internal signal that drives smart-assignment scoring/auto-assign off a
+        # workflow activity handler; not a user-facing group action.
+        ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
     )
 )
 

--- a/tests/sentry/models/test_activity.py
+++ b/tests/sentry/models/test_activity.py
@@ -21,6 +21,30 @@ class ActivityTest(TestCase):
         assert len(act_for_group) == 1
         assert act_for_group[0].type == ActivityType.FIRST_SEEN.value
 
+    def test_get_activities_for_group_excludes_hidden(self) -> None:
+        project = self.create_project(name="test_activities_group")
+        group = self.create_group(project)
+        user1 = self.create_user()
+
+        visible = Activity.objects.create_group_activity(
+            group=group,
+            type=ActivityType.SET_RESOLVED,
+            user=user1,
+            send_notification=False,
+        )
+        # Internal signal that drives workflow handlers; it must never reach the feed.
+        Activity.objects.create_group_activity(
+            group=group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED,
+            send_notification=False,
+        )
+
+        act_for_group = Activity.objects.get_activities_for_group(group=group, num=100)
+        types = {a.type for a in act_for_group}
+        assert ActivityType.SMART_ASSIGNMENT_COMPLETED.value not in types
+        assert visible.id in {a.id for a in act_for_group}
+        assert act_for_group[-1].type == ActivityType.FIRST_SEEN.value
+
     def test_get_activities_for_group_priority(self) -> None:
         manager = EventManager(make_event(level=logging.FATAL))
         project = self.create_project(name="test_activities_group")

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -1,5 +1,6 @@
 from typing import Any
 from unittest.mock import patch
+from uuid import UUID
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -32,10 +33,10 @@ class TestDeliverNightShiftResult(TestCase):
         )
         return run
 
-    def _run_uuid(self, run: SeerNightShiftRun) -> str:
+    def _run_uuid(self, run: SeerNightShiftRun) -> UUID:
         seer_run = run.shards.get().seer_run
         assert seer_run is not None
-        return str(seer_run.uuid)
+        return seer_run.uuid
 
     def test_missing_run_logs_warning(self) -> None:
         """When run_uuid doesn't match any SeerNightShiftRun, log and return."""
@@ -44,7 +45,7 @@ class TestDeliverNightShiftResult(TestCase):
         with patch("sentry.seer.night_shift.delivery.logger") as mock_logger:
             deliver_night_shift_result(
                 organization_id=org.id,
-                run_uuid="00000000-0000-0000-0000-000000000000",
+                run_uuid=UUID("00000000-0000-0000-0000-000000000000"),
                 status="completed",
                 result={"verdicts": []},
                 error=None,
@@ -87,7 +88,7 @@ class TestDeliverNightShiftResult(TestCase):
 
         deliver_night_shift_result(
             organization_id=org.id,
-            run_uuid=str(failed_seer_run.uuid),
+            run_uuid=failed_seer_run.uuid,
             status="error",
             result=None,
             error="shard failed",
@@ -95,7 +96,7 @@ class TestDeliverNightShiftResult(TestCase):
         with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1):
             deliver_night_shift_result(
                 organization_id=org.id,
-                run_uuid=str(ok_seer_run.uuid),
+                run_uuid=ok_seer_run.uuid,
                 status="completed",
                 result={
                     "verdicts": [

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -70,7 +70,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
         )
 
         data = self._completion_activity().data
-        assert data["run_id"] == self.mirror.id
+        assert data["run_id"] == self.seer_run.id
         assert data["run_uuid"] == str(self.seer_run.uuid)
         assert data["predicted_assignee_user_ids"] == [alice.id]
 

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -75,6 +75,28 @@ class DeliverSmartAssignmentResultTest(TestCase):
         assert data["predicted_assignee_user_ids"] == [alice.id]
 
     @patch(METRICS_PATH)
+    def test_redelivery_does_not_duplicate_activity(self, mock_metrics: MagicMock) -> None:
+        # A Seer retry/redelivery re-invokes the handler for the same run: the second
+        # delivery must not record a second completion activity (which would re-run
+        # scoring/auto-assignment), and is reported as a distinct `duplicate` outcome.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        verdict = {"candidates": [{"identifier": "alice", "identifier_kind": "username"}]}
+
+        self._deliver(verdict)
+        self._deliver(verdict)
+
+        assert (
+            Activity.objects.filter(
+                group=self.group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+            ).count()
+            == 1
+        )
+        mock_metrics.incr.assert_any_call(
+            "smart_assignment.delivery", tags={"outcome": "duplicate"}
+        )
+
+    @patch(METRICS_PATH)
     def test_error_status_records_nothing(self, mock_metrics: MagicMock) -> None:
         self._deliver(None, status="error", error="boom")
         # No prediction recorded on error; the Seer run holds the failure.

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -1,8 +1,10 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
 from sentry.models.activity import Activity
+from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
 from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
@@ -29,11 +31,16 @@ class DeliverSmartAssignmentResultTest(TestCase):
             extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
         )
 
-    def _extras(self) -> dict:
+    def _extras(self) -> dict[str, Any]:
         self.mirror.refresh_from_db()
         return self.mirror.extras
 
-    def _deliver(self, result: dict | None, status: str = "completed", error: str | None = None):
+    def _deliver(
+        self,
+        result: dict[str, Any] | None,
+        status: FeatureRunStatus = "completed",
+        error: str | None = None,
+    ) -> None:
         deliver_smart_assignment_result(
             self.organization.id, str(self.seer_run.uuid), status, result, error
         )

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -48,7 +48,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
 
     def _assert_outcome(self, mock_metrics: MagicMock, expected: str) -> None:
         mock_metrics.incr.assert_called_once_with(
-            "smart_assignment.delivery", tags={"outcome": expected}
+            "smart_assignment.delivery", tags={"outcome": expected}, sample_rate=1.0
         )
 
     def _completion_activity(self) -> Activity:
@@ -94,7 +94,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
             == 1
         )
         mock_metrics.incr.assert_any_call(
-            "smart_assignment.delivery", tags={"outcome": "duplicate"}
+            "smart_assignment.delivery", tags={"outcome": "duplicate"}, sample_rate=1.0
         )
 
     @patch(METRICS_PATH)

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -1,0 +1,219 @@
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+from sentry.models.activity import Activity
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
+from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+METRICS_PATH = "sentry.seer.smart_assignment.delivery.metrics"
+
+
+class DeliverSmartAssignmentResultTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        # The run mirror the client would have created at dispatch.
+        self.mirror = SeerAgentRun.objects.create(
+            run=self.seer_run,
+            source=SEER_FEATURE_ID,
+            group=self.group,
+            extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
+        )
+
+    def _extras(self) -> dict:
+        self.mirror.refresh_from_db()
+        return self.mirror.extras
+
+    def _deliver(self, result: dict | None, status: str = "completed", error: str | None = None):
+        deliver_smart_assignment_result(
+            self.organization.id, str(self.seer_run.uuid), status, result, error
+        )
+
+    def _assert_outcome(self, mock_metrics: MagicMock, expected: str) -> None:
+        mock_metrics.incr.assert_called_once_with(
+            "smart_assignment.delivery", tags={"outcome": expected}
+        )
+
+    def _completion_activity(self) -> Activity:
+        return Activity.objects.get(
+            group=self.group, type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        )
+
+    @patch(METRICS_PATH)
+    def test_records_top_pick_resolved_to_user(self, mock_metrics: MagicMock) -> None:
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "suspect commit",
+                    "confidence": "high",
+                },
+                {
+                    "identifier": "bob",
+                    "identifier_kind": "username",
+                    "reason": "code owner",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        # Every candidate resolved (best-first) and cached on the run mirror: alice is
+        # an org member; "bob" maps to no org user, so its rank is held with None. The
+        # full verdict itself lives on the Seer run, not here.
+        assert self._extras()["predicted_assignee_user_ids"] == [alice.id, None]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_creates_completion_activity_referencing_run(self, mock_metrics: MagicMock) -> None:
+        # The delivered verdict is handed off via a SMART_ASSIGNMENT_COMPLETED
+        # activity that points back at the Seer run and carries the resolved picks.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self._deliver(
+            {
+                "candidates": [
+                    {"identifier": "alice", "identifier_kind": "username"},
+                ]
+            }
+        )
+
+        data = self._completion_activity().data
+        assert data["run_id"] == self.mirror.id
+        assert data["run_uuid"] == str(self.seer_run.uuid)
+        assert data["predicted_assignee_user_ids"] == [alice.id]
+
+    @patch(METRICS_PATH)
+    def test_email_kind_resolves_by_verified_email(self, mock_metrics: MagicMock) -> None:
+        # An email-kind pick (unlinked commit author) resolves by verified org email,
+        # even when the address happens to also be someone's username-shaped handle.
+        carol = self.create_user(email="carol@example.com")
+        self.create_member(user=carol, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "carol@example.com",
+                    "identifier_kind": "email",
+                    "reason": "unlinked commit author",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [carol.id]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_unresolvable_identifier_records_no_user(self, mock_metrics: MagicMock) -> None:
+        result = {
+            "candidates": [
+                {
+                    "identifier": "nobody-here",
+                    "identifier_kind": "username",
+                    "reason": "guess",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [None]
+        self._assert_outcome(mock_metrics, "unlinked")
+
+    @patch(METRICS_PATH)
+    def test_empty_candidates_is_abstain(self, mock_metrics: MagicMock) -> None:
+        self._deliver({"candidates": []})
+        assert self._extras()["predicted_assignee_user_ids"] == []
+        self._assert_outcome(mock_metrics, "abstain")
+
+    @patch(METRICS_PATH)
+    def test_error_status_records_nothing(self, mock_metrics: MagicMock) -> None:
+        self._deliver(None, status="error", error="boom")
+        # No prediction recorded on error; the Seer run holds the failure.
+        assert "predicted_assignee_user_ids" not in self._extras()
+        self._assert_outcome(mock_metrics, "error")
+
+    @patch("sentry.seer.smart_assignment.scoring.metrics")
+    def test_scores_when_ground_truth_already_present(
+        self, mock_scoring_metrics: MagicMock
+    ) -> None:
+        # Assignment landed before Seer finished: ground truth is already on the run
+        # mirror, so delivering the prediction completes the pair and scores it.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self.mirror.extras = {**self.mirror.extras, "actual_assignee_user_id": alice.id}
+        self.mirror.save(update_fields=["extras"])
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "x",
+                    "confidence": "high",
+                }
+            ]
+        }
+        self._deliver(result)
+
+        mock_scoring_metrics.incr.assert_called_once_with(
+            "smart_assignment.scored",
+            tags={
+                "result": SmartAssignmentScore.EXACT,
+                "hit_rank": 1,
+                "trigger": ActivityType.SEER_RCA_STARTED.name,
+            },
+        )
+
+    @patch(METRICS_PATH)
+    def test_untied_run_is_missing_group(self, mock_metrics: MagicMock) -> None:
+        # Run mirror was never tied to a group (group_id is NULL): there's nothing to
+        # record the prediction against, so it must not count as a delivery success.
+        self.mirror.group = None
+        self.mirror.save(update_fields=["group"])
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self._deliver({"candidates": [{"identifier": "alice", "identifier_kind": "username"}]})
+
+        assert not Activity.objects.filter(
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        ).exists()
+        self._assert_outcome(mock_metrics, "missing_group")
+
+    @patch(METRICS_PATH)
+    def test_deleted_group_is_missing_group(self, mock_metrics: MagicMock) -> None:
+        # Group deleted between dispatch and delivery (stale, dangling group_id): the
+        # activity can't be created, so this is reported distinctly, not as a success.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self.group.delete()
+        self._deliver({"candidates": [{"identifier": "alice", "identifier_kind": "username"}]})
+
+        assert not Activity.objects.filter(
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value
+        ).exists()
+        self._assert_outcome(mock_metrics, "missing_group")
+
+    @patch(METRICS_PATH)
+    def test_missing_run_is_noop(self, mock_metrics: MagicMock) -> None:
+        # Unknown run uuid: should not raise.
+        deliver_smart_assignment_result(
+            self.organization.id,
+            "00000000-0000-0000-0000-000000000000",
+            "completed",
+            {"candidates": []},
+            None,
+        )
+        self._assert_outcome(mock_metrics, "missing_run")

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -1,5 +1,6 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 from django.utils import timezone
 
@@ -42,7 +43,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
         error: str | None = None,
     ) -> None:
         deliver_smart_assignment_result(
-            self.organization.id, str(self.seer_run.uuid), status, result, error
+            self.organization.id, self.seer_run.uuid, status, result, error
         )
 
     def _assert_outcome(self, mock_metrics: MagicMock, expected: str) -> None:
@@ -137,7 +138,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
         # Unknown run uuid: should not raise.
         deliver_smart_assignment_result(
             self.organization.id,
-            "00000000-0000-0000-0000-000000000000",
+            UUID("00000000-0000-0000-0000-000000000000"),
             "completed",
             {"candidates": []},
             None,

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -7,7 +7,7 @@ from sentry.models.activity import Activity
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
-from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 
@@ -56,34 +56,6 @@ class DeliverSmartAssignmentResultTest(TestCase):
         )
 
     @patch(METRICS_PATH)
-    def test_records_top_pick_resolved_to_user(self, mock_metrics: MagicMock) -> None:
-        alice = self.create_user(username="alice")
-        self.create_member(user=alice, organization=self.organization)
-        result = {
-            "candidates": [
-                {
-                    "identifier": "alice",
-                    "identifier_kind": "username",
-                    "reason": "suspect commit",
-                    "confidence": "high",
-                },
-                {
-                    "identifier": "bob",
-                    "identifier_kind": "username",
-                    "reason": "code owner",
-                    "confidence": "low",
-                },
-            ]
-        }
-        self._deliver(result)
-
-        # Every candidate resolved (best-first) and cached on the run mirror: alice is
-        # an org member; "bob" maps to no org user, so its rank is held with None. The
-        # full verdict itself lives on the Seer run, not here.
-        assert self._extras()["predicted_assignee_user_ids"] == [alice.id, None]
-        self._assert_outcome(mock_metrics, "resolved")
-
-    @patch(METRICS_PATH)
     def test_creates_completion_activity_referencing_run(self, mock_metrics: MagicMock) -> None:
         # The delivered verdict is handed off via a SMART_ASSIGNMENT_COMPLETED
         # activity that points back at the Seer run and carries the resolved picks.
@@ -103,86 +75,11 @@ class DeliverSmartAssignmentResultTest(TestCase):
         assert data["predicted_assignee_user_ids"] == [alice.id]
 
     @patch(METRICS_PATH)
-    def test_email_kind_resolves_by_verified_email(self, mock_metrics: MagicMock) -> None:
-        # An email-kind pick (unlinked commit author) resolves by verified org email,
-        # even when the address happens to also be someone's username-shaped handle.
-        carol = self.create_user(email="carol@example.com")
-        self.create_member(user=carol, organization=self.organization)
-        result = {
-            "candidates": [
-                {
-                    "identifier": "carol@example.com",
-                    "identifier_kind": "email",
-                    "reason": "unlinked commit author",
-                    "confidence": "low",
-                },
-            ]
-        }
-        self._deliver(result)
-
-        assert self._extras()["predicted_assignee_user_ids"] == [carol.id]
-        self._assert_outcome(mock_metrics, "resolved")
-
-    @patch(METRICS_PATH)
-    def test_unresolvable_identifier_records_no_user(self, mock_metrics: MagicMock) -> None:
-        result = {
-            "candidates": [
-                {
-                    "identifier": "nobody-here",
-                    "identifier_kind": "username",
-                    "reason": "guess",
-                    "confidence": "low",
-                },
-            ]
-        }
-        self._deliver(result)
-
-        assert self._extras()["predicted_assignee_user_ids"] == [None]
-        self._assert_outcome(mock_metrics, "unlinked")
-
-    @patch(METRICS_PATH)
-    def test_empty_candidates_is_abstain(self, mock_metrics: MagicMock) -> None:
-        self._deliver({"candidates": []})
-        assert self._extras()["predicted_assignee_user_ids"] == []
-        self._assert_outcome(mock_metrics, "abstain")
-
-    @patch(METRICS_PATH)
     def test_error_status_records_nothing(self, mock_metrics: MagicMock) -> None:
         self._deliver(None, status="error", error="boom")
         # No prediction recorded on error; the Seer run holds the failure.
         assert "predicted_assignee_user_ids" not in self._extras()
         self._assert_outcome(mock_metrics, "error")
-
-    @patch("sentry.seer.smart_assignment.scoring.metrics")
-    def test_scores_when_ground_truth_already_present(
-        self, mock_scoring_metrics: MagicMock
-    ) -> None:
-        # Assignment landed before Seer finished: ground truth is already on the run
-        # mirror, so delivering the prediction completes the pair and scores it.
-        alice = self.create_user(username="alice")
-        self.create_member(user=alice, organization=self.organization)
-        self.mirror.extras = {**self.mirror.extras, "actual_assignee_user_id": alice.id}
-        self.mirror.save(update_fields=["extras"])
-        result = {
-            "candidates": [
-                {
-                    "identifier": "alice",
-                    "identifier_kind": "username",
-                    "reason": "x",
-                    "confidence": "high",
-                }
-            ]
-        }
-        self._deliver(result)
-
-        mock_scoring_metrics.incr.assert_called_once_with(
-            "smart_assignment.scored",
-            tags={
-                "result": SmartAssignmentScore.EXACT,
-                "hit_rank": 1,
-                "trigger": ActivityType.SEER_RCA_STARTED.name,
-            },
-        )
 
     @patch(METRICS_PATH)
     def test_untied_run_is_missing_group(self, mock_metrics: MagicMock) -> None:


### PR DESCRIPTION
Create/register the Seer delivery handler for `smart_assignment`:

- Looks up `SeerAgentRun`, `Group` for the run
- Resolves user ids of predicted users
- Creates a new `ActivityType.SMART_ASSIGNMENT_COMPLETED`, which we'll handle in #119945
- Records metrics for this phase

`ActivityType.SMART_ASSIGNMENT_COMPLETED` is new, and we don't want it to appear as a user-facing action.

Bonus tweak: in `models.py` don't trigger smart assignment on `ActivityType.SET_RESOLVED_IN_PULL_REQUEST`: in practice it'll result in an `ASSIGNED` activity we already handle. (Doesn't exactly fit in this PR but it's a one-liner followup to #119693)