### PR TITLE
feat(seer): Smart Assignment completion

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -264,8 +264,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Run the Seer smart assignment feature (predictions + ground truth) on issues
     manager.add("organizations:seer-smart-assignment-run", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Send notifications for Seer smart assignment predictions
-    manager.add("organizations:seer-smart-assignment-notifications", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Auto-assign the top Seer smart assignment pick when a verdict is delivered
+    manager.add("organizations:seer-smart-assignment-assign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display nightshift settings
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display the Seer Night Shift UI

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -311,3 +311,4 @@ class ActivityIntegration(Enum):
     MSTEAMS = IntegrationProviderSlug.MSTEAMS.value
     DISCORD = IntegrationProviderSlug.DISCORD.value
     SUSPECT_COMMITTER = "suspectCommitter"
+    SEER_SUGGESTED = "seerSuggested"

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -35,6 +35,7 @@ class GroupOwnerType(Enum):
     SUSPECT_COMMIT = 0
     OWNERSHIP_RULE = 1
     CODEOWNERS = 2
+    SEER_SUGGESTED = 3
 
 
 class OwnerRuleType(Enum):
@@ -46,6 +47,7 @@ GROUP_OWNER_TYPE = {
     GroupOwnerType.SUSPECT_COMMIT: "suspectCommit",
     GroupOwnerType.OWNERSHIP_RULE: "ownershipRule",
     GroupOwnerType.CODEOWNERS: "codeowners",
+    GroupOwnerType.SEER_SUGGESTED: "seerSuggested",
 }
 
 

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -119,6 +119,7 @@ class GroupOwner(Model):
             (GroupOwnerType.SUSPECT_COMMIT, "Suspect Commit"),
             (GroupOwnerType.OWNERSHIP_RULE, "Ownership Rule"),
             (GroupOwnerType.CODEOWNERS, "Codeowners"),
+            (GroupOwnerType.SEER_SUGGESTED, "Seer Suggested"),
         )
     )
     context = LegacyTextJSONField(null=True)

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -251,7 +251,11 @@ class ProjectOwnership(Model):
 
         if ownership.auto_assignment:
             autoassignment_types.extend(
-                [GroupOwnerType.OWNERSHIP_RULE.value, GroupOwnerType.CODEOWNERS.value]
+                [
+                    GroupOwnerType.OWNERSHIP_RULE.value,
+                    GroupOwnerType.CODEOWNERS.value,
+                    GroupOwnerType.SEER_SUGGESTED.value,
+                ]
             )
         return autoassignment_types
 
@@ -330,6 +334,8 @@ class ProjectOwnership(Model):
             elif issue_owner.type == GroupOwnerType.OWNERSHIP_RULE.value:
                 activity_details["integration"] = ActivityIntegration.PROJECT_OWNERSHIP.value
                 activity_details["rule"] = (issue_owner.context or {}).get("rule", "")
+            elif issue_owner.type == GroupOwnerType.SEER_SUGGESTED.value:
+                activity_details["integration"] = ActivityIntegration.SEER_SUGGESTED.value
             else:
                 activity_details["integration"] = ActivityIntegration.CODEOWNERS.value
                 activity_details["rule"] = (issue_owner.context or {}).get("rule", "")

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -40,6 +40,9 @@ def _apply_prediction(
     predicted_assignee_user_ids: list[int | None],
     run_uuid: str | None,
 ) -> None:
+    """If the feature flag is enabled and we predicted an acutal org user,
+    create a (suggested) GroupOwner for them. Then promote the suggestion to an
+    assignment iff the project auto-assigns to owners."""
     if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
         return
 

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -34,7 +34,8 @@ def process_smart_assignment_completion(group: Group, activity: Activity) -> Non
     # set by delivery); scores immediately if ground truth already landed (assignment
     # before Seer finished), otherwise waits for it. This is not user-facing, so it runs
     # regardless of the feature flag.
-    run = SeerAgentRun.objects.filter(id=data.get("run_id")).first()
+    run_id = data.get("run_id")
+    run = SeerAgentRun.objects.filter(id=run_id).first() if run_id is not None else None
     if run is not None:
         record_prediction(run, predicted_assignee_user_ids)
 

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -9,6 +9,7 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.projectownership import ProjectOwnership
+from sentry.seer.models.run import SeerAgentRun
 from sentry.seer.smart_assignment.scoring import record_prediction
 from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
@@ -29,10 +30,13 @@ def process_smart_assignment_completion(group: Group, activity: Activity) -> Non
     data = activity.data or {}
     predicted_assignee_user_ids: list[int | None] = data.get("predicted_assignee_user_ids") or []
 
-    # Mirror the ranked predictions onto the run; scores immediately if ground truth
-    # already landed (assignment before Seer finished), otherwise waits for it. This is
-    # not user-facing, so it runs regardless of the feature flag.
-    record_prediction(group.id, predicted_assignee_user_ids)
+    # Mirror the ranked predictions onto the run the completion activity points at (always
+    # set by delivery); scores immediately if ground truth already landed (assignment
+    # before Seer finished), otherwise waits for it. This is not user-facing, so it runs
+    # regardless of the feature flag.
+    run = SeerAgentRun.objects.filter(id=data.get("run_id")).first()
+    if run is not None:
+        record_prediction(run, predicted_assignee_user_ids)
 
     _apply_prediction(group, predicted_assignee_user_ids, run_uuid=data.get("run_uuid"))
 

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -34,8 +34,12 @@ def process_smart_assignment_completion(group: Group, activity: Activity) -> Non
     # set by delivery); scores immediately if ground truth already landed (assignment
     # before Seer finished), otherwise waits for it. This is not user-facing, so it runs
     # regardless of the feature flag.
-    run_id = data.get("run_id")
-    run = SeerAgentRun.objects.filter(id=run_id).first() if run_id is not None else None
+    # `run_id` here is the SeerRun PK (the identifier delivery and ground truth share),
+    # not the SeerAgentRun row id, so match on the run FK.
+    seer_run_id = data.get("run_id")
+    run = (
+        SeerAgentRun.objects.filter(run_id=seer_run_id).first() if seer_run_id is not None else None
+    )
     if run is not None:
         record_prediction(run, predicted_assignee_user_ids)
 

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -20,27 +20,16 @@ AUTO_ASSIGN_FEATURE_FLAG = "organizations:seer-smart-assignment-assign"
 
 
 def process_smart_assignment_completion(group: Group, activity: Activity) -> None:
-    """Score and act on the delivered prediction.
-
-    Reads the ranked, org-resolved candidate user ids (best-first, `None` for a rank we
-    couldn't map to an org user) that delivery stashed on the activity. Scoring is
-    internal bookkeeping and always runs (it no-ops until ground truth lands); acting on
-    the verdict is a single user-facing step gated behind the feature flag.
-    """
     data = activity.data or {}
     predicted_assignee_user_ids: list[int | None] = data.get("predicted_assignee_user_ids") or []
 
-    # Mirror the ranked predictions onto the run the completion activity points at (always
-    # set by delivery); scores immediately if ground truth already landed (assignment
-    # before Seer finished), otherwise waits for it. This is not user-facing, so it runs
-    # regardless of the feature flag.
-    # `run_id` here is the SeerRun PK (the identifier delivery and ground truth share),
-    # not the SeerAgentRun row id, so match on the run FK.
     seer_run_id = data.get("run_id")
     run = (
         SeerAgentRun.objects.filter(run_id=seer_run_id).first() if seer_run_id is not None else None
     )
     if run is not None:
+        # Save the prediction to the run so it can be scored, either now (if ground truth
+        # already landed) or later (if ground truth hasn't landed yet).
         record_prediction(run, predicted_assignee_user_ids)
 
     _apply_prediction(group, predicted_assignee_user_ids, run_uuid=data.get("run_uuid"))
@@ -51,11 +40,6 @@ def _apply_prediction(
     predicted_assignee_user_ids: list[int | None],
     run_uuid: str | None,
 ) -> None:
-    """Record the top pick as a suggested owner and let the project decide if it assigns.
-    No-op when the org isn't flagged in, the agent abstained, or the top pick doesn't
-    resolve to an org user. Runs synchronously during activity creation, so the owner
-    (and any assignment) exists before any workflow notification fires off this completion.
-    """
     if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
         return
 
@@ -66,6 +50,7 @@ def _apply_prediction(
         return
 
     if user_service.get_user(user_id=top_user_id) is None:
+        # The top pick doesn't resolve to an org user.
         metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "user_missing"})
         return
 

--- a/src/sentry/seer/smart_assignment/completion.py
+++ b/src/sentry/seer/smart_assignment/completion.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import logging
+
+from django.utils import timezone
+
+from sentry import features
+from sentry.models.activity import Activity
+from sentry.models.group import Group
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.projectownership import ProjectOwnership
+from sentry.seer.smart_assignment.scoring import record_prediction
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+AUTO_ASSIGN_FEATURE_FLAG = "organizations:seer-smart-assignment-assign"
+
+
+def process_smart_assignment_completion(group: Group, activity: Activity) -> None:
+    """Score and act on the delivered prediction.
+
+    Reads the ranked, org-resolved candidate user ids (best-first, `None` for a rank we
+    couldn't map to an org user) that delivery stashed on the activity. Scoring is
+    internal bookkeeping and always runs (it no-ops until ground truth lands); acting on
+    the verdict is a single user-facing step gated behind the feature flag.
+    """
+    data = activity.data or {}
+    predicted_assignee_user_ids: list[int | None] = data.get("predicted_assignee_user_ids") or []
+
+    # Mirror the ranked predictions onto the run; scores immediately if ground truth
+    # already landed (assignment before Seer finished), otherwise waits for it. This is
+    # not user-facing, so it runs regardless of the feature flag.
+    record_prediction(group.id, predicted_assignee_user_ids)
+
+    _apply_prediction(group, predicted_assignee_user_ids, run_uuid=data.get("run_uuid"))
+
+
+def _apply_prediction(
+    group: Group,
+    predicted_assignee_user_ids: list[int | None],
+    run_uuid: str | None,
+) -> None:
+    """Record the top pick as a suggested owner and let the project decide if it assigns.
+    No-op when the org isn't flagged in, the agent abstained, or the top pick doesn't
+    resolve to an org user. Runs synchronously during activity creation, so the owner
+    (and any assignment) exists before any workflow notification fires off this completion.
+    """
+    if not features.has(AUTO_ASSIGN_FEATURE_FLAG, group.organization):
+        return
+
+    top_user_id = predicted_assignee_user_ids[0] if predicted_assignee_user_ids else None
+    if top_user_id is None:
+        # Agent abstained or named someone we couldn't map to an org user.
+        metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "no_candidate"})
+        return
+
+    if user_service.get_user(user_id=top_user_id) is None:
+        metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "user_missing"})
+        return
+
+    # Persist the pick as a suggested owner (idempotent upsert).
+    context: dict[str, object] = {"run_uuid": run_uuid} if run_uuid else {}
+    GroupOwner.objects.update_or_create_and_preserve_context(
+        lookup_kwargs={
+            "group_id": group.id,
+            "type": GroupOwnerType.SEER_SUGGESTED.value,
+            "user_id": top_user_id,
+            "project_id": group.project_id,
+            "organization_id": group.organization.id,
+        },
+        defaults={"date_added": timezone.now()},
+        context_defaults=context,
+    )
+
+    # Promote the suggestion to an assignment iff the project auto-assigns to owners.
+    # The ASSIGNED activity written is tagged with ActivityIntegration.SEER_SUGGESTED so
+    # ground-truth capture skips our own assignment (see scoring.record_ground_truth).
+    ProjectOwnership.handle_auto_assignment(project_id=group.project_id, group=group)
+
+    metrics.incr("smart_assignment.apply_prediction", tags={"outcome": "applied"})
+    logger.info(
+        "smart_assignment.apply_prediction.applied",
+        extra={"group_id": group.id, "user_id": top_user_id},
+    )

--- a/src/sentry/seer/smart_assignment/scoring.py
+++ b/src/sentry/seer/smart_assignment/scoring.py
@@ -5,7 +5,7 @@ from typing import TypedDict
 
 from django.db import router, transaction
 
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -70,11 +70,18 @@ def _ground_truth_updates(
     """Build the ground-truth mirror updates for an activity, or ``None`` when it
     carries no useful signal.
 
-    For an assignment we mirror the current assignee (user and/or team). For a
-    user-driven resolution we record the resolver as the assumed assignee only when no
-    explicit assignee has been recorded -- an assignment is better truth.
+    For an assignment we mirror the current assignee (user and/or team), unless it is
+    our own auto-assignment (tagged with the ``SEER_SUGGESTED`` integration by
+    ProjectOwnership.handle_auto_assignment, which would score us against ourselves).
+    For a user-driven resolution we record the resolver as the assumed assignee only
+    when no explicit assignee has been recorded -- an assignment is better truth.
     """
     if activity_type == ActivityType.ASSIGNED:
+        if (
+            activity is not None
+            and (activity.data or {}).get("integration") == ActivityIntegration.SEER_SUGGESTED.value
+        ):
+            return None
         return _assignment_updates(group)
     if activity_type in RESOLUTION_ACTIVITIES:
         if activity is None or activity.user_id is None:

--- a/src/sentry/workflow_engine/handlers/workflow/__init__.py
+++ b/src/sentry/workflow_engine/handlers/workflow/__init__.py
@@ -1,11 +1,13 @@
 from .workflow_activity_handlers import (
     activity_handler,
     seer_activity_handler,
-    smart_assignment_activity_handler,
+    smart_assignment_completed_handler,
+    smart_assignment_trigger_handler,
 )
 
 __all__ = [
     "activity_handler",
     "seer_activity_handler",
-    "smart_assignment_activity_handler",
+    "smart_assignment_completed_handler",
+    "smart_assignment_trigger_handler",
 ]

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -97,8 +97,8 @@ def seer_activity_handler(
     logger.info("workflow_engine.seer_activity_handler.complete", extra=logging_ctx)
 
 
-@workflow_activity_registry.register("smart_assignment")
-def smart_assignment_activity_handler(
+@workflow_activity_registry.register("smart_assignment_trigger")
+def smart_assignment_trigger_handler(
     group: Group,
     activity: Activity,
     detector_id: DetectorId | None = None,
@@ -122,6 +122,33 @@ def smart_assignment_activity_handler(
     from sentry.seer.smart_assignment.trigger import trigger_smart_assignment
 
     trigger_smart_assignment(group, activity_type, activity)
+
+
+@workflow_activity_registry.register("smart_assignment_completed")
+def smart_assignment_completed_handler(
+    group: Group,
+    activity: Activity,
+    detector_id: DetectorId | None = None,
+) -> None:
+    """Act on a delivered smart-assignment verdict.
+
+    Fires off the SMART_ASSIGNMENT_COMPLETED activity that delivery records when Seer
+    returns a result (the activity references the originating Seer run). Invoked
+    unconditionally for every group activity, so it self-filters and delegates scoring
+    and auto-assignment to process_smart_assignment_completion -- decoupled from the
+    dispatch/ground-truth path that reacts to the *triggering* activities.
+    """
+    try:
+        activity_type = ActivityType(activity.type)
+    except ValueError:
+        return
+
+    if activity_type != ActivityType.SMART_ASSIGNMENT_COMPLETED:
+        return
+
+    from sentry.seer.smart_assignment.completion import process_smart_assignment_completion
+
+    process_smart_assignment_completion(group, activity)
 
 
 @workflow_activity_registry.register("generic_activity")

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -103,13 +103,8 @@ def smart_assignment_trigger_handler(
     activity: Activity,
     detector_id: DetectorId | None = None,
 ) -> None:
-    """Trigger the smart assignment feature off Seer AI-step starts, assignment, and
-    resolution.
-
-    Invoked unconditionally for every group activity (via
-    invoke_workflow_activity_handlers), so it self-filters to the activities we care
-    about and delegates gating, dispatch (deduped to one run per group), and
-    ground-truth capture to trigger_smart_assignment.
+    """Trigger the smart assignment feature off Seer RCA/PR start, issue assignment, and
+    issue resolution.
     """
     try:
         activity_type = ActivityType(activity.type)
@@ -132,11 +127,10 @@ def smart_assignment_completed_handler(
 ) -> None:
     """Act on a delivered smart-assignment verdict.
 
-    Fires off the SMART_ASSIGNMENT_COMPLETED activity that delivery records when Seer
-    returns a result (the activity references the originating Seer run). Invoked
-    unconditionally for every group activity, so it self-filters and delegates scoring
-    and auto-assignment to process_smart_assignment_completion -- decoupled from the
-    dispatch/ground-truth path that reacts to the *triggering* activities.
+    Responds to the SMART_ASSIGNMENT_COMPLETED activity created when when Seer
+    returns a result. Records the prediction, maybe-scores it against ground truth
+    (if we have it), creates a GroupOwner indicating a suggested owner, and promotes
+    the suggestion to an assignment iff the project auto-assigns to owners.
     """
     try:
         activity_type = ActivityType(activity.type)

--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -20,6 +20,7 @@ type AssignmentSource =
   | 'codeowners'
   | 'ownershipRule'
   | 'projectOwnership'
+  | 'seerSuggested'
   | 'suspectCommit'
   | 'suspectCommitter';
 
@@ -112,6 +113,8 @@ function getAssignmentSourceLabel(source: AssignmentDetails['source']) {
     case 'suspectCommit':
     case 'suspectCommitter':
       return t('Based on commit data');
+    case 'seerSuggested':
+      return t('Suggested by Seer');
     default:
       return null;
   }

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -34,6 +34,7 @@ const suggestedReasonTable: Record<SuggestedOwnerReason, string> = {
   suspectCommit: t('Suspect Commit'),
   ownershipRule: t('Ownership Rule'),
   projectOwnership: t('Ownership Rule'),
+  seerSuggested: t('Suggested by Seer'),
   // TODO: codeowners may no longer exist
   codeowners: t('Codeowners'),
 };
@@ -128,6 +129,7 @@ function AssigneeAvatar({
     }),
     ownershipRule: t('Matching Issue Owners Rule'),
     projectOwnership: t('Matching Issue Owners Rule'),
+    seerSuggested: t('Suggested by Seer'),
     codeowners: t('Matching Codeowners Rule'),
   };
   const assignedToSuggestion = suggestedActors.find(actor => actor.id === assignedTo?.id);

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -550,6 +550,7 @@ export type SuggestedOwnerReason =
   | 'suspectCommit'
   | 'ownershipRule'
   | 'projectOwnership'
+  | 'seerSuggested'
   // TODO: codeowners may no longer exist
   | 'codeowners';
 

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -925,7 +925,8 @@ export interface GroupActivityAssigned extends GroupActivityBase {
       | 'codeowners'
       | 'slack'
       | 'msteams'
-      | 'suspectCommitter';
+      | 'suspectCommitter'
+      | 'seerSuggested';
     /** Codeowner or Project owner rule as a string */
     rule?: string;
     user?: Team | User;

--- a/static/app/views/issueDetails/activitySection/assignmentIntegration.ts
+++ b/static/app/views/issueDetails/activitySection/assignmentIntegration.ts
@@ -15,6 +15,8 @@ export function getAssignmentIntegrationName(integration: AssignmentIntegration)
       return t('Codeowners Rule');
     case 'suspectCommitter':
       return t('Suspect Commit');
+    case 'seerSuggested':
+      return t('Suggested by Seer');
     default:
       return null;
   }
@@ -24,6 +26,7 @@ export function isAutoAssignmentIntegration(integration: AssignmentIntegration) 
   return (
     integration === 'projectOwnership' ||
     integration === 'codeowners' ||
-    integration === 'suspectCommitter'
+    integration === 'suspectCommitter' ||
+    integration === 'seerSuggested'
   );
 }

--- a/static/app/views/issueDetails/header/assigneeSelector.tsx
+++ b/static/app/views/issueDetails/header/assigneeSelector.tsx
@@ -68,6 +68,7 @@ function getAssignmentSource(
     case 'projectOwnership':
     case 'codeowners':
     case 'suspectCommitter':
+    case 'seerSuggested':
       return activity.data.integration;
     default:
       return undefined;

--- a/tests/sentry/notifications/platform/strategies/test_issue_owners.py
+++ b/tests/sentry/notifications/platform/strategies/test_issue_owners.py
@@ -123,6 +123,38 @@ class TestIssueOwnersActivityAlertStrategy(TestCase):
         emails = [t.resource_id for t in targets]
         assert emails.count(self.user.email) == 1
 
+    def test_seer_suggested_owner_notified_when_no_assignee(self) -> None:
+        seer_user = self.create_user(email="seer-pick@example.com")
+        self.create_member(organization=self.organization, user=seer_user)
+        self.create_group_owner(
+            group=self.group,
+            type=GroupOwnerType.SEER_SUGGESTED.value,
+            user_id=seer_user.id,
+        )
+
+        strategy = IssueOwnersActivityAlertStrategy(group=self.group)
+        targets = strategy.get_targets()
+
+        assert len(targets) == 1
+        assert targets[0].resource_id == "seer-pick@example.com"
+
+    def test_assignee_supersedes_seer_suggested_owner(self) -> None:
+        seer_user = self.create_user(email="seer-pick@example.com")
+        self.create_member(organization=self.organization, user=seer_user)
+        self.create_group_owner(
+            group=self.group,
+            type=GroupOwnerType.SEER_SUGGESTED.value,
+            user_id=seer_user.id,
+        )
+        GroupAssignee.objects.assign(self.group, self.user)
+
+        strategy = IssueOwnersActivityAlertStrategy(group=self.group)
+        targets = strategy.get_targets()
+
+        emails = {t.resource_id for t in targets}
+        assert self.user.email in emails
+        assert "seer-pick@example.com" not in emails
+
     def test_no_assignee_no_owners_returns_empty(self) -> None:
         strategy = IssueOwnersActivityAlertStrategy(group=self.group)
         assert strategy.get_targets() == []

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -1,0 +1,154 @@
+from django.utils import timezone
+
+from sentry.models.activity import Activity, ActivityIntegration
+from sentry.models.groupassignee import GroupAssignee
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.projectownership import ProjectOwnership
+from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
+from sentry.seer.smart_assignment.completion import process_smart_assignment_completion
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+AUTO_ASSIGN_FLAG = "organizations:seer-smart-assignment-assign"
+
+
+class ProcessSmartAssignmentCompletionTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        self.seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        self.mirror = SeerAgentRun.objects.create(
+            run=self.seer_run,
+            source=SEER_FEATURE_ID,
+            group=self.group,
+            extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
+        )
+
+    def _activity(self, predicted_assignee_user_ids: list[int | None]) -> Activity:
+        return Activity.objects.create_without_group_action(
+            project_id=self.group.project_id,
+            group=self.group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+            data={
+                "run_id": self.mirror.id,
+                "run_uuid": str(self.seer_run.uuid),
+                "predicted_assignee_user_ids": predicted_assignee_user_ids,
+            },
+        )
+
+    def _extras(self) -> dict:
+        self.mirror.refresh_from_db()
+        return self.mirror.extras
+
+    def _member(self, username: str = "alice"):
+        user = self.create_user(username=username)
+        self.create_member(user=user, organization=self.organization)
+        return user
+
+    def _set_project_auto_assignment(self, enabled: bool) -> None:
+        # The post_save signal keeps get_ownership_cached in sync with this row.
+        ProjectOwnership.objects.create(
+            project_id=self.group.project_id,
+            auto_assignment=enabled,
+            suspect_committer_auto_assignment=False,
+        )
+
+    def _suggested_owners(self) -> list[GroupOwner]:
+        return list(
+            GroupOwner.objects.filter(group=self.group, type=GroupOwnerType.SEER_SUGGESTED.value)
+        )
+
+    def test_records_prediction_regardless_of_flag(self) -> None:
+        # Scoring bookkeeping is internal, not user-facing, so it runs without the flag.
+        alice = self._member()
+        process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        assert self._extras()["predicted_assignee_user_ids"] == [alice.id]
+
+    def test_handles_missing_payload(self) -> None:
+        activity = Activity.objects.create_without_group_action(
+            project_id=self.group.project_id,
+            group=self.group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+            data={},
+        )
+        process_smart_assignment_completion(self.group, activity)
+        assert self._extras()["predicted_assignee_user_ids"] == []
+
+    def test_no_writes_without_flag(self) -> None:
+        alice = self._member()
+        process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        # Everything user-facing is behind the flag: no suggested owner, no assignment.
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_suggests_without_assigning_when_project_auto_assign_off(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id, None]))
+
+        owners = self._suggested_owners()
+        assert len(owners) == 1
+        assert owners[0].user_id == alice.id
+        assert owners[0].context == {"run_uuid": str(self.seer_run.uuid)}
+        # Project doesn't auto-assign to owners -> the pick stays a suggestion.
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_promotes_suggestion_to_assignment_when_project_auto_assigns(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(True)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        # Suggested owner is always written...
+        assert len(self._suggested_owners()) == 1
+        # ...and promoted to a real assignment via the existing auto-assign machinery.
+        assignee = GroupAssignee.objects.get(group=self.group)
+        assert assignee.user_id == alice.id
+        # The ASSIGNED activity is tagged so ground-truth capture skips our own work.
+        assigned = Activity.objects.filter(
+            group=self.group, type=ActivityType.ASSIGNED.value
+        ).latest("datetime")
+        assert assigned.data["integration"] == ActivityIntegration.SEER_SUGGESTED.value
+
+    def test_does_not_override_existing_assignee(self) -> None:
+        existing = self.create_user()
+        alice = self._member()
+        GroupAssignee.objects.assign(self.group, existing)
+        self._set_project_auto_assignment(True)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        # We record the suggestion but never override a manual assignment.
+        assert len(self._suggested_owners()) == 1
+        assert GroupAssignee.objects.get(group=self.group).user_id == existing.id
+
+    def test_no_writes_when_top_pick_unlinked(self) -> None:
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([None]))
+
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_no_writes_on_abstain(self) -> None:
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([]))
+
+        assert self._suggested_owners() == []
+        assert not GroupAssignee.objects.filter(group=self.group).exists()
+
+    def test_suggested_owner_is_idempotent(self) -> None:
+        alice = self._member()
+        self._set_project_auto_assignment(False)
+        with self.feature(AUTO_ASSIGN_FLAG):
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+            process_smart_assignment_completion(self.group, self._activity([alice.id]))
+
+        assert len(self._suggested_owners()) == 1

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.utils import timezone
 
 from sentry.models.activity import Activity, ActivityIntegration
@@ -9,6 +11,7 @@ from sentry.seer.smart_assignment.completion import process_smart_assignment_com
 from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
+from sentry.users.models.user import User
 
 AUTO_ASSIGN_FLAG = "organizations:seer-smart-assignment-assign"
 
@@ -41,11 +44,11 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
             },
         )
 
-    def _extras(self) -> dict:
+    def _extras(self) -> dict[str, Any]:
         self.mirror.refresh_from_db()
         return self.mirror.extras
 
-    def _member(self, username: str = "alice"):
+    def _member(self, username: str = "alice") -> User:
         user = self.create_user(username=username)
         self.create_member(user=user, organization=self.organization)
         return user

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -74,11 +74,13 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
         assert self._extras()["predicted_assignee_user_ids"] == [alice.id]
 
     def test_handles_missing_payload(self) -> None:
+        # Defensive: run_id is always set by delivery, but a payload missing the picks
+        # still records an (empty) prediction on the run rather than raising.
         activity = Activity.objects.create_without_group_action(
             project_id=self.group.project_id,
             group=self.group,
             type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
-            data={},
+            data={"run_id": self.mirror.id},
         )
         process_smart_assignment_completion(self.group, activity)
         assert self._extras()["predicted_assignee_user_ids"] == []

--- a/tests/sentry/seer/smart_assignment/test_completion.py
+++ b/tests/sentry/seer/smart_assignment/test_completion.py
@@ -38,7 +38,7 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
             group=self.group,
             type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
             data={
-                "run_id": self.mirror.id,
+                "run_id": self.seer_run.id,
                 "run_uuid": str(self.seer_run.uuid),
                 "predicted_assignee_user_ids": predicted_assignee_user_ids,
             },
@@ -80,7 +80,7 @@ class ProcessSmartAssignmentCompletionTest(TestCase):
             project_id=self.group.project_id,
             group=self.group,
             type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
-            data={"run_id": self.mirror.id},
+            data={"run_id": self.seer_run.id},
         )
         process_smart_assignment_completion(self.group, activity)
         assert self._extras()["predicted_assignee_user_ids"] == []

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -8,7 +8,7 @@ from sentry.models.activity import Activity
 from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
-from sentry.seer.smart_assignment.models import SEER_FEATURE_ID
+from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 
@@ -57,6 +57,34 @@ class DeliverSmartAssignmentResultTest(TestCase):
         )
 
     @patch(METRICS_PATH)
+    def test_records_top_pick_resolved_to_user(self, mock_metrics: MagicMock) -> None:
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "suspect commit",
+                    "confidence": "high",
+                },
+                {
+                    "identifier": "bob",
+                    "identifier_kind": "username",
+                    "reason": "code owner",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        # Every candidate resolved (best-first) and cached on the run mirror: alice is
+        # an org member; "bob" maps to no org user, so its rank is held with None. The
+        # full verdict itself lives on the Seer run, not here.
+        assert self._extras()["predicted_assignee_user_ids"] == [alice.id, None]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
     def test_creates_completion_activity_referencing_run(self, mock_metrics: MagicMock) -> None:
         # The delivered verdict is handed off via a SMART_ASSIGNMENT_COMPLETED
         # activity that points back at the Seer run and carries the resolved picks.
@@ -98,11 +126,112 @@ class DeliverSmartAssignmentResultTest(TestCase):
         )
 
     @patch(METRICS_PATH)
+    def test_email_kind_resolves_by_verified_email(self, mock_metrics: MagicMock) -> None:
+        # An email-kind pick (unlinked commit author) resolves by verified org email,
+        # even when the address happens to also be someone's username-shaped handle.
+        carol = self.create_user(email="carol@example.com")
+        self.create_member(user=carol, organization=self.organization)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "carol@example.com",
+                    "identifier_kind": "email",
+                    "reason": "unlinked commit author",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [carol.id]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_unresolvable_identifier_records_no_user(self, mock_metrics: MagicMock) -> None:
+        result = {
+            "candidates": [
+                {
+                    "identifier": "nobody-here",
+                    "identifier_kind": "username",
+                    "reason": "guess",
+                    "confidence": "low",
+                },
+            ]
+        }
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [None]
+        self._assert_outcome(mock_metrics, "unlinked")
+
+    @patch(METRICS_PATH)
+    def test_empty_candidates_is_abstain(self, mock_metrics: MagicMock) -> None:
+        self._deliver({"candidates": []})
+        assert self._extras()["predicted_assignee_user_ids"] == []
+        self._assert_outcome(mock_metrics, "abstain")
+
+    @patch(METRICS_PATH)
     def test_error_status_records_nothing(self, mock_metrics: MagicMock) -> None:
         self._deliver(None, status="error", error="boom")
         # No prediction recorded on error; the Seer run holds the failure.
         assert "predicted_assignee_user_ids" not in self._extras()
         self._assert_outcome(mock_metrics, "error")
+
+    @patch("sentry.seer.smart_assignment.scoring.metrics")
+    def test_scores_when_ground_truth_already_present(
+        self, mock_scoring_metrics: MagicMock
+    ) -> None:
+        # Assignment landed before Seer finished: ground truth is already on the run
+        # mirror, so delivering the prediction completes the pair and scores it.
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self.mirror.extras = {**self.mirror.extras, "actual_assignee_user_id": alice.id}
+        self.mirror.save(update_fields=["extras"])
+        result = {
+            "candidates": [
+                {
+                    "identifier": "alice",
+                    "identifier_kind": "username",
+                    "reason": "x",
+                    "confidence": "high",
+                }
+            ]
+        }
+        self._deliver(result)
+
+        mock_scoring_metrics.incr.assert_called_once_with(
+            "smart_assignment.scored",
+            tags={
+                "result": SmartAssignmentScore.EXACT,
+                "hit_rank": 1,
+                "trigger": ActivityType.SEER_RCA_STARTED.name,
+            },
+        )
+
+    @patch(METRICS_PATH)
+    def test_prediction_lands_on_delivered_run_not_latest_mirror(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # A race left a second, newer smart-assignment mirror on the same group. Delivery
+        # resolves the exact run from the delivered uuid, so the prediction must land on
+        # that row -- not the latest one by date_added.
+        newer_seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        newer_mirror = SeerAgentRun.objects.create(
+            run=newer_seer_run,
+            source=SEER_FEATURE_ID,
+            group=self.group,
+            extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
+        )
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        self._deliver({"candidates": [{"identifier": "alice", "identifier_kind": "username"}]})
+
+        assert self._extras()["predicted_assignee_user_ids"] == [alice.id]
+        newer_mirror.refresh_from_db()
+        assert "predicted_assignee_user_ids" not in (newer_mirror.extras or {})
 
     @patch(METRICS_PATH)
     def test_untied_run_is_missing_group(self, mock_metrics: MagicMock) -> None:

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -263,7 +263,7 @@ class DeliverSmartAssignmentResultTest(TestCase):
         self.create_member(user=alice, organization=self.organization)
         deliver_smart_assignment_result(
             self.organization.id,
-            str(seer_run.uuid),
+            seer_run.uuid,
             "completed",
             {"candidates": [{"identifier": "alice", "identifier_kind": "username"}]},
             None,

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -234,6 +234,45 @@ class DeliverSmartAssignmentResultTest(TestCase):
         assert "predicted_assignee_user_ids" not in (newer_mirror.extras or {})
 
     @patch(METRICS_PATH)
+    def test_prediction_lands_when_seer_run_and_mirror_ids_diverge(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        # The completion activity carries the SeerRun PK as `run_id`, which equals the
+        # SeerAgentRun row id only when their sequences happen to line up. Create extra
+        # SeerRuns with no mirror so the two ids diverge, then assert the resolved picks
+        # still land on the right mirror (the completion handler must match on the run FK).
+        for _ in range(3):
+            SeerRun.objects.create(
+                organization=self.organization,
+                type=SeerRunType.FEATURE_RUN,
+                last_triggered_at=timezone.now(),
+            )
+        seer_run = SeerRun.objects.create(
+            organization=self.organization,
+            type=SeerRunType.FEATURE_RUN,
+            last_triggered_at=timezone.now(),
+        )
+        mirror = SeerAgentRun.objects.create(
+            run=seer_run,
+            source=SEER_FEATURE_ID,
+            group=self.group,
+            extras={"trigger": ActivityType.SEER_RCA_STARTED.name},
+        )
+        assert seer_run.id != mirror.id
+        alice = self.create_user(username="alice")
+        self.create_member(user=alice, organization=self.organization)
+        deliver_smart_assignment_result(
+            self.organization.id,
+            str(seer_run.uuid),
+            "completed",
+            {"candidates": [{"identifier": "alice", "identifier_kind": "username"}]},
+            None,
+        )
+
+        mirror.refresh_from_db()
+        assert mirror.extras["predicted_assignee_user_ids"] == [alice.id]
+
+    @patch(METRICS_PATH)
     def test_untied_run_is_missing_group(self, mock_metrics: MagicMock) -> None:
         # Run mirror was never tied to a group (group_id is NULL): there's nothing to
         # record the prediction against, so it must not count as a delivery success.

--- a/tests/sentry/seer/smart_assignment/test_scoring.py
+++ b/tests/sentry/seer/smart_assignment/test_scoring.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
-from sentry.models.activity import Activity
+from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
@@ -219,6 +219,27 @@ class RecordGroundTruthTest(ScoringTestBase):
         record_ground_truth(self.group, ActivityType.SEER_RCA_STARTED)
 
         run.refresh_from_db()
+        assert "ground_truth_source" not in run.extras
+
+    def test_our_auto_assignment_is_not_recorded(self) -> None:
+        run = self._run()
+        assignee = self.create_user()
+        GroupAssignee.objects.create(
+            group=self.group, project=self.group.project, user_id=assignee.id
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.ASSIGNED.value,
+            data={
+                "assignee": str(assignee.id),
+                "assigneeType": "user",
+                "integration": ActivityIntegration.SEER_SUGGESTED.value,
+            },
+        )
+        record_ground_truth(self.group, ActivityType.ASSIGNED, activity)
+
+        run.refresh_from_db()
+        assert "actual_assignee_user_id" not in run.extras
         assert "ground_truth_source" not in run.extras
 
     @patch(METRICS_PATH)

--- a/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/workflow/test_workflow_activity_handlers.py
@@ -10,7 +10,8 @@ from sentry.workflow_engine.handlers.workflow.workflow_activity_handlers import 
     SUPPORTED_ACTIVITIES,
     activity_handler,
     seer_activity_handler,
-    smart_assignment_activity_handler,
+    smart_assignment_completed_handler,
+    smart_assignment_trigger_handler,
 )
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.registry import workflow_activity_registry
@@ -21,8 +22,9 @@ class WorkflowActivityRegistryTest(TestCase):
     def test_registrants(self) -> None:
         assert "seer_activity" in workflow_activity_registry.registrations
         assert "generic_activity" in workflow_activity_registry.registrations
-        assert "smart_assignment" in workflow_activity_registry.registrations
-        assert len(workflow_activity_registry.registrations) == 3
+        assert "smart_assignment_trigger" in workflow_activity_registry.registrations
+        assert "smart_assignment_completed" in workflow_activity_registry.registrations
+        assert len(workflow_activity_registry.registrations) == 4
 
 
 class SmartAssignmentActivityHandlerTest(TestCase):
@@ -47,7 +49,7 @@ class SmartAssignmentActivityHandlerTest(TestCase):
             activity = self.create_group_activity(
                 group=self.group, type=activity_type.value, data=data
             )
-            smart_assignment_activity_handler(self.group, activity, None)
+            smart_assignment_trigger_handler(self.group, activity, None)
             mock_trigger.assert_called_once_with(self.group, activity_type, activity)
 
     @mock.patch(TRIGGER)
@@ -63,8 +65,41 @@ class SmartAssignmentActivityHandlerTest(TestCase):
             ActivityType.NOTE,
         ):
             activity = self.create_group_activity(group=self.group, type=activity_type.value)
-            smart_assignment_activity_handler(self.group, activity, None)
+            smart_assignment_trigger_handler(self.group, activity, None)
         mock_trigger.assert_not_called()
+
+
+class SmartAssignmentCompletedHandlerTest(TestCase):
+    COMPLETION = "sentry.seer.smart_assignment.completion.process_smart_assignment_completion"
+
+    def setUp(self) -> None:
+        self.group = self.create_group()
+
+    @mock.patch(COMPLETION)
+    def test_delegates_for_completed_activity(self, mock_completion: MagicMock) -> None:
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SMART_ASSIGNMENT_COMPLETED.value,
+        )
+        # create_group_activity invokes the registered handlers itself, so the delegate
+        # is already called once for the real activity; assert on a direct call to keep
+        # this focused on the handler's own filtering + delegation.
+        mock_completion.reset_mock()
+        smart_assignment_completed_handler(self.group, activity, None)
+        mock_completion.assert_called_once_with(self.group, activity)
+
+    @mock.patch(COMPLETION)
+    def test_skips_unrelated_activities(self, mock_completion: MagicMock) -> None:
+        for activity_type in (
+            ActivityType.SEER_RCA_STARTED,
+            ActivityType.SEER_PR_CREATED,
+            ActivityType.SET_RESOLVED,
+            ActivityType.NOTE,
+        ):
+            activity = self.create_group_activity(group=self.group, type=activity_type.value)
+            mock_completion.reset_mock()
+            smart_assignment_completed_handler(self.group, activity, None)
+            mock_completion.assert_not_called()
 
 
 class SeerActivityHandlerTest(TestCase):


### PR DESCRIPTION
A new `smart_assignment_completed_handler()` is added to the `workflow_activity_registry` that responds to the `ActivityType.SMART_ASSIGNMENT_COMPLETED` introduced in #119943.

`process_smart_assignment_completion()`:
- calls `record_prediction()` introduced in #119944 to track the SA result on the `SeerAgentRun`, and score the result if we have a ground truth already
- if the `organizations:seer-smart-assignment-assign` flag (renamed from `-notifications`) is enabled for this org and we have an actual user as the result:
  - adds the predicted user as a `GroupOwner` (suggested assignee)
  - calls `ProjectOwnership.handle_auto_assignment()` to make them a `GroupAssignee` if auto-assignment setting is on (existing setting for things like suspect commits etc.)
-  metrics and stuff

To enable all this, we add `SEER_SUGGESTED` as a `GroupOwnerType`, and add that to `autoassignment_types`, and make sure it'll display properly to the user as a `SuggestedOwnerReason`: `Suggested by Seer` will be what they see.