### PR TITLE
ref(workflow_engine): Update the workflow_engine/evaluations for Detector / Workflow Evals

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -124,7 +124,7 @@ def _build_evidence_text(
 
     # Threshold: type > value
     threshold_part = ""
-    condition_evaluations = evaluation.data["condition_evaluations"]
+    condition_evaluations = evaluation.data.get("condition_evaluations", [])
     if condition_evaluations:
         condition = condition_evaluations[0].condition
         threshold_label = _THRESHOLD_TYPE_LABELS.get(threshold_type, threshold_type)

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -124,8 +124,9 @@ def _build_evidence_text(
 
     # Threshold: type > value
     threshold_part = ""
-    if evaluation.result:
-        condition = evaluation.result[0].condition
+    condition_evaluations = evaluation.data["condition_evaluations"]
+    if condition_evaluations:
+        condition = condition_evaluations[0].condition
         threshold_label = _THRESHOLD_TYPE_LABELS.get(threshold_type, threshold_type)
 
         if threshold_type == "relative_diff":
@@ -254,7 +255,7 @@ class PreprodSizeAnalysisDetectorHandler(
 
         priorities = [
             condition_evaluation.result
-            for condition_evaluation in group_evaluation.result
+            for condition_evaluation in group_evaluation.data["condition_evaluations"]
             if isinstance(condition_evaluation.result, DetectorPriorityLevel)
         ]
         if not priorities:
@@ -323,7 +324,7 @@ class PreprodSizeAnalysisDetectorHandler(
             "value": self.extract_value(data_packet),
             "conditions": [
                 condition_evaluation.condition.get_snapshot()
-                for condition_evaluation in evaluation.result
+                for condition_evaluation in evaluation.data["condition_evaluations"]
             ],
             "config": self.detector.config,
         }

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -401,7 +401,7 @@ class StatefulDetectorHandler(
             "data_packet_source_id": str(data_packet.source_id),
             "conditions": [
                 condition_evaluation.condition.get_snapshot()
-                for condition_evaluation in group_evaluation.result
+                for condition_evaluation in group_evaluation.data["condition_evaluations"]
                 if condition_evaluation.outcome.triggered
             ],
             "config": self.detector.config,
@@ -684,7 +684,7 @@ class StatefulDetectorHandler(
             """
             validated_condition_results: list[DetectorPriorityLevel] = [
                 condition_evaluation.result
-                for condition_evaluation in group_evaluation.result
+                for condition_evaluation in group_evaluation.data["condition_evaluations"]
                 if condition_evaluation.outcome.triggered
                 and isinstance(condition_evaluation.result, DetectorPriorityLevel)
             ]

--- a/src/sentry/workflow_engine/models/data_condition.py
+++ b/src/sentry/workflow_engine/models/data_condition.py
@@ -230,6 +230,8 @@ class DataCondition(DefaultFieldsModel):
         return result
 
     def evaluate_value(self, value: T) -> DataConditionEvaluation:
+        error: ConditionError | None = None
+
         try:
             condition_type = Condition(self.type)
 
@@ -242,10 +244,6 @@ class DataCondition(DefaultFieldsModel):
             # handling of DataConditionEvaluationExceptions.
             raise DataConditionEvaluationException("Unable to evaluate condition") from ve
 
-        metrics.incr("workflow_engine.data_condition.evaluation", tags={"type": self.type})
-
-        error: ConditionError | None = None
-
         if isinstance(result, bool):
             result = self.get_condition_result() if result else None
 
@@ -253,11 +251,14 @@ class DataCondition(DefaultFieldsModel):
             error = result
             result = None
 
+        metrics.incr("workflow_engine.data_condition.evaluation", tags={"type": self.type})
+
         return DataConditionEvaluation(
             condition=self,
+            triggered=(result is not None),
             error=error,
             result=result,
-            value=value,
+            data=value,
         )
 
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -183,7 +183,7 @@ def _is_conclusive_evaluation(evaluation: DataConditionGroupEvaluation) -> bool:
     logic_type = evaluation.data.get("logic_type")
 
     match logic_type:
-        case DataConditionGroup.Type.ALL:
+        case DataConditionGroup.Type.ALL | DataConditionGroup.Type.NONE:
             return not evaluation.outcome.triggered
         case DataConditionGroup.Type.ANY | DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
             return evaluation.outcome.triggered

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -67,34 +67,27 @@ def evaluate_condition_group_results(
     logic_type: DataConditionGroup.Type,
 ) -> DataConditionGroupEvaluation:
     logic_result = TriggerResult.FALSE
-    passing_evaluations: list[DataConditionEvaluation] = []
+    outcomes = [condition_result.outcome for condition_result in condition_results]
 
     match logic_type:
         case DataConditionGroup.Type.NONE:
-            logic_result = TriggerResult.none(
-                condition_result.outcome for condition_result in condition_results
-            )
+            logic_result = TriggerResult.none(outcomes)
         case DataConditionGroup.Type.ANY | DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-            logic_result = TriggerResult.any(
-                condition_result.outcome for condition_result in condition_results
-            )
-
-            if logic_result.triggered:
-                passing_evaluations = [
-                    condition_result
-                    for condition_result in condition_results
-                    if condition_result.outcome.triggered
-                ]
+            logic_result = TriggerResult.any(outcomes)
         case DataConditionGroup.Type.ALL:
-            conditions_met = [condition_result.outcome for condition_result in condition_results]
-            logic_result = TriggerResult.all(conditions_met)
+            logic_result = TriggerResult.all(outcomes)
 
-            if logic_result.triggered:
-                passing_evaluations = [
-                    condition_result
-                    for condition_result in condition_results
-                    if condition_result.outcome.triggered
-                ]
+    # When the group didn't trigger, or it's a NONE group (which triggers precisely
+    # when nothing matched), this is empty.
+    passing_evaluations = (
+        [
+            condition_result
+            for condition_result in condition_results
+            if condition_result.outcome.triggered
+        ]
+        if logic_result.triggered
+        else []
+    )
 
     return DataConditionGroupEvaluation(
         result=logic_result.triggered,

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -67,40 +67,41 @@ def evaluate_condition_group_results(
     logic_type: DataConditionGroup.Type,
 ) -> DataConditionGroupEvaluation:
     logic_result = TriggerResult.FALSE
-    group_condition_results: list[DataConditionEvaluation] = []
+    passing_evaluations: list[DataConditionEvaluation] = []
 
-    if logic_type == DataConditionGroup.Type.NONE:
-        # if we get to this point, no conditions were met
-        # because we would have short-circuited
-        logic_result = TriggerResult.none(
-            condition_result.outcome for condition_result in condition_results
-        )
+    match logic_type:
+        case DataConditionGroup.Type.NONE:
+            logic_result = TriggerResult.none(
+                condition_result.outcome for condition_result in condition_results
+            )
+        case DataConditionGroup.Type.ANY | DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
+            logic_result = TriggerResult.any(
+                condition_result.outcome for condition_result in condition_results
+            )
 
-    elif logic_type == DataConditionGroup.Type.ANY:
-        logic_result = TriggerResult.any(
-            condition_result.outcome for condition_result in condition_results
-        )
+            if logic_result.triggered:
+                passing_evaluations = [
+                    condition_result
+                    for condition_result in condition_results
+                    if condition_result.outcome.triggered
+                ]
+        case DataConditionGroup.Type.ALL:
+            conditions_met = [condition_result.outcome for condition_result in condition_results]
+            logic_result = TriggerResult.all(conditions_met)
 
-        if logic_result.triggered:
-            group_condition_results = [
-                condition_result
-                for condition_result in condition_results
-                if condition_result.outcome.triggered
-            ]
-
-    elif logic_type == DataConditionGroup.Type.ALL:
-        conditions_met = [condition_result.outcome for condition_result in condition_results]
-        logic_result = TriggerResult.all(conditions_met)
-
-        if logic_result.triggered:
-            group_condition_results = [
-                condition_result
-                for condition_result in condition_results
-                if condition_result.outcome.triggered
-            ]
+            if logic_result.triggered:
+                passing_evaluations = [
+                    condition_result
+                    for condition_result in condition_results
+                    if condition_result.outcome.triggered
+                ]
 
     return DataConditionGroupEvaluation(
-        result=group_condition_results,
+        result=logic_result.triggered,
+        data={
+            "condition_evaluations": passing_evaluations,
+            "logic_type": logic_type,
+        },
         triggered=logic_result.triggered,
         error=logic_result.error,
     )
@@ -115,33 +116,79 @@ def evaluate_data_conditions(
     Evaluate a list of conditions. Each condition is a tuple with the value to evaluate the condition against.
     Next we apply the logic_type to get the results of the list of conditions.
     """
-    condition_results: list[DataConditionEvaluation] = []
+    condition_evaluations: list[DataConditionEvaluation] = []
 
-    if len(conditions_to_evaluate) == 0:
-        # if we don't have any conditions, always return True
-        return DataConditionGroupEvaluation(result=[], triggered=True)
+    if not conditions_to_evaluate:
+        # if there are no conditions on the group, always return True.
+        return DataConditionGroupEvaluation(
+            result=True,
+            triggered=True,
+            data={
+                "condition_evaluations": condition_evaluations,
+                "logic_type": logic_type,
+            },
+        )
 
     for condition, value in conditions_to_evaluate:
-        condition_evaluation = condition.evaluate_value(value)
+        evaluation = condition.evaluate_value(value)
 
         # Check for short-circuiting evaluations
-        if condition_evaluation.outcome.triggered:
-            if logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
-                return DataConditionGroupEvaluation(
-                    result=[condition_evaluation],
-                    triggered=True,
-                    error=condition_evaluation.outcome.error,
-                )
+        if evaluation.outcome.triggered:
+            match logic_type:
+                case DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
+                    # The first matching condition conclusively satisfies the group.
+                    return DataConditionGroupEvaluation(
+                        result=True,
+                        triggered=True,
+                        error=evaluation.outcome.error,
+                        data={
+                            "condition_evaluations": [evaluation],
+                            "logic_type": logic_type,
+                        },
+                    )
+                case DataConditionGroup.Type.NONE:
+                    # A NONE group requires that no condition matches; a match
+                    # makes the group conclusively not triggered.
+                    return DataConditionGroupEvaluation(
+                        result=False,
+                        triggered=False,
+                        error=evaluation.outcome.error,
+                        data={
+                            "condition_evaluations": [],
+                            "logic_type": logic_type,
+                        },
+                    )
 
-            if logic_type == DataConditionGroup.Type.NONE:
-                return DataConditionGroupEvaluation(
-                    error=condition_evaluation.error,
-                )
-
-        condition_results.append(condition_evaluation)
+        condition_evaluations.append(evaluation)
 
     # Apply the grouping logic to the condition evaluation results.
-    return evaluate_condition_group_results(condition_results, logic_type)
+    return evaluate_condition_group_results(condition_evaluations, logic_type)
+
+
+def _resolve_group_conditions(group: DataConditionGroup) -> list[DataCondition]:
+    if (
+        hasattr(group, "_prefetched_objects_cache")
+        and "conditions" in group._prefetched_objects_cache
+    ):
+        return list(group.conditions.all())
+
+    return _get_data_conditions_for_group_shim(group.id)
+
+
+def _is_conclusive_evaluation(evaluation: DataConditionGroupEvaluation) -> bool:
+    """
+    Determines if a given group evaluation is completed based on the logic_type
+    and the results of the conditions in the evaluation.
+    """
+    logic_type = evaluation.data.get("logic_type")
+
+    match logic_type:
+        case DataConditionGroup.Type.ALL:
+            return not evaluation.outcome.triggered
+        case DataConditionGroup.Type.ANY | DataConditionGroup.Type.ANY_SHORT_CIRCUIT:
+            return evaluation.outcome.triggered
+
+    return False
 
 
 @scopedstats.timer()
@@ -151,54 +198,45 @@ def process_data_condition_group(
     data_conditions_for_group: list[DataCondition] | None = None,
 ) -> DataConditionGroupResult:
     condition_results: list[DataConditionEvaluation] = []
+    all_conditions: list[DataCondition]
 
     try:
         logic_type = DataConditionGroup.Type(group.logic_type)
     except ValueError:
-        logger.exception(
-            "Invalid DataConditionGroup.logic_type found in process_data_condition_group",
-            extra={"logic_type": group.logic_type},
-        )
         return DataConditionGroupEvaluation(
-            error=ConditionError(msg="Invalid DataConditionGroup.logic_type")
+            result=False,
+            triggered=False,
+            data={
+                "condition_evaluations": condition_results,
+                "logic_type": group.logic_type,
+            },
+            error=ConditionError(msg="Invalid DataConditionGroup.logic_type"),
         ), []
 
-    # Check if conditions are already prefetched before using cache
-    all_conditions: list[DataCondition]
-    if data_conditions_for_group is not None:
-        all_conditions = data_conditions_for_group
-    elif (
-        hasattr(group, "_prefetched_objects_cache")
-        and "conditions" in group._prefetched_objects_cache
-    ):
-        all_conditions = list(group.conditions.all())
-    else:
-        all_conditions = _get_data_conditions_for_group_shim(group.id)
+    all_conditions = (
+        _resolve_group_conditions(group)
+        if data_conditions_for_group is None
+        else data_conditions_for_group
+    )
+    conditions = split_conditions_by_speed(all_conditions)
 
-    split_conds = split_conditions_by_speed(all_conditions)
+    if not conditions.fast and conditions.slow:
+        # There are only slow conditions to evaluate. Don't evaluate an empty list
+        # of fast conditions, which would incorrectly resolve to triggered=True
+        # before the slow conditions have been evaluated.
+        return DataConditionGroupEvaluation(
+            result=False,
+            triggered=False,
+            data={
+                "condition_evaluations": condition_results,
+                "logic_type": logic_type,
+            },
+        ), conditions.slow
 
-    if not split_conds.fast and split_conds.slow:
-        # there are only slow conditions to evaluate, do not evaluate an empty list of conditions
-        # which would evaluate to True
-        condition_group_result = DataConditionGroupEvaluation(result=condition_results)
-        return condition_group_result, split_conds.slow
-
-    conditions_to_evaluate = [(condition, value) for condition in split_conds.fast]
+    conditions_to_evaluate = [(condition, value) for condition in conditions.fast]
     group_evaluation = evaluate_data_conditions(conditions_to_evaluate, logic_type)
 
-    outcome = group_evaluation.outcome
-
-    # Check to see if we should return any remaining conditions based on the results
-    is_short_circuit_all = not outcome.triggered and logic_type == DataConditionGroup.Type.ALL
-    is_short_circuit_any = outcome.triggered and logic_type in (
-        DataConditionGroup.Type.ANY,
-        DataConditionGroup.Type.ANY_SHORT_CIRCUIT,
-    )
-
-    if is_short_circuit_all or is_short_circuit_any:
-        # if we have a logic type of all and a False result,
-        # or if we have a logic type of any and a True result, then
-        #  we can short-circuit any remaining conditions since we have a completed logic result
+    if _is_conclusive_evaluation(group_evaluation):
         return group_evaluation, []
 
-    return group_evaluation, split_conds.slow
+    return group_evaluation, conditions.slow

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -534,7 +534,15 @@ def _evaluate_group_result_for_dcg(
             sample_rate=1.0,
         )
         logger.warning("workflow_engine.delayed_workflow.missing_query_result", exc_info=True)
-        return DataConditionGroupEvaluation(error=ConditionError(msg="Missing query result"))
+        return DataConditionGroupEvaluation(
+            result=False,
+            triggered=False,
+            data={
+                "condition_evaluations": [],
+                "logic_type": dcg.logic_type,
+            },
+            error=ConditionError(msg="Missing query result"),
+        )
 
 
 def _group_result_for_dcg(
@@ -686,7 +694,7 @@ def get_groups_to_fire(
                 if if_result.triggered:
                     groups_to_fire[group_id].add(dcg)
                     if_dcg_passed[workflow_id][group_id][dcg.id] = [
-                        pc.condition.id for pc in if_group.result
+                        pc.condition.id for pc in if_group.data["condition_evaluations"]
                     ]
                 else:
                     if_dcg_failed[workflow_id][group_id].append(dcg.id)

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -34,6 +34,8 @@ class BaseWorkflowEngineEvaluation[R, D]:
     def outcome(self) -> TriggerResult:
         if self.triggered is not None:
             triggered = self.triggered
+        elif isinstance(self.result, bool):
+            triggered = self.result
         elif isinstance(self.result, Collection):
             triggered = len(self.result) > 0
         else:

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -32,8 +32,8 @@ class BaseWorkflowEngineEvaluation[R, D]:
 
     @cached_property
     def outcome(self) -> TriggerResult:
-        if isinstance(self.result, bool):
-            triggered = self.result
+        if self.triggered is not None:
+            triggered = self.triggered
         elif isinstance(self.result, Collection):
             triggered = len(self.result) > 0
         else:

--- a/src/sentry/workflow_engine/processors/evaluations/base.py
+++ b/src/sentry/workflow_engine/processors/evaluations/base.py
@@ -7,28 +7,33 @@ from sentry.workflow_engine.types import ConditionError
 
 
 @dataclass(frozen=True, kw_only=True)
-class BaseWorkflowEngineEvaluation[R, E: ConditionError]:
+class BaseWorkflowEngineEvaluation[R, D]:
     """
     This is a shared base class for all Evaluation classes.
 
-    Should `result` be an abstract property?
+    - result: R - the result of the evaluation, this is what should be consumed.
+    - data: D - this is to store data used to generate the evaluation.
+    - error: ConditionError - if there is an error while evaluating something in workflow engine, create a condition error
+    - outcome: TriggerResult - this is a two fold helper, first it allows us to reuse the `TriggerResult`
+        to simplify the migration. Second, it allows us to do taint tracking with the result and error fields.
+    - triggered: bool | None - The authoritative triggered state, set by the evaluation when `result` alone
+        can't express it. A group can trigger with an empty `result` - e.g. it has no
+        conditions, or it's a NONE group where nothing matched - and `len(result)` can't
+        tell that apart from an ANY/ALL group that failed. When left unset we infer it
+        from `result`. Excluded from equality so evaluations still compare on `result`
+        and `error`.
     """
 
     result: R
-    error: E | None = None
+    data: D
+    error: ConditionError | None = None
 
-    # The authoritative triggered state, set by the evaluation when `result` alone
-    # can't express it. A group can trigger with an empty `result` - e.g. it has no
-    # conditions, or it's a NONE group where nothing matched - and `len(result)` can't
-    # tell that apart from an ANY/ALL group that failed. When left unset we infer it
-    # from `result`. Excluded from equality so evaluations still compare on `result`
-    # and `error`.
     triggered: bool | None = field(default=None, compare=False)
 
     @cached_property
     def outcome(self) -> TriggerResult:
-        if self.triggered is not None:
-            triggered = self.triggered
+        if isinstance(self.result, bool):
+            triggered = self.result
         elif isinstance(self.result, Collection):
             triggered = len(self.result) > 0
         else:

--- a/src/sentry/workflow_engine/processors/evaluations/condition.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
-from sentry.workflow_engine.types import ConditionError, DataConditionResult
+from sentry.workflow_engine.types import DataConditionResult
 
 from .base import BaseWorkflowEngineEvaluation
 
@@ -15,20 +15,29 @@ class DataConditionEvaluationException(Exception):
     pass
 
 
+ConditionEvaluationData: TypeAlias = Any
+
+
 @dataclass(frozen=True, kw_only=True)
-class DataConditionEvaluation(BaseWorkflowEngineEvaluation[DataConditionResult, ConditionError]):
+class DataConditionEvaluation(
+    BaseWorkflowEngineEvaluation[DataConditionResult, ConditionEvaluationData]
+):
     """
     This class is used to track the evaluation of a DataCondition's logic.
 
     This is created by DataCondition.evaluate_value(value) as a result.
 
     Attributes
-    - value: Any - this is the value that was evaluated against.
     - condition: DataCondition - This is the condition that was evaluated.
+    - result - This is set as None by default here.
 
-    Inherits `result`, `error`, and `outcome`.
+    Inherits
+    - result: DataConditionResult - If the condition failed, this will be set to None.
+        Otherwise, it will use the `DataCondition.condition_result` or boolean representation
+        of the evaluation.
+    - data: Any - The value that was used in the data conditions evaluation
+    - error: ConditionError - Set when there's an error while evaluating a condition
     """
 
     result: DataConditionResult = None
-    value: Any
     condition: DataCondition

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -1,18 +1,22 @@
-from dataclasses import dataclass, field
+from __future__ import annotations
 
-from sentry.workflow_engine.types import ConditionError
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
 
 from .base import BaseWorkflowEngineEvaluation
 from .condition import DataConditionEvaluation
 
+if TYPE_CHECKING:
+    from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+
+
+class GroupEvaluationData(TypedDict):
+    condition_evaluations: list[DataConditionEvaluation]
+    logic_type: DataConditionGroup.Type | str
+
 
 @dataclass(frozen=True, kw_only=True)
-class DataConditionGroupEvaluation(
-    BaseWorkflowEngineEvaluation[
-        list[DataConditionEvaluation],
-        ConditionError,
-    ]
-):
+class DataConditionGroupEvaluation(BaseWorkflowEngineEvaluation[bool, GroupEvaluationData]):
     """
     This class is used to track the evaluation of a DataConditionGroup.
 
@@ -21,9 +25,10 @@ class DataConditionGroupEvaluation(
     anywhere we evaluate a condition group.
 
     Inherited properties
-    - result: list[DataConditionEvaluation]
+    - result: bool - evaluation of the logic_type and conditions
+    - data: GroupEvaluationData - The list of condition evaluations and the logic used to evaluate it
     - error: ConditionError
     - outcome: TriggerResult
     """
 
-    result: list[DataConditionEvaluation] = field(default_factory=list)
+    data: GroupEvaluationData

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -31,7 +31,7 @@ class ConditionTestCase(BaseWorkflowTest):
     ) -> None:
         evaluation = data_condition.evaluate_value(job)
 
-        assert evaluation.value == job
+        assert evaluation.data == job
         assert evaluation.outcome.triggered is True
         assert evaluation.result == data_condition.get_condition_result()
 
@@ -39,7 +39,7 @@ class ConditionTestCase(BaseWorkflowTest):
         self, data_condition: DataCondition, job: WorkflowEventData | DataPacket[Any]
     ) -> None:
         evaluation = data_condition.evaluate_value(job)
-        assert evaluation.value == job
+        assert evaluation.data == job
         assert evaluation.outcome.triggered is False
         assert evaluation.result != data_condition.get_condition_result()
 

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -10,11 +10,7 @@ from sentry.workflow_engine.processors.data_condition_group import (
     get_slow_conditions_for_groups,
     process_data_condition_group,
 )
-from sentry.workflow_engine.processors.evaluations import (
-    DataConditionEvaluation,
-    DataConditionGroupEvaluation,
-    TriggerResult,
-)
+from sentry.workflow_engine.processors.evaluations import DataConditionEvaluation, TriggerResult
 from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel
 
 
@@ -58,65 +54,56 @@ class TestEvaluateConditionGroupTypeAny(TestEvaluationConditionCase):
     def test_evaluate_data_conditions__passes_all(self) -> None:
         input_value = 10
 
-        expected_result = DataConditionGroupEvaluation(
-            result=[
-                DataConditionEvaluation(
-                    value=input_value,
-                    condition=self.data_condition,
-                    result=DetectorPriorityLevel.HIGH,
-                ),
-                DataConditionEvaluation(
-                    value=input_value,
-                    condition=self.data_condition_two,
-                    result=DetectorPriorityLevel.LOW,
-                ),
-            ],
-        )
-
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(input_value),
             self.data_condition_group.logic_type,
         )
 
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == [
+            DataConditionEvaluation(
+                data=input_value,
+                condition=self.data_condition,
+                result=DetectorPriorityLevel.HIGH,
+            ),
+            DataConditionEvaluation(
+                data=input_value,
+                condition=self.data_condition_two,
+                result=DetectorPriorityLevel.LOW,
+            ),
+        ]
 
     def test_evaluate_data_conditions__passes_one(self) -> None:
         input_value = 4
 
-        expected_result = DataConditionGroupEvaluation(
-            result=[
-                DataConditionEvaluation(
-                    condition=self.data_condition_two,
-                    result=DetectorPriorityLevel.LOW,
-                    value=input_value,
-                )
-            ],
-        )
-
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(input_value),
             self.data_condition_group.logic_type,
         )
 
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == [
+            DataConditionEvaluation(
+                condition=self.data_condition_two,
+                result=DetectorPriorityLevel.LOW,
+                data=input_value,
+            )
+        ]
 
     def test_evaluate_data_conditions__fails_all(self) -> None:
-        expected_result = DataConditionGroupEvaluation(
-            result=[],
-        )
-
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(1),
             self.data_condition_group.logic_type,
         )
 
-        assert result == expected_result
+        assert result.outcome.triggered is False
+        assert result.data["condition_evaluations"] == []
 
     def test_evaluate_data_conditions__passes_without_conditions(self) -> None:
         result = evaluate_data_conditions([], self.data_condition_group.logic_type)
-        expected_result = DataConditionGroupEvaluation(result=[])
 
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == []
 
 
 class TestEvaluateConditionGroupTypeAnyShortCircuit(TestEvaluationConditionCase):
@@ -127,17 +114,18 @@ class TestEvaluateConditionGroupTypeAnyShortCircuit(TestEvaluationConditionCase)
     def test_evaluate_data_conditions__passes_all(self) -> None:
         input_value = 10
 
-        assert evaluate_data_conditions(
+        result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(input_value), self.data_condition_group.logic_type
-        ) == DataConditionGroupEvaluation(
-            result=[
-                DataConditionEvaluation(
-                    condition=self.data_condition,
-                    result=DetectorPriorityLevel.HIGH,
-                    value=input_value,
-                )
-            ],
         )
+
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == [
+            DataConditionEvaluation(
+                condition=self.data_condition,
+                result=DetectorPriorityLevel.HIGH,
+                data=input_value,
+            )
+        ]
 
     def test_evaluate_data_conditions__passes_one(self) -> None:
         input_value = 4
@@ -146,29 +134,27 @@ class TestEvaluateConditionGroupTypeAnyShortCircuit(TestEvaluationConditionCase)
             self.data_condition_group.logic_type,
         )
 
-        expected_result = DataConditionGroupEvaluation(
-            result=[
-                DataConditionEvaluation(
-                    condition=self.data_condition_two,
-                    result=DetectorPriorityLevel.LOW,
-                    value=input_value,
-                )
-            ],
-        )
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == [
+            DataConditionEvaluation(
+                condition=self.data_condition_two,
+                result=DetectorPriorityLevel.LOW,
+                data=input_value,
+            )
+        ]
 
     def test_evaluate_data_conditions__fails_all(self) -> None:
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(1),
             self.data_condition_group.logic_type,
         )
-        expected_result = DataConditionGroupEvaluation(result=[])
-        assert result == expected_result
+        assert result.outcome.triggered is False
+        assert result.data["condition_evaluations"] == []
 
     def test_evaluate_data_conditions__passes_without_conditions(self) -> None:
-        expected_result = DataConditionGroupEvaluation(result=[])
         result = evaluate_data_conditions([], self.data_condition_group.logic_type)
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == []
 
 
 class TestEvaluateConditionGroupTypeAll(TestEvaluationConditionCase):
@@ -183,43 +169,39 @@ class TestEvaluateConditionGroupTypeAll(TestEvaluationConditionCase):
             self.get_conditions_to_evaluate(input_value), self.data_condition_group.logic_type
         )
 
-        expected_result = DataConditionGroupEvaluation(
-            result=[
-                DataConditionEvaluation(
-                    condition=self.data_condition,
-                    result=DetectorPriorityLevel.HIGH,
-                    value=input_value,
-                ),
-                DataConditionEvaluation(
-                    condition=self.data_condition_two,
-                    result=DetectorPriorityLevel.LOW,
-                    value=input_value,
-                ),
-            ],
-        )
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == [
+            DataConditionEvaluation(
+                condition=self.data_condition,
+                result=DetectorPriorityLevel.HIGH,
+                data=input_value,
+            ),
+            DataConditionEvaluation(
+                condition=self.data_condition_two,
+                result=DetectorPriorityLevel.LOW,
+                data=input_value,
+            ),
+        ]
 
     def test_evaluate_data_conditions__passes_one(self) -> None:
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(4), self.data_condition_group.logic_type
         )
-        expected_result = DataConditionGroupEvaluation(result=[])
-        assert result == expected_result
+        assert result.outcome.triggered is False
+        assert result.data["condition_evaluations"] == []
 
     def test_evaluate_data_conditions__fails_all(self) -> None:
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(1),
             self.data_condition_group.logic_type,
         )
-        expected_result = DataConditionGroupEvaluation(result=[])
-
-        assert result == expected_result
+        assert result.outcome.triggered is False
+        assert result.data["condition_evaluations"] == []
 
     def test_evaluate_data_conditions__passes_without_conditions(self) -> None:
         result = evaluate_data_conditions([], self.data_condition_group.logic_type)
-        expected_result = DataConditionGroupEvaluation(result=[])
-
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == []
 
 
 class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
@@ -233,16 +215,15 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
             self.data_condition_group.logic_type,
         )
 
-        expected_result = DataConditionGroupEvaluation(result=[])
-        assert result == expected_result
+        assert result.outcome.triggered is False
+        assert result.data["condition_evaluations"] == []
 
     def test_evaluate_data_conditions__one_condition_pass__fails(self) -> None:
         result = evaluate_data_conditions(
             self.get_conditions_to_evaluate(4), self.data_condition_group.logic_type
         )
 
-        expected_result = DataConditionGroupEvaluation(result=[])
-        assert result == expected_result
+        assert result.outcome.triggered is False
 
     def test_evaluate_data_conditions__no_conditions_pass__passes(self) -> None:
         result = evaluate_data_conditions(
@@ -250,8 +231,8 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
             self.data_condition_group.logic_type,
         )
 
-        expected_result = DataConditionGroupEvaluation(result=[])
-        assert result == expected_result
+        assert result.outcome.triggered is True
+        assert result.data["condition_evaluations"] == []
 
     def test_evaluate_data_conditions__error_with_no_pass__tainted_true(self) -> None:
         error = ConditionError(msg="test error")
@@ -263,7 +244,7 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                     condition=self.data_condition,
                     result=None,
                     error=None,
-                    value="error",
+                    data="error",
                 ),
             ),
             mock.patch.object(
@@ -273,7 +254,7 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
                     condition=self.data_condition_two,
                     result=None,
                     error=error,
-                    value="error",
+                    data="error",
                 ),
             ),
         ):
@@ -284,7 +265,7 @@ class TestEvaluateConditionGroupTypeNone(TestEvaluationConditionCase):
 
         assert result.outcome.triggered is True
         assert result.outcome.error == error
-        assert result.result == []
+        assert result.data["condition_evaluations"] == []
 
 
 class TestEvaluateConditionGroupWithSlowConditions(TestCase):
@@ -313,7 +294,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         expected_condition_result = DataConditionEvaluation(
             condition=self.data_condition,
             result=True,
-            value=input_value,
+            data=input_value,
         )
 
         group_evaluation, remaining_conditions = process_data_condition_group(
@@ -321,9 +302,10 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
             input_value,
         )
 
+        condition_evaluations = group_evaluation.data["condition_evaluations"]
         assert group_evaluation.outcome.triggered is True
-        assert isinstance(group_evaluation.result[0], DataConditionEvaluation)
-        assert group_evaluation.result[0].condition.id == expected_condition_result.condition.id
+        assert isinstance(condition_evaluations[0], DataConditionEvaluation)
+        assert condition_evaluations[0].condition.id == expected_condition_result.condition.id
         assert remaining_conditions == [self.slow_condition]
 
     def test_basic_only_slow_conditions(self) -> None:
@@ -334,7 +316,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         )
 
         assert group_evaluation.outcome.triggered is False
-        assert group_evaluation.result == []
+        assert group_evaluation.data["condition_evaluations"] == []
         assert remaining_conditions == [self.slow_condition]
 
     def test_short_circuit_with_all(self) -> None:
@@ -344,7 +326,7 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         )
 
         assert group_evaluation.outcome.triggered is False
-        assert group_evaluation.result == []
+        assert group_evaluation.data["condition_evaluations"] == []
         assert remaining_conditions == []
 
     def test_short_circuit_with_any(self) -> None:
@@ -356,11 +338,11 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         )
 
         assert group_evaluation.outcome.triggered is True
-        assert group_evaluation.result == [
+        assert group_evaluation.data["condition_evaluations"] == [
             DataConditionEvaluation(
                 condition=self.data_condition,
                 result=True,
-                value=input_value,
+                data=input_value,
             )
         ]
         assert remaining_conditions == []

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -347,6 +347,32 @@ class TestEvaluateConditionGroupWithSlowConditions(TestCase):
         ]
         assert remaining_conditions == []
 
+    def test_short_circuit_with_none(self) -> None:
+        # A NONE group is conclusively not triggered once a fast condition
+        # matches, so the pending slow condition should not be evaluated.
+        self.data_condition_group.update(logic_type=DataConditionGroup.Type.NONE)
+        group_evaluation, remaining_conditions = process_data_condition_group(
+            self.data_condition_group,
+            10,
+        )
+
+        assert group_evaluation.outcome.triggered is False
+        assert group_evaluation.data["condition_evaluations"] == []
+        assert remaining_conditions == []
+
+    def test_no_short_circuit_with_none(self) -> None:
+        # A NONE group is not yet conclusive when no fast condition matches, so
+        # the slow condition must still be evaluated before deciding the group.
+        self.data_condition_group.update(logic_type=DataConditionGroup.Type.NONE)
+        group_evaluation, remaining_conditions = process_data_condition_group(
+            self.data_condition_group,
+            1,
+        )
+
+        assert group_evaluation.outcome.triggered is True
+        assert group_evaluation.data["condition_evaluations"] == []
+        assert remaining_conditions == [self.slow_condition]
+
 
 class TestGetSlowConditionsForGroups(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -1006,7 +1006,10 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_fire_actions_for_groups__workflow_fire_history(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            DataConditionGroupEvaluation(result=[]),
+            DataConditionGroupEvaluation(
+                result=False,
+                data={"condition_evaluations": [], "logic_type": DataConditionGroup.Type.ANY},
+            ),
             [],
         )
 
@@ -1040,7 +1043,10 @@ class TestFireActionsForGroups(TestDelayedWorkflowBase):
     ) -> None:
         """Verify notification_uuid from WorkflowFireHistory is passed to triggered actions."""
         mock_process.return_value = (
-            DataConditionGroupEvaluation(result=[]),
+            DataConditionGroupEvaluation(
+                result=False,
+                data={"condition_evaluations": [], "logic_type": DataConditionGroup.Type.ANY},
+            ),
             [],
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -689,7 +689,11 @@ class TestTaintTracking(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.data_condition_group.process_data_condition_group")
     def test_trigger_stats_tainted_not_triggered(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            DataConditionGroupEvaluation(result=[], error=ERR),
+            DataConditionGroupEvaluation(
+                result=False,
+                data={"condition_evaluations": [], "logic_type": DataConditionGroup.Type.ANY},
+                error=ERR,
+            ),
             [],
         )
 
@@ -713,7 +717,11 @@ class TestTaintTracking(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.workflow.process_data_condition_group")
     def test_action_filter_stats_tainted_from_action_filter(self, mock_process: MagicMock) -> None:
         mock_process.return_value = (
-            DataConditionGroupEvaluation(result=[], error=ERR),
+            DataConditionGroupEvaluation(
+                result=False,
+                data={"condition_evaluations": [], "logic_type": DataConditionGroup.Type.ANY},
+                error=ERR,
+            ),
             [],
         )
 


### PR DESCRIPTION
# Description
When implementing the `DetectorEvaluation` the base abstractions felt a little off, the `result` was often storing artifacts of the evaluation, and then we needed each child to implement more or less the `data` attribute.

This PR aims to start solving for that by updating the `BaseWorkflowEngineEvaluation`, `DataConditionEvaluation`, and `DataConditionGroupEvaluation` classes to have a structure that's a bit more generic and understandable; where before it was reusing the `result` in awkward ways or attaching a lot of info to the Child class that could be encapsulated as `data` instead.