### PR TITLE
feat(issues): Explain Seer root cause starts

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -941,9 +941,12 @@ interface GroupActivityDeletedAttachment extends GroupActivityBase {
   type: GroupActivityType.DELETED_ATTACHMENT;
 }
 
+type SeerRcaStartReason = 'issue_predicted_fixable' | 'night_shift';
+
 interface GroupActivitySeerRcaStarted extends GroupActivityBase {
   data: {
     run_id?: number;
+    start_reason?: SeerRcaStartReason;
   };
   type: GroupActivityType.SEER_RCA_STARTED;
 }

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -448,6 +448,23 @@ export function getCompactGroupActivityItem({
         title: t('Deleted an attachment'),
       };
     case GroupActivityType.SEER_RCA_STARTED:
+      if (activity.user) {
+        return {
+          title: t('Started root cause analysis'),
+        };
+      }
+      if (activity.data.start_reason === 'issue_predicted_fixable') {
+        return {
+          title: t('Root cause analysis started'),
+          details: t('because the issue was predicted to be fixable'),
+        };
+      }
+      if (activity.data.start_reason === 'night_shift') {
+        return {
+          title: t('Root cause analysis started'),
+          details: t('after Night Shift identified the issue'),
+        };
+      }
       return {
         title: t('Root cause analysis started'),
       };

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -811,6 +811,28 @@ export function getGroupActivityItem(
           message: tct('by [author]', {author}),
         };
       case GroupActivityType.SEER_RCA_STARTED:
+        if (activity.user) {
+          return {
+            title: t('Root Cause Analysis'),
+            message: tct('[author] started analyzing the root cause', {author}),
+          };
+        }
+        if (activity.data.start_reason === 'issue_predicted_fixable') {
+          return {
+            title: t('Root Cause Analysis'),
+            message: t(
+              'Seer started analyzing the root cause because this issue was predicted to be fixable'
+            ),
+          };
+        }
+        if (activity.data.start_reason === 'night_shift') {
+          return {
+            title: t('Root Cause Analysis'),
+            message: t(
+              'Seer started analyzing the root cause after Night Shift identified this issue'
+            ),
+          };
+        }
         return {
           title: t('Root Cause Analysis'),
           message: t('Seer started analyzing the root cause'),

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1574,6 +1574,115 @@ describe('ActivitySection', () => {
     expect(screen.getByText('Seer completed root cause analysis')).toBeInTheDocument();
   });
 
+  it('renders the user who started Seer root cause analysis in the compact feed', async () => {
+    const initiatingUser = UserFixture({name: 'Alice Example'});
+    const seerGroup = GroupFixture({
+      id: 'seer-user-start',
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_STARTED,
+          id: 'seer-rca-user-start',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {run_id: 123},
+          user: initiatingUser,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={seerGroup} project={seerGroup.project}>
+        <ActivitySection group={seerGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: [
+            'display-seer-actions-as-issue-activities',
+            'issue-activity-feed-v2',
+          ],
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Started root cause analysis')).toBeInTheDocument();
+    expect(screen.getByTestId('user-activity-actor')).toBeInTheDocument();
+    expect(screen.queryByText(/by Alice Example/)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'issue_predicted_fixable' as const,
+      'Seer started analyzing the root cause because this issue was predicted to be fixable',
+    ],
+    [
+      'night_shift' as const,
+      'Seer started analyzing the root cause after Night Shift identified this issue',
+    ],
+  ])('renders the %s automatic Seer start reason', async (startReason, message) => {
+    const seerGroup = GroupFixture({
+      id: `seer-${startReason}`,
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_STARTED,
+          id: `seer-rca-${startReason}`,
+          dateCreated: '2020-01-01T00:00:00',
+          data: {run_id: 123, start_reason: startReason},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={seerGroup} project={seerGroup.project}>
+        <ActivitySection group={seerGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: ['display-seer-actions-as-issue-activities'],
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Root Cause Analysis')).toBeInTheDocument();
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('renders an automatic Seer start reason in the compact activity feed', async () => {
+    const seerGroup = GroupFixture({
+      id: 'seer-compact-start',
+      activity: [
+        {
+          type: GroupActivityType.SEER_RCA_STARTED,
+          id: 'seer-rca-compact-start',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {run_id: 123, start_reason: 'night_shift'},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={seerGroup} project={seerGroup.project}>
+        <ActivitySection group={seerGroup} />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: [
+            'display-seer-actions-as-issue-activities',
+            'issue-activity-feed-v2',
+          ],
+        }),
+      }
+    );
+
+    expect(await screen.findByText('Root cause analysis started')).toBeInTheDocument();
+    expect(
+      screen.getByText('after Night Shift identified the issue')
+    ).toBeInTheDocument();
+  });
+
   it('hides Seer activity when feature flag is disabled', () => {
     const seerGroup = GroupFixture({
       id: '1343',


### PR DESCRIPTION
Root cause analysis starts in the issue activity feed all looked like generic Seer actions.

User-started runs now show the user's avatar in v2 and name in the legacy activity feed. Automatic starts say whether issue fixability or Night Shift triggered Seer, with the existing generic copy as a fallback.

The v2 user-started row changes from a Seer avatar with `Root cause analysis started by Alice` to Alice's avatar with `Started root cause analysis`.

Pairs with #119990, which adds the user and `start_reason` to the activity JSON.

refs https://linear.app/getsentry/issue/ID-1692