### PR TITLE
fix(bitbucket-server): skip get_commits when fromHash is all zeros (new ref push)

### DIFF
--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -100,6 +100,13 @@ class PushEventWebhook(BitbucketServerWebhook):
 
             for change in event["changes"]:
                 from_hash = None if change.get("fromHash") == "0" * 40 else change.get("fromHash")
+                if from_hash is None:
+                    # New ref (tag/branch creation) — fromHash is all zeros, meaning there
+                    # is no prior state to diff against. Fetching with since=None would pull
+                    # the entire repository history, causing unbounded queries and truncated
+                    # JSON responses. Commit tracking for a brand-new ref is also meaningless
+                    # without a previous state, so skip it.
+                    continue
                 try:
                     commits = client.get_commits(
                         project_name, repo_name, from_hash, change.get("toHash")

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -213,6 +213,53 @@ class RefsChangedWebhookTest(WebhookTestBase):
             status_code=400,
         )
 
+    @patch("sentry.integrations.bitbucket_server.client.BitbucketServerClient.get_commits")
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_new_ref_push_skips_get_commits(
+        self, mock_record: MagicMock, mock_get_commits: MagicMock
+    ) -> None:
+        """
+        When fromHash is all zeros (new tag or branch creation), get_commits must NOT be
+        called — passing since=None would fetch the entire repo history and produce a
+        truncated JSON response (JSONDecodeError).
+        """
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration.add_organization(self.organization, default_auth_id=self.identity.id)
+
+        self.create_repository()
+
+        payload = {
+            "changes": [
+                {
+                    "fromHash": "0" * 40,
+                    "toHash": "abcdef1234567890abcdef1234567890abcdef12",
+                    "ref": {
+                        "displayId": "refs/tags/v1.0.0",
+                        "id": "refs/tags/v1.0.0",
+                        "type": "TAG",
+                    },
+                    "refId": "refs/tags/v1.0.0",
+                    "type": "ADD",
+                }
+            ],
+            "repository": {
+                "id": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+                "project": {"key": "my-project"},
+                "slug": "marcos",
+            },
+        }
+
+        self.get_success_response(
+            self.organization.id,
+            self.integration.id,
+            raw_data=orjson.dumps(payload),
+            extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
+            status_code=204,
+        )
+
+        mock_get_commits.assert_not_called()
+        assert_success_metric(mock_record)
+
     @responses.activate
     def test_handle_unreachable_host(self) -> None:
         responses.add(


### PR DESCRIPTION
## Summary

Fixes a `JSONDecodeError` that occurs when Bitbucket Server sends a push webhook for a **new tag or branch** (i.e. a ref creation rather than an update).

Sentry issue: https://sentry.io/organizations/sentry/issues/7541735947/
Triage session: https://claude.ai/code/session_01UUMHgM19WtaGRVtfrfzbY2

## Root Cause

When Bitbucket Server fires a `repo:refs_changed` event for a new ref, `fromHash` is `"0000000000000000000000000000000000000000"` (40 zeros) — a sentinel indicating no prior commit exists. The existing code translates this to `from_hash = None`, then passes it straight to `client.get_commits(..., None, toHash)`.

`get_commits` forwards `since=None` to the Bitbucket Server REST API, which interprets it as **no lower bound** and returns the full repository commit history up to the tag/branch tip. For repos with substantial history this produces a very large response that gets truncated mid-JSON, causing:

```
JSONDecodeError: Expecting ',' delimiter or ']': line 1 column 24282 (char 24281)
```

at `BaseApiResponse.from_response()`.

## What Was Ruled Out

- **Fixing at the JSON layer** — the truncation is a symptom of fetching unbounded data, not a parsing bug.
- **Falling back to `get_last_commits`** — Sentry's commit tracking is meant to associate commits *introduced between two known states*. When there is no prior state (new ref), there is no meaningful diff range to record; storing an arbitrary window of commits from history would be misleading and not actionable for release tracking.

## The Fix

After computing `from_hash`, skip the change entry immediately when `from_hash is None`. This avoids calling `get_commits` with no lower bound and is semantically correct: there are no "introduced commits" to associate with a new ref.

```python
if from_hash is None:
    # New ref (tag/branch creation) — fromHash is all zeros, meaning there
    # is no prior state to diff against. Fetching with since=None would pull
    # the entire repository history, causing unbounded queries and truncated
    # JSON responses. Commit tracking for a brand-new ref is also meaningless
    # without a previous state, so skip it.
    continue
```

## Test Coverage Added

`test_new_ref_push_skips_get_commits` in `tests/sentry/integrations/bitbucket_server/test_webhook.py`:

- Sends a `repo:refs_changed` webhook payload where `fromHash` is 40 zeros (simulating a new tag push).
- Asserts the response is `204` (success, not an error).
- Asserts `get_commits` is **never called**.
- Asserts the success lifecycle metric is recorded.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UUMHgM19WtaGRVtfrfzbY2)_