### PR TITLE
ref(seer-billing): Replace org contributor get-or-create helpers with Django lookups

### DIFF
--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -12,7 +12,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import sentry_sdk
-from django.db import IntegrityError, router, transaction
+from django.db import router, transaction
 from django.db.models import F
 
 from sentry import features, quotas
@@ -92,81 +92,6 @@ def should_increment_contributor_seat(
     )
 
 
-def get_canonical_contributor(
-    *,
-    organization_id: int,
-    integration: Integration | RpcIntegration,
-    external_identifier: str,
-) -> OrganizationContributors | None:
-    """
-    TODO(CW-1539): Replace with get() after the contributor deduplication
-    migration has completed.
-    """
-    try:
-        hostname = instance_hostname(integration)
-    except InstanceHostnameError as e:
-        sentry_sdk.capture_exception(e)
-        return None
-
-    # Prefer the current billing period's seat holder (contributor with the most
-    # actions), with id as a stable tiebreaker.
-    return (
-        OrganizationContributors.objects.filter(
-            organization_id=organization_id,
-            provider=integration.provider,
-            hostname=hostname,
-            external_identifier=external_identifier,
-        )
-        .order_by("-num_actions", "id")
-        .first()
-    )
-
-
-def get_or_create_contributor(
-    *,
-    organization: Organization,
-    integration: Integration | RpcIntegration,
-    external_identifier: str,
-    alias: str | None,
-) -> OrganizationContributors | None:
-    """
-    TODO(CW-1539): Replace with get_or_create() after the contributor deduplication
-    migration has completed.
-    """
-    try:
-        hostname = instance_hostname(integration)
-    except InstanceHostnameError as e:
-        sentry_sdk.capture_exception(e)
-        return None
-
-    if contributor := get_canonical_contributor(
-        organization_id=organization.id,
-        integration=integration,
-        external_identifier=external_identifier,
-    ):
-        return contributor
-
-    try:
-        with transaction.atomic(router.db_for_write(OrganizationContributors)):
-            return OrganizationContributors.objects.create(
-                organization_id=organization.id,
-                integration_id=integration.id,
-                external_identifier=external_identifier,
-                provider=integration.provider,
-                hostname=hostname,
-                alias=alias,
-            )
-    except IntegrityError:
-        contributor = get_canonical_contributor(
-            organization_id=organization.id,
-            integration=integration,
-            external_identifier=external_identifier,
-        )
-        if not contributor:
-            raise
-        return contributor
-
-
 def track_contributor_seat(
     *,
     organization: Organization,
@@ -177,13 +102,20 @@ def track_contributor_seat(
     logs_extra: Mapping[str, Any] | None = None,
 ) -> None:
     """Informational logging for the legacy seat-charging path."""
-    contributor = get_or_create_contributor(
-        organization=organization,
-        integration=integration,
+    try:
+        hostname = instance_hostname(integration)
+    except InstanceHostnameError as e:
+        sentry_sdk.capture_exception(e)
+        return
+
+    contributor, _ = OrganizationContributors.objects.get_or_create(
+        organization_id=organization.id,
+        provider=integration.provider,
+        hostname=hostname,
         external_identifier=str(user_id),
-        alias=user_username,
+        defaults={"integration_id": integration.id, "alias": user_username},
     )
-    if not contributor or not should_increment_contributor_seat(organization, repo, contributor):
+    if not should_increment_contributor_seat(organization, repo, contributor):
         return
 
     logger.info(
@@ -218,18 +150,21 @@ def record_contributor_action(
     tags: Mapping[str, Any] | None = None,
 ) -> None:
     """Seed a contributor and record the contributor's PR-opened action."""
-    contributor = get_or_create_contributor(
-        organization=organization,
-        integration=integration,
+    try:
+        hostname = instance_hostname(integration)
+    except InstanceHostnameError as e:
+        sentry_sdk.capture_exception(e)
+        return
+
+    contributor, _ = OrganizationContributors.objects.get_or_create(
+        organization_id=organization.id,
+        provider=integration.provider,
+        hostname=hostname,
         external_identifier=str(user_id),
-        alias=user_username,
+        defaults={"integration_id": integration.id, "alias": user_username},
     )
 
-    if (
-        not contributor
-        or not is_opened
-        or not should_increment_contributor_seat(organization, repo, contributor)
-    ):
+    if not is_opened or not should_increment_contributor_seat(organization, repo, contributor):
         return
 
     with transaction.atomic(router.db_for_write(OrganizationContributors)):

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -112,7 +112,7 @@ class CodeReviewPreflightService:
             hostname = instance_hostname(self.integration)
         except InstanceHostnameError as e:
             sentry_sdk.capture_exception(e)
-            return PreflightDenialReason.ORG_CONTRIBUTOR_NOT_FOUND
+            return PreflightDenialReason.BILLING_MISSING_CONTRIBUTOR_INFO
 
         try:
             contributor = OrganizationContributors.objects.get(

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -5,19 +5,22 @@ from dataclasses import dataclass
 from enum import StrEnum
 from functools import cached_property
 
+import sentry_sdk
+
 from sentry import features, options, quotas
 from sentry.constants import (
     HIDE_AI_FEATURES_DEFAULT,
     DataCategory,
 )
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.utils.hostname import InstanceHostnameError, instance_hostname
 from sentry.models.organization import Organization
+from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import (
     CodeReviewSettings,
     RepositorySettings,
 )
-from sentry.seer.code_review.contributor_seats import get_canonical_contributor
 
 
 class PreflightDenialReason(StrEnum):
@@ -105,12 +108,20 @@ class CodeReviewPreflightService:
         if self.integration is None or self.pr_author_external_id is None:
             return PreflightDenialReason.BILLING_MISSING_CONTRIBUTOR_INFO
 
-        contributor = get_canonical_contributor(
-            organization_id=self.organization.id,
-            integration=self.integration,
-            external_identifier=self.pr_author_external_id,
-        )
-        if contributor is None:
+        try:
+            hostname = instance_hostname(self.integration)
+        except InstanceHostnameError as e:
+            sentry_sdk.capture_exception(e)
+            return PreflightDenialReason.ORG_CONTRIBUTOR_NOT_FOUND
+
+        try:
+            contributor = OrganizationContributors.objects.get(
+                organization_id=self.organization.id,
+                provider=self.integration.provider,
+                hostname=hostname,
+                external_identifier=self.pr_author_external_id,
+            )
+        except OrganizationContributors.DoesNotExist:
             return PreflightDenialReason.ORG_CONTRIBUTOR_NOT_FOUND
 
         # Excluded author check applies to all organization types

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -1,10 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-from django.db import IntegrityError
-
 from sentry.constants import ObjectStatus
-from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.integrations.utils.hostname import InstanceHostnameError
 from sentry.models.organizationcontributors import (
@@ -15,7 +11,6 @@ from sentry.models.organizationcontributors import (
 from sentry.models.project import Project
 from sentry.seer.code_review.contributor_seats import (
     _is_autofix_enabled_for_repo,
-    get_or_create_contributor,
     record_contributor_action,
     should_increment_contributor_seat,
     track_contributor_seat,
@@ -472,115 +467,4 @@ class RecordContributorActionTest(TestCase):
             external_identifier="123",
         ).exists()
         assert self._action_count() == 0
-        mock_capture.assert_called_once()
-
-
-class GetOrCreateContributorTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.integration = self.create_integration(
-            organization=self.organization, provider="github", external_id="github:1"
-        )
-        # Second github integration -> same provider/hostname, so rows created via
-        # each land in the same (org, provider, hostname, external_identifier) group.
-        self.other_integration = self.create_integration(
-            organization=self.organization, provider="github", external_id="github:2"
-        )
-
-    def _call(
-        self,
-        integration: Integration | None = None,
-        external_identifier: str = "123",
-        alias: str | None = "alice",
-    ) -> OrganizationContributors | None:
-        return get_or_create_contributor(
-            organization=self.organization,
-            integration=integration or self.integration,
-            external_identifier=external_identifier,
-            alias=alias,
-        )
-
-    def _group_count(self, external_identifier: str = "123") -> int:
-        return OrganizationContributors.objects.filter(
-            organization_id=self.organization.id, external_identifier=external_identifier
-        ).count()
-
-    def test_creates_when_none_exists(self) -> None:
-        contributor = self._call()
-
-        assert contributor is not None
-        assert OrganizationContributors.objects.filter(id=contributor.id).exists()
-        assert contributor.provider == "github"
-        assert contributor.hostname == "github.com"
-        assert contributor.external_identifier == "123"
-        assert contributor.alias == "alice"
-
-    def test_returns_existing_without_creating(self) -> None:
-        existing = self.create_organization_contributor(
-            organization=self.organization,
-            integration=self.integration,
-            external_identifier="123",
-        )
-
-        contributor = self._call()
-
-        assert contributor is not None
-        assert contributor.id == existing.id
-        assert self._group_count() == 1
-
-    @patch("sentry.seer.code_review.contributor_seats.get_canonical_contributor")
-    def test_integrityerror_returns_existing_on_race(self, mock_get_canonical: MagicMock) -> None:
-        existing = self.create_organization_contributor(
-            organization=self.organization,
-            integration=self.integration,
-            external_identifier="123",
-        )
-        # Race: first lookup misses, our create loses to a concurrent insert
-        # (IntegrityError), retry lookup finds the winner.
-        mock_get_canonical.side_effect = [None, existing]
-        with patch.object(
-            OrganizationContributors.objects, "create", side_effect=IntegrityError("dupe")
-        ):
-            contributor = self._call()
-
-        assert contributor is not None
-        assert contributor.id == existing.id
-
-    @patch("sentry.seer.code_review.contributor_seats.get_canonical_contributor")
-    def test_integrityerror_reraises_when_still_missing(
-        self, mock_get_canonical: MagicMock
-    ) -> None:
-        # Both lookups miss but create keeps failing -> propagate.
-        mock_get_canonical.side_effect = [None, None]
-        with (
-            patch.object(
-                OrganizationContributors.objects, "create", side_effect=IntegrityError("dupe")
-            ),
-            pytest.raises(IntegrityError),
-        ):
-            self._call()
-
-    def test_returns_existing_when_looked_up_via_different_integration(self) -> None:
-        existing = self.create_organization_contributor(
-            organization=self.organization,
-            integration=self.integration,
-            external_identifier="123",
-        )
-
-        contributor = self._call(integration=self.other_integration)
-
-        assert contributor is not None
-        assert contributor.id == existing.id
-        assert self._group_count() == 1
-
-    @patch("sentry.seer.code_review.contributor_seats.sentry_sdk.capture_exception")
-    @patch(
-        "sentry.seer.code_review.contributor_seats.instance_hostname",
-        side_effect=InstanceHostnameError("missing"),
-    )
-    def test_returns_none_on_missing_hostname(
-        self, mock_hostname: MagicMock, mock_capture: MagicMock
-    ) -> None:
-        assert self._call() is None
-        assert self._group_count() == 0
         mock_capture.assert_called_once()

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -297,9 +297,9 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.allowed is False
         assert result.denial_reason == PreflightDenialReason.BILLING_MISSING_CONTRIBUTOR_INFO
 
-    @patch("sentry.seer.code_review.contributor_seats.sentry_sdk.capture_exception")
+    @patch("sentry.seer.code_review.preflight.sentry_sdk.capture_exception")
     @patch(
-        "sentry.seer.code_review.contributor_seats.instance_hostname",
+        "sentry.seer.code_review.preflight.instance_hostname",
         side_effect=InstanceHostnameError("missing"),
     )
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])
@@ -320,7 +320,7 @@ class TestCodeReviewPreflightService(TestCase):
         result = service.check()
 
         assert result.allowed is False
-        assert result.denial_reason == PreflightDenialReason.ORG_CONTRIBUTOR_NOT_FOUND
+        assert result.denial_reason == PreflightDenialReason.BILLING_MISSING_CONTRIBUTOR_INFO
         mock_capture.assert_called_once()
 
     @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])


### PR DESCRIPTION
relates to CW-1539, INC-2306

Depends on https://github.com/getsentry/sentry/pull/119965 uniqueness constraint post-deployment migration to run in all regions.

Replace the now-defunct get_or_create helpers for OrganizationContributors model. We've switched the uniqueness constraint over to include provider+hostname instead of integration id, so Django will now raise IntegrityError on the correct duplicates.