### PR TITLE
fix(GAL): Add missing action_context_scope to process_commit_context task

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -21,6 +21,7 @@ from sentry.integrations.utils.commit_context import (
     find_commit_context_for_event_all_frames,
     get_or_create_commit_from_blame,
 )
+from sentry.issues.action_log import action_context_scope
 from sentry.issues.auto_source_code_config.code_mapping import get_sorted_code_mapping_configs
 from sentry.locks import locks
 from sentry.models.commit import Commit
@@ -181,18 +182,19 @@ def process_commit_context(
             if installation and isinstance(installation, CommitContextIntegration):
                 installation.queue_pr_comment_task_if_needed(project, commit, group_owner, group_id)
 
-            ProjectOwnership.handle_auto_assignment(
-                project_id=project.id,
-                organization_id=project.organization_id,
-                group=group_owner.group,
-                logging_extra={
-                    "event_id": event_id,
-                    "group_id": group_id,
-                    "project_id": str(project.id),
-                    "organization_id": project.organization_id,
-                    "source": "process_commit_context",
-                },
-            )
+            with action_context_scope(source="process_commit_context"):
+                ProjectOwnership.handle_auto_assignment(
+                    project_id=project.id,
+                    organization_id=project.organization_id,
+                    group=group_owner.group,
+                    logging_extra={
+                        "event_id": event_id,
+                        "group_id": group_id,
+                        "project_id": str(project.id),
+                        "organization_id": project.organization_id,
+                        "source": "process_commit_context",
+                    },
+                )
             metrics.incr(
                 "sentry.tasks.process_commit_context.success",
                 tags={

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -22,9 +22,11 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.integrations.source_code_management.metrics import CommitContextHaltReason
 from sentry.integrations.types import EventLifecycleOutcome
+from sentry.issues.action_log import get_action_context
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.groupowner import GroupOwner, GroupOwnerType, SuspectCommitStrategy
+from sentry.models.projectownership import ProjectOwnership
 from sentry.models.pullrequest import (
     CommentType,
     PullRequest,
@@ -1146,6 +1148,52 @@ class TestCommitContextAllFrames(TestCommitContextIntegration):
                 selected_code_mapping_id=self.code_mapping.id,
             ),
         )
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_commit_context_all_frames",
+    )
+    def test_handle_auto_assignment_called_within_action_context_scope(
+        self, mock_get_commit_context: MagicMock
+    ) -> None:
+        """
+        Regression test for Sentry event 2a0880f3db5b47eb94407422f4166af1.
+
+        process_commit_context must set action_context_scope before calling
+        handle_auto_assignment. Without it, any Activity created inside the
+        assignment stack calls publish_action_from_context with a None context,
+        which logs an error ("publish_action_from_context called without ActionContext").
+        """
+        mock_get_commit_context.return_value = [self.blame_existing_commit]
+
+        captured_contexts: list = []
+        mock_handle = MagicMock(side_effect=lambda *a, **kw: captured_contexts.append(get_action_context()))
+
+        existing_commit = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.commit_author,
+            key="existing-commit",
+        )
+        existing_commit.update(message="")
+
+        with patch.object(ProjectOwnership, "handle_auto_assignment", mock_handle):
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+
+        assert mock_handle.called, "handle_auto_assignment was not called"
+        assert len(captured_contexts) == 1
+        ctx = captured_contexts[0]
+        assert ctx is not None, (
+            "action_context_scope was not set when handle_auto_assignment was called; "
+            "this would cause 'publish_action_from_context called without ActionContext' errors"
+        )
+        assert ctx.source == "process_commit_context"
 
 
 @patch(


### PR DESCRIPTION
## Summary

Fixes a recurring Sentry error (event ID `2a0880f3db5b47eb94407422f4166af1`) where `publish_action_from_context` was called without an `ActionContext` from within the `process_commit_context` Celery task.

- Wraps the `ProjectOwnership.handle_auto_assignment(...)` call in `process_commit_context` with `action_context_scope(source="process_commit_context")`
- Adds a regression test that asserts `get_action_context()` is non-None (with source `"process_commit_context"`) when `handle_auto_assignment` is called from this task

## Root Cause Analysis

**Call chain that produced the error:**

1. `sentry/tasks/commit_context.py` — `process_commit_context` task runs in a Celery worker
2. → calls `ProjectOwnership.handle_auto_assignment(...)` (no `ActionContext` in scope at this point)
3. → `handle_auto_assignment` identifies a suspect-committer owner and calls `GroupAssignee.objects.assign(...)`
4. → `assign` calls `Activity.objects.create_group_activity(...)` which calls `ActivityManager.create()`
5. → `ActivityManager.create()` calls `publish_action_from_context(group_action, ...)`
6. → `publish_action_from_context` reads `_action_context` ContextVar, finds `None`, and logs:
   ```
   publish_action_from_context called without ActionContext
   ```

The ContextVar `_action_context` is set to `None` by default and is only populated when code runs inside an `action_context_scope()` context manager. Celery task bodies run outside any request boundary, so no scope is ever established unless the task itself sets one.

## Why This Fix

Wrapping the `handle_auto_assignment(...)` call at the task entry point ensures the ContextVar is set before any code deeper in the assignment stack calls `publish_action_from_context`. The source string `"process_commit_context"` gives correct attribution for action log entries produced by this code path.

## What Was Ruled Out

- **Catching the error / skipping publish**: The error path in `publish_action_from_context` already falls back to `ActionSource.UNKNOWN`; silencing it further would mask the missing attribution and lose observability. The fix must address the root cause.
- **Adding a guard in `ActivityManager.create`**: That would suppress the error globally rather than fixing each missing call site; other callers would continue to produce mis-attributed entries.
- **Fixing it inside `handle_auto_assignment`**: `handle_auto_assignment` already wraps `GroupAssignee.objects.assign` with an inner `action_context_scope(source=ActionSource.SYSTEM)`. Adding the outer scope at the task level provides correct task-level source attribution and defence-in-depth for any code paths that run before the inner scope is entered.

## Session & Event Links

- Claude session: https://claude.ai/code/session_01MS4vDWU3fZeJKTX6XkB7cs
- Sentry event ID: `2a0880f3db5b47eb94407422f4166af1`
- Logger: `sentry.issues.action_log.publish`
- Culprit: `sentry.tasks.process_commit_context`
- Release: `backend@8d436700aa542ff3cbbdda29c2ffdddf7c64da37`

## Test Plan

- [ ] New regression test `test_handle_auto_assignment_called_within_action_context_scope` in `tests/sentry/tasks/test_commit_context.py` verifies that `get_action_context()` is non-None with `source="process_commit_context"` when `handle_auto_assignment` is called from within `process_commit_context`
- [ ] Existing `TestCommitContextAllFrames` tests continue to pass (no behaviour change, only context establishment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MS4vDWU3fZeJKTX6XkB7cs

---
_Generated by [Claude Code](https://claude.ai/code/session_01MS4vDWU3fZeJKTX6XkB7cs)_