### PR TITLE
fix(issues): Stop activity line at final marker

### DIFF
--- a/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
@@ -58,19 +58,6 @@ export const ActivityLineRow = styled('div')`
   align-items: start;
   column-gap: ${p => p.theme.space.xs};
 
-  &:last-child {
-    &::after {
-      content: '';
-      position: absolute;
-      z-index: 1;
-      left: 10.5px;
-      top: 22px;
-      bottom: 0;
-      width: 1px;
-      background: ${p => p.theme.tokens.background.overlay};
-    }
-  }
-
   @container activity-list (min-width: 90px) {
     column-gap: ${p => p.theme.space.sm};
   }

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -434,7 +434,7 @@ const ActivityLineList = styled('div')`
     position: absolute;
     left: 10.5px;
     top: 11px;
-    bottom: 0;
+    bottom: 11px;
     width: 0;
     border-left: 1px solid ${p => p.theme.tokens.border.transparent.neutral.muted};
   }


### PR DESCRIPTION
The new issue activity line extended below its final dot.

before

<img width="157" height="53" alt="image" src="https://github.com/user-attachments/assets/eb6e59f1-1703-444d-bca5-15f9f66ad52d" />


after

<img width="182" height="52" alt="image" src="https://github.com/user-attachments/assets/dcd9ceb9-3b9e-4a73-9680-ecc033acddd2" />

