### PR TITLE
feat(external-mcp): Switch datadog mcp integrations to all pass authentication via headers, instead of the deprecated datadog specific token

### DIFF
--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -113,8 +113,8 @@ def _get_personal_monitoring_connections(
             urls = provider.build_mcp_urls(identity.data)
             if not urls:
                 continue
-            encrypted_access_token = encrypt_access_token_for_seer(access_token)
-            if not encrypted_access_token:
+            encrypted_auth_header = encrypt_access_token_for_seer(f"Bearer {access_token}")
+            if not encrypted_auth_header:
                 continue
             auth_method = "oauth" if is_oauth_provider else "pat"
             for url in urls:
@@ -122,7 +122,7 @@ def _get_personal_monitoring_connections(
                     MonitoringProviderConnectionData(
                         provider_key=provider_type,
                         url=url,
-                        encrypted_access_token=encrypted_access_token,
+                        encrypted_auth_headers={"Authorization": encrypted_auth_header},
                         identity_id=identity.id,
                         auth_method=auth_method,
                         refreshable=is_oauth_provider,

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -928,8 +928,8 @@ def refresh_monitoring_provider_token(
         )
         return RefreshMonitoringProviderTokenErrorResponse(error="identity_not_valid")
 
-    encrypted_access_token = encrypt_access_token_for_seer(access_token)
-    if not encrypted_access_token:
+    encrypted_auth_header = encrypt_access_token_for_seer(f"Bearer {access_token}")
+    if not encrypted_auth_header:
         logger.error(
             "monitoring_provider.refresh.access_token_encryption_failed",
             extra={"identity_id": identity.id},
@@ -937,7 +937,7 @@ def refresh_monitoring_provider_token(
         return RefreshMonitoringProviderTokenErrorResponse(error="encryption_failed")
 
     return RefreshMonitoringProviderTokenSuccessResponse(
-        encrypted_access_token=encrypted_access_token,
+        encrypted_auth_headers={"Authorization": encrypted_auth_header},
         expires=identity.data.get("expires"),
     )
 

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -862,7 +862,6 @@ class ExecuteTimeseriesQueryErrorResponse(BaseModel):
 class MonitoringProviderConnectionData(BaseModel):
     provider_key: str
     url: str
-    encrypted_access_token: str | None = None
     encrypted_auth_headers: dict[str, str] | None = None
     identity_id: int | None = None
     auth_method: str
@@ -874,8 +873,8 @@ class MonitoringProviderConnectionData(BaseModel):
 
 class MonitoringProviderConnectionsResponse(BaseModel):
     """`get_monitoring_provider_connections` success: the caller's connected
-    monitoring provider identities, each carrying a freshly-encrypted access
-    token."""
+    monitoring provider identities, each carrying freshly-encrypted auth
+    headers."""
 
     connections: list[MonitoringProviderConnectionData]
 
@@ -884,11 +883,7 @@ class MonitoringProviderConnectionsResponse(BaseModel):
 
 
 class RefreshMonitoringProviderTokenSuccessResponse(BaseModel):
-    """`refresh_monitoring_provider_token` success: the freshly-encrypted access
-    token plus the Unix-second expiry the OAuth2 base helper stamps onto
-    `identity.data["expires"]` (`int(time()) + int(payload["expires_in"])`)."""
-
-    encrypted_access_token: str
+    encrypted_auth_headers: dict[str, str]
     expires: int | None
 
     def __getitem__(self, key: str) -> Any:

--- a/tests/sentry/seer/agent/test_monitoring_providers.py
+++ b/tests/sentry/seer/agent/test_monitoring_providers.py
@@ -52,10 +52,10 @@ class TestGetMonitoringProviderConnections(TestCase):
         assert connection["identity_id"] == identity.id
         assert connection["auth_method"] == "oauth"
         fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
-        decrypted_access_token = fernet.decrypt(
-            connection["encrypted_access_token"].encode("utf-8")
+        auth_header = fernet.decrypt(
+            connection["encrypted_auth_headers"]["Authorization"].encode("utf-8")
         ).decode("utf-8")
-        assert decrypted_access_token == "access-token"
+        assert auth_header == "Bearer access-token"
 
     def test_returns_multiple_connections(self) -> None:
         for site, ext_id in [("datadoghq.com", "org-1"), ("datadoghq.eu", "org-2")]:
@@ -212,10 +212,10 @@ class TestGetMonitoringProviderConnections(TestCase):
             assert connection["identity_id"] == identity.id
             assert connection["auth_method"] == "oauth"
             fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
-            decrypted = fernet.decrypt(connection["encrypted_access_token"].encode("utf-8")).decode(
-                "utf-8"
-            )
-            assert decrypted == "gcp-access-token"
+            auth_header = fernet.decrypt(
+                connection["encrypted_auth_headers"]["Authorization"].encode("utf-8")
+            ).decode("utf-8")
+            assert auth_header == "Bearer gcp-access-token"
 
     def test_gcp_and_datadog_connections_together(self) -> None:
         gcp_idp = self.create_identity_provider(type="gcp", external_id="")
@@ -284,7 +284,7 @@ class TestGetMonitoringProviderConnections(TestCase):
         result = get_monitoring_provider_connections(self.organization, self.user.id)
 
         assert len(result) == 3
-        mock_encrypt.assert_called_once_with("gcp-token")
+        mock_encrypt.assert_called_once_with("Bearer gcp-token")
 
     def _create_org_datadog_integration(self, site: str = "datadoghq.com") -> None:
         self.create_integration(
@@ -307,7 +307,6 @@ class TestGetMonitoringProviderConnections(TestCase):
         assert conn["identity_id"] is None
         assert conn["auth_method"] == "api_key"
         assert conn["refreshable"] is False
-        assert conn["encrypted_access_token"] is None
 
         fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
         headers = conn["encrypted_auth_headers"]
@@ -331,8 +330,10 @@ class TestGetMonitoringProviderConnections(TestCase):
         conn = result[0]
         assert conn["identity_id"] == identity.id
         assert conn["auth_method"] == "oauth"
-        assert conn["encrypted_auth_headers"] is None
         assert conn["refreshable"] is True
+        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+        headers = conn["encrypted_auth_headers"]
+        assert fernet.decrypt(headers["Authorization"].encode()).decode() == "Bearer personal-token"
 
     def test_personal_datadog_pat_overrides_org(self) -> None:
         self._create_org_datadog_integration()
@@ -351,8 +352,13 @@ class TestGetMonitoringProviderConnections(TestCase):
         conn = result[0]
         assert conn["identity_id"] == identity.id
         assert conn["auth_method"] == "pat"
-        assert conn["encrypted_auth_headers"] is None
         assert conn["refreshable"] is False
+        fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
+        headers = conn["encrypted_auth_headers"]
+        assert (
+            fernet.decrypt(headers["Authorization"].encode()).decode()
+            == "Bearer personal-pat-token"
+        )
 
     def test_org_datadog_kept_when_personal_is_different_family(self) -> None:
         self._create_org_datadog_integration()

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -895,11 +895,11 @@ class TestGetMonitoringProviderConnections(APITestCase):
         assert connection.url == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection.identity_id == identity.id
         assert connection.auth_method == "oauth"
-        assert connection.encrypted_access_token is not None
+        assert connection.encrypted_auth_headers is not None
         decrypted = Fernet(TEST_FERNET_KEY.encode("utf-8")).decrypt(
-            connection.encrypted_access_token.encode("utf-8")
+            connection.encrypted_auth_headers["Authorization"].encode("utf-8")
         )
-        assert decrypted.decode("utf-8") == "access-token"
+        assert decrypted.decode("utf-8") == "Bearer access-token"
 
     def test_unknown_organization_returns_empty(self) -> None:
         result = get_monitoring_provider_connections(organization_id=999999, user_id=self.user.id)
@@ -962,11 +962,11 @@ class TestRefreshMonitoringProviderToken(APITestCase):
         result = refresh_monitoring_provider_token(identity_id=self.identity.id)
 
         fernet = Fernet(TEST_FERNET_KEY.encode("utf-8"))
-        decrypted_access_token = fernet.decrypt(
-            result["encrypted_access_token"].encode("utf-8")
+        auth_header = fernet.decrypt(
+            result["encrypted_auth_headers"]["Authorization"].encode("utf-8")
         ).decode("utf-8")
 
-        assert decrypted_access_token == "new-access-token"
+        assert auth_header == "Bearer new-access-token"
         assert result["expires"] is not None
         assert len(responses.calls) == 1
 


### PR DESCRIPTION
We're moving to pass all authentication via headers, so that we don't need to write customized logic for header handling in Seer. This pr switches deprecated uses of the old token to work in this new way.
