### PR TITLE
feat(derived data): Stamp GroupDerivedData with its initial pipeline hash

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -30,7 +30,7 @@ class ProcessingStrategy(enum.Enum):
     INLINE = "inline"  # try to process all pending actions quickly; fall back to ASYNC
 
 
-def _ensure_derived(group_id: int) -> GroupDerivedData:
+def _ensure_derived(group_id: int, pipeline_hash: str) -> GroupDerivedData:
     """Get or create the GroupDerivedData row for a group.
 
     Raises Group.DoesNotExist if the group has been deleted.
@@ -43,7 +43,12 @@ def _ensure_derived(group_id: int) -> GroupDerivedData:
     try:
         derived, _created = GroupDerivedData.objects.get_or_create(
             group_id=group_id,
-            defaults={"cursor_date": EPOCH, "cursor_id": 0, "data": {}},
+            defaults={
+                "cursor_date": EPOCH,
+                "cursor_id": 0,
+                "data": {},
+                "pipeline_hash": pipeline_hash,
+            },
         )
     except IntegrityError:
         raise Group.DoesNotExist(f"Group {group_id} does not exist")
@@ -104,7 +109,9 @@ def _process_batch(
     state_update = GroupDerivedDataStore.build_update(p, result)
 
     updated = GroupDerivedData.objects.filter(
-        Q(group_id=group_id) & _cursor_lte(last_date, last_id)
+        Q(group_id=group_id)
+        & _cursor_lte(last_date, last_id)
+        & Q(pipeline_hash=derived.pipeline_hash)
     ).update(cursor_date=last_date, cursor_id=last_id, **state_update)
 
     if updated:
@@ -166,7 +173,7 @@ def process_group_log(
     start = time.monotonic()
 
     with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
-        derived = _ensure_derived(group_id)
+        derived = _ensure_derived(group_id, p.pipeline_hash)
 
     has_more = _process_batch(p, derived, group_id, batch_size)
     while has_more:
@@ -200,14 +207,16 @@ def trigger_group_log_processing(group_id: int, *, strategy: ProcessingStrategy)
 
     assert strategy is ProcessingStrategy.INLINE
 
+    pipeline = PIPELINE
+
     with metrics.timer("issues.derived.inline_processing"):
         try:
             with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
-                derived = _ensure_derived(group_id)
+                derived = _ensure_derived(group_id, pipeline.pipeline_hash)
         except ObjectDoesNotExist:
             return
 
-        has_more = _process_batch(PIPELINE, derived, group_id, INLINE_BATCH_SIZE)
+        has_more = _process_batch(pipeline, derived, group_id, INLINE_BATCH_SIZE)
     if has_more:
         # Derived data will be stale for any code running between now and
         # when the task completes.

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -394,6 +394,50 @@ class ProcessGroupLogTest(TestCase):
         assert second.last_progressed_at == first_last_progressed_at
         assert second.progress == IssueProgressState.DIAGNOSED.value
 
+    def test_pipeline_hash_set_on_create(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        derived = process_group_log(group.id)
+        assert derived.pipeline_hash == PIPELINE.pipeline_hash
+
+    def test_pipeline_hash_concurrent_change_skips_cursor_update(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        derived = process_group_log(group.id)
+        first_cursor = derived.cursor_id
+
+        # Insert a log entry directly to avoid inline processing from _publish
+        GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.VIEW,
+            actor_type=GroupActorType.SYSTEM,
+            actor_id=0,
+            source=SOURCE,
+            data={},
+        )
+
+        # Simulate a concurrent pipeline_hash change (e.g. migration reset)
+        # between our load and the UPDATE in _process_batch.
+        GroupDerivedData.objects.filter(group_id=group.id).update(pipeline_hash="reset")
+
+        processing._process_batch(processing.PIPELINE, derived, group.id, 1)
+
+        # The UPDATE should not have matched because the DB hash changed
+        derived.refresh_from_db()
+        assert derived.cursor_id == first_cursor
+        assert derived.pipeline_hash == "reset"
+
+    def test_invalidate_and_reprocess_restores_pipeline_hash(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        process_group_log(group.id)
+
+        invalidate_group_derived_data(group.id)
+        derived = process_group_log(group.id)
+        assert derived.pipeline_hash == PIPELINE.pipeline_hash
+
 
 # --- Pure Python tests (no DB) ---
 


### PR DESCRIPTION
This allows us to reliably identify derived data that was generated with older algorithms or are lacking features.

Since it doesn't make sense to update a GroupDerivedData if the pipeline hash isn't what you expected, we also add a check for that. This makes it possible to do in-place updates of the GroupDerivedData with new pipeline relatively safely.