### PR TITLE
ref(onboarding): Graduate onboarding-copy-setup-instructions flag

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -5,10 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 
 import {OnboardingAdditionalFeatures} from 'sentry/components/events/featureFlags/onboarding/onboardingAdditionalFeatures';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -40,7 +37,6 @@ export function FeatureFlagOnboardingLayout({
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const {steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
@@ -101,7 +97,7 @@ export function FeatureFlagOnboardingLayout({
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 && copyEnabled ? (
+                  index === 0 ? (
                     <OnboardingCopyMarkdownButton
                       borderless
                       steps={steps}

--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -5,10 +5,7 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {FeedbackConfigToggle} from 'sentry/components/feedback/feedbackOnboarding/feedbackConfigToggle';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -41,7 +38,6 @@ export function FeedbackOnboardingLayout({
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
   const {introduction, steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
 
@@ -161,7 +157,7 @@ export function FeedbackOnboardingLayout({
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 && copyEnabled ? (
+                  index === 0 ? (
                     <OnboardingCopyMarkdownButton
                       borderless
                       steps={transformedSteps}

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -119,34 +119,13 @@ export function OnboardingCopyMarkdownButton({
   );
 }
 
-type CopySetupInstructionsType = 'onboarding' | 'project_creation';
-
-const FEATURE_FLAGS: Record<CopySetupInstructionsType, string> = {
-  onboarding: 'onboarding-copy-setup-instructions',
-  project_creation: 'onboarding-copy-setup-instructions-project-creation',
-};
-
 /**
- * Returns whether the copy setup instructions button should be shown
- * for the given context type.
+ * Returns whether the "Copy setup instructions" button should be shown on the
+ * project creation onboarding flow.
  */
-export function useCopySetupInstructionsEnabled(
-  type: CopySetupInstructionsType = 'onboarding'
-): boolean {
+export function useCopySetupInstructionsProjectCreationEnabled(): boolean {
   const organization = useOrganization();
-  return organization.features.includes(FEATURE_FLAGS[type]);
-}
-
-export function CopySetupInstructionsGate({
-  children,
-  type,
-}: {
-  children: React.ReactNode;
-  type?: CopySetupInstructionsType;
-}) {
-  const enabled = useCopySetupInstructionsEnabled(type);
-  if (!enabled) {
-    return null;
-  }
-  return children;
+  return organization.features.includes(
+    'onboarding-copy-setup-instructions-project-creation'
+  );
 }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -9,7 +9,7 @@ import {ListItem} from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
   OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
+  useCopySetupInstructionsProjectCreationEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -75,7 +75,7 @@ export function OnboardingLayout({
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled('project_creation');
+  const copyEnabled = useCopySetupInstructionsProjectCreationEnabled();
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -11,10 +11,7 @@ import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -232,7 +229,6 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   const api = useApi();
   const organization = useOrganization();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
   const firstIssue = useEventWaiter({
     eventType: 'transaction',
     organization,
@@ -347,7 +343,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
               stepIndex={index}
               {...step}
               trailingItems={
-                index === 0 && copyEnabled ? (
+                index === 0 ? (
                   <OnboardingCopyMarkdownButton
                     borderless
                     steps={steps}

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -12,10 +12,7 @@ import {IdBadge} from 'sentry/components/idBadge';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {DeprecatedPlatformInfo} from 'sentry/components/onboarding/gettingStartedDoc/deprecatedPlatformInfo';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
@@ -276,7 +273,6 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     useSourcePackageRegistries(organization);
 
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   if (isLoading) {
     return <LoadingIndicator />;
@@ -376,7 +372,7 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 && copyEnabled ? (
+                  index === 0 ? (
                     <OnboardingCopyMarkdownButton
                       borderless
                       steps={steps}

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -4,10 +4,7 @@ import styled from '@emotion/styled';
 import {Stack} from '@sentry/scraps/layout';
 
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -39,7 +36,6 @@ export function ReplayOnboardingLayout({
   const [mask, setMask] = useState(true);
   const [block, setBlock] = useState(true);
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const {introduction, steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
@@ -152,7 +148,7 @@ export function ReplayOnboardingLayout({
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 && copyEnabled ? (
+                  index === 0 ? (
                     <OnboardingCopyMarkdownButton
                       borderless
                       steps={transformedSteps}

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -11,10 +11,7 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -95,7 +92,6 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     useSourcePackageRegistries(organization);
 
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const currentPlatformKey = project?.platform ?? 'other';
   const currentPlatform = platforms.find(p => p.id === currentPlatformKey)!;
@@ -208,7 +204,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
                       stepKey={title}
                       title={title}
                       trailingItems={
-                        index === 0 && copyEnabled ? (
+                        index === 0 ? (
                           <OnboardingCopyMarkdownButton
                             borderless
                             steps={steps}

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
@@ -10,10 +10,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
-import {
-  CopyMarkdownButton,
-  CopySetupInstructionsGate,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {CopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {simpleHtmlToMarkdown} from 'sentry/components/onboarding/utils/stepsToMarkdown';
 import {Container as WorkflowEngineContainer} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
@@ -215,13 +212,11 @@ export function InstrumentationGuide() {
                     }))}
                   />
                 )}
-                <CopySetupInstructionsGate>
-                  <CopyMarkdownButton
-                    borderless
-                    getMarkdown={getGuideMarkdown}
-                    source="crons_detector_guide"
-                  />
-                </CopySetupInstructionsGate>
+                <CopyMarkdownButton
+                  borderless
+                  getMarkdown={getGuideMarkdown}
+                  source="crons_detector_guide"
+                />
               </Flex>
             }
           >

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -17,10 +17,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -380,7 +377,6 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -524,7 +520,7 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
               isLastStep={index === steps.length - 1}
               onDismiss={onDismiss}
               trailingItems={
-                index === 0 && copyEnabled ? (
+                index === 0 ? (
                   <OnboardingCopyMarkdownButton
                     borderless
                     steps={steps}

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -15,10 +15,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {OnboardingCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -251,7 +248,6 @@ function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
   const currentPlatform = project.platform
     ? platforms.find(p => p.id === project.platform)
     : undefined;
@@ -409,7 +405,7 @@ function Onboarding({organization, project}: OnboardingProps) {
               stepKey={title}
               title={title}
               trailingItems={
-                index === 0 && copyEnabled ? (
+                index === 0 ? (
                   <OnboardingCopyMarkdownButton
                     borderless
                     steps={steps}

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -12,10 +12,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -119,7 +116,6 @@ function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
   const currentPlatform = project.platform
     ? platforms.find(p => p.id === project.platform)
     : undefined;
@@ -274,7 +270,7 @@ function Onboarding({organization, project}: OnboardingProps) {
               stepKey={title}
               title={title}
               trailingItems={
-                index === 0 && copyEnabled ? (
+                index === 0 ? (
                   <OnboardingCopyMarkdownButton
                     borderless
                     steps={steps}

--- a/static/app/views/explore/profiling/onboarding.tsx
+++ b/static/app/views/explore/profiling/onboarding.tsx
@@ -9,10 +9,7 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -203,7 +200,6 @@ export function Onboarding() {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const currentPlatform = project?.platform
     ? platforms.find(p => p.id === project.platform)
@@ -321,7 +317,7 @@ export function Onboarding() {
             stepIndex={index}
             isLastStep={index === steps.length - 1}
             trailingItems={
-              index === 0 && copyEnabled ? (
+              index === 0 ? (
                 <OnboardingCopyMarkdownButton
                   borderless
                   steps={steps}

--- a/static/app/views/explore/releases/list/releasesPromo.tsx
+++ b/static/app/views/explore/releases/list/releasesPromo.tsx
@@ -24,10 +24,7 @@ import {sentryAppsApiOptions} from 'sentry/actionCreators/sentryApps';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {TourStep} from 'sentry/components/modals/featureTourModal';
 import {TourImage, TourText} from 'sentry/components/modals/featureTourModal';
-import {
-  CopyMarkdownButton,
-  CopySetupInstructionsGate,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {CopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {simpleHtmlToMarkdown} from 'sentry/components/onboarding/utils/stepsToMarkdown';
 import {Panel} from 'sentry/components/panels/panel';
 import {t, tct} from 'sentry/locale';
@@ -308,13 +305,11 @@ sentry-cli releases finalize "$VERSION"`;
               generateAndSetNewToken(app.slug);
             }}
           />
-          <CopySetupInstructionsGate>
-            <CopyMarkdownButton
-              borderless
-              getMarkdown={getMarkdown}
-              source="releases_quickstart"
-            />
-          </CopySetupInstructionsGate>
+          <CopyMarkdownButton
+            borderless
+            getMarkdown={getMarkdown}
+            source="releases_quickstart"
+          />
         </Flex>
         <div ref={containerRef}>
           <CodeBlock

--- a/static/app/views/insights/crons/components/cronsLandingPanel.tsx
+++ b/static/app/views/insights/crons/components/cronsLandingPanel.tsx
@@ -5,10 +5,7 @@ import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 
-import {
-  CopyMarkdownButton,
-  CopySetupInstructionsGate,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {CopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {simpleHtmlToMarkdown} from 'sentry/components/onboarding/utils/stepsToMarkdown';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {Panel} from 'sentry/components/panels/panel';
@@ -117,13 +114,11 @@ export function CronsLandingPanel() {
                 ]}
               </TabList>
               {guideKey !== 'manual' && (
-                <CopySetupInstructionsGate>
-                  <CopyMarkdownButton
-                    borderless
-                    getMarkdown={getGuideMarkdown}
-                    source="crons_upsert_guide"
-                  />
-                </CopySetupInstructionsGate>
+                <CopyMarkdownButton
+                  borderless
+                  getMarkdown={getGuideMarkdown}
+                  source="crons_upsert_guide"
+                />
               )}
             </Flex>
             <TabPanels>

--- a/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
@@ -9,10 +9,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
-import {
-  CopyMarkdownButton,
-  CopySetupInstructionsGate,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {CopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {simpleHtmlToMarkdown} from 'sentry/components/onboarding/utils/stepsToMarkdown';
 import {IconGlobe, IconTerminal} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -285,13 +282,11 @@ export function MonitorQuickStartGuide({monitorSlug, project}: Props) {
           onChange={({value}) => setSelectedGuide(value)}
           size="sm"
         />
-        <CopySetupInstructionsGate>
-          <CopyMarkdownButton
-            borderless
-            getMarkdown={getGuideMarkdown}
-            source="crons_onboarding"
-          />
-        </CopySetupInstructionsGate>
+        <CopyMarkdownButton
+          borderless
+          getMarkdown={getGuideMarkdown}
+          source="crons_onboarding"
+        />
       </Flex>
       <div ref={guideContainerRef}>
         <Guide {...guideProps} />

--- a/static/app/views/insights/pages/agents/llmOnboardingInstructions.spec.tsx
+++ b/static/app/views/insights/pages/agents/llmOnboardingInstructions.spec.tsx
@@ -7,10 +7,8 @@ import {ManualInstrumentationNote} from './llmOnboardingInstructions';
 describe('ManualInstrumentationNote', () => {
   const docsLink = <a href="https://docs.sentry.io">docs</a>;
 
-  it('renders "Copy instructions" text when feature is enabled', () => {
-    const organization = OrganizationFixture({
-      features: ['onboarding-copy-setup-instructions'],
-    });
+  it('renders "Copy instructions" text', () => {
+    const organization = OrganizationFixture();
 
     render(<ManualInstrumentationNote docsLink={docsLink} />, {organization});
 
@@ -18,16 +16,5 @@ describe('ManualInstrumentationNote', () => {
     expect(
       screen.queryByRole('button', {name: 'Copy Prompt for AI Agent'})
     ).not.toBeInTheDocument();
-  });
-
-  it('renders CopyLLMPromptButton when feature is disabled', () => {
-    const organization = OrganizationFixture();
-
-    render(<ManualInstrumentationNote docsLink={docsLink} />, {organization});
-
-    expect(
-      screen.getByRole('button', {name: 'Copy Prompt for AI Agent'})
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/Copy instructions/)).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/insights/pages/agents/llmOnboardingInstructions.tsx
+++ b/static/app/views/insights/pages/agents/llmOnboardingInstructions.tsx
@@ -1,8 +1,5 @@
-import {Fragment} from 'react';
-
 import {Button} from '@sentry/scraps/button';
 
-import {useCopySetupInstructionsEnabled} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {IconCopy} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -10,35 +7,16 @@ import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function ManualInstrumentationNote({docsLink}: {docsLink: React.ReactNode}) {
-  const copyEnabled = useCopySetupInstructionsEnabled();
-
-  if (copyEnabled) {
-    return (
-      <p>
-        {tct(
-          'Then follow the [link:manual instrumentation guide] to instrument your AI calls, or click [bold:Copy instructions] to have an AI coding agent do it for you.',
-          {link: docsLink, bold: <strong />}
-        )}
-      </p>
-    );
-  }
-
   return (
-    <Fragment>
-      <p>
-        {tct(
-          'Then follow the [link:manual instrumentation guide] to instrument your AI calls, or use an AI coding agent to do it for you.',
-          {link: docsLink}
-        )}
-      </p>
-      <CopyLLMPromptButton />
-    </Fragment>
+    <p>
+      {tct(
+        'Then follow the [link:manual instrumentation guide] to instrument your AI calls, or click [bold:Copy instructions] to have an AI coding agent do it for you.',
+        {link: docsLink, bold: <strong />}
+      )}
+    </p>
   );
 }
 
-/**
- * @deprecated Will be removed when the `onboarding-copy-setup-instructions` feature flag GAs.
- */
 export function CopyLLMPromptButton() {
   const {copy} = useCopyToClipboard();
   const organization = useOrganization();

--- a/static/app/views/insights/pages/agents/onboarding.spec.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.spec.tsx
@@ -15,10 +15,8 @@ describe('UnsupportedPlatformOnboarding', () => {
     });
   });
 
-  it('renders CopyMarkdownButton and flag-on copy when feature is enabled', () => {
-    const organization = OrganizationFixture({
-      features: ['onboarding-copy-setup-instructions'],
-    });
+  it('renders CopyMarkdownButton', () => {
+    const organization = OrganizationFixture();
 
     render(<UnsupportedPlatformOnboarding project={project} platformName="ruby" />, {
       organization,
@@ -37,52 +35,14 @@ describe('UnsupportedPlatformOnboarding', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders CopyLLMPromptButton and flag-off copy when feature is disabled', () => {
-    const organization = OrganizationFixture();
-
-    render(<UnsupportedPlatformOnboarding project={project} platformName="ruby" />, {
-      organization,
-    });
-
-    expect(
-      screen.getByRole('button', {name: 'Copy Prompt for AI Agent'})
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: 'Copy instructions'})
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          'You can manually instrument your agents using the Sentry SDK tracing API, or use an AI coding agent to do it for you.'
-        )
-      )
-    ).toBeInTheDocument();
-  });
-
   it('copies LLM instructions to clipboard when CopyMarkdownButton is clicked', async () => {
-    const organization = OrganizationFixture({
-      features: ['onboarding-copy-setup-instructions'],
-    });
+    const organization = OrganizationFixture();
 
     render(<UnsupportedPlatformOnboarding project={project} platformName="ruby" />, {
       organization,
     });
 
     await userEvent.click(screen.getByRole('button', {name: 'Copy instructions'}));
-
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Instrument Sentry AI Agent Monitoring')
-    );
-  });
-
-  it('copies LLM instructions to clipboard when CopyLLMPromptButton is clicked', async () => {
-    const organization = OrganizationFixture();
-
-    render(<UnsupportedPlatformOnboarding project={project} platformName="ruby" />, {
-      organization,
-    });
-
-    await userEvent.click(screen.getByRole('button', {name: 'Copy Prompt for AI Agent'}));
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining('Instrument Sentry AI Agent Monitoring')
@@ -99,10 +59,8 @@ describe('NoDocsOnboarding', () => {
     });
   });
 
-  it('renders CopyMarkdownButton and flag-on copy when feature is enabled', () => {
-    const organization = OrganizationFixture({
-      features: ['onboarding-copy-setup-instructions'],
-    });
+  it('renders CopyMarkdownButton', () => {
+    const organization = OrganizationFixture();
 
     render(<NoDocsOnboarding project={project} />, {organization});
 
@@ -119,46 +77,12 @@ describe('NoDocsOnboarding', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders CopyLLMPromptButton and flag-off copy when feature is disabled', () => {
-    const organization = OrganizationFixture();
-
-    render(<NoDocsOnboarding project={project} />, {organization});
-
-    expect(
-      screen.getByRole('button', {name: 'Copy Prompt for AI Agent'})
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: 'Copy instructions'})
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          'You can set up the Sentry SDK by following our documentation, or use an AI coding agent to do it for you.'
-        )
-      )
-    ).toBeInTheDocument();
-  });
-
   it('copies LLM instructions to clipboard when CopyMarkdownButton is clicked', async () => {
-    const organization = OrganizationFixture({
-      features: ['onboarding-copy-setup-instructions'],
-    });
+    const organization = OrganizationFixture();
 
     render(<NoDocsOnboarding project={project} />, {organization});
 
     await userEvent.click(screen.getByRole('button', {name: 'Copy instructions'}));
-
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      expect.stringContaining('Instrument Sentry AI Agent Monitoring')
-    );
-  });
-
-  it('copies LLM instructions to clipboard when CopyLLMPromptButton is clicked', async () => {
-    const organization = OrganizationFixture();
-
-    render(<NoDocsOnboarding project={project} />, {organization});
-
-    await userEvent.click(screen.getByRole('button', {name: 'Copy Prompt for AI Agent'}));
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining('Instrument Sentry AI Agent Monitoring')

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -15,7 +15,6 @@ import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStarted
 import {
   CopyMarkdownButton,
   OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -49,10 +48,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {
-  CopyLLMPromptButton,
-  LLM_ONBOARDING_COPY_MARKDOWN,
-} from 'sentry/views/insights/pages/agents/llmOnboardingInstructions';
+import {LLM_ONBOARDING_COPY_MARKDOWN} from 'sentry/views/insights/pages/agents/llmOnboardingInstructions';
 import {
   AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
@@ -229,7 +225,6 @@ export function Onboarding() {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -378,7 +373,7 @@ export function Onboarding() {
             stepIndex={index}
             isLastStep={index === steps.length - 1}
             trailingItems={
-              index === 0 && copyEnabled ? (
+              index === 0 ? (
                 <OnboardingCopyMarkdownButton
                   borderless
                   steps={steps}
@@ -401,11 +396,6 @@ export function Onboarding() {
 
 function CopyInstructionsButton() {
   const organization = useOrganization();
-  const copySetupInstructionsEnabled = useCopySetupInstructionsEnabled();
-
-  if (!copySetupInstructionsEnabled) {
-    return <CopyLLMPromptButton />;
-  }
 
   return (
     <CopyMarkdownButton
@@ -428,8 +418,6 @@ export function UnsupportedPlatformOnboarding({
   platformName: string;
   project: Project;
 }) {
-  const copyEnabled = useCopySetupInstructionsEnabled();
-
   return (
     <OnboardingPanel project={project}>
       <DescriptionWrapper>
@@ -442,24 +430,15 @@ export function UnsupportedPlatformOnboarding({
           )}
         </p>
         <p>
-          {copyEnabled
-            ? tct(
-                'You can [link:manually instrument] your agents using the Sentry SDK tracing API, or click [bold:Copy instructions] to have an AI coding agent do it for you.',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
-                  ),
-                  bold: <strong />,
-                }
-              )
-            : tct(
-                'You can [link:manually instrument] your agents using the Sentry SDK tracing API, or use an AI coding agent to do it for you.',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
-                  ),
-                }
-              )}
+          {tct(
+            'You can [link:manually instrument] your agents using the Sentry SDK tracing API, or click [bold:Copy instructions] to have an AI coding agent do it for you.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/ai-agents-module/" />
+              ),
+              bold: <strong />,
+            }
+          )}
         </p>
         <CopyInstructionsButton />
       </DescriptionWrapper>
@@ -468,8 +447,6 @@ export function UnsupportedPlatformOnboarding({
 }
 
 export function NoDocsOnboarding({project}: {project: Project}) {
-  const copyEnabled = useCopySetupInstructionsEnabled();
-
   return (
     <OnboardingPanel project={project}>
       <DescriptionWrapper>
@@ -480,24 +457,15 @@ export function NoDocsOnboarding({project}: {project: Project}) {
           )}
         </p>
         <p>
-          {copyEnabled
-            ? tct(
-                'You can set up the Sentry SDK by following our [link:documentation], or click [bold:Copy instructions] to have an AI coding agent do it for you.',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/insights/ai/agents/getting-started/" />
-                  ),
-                  bold: <strong />,
-                }
-              )
-            : tct(
-                'You can set up the Sentry SDK by following our [link:documentation], or use an AI coding agent to do it for you.',
-                {
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/insights/ai/agents/getting-started/" />
-                  ),
-                }
-              )}
+          {tct(
+            'You can set up the Sentry SDK by following our [link:documentation], or click [bold:Copy instructions] to have an AI coding agent do it for you.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/insights/ai/agents/getting-started/" />
+              ),
+              bold: <strong />,
+            }
+          )}
         </p>
         <CopyInstructionsButton />
       </DescriptionWrapper>

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -11,10 +11,7 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -217,7 +214,6 @@ export function Onboarding() {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const currentPlatform = project?.platform
     ? platforms.find(p => p.id === project.platform)
@@ -351,7 +347,7 @@ export function Onboarding() {
             stepIndex={index}
             isLastStep={index === steps.length - 1}
             trailingItems={
-              index === 0 && copyEnabled ? (
+              index === 0 ? (
                 <OnboardingCopyMarkdownButton
                   borderless
                   steps={steps}

--- a/static/app/views/performance/onboarding.spec.tsx
+++ b/static/app/views/performance/onboarding.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 import {RouterFixture} from 'sentry-fixture/routerFixture';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
@@ -240,11 +240,10 @@ describe('Testing new onboarding ui', () => {
       },
     });
 
-    expect(
-      await screen.findByRole('button', {
-        name: 'Take me to my trace',
-      })
-    ).toHaveAttribute('aria-busy', 'false');
+    const traceButton = await screen.findByRole('button', {
+      name: 'Take me to my trace',
+    });
+    await waitFor(() => expect(traceButton).toHaveAttribute('aria-busy', 'false'));
 
     expect(testableWindowLocation.assign).not.toHaveBeenCalled();
 

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -24,10 +24,7 @@ import {
 } from 'sentry/components/modals/featureTourModal';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
   TabSelectionScope,
@@ -341,7 +338,6 @@ export function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
-  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const doesNotSupportPerformance = project.platform
     ? withoutPerformanceSupport.has(project.platform)
@@ -525,7 +521,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
               stepKey={title}
               title={title}
               trailingItems={
-                index === 0 && copyEnabled ? (
+                index === 0 ? (
                   <OnboardingCopyMarkdownButton
                     borderless
                     steps={steps}


### PR DESCRIPTION
Graduate `organizations:onboarding-copy-setup-instructions`. This flag was fully rolled out to GA (100%) in the automator in getsentry/sentry-options-automator#6606 on 2/25/26 and hasn't been touched since. Removes the flag checks on onboarding surfaces so the "Copy instructions" button is always shown, and drops the now-dead flag-off code paths.

The sibling `organizations:onboarding-copy-setup-instructions-project-creation` flag is unaffected.

Companion PRs (backend split, land this one first):
- Registration removal: #119969
- Automator config removal: getsentry/sentry-options-automator#8736

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.