### PR TITLE
feat(action log): Add GALE serializer and swap response in group details

### DIFF
--- a/src/sentry/api/serializers/models/__init__.py
+++ b/src/sentry/api/serializers/models/__init__.py
@@ -19,6 +19,7 @@ from .exporteddata import *  # noqa: F401,F403
 from .filechange import *  # noqa: F401,F403
 from .group import *  # noqa: F401,F403
 from .group_stream import *  # noqa: F401,F403
+from .groupactionlogentry import *  # noqa: F401,F403
 from .grouprelease import GroupReleaseSerializer, GroupReleaseWithStatsSerializer  # noqa: F401,F403
 from .groupseen import *  # noqa: F401,F403
 from .grouptombstone import *  # noqa: F401,F403

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -7,7 +7,13 @@ from django.contrib.auth.models import AnonymousUser
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.activity import _ActivitySentryAppEmbed
 from sentry.api.serializers.models.commit import CommitWithReleaseSerializer
-from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.issues.action_log.types import (
+    ACTION_TYPES_WITH_COMMIT_DATA,
+    COMMIT_ACTION_TYPES,
+    PULL_REQUEST_ACTION_TYPES,
+    GroupActionType,
+    GroupActorType,
+)
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.commit import Commit
 from sentry.models.pullrequest import PullRequest
@@ -21,50 +27,12 @@ from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 from sentry.utils.action_log.activity_translator import (
-    ACTIVITY_TYPE_TO_ARG_TRANSLATIONS,
-    ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE,
+    GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS,
+    GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE,
 )
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
-
-# GroupActionTypes are serialized with the same `type` string as their
-# equivalent Activity so the frontend can consume both identically
-_GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE = {
-    action_cls.get_type().value: activity_type
-    for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
-}
-
-# GALE payloads are stored with the snake_case GroupAction field names, but the
-# frontend consumes the Activity `data` shape. Reverse the camelCase -> snake_case
-# renames that activity_translator applies when mirroring Activities into
-# GroupActions, keyed by GroupActionType value.
-_GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS = {
-    action_cls.get_type().value: {
-        gale_key: activity_key
-        for activity_key, gale_key in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS[activity_type].items()
-    }
-    for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
-    if activity_type in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS
-}
-
-COMMIT_ACTION_TYPES = {
-    GroupActionType.SET_RESOLVED_IN_COMMIT.value,
-    GroupActionType.REFERENCED_IN_COMMIT.value,
-}
-
-ACTION_TYPES_WITH_COMMIT_DATA = {
-    *COMMIT_ACTION_TYPES,
-    GroupActionType.SET_RESOLVED_IN_RELEASE.value,
-}
-
-PULL_REQUEST_ACTION_TYPES = {
-    GroupActionType.RESOLVED_IN_PULL_REQUEST.value,
-    GroupActionType.PULL_REQUEST_CLOSED.value,
-    GroupActionType.PULL_REQUEST_REOPENED.value,
-    GroupActionType.PULL_REQUEST_MERGED.value,
-    GroupActionType.PULL_REQUEST_UNLINKED.value,
-}
 
 
 class GroupActionLogEntrySerializerResponse(TypedDict):
@@ -208,7 +176,7 @@ class GroupActionLogEntrySerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> GroupActionLogEntrySerializerResponse:
-        activity_type = _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE.get(obj.type)
+        activity_type = GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE.get(obj.type)
         type_display = (
             ActivityType(activity_type).name.lower()
             if activity_type is not None
@@ -231,7 +199,7 @@ class GroupActionLogEntrySerializer(Serializer):
             data = {"issues": [{"id": str(group_id)} for group_id in counterpart_group_ids]}
         else:
             raw_data = obj.data or {}
-            key_translations = _GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS.get(obj.type)
+            key_translations = GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS.get(obj.type)
             if key_translations:
                 data = {key_translations.get(key, key): value for key, value in raw_data.items()}
             else:

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -83,19 +83,24 @@ class GroupActionLogEntrySerializer(Serializer):
 
         # add sentry app data
 
-        # If an entry is created by the proxy user of a Sentry App, attach it to the payload
+        # If an entry is created by a Sentry App, attach it to the payload. For
+        # SENTRY_APP entries, actor_id is the SentryApp id (not its proxy user id).
+        sentry_app_ids = [
+            i.actor_id
+            for i in item_list
+            if i.actor_id and i.actor_type == GroupActorType.SENTRY_APP
+        ]
         sentry_apps_list: list[RpcSentryApp] = []
-        if user_ids:
-            sentry_apps_list = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=user_ids)
+        if sentry_app_ids:
+            sentry_apps_list = app_service.get_sentry_apps_by_ids(ids=sentry_app_ids)
         # Minimal Sentry App serialization to keep the payload minimal
-        apps_with_proxy = [app for app in sentry_apps_list if app.proxy_user_id]
-        all_avatars = [avatar for app in apps_with_proxy for avatar in app.avatars]
+        all_avatars = [avatar for app in sentry_apps_list for avatar in app.avatars]
         serialized_avatars = serialize(all_avatars, user, serializer=SentryAppAvatarSerializer())
         sentry_apps: dict[str, _ActivitySentryAppEmbed] = {}
         avatar_offset = 0
-        for app in apps_with_proxy:
+        for app in sentry_apps_list:
             avatar_count = len(app.avatars)
-            sentry_apps[str(app.proxy_user_id)] = {
+            sentry_apps[str(app.id)] = {
                 "id": str(app.id),
                 "name": app.name,
                 "slug": app.slug,
@@ -152,7 +157,11 @@ class GroupActionLogEntrySerializer(Serializer):
                     if item.actor_type == GroupActorType.USER
                     else None
                 ),
-                "sentry_app": sentry_apps.get(str(item.actor_id)) if item.actor_id else None,
+                "sentry_app": (
+                    sentry_apps.get(str(item.actor_id))
+                    if item.actor_type == GroupActorType.SENTRY_APP
+                    else None
+                ),
                 "commit": commits.get(item),
                 "pull_request": pull_requests.get(item),
             }

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 from typing import Any, TypedDict
 
-from sentry.api.serializers import Serializer, register
+from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.activity import _ActivitySentryAppEmbed
-from sentry.issues.action_log.types import GroupActorType
+from sentry.api.serializers.models.commit import CommitWithReleaseSerializer
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.models.commit import Commit
+from sentry.models.pullrequest import PullRequest
 from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -15,6 +18,24 @@ from sentry.utils.action_log.activity_translator import ACTIVITY_TYPE_TO_GROUP_A
 _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE = {
     action_cls.get_type().value: activity_type
     for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
+}
+
+COMMIT_ACTION_TYPES = {
+    GroupActionType.SET_RESOLVED_IN_COMMIT.value,
+    GroupActionType.REFERENCED_IN_COMMIT.value,
+}
+
+ACTION_TYPES_WITH_COMMIT_DATA = {
+    *COMMIT_ACTION_TYPES,
+    GroupActionType.SET_RESOLVED_IN_RELEASE.value,
+}
+
+PULL_REQUEST_ACTION_TYPES = {
+    GroupActionType.RESOLVED_IN_PULL_REQUEST.value,
+    GroupActionType.PULL_REQUEST_CLOSED.value,
+    GroupActionType.PULL_REQUEST_REOPENED.value,
+    GroupActionType.PULL_REQUEST_MERGED.value,
+    GroupActionType.PULL_REQUEST_UNLINKED.value,
 }
 
 
@@ -31,7 +52,9 @@ class GroupActionLogEntrySerializerResponse(TypedDict):
 @register(GroupActionLogEntry)
 class GroupActionLogEntrySerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        user_ids = [i.actor_id for i in item_list if i.actor_id]
+        user_ids = [
+            i.actor_id for i in item_list if i.actor_id and i.actor_type == GroupActorType.USER
+        ]
         users = {}
         if user_ids:
             user_list = user_service.serialize_many(
@@ -39,13 +62,55 @@ class GroupActionLogEntrySerializer(Serializer):
             )
             users = {u["id"]: u for u in user_list}
 
+        commit_ids = {
+            i.data["commit"]
+            for i in item_list
+            if i.type in ACTION_TYPES_WITH_COMMIT_DATA and i.data and i.data.get("commit")
+        }
+        if commit_ids:
+            commit_list = list(Commit.objects.filter(id__in=commit_ids))
+            commits_by_id = {
+                c.id: d
+                for c, d in zip(
+                    commit_list,
+                    serialize(commit_list, user, serializer=CommitWithReleaseSerializer()),
+                )
+            }
+            commits = {
+                i: commits_by_id.get(i.data["commit"])
+                for i in item_list
+                if i.type in ACTION_TYPES_WITH_COMMIT_DATA and i.data and i.data.get("commit")
+            }
+        else:
+            commits = {}
+
+        pull_request_ids = {
+            i.data["pull_request"]
+            for i in item_list
+            if i.type in PULL_REQUEST_ACTION_TYPES and i.data and i.data.get("pull_request")
+        }
+        if pull_request_ids:
+            pull_request_list = list(PullRequest.objects.filter(id__in=pull_request_ids))
+            pull_requests_by_id = {
+                c.id: d for c, d in zip(pull_request_list, serialize(pull_request_list, user))
+            }
+            pull_requests = {
+                i: pull_requests_by_id.get(i.data["pull_request"])
+                for i in item_list
+                if i.type in PULL_REQUEST_ACTION_TYPES and i.data and i.data.get("pull_request")
+            }
+        else:
+            pull_requests = {}
+
         return {
             item: {
                 "user": (
                     users.get(str(item.actor_id))
                     if item.actor_type == GroupActorType.USER
                     else None
-                )
+                ),
+                "commit": commits.get(item),
+                "pull_request": pull_requests.get(item),
             }
             for item in item_list
         }
@@ -57,11 +122,25 @@ class GroupActionLogEntrySerializer(Serializer):
             if activity_type is not None
             else obj.get_type_display()
         )
+
+        if (
+            obj.type == GroupActionType.SET_RESOLVED_IN_RELEASE.value
+            and obj.data
+            and obj.data.get("commit")
+        ):
+            data = {**obj.data, "commit": attrs["commit"]}
+        elif obj.type in COMMIT_ACTION_TYPES:
+            data = {"commit": attrs["commit"]}
+        elif obj.type in PULL_REQUEST_ACTION_TYPES:
+            data = {"pullRequest": attrs["pull_request"]}
+        else:
+            data = obj.data or {}
+
         return {
             "id": str(obj.id),
             "type": type_display,
             "user": attrs["user"],
             "sentry_app": None,  # mimic Activity serializer
-            "data": obj.data or {},
+            "data": data,
             "dateCreated": obj.date_added,
         }

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -16,8 +16,8 @@ from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 from sentry.utils.action_log.activity_translator import ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE
 
-# Mirror GroupActionTypes are serialized with the same `type` string as their
-# equivalent Activity so the frontend can consume both identically.
+# GroupActionTypes are serialized with the same `type` string as their
+# equivalent Activity so the frontend can consume both identically
 _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE = {
     action_cls.get_type().value: activity_type
     for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
@@ -44,7 +44,7 @@ PULL_REQUEST_ACTION_TYPES = {
 
 class GroupActionLogEntrySerializerResponse(TypedDict):
     id: str
-    # The serialized acting user when actorType is USER, otherwise null.
+    # the serialized acting user when actorType is USER, otherwise null
     user: dict[str, Any] | None
     sentry_app: _ActivitySentryAppEmbed | None
     type: str

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -2,30 +2,36 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register
+from sentry.api.serializers.models.activity import _ActivitySentryAppEmbed
 from sentry.issues.action_log.types import GroupActorType
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
+from sentry.utils.action_log.activity_translator import ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE
+
+# Mirror GroupActionTypes are serialized with the same `type` string as their
+# equivalent Activity so the frontend can consume both identically.
+_GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE = {
+    action_cls.get_type().value: activity_type
+    for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
+}
 
 
 class GroupActionLogEntrySerializerResponse(TypedDict):
     id: str
-    type: str
-    actorType: str
     # The serialized acting user when actorType is USER, otherwise null.
     user: dict[str, Any] | None
-    actorId: str
-    source: str
+    sentry_app: _ActivitySentryAppEmbed | None
+    type: str
     data: dict[str, Any]
-    dateAdded: datetime
+    dateCreated: datetime
 
 
 @register(GroupActionLogEntry)
 class GroupActionLogEntrySerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        user_ids = [
-            i.actor_id for i in item_list if i.actor_type == GroupActorType.USER and i.actor_id
-        ]
+        user_ids = [i.actor_id for i in item_list if i.actor_id]
         users = {}
         if user_ids:
             user_list = user_service.serialize_many(
@@ -45,13 +51,16 @@ class GroupActionLogEntrySerializer(Serializer):
         }
 
     def serialize(self, obj, attrs, user, **kwargs) -> GroupActionLogEntrySerializerResponse:
+        activity_type = _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE.get(obj.type)
+        type_display = (
+            ActivityType(activity_type).name.lower()
+            if activity_type is not None
+            else obj.get_type_display()
+        )
         return {
             "id": str(obj.id),
-            "type": obj.get_type_display(),
-            # "actorType": obj.get_actor_type_display(),
-            "user": attrs["user"],  # TODO compare with Activity serializer
-            # "actorId": str(obj.actor_id),
-            # "source": obj.source,
+            "type": type_display,
+            "user": attrs["user"],
             "sentry_app": None,  # mimic Activity serializer
             "data": obj.data or {},
             "dateCreated": obj.date_added,

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, Sequence, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.activity import _ActivitySentryAppEmbed
@@ -14,13 +14,29 @@ from sentry.sentry_apps.services.app.model import RpcSentryApp
 from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
-from sentry.utils.action_log.activity_translator import ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE
+from sentry.utils.action_log.activity_translator import (
+    ACTIVITY_TYPE_TO_ARG_TRANSLATIONS,
+    ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE,
+)
 
 # GroupActionTypes are serialized with the same `type` string as their
 # equivalent Activity so the frontend can consume both identically
 _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE = {
     action_cls.get_type().value: activity_type
     for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
+}
+
+# GALE payloads are stored with the snake_case GroupAction field names, but the
+# frontend consumes the Activity `data` shape. Reverse the camelCase -> snake_case
+# renames that activity_translator applies when mirroring Activities into
+# GroupActions, keyed by GroupActionType value.
+_GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS = {
+    action_cls.get_type().value: {
+        gale_key: activity_key
+        for activity_key, gale_key in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS[activity_type].items()
+    }
+    for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
+    if activity_type in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS
 }
 
 COMMIT_ACTION_TYPES = {
@@ -54,7 +70,7 @@ class GroupActionLogEntrySerializerResponse(TypedDict):
 
 @register(GroupActionLogEntry)
 class GroupActionLogEntrySerializer(Serializer):
-    def get_attrs(self, item_list, user, **kwargs):
+    def get_attrs(self, item_list: Sequence[GroupActionLogEntry], user, **kwargs):
         user_ids = [
             i.actor_id for i in item_list if i.actor_id and i.actor_type == GroupActorType.USER
         ]
@@ -72,16 +88,20 @@ class GroupActionLogEntrySerializer(Serializer):
         if user_ids:
             sentry_apps_list = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=user_ids)
         # Minimal Sentry App serialization to keep the payload minimal
-        sentry_apps: dict[str, _ActivitySentryAppEmbed] = {
-            str(app.proxy_user_id): {
+        apps_with_proxy = [app for app in sentry_apps_list if app.proxy_user_id]
+        all_avatars = [avatar for app in apps_with_proxy for avatar in app.avatars]
+        serialized_avatars = serialize(all_avatars, user, serializer=SentryAppAvatarSerializer())
+        sentry_apps: dict[str, _ActivitySentryAppEmbed] = {}
+        avatar_offset = 0
+        for app in apps_with_proxy:
+            avatar_count = len(app.avatars)
+            sentry_apps[str(app.proxy_user_id)] = {
                 "id": str(app.id),
                 "name": app.name,
                 "slug": app.slug,
-                "avatars": serialize(app.avatars, user, serializer=SentryAppAvatarSerializer()),
+                "avatars": serialized_avatars[avatar_offset : avatar_offset + avatar_count],
             }
-            for app in sentry_apps_list
-            if app.proxy_user_id
-        }
+            avatar_offset += avatar_count
 
         # add commit data
         commit_ids = {
@@ -139,7 +159,9 @@ class GroupActionLogEntrySerializer(Serializer):
             for item in item_list
         }
 
-    def serialize(self, obj, attrs, user, **kwargs) -> GroupActionLogEntrySerializerResponse:
+    def serialize(
+        self, obj: GroupActionLogEntry, attrs, user, **kwargs
+    ) -> GroupActionLogEntrySerializerResponse:
         activity_type = _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE.get(obj.type)
         type_display = (
             ActivityType(activity_type).name.lower()
@@ -157,8 +179,17 @@ class GroupActionLogEntrySerializer(Serializer):
             data = {"commit": attrs["commit"]}
         elif obj.type in PULL_REQUEST_ACTION_TYPES:
             data = {"pullRequest": attrs["pull_request"]}
+        elif obj.type == GroupActionType.MERGE_FROM_OTHER.value:
+            # Activity stores merged issues as a list of objects; GALE stores only ids.
+            counterpart_group_ids = (obj.data or {}).get("counterpart_group_ids", [])
+            data = {"issues": [{"id": str(group_id)} for group_id in counterpart_group_ids]}
         else:
-            data = obj.data or {}
+            raw_data = obj.data or {}
+            key_translations = _GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS.get(obj.type)
+            if key_translations:
+                data = {key_translations.get(key, key): value for key, value in raw_data.items()}
+            else:
+                data = raw_data
 
         return {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,5 +1,8 @@
+from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Sequence, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
+
+from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.activity import _ActivitySentryAppEmbed
@@ -13,6 +16,8 @@ from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.app.model import RpcSentryApp
 from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
+from sentry.users.models.user import User
+from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 from sentry.utils.action_log.activity_translator import (
@@ -93,7 +98,12 @@ def serialize_first_seen_entry(group: "Group") -> GroupActionLogEntrySerializerR
 
 @register(GroupActionLogEntry)
 class GroupActionLogEntrySerializer(Serializer):
-    def get_attrs(self, item_list: Sequence[GroupActionLogEntry], user, **kwargs):
+    def get_attrs(
+        self,
+        item_list: Sequence[GroupActionLogEntry],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> dict[GroupActionLogEntry, Any]:
         user_ids = [
             i.actor_id for i in item_list if i.actor_id and i.actor_type == GroupActorType.USER
         ]
@@ -192,7 +202,11 @@ class GroupActionLogEntrySerializer(Serializer):
         }
 
     def serialize(
-        self, obj: GroupActionLogEntry, attrs, user, **kwargs
+        self,
+        obj: GroupActionLogEntry,
+        attrs: Mapping[Any, Any],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
     ) -> GroupActionLogEntrySerializerResponse:
         activity_type = _GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE.get(obj.type)
         type_display = (

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from typing import Any, TypedDict
+
+from sentry.api.serializers import Serializer, register
+from sentry.issues.action_log.types import GroupActorType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
+from sentry.users.services.user.serial import serialize_generic_user
+from sentry.users.services.user.service import user_service
+
+
+class GroupActionLogEntrySerializerResponse(TypedDict):
+    id: str
+    type: str
+    actorType: str
+    # The serialized acting user when actorType is USER, otherwise null.
+    user: dict[str, Any] | None
+    actorId: str
+    source: str
+    data: dict[str, Any]
+    dateAdded: datetime
+
+
+@register(GroupActionLogEntry)
+class GroupActionLogEntrySerializer(Serializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        user_ids = [
+            i.actor_id for i in item_list if i.actor_type == GroupActorType.USER and i.actor_id
+        ]
+        users = {}
+        if user_ids:
+            user_list = user_service.serialize_many(
+                filter={"user_ids": user_ids}, as_user=serialize_generic_user(user)
+            )
+            users = {u["id"]: u for u in user_list}
+
+        return {
+            item: {
+                "user": (
+                    users.get(str(item.actor_id))
+                    if item.actor_type == GroupActorType.USER
+                    else None
+                )
+            }
+            for item in item_list
+        }
+
+    def serialize(self, obj, attrs, user, **kwargs) -> GroupActionLogEntrySerializerResponse:
+        return {
+            "id": str(obj.id),
+            "type": obj.get_type_display(),
+            # "actorType": obj.get_actor_type_display(),
+            "user": attrs["user"],  # TODO compare with Activity serializer
+            # "actorId": str(obj.actor_id),
+            # "source": obj.source,
+            "sentry_app": None,  # mimic Activity serializer
+            "data": obj.data or {},
+            "dateCreated": obj.date_added,
+        }

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -8,6 +8,9 @@ from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.commit import Commit
 from sentry.models.pullrequest import PullRequest
+from sentry.sentry_apps.api.serializers.sentry_app_avatar import SentryAppAvatarSerializer
+from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.app.model import RpcSentryApp
 from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -62,6 +65,25 @@ class GroupActionLogEntrySerializer(Serializer):
             )
             users = {u["id"]: u for u in user_list}
 
+        # add sentry app data
+
+        # If an entry is created by the proxy user of a Sentry App, attach it to the payload
+        sentry_apps_list: list[RpcSentryApp] = []
+        if user_ids:
+            sentry_apps_list = app_service.get_sentry_apps_by_proxy_users(proxy_user_ids=user_ids)
+        # Minimal Sentry App serialization to keep the payload minimal
+        sentry_apps: dict[str, _ActivitySentryAppEmbed] = {
+            str(app.proxy_user_id): {
+                "id": str(app.id),
+                "name": app.name,
+                "slug": app.slug,
+                "avatars": serialize(app.avatars, user, serializer=SentryAppAvatarSerializer()),
+            }
+            for app in sentry_apps_list
+            if app.proxy_user_id
+        }
+
+        # add commit data
         commit_ids = {
             i.data["commit"]
             for i in item_list
@@ -84,6 +106,7 @@ class GroupActionLogEntrySerializer(Serializer):
         else:
             commits = {}
 
+        # add pull request data
         pull_request_ids = {
             i.data["pull_request"]
             for i in item_list
@@ -109,6 +132,7 @@ class GroupActionLogEntrySerializer(Serializer):
                     if item.actor_type == GroupActorType.USER
                     else None
                 ),
+                "sentry_app": sentry_apps.get(str(item.actor_id)) if item.actor_id else None,
                 "commit": commits.get(item),
                 "pull_request": pull_requests.get(item),
             }
@@ -140,7 +164,7 @@ class GroupActionLogEntrySerializer(Serializer):
             "id": str(obj.id),
             "type": type_display,
             "user": attrs["user"],
-            "sentry_app": None,  # mimic Activity serializer
+            "sentry_app": attrs["sentry_app"],
             "data": data,
             "dateCreated": obj.date_added,
         }

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Sequence, TypedDict
+from typing import TYPE_CHECKING, Any, Sequence, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.activity import _ActivitySentryAppEmbed
@@ -12,12 +12,16 @@ from sentry.sentry_apps.api.serializers.sentry_app_avatar import SentryAppAvatar
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.services.app.model import RpcSentryApp
 from sentry.types.activity import ActivityType
+from sentry.types.group import PriorityLevel
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 from sentry.utils.action_log.activity_translator import (
     ACTIVITY_TYPE_TO_ARG_TRANSLATIONS,
     ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE,
 )
+
+if TYPE_CHECKING:
+    from sentry.models.group import Group
 
 # GroupActionTypes are serialized with the same `type` string as their
 # equivalent Activity so the frontend can consume both identically
@@ -66,6 +70,25 @@ class GroupActionLogEntrySerializerResponse(TypedDict):
     type: str
     data: dict[str, Any]
     dateCreated: datetime
+
+
+def serialize_first_seen_entry(group: "Group") -> GroupActionLogEntrySerializerResponse:
+    """
+    GALE has no FIRST_SEEN action type, so synthesize the entry the same way
+    ActivityManager.get_activities_for_group does.
+    """
+    initial_priority_value = group.get_event_metadata().get("initial_priority")
+    initial_priority = (
+        PriorityLevel(initial_priority_value).to_str() if initial_priority_value else None
+    )
+    return {
+        "id": "0",
+        "user": None,
+        "sentry_app": None,
+        "type": ActivityType.FIRST_SEEN.name.lower(),
+        "data": {"priority": initial_priority},
+        "dateCreated": group.first_seen,
+    }
 
 
 @register(GroupActionLogEntry)

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -221,7 +221,8 @@ class GroupActionLogEntrySerializer(Serializer):
             if key_translations:
                 data = {key_translations.get(key, key): value for key, value in raw_data.items()}
             else:
-                data = raw_data
+                data = dict(raw_data)
+            data.pop("mentions", None)
 
         return {
             "id": str(obj.id),

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -151,6 +151,25 @@ class ActionSource(StrEnum):
     )
 
 
+COMMIT_ACTION_TYPES = {
+    GroupActionType.SET_RESOLVED_IN_COMMIT.value,
+    GroupActionType.REFERENCED_IN_COMMIT.value,
+}
+
+ACTION_TYPES_WITH_COMMIT_DATA = {
+    *COMMIT_ACTION_TYPES,
+    GroupActionType.SET_RESOLVED_IN_RELEASE.value,
+}
+
+PULL_REQUEST_ACTION_TYPES = {
+    GroupActionType.RESOLVED_IN_PULL_REQUEST.value,
+    GroupActionType.PULL_REQUEST_CLOSED.value,
+    GroupActionType.PULL_REQUEST_REOPENED.value,
+    GroupActionType.PULL_REQUEST_MERGED.value,
+    GroupActionType.PULL_REQUEST_UNLINKED.value,
+}
+
+
 class GroupAction(BaseModel, abc.ABC):
     """Typed payload for a group action log entry. Frozen after construction."""
 

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -379,7 +379,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             if features.has(
                 "projects:issue-action-log-write-to-db", group.project, actor=request.user
             ):
-                action_log = GroupActionLogEntry.objects.get_actions_for_group(group, 100)
+                action_log = GroupActionLogEntry.objects.get_actions_for_group(group, 99)
                 if action_log:
                     # swap action log data in under the activity name
                     first_seen_entry = cast(dict[str, Any], serialize_first_seen_entry(group))

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -55,6 +55,7 @@ from sentry.issues.constants import (
 from sentry.issues.derived.features import STATUS, IssueStatus
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.activity import Activity
 from sentry.models.eventattachment import EventAttachment
@@ -373,6 +374,18 @@ class GroupDetailsEndpoint(GroupEndpoint):
                     "count": get_group_global_count(group),
                 }
             )
+
+            if features.has(
+                "projects:issue-action-log-write-to-db", group.project, actor=request.user
+            ):
+                action_log = GroupActionLogEntry.objects.filter(group_id=group.id).first()
+
+                if not action_log:
+                    logger.info(
+                        "group_details.groupactionlogeentry.not_found", extra={"group_id": group.id}
+                    )
+                else:
+                    data.update({"actionLog": serialize(action_log, request.user)})
 
             if "stats" not in collapse:
                 hourly_stats, daily_stats = self.__group_hourly_daily_stats(group, environment_ids)

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -384,7 +384,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
                     # swap action log data in under the activity name
                     first_seen_entry = cast(dict[str, Any], serialize_first_seen_entry(group))
                     data.update(
-                        {"activity": [first_seen_entry, *serialize(action_log, request.user)]}
+                        {"activity": [*serialize(action_log, request.user), first_seen_entry]}
                     )
                 else:
                     logger.info(

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -378,14 +378,14 @@ class GroupDetailsEndpoint(GroupEndpoint):
             if features.has(
                 "projects:issue-action-log-write-to-db", group.project, actor=request.user
             ):
-                action_log = GroupActionLogEntry.objects.filter(group_id=group.id).first()
-
-                if not action_log:
-                    logger.info(
-                        "group_details.groupactionlogeentry.not_found", extra={"group_id": group.id}
-                    )
+                action_log = GroupActionLogEntry.objects.get_actions_for_group(group, 100)
+                if action_log:
+                    # swap action log data in under the activity name
+                    data.update({"activity": serialize(action_log, request.user)})
                 else:
-                    data.update({"actionLog": serialize(action_log, request.user)})
+                    logger.info(
+                        "group_details.groupactionlogentry.not_found", extra={"group_id": group.id}
+                    )
 
             if "stats" not in collapse:
                 hourly_stats, daily_stats = self.__group_hourly_daily_stats(group, environment_ids)

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -27,6 +27,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.helpers.group_index.validators import GroupValidator
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
 from sentry.api.serializers.models.group import BaseGroupSerializerResponse, GroupDetailsResponse
+from sentry.api.serializers.models.groupactionlogentry import serialize_first_seen_entry
 from sentry.apidocs.constants import (
     RESPONSE_ACCEPTED,
     RESPONSE_BAD_REQUEST,
@@ -381,7 +382,10 @@ class GroupDetailsEndpoint(GroupEndpoint):
                 action_log = GroupActionLogEntry.objects.get_actions_for_group(group, 100)
                 if action_log:
                     # swap action log data in under the activity name
-                    data.update({"activity": serialize(action_log, request.user)})
+                    first_seen_entry = cast(dict[str, Any], serialize_first_seen_entry(group))
+                    data.update(
+                        {"activity": [first_seen_entry, *serialize(action_log, request.user)]}
+                    )
                 else:
                     logger.info(
                         "group_details.groupactionlogentry.not_found", extra={"group_id": group.id}

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -25,7 +25,12 @@ if TYPE_CHECKING:
 
 class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
     def get_actions_for_group(self, group: Group, num: int) -> Sequence[GroupActionLogEntry]:
-        return list(self.filter(group_id=group.id).order_by("-date_added")[:num])
+        return list(
+            self.filter(group_id=group.id)
+            # XXX: hard code exclude for now - in the future make this an attribute on GroupAction
+            .exclude(type=GroupActionType.VIEW.value)
+            .order_by("-date_added", "-id")[:num]
+        )
 
 
 class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -23,12 +23,40 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
+# GALE-only action types that have no Activity equivalent. The frontend activity
+# feed only understands Activity-mirrored types, so these are excluded from
+# get_actions_for_group to avoid unknown-activity noise and empty UI rows.
+_ACTIVITY_FEED_EXCLUDED_TYPES = frozenset(
+    t.value
+    for t in (
+        GroupActionType.VIEW,
+        GroupActionType.MERGE_INTO_OTHER,
+        GroupActionType.DELETE,
+        GroupActionType.BOOKMARK,
+        GroupActionType.COMMENT_EDIT,
+        GroupActionType.COMMENT_DELETE,
+        GroupActionType.SUBSCRIBE,
+        GroupActionType.UNSUBSCRIBE,
+        GroupActionType.TRIGGER_AUTOFIX,
+        GroupActionType.CREATE_EXTERNAL_ISSUE,
+        GroupActionType.LINK_EXTERNAL_ISSUE,
+        GroupActionType.UNLINK_EXTERNAL_ISSUE,
+        GroupActionType.CREATE_PLATFORM_EXTERNAL_ISSUE,
+        GroupActionType.LINK_PLATFORM_EXTERNAL_ISSUE,
+        GroupActionType.UNLINK_PLATFORM_EXTERNAL_ISSUE,
+        GroupActionType.AUTOFIX_PR_CREATED,
+        GroupActionType.ROOT_CAUSE_IDENTIFIED,
+        GroupActionType.AUTOFIX_CODING_COMPLETE,
+        GroupActionType.RECONCILE_STATUS,
+    )
+)
+
+
 class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
     def get_actions_for_group(self, group: Group, num: int) -> Sequence[GroupActionLogEntry]:
         return list(
             self.filter(group_id=group.id)
-            # XXX: hard code exclude for now - in the future make this an attribute on GroupAction
-            .exclude(type=GroupActionType.VIEW.value)
+            .exclude(type__in=_ACTIVITY_FEED_EXCLUDED_TYPES)
             .order_by("-date_added", "-id")[:num]
         )
 

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import functools
-from typing import ClassVar
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, ClassVar
 
 from django.db import models
 from django.db.models.functions import Now
@@ -16,6 +18,14 @@ from sentry.db.models import (
 )
 from sentry.db.models.manager.base import BaseManager
 from sentry.issues.action_log.types import GroupAction, GroupActionType, GroupActorType
+
+if TYPE_CHECKING:
+    from sentry.models.group import Group
+
+
+class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
+    def get_actions_for_group(self, group: Group, num: int) -> Sequence[GroupActionLogEntry]:
+        return list(self.filter(group_id=group.id).order_by("-date_added")[:num])
 
 
 class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
@@ -38,6 +48,8 @@ class GroupActionLogEntry(Model):
     objects: ClassVar[GroupActionLogEntryManager] = GroupActionLogEntryManager()
 
     __relocation_scope__ = RelocationScope.Excluded
+
+    objects: ClassVar[GroupActionLogEntryManager] = GroupActionLogEntryManager()
 
     # The id of the Group currently associated with this action.
     group_id = BoundedBigIntegerField()

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -27,6 +27,9 @@ class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
         return self.filter(type__in=GroupAction.get_user_visible_types())
 
     def get_actions_for_group(self, group: Group, num: int) -> Sequence[GroupActionLogEntry]:
+        """
+        Fetch user visible GALE rows for a given group
+        """
         return list(
             self.user_visible().filter(group_id=group.id).order_by("-date_added", "-id")[:num]
         )

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, ClassVar
 
@@ -23,47 +22,14 @@ if TYPE_CHECKING:
     from sentry.models.group import Group
 
 
-# GALE-only action types that have no Activity equivalent. The frontend activity
-# feed only understands Activity-mirrored types, so these are excluded from
-# get_actions_for_group to avoid unknown-activity noise and empty UI rows.
-_ACTIVITY_FEED_EXCLUDED_TYPES = frozenset(
-    t.value
-    for t in (
-        GroupActionType.VIEW,
-        GroupActionType.MERGE_INTO_OTHER,
-        GroupActionType.DELETE,
-        GroupActionType.BOOKMARK,
-        GroupActionType.COMMENT_EDIT,
-        GroupActionType.COMMENT_DELETE,
-        GroupActionType.SUBSCRIBE,
-        GroupActionType.UNSUBSCRIBE,
-        GroupActionType.TRIGGER_AUTOFIX,
-        GroupActionType.CREATE_EXTERNAL_ISSUE,
-        GroupActionType.LINK_EXTERNAL_ISSUE,
-        GroupActionType.UNLINK_EXTERNAL_ISSUE,
-        GroupActionType.CREATE_PLATFORM_EXTERNAL_ISSUE,
-        GroupActionType.LINK_PLATFORM_EXTERNAL_ISSUE,
-        GroupActionType.UNLINK_PLATFORM_EXTERNAL_ISSUE,
-        GroupActionType.AUTOFIX_PR_CREATED,
-        GroupActionType.ROOT_CAUSE_IDENTIFIED,
-        GroupActionType.AUTOFIX_CODING_COMPLETE,
-        GroupActionType.RECONCILE_STATUS,
-    )
-)
-
-
-class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
-    def get_actions_for_group(self, group: Group, num: int) -> Sequence[GroupActionLogEntry]:
-        return list(
-            self.filter(group_id=group.id)
-            .exclude(type__in=_ACTIVITY_FEED_EXCLUDED_TYPES)
-            .order_by("-date_added", "-id")[:num]
-        )
-
-
 class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
     def user_visible(self) -> models.QuerySet[GroupActionLogEntry]:
         return self.filter(type__in=GroupAction.get_user_visible_types())
+
+    def get_actions_for_group(self, group: Group, num: int) -> Sequence[GroupActionLogEntry]:
+        return list(
+            self.user_visible().filter(group_id=group.id).order_by("-date_added", "-id")[:num]
+        )
 
 
 @cell_silo_model
@@ -81,8 +47,6 @@ class GroupActionLogEntry(Model):
     objects: ClassVar[GroupActionLogEntryManager] = GroupActionLogEntryManager()
 
     __relocation_scope__ = RelocationScope.Excluded
-
-    objects: ClassVar[GroupActionLogEntryManager] = GroupActionLogEntryManager()
 
     # The id of the Group currently associated with this action.
     group_id = BoundedBigIntegerField()

--- a/src/sentry/sentry_apps/services/app/impl.py
+++ b/src/sentry/sentry_apps/services/app/impl.py
@@ -132,6 +132,12 @@ class DatabaseBackedAppService(AppService):
             serialize_sentry_app(app=app, avatars=list(app.avatar.all())) for app in sentry_apps
         ]
 
+    def get_sentry_apps_by_ids(self, *, ids: list[int]) -> list[RpcSentryApp]:
+        sentry_apps = SentryApp.objects.filter(id__in=ids).prefetch_related("avatar")
+        return [
+            serialize_sentry_app(app=app, avatars=list(app.avatar.all())) for app in sentry_apps
+        ]
+
     def get_installations_for_organization(
         self, *, organization_id: int
     ) -> list[RpcSentryAppInstallation]:

--- a/src/sentry/sentry_apps/services/app/service.py
+++ b/src/sentry/sentry_apps/services/app/service.py
@@ -94,6 +94,11 @@ class AppService(RpcService):
 
     @rpc_method
     @abc.abstractmethod
+    def get_sentry_apps_by_ids(self, *, ids: list[int]) -> list[RpcSentryApp]:
+        pass
+
+    @rpc_method
+    @abc.abstractmethod
     def get_installation_by_id(self, *, id: int) -> RpcSentryAppInstallation | None:
         pass
 

--- a/src/sentry/utils/action_log/activity_translator.py
+++ b/src/sentry/utils/action_log/activity_translator.py
@@ -124,6 +124,26 @@ ACTIVITY_TYPE_TO_ARG_TRANSLATIONS: Mapping[int, Mapping[str, str]] = {
     },
 }
 
+# GroupActionTypes are serialized with the same `type` string as their
+# equivalent Activity so the frontend can consume both identically
+GROUP_ACTION_TYPE_TO_ACTIVITY_TYPE = {
+    action_cls.get_type().value: activity_type
+    for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
+}
+
+# GALE payloads are stored with the snake_case GroupAction field names, but the
+# frontend consumes the Activity `data` shape. Reverse the camelCase -> snake_case
+# renames that activity_translator applies when mirroring Activities into
+# GroupActions, keyed by GroupActionType value.
+GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS = {
+    action_cls.get_type().value: {
+        gale_key: activity_key
+        for activity_key, gale_key in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS[activity_type].items()
+    }
+    for activity_type, action_cls in ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE.items()
+    if activity_type in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS
+}
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -1,0 +1,169 @@
+from sentry.api.serializers import serialize
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.models.commit import Commit
+from sentry.models.group import GroupStatus
+from sentry.models.pullrequest import PullRequest
+from sentry.testutils.cases import TestCase
+
+
+class GroupActionLogEntrySerializerTestCase(TestCase):
+    def test_pull_request_entry(self) -> None:
+        self.org = self.create_organization(name="Rowdy Tiger")
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(self.project, name="organization-bar")
+        pr = PullRequest.objects.create(
+            organization_id=self.org.id,
+            repository_id=repo.id,
+            key=5,
+            title="aaaa",
+            message="kartoffel",
+        )
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.RESOLVED_IN_PULL_REQUEST,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"pull_request": pr.id},
+        )
+
+        result = serialize([entry], user)[0]["data"]
+        pull_request = result["pullRequest"]
+        assert pull_request["repository"]["name"] == "organization-bar"
+        assert pull_request["message"] == "kartoffel"
+
+    def test_pull_request_closed_entry(self) -> None:
+        self.org = self.create_organization(name="Rowdy Tiger")
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(self.project, name="organization-bar")
+        pr = PullRequest.objects.create(
+            organization_id=self.org.id,
+            repository_id=repo.id,
+            key=5,
+            title="aaaa",
+            message="kartoffel",
+        )
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.PULL_REQUEST_CLOSED,
+            data={"pull_request": pr.id},
+        )
+
+        result = serialize([entry], user)[0]
+        assert result["type"] == "pull_request_closed"
+        pull_request = result["data"]["pullRequest"]
+        assert pull_request["repository"]["name"] == "organization-bar"
+        assert pull_request["message"] == "kartoffel"
+
+    def test_commit_entry(self) -> None:
+        self.org = self.create_organization(name="Rowdy Tiger")
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(self.project, name="organization-bar")
+
+        commit = Commit.objects.create(
+            organization_id=self.org.id, repository_id=repo.id, key="11111111", message="gemuse"
+        )
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SET_RESOLVED_IN_COMMIT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"commit": commit.id},
+        )
+
+        result = serialize([entry], user)[0]["data"]
+        commit_data = result["commit"]
+        assert commit_data["repository"]["name"] == "organization-bar"
+        assert commit_data["message"] == "gemuse"
+
+    def test_referenced_in_commit_entry(self) -> None:
+        self.org = self.create_organization(name="Rowdy Tiger")
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(self.project, name="organization-bar")
+
+        commit = Commit.objects.create(
+            organization_id=self.org.id, repository_id=repo.id, key="11111111", message="gemuse"
+        )
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.REFERENCED_IN_COMMIT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"commit": commit.id},
+        )
+
+        result = serialize([entry], user)[0]
+        assert result["type"] == "referenced_in_commit"
+        commit_data = result["data"]["commit"]
+        assert commit_data["repository"]["name"] == "organization-bar"
+        assert commit_data["message"] == "gemuse"
+
+    def test_serialize_set_resolve_in_commit_entry_with_release(self) -> None:
+        project = self.create_project(name="test_throwaway")
+        group = self.create_group(project)
+        user = self.create_user()
+        release = self.create_release(project=project, user=user)
+        release.save()
+        commit = Commit.objects.filter(releasecommit__release_id=release.id).get()
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SET_RESOLVED_IN_COMMIT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"commit": commit.id},
+        )
+
+        serialized = serialize(entry)
+
+        assert len(serialized["data"]["commit"]["releases"]) == 1
+
+    def test_serialize_set_resolve_in_commit_entry_with_no_releases(self) -> None:
+        self.org = self.create_organization(name="komal-test")
+        project = self.create_project(name="random-proj")
+        user = self.create_user()
+        repo = self.create_repo(self.project, name="idk-repo")
+        group = self.create_group(project)
+
+        commit = Commit.objects.create(organization_id=self.org.id, repository_id=repo.id)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SET_RESOLVED_IN_COMMIT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"commit": commit.id},
+        )
+
+        serialized = serialize(entry)
+
+        assert len(serialized["data"]["commit"]["releases"]) == 0
+        assert not Commit.objects.filter(releasecommit__id=commit.id).exists()
+
+    def test_serialize_set_resolve_in_commit_entry_with_release_not_deployed(self) -> None:
+        project = self.create_project(name="random-test")
+        group = self.create_group(project)
+        user = self.create_user()
+        release = self.create_release(project=project, user=user)
+        release.date_released = None
+        release.save()
+        commit = Commit.objects.filter(releasecommit__release_id=release.id).get()
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SET_RESOLVED_IN_COMMIT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"commit": commit.id},
+        )
+
+        serialized = serialize(entry)
+
+        assert len(serialized["data"]["commit"]["releases"]) == 1

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -6,7 +6,6 @@ from sentry.models.pullrequest import PullRequest
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode
-from sentry.users.models.user import User
 
 
 class GroupActionLogEntrySerializerTestCase(TestCase):
@@ -188,7 +187,6 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
         default_avatar = self.create_sentry_app_avatar(sentry_app=sentry_app)
         upload_avatar = self.create_sentry_app_avatar(sentry_app=sentry_app)
         with assume_test_silo_mode(SiloMode.CONTROL):
-            proxy_user = User.objects.get(id=sentry_app.proxy_user_id)
             upload_avatar.avatar_type = 1  # an upload
             upload_avatar.color = True  # a logo
             upload_avatar.save()
@@ -196,8 +194,8 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
         entry = self.create_group_action_log_entry(
             group=group,
             type=GroupActionType.RESOLVE,
-            actor_type=GroupActorType.USER,
-            actor_id=proxy_user.id,
+            actor_type=GroupActorType.SENTRY_APP,
+            actor_id=sentry_app.id,
         )
 
         result = serialize(entry, user)

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -218,3 +218,88 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
             "color": True,
             "photoType": "logo",
         } in result["sentry_app"]["avatars"]
+
+    def test_archive_entry_translates_keys(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.ARCHIVE,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"ignore_count": 5, "ignore_until_escalating": True},
+        )
+
+        result = serialize(entry, user)
+        assert result["data"] == {"ignoreCount": 5, "ignoreUntilEscalating": True}
+
+    def test_assign_entry_translates_keys(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.ASSIGN,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={
+                "assignee": "1",
+                "assignee_email": "user@example.com",
+                "assignee_type": "user",
+                "rule": "codeowners",
+            },
+        )
+
+        result = serialize(entry, user)
+        assert result["data"] == {
+            "assignee": "1",
+            "assigneeEmail": "user@example.com",
+            "assigneeType": "user",
+            "rule": "codeowners",
+        }
+
+    def test_set_resolved_by_age_entry_translates_keys(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.SET_RESOLVED_BY_AGE,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"auto_resolve_age_threshold": 720},
+        )
+
+        result = serialize(entry, user)
+        assert result["data"] == {"age": 720}
+
+    def test_reprocess_entry_translates_keys(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.REPROCESS,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"event_count": 3, "old_group_id": 10, "new_group_id": 11},
+        )
+
+        result = serialize(entry, user)
+        assert result["data"] == {"eventCount": 3, "oldGroupId": 10, "newGroupId": 11}
+
+    def test_merge_entry_reshapes_issues(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.MERGE_FROM_OTHER,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"counterpart_group_ids": [2, 3]},
+        )
+
+        result = serialize(entry, user)
+        assert result["data"] == {"issues": [{"id": "2"}, {"id": "3"}]}

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -3,7 +3,10 @@ from sentry.issues.action_log.types import GroupActionType, GroupActorType
 from sentry.models.commit import Commit
 from sentry.models.group import GroupStatus
 from sentry.models.pullrequest import PullRequest
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.users.models.user import User
 
 
 class GroupActionLogEntrySerializerTestCase(TestCase):
@@ -167,3 +170,51 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
         serialized = serialize(entry)
 
         assert len(serialized["data"]["commit"]["releases"]) == 1
+
+    def test_sentry_app_entry(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        # regular user with no sentry_app
+        user_entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.RESOLVE,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+        )
+        assert serialize(user_entry, user)["sentry_app"] is None
+
+        sentry_app = self.create_sentry_app(name="test_sentry_app")
+        default_avatar = self.create_sentry_app_avatar(sentry_app=sentry_app)
+        upload_avatar = self.create_sentry_app_avatar(sentry_app=sentry_app)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            proxy_user = User.objects.get(id=sentry_app.proxy_user_id)
+            upload_avatar.avatar_type = 1  # an upload
+            upload_avatar.color = True  # a logo
+            upload_avatar.save()
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.RESOLVE,
+            actor_type=GroupActorType.USER,
+            actor_id=proxy_user.id,
+        )
+
+        result = serialize(entry, user)
+        assert result["sentry_app"]["id"] == str(sentry_app.id)
+        assert result["sentry_app"]["name"] == sentry_app.name
+        assert result["sentry_app"]["slug"] == sentry_app.slug
+        assert {
+            "avatarType": "default",
+            "avatarUuid": default_avatar.ident,
+            "avatarUrl": f"http://testserver/sentry-app-avatar/{default_avatar.ident}/",
+            "color": False,
+            "photoType": "icon",
+        } in result["sentry_app"]["avatars"]
+        assert {
+            "avatarType": "upload",
+            "avatarUuid": upload_avatar.ident,
+            "avatarUrl": f"http://testserver/sentry-app-avatar/{upload_avatar.ident}/",
+            "color": True,
+            "photoType": "logo",
+        } in result["sentry_app"]["avatars"]

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -9,7 +9,12 @@ from sentry import audit_log, buffer, tsdb
 from sentry.analytics.events.issue_viewed import IssueViewedEvent
 from sentry.buffer.redis import RedisBuffer
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
-from sentry.issues.action_log.types import ReconcileStatusAction
+from sentry.issues.action_log import action_context_scope
+from sentry.issues.action_log.types import (
+    ActionSource,
+    GroupActionActor,
+    ReconcileStatusAction,
+)
 from sentry.issues.constants import cache_key_for_issue_view
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
 from sentry.issues.models.groupderiveddata import GroupDerivedData
@@ -98,13 +103,40 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
     @with_feature("projects:issue-action-log-write-to-db")
     def test_group_action_log_entry(self) -> None:
         group = self.create_group()
-        self.create_group_action_log_entry(group=group)
+
+        # activity dual writes to GALE. use action context scope to attribute it to the user rather than system
+        data = {"assignee": str(self.user.id)}
+        with action_context_scope(
+            source=ActionSource.WEB, actor=GroupActionActor.user(self.user.id)
+        ):
+            Activity.objects.create(
+                group=group,
+                project=group.project,
+                type=ActivityType.ASSIGNED.value,
+                user_id=self.user.id,
+                data=data,
+            )
+
         self.login_as(user=self.user)
 
         url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
-        assert response.data["actionLog"]
+        activity = response.data["activity"]
+        assert len(activity) == 1
+        entry = activity[0]
+        assert entry["type"] == "assigned"
+        assert entry["user"]["id"] == str(self.user.id)
+        assert entry["sentry_app"] is None
+        assert entry["data"] == {
+            "assignee": str(self.user.id),
+            "assignee_email": None,
+            "assignee_name": None,
+            "assignee_type": None,
+            "integration": None,
+            "rule": None,
+        }
+        assert entry["dateCreated"] is not None
 
     def test_pending_delete_pending_merge_excluded(self) -> None:
         group1 = self.create_group(status=GroupStatus.PENDING_DELETION)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -123,7 +123,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         activity = response.data["activity"]
-        assert len(activity) == 1
+        assert len(activity) == 2  # first seen + assigned
         entry = activity[0]
         assert entry["type"] == "assigned"
         assert entry["user"]["id"] == str(self.user.id)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -95,6 +95,17 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["firstRelease"] is None
         assert response.data["lastRelease"] is None
 
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_group_action_log_entry(self) -> None:
+        group = self.create_group()
+        self.create_group_action_log_entry(group=group)
+        self.login_as(user=self.user)
+
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        response = self.client.get(url, format="json")
+
+        assert response.data["actionLog"]
+
     def test_pending_delete_pending_merge_excluded(self) -> None:
         group1 = self.create_group(status=GroupStatus.PENDING_DELETION)
         group2 = self.create_group(status=GroupStatus.DELETION_IN_PROGRESS)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -130,9 +130,9 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert entry["sentry_app"] is None
         assert entry["data"] == {
             "assignee": str(self.user.id),
-            "assignee_email": None,
-            "assignee_name": None,
-            "assignee_type": None,
+            "assigneeEmail": None,
+            "assigneeName": None,
+            "assigneeType": None,
             "integration": None,
             "rule": None,
         }


### PR DESCRIPTION
Create a `GroupActionLogEntry` serializer and swap in that data in place of `Activity` data for the `GroupDetailsEndpoint`. This is largely based off of the [Activity serializer](https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/activity.py). 

Future TODOS: Swap GALE data in place of Activity for:
- [ ] `GroupNotesEndpoint`
- [ ] `GroupNotesDetailsEndpoint`
- [ ] `GroupActivitiesEndpoint`