### PR TITLE
feat(slack): Make nudge frequency configurable via option

### DIFF
--- a/src/sentry/integrations/slack/utils/nudge.py
+++ b/src/sentry/integrations/slack/utils/nudge.py
@@ -2,7 +2,7 @@ import random
 
 import sentry_sdk
 
-from sentry import features
+from sentry import features, options
 from sentry.models.organization import Organization
 from sentry.utils import metrics
 
@@ -27,8 +27,9 @@ def should_send_nudge_block(
     if not features.has("organizations:slack-reinstall-nudge-on-issue-alert", organization):
         return False
 
-    # only 30% of the alerts should have the nudge blocks
-    if random.random() >= 0.3:
+    # Configurable frequency of nudge blocks (default 0.3 = 30%)
+    nudge_frequency = options.get("slack.nudge-frequency")
+    if random.random() >= nudge_frequency:
         record_nudge_metric("skipped_random_check")
         return False
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -607,6 +607,13 @@ register("slack.debug-workspace", flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("slack.debug-channel", flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Log unfurl payloads for debugging
 register("slack.log-unfurl-payload", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
+# Frequency of slack nudge blocks on issue alerts (0.0 to 1.0, where 0.3 = 30%)
+register(
+    "slack.nudge-frequency",
+    type=Float,
+    default=0.3,
+    flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Slack Staging App
 register("slack-staging.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/integrations/slack/utils/test_nudge.py
+++ b/tests/sentry/integrations/slack/utils/test_nudge.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-from sentry import options
 from sentry.integrations.slack.utils.nudge import should_send_nudge_block
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature

--- a/tests/sentry/integrations/slack/utils/test_nudge.py
+++ b/tests/sentry/integrations/slack/utils/test_nudge.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from sentry import options
 from sentry.integrations.slack.utils.nudge import should_send_nudge_block
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
@@ -12,7 +13,7 @@ class ShouldSendNudgeBlockTest(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # By default make the 30% random gate pass; individual tests override this.
+        # By default make the random gate pass; individual tests override this.
         patcher = patch("sentry.integrations.slack.utils.nudge.random.random", return_value=0.0)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -26,11 +27,34 @@ class ShouldSendNudgeBlockTest(TestCase):
 
     @with_feature(FEATURE_FLAG)
     def test_random_gate_fails(self) -> None:
+        # Default nudge frequency is 0.3 (30%), so 0.5 should fail the check
         with patch("sentry.integrations.slack.utils.nudge.random.random", return_value=0.5):
             assert (
                 should_send_nudge_block(channel_id=self.channel_id, organization=self.organization)
                 is False
             )
+
+    @with_feature(FEATURE_FLAG)
+    def test_custom_nudge_frequency(self) -> None:
+        # Set a custom nudge frequency to 50%
+        with self.options({"slack.nudge-frequency": 0.5}):
+            # Random value 0.4 should pass with 50% threshold
+            with patch("sentry.integrations.slack.utils.nudge.random.random", return_value=0.4):
+                assert (
+                    should_send_nudge_block(
+                        channel_id=self.channel_id, organization=self.organization
+                    )
+                    is True
+                )
+
+            # Random value 0.6 should fail with 50% threshold
+            with patch("sentry.integrations.slack.utils.nudge.random.random", return_value=0.6):
+                assert (
+                    should_send_nudge_block(
+                        channel_id=self.channel_id, organization=self.organization
+                    )
+                    is False
+                )
 
     @with_feature(FEATURE_FLAG)
     def test_posts_block(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds a configurable option to control the Slack nudge frequency on issue alerts, replacing the hardcoded 30% value.

## Changes

- Added `slack.nudge-frequency` option in `src/sentry/options/defaults.py` (default: 0.3 / 30%)
  - Uses `FLAG_MODIFIABLE_RATE` for validation (ensures value is between 0.0 and 1.0)
  - Uses `FLAG_AUTOMATOR_MODIFIABLE` to allow runtime configuration
- Updated `should_send_nudge_block()` to use `options.get("slack.nudge-frequency")` instead of hardcoded `0.3`
- Added test coverage for custom nudge frequency values in `test_nudge.py`

## Why

This allows operations to dynamically adjust the nudge frequency without code changes, enabling easier A/B testing and rollout control.

## How to Test

The option can be configured through the Sentry options system. For example, to set it to 50%:

```python
from sentry import options
options.set("slack.nudge-frequency", 0.5)
```

The feature flag `organizations:slack-reinstall-nudge-on-issue-alert` must also be enabled for nudges to appear.

Follows up on #119926
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/D0B1U74VAJF/p1784307629904999?thread_ts=1784307629.904999&cid=D0B1U74VAJF)

<div><a href="https://cursor.com/agents/bc-4ceabb7b-3ab0-54a7-9968-4033113917d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ceabb7b-3ab0-54a7-9968-4033113917d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

