### PR TITLE
fix(dashboards): Stop time series vanishing on hover in Safari

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -1,6 +1,5 @@
 import type {LineSeriesOption} from 'echarts';
 
-import {LineSeries} from 'sentry/components/charts/series/lineSeries';
 import {scaleTimeSeriesData} from 'sentry/utils/timeSeries/scaleTimeSeriesData';
 import {segmentTimeSeriesByIncompleteData} from 'sentry/utils/timeSeries/segmentTimeSeriesByIncompleteData';
 import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
@@ -49,47 +48,46 @@ export class Area extends ContinuousTimeSeries implements Plottable {
     const plottableSeries: LineSeriesOption[] = [];
 
     const commonOptions = {
+      type: 'line' as const,
+      showSymbol: false,
+      symbolSize: 6,
+      animation: false,
       name: this.name,
       color,
-      animation: false,
       yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,
     };
 
     this.#timeSeriesAndIsIncomplete.forEach(([timeSeries, isIncomplete], index) => {
       if (isIncomplete) {
-        plottableSeries.push(
-          LineSeries({
-            ...commonOptions,
-            stack: `incomplete-${index}`,
-            data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
-              timeSeriesItemToEChartsDataPoint
-            ),
-            lineStyle: {
-              type: 'dotted',
-            },
-            areaStyle: {
-              color,
-              opacity: 0.8,
-            },
-            silent: true,
-          })
-        );
+        plottableSeries.push({
+          ...commonOptions,
+          stack: `incomplete-${index}`,
+          data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
+            timeSeriesItemToEChartsDataPoint
+          ),
+          lineStyle: {
+            type: 'dotted',
+          },
+          areaStyle: {
+            color,
+            opacity: 0.8,
+          },
+          silent: true,
+        });
       }
 
       if (!isIncomplete) {
-        plottableSeries.push(
-          LineSeries({
-            ...commonOptions,
-            stack: `complete-${index}`,
-            areaStyle: {
-              color,
-              opacity: 1,
-            },
-            data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
-              timeSeriesItemToEChartsDataPoint
-            ),
-          })
-        );
+        plottableSeries.push({
+          ...commonOptions,
+          stack: `complete-${index}`,
+          areaStyle: {
+            color,
+            opacity: 1,
+          },
+          data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
+            timeSeriesItemToEChartsDataPoint
+          ),
+        });
       }
     });
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
@@ -1,6 +1,5 @@
 import type {LineSeriesOption} from 'echarts';
 
-import {LineSeries} from 'sentry/components/charts/series/lineSeries';
 import {scaleTimeSeriesData} from 'sentry/utils/timeSeries/scaleTimeSeriesData';
 import {segmentTimeSeriesByIncompleteData} from 'sentry/utils/timeSeries/segmentTimeSeriesByIncompleteData';
 import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
@@ -49,37 +48,36 @@ export class Line extends ContinuousTimeSeries implements Plottable {
     const plottableSeries: LineSeriesOption[] = [];
 
     const commonOptions: LineSeriesOption = {
+      type: 'line' as const,
+      showSymbol: false,
+      symbolSize: 6,
+      animation: false,
       name: this.name,
       color,
-      animation: false,
       yAxisIndex: plottingOptions.yAxisPosition === 'left' ? 0 : 1,
     };
 
     this.#timeSeriesAndIsIncomplete.forEach(([timeSeries, isIncomplete]) => {
       if (isIncomplete) {
-        plottableSeries.push(
-          LineSeries({
-            ...commonOptions,
-            data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
-              timeSeriesItemToEChartsDataPoint
-            ),
-            lineStyle: {
-              type: 'dotted',
-            },
-            silent: true,
-          })
-        );
+        plottableSeries.push({
+          ...commonOptions,
+          data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
+            timeSeriesItemToEChartsDataPoint
+          ),
+          lineStyle: {
+            type: 'dotted',
+          },
+          silent: true,
+        });
       }
 
       if (!isIncomplete) {
-        plottableSeries.push(
-          LineSeries({
-            ...commonOptions,
-            data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
-              timeSeriesItemToEChartsDataPoint
-            ),
-          })
-        );
+        plottableSeries.push({
+          ...commonOptions,
+          data: scaleTimeSeriesData(timeSeries, plottingOptions.unit).values.map(
+            timeSeriesItemToEChartsDataPoint
+          ),
+        });
       }
     });
 


### PR DESCRIPTION
Line and area time-series widgets vanish while hovered in Safari (the tooltip
and axes stay, but the series paths/fills disappear). It reproduces reliably
with more than one widget on the page.

## Why

Sentry charts use ECharts' **SVG renderer**. On hover, ECharts re-patches the
series SVG nodes; WebKit has a long-standing bug where it drops the repaint of
**style-only** hover changes to SVG, leaving the series blank until some later
repaint is forced. This is a known, still-unfixed upstream WebKit/ECharts issue
(apache/echarts [#20869](https://github.com/apache/echarts/issues/20869),
[#20390](https://github.com/apache/echarts/issues/20390)); no ECharts config
prevents it.

The Line/Area plottables built their series through the shared `LineSeries`
wrapper, which sets `emphasis: { scale: false }`. With scaling off, hovering a
data point is a **style-only** change (stroke/fill color), so WebKit never
re-rasterizes the SVG and the lines vanish.

Building the series options directly (dropping the `LineSeries` wrapper) lets
`emphasis.scale` default to `true`. Now the hovered symbol gets a **transform**
change on emphasis (`Symbol.js` sets `emphasisState.scaleX/scaleY` to a scaled
value), and a transform mutation forces WebKit to re-rasterize the SVG — which
commits the repaint it was dropping. The scale transform is effectively a
built-in, perfectly-timed repaint nudge inside ECharts' own render loop.

## Behavior change

The hover dot on line/area series now scales up slightly on hover (ECharts'
default emphasis behavior) instead of staying fixed size. This is the mechanism
that fixes the repaint, and it matches ECharts' default across the rest of the
app.

## Alternatives considered (all rejected)

Confirmed in real Safari via profiling + live `setOption` bisection that **none**
of these prevent the vanish: `triggerEmphasis: false` (also removes the hover
dot), global `animation: false`, series `clip: false`, disabling
`universalTransition`/emphasis/`dataZoom`/`markLine`, removing the
`echarts.connect` group, and static CSS compositing hints
(`translateZ`/`will-change`/`backface-visibility`) on the `<svg>`. A JS
repaint-nudge on the `rendered` event and switching Safari to the canvas
renderer both work but are heavier; the `emphasis.scale` fix is the smallest and
keeps the SVG renderer everywhere.

Fixes [DAIN-1778](https://linear.app/getsentry/issue/DAIN-1778)
