### PR TITLE
ref(workflow_engine): Update results for detectors to use the DetectorEvaluation class

### DIFF
--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -6,8 +6,8 @@ from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.endpoints.validators.error_detector import ErrorDetectorValidator
 from sentry.workflow_engine.handlers.detector.base import DetectorHandler
 from sentry.workflow_engine.models.data_source import DataPacket
+from sentry.workflow_engine.processors import DetectorEvaluation
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorSettings,
 )
@@ -18,7 +18,7 @@ class ErrorDetectorHandler(DetectorHandler[object]):
 
     def evaluate(
         self, data_packet: DataPacket[object]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+    ) -> dict[DetectorGroupKey, DetectorEvaluation]:
         return {}
 
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -30,8 +30,9 @@ from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime
 from sentry.utils.memory import track_memory_usage
 from sentry.workflow_engine.models import DataPacket, Detector
+from sentry.workflow_engine.processors import DetectorEvaluation
 from sentry.workflow_engine.processors.data_packet import process_data_packet
-from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorGroupKey
+from sentry.workflow_engine.types import DetectorGroupKey
 
 logger = logging.getLogger(__name__)
 REDIS_TTL = int(timedelta(days=7).total_seconds())
@@ -173,7 +174,7 @@ class SubscriptionProcessor:
         detector: Detector,
         subscription_update: QuerySubscriptionUpdate,
         aggregation_value: float,
-    ) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]]:
+    ) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluation]]]:
         detector_cfg: MetricIssueDetectorConfig = detector.config
         if detector_cfg["detection_type"] == AlertRuleDetectionType.DYNAMIC.value:
             anomaly_detection_packet = AnomalyDetectionUpdate(

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -20,12 +20,12 @@ from sentry.workflow_engine.handlers.detector.base import (
     GroupedDetectorEvaluationResult,
 )
 from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
 from sentry.workflow_engine.processors.data_condition_group import (
     process_data_condition_group,
 )
+from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorPriorityLevel,
     DetectorSettings,
 )
@@ -233,12 +233,15 @@ class PreprodSizeAnalysisDetectorHandler(
             additional_evidence_data={},
             fingerprint=[uuid4().hex],
         )
-        result = DetectorEvaluationResult(
-            group_key=None,
-            is_triggered=True,
-            priority=priority,
-            event_data=event_data,
+        result = DetectorEvaluation(
             result=occurrence,
+            data=DetectorEvaluationData(
+                group_key=None,
+                trigger_group_evaluation=evaluation,
+                event_data=event_data,
+            ),
+            triggered=True,
+            priority=priority,
         )
         return GroupedDetectorEvaluationResult(result={None: result}, tainted=False)
 

--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -193,7 +193,7 @@ def _detect_for_config(
 
     for _detector, detector_results in results:
         for _group_key, result in detector_results.items():
-            if result.is_triggered:
+            if result.outcome.triggered:
                 _set_detector_triggered(config, project_id)
                 metrics.incr(f"processing_errors.{config.slug}.triggered")
                 error_types = sorted(

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -27,9 +27,8 @@ from sentry.workflow_engine.handlers.detector.stateful import (
     StatefulDetectorHandler,
 )
 from sentry.workflow_engine.models import DataPacket, DetectorState
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorPriorityLevel,
     DetectorSettings,
@@ -177,7 +176,7 @@ class ProcessingErrorDetectorHandler(
         parent's batched state manager approach.
         """
         data_value = self.extract_value(data_packet)
-        results: dict[DetectorGroupKey, DetectorEvaluationResult] = {}
+        results: dict[DetectorGroupKey, DetectorEvaluation] = {}
 
         detector_trigger_evaluations, evaluated_priority = self._evaluation_detector_conditions(
             data_value

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -25,9 +25,8 @@ from sentry.workflow_engine.handlers.detector.stateful import (
     StatefulDetectorHandler,
 )
 from sentry.workflow_engine.models import DataPacket, Detector
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorPriorityLevel,
     DetectorSettings,
@@ -131,7 +130,7 @@ class UptimeDetectorHandler(StatefulDetectorHandler[UptimePacketValue, CheckStat
     @override
     def evaluate(
         self, data_packet: DataPacket[UptimePacketValue]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+    ) -> dict[DetectorGroupKey, DetectorEvaluation]:
         result = super().evaluate(data_packet)
 
         if not result:

--- a/src/sentry/workflow_engine/handlers/detector/base.py
+++ b/src/sentry/workflow_engine/handlers/detector/base.py
@@ -13,9 +13,8 @@ from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.types.actor import Actor
 from sentry.utils import metrics
 from sentry.workflow_engine.models import DataConditionGroup, DataPacket, Detector
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorId,
     DetectorPriorityLevel,
@@ -83,7 +82,7 @@ class DetectorOccurrence:
 
 @dataclass(frozen=True)
 class GroupedDetectorEvaluationResult:
-    result: dict[DetectorGroupKey, DetectorEvaluationResult]
+    result: dict[DetectorGroupKey, DetectorEvaluation]
     tainted: bool
 
 
@@ -98,7 +97,7 @@ class DetectorHandler(abc.ABC, Generic[DataPacketType]):
     @abc.abstractmethod
     def evaluate(
         self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+    ) -> dict[DetectorGroupKey, DetectorEvaluation]:
         pass
 
 
@@ -142,7 +141,7 @@ class BaseDetectorHandler(
 
     def evaluate(
         self, data_packet: DataPacket[DataPacketType]
-    ) -> dict[DetectorGroupKey, DetectorEvaluationResult]:
+    ) -> dict[DetectorGroupKey, DetectorEvaluation]:
         tags = {
             "detector_type": self.detector.type,
             "result": "unknown",

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -25,10 +25,10 @@ from sentry.workflow_engine.handlers.detector.base import (
     GroupedDetectorEvaluationResult,
 )
 from sentry.workflow_engine.models import DataPacket, DataSource, Detector, DetectorState
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
 from sentry.workflow_engine.processors.data_condition_group import process_data_condition_group
+from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorPriorityLevel,
 )
@@ -416,7 +416,7 @@ class StatefulDetectorHandler(
         dedupe_value = self.extract_dedupe_value(data_packet)
         group_data_values = self._extract_value_from_packet(data_packet)
         state = self.state_manager.get_state_data(list(group_data_values.keys()))
-        results: dict[DetectorGroupKey, DetectorEvaluationResult] = {}
+        results: dict[DetectorGroupKey, DetectorEvaluation] = {}
 
         tainted = False
 
@@ -558,7 +558,7 @@ class StatefulDetectorHandler(
         group_evaluation: DataConditionGroupEvaluation,
         data_packet: DataPacket[DataPacketType],
         evaluation_value: DataPacketEvaluationType,
-    ) -> DetectorEvaluationResult:
+    ) -> DetectorEvaluation:
         detector_result: IssueOccurrence | StatusChangeMessage
         event_data: EventData | None = None
 
@@ -593,12 +593,15 @@ class StatefulDetectorHandler(
             event_data.setdefault("received", detector_result.detection_time)
             event_data.setdefault("tags", {})
 
-        return DetectorEvaluationResult(
-            group_key=group_key,
-            is_triggered=new_priority != DetectorPriorityLevel.OK,
-            priority=new_priority,
+        return DetectorEvaluation(
             result=detector_result,
-            event_data=event_data,
+            data=DetectorEvaluationData(
+                group_key=group_key,
+                trigger_group_evaluation=group_evaluation,
+                event_data=event_data,
+            ),
+            triggered=new_priority != DetectorPriorityLevel.OK,
+            priority=new_priority,
         )
 
     def _is_detector_group_value(self, value: Any) -> bool:

--- a/src/sentry/workflow_engine/processors/__init__.py
+++ b/src/sentry/workflow_engine/processors/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "DataConditionEvaluation",
     "DataConditionGroupEvaluation",
+    "DetectorEvaluation",
 ]
 
-from .evaluations import DataConditionEvaluation, DataConditionGroupEvaluation
+from .evaluations import DataConditionEvaluation, DataConditionGroupEvaluation, DetectorEvaluation

--- a/src/sentry/workflow_engine/processors/data_packet.py
+++ b/src/sentry/workflow_engine/processors/data_packet.py
@@ -1,12 +1,13 @@
 from sentry.workflow_engine.models import DataPacket, Detector
+from sentry.workflow_engine.processors import DetectorEvaluation
 from sentry.workflow_engine.processors.data_source import process_data_source
 from sentry.workflow_engine.processors.detector import process_detectors
-from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorGroupKey
+from sentry.workflow_engine.types import DetectorGroupKey
 
 
 def process_data_packet[T](
     data_packet: DataPacket[T], query_type: str
-) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]]:
+) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluation]]]:
     """
     This method ties the two main pre-processing methods together to process
     the incoming data and create issue occurrences.

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -20,8 +20,8 @@ from sentry.workflow_engine.defaults.detectors import (
 )
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.detector_group import DetectorGroup
+from sentry.workflow_engine.processors import DetectorEvaluation
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorId,
     WorkflowEventData,
@@ -195,7 +195,7 @@ def get_preferred_detector(event_data: WorkflowEventData) -> Detector:
         raise
 
 
-def create_issue_platform_payload(result: DetectorEvaluationResult, detector_type: str) -> None:
+def create_issue_platform_payload(result: DetectorEvaluation, detector_type: str) -> None:
     occurrence, status_change = None, None
 
     if isinstance(result.result, IssueOccurrence):
@@ -220,15 +220,15 @@ def create_issue_platform_payload(result: DetectorEvaluationResult, detector_typ
         payload_type=payload_type,
         occurrence=occurrence,
         status_change=status_change,
-        event_data=result.event_data,
+        event_data=result.data["event_data"],
     )
 
 
 @trace
 def process_detectors[T](
     data_packet: DataPacket[T], detectors: list[Detector]
-) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]]:
-    results: list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluationResult]]] = []
+) -> list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluation]]]:
+    results: list[tuple[Detector, dict[DetectorGroupKey, DetectorEvaluation]]] = []
 
     for detector in detectors:
         handler = detector.detector_handler

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -2,9 +2,12 @@ __all__ = [
     "DataConditionEvaluation",
     "DataConditionEvaluationException",
     "DataConditionGroupEvaluation",
+    "DetectorEvaluation",
+    "DetectorEvaluationData",
     "TriggerResult",
 ]
 
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
+from .detector import DetectorEvaluation, DetectorEvaluationData
 from .trigger_result import TriggerResult

--- a/src/sentry/workflow_engine/processors/evaluations/condition_group.py
+++ b/src/sentry/workflow_engine/processors/evaluations/condition_group.py
@@ -31,4 +31,4 @@ class DataConditionGroupEvaluation(BaseWorkflowEngineEvaluation[bool, GroupEvalu
     - outcome: TriggerResult
     """
 
-    data: GroupEvaluationData
+    pass

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -10,7 +10,7 @@ from .condition_group import DataConditionGroupEvaluation
 class DetectorEvaluationData(TypedDict):
     group_key: DetectorGroupKey
     trigger_group_evaluation: DataConditionGroupEvaluation
-    event_data: dict[str, Any] | None
+    event_data: dict[str, Any] | None  # TODO - improve this typing, for now migrating
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -29,10 +29,10 @@ class DetectorEvaluation(
     Inherited properties
     - result: DetectorResult - The information to send to the issue platforms Kafka topic,
         each individual DetectorHandler will determine if they should create a new issue (IssueOccurrence)
-        or if it will send an update to an existing Issue (StatusChangeMessage). May be None when a
-        detector triggers without an accompanying occurrence/status change.
-    - data: DetectorEvaluationData - This data includes the group key, the evaluation of the Detector
-        triggers (DataConditionGroupEvaluation), and the event data that triggered the detector evaluation.
+        or if it will send an update to an existing Issue (StatusChangeMessage). Set to None when the detector
+        is not triggered. By default this is set to None, to signify a detector's not expected to be triggered.
+    - data: DetectorEvaluationData - This data includes the group key (DetectorGroupKey), the evaluation of the Detector
+        triggers (DataConditionGroupEvaluation), and the event data (dict) that triggered the detector evaluation.
     - error: ConditionError - An error during the processing of the conditions in the trigger group.
     - triggered: bool - If there is an event that should trigger the next phase in the system.
     """

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import Any, TypedDict
+
+from sentry.workflow_engine.processors.evaluations import (
+    BaseWorkflowEngineEvaluation,
+    DataConditionGroupEvaluation,
+)
+from sentry.workflow_engine.types import DetectorPriorityLevel, DetectorResult
+
+
+class DetectorEvaluationData(TypedDict):
+    trigger_group_evaluation: DataConditionGroupEvaluation
+    event_data: dict[str, Any] | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class DetectorEvaluation(
+    BaseWorkflowEngineEvaluation[
+        DetectorResult,
+        DetectorEvaluationData,
+    ]
+):
+    """
+    Defines the Evaluation of a Detector.
+
+    Properties
+    - priority: DetectorPriorityLevel - The resulting priority for the detector
+
+    Inherited properties
+    - result: DetectorEvaluationResult - The information to send to the issue platforms Kafka topic,
+        each individual DetectorHandler will determine if they should create a new issue (IssueOccurrence)
+        or if it will send an update to an existing Issue (StatusChangeMessage).
+    - data: DetectorEvaluationData - This data includes the evaluation of the Detector triggers (DataConditionGroupEvaluation),
+        and the event data that triggered the detector evaluation.
+    - error: ConditionError - An error during the processing of the conditions in the trigger group.
+    - triggered: bool - If there is an event that should trigger the next phase in the system.
+    """
+
+    priority: DetectorPriorityLevel

--- a/src/sentry/workflow_engine/processors/evaluations/detector.py
+++ b/src/sentry/workflow_engine/processors/evaluations/detector.py
@@ -1,14 +1,14 @@
 from dataclasses import dataclass
 from typing import Any, TypedDict
 
-from sentry.workflow_engine.processors.evaluations import (
-    BaseWorkflowEngineEvaluation,
-    DataConditionGroupEvaluation,
-)
-from sentry.workflow_engine.types import DetectorPriorityLevel, DetectorResult
+from sentry.workflow_engine.types import DetectorGroupKey, DetectorPriorityLevel, DetectorResult
+
+from .base import BaseWorkflowEngineEvaluation
+from .condition_group import DataConditionGroupEvaluation
 
 
 class DetectorEvaluationData(TypedDict):
+    group_key: DetectorGroupKey
     trigger_group_evaluation: DataConditionGroupEvaluation
     event_data: dict[str, Any] | None
 
@@ -27,13 +27,15 @@ class DetectorEvaluation(
     - priority: DetectorPriorityLevel - The resulting priority for the detector
 
     Inherited properties
-    - result: DetectorEvaluationResult - The information to send to the issue platforms Kafka topic,
+    - result: DetectorResult - The information to send to the issue platforms Kafka topic,
         each individual DetectorHandler will determine if they should create a new issue (IssueOccurrence)
-        or if it will send an update to an existing Issue (StatusChangeMessage).
-    - data: DetectorEvaluationData - This data includes the evaluation of the Detector triggers (DataConditionGroupEvaluation),
-        and the event data that triggered the detector evaluation.
+        or if it will send an update to an existing Issue (StatusChangeMessage). May be None when a
+        detector triggers without an accompanying occurrence/status change.
+    - data: DetectorEvaluationData - This data includes the group key, the evaluation of the Detector
+        triggers (DataConditionGroupEvaluation), and the event data that triggered the detector evaluation.
     - error: ConditionError - An error during the processing of the conditions in the trigger group.
     - triggered: bool - If there is an event that should trigger the next phase in the system.
     """
 
+    result: DetectorResult = None
     priority: DetectorPriorityLevel

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -87,6 +87,10 @@ class ConditionError:
     msg: str
 
 
+DetectorResult: TypeAlias = IssueOccurrence | StatusChangeMessage
+
+
+# TODO - delete this in favor of DetectorEvaluation
 @dataclass(frozen=True)
 class DetectorEvaluationResult:
     # TODO - Should group key live at this level?

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -87,22 +87,7 @@ class ConditionError:
     msg: str
 
 
-DetectorResult: TypeAlias = IssueOccurrence | StatusChangeMessage
-
-
-# TODO - delete this in favor of DetectorEvaluation
-@dataclass(frozen=True)
-class DetectorEvaluationResult:
-    # TODO - Should group key live at this level?
-    group_key: DetectorGroupKey
-    # TODO: Are these actually necessary? We're going to produce the occurrence in the detector, so we probably don't
-    # need to know the other results externally
-    is_triggered: bool
-    priority: DetectorPriorityLevel
-    # TODO: This is only temporarily optional. We should always have a value here if returning a result
-    result: IssueOccurrence | StatusChangeMessage | None = None
-    # Event data to supplement the `IssueOccurrence`, if passed.
-    event_data: dict[str, Any] | None = None
+type DetectorResult = IssueOccurrence | StatusChangeMessage | None
 
 
 class _WorkflowEventLocalCache(TypedDict, total=False):

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -137,8 +137,8 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         data_packet = self.create_subscription_packet(value)
         results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
         evaluation_result = results[0][1][self.detector_group_key]
-        assert evaluation_result.event_data is not None
-        assert evaluation_result.event_data["environment"] == self.environment.name
+        assert evaluation_result.data["event_data"] is not None
+        assert evaluation_result.data["event_data"]["environment"] == self.environment.name
 
     def test_event_data_environment_unset(self) -> None:
         self.snuba_query.environment = None
@@ -147,8 +147,8 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         data_packet = self.create_subscription_packet(value)
         results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
         evaluation_result = results[0][1][self.detector_group_key]
-        assert evaluation_result.event_data is not None
-        assert evaluation_result.event_data["environment"] is None
+        assert evaluation_result.data["event_data"] is not None
+        assert evaluation_result.data["event_data"]["environment"] is None
 
     def test_flipped_detector_trigger(self) -> None:
         self.warning_detector_trigger.delete()

--- a/tests/sentry/incidents/utils/test_metric_issue_base.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_base.py
@@ -14,8 +14,9 @@ from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscrip
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.models import DataPacket
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors import DetectorEvaluation
 from sentry.workflow_engine.processors.data_packet import process_data_packet
-from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
 class BaseMetricIssueTest(TestCase):
@@ -96,5 +97,5 @@ class BaseMetricIssueTest(TestCase):
         if not results:
             # alert did not trigger
             return None
-        evaluation_result: DetectorEvaluationResult = results[0][1][self.detector_group_key]
+        evaluation_result: DetectorEvaluation = results[0][1][self.detector_group_key]
         return evaluation_result.result

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -661,7 +661,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
 
         assert None in result
         occurrence = result[None].result
-        event_data = result[None].event_data
+        event_data = result[None].data["event_data"]
         assert isinstance(occurrence, IssueOccurrence)
         assert event_data is not None
 
@@ -730,7 +730,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
 
         assert None in result
         occurrence = result[None].result
-        event_data = result[None].event_data
+        event_data = result[None].data["event_data"]
         assert isinstance(occurrence, IssueOccurrence)
         assert event_data is not None
 
@@ -773,7 +773,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         result = self._evaluate_with_metadata("install_size", metadata)
 
         assert None in result
-        event_data = result[None].event_data
+        event_data = result[None].data["event_data"]
         assert event_data is not None
 
         assert event_data["tags"]["head.preprod_artifact_id"] == str(head_artifact.id)
@@ -802,7 +802,7 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
 
         assert None in result
         occurrence = result[None].result
-        event_data = result[None].event_data
+        event_data = result[None].data["event_data"]
         assert isinstance(occurrence, IssueOccurrence)
         assert event_data is not None
 

--- a/tests/sentry/processing_errors/test_grouptype.py
+++ b/tests/sentry/processing_errors/test_grouptype.py
@@ -12,7 +12,8 @@ from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.models.detector_state import DetectorState
-from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel
+from sentry.workflow_engine.processors import DetectorEvaluation
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
 class TestSourcemapDetectorHandler(TestCase):
@@ -72,7 +73,7 @@ class TestSourcemapDetectorHandler(TestCase):
 
     def handle_result(
         self, detector: Detector, data_packet: DataPacket[ProcessingErrorPacketValue]
-    ) -> DetectorEvaluationResult | None:
+    ) -> DetectorEvaluation | None:
         handler = SourcemapDetectorHandler(detector)
         evaluation = handler.evaluate(data_packet)
         if None not in evaluation:
@@ -98,8 +99,8 @@ class TestSourcemapDetectorHandler(TestCase):
         assert result.result.issue_title == "Source maps are misconfigured"
         assert result.result.evidence_data["error_types"] == ["js_invalid_source", "js_no_source"]
         assert result.result.evidence_data["sample_event_id"] == "test-event-123"
-        assert result.event_data is not None
-        assert result.event_data["platform"] == "javascript"
+        assert result.data["event_data"] is not None
+        assert result.data["event_data"]["platform"] == "javascript"
 
         state = DetectorState.objects.get(detector=detector)
         assert state.is_triggered is True

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -33,7 +33,8 @@ from sentry.uptime.utils import build_detector_fingerprint_component, build_fing
 from sentry.utils import json
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.models.detector import Detector
-from sentry.workflow_engine.types import DetectorEvaluationResult, DetectorPriorityLevel
+from sentry.workflow_engine.processors import DetectorEvaluation
+from sentry.workflow_engine.types import DetectorPriorityLevel
 
 
 class ResolveUptimeIssueTest(UptimeTestCase):
@@ -130,7 +131,7 @@ class BuildEventDataTest(UptimeTestCase):
 class TestUptimeHandler(UptimeTestCase):
     def handle_result(
         self, detector: Detector, sub: UptimeSubscription, check_result: CheckResult
-    ) -> DetectorEvaluationResult | None:
+    ) -> DetectorEvaluation | None:
         handler = UptimeDetectorHandler(detector)
 
         value = UptimePacketValue(
@@ -165,7 +166,7 @@ class TestUptimeHandler(UptimeTestCase):
         )
         assert evaluation is None
 
-        # Second evaluation produces a DetectorEvaluationResult
+        # Second evaluation produces a DetectorEvaluation
         evaluation = self.handle_result(
             detector,
             uptime_subscription,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -20,9 +20,9 @@ from sentry.workflow_engine.handlers.detector import (
 )
 from sentry.workflow_engine.handlers.detector.base import EventData
 from sentry.workflow_engine.models import DataPacket
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
+from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorPriorityLevel,
     DetectorSettings,
 )
@@ -47,7 +47,21 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
                 self, data_packet: DataPacket[dict[Never, Never]]
             ) -> GroupedDetectorEvaluationResult:
                 return GroupedDetectorEvaluationResult(
-                    result={None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)},
+                    result={
+                        None: DetectorEvaluation(
+                            result=None,
+                            data=DetectorEvaluationData(
+                                group_key=None,
+                                trigger_group_evaluation=DataConditionGroupEvaluation(
+                                    result=True,
+                                    data={"condition_evaluations": [], "logic_type": "any"},
+                                ),
+                                event_data=None,
+                            ),
+                            triggered=True,
+                            priority=DetectorPriorityLevel.HIGH,
+                        )
+                    },
                     tainted=False,
                 )
 

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -17,14 +17,23 @@ from sentry.workflow_engine.handlers.detector import (
 from sentry.workflow_engine.handlers.detector.stateful import DetectorCounters
 from sentry.workflow_engine.models import DataPacket, Detector
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors import DataConditionGroupEvaluation
+from sentry.workflow_engine.processors import DataConditionGroupEvaluation, DetectorEvaluation
+from sentry.workflow_engine.processors.evaluations import DetectorEvaluationData
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorGroupKey,
     DetectorPriorityLevel,
+    DetectorResult,
     DetectorSettings,
 )
 from tests.sentry.issues.test_grouptype import BaseGroupTypeTest
+
+
+def build_mock_group_evaluation() -> DataConditionGroupEvaluation:
+    """A minimal trigger-group evaluation for use in mock detector evaluations."""
+    return DataConditionGroupEvaluation(
+        result=True,
+        data={"condition_evaluations": [], "logic_type": "any"},
+    )
 
 
 def build_mock_occurrence_and_event(
@@ -104,7 +113,18 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
                 self, data_packet: DataPacket[dict[str, Any]]
             ) -> GroupedDetectorEvaluationResult:
                 return GroupedDetectorEvaluationResult(
-                    result={None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)},
+                    result={
+                        None: DetectorEvaluation(
+                            result=None,
+                            data=DetectorEvaluationData(
+                                group_key=None,
+                                trigger_group_evaluation=build_mock_group_evaluation(),
+                                event_data=None,
+                            ),
+                            triggered=True,
+                            priority=DetectorPriorityLevel.HIGH,
+                        )
+                    },
                     tainted=False,
                 )
 
@@ -136,8 +156,15 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
                 return GroupedDetectorEvaluationResult(
                     result={
-                        None: DetectorEvaluationResult(
-                            None, True, DetectorPriorityLevel.HIGH, status_change
+                        None: DetectorEvaluation(
+                            result=status_change,
+                            data=DetectorEvaluationData(
+                                group_key=None,
+                                trigger_group_evaluation=build_mock_group_evaluation(),
+                                event_data=None,
+                            ),
+                            triggered=True,
+                            priority=DetectorPriorityLevel.HIGH,
                         )
                     },
                     tainted=False,
@@ -250,6 +277,27 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
 
         if priority is not None:
             assert state_data.status == priority
+
+    def assert_evaluation(
+        self,
+        evaluation: DetectorEvaluation,
+        *,
+        group_key: DetectorGroupKey,
+        triggered: bool,
+        priority: DetectorPriorityLevel,
+        result: DetectorResult = None,
+        event_data: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Assert the meaningful fields of a DetectorEvaluation. We assert on fields
+        rather than whole-object equality because the evaluation's `data` carries a
+        DataConditionGroupEvaluation that is impractical to reconstruct in tests.
+        """
+        assert evaluation.data["group_key"] == group_key
+        assert evaluation.outcome.triggered is triggered
+        assert evaluation.priority == priority
+        assert evaluation.result == result
+        assert evaluation.data["event_data"] == event_data
 
     def detector_to_issue_occurrence(
         self,

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -34,7 +34,6 @@ from sentry.workflow_engine.processors.detector import (
     process_detectors,
 )
 from sentry.workflow_engine.types import (
-    DetectorEvaluationResult,
     DetectorPriorityLevel,
     WorkflowEventData,
 )
@@ -85,12 +84,16 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         detector = self.create_detector(type=self.handler_type.slug)
         data_packet = self.build_data_packet()
         results = process_detectors(data_packet, [detector])
-        assert results == [
-            (
-                detector,
-                {None: DetectorEvaluationResult(None, True, DetectorPriorityLevel.HIGH)},
-            )
-        ]
+        assert len(results) == 1
+        result_detector, group_results = results[0]
+        assert result_detector == detector
+        assert set(group_results.keys()) == {None}
+        self.assert_evaluation(
+            group_results[None],
+            group_key=None,
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+        )
 
     @mock.patch("sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka")
     def test_state_results(self, mock_produce_occurrence_to_kafka: MagicMock) -> None:
@@ -112,19 +115,18 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
-        result = DetectorEvaluationResult(
-            None,
-            True,
-            DetectorPriorityLevel.HIGH,
-            issue_occurrence,
-            expected_event_data,
+        assert len(results) == 1
+        result_detector, group_results = results[0]
+        assert result_detector == detector
+        assert set(group_results.keys()) == {None}
+        self.assert_evaluation(
+            group_results[None],
+            group_key=None,
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence,
+            event_data=expected_event_data,
         )
-        assert results == [
-            (
-                detector,
-                {result.group_key: result},
-            )
-        ]
         mock_produce_occurrence_to_kafka.assert_called_once_with(
             payload_type=PayloadType.OCCURRENCE,
             occurrence=issue_occurrence,
@@ -152,14 +154,6 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
-        result_1 = DetectorEvaluationResult(
-            "group_1",
-            True,
-            DetectorPriorityLevel.HIGH,
-            issue_occurrence_1,
-            event_data_1,
-        )
-
         assert detector.detector_handler is not None
         detector_occurrence_2, _ = build_mock_occurrence_and_event(
             detector.detector_handler, "group_2", PriorityLevel.HIGH
@@ -174,19 +168,26 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
-        result_2 = DetectorEvaluationResult(
-            "group_2",
-            True,
-            DetectorPriorityLevel.HIGH,
-            issue_occurrence_2,
-            event_data_2,
+        assert len(results) == 1
+        result_detector, group_results = results[0]
+        assert result_detector == detector
+        assert set(group_results.keys()) == {"group_1", "group_2"}
+        self.assert_evaluation(
+            group_results["group_1"],
+            group_key="group_1",
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence_1,
+            event_data=event_data_1,
         )
-        assert results == [
-            (
-                detector,
-                {result_1.group_key: result_1, result_2.group_key: result_2},
-            )
-        ]
+        self.assert_evaluation(
+            group_results["group_2"],
+            group_key="group_2",
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence_2,
+            event_data=event_data_2,
+        )
         mock_produce_occurrence_to_kafka.assert_has_calls(
             [
                 call(
@@ -262,19 +263,18 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
-        result = DetectorEvaluationResult(
+        assert len(results) == 1
+        result_detector, group_results = results[0]
+        assert result_detector == detector
+        assert set(group_results.keys()) == {None}
+        self.assert_evaluation(
+            group_results[None],
             group_key=None,
-            is_triggered=True,
+            triggered=True,
             priority=DetectorPriorityLevel.HIGH,
             result=issue_occurrence,
             event_data=expected_event_data,
         )
-        assert results == [
-            (
-                detector,
-                {result.group_key: result},
-            )
-        ]
         mock_produce_occurrence_to_kafka.assert_called_once_with(
             payload_type=PayloadType.OCCURRENCE,
             occurrence=issue_occurrence,
@@ -309,21 +309,26 @@ class TestProcessDetectors(BaseDetectorHandlerTest):
         build_mock_occurrence_and_event(detector.detector_handler, None, PriorityLevel.HIGH)
 
         data_packet = DataPacket("1", {"dedupe": 3, "group_vals": {None: 0}})
-        result = DetectorEvaluationResult(
-            group_key=None,
-            is_triggered=False,
-            priority=DetectorPriorityLevel.OK,
-            result=StatusChangeMessage(
-                fingerprint=[f"detector:{detector.id}"],
-                project_id=self.project.id,
-                new_status=GroupStatus.RESOLVED,
-                new_substatus=None,
-                id=str(self.mock_uuid4.return_value),
-            ),
-            event_data=None,
+        expected_status_change = StatusChangeMessage(
+            fingerprint=[f"detector:{detector.id}"],
+            project_id=self.project.id,
+            new_status=GroupStatus.RESOLVED,
+            new_substatus=None,
+            id=str(self.mock_uuid4.return_value),
         )
         results = process_detectors(data_packet, [detector])
-        assert results == [(detector, {result.group_key: result})]
+        assert len(results) == 1
+        result_detector, group_results = results[0]
+        assert result_detector == detector
+        assert set(group_results.keys()) == {None}
+        self.assert_evaluation(
+            group_results[None],
+            group_key=None,
+            triggered=False,
+            priority=DetectorPriorityLevel.OK,
+            result=expected_status_change,
+            event_data=None,
+        )
         mock_metrics.incr.assert_has_calls(
             [
                 call(
@@ -558,15 +563,16 @@ class TestEvaluate(BaseDetectorHandlerTest):
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
-        assert handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}})) == {
-            "val1": DetectorEvaluationResult(
-                group_key="val1",
-                is_triggered=True,
-                priority=DetectorPriorityLevel.HIGH,
-                result=issue_occurrence,
-                event_data=event_data,
-            )
-        }
+        result = handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}}))
+        assert set(result.keys()) == {"val1"}
+        self.assert_evaluation(
+            result["val1"],
+            group_key="val1",
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence,
+            event_data=event_data,
+        )
 
         self.assert_updates(
             handler,
@@ -597,29 +603,32 @@ class TestEvaluate(BaseDetectorHandlerTest):
             occurrence_id=str(self.mock_uuid4.return_value),
         )
 
-        assert handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}})) == {
-            "val1": DetectorEvaluationResult(
-                group_key="val1",
-                is_triggered=True,
-                priority=DetectorPriorityLevel.HIGH,
-                result=issue_occurrence,
-                event_data=event_data,
-            )
-        }
+        result = handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 6}}))
+        assert set(result.keys()) == {"val1"}
+        self.assert_evaluation(
+            result["val1"],
+            group_key="val1",
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence,
+            event_data=event_data,
+        )
         assert handler.evaluate(DataPacket("1", {"dedupe": 3, "group_vals": {"val1": 6}})) == {}
-        assert handler.evaluate(DataPacket("1", {"dedupe": 4, "group_vals": {"val1": 0}})) == {
-            "val1": DetectorEvaluationResult(
-                group_key="val1",
-                is_triggered=False,
-                result=StatusChangeMessage(
-                    fingerprint=[f"detector:{handler.detector.id}:val1"],
-                    project_id=self.project.id,
-                    new_status=1,
-                    new_substatus=None,
-                ),
-                priority=DetectorPriorityLevel.OK,
-            )
-        }
+        result = handler.evaluate(DataPacket("1", {"dedupe": 4, "group_vals": {"val1": 0}}))
+        assert set(result.keys()) == {"val1"}
+        self.assert_evaluation(
+            result["val1"],
+            group_key="val1",
+            triggered=False,
+            priority=DetectorPriorityLevel.OK,
+            result=StatusChangeMessage(
+                fingerprint=[f"detector:{handler.detector.id}:val1"],
+                project_id=self.project.id,
+                new_status=1,
+                new_substatus=None,
+            ),
+            event_data=None,
+        )
 
     def test_no_condition_group(self) -> None:
         detector = self.create_detector(type=self.handler_type.slug)
@@ -653,15 +662,15 @@ class TestEvaluate(BaseDetectorHandlerTest):
 
         result = handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 100}}))
 
-        assert result == {
-            "val1": DetectorEvaluationResult(
-                group_key="val1",
-                is_triggered=True,
-                priority=DetectorPriorityLevel.HIGH,
-                result=issue_occurrence,
-                event_data=event_data,
-            )
-        }
+        assert set(result.keys()) == {"val1"}
+        self.assert_evaluation(
+            result["val1"],
+            group_key="val1",
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence,
+            event_data=event_data,
+        )
         self.assert_updates(
             handler,
             "val1",
@@ -694,15 +703,15 @@ class TestEvaluate(BaseDetectorHandlerTest):
 
         result = handler.evaluate(DataPacket("1", {"dedupe": 2, "group_vals": {"val1": 8}}))
 
-        assert result == {
-            "val1": DetectorEvaluationResult(
-                group_key="val1",
-                is_triggered=True,
-                priority=DetectorPriorityLevel.HIGH,
-                result=issue_occurrence,
-                event_data=event_data,
-            )
-        }
+        assert set(result.keys()) == {"val1"}
+        self.assert_evaluation(
+            result["val1"],
+            group_key="val1",
+            triggered=True,
+            priority=DetectorPriorityLevel.HIGH,
+            result=issue_occurrence,
+            event_data=event_data,
+        )
         self.assert_updates(
             handler,
             "val1",
@@ -754,14 +763,6 @@ class TestEvaluateGroupValue(BaseDetectorHandlerTest):
                 occurrence_id=str(self.mock_uuid4.return_value),
             )
 
-            expected_result = DetectorEvaluationResult(
-                "group_key",
-                True,
-                DetectorPriorityLevel.HIGH,
-                result=issue_occurrence,
-                event_data=event_data,
-            )
-
             handler.state_manager.enqueue_state_update(
                 "group_key",
                 False,
@@ -778,7 +779,14 @@ class TestEvaluateGroupValue(BaseDetectorHandlerTest):
             if not result:
                 raise AssertionError("Expected result to not be empty")
 
-            assert result["group_key"] == expected_result
+            self.assert_evaluation(
+                result["group_key"],
+                group_key="group_key",
+                triggered=True,
+                priority=DetectorPriorityLevel.HIGH,
+                result=issue_occurrence,
+                event_data=event_data,
+            )
             assert not mock_metrics.incr.called
 
     def test_dedupe__already_processed(self) -> None:


### PR DESCRIPTION
# Description
Continue the migration for the `Evaluation` classes, now at a leaf node, `DetectorEvaluation` 🎉 

The majority of this PR is adopting the DetectorEvaluation class as a drop in replacement. 