### PR TITLE
fix(detectors): Stop short-circuiting detection on first error

### DIFF
--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -704,7 +704,18 @@ def _detect_performance_problems(
 
     for detector in detectors:
         with start_span(op="function", name=f"run_detector_on_data.{detector.type.value}"):
-            run_detector_on_data(detector, data)
+            try:
+                run_detector_on_data(detector, data)
+            except Exception:
+                logger.exception(
+                    f"Error running issue detector `{detector.__class__.__name__}`",
+                    extra={
+                        "project_id": project.id,
+                        "org_id": organization.id,
+                        "event_id": event_id,
+                        "standalone": standalone,
+                    },
+                )
 
     with start_span(op="function", name="report_metrics_for_detectors"):
         # Metrics reporting only for detection, not created issues.

--- a/tests/sentry/issue_detection/test_performance_detection.py
+++ b/tests/sentry/issue_detection/test_performance_detection.py
@@ -9,6 +9,7 @@ from sentry.issue_detection.base import DetectorType
 from sentry.issue_detection.detectors.n_plus_one_db_span_detector import NPlusOneDBSpanDetector
 from sentry.issue_detection.detectors.utils import total_span_time
 from sentry.issue_detection.performance_detection import (
+    DETECTOR_CLASSES,
     PERFORMANCE_DETECTOR_CONFIG_MAPPINGS,
     SETTINGS_PROJECT_OPTION_KEY,
     SettingsMode,
@@ -17,6 +18,7 @@ from sentry.issue_detection.performance_detection import (
     get_detection_settings,
     reset_performance_settings,
     reset_wfe_detector_configs,
+    run_detector_on_data,
     sync_project_options_to_wfe_detectors,
     update_performance_settings,
 )
@@ -474,6 +476,46 @@ class PerformanceDetectionTest(TestCase):
         # Ensure all other detections are set to false in tags
         pre_checked_keys = ["sdk_name", "is_early_adopter", "browser_name", "uncompressed_assets"]
         assert not any([v for k, v in tags.items() if k not in pre_checked_keys])
+
+    def test_other_detectors_run_even_when_one_errors(self) -> None:
+        n_plus_one_event = get_event("n-plus-one-db/n-plus-one-db-mongodb")
+        sdk_span_mock = MagicMock()
+
+        with (
+            # Make the slow DB detector error out, to check if the other detectors run anyway
+            patch(
+                "sentry.issue_detection.performance_detection.SlowDBQueryDetector.visit_span",
+                side_effect=ValueError,
+            ),
+            patch(
+                "sentry.issue_detection.performance_detection.logger.exception"
+            ) as logger_exception_mock,
+            patch(
+                "sentry.issue_detection.performance_detection.run_detector_on_data",
+                wraps=run_detector_on_data,
+            ) as run_detector_spy,
+        ):
+            _detect_performance_problems(n_plus_one_event, sdk_span_mock, self.project)
+
+            logger_exception_mock.assert_called_with(
+                "Error running issue detector `SlowDBQueryDetector`",
+                extra={
+                    "project_id": self.project.id,
+                    "org_id": self.organization.id,
+                    "event_id": n_plus_one_event["event_id"],
+                    "standalone": False,
+                },
+            )
+
+            num_enabled_detectors = len(
+                [
+                    detector_class
+                    for detector_class in DETECTOR_CLASSES
+                    if detector_class.is_detection_allowed_for_system()
+                ]
+            )
+            # All of the detectors ran, even though the slow DB detector errored out
+            assert run_detector_spy.call_count == num_enabled_detectors
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
During ingest, our performance detectors run inside of the `_detect_performance_problems` function, which is called by the similarly-named public function `detect_performance_problems`, in a setup more or less like this:

```python
def detect_performance_problems(data, ...):
    ...
    ...
    try:
        _detect_performance_problems(data, ...)
    except Exception:
        logger.exception("Failed to detect performance problems")
    ...
    ...

def _detect_performance_problems(data, ...):
    ...
    ...
    for detector in detectors:
        run_detector_on_data(detector, data)
    ...
    ...
```

What that setup means is that if there are, say, a dozen detectors, and the second one errors out, detectors 3-12 won't ever run. A buggy detector therefore potentially prevents us from detecting a whole range of issue types, not just its own.

This fixes that by wrapping the `run_detector_on_data` call in a `try/except`, inside the loop, so that we can capture the error, but don't miss out on running totally unrelated detectors.