### PR TITLE
build(deps): Update Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,4 @@
 version: 2
-# Dependabot reviewer configuration was removed in favor of CODEOWNERS:
-# https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/
 updates:
   - package-ecosystem: npm
     open-pull-requests-limit: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,15 @@
 version: 2
+# Dependabot reviewer configuration was removed in favor of CODEOWNERS:
+# https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/
 updates:
   - package-ecosystem: npm
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     directory: '/'
     schedule:
       # Going to start with a high interval, and then tone it back
       interval: daily
       timezone: America/Los_Angeles
       time: '15:30'
-    reviewers:
-      - '@getsentry/owners-js-deps'
     labels: []
     # Group dependency updates together in one PR
     # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
@@ -18,8 +18,12 @@ updates:
       swc-dependencies:
         patterns:
           - '@swc/*'
+      dnd-kit-dependencies:
+        patterns:
+          - '@dnd-kit/*'
       sentry-dependencies:
         patterns:
+          - '@sentry/browser'
           - '@sentry/core'
           - '@sentry/node'
           - '@sentry/react'
@@ -34,11 +38,24 @@ updates:
           - '@emotion/*'
       jest-dependencies:
         patterns:
+          - '@jest/*'
           - 'jest'
           - 'jest-*'
       react-testing-library-dependencies:
         patterns:
           - '@testing-library/*'
+      # Keep React Router updates within the current major version.
+      react-router-dependencies:
+        patterns:
+          - 'react-router*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      tanstack-query-dependencies:
+        patterns:
+          - '@tanstack/eslint-plugin-query'
+          - '@tanstack/query-*'
+          - '@tanstack/react-query*'
       react-dependencies:
         patterns:
           - 'react'
@@ -52,22 +69,16 @@ updates:
 
       # We ignore everything that hasn't yet been upgrade, this way we will
       # only get the _freshest_ of new packages to consider upgrading
-      - dependency-name: '@types/react-router'
       - dependency-name: '@types/react-select'
       - dependency-name: '@types/reflux'
       - dependency-name: 'gettext-parser'
       - dependency-name: 'react-lazyload'
-      - dependency-name: 'react-router'
       - dependency-name: 'react-select'
       - dependency-name: 'reflux'
       - dependency-name: 'sprintf-js'
-      - dependency-name: 'u2f-api'
   - package-ecosystem: 'docker'
     directory: 'self-hosted/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - '@getsentry/dev-infra'
-      - '@getsentry/security'
     # security only updates
     open-pull-requests-limit: 0


### PR DESCRIPTION
Groups dnd-kit, Sentry SDK, Jest, React Router, TanStack Query, and React updates so packages that move together land together. Also bumps the open PR limit and cleans up stale ignores.

Removes the retired Dependabot reviewers config in favor of CODEOWNERS: https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/