### PR TITLE
ref(workflow_engine): Refactor the `WorkflowEvaluation` class to use `BaseWorkflowEngineEvaluation`

### DIFF
--- a/src/sentry/workflow_engine/models/workflow.py
+++ b/src/sentry/workflow_engine/models/workflow.py
@@ -19,7 +19,7 @@ from sentry.workflow_engine.models.data_condition_group import (
     DataConditionGroup,
     DataConditionGroupSnapshot,
 )
-from sentry.workflow_engine.processors.evaluations import TriggerResult
+from sentry.workflow_engine.processors.evaluations import DataConditionGroupEvaluation
 from sentry.workflow_engine.types import ConditionError, WorkflowEventData
 
 from .json_config import JSONConfigBase
@@ -129,9 +129,9 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         event_data: WorkflowEventData,
         when_data_conditions: list[DataCondition] | None = None,
         group: DataConditionGroup | None = None,
-    ) -> tuple[TriggerResult, list[DataCondition]]:
+    ) -> tuple[DataConditionGroupEvaluation, list[DataCondition]]:
         """
-        Evaluate the conditions for the workflow trigger and return if the evaluation was successful.
+        Evaluate the conditions for the workflow trigger and return the group evaluation.
         If there aren't any workflow trigger conditions, the workflow is considered triggered.
         """
         # TODO - investigate circular import issue
@@ -140,7 +140,17 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         )
 
         if self.when_condition_group_id is None:
-            return TriggerResult.TRUE, []
+            return (
+                DataConditionGroupEvaluation(
+                    result=True,
+                    triggered=True,
+                    data={
+                        "condition_evaluations": [],
+                        "logic_type": DataConditionGroup.Type.ANY,
+                    },
+                ),
+                [],
+            )
 
         workflow_event_data = replace(event_data, workflow_env=self.environment)
 
@@ -157,7 +167,15 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
                     extra={"id": self.when_condition_group_id},
                 )
                 return (
-                    TriggerResult(False, ConditionError(msg="DataConditionGroup does not exist")),
+                    DataConditionGroupEvaluation(
+                        result=False,
+                        triggered=False,
+                        data={
+                            "condition_evaluations": [],
+                            "logic_type": DataConditionGroup.Type.ANY,
+                        },
+                        error=ConditionError(msg="DataConditionGroup does not exist"),
+                    ),
                     [],
                 )
         else:
@@ -168,7 +186,7 @@ class Workflow(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         group_evaluation, remaining_conditions = process_data_condition_group(
             group, workflow_event_data, when_data_conditions
         )
-        return group_evaluation.outcome, remaining_conditions
+        return group_evaluation, remaining_conditions
 
 
 def get_slow_conditions(workflow: Workflow) -> list[DataCondition]:

--- a/src/sentry/workflow_engine/processors/evaluations/__init__.py
+++ b/src/sentry/workflow_engine/processors/evaluations/__init__.py
@@ -4,10 +4,18 @@ __all__ = [
     "DataConditionGroupEvaluation",
     "DetectorEvaluation",
     "DetectorEvaluationData",
+    "GroupedWorkflowEvaluationResult",
     "TriggerResult",
+    "WorkflowEvaluation",
+    "WorkflowEvaluationData",
 ]
 
 from .condition import DataConditionEvaluation, DataConditionEvaluationException
 from .condition_group import DataConditionGroupEvaluation
 from .detector import DetectorEvaluation, DetectorEvaluationData
 from .trigger_result import TriggerResult
+from .workflow import (
+    GroupedWorkflowEvaluationResult,
+    WorkflowEvaluation,
+    WorkflowEvaluationData,
+)

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -1,0 +1,41 @@
+from typing import Sequence, TypedDict
+
+from sentry.workflow_engine.processors.evaluations import (
+    BaseWorkflowEngineEvaluation,
+    DataConditionGroupEvaluation,
+)
+from sentry.workflow_engine.types import WorkflowEvaluationResult, WorkflowEventData
+
+
+class WorkflowEvaluationData(TypedDict):
+    """
+    Track all of the data that went into evaluating the workflow.
+
+    # TODO - Should this also include the DetectorWorkflow information?
+
+    `trigger_group_eval`: The evaluation of the conditions for triggering a workflow.
+    `filter_group_evals`: All of the condition groups that determine if an action should be triggered.
+    `event`: The data that started the workflow's evaluation.
+    """
+
+    trigger_group_eval: DataConditionGroupEvaluation
+    filter_group_evals: Sequence[DataConditionGroupEvaluation]
+    event: WorkflowEventData
+
+
+class WorkflowEvaluation(
+    BaseWorkflowEngineEvaluation[
+        WorkflowEvaluationResult,
+        WorkflowEvaluationData,
+    ]
+):
+    """
+    Stores the evaluation of a workflow.
+
+    Inherited Properties
+    - `result`: The actions that are triggered from the workflow, or if there
+        are deferred conditions to batch evaluate.
+    - `data`: WorkflowEvaluationData
+    """
+
+    pass

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -182,7 +182,7 @@ class GroupedWorkflowEvaluationResult:
         log_str = "workflow_engine.process_workflows.evaluation"
 
         if self.tainted:
-            if self.triggered_workflows is None:
+            if not self.triggered_workflows:
                 log_str = f"{log_str}.workflows.not_triggered"
             else:
                 log_str = f"{log_str}.workflows.triggered"

--- a/src/sentry/workflow_engine/processors/evaluations/workflow.py
+++ b/src/sentry/workflow_engine/processors/evaluations/workflow.py
@@ -1,15 +1,37 @@
-from typing import Sequence, TypedDict
+from __future__ import annotations
 
-from sentry.workflow_engine.processors.evaluations import (
-    BaseWorkflowEngineEvaluation,
-    DataConditionGroupEvaluation,
-)
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
+
+from sentry_sdk import logger as sentry_logger
+
+from sentry import features, options
 from sentry.workflow_engine.types import WorkflowEvaluationResult, WorkflowEventData
+
+from .base import BaseWorkflowEngineEvaluation
+from .condition_group import DataConditionGroupEvaluation
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from sentry.models.activity import Activity
+    from sentry.models.group import Group
+    from sentry.models.organization import Organization
+    from sentry.services.eventstore.models import GroupEvent
+    from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowItem
+    from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
+    from sentry.workflow_engine.models.action import ActionSnapshot
+    from sentry.workflow_engine.models.data_condition_group import DataConditionGroupSnapshot
+    from sentry.workflow_engine.models.detector import DetectorSnapshot
+    from sentry.workflow_engine.models.workflow import WorkflowSnapshot
+    from sentry.workflow_engine.types import WorkflowId
 
 
 class WorkflowEvaluationData(TypedDict):
     """
-    Track all of the data that went into evaluating the workflow.
+    Track all of the data that went into evaluating a single workflow.
 
     # TODO - Should this also include the DetectorWorkflow information?
 
@@ -23,6 +45,7 @@ class WorkflowEvaluationData(TypedDict):
     event: WorkflowEventData
 
 
+@dataclass(frozen=True, kw_only=True)
 class WorkflowEvaluation(
     BaseWorkflowEngineEvaluation[
         WorkflowEvaluationResult,
@@ -30,12 +53,166 @@ class WorkflowEvaluation(
     ]
 ):
     """
-    Stores the evaluation of a workflow.
+    Stores the evaluation of a single workflow.
 
     Inherited Properties
-    - `result`: The actions that are triggered from the workflow, or if there
-        are deferred conditions to batch evaluate.
+    - `result`: The actions that are triggered from the workflow, or the "deferred"
+        sentinel when there are slow conditions to batch evaluate.
     - `data`: WorkflowEvaluationData
+    - `error`: ConditionError - Set when there's an error while evaluating the workflow.
+    - `triggered`: bool - Whether the workflow's trigger (WHEN) conditions passed.
     """
 
     pass
+
+
+class WorkflowEvaluationSnapshot(TypedDict):
+    """
+    A snapshot of data used to evaluate workflows for an event.
+    Ensure that this size is kept smaller, since it's used in logging.
+    """
+
+    associated_detector: DetectorSnapshot | None
+    event_id: str | None  # ID in NodeStore
+    group: Group | None
+    workflow_ids: list[int] | None
+    triggered_workflows: list[WorkflowSnapshot] | None
+    delayed_conditions: list[str] | None
+    action_filter_conditions: list[DataConditionGroupSnapshot] | None
+    triggered_actions: list[ActionSnapshot] | None
+
+
+@dataclass(frozen=True, kw_only=True)
+class GroupedWorkflowEvaluationResult:
+    """
+    The result of `process_workflows` for a single event: the per-workflow
+    `WorkflowEvaluation` objects plus the batch-level context needed for logging
+    and to drive downstream side effects (service hooks).
+
+    Mirrors `GroupedDetectorEvaluationResult` from the detector path.
+
+    The `tainted` flag indicates whether actions have been triggered during the
+    workflows evaluation (`False` only once actions fire, `True` for every early exit).
+
+    The `msg` field is used for debug information during the evaluation.
+    """
+
+    # Per-workflow evaluations, keyed by workflow id. Empty for sentinel early-returns.
+    result: dict[WorkflowId, WorkflowEvaluation]
+    tainted: bool
+
+    # Batch-level context used by log_to / get_snapshot / consumers.
+    organization: Organization
+    event: GroupEvent | Activity
+    group: Group | None = None
+    msg: str | None = None
+    associated_detector: Detector | None = None
+    workflows: set[Workflow] | None = None
+    triggered_workflows: set[Workflow] | None = None
+    action_groups: set[DataConditionGroup] | None = None
+    triggered_actions: set[Action] | None = None
+    delayed_conditions: dict[Workflow, DelayedWorkflowItem] | None = None
+
+    def get_snapshot(self) -> WorkflowEvaluationSnapshot:
+        """
+        This method will take the complex data structures, like models / list of models,
+        and turn them into the critical attributes of a model or lists of IDs.
+        """
+
+        associated_detector = None
+        if self.associated_detector:
+            associated_detector = self.associated_detector.get_snapshot()
+
+        workflow_ids = None
+        if self.workflows:
+            workflow_ids = [workflow.id for workflow in self.workflows]
+
+        triggered_workflows = None
+        if self.triggered_workflows:
+            triggered_workflows = [workflow.get_snapshot() for workflow in self.triggered_workflows]
+
+        action_filter_conditions = None
+        if self.action_groups:
+            action_filter_conditions = [group.get_snapshot() for group in self.action_groups]
+
+        triggered_actions = None
+        if self.triggered_actions:
+            triggered_actions = [action.get_snapshot() for action in self.triggered_actions]
+
+        event_id = None
+        if hasattr(self.event, "event_id"):
+            event_id = str(self.event.event_id)
+
+        delayed_conditions = None
+        if self.delayed_conditions:
+            delayed_conditions = [
+                delayed_item.buffer_key() for _, delayed_item in self.delayed_conditions.items()
+            ]
+
+        return {
+            "associated_detector": associated_detector,
+            "event_id": event_id,
+            "group": self.event.group,
+            "workflow_ids": workflow_ids,
+            "triggered_workflows": triggered_workflows,
+            "delayed_conditions": delayed_conditions,
+            "action_filter_conditions": action_filter_conditions,
+            "triggered_actions": triggered_actions,
+        }
+
+    def log_to(self, logger: Logger) -> bool:
+        """
+        Logs workflow evaluation data.
+        Logging may be skipped if the organization isn't opted in and logs are being
+        sampled.
+        Returns True if logged, False otherwise.
+        """
+        # Check if we should log this evaluation
+        organization = self.organization
+        should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
+        direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
+
+        if not should_log:
+            sample_rate = options.get("workflow_engine.evaluation_log_sample_rate")
+            should_log = random.random() < sample_rate
+
+        if not should_log:
+            return False
+
+        log_str = "workflow_engine.process_workflows.evaluation"
+
+        if self.tainted:
+            if self.triggered_workflows is None:
+                log_str = f"{log_str}.workflows.not_triggered"
+            else:
+                log_str = f"{log_str}.workflows.triggered"
+        else:
+            log_str = f"{log_str}.actions.triggered"
+
+        data_snapshot = self.get_snapshot()
+        detection_type = (
+            data_snapshot["associated_detector"]["type"]
+            if data_snapshot["associated_detector"]
+            else None
+        )
+        group_id = data_snapshot["group"].id if data_snapshot["group"] else None
+        triggered_workflows = data_snapshot["triggered_workflows"] or []
+        action_filter_conditions = data_snapshot["action_filter_conditions"] or []
+        triggered_actions = data_snapshot["triggered_actions"] or []
+        extra = {
+            "event_id": data_snapshot["event_id"],
+            "group_id": group_id,
+            "detection_type": detection_type,
+            "workflow_ids": data_snapshot["workflow_ids"],
+            "triggered_workflow_ids": [w["id"] for w in triggered_workflows],
+            "delayed_conditions": data_snapshot["delayed_conditions"],
+            "action_filter_group_ids": [afg["id"] for afg in action_filter_conditions],
+            "triggered_action_ids": [a["id"] for a in triggered_actions],
+            "debug_msg": self.msg,
+        }
+
+        if direct_to_sentry:
+            sentry_logger.info(log_str, attributes=extra)
+        else:
+            logger.info(log_str, extra=extra)
+        return True

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -15,7 +15,7 @@ from sentry.utils.tracing import trace
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient, DelayedWorkflowItem
 from sentry.workflow_engine.caches.action_filters import get_action_filters_by_workflows
 from sentry.workflow_engine.caches.workflow import get_workflows_by_detectors
-from sentry.workflow_engine.models import DataConditionGroup, Detector, Workflow
+from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
 from sentry.workflow_engine.models.data_condition import DataCondition
 from sentry.workflow_engine.processors.contexts.workflow_event_context import (
     WorkflowEventContext,
@@ -26,11 +26,17 @@ from sentry.workflow_engine.processors.data_condition_group import (
     process_data_condition_group,
 )
 from sentry.workflow_engine.processors.detector import get_detectors_for_event_data
-from sentry.workflow_engine.processors.evaluations import TriggerResult
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    TriggerResult,
+)
+from sentry.workflow_engine.processors.evaluations.workflow import (
+    GroupedWorkflowEvaluationResult,
+    WorkflowEvaluation,
+)
 from sentry.workflow_engine.processors.workflow_fire_history import create_workflow_fire_histories
 from sentry.workflow_engine.types import (
-    WorkflowEvaluation,
-    WorkflowEvaluationData,
+    WorkflowEvaluationResult,
     WorkflowEventData,
     WorkflowId,
 )
@@ -139,17 +145,25 @@ def evaluate_workflow_triggers(
     workflows: set[Workflow],
     event_data: WorkflowEventData,
     event_start_time: datetime,
-) -> tuple[dict[Workflow, TriggerResult], dict[Workflow, DelayedWorkflowItem], EvaluationStats]:
+) -> tuple[
+    dict[Workflow, TriggerResult],
+    dict[Workflow, DelayedWorkflowItem],
+    EvaluationStats,
+    dict[Workflow, DataConditionGroupEvaluation],
+]:
     """
-    Returns a tuple of (triggered_workflows, queue_items_by_workflow, stats)
+    Returns a tuple of (triggered_workflows, queue_items_by_workflow, stats, trigger_evals)
     - triggered_workflows: mapping of workflows that triggered to their evaluation result
     - queue_items_by_workflow: mapping of workflow to the delayed workflow item, used
       in the next step (evaluate action filters) to enqueue workflows with slow conditions
       within that function
     - stats: tainted/untainted counts for workflows that didn't trigger (fully evaluated)
+    - trigger_evals: the trigger (WHEN) group evaluation for every evaluated workflow,
+      including those enqueued for slow evaluation
     """
     triggered_workflows: dict[Workflow, TriggerResult] = {}
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem] = {}
+    trigger_evals: dict[Workflow, DataConditionGroupEvaluation] = {}
 
     dcg_ids = [
         workflow.when_condition_group_id
@@ -175,6 +189,7 @@ def evaluate_workflow_triggers(
         evaluation, remaining_conditions = workflow.evaluate_trigger_conditions(
             event_data, when_data_conditions, when_condition_group
         )
+        trigger_evals[workflow] = evaluation
 
         if remaining_conditions:
             if isinstance(event_data.event, GroupEvent):
@@ -198,10 +213,10 @@ def evaluate_workflow_triggers(
                     },
                 )
         else:
-            if evaluation.triggered:
-                triggered_workflows[workflow] = evaluation
+            if evaluation.outcome.triggered:
+                triggered_workflows[workflow] = evaluation.outcome
             else:
-                if evaluation.is_tainted():
+                if evaluation.outcome.is_tainted():
                     tainted_untriggered += 1
                 else:
                     untainted_untriggered += 1
@@ -215,7 +230,7 @@ def evaluate_workflow_triggers(
         try:
             environment = get_environment_by_event(event_data)
         except Environment.DoesNotExist:
-            return {}, {}, stats
+            return {}, {}, stats, {}
 
     event_id = (
         event_data.event.event_id
@@ -234,7 +249,7 @@ def evaluate_workflow_triggers(
         },
     )
 
-    return triggered_workflows, queue_items_by_workflow, stats
+    return triggered_workflows, queue_items_by_workflow, stats, trigger_evals
 
 
 @trace
@@ -244,13 +259,19 @@ def evaluate_workflows_action_filters(
     event_data: WorkflowEventData,
     queue_items_by_workflow: dict[Workflow, DelayedWorkflowItem],
     event_start_time: datetime,
-) -> tuple[set[DataConditionGroup], dict[Workflow, DelayedWorkflowItem], EvaluationStats]:
+) -> tuple[
+    set[DataConditionGroup],
+    dict[Workflow, DelayedWorkflowItem],
+    EvaluationStats,
+    dict[Workflow, list[DataConditionGroupEvaluation]],
+]:
     """
     Evaluate the action filters for the given workflows.
-    Returns a tuple of (filtered_action_groups, queue_items_by_workflow, stats)
+    Returns a tuple of (filtered_action_groups, queue_items_by_workflow, stats, filter_evals)
     - filtered_action_groups: set of DataConditionGroups that were evaluated to True
     - queue_items_by_workflow: updated with workflows that have slow conditions
     - stats: tainted/untainted counts for fully-evaluated workflows
+    - filter_evals: the action-filter (IF) group evaluations per workflow
     """
     # Collect all workflows, including those with pending slow condition results (queue_items_by_workflow)
     # to evaluate all fast conditions
@@ -287,6 +308,7 @@ def evaluate_workflows_action_filters(
     workflow_to_result: dict[int, TriggerResult] = {
         wf.id: result for wf, result in triggered_workflows.items()
     }
+    filter_evals_by_workflow: dict[Workflow, list[DataConditionGroupEvaluation]] = defaultdict(list)
     for action_condition_group, workflow in action_conditions_to_workflow.items():
         env = env_by_id.get(workflow.environment_id) if workflow.environment_id else None
         workflow_event_data = replace(event_data, workflow_env=env)
@@ -295,6 +317,7 @@ def evaluate_workflows_action_filters(
             workflow_event_data,
             data_conditions_by_dcg_id.get(action_condition_group.id),
         )
+        filter_evals_by_workflow[workflow].append(group_evaluation)
 
         if slow_conditions:
             # If there are remaining conditions for the action filter to evaluate,
@@ -369,7 +392,7 @@ def evaluate_workflows_action_filters(
         },
     )
 
-    return filtered_action_groups, queue_items_by_workflow, stats
+    return filtered_action_groups, queue_items_by_workflow, stats, filter_evals_by_workflow
 
 
 def get_environment_by_event(event_data: WorkflowEventData) -> Environment | None:
@@ -415,13 +438,57 @@ def _get_associated_workflows(
     )
 
 
+def _build_workflow_evaluations(
+    *,
+    event_data: WorkflowEventData,
+    trigger_evals: dict[Workflow, DataConditionGroupEvaluation],
+    filter_evals: dict[Workflow, list[DataConditionGroupEvaluation]],
+    deferred_workflow_ids: set[WorkflowId],
+    actions: Iterable[Action],
+    action_to_workflow_id: dict[int, WorkflowId],
+) -> dict[WorkflowId, WorkflowEvaluation]:
+    """
+    Build a per-workflow WorkflowEvaluation for every evaluated workflow, capturing its
+    trigger (WHEN) evaluation, action-filter (IF) evaluations, and resulting actions.
+
+    `result` is the "deferred" sentinel for workflows enqueued for slow evaluation, otherwise
+    the actions that fired for that workflow (empty when the workflow triggered but no actions
+    fired). `action_to_workflow_id` attributes each action to a single workflow, so an action
+    shared across workflows is counted once here; the batch-level triggered_actions holds the
+    complete set.
+    """
+    actions_by_workflow_id: dict[WorkflowId, list[Action]] = defaultdict(list)
+    for action in actions:
+        if (workflow_id := action_to_workflow_id.get(action.id)) is not None:
+            actions_by_workflow_id[workflow_id].append(action)
+
+    workflow_evaluations: dict[WorkflowId, WorkflowEvaluation] = {}
+    for workflow, trigger_eval in trigger_evals.items():
+        result: WorkflowEvaluationResult = (
+            "deferred"
+            if workflow.id in deferred_workflow_ids
+            else actions_by_workflow_id.get(workflow.id, [])
+        )
+        workflow_evaluations[workflow.id] = WorkflowEvaluation(
+            result=result,
+            triggered=trigger_eval.outcome.triggered,
+            error=trigger_eval.outcome.error,
+            data={
+                "trigger_group_eval": trigger_eval,
+                "filter_group_evals": filter_evals.get(workflow, []),
+                "event": event_data,
+            },
+        )
+    return workflow_evaluations
+
+
 @log_context.root()
 def process_workflows(
     batch_client: DelayedWorkflowClient,
     event_data: WorkflowEventData,
     event_start_time: datetime,
     detector: Detector | None = None,
-) -> WorkflowEvaluation:
+) -> GroupedWorkflowEvaluationResult:
     """
     This method will get the detector based on the event, and then gather the associated workflows.
     Next, it will evaluate the "when" (or trigger) conditions for each workflow, if the conditions are met,
@@ -435,9 +502,6 @@ def process_workflows(
     )
 
     organization = event_data.event.project.organization
-    workflow_evaluation_data = WorkflowEvaluationData(
-        event=event_data.event, organization=organization
-    )
 
     try:
         event_detectors = get_detectors_for_event_data(event_data, detector)
@@ -457,13 +521,16 @@ def process_workflows(
             )
         )
     except Detector.DoesNotExist:
-        return WorkflowEvaluation(
+        return GroupedWorkflowEvaluationResult(
+            result={},
             tainted=True,
+            organization=organization,
+            event=event_data.event,
+            group=event_data.group,
             msg="No Detectors associated with the issue were found",
-            data=workflow_evaluation_data,
         )
 
-    workflow_evaluation_data.associated_detector = event_detectors.preferred_detector
+    associated_detector = event_detectors.preferred_detector
 
     try:
         environment = get_environment_by_event(event_data)
@@ -471,16 +538,20 @@ def process_workflows(
         # Set the full context now that we've gotten everything.
         WorkflowEventContext.set(
             WorkflowEventContextData(
-                detector=event_detectors.preferred_detector,
+                detector=associated_detector,
                 environment=environment,
                 organization=organization,
             )
         )
     except Environment.DoesNotExist:
-        return WorkflowEvaluation(
+        return GroupedWorkflowEvaluationResult(
+            result={},
             tainted=True,
+            organization=organization,
+            event=event_data.event,
+            group=event_data.group,
             msg="Environment for event not found",
-            data=workflow_evaluation_data,
+            associated_detector=associated_detector,
         )
 
     if features.has("organizations:workflow-engine-process-workflows-logs", organization):
@@ -523,33 +594,42 @@ def process_workflows(
             },
         )
 
-    workflow_evaluation_data.workflows = workflows
-
     if not workflows:
-        return WorkflowEvaluation(
+        return GroupedWorkflowEvaluationResult(
+            result={},
             tainted=True,
+            organization=organization,
+            event=event_data.event,
+            group=event_data.group,
             msg="No workflows are associated with the detector in the event",
-            data=workflow_evaluation_data,
+            associated_detector=associated_detector,
+            workflows=workflows,
         )
 
-    triggered_workflows, queue_items_by_workflow_id, trigger_stats = evaluate_workflow_triggers(
-        workflows, event_data, event_start_time
+    triggered_workflows, queue_items_by_workflow_id, trigger_stats, trigger_evals = (
+        evaluate_workflow_triggers(workflows, event_data, event_start_time)
     )
 
-    workflow_evaluation_data.triggered_workflows = set(triggered_workflows.keys())
+    triggered_workflow_set = set(triggered_workflows.keys())
 
     if not triggered_workflows and not queue_items_by_workflow_id:
         trigger_stats.report_metrics("process_workflows.workflows_evaluated")
         # TODO - re-think tainted once the actions are removed from process_workflows.
-        return WorkflowEvaluation(
+        return GroupedWorkflowEvaluationResult(
+            result={},
             tainted=True,
+            organization=organization,
+            event=event_data.event,
+            group=event_data.group,
             msg="No items were triggered or queued for slow evaluation",
-            data=workflow_evaluation_data,
+            associated_detector=associated_detector,
+            workflows=workflows,
+            triggered_workflows=triggered_workflow_set,
         )
 
     # TODO - we should probably return here and have the rest from here be
     # `process_actions`, this will take a list of "triggered_workflows"
-    actions_to_trigger, queue_items_by_workflow_id, action_stats = (
+    actions_to_trigger, queue_items_by_workflow_id, action_stats, filter_evals = (
         evaluate_workflows_action_filters(
             triggered_workflows, event_data, queue_items_by_workflow_id, event_start_time
         )
@@ -562,22 +642,33 @@ def process_workflows(
         actions_to_trigger, event_data
     )
 
-    workflow_evaluation_data.action_groups = actions_to_trigger
-    workflow_evaluation_data.triggered_actions = set(actions)
-    workflow_evaluation_data.delayed_conditions = queue_items_by_workflow_id
+    workflow_evaluations = _build_workflow_evaluations(
+        event_data=event_data,
+        trigger_evals=trigger_evals,
+        filter_evals=filter_evals,
+        deferred_workflow_ids={wf.id for wf in queue_items_by_workflow_id},
+        actions=actions,
+        action_to_workflow_id=action_to_workflow_id,
+    )
 
-    sentry_sdk.set_tag(
-        "workflow_engine.triggered_actions", len(workflow_evaluation_data.triggered_actions)
-    )
-    sentry_sdk.set_attribute(
-        "workflow_engine.triggered_actions", len(workflow_evaluation_data.triggered_actions)
-    )
+    triggered_actions = set(actions)
+    sentry_sdk.set_tag("workflow_engine.triggered_actions", len(triggered_actions))
+    sentry_sdk.set_attribute("workflow_engine.triggered_actions", len(triggered_actions))
 
     if not actions:
-        return WorkflowEvaluation(
+        return GroupedWorkflowEvaluationResult(
+            result=workflow_evaluations,
             tainted=True,
+            organization=organization,
+            event=event_data.event,
+            group=event_data.group,
             msg="No actions to evaluate; filtered or not triggered",
-            data=workflow_evaluation_data,
+            associated_detector=associated_detector,
+            workflows=workflows,
+            triggered_workflows=triggered_workflow_set,
+            action_groups=actions_to_trigger,
+            triggered_actions=triggered_actions,
+            delayed_conditions=queue_items_by_workflow_id,
         )
 
     fire_histories = create_workflow_fire_histories(
@@ -601,4 +692,16 @@ def process_workflows(
         action_to_workflow_id=action_to_workflow_id,
     )
 
-    return WorkflowEvaluation(tainted=False, data=workflow_evaluation_data)
+    return GroupedWorkflowEvaluationResult(
+        result=workflow_evaluations,
+        tainted=False,
+        organization=organization,
+        event=event_data.event,
+        group=event_data.group,
+        associated_detector=associated_detector,
+        workflows=workflows,
+        triggered_workflows=triggered_workflow_set,
+        action_groups=actions_to_trigger,
+        triggered_actions=triggered_actions,
+        delayed_conditions=queue_items_by_workflow_id,
+    )

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -168,8 +168,8 @@ def _process_workflows_event(
             if isinstance(event_data.event, GroupEvent):
                 kick_off_service_hooks(
                     event_data.event,
-                    evaluation.data.triggered_actions is not None
-                    and len(evaluation.data.triggered_actions) > 0,
+                    evaluation.triggered_actions is not None
+                    and len(evaluation.triggered_actions) > 0,
                 )
 
     evaluation.log_to(logger)

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import random
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
-from logging import Logger
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -19,9 +17,7 @@ from typing import (
 )
 
 from django.db.models import Q
-from sentry_sdk import logger as sentry_logger
 
-from sentry import features, options
 from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
@@ -37,16 +33,11 @@ if TYPE_CHECKING:
     from sentry.services.eventstore.models import GroupEvent
     from sentry.snuba.dataset import Dataset
     from sentry.snuba.models import ExtrapolationMode, SnubaQuery, SnubaQueryEventType
-    from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowItem
     from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
     from sentry.workflow_engine.handlers.detector import DetectorHandler
-    from sentry.workflow_engine.models import Action, DataConditionGroup, Detector, Workflow
-    from sentry.workflow_engine.models.action import ActionSnapshot
+    from sentry.workflow_engine.models import Action, Detector
     from sentry.workflow_engine.models.data_condition import Condition
-    from sentry.workflow_engine.models.data_condition_group import DataConditionGroupSnapshot
     from sentry.workflow_engine.models.data_source import DataSource
-    from sentry.workflow_engine.models.detector import DetectorSnapshot
-    from sentry.workflow_engine.models.workflow import WorkflowSnapshot
 
 T = TypeVar("T")
 
@@ -138,158 +129,6 @@ class ActionInvocation:
     # The workflow that triggered this action. An action may be associated
     # with multiple workflows; this is an arbitrary choice among them.
     workflow_id: WorkflowId
-
-
-class WorkflowEvaluationSnapshot(TypedDict):
-    """
-    A snapshot of data used to evaluate a workflow.
-    Ensure that this size is kept smaller, since it's used in logging.
-    """
-
-    associated_detector: DetectorSnapshot | None
-    event_id: str | None  # ID in NodeStore
-    group: Group | None
-    workflow_ids: list[int] | None
-    triggered_workflows: list[WorkflowSnapshot] | None
-    delayed_conditions: list[str] | None
-    action_filter_conditions: list[DataConditionGroupSnapshot] | None
-    triggered_actions: list[ActionSnapshot] | None
-
-
-@dataclass
-class WorkflowEvaluationData:
-    event: GroupEvent | Activity
-    organization: Organization
-    associated_detector: Detector | None = None
-    action_groups: set[DataConditionGroup] | None = None
-    workflows: set[Workflow] | None = None
-    triggered_workflows: set[Workflow] | None = None
-    delayed_conditions: dict[Workflow, DelayedWorkflowItem] | None = None
-    triggered_actions: set[Action] | None = None
-
-    def get_snapshot(self) -> WorkflowEvaluationSnapshot:
-        """
-        This method will take the complex data structures, like models / list of models,
-        and turn them into the critical attributes of a model or lists of IDs.
-        """
-
-        associated_detector = None
-        if self.associated_detector:
-            associated_detector = self.associated_detector.get_snapshot()
-
-        workflow_ids = None
-        if self.workflows:
-            workflow_ids = [workflow.id for workflow in self.workflows]
-
-        triggered_workflows = None
-        if self.triggered_workflows:
-            triggered_workflows = [workflow.get_snapshot() for workflow in self.triggered_workflows]
-
-        action_filter_conditions = None
-        if self.action_groups:
-            action_filter_conditions = [group.get_snapshot() for group in self.action_groups]
-
-        triggered_actions = None
-        if self.triggered_actions:
-            triggered_actions = [action.get_snapshot() for action in self.triggered_actions]
-
-        event_id = None
-        if hasattr(self.event, "event_id"):
-            event_id = str(self.event.event_id)
-
-        delayed_conditions = None
-        if self.delayed_conditions:
-            delayed_conditions = [
-                delayed_item.buffer_key() for _, delayed_item in self.delayed_conditions.items()
-            ]
-
-        return {
-            "associated_detector": associated_detector,
-            "event_id": event_id,
-            "group": self.event.group,
-            "workflow_ids": workflow_ids,
-            "triggered_workflows": triggered_workflows,
-            "delayed_conditions": delayed_conditions,
-            "action_filter_conditions": action_filter_conditions,
-            "triggered_actions": triggered_actions,
-        }
-
-
-@dataclass(frozen=True)
-class WorkflowEvaluation:
-    """
-    This is the result of `process_workflows`, and is used to
-    encapsulate different stages of completion for the method.
-
-    The `tainted` flag is used to indicate whether or not actions
-    have been triggered during the workflows evaluation.
-
-    The `msg` field is used for debug information during the evaluation.
-
-    The `data` attribute will include all the data used to evaluate the
-    workflows, and determine if an action should be triggered.
-    """
-
-    tainted: bool
-    data: WorkflowEvaluationData
-    msg: str | None = None
-
-    def log_to(self, logger: Logger) -> bool:
-        """
-        Logs workflow evaluation data.
-        Logging may be skipped if the organization isn't opted in and logs are being
-        sampled.
-        Returns True if logged, False otherwise.
-        """
-        # Check if we should log this evaluation
-        organization = self.data.organization
-        should_log = features.has("organizations:workflow-engine-log-evaluations", organization)
-        direct_to_sentry = options.get("workflow_engine.evaluation_logs_direct_to_sentry")
-
-        if not should_log:
-            sample_rate = options.get("workflow_engine.evaluation_log_sample_rate")
-            should_log = random.random() < sample_rate
-
-        if not should_log:
-            return False
-
-        log_str = "workflow_engine.process_workflows.evaluation"
-
-        if self.tainted:
-            if self.data.triggered_workflows is None:
-                log_str = f"{log_str}.workflows.not_triggered"
-            else:
-                log_str = f"{log_str}.workflows.triggered"
-        else:
-            log_str = f"{log_str}.actions.triggered"
-
-        data_snapshot = self.data.get_snapshot()
-        detection_type = (
-            data_snapshot["associated_detector"]["type"]
-            if data_snapshot["associated_detector"]
-            else None
-        )
-        group_id = data_snapshot["group"].id if data_snapshot["group"] else None
-        triggered_workflows = data_snapshot["triggered_workflows"] or []
-        action_filter_conditions = data_snapshot["action_filter_conditions"] or []
-        triggered_actions = data_snapshot["triggered_actions"] or []
-        extra = {
-            "event_id": data_snapshot["event_id"],
-            "group_id": group_id,
-            "detection_type": detection_type,
-            "workflow_ids": data_snapshot["workflow_ids"],
-            "triggered_workflow_ids": [w["id"] for w in triggered_workflows],
-            "delayed_conditions": data_snapshot["delayed_conditions"],
-            "action_filter_group_ids": [afg["id"] for afg in action_filter_conditions],
-            "triggered_action_ids": [a["id"] for a in triggered_actions],
-            "debug_msg": self.msg,
-        }
-
-        if direct_to_sentry:
-            sentry_logger.info(log_str, attributes=extra)
-        else:
-            logger.info(log_str, extra=extra)
-        return True
 
 
 class ConfigTransformer(ABC):

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -6,7 +6,17 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from logging import Logger
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, Sequence, TypeAlias, TypedDict, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    Literal,
+    Sequence,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+)
 
 from django.db.models import Q
 from sentry_sdk import logger as sentry_logger
@@ -88,6 +98,8 @@ class ConditionError:
 
 
 type DetectorResult = IssueOccurrence | StatusChangeMessage | None
+type WorkflowEvaluationDeferred = Literal["deferred"]
+type WorkflowEvaluationResult = Sequence[Action] | WorkflowEvaluationDeferred
 
 
 class _WorkflowEventLocalCache(TypedDict, total=False):

--- a/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/evaluations/test_workflow.py
@@ -3,23 +3,28 @@ from unittest import mock
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import Feature
 from sentry.testutils.helpers.options import override_options
-from sentry.workflow_engine.types import WorkflowEvaluation, WorkflowEvaluationData
+from sentry.workflow_engine.processors.evaluations.workflow import GroupedWorkflowEvaluationResult
+
+LOG_TO_MODULE = "sentry.workflow_engine.processors.evaluations.workflow"
 
 
-class TestWorkflowEvaluationLogTo(TestCase):
+class TestGroupedWorkflowEvaluationResultLogTo(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
         self.event = self.store_event(data={}, project_id=self.project.id)
 
-        self.evaluation_data = WorkflowEvaluationData(
-            event=self.event,
+    def _build_result(self) -> GroupedWorkflowEvaluationResult:
+        return GroupedWorkflowEvaluationResult(
+            result={},
+            tainted=True,
             organization=self.organization,
+            event=self.event,
         )
 
     def test_log_to_always_logs_with_feature_enabled(self) -> None:
-        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        evaluation = self._build_result()
 
         mock_logger = mock.MagicMock()
 
@@ -33,7 +38,7 @@ class TestWorkflowEvaluationLogTo(TestCase):
                 assert evaluation.log_to(mock_logger) is True
 
     def test_log_to_respects_sample_rate_when_feature_disabled(self) -> None:
-        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        evaluation = self._build_result()
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": False}):
@@ -43,7 +48,7 @@ class TestWorkflowEvaluationLogTo(TestCase):
                     "workflow_engine.evaluation_logs_direct_to_sentry": False,
                 }
             ):
-                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.5):
+                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.5):
                     assert not evaluation.log_to(mock_logger)
 
             with override_options(
@@ -52,11 +57,11 @@ class TestWorkflowEvaluationLogTo(TestCase):
                     "workflow_engine.evaluation_logs_direct_to_sentry": False,
                 }
             ):
-                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.5):
+                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.5):
                     assert evaluation.log_to(mock_logger)
 
     def test_log_to_samples_correctly(self) -> None:
-        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        evaluation = self._build_result()
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": False}):
@@ -66,30 +71,30 @@ class TestWorkflowEvaluationLogTo(TestCase):
                     "workflow_engine.evaluation_logs_direct_to_sentry": False,
                 }
             ):
-                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.05):
+                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.05):
                     assert evaluation.log_to(mock_logger)
 
-                with mock.patch("sentry.workflow_engine.types.random.random", return_value=0.15):
+                with mock.patch(f"{LOG_TO_MODULE}.random.random", return_value=0.15):
                     assert not evaluation.log_to(mock_logger)
 
     def test_log_to_sentry_logger_when_direct_to_sentry_enabled(self) -> None:
-        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        evaluation = self._build_result()
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": True}):
             with override_options({"workflow_engine.evaluation_logs_direct_to_sentry": True}):
-                with mock.patch("sentry.workflow_engine.types.sentry_logger") as mock_sentry_logger:
+                with mock.patch(f"{LOG_TO_MODULE}.sentry_logger") as mock_sentry_logger:
                     assert evaluation.log_to(mock_logger)
                     mock_sentry_logger.info.assert_called_once()
                     mock_logger.info.assert_not_called()
 
     def test_log_to_regular_logger_when_direct_to_sentry_disabled(self) -> None:
-        evaluation = WorkflowEvaluation(tainted=True, data=self.evaluation_data)
+        evaluation = self._build_result()
         mock_logger = mock.MagicMock()
 
         with Feature({"organizations:workflow-engine-log-evaluations": True}):
             with override_options({"workflow_engine.evaluation_logs_direct_to_sentry": False}):
-                with mock.patch("sentry.workflow_engine.types.sentry_logger") as mock_sentry_logger:
+                with mock.patch(f"{LOG_TO_MODULE}.sentry_logger") as mock_sentry_logger:
                     assert evaluation.log_to(mock_logger)
                     mock_logger.info.assert_called_once()
                     mock_sentry_logger.info.assert_not_called()

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -91,7 +91,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow}
+        assert result.triggered_workflows == {self.error_workflow}
 
     def test_filters_cross_org_workflows(self) -> None:
         other_org = self.create_organization()
@@ -115,13 +115,13 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
         with self.options({"workflow_engine.filter_cross_org_workflows": True}):
             result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow}
-        assert result.data.workflows is not None
-        assert cross_org_workflow not in result.data.workflows
+        assert result.triggered_workflows == {self.error_workflow}
+        assert result.workflows is not None
+        assert cross_org_workflow not in result.workflows
 
     def test_error_event(self) -> None:
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow}
+        assert result.triggered_workflows == {self.error_workflow}
 
     @patch("sentry.workflow_engine.processors.action.fire_actions")
     def test_process_workflows_event(self, mock_fire_actions: MagicMock) -> None:
@@ -325,7 +325,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow, matching_env_workflow}
+        assert result.triggered_workflows == {self.error_workflow, matching_env_workflow}
 
     def test_issue_occurrence_event(self) -> None:
         issue_occurrence = self.build_occurrence(evidence_data={"detector_id": self.detector.id})
@@ -333,7 +333,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         self.group_event.group.type = issue_occurrence.type.type_id
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.workflow}
+        assert result.triggered_workflows == {self.workflow}
 
     def test_regressed_event(self) -> None:
         dcg = self.create_data_condition_group()
@@ -351,7 +351,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow, workflow}
+        assert result.triggered_workflows == {self.error_workflow, workflow}
 
     @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.detector.logger")
@@ -385,7 +385,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         cache.clear()
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
-        assert not result.data.triggered_workflows
+        assert not result.triggered_workflows
         assert result.msg == "Environment for event not found"
 
         mock_logger.info.assert_called_once_with(
@@ -472,9 +472,9 @@ class TestProcessWorkflows(BaseWorkflowTest):
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         assert result.tainted is True
-        assert result.data.triggered_workflows == {issue_stream_workflow}
-        assert result.data.triggered_actions is not None
-        assert len(result.data.triggered_actions) == 0
+        assert result.triggered_workflows == {issue_stream_workflow}
+        assert result.triggered_actions is not None
+        assert len(result.triggered_actions) == 0
 
     def test_multiple_detectors__preferred(self) -> None:
         self.create_detector_workflow(
@@ -483,8 +483,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         )
 
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
-        assert result.data.triggered_workflows == {self.error_workflow}
-        assert result.data.associated_detector == self.error_detector
+        assert result.triggered_workflows == {self.error_workflow}
+        assert result.associated_detector == self.error_detector
 
 
 class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
@@ -504,7 +504,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         self.event_start_time = timezone.now()
 
     def test_workflow_trigger(self) -> None:
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert set(triggered_workflows.keys()) == {self.workflow}
@@ -513,13 +513,13 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
         assert self.workflow.when_condition_group
         self.workflow.when_condition_group.conditions.all().delete()
 
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert set(triggered_workflows.keys()) == {self.workflow}
 
     def test_no_workflow_trigger(self) -> None:
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             set(), self.event_data, self.event_start_time
         )
         assert not triggered_workflows
@@ -535,7 +535,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=75,
         )
 
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert set(triggered_workflows.keys()) == {self.workflow}
@@ -550,14 +550,14 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             comparison=self.detector.id + 1,
         )
 
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         assert not triggered_workflows
 
     def test_many_workflows(self) -> None:
         workflow_two, _, _, _ = self.create_detector_and_workflow(name_prefix="two")
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow, workflow_two}, self.event_data, self.event_start_time
         )
 
@@ -605,7 +605,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
         # no workflows are triggered because the slow conditions need to be evaluated
@@ -638,7 +638,7 @@ class TestEvaluateWorkflowTriggers(BaseWorkflowTest):
             event=self.event,
             group=self.group,
         )
-        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, self.event_start_time
         )
 
@@ -668,7 +668,7 @@ class TestTaintTracking(BaseWorkflowTest):
         self.action_group, _ = self.create_workflow_action(self.workflow)
 
     def test_trigger_stats_excludes_triggered_workflows(self) -> None:
-        _, _, stats = evaluate_workflow_triggers({self.workflow}, self.event_data, FROZEN_TIME)
+        _, _, stats, _ = evaluate_workflow_triggers({self.workflow}, self.event_data, FROZEN_TIME)
         assert stats == EvaluationStats(tainted=0, untainted=0)
 
     def test_trigger_stats_untainted_not_triggered(self) -> None:
@@ -680,7 +680,7 @@ class TestTaintTracking(BaseWorkflowTest):
             comparison=self.detector.id + 1,
         )
 
-        triggered_workflows, _, stats = evaluate_workflow_triggers(
+        triggered_workflows, _, stats, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert triggered_workflows == {}
@@ -697,19 +697,19 @@ class TestTaintTracking(BaseWorkflowTest):
             [],
         )
 
-        triggered_workflows, _, stats = evaluate_workflow_triggers(
+        triggered_workflows, _, stats, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert triggered_workflows == {}
         assert stats == EvaluationStats(tainted=1, untainted=0)
 
     def test_action_filter_stats_from_trigger_result(self) -> None:
-        _, _, stats = evaluate_workflows_action_filters(
+        _, _, stats, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert stats == EvaluationStats(tainted=0, untainted=1)
 
-        _, _, stats = evaluate_workflows_action_filters(
+        _, _, stats, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE.with_error(ERR)}, self.event_data, {}, FROZEN_TIME
         )
         assert stats == EvaluationStats(tainted=1, untainted=0)
@@ -725,7 +725,7 @@ class TestTaintTracking(BaseWorkflowTest):
             [],
         )
 
-        _, _, stats = evaluate_workflows_action_filters(
+        _, _, stats, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert stats == EvaluationStats(tainted=1, untainted=0)
@@ -737,7 +737,7 @@ class TestTaintTracking(BaseWorkflowTest):
             comparison={"interval": "1d", "value": 7},
         )
 
-        _, queue_items, stats = evaluate_workflows_action_filters(
+        _, queue_items, stats, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert self.workflow in queue_items
@@ -784,7 +784,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert not triggered_workflows
@@ -817,7 +817,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, _, _ = evaluate_workflow_triggers(
+        triggered_workflows, _, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert not triggered_workflows
@@ -847,7 +847,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert set(triggered_workflows.keys()) == {self.workflow}
@@ -874,7 +874,7 @@ class TestWorkflowEnqueuing(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_workflows, queue_items_by_workflow_id, _ = evaluate_workflow_triggers(
+        triggered_workflows, queue_items_by_workflow_id, _, _ = evaluate_workflow_triggers(
             {self.workflow}, self.event_data, FROZEN_TIME
         )
         assert not triggered_workflows
@@ -995,7 +995,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         mock_trigger.assert_called_once()
 
     def test_basic__no_filter(self) -> None:
-        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+        triggered_action_filters, _, _, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert set(triggered_action_filters) == {self.action_group}
@@ -1008,7 +1008,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             condition_result=True,
         )
 
-        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+        triggered_action_filters, _, _, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert set(triggered_action_filters) == {self.action_group}
@@ -1020,7 +1020,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             comparison=self.detector.id + 1,
         )
 
-        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+        triggered_action_filters, _, _, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
         assert not triggered_action_filters
@@ -1042,7 +1042,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
         )
         self.action_group.save()
 
-        triggered_action_filters, _, _ = evaluate_workflows_action_filters(
+        triggered_action_filters, _, _, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
 
@@ -1101,7 +1101,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             group=self.group,
         )
 
-        _, queue_items, _ = evaluate_workflows_action_filters(
+        _, queue_items, _, _ = evaluate_workflows_action_filters(
             {self.workflow: TriggerResult.TRUE}, self.event_data, {}, FROZEN_TIME
         )
 
@@ -1120,7 +1120,7 @@ class TestEvaluateWorkflowActionFilters(BaseWorkflowTest):
             )
         }
 
-        triggered_action_filters, queue_items, _ = evaluate_workflows_action_filters(
+        triggered_action_filters, queue_items, _, _ = evaluate_workflows_action_filters(
             {}, self.event_data, queue_items_by_workflow_id, FROZEN_TIME
         )
         assert not triggered_action_filters

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -12,7 +12,10 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.activity import ActivityType
-from sentry.workflow_engine.processors.evaluations import TriggerResult
+from sentry.workflow_engine.processors.evaluations import (
+    DataConditionGroupEvaluation,
+    TriggerResult,
+)
 from sentry.workflow_engine.processors.workflow import EvaluationStats
 from sentry.workflow_engine.tasks.utils import fetch_event
 from sentry.workflow_engine.tasks.workflows import process_workflow_activity
@@ -84,11 +87,11 @@ class TestProcessWorkflowActivity(TestCase):
     @override_options({"workflow_engine.evaluation_log_sample_rate": 1.0})
     @mock.patch(
         "sentry.workflow_engine.processors.workflow.evaluate_workflow_triggers",
-        return_value=({}, {}, EvaluationStats()),
+        return_value=({}, {}, EvaluationStats(), {}),
     )
     @mock.patch(
         "sentry.workflow_engine.processors.workflow.evaluate_workflows_action_filters",
-        return_value=(set(), {}, EvaluationStats()),
+        return_value=(set(), {}, EvaluationStats(), {}),
     )
     @mock.patch("sentry.workflow_engine.tasks.workflows.logger")
     def test_process_workflow_activity__workflows__no_actions(
@@ -198,6 +201,12 @@ class TestProcessWorkflowActivity(TestCase):
             {self.workflow: TriggerResult.TRUE},
             {},
             EvaluationStats(),
+            {
+                self.workflow: DataConditionGroupEvaluation(
+                    result=True,
+                    data={"condition_evaluations": [], "logic_type": "any"},
+                )
+            },
         )
         process_workflow_activity(
             activity_id=self.activity.id,

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -121,7 +121,7 @@ class TestProcessWorkflowActivity(TestCase):
         assert mock_eval_actions.call_count == 0
 
         mock_logger.info.assert_called_once_with(
-            "workflow_engine.process_workflows.evaluation.workflows.triggered",
+            "workflow_engine.process_workflows.evaluation.workflows.not_triggered",
             extra={
                 "workflow_ids": [self.workflow.id],
                 "detection_type": self.detector.type,


### PR DESCRIPTION
# Description
Creates a new `WorkflowEvaluation`

- Adopted in `process_workflows`, but not the `delayed_workflow` processing to reduce the size / scope of this PR
- Moved the workflow evaluation stuff into a grouped evaluation, starting the process to refactor these into the base.

TODO
- Adopt `WorkflowEvaluation` in `delayed_workflows`
- Start cleaning up `process_workflows` to use the Evaluation result to simplify
- Update the Base to handle `.to_log`