### PR TITLE
ref(onboarding): Graduate onboarding-copy-setup-instructions-project-creation

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -8,7 +8,6 @@ import {stepsToMarkdown} from 'sentry/components/onboarding/utils/stepsToMarkdow
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface CopyMarkdownButtonProps {
   getMarkdown: () => string;
@@ -123,16 +122,5 @@ export function OnboardingCopyMarkdownButton({
       onCopy={onCopy}
       variant={variant}
     />
-  );
-}
-
-/**
- * Returns whether the "Copy setup instructions" button should be shown on the
- * project creation onboarding flow.
- */
-export function useCopySetupInstructionsProjectCreationEnabled(): boolean {
-  const organization = useOrganization();
-  return organization.features.includes(
-    'onboarding-copy-setup-instructions-project-creation'
   );
 }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.spec.tsx
@@ -75,22 +75,13 @@ function renderLayout(docsConfig: Docs, features: string[] = []) {
 
 describe('OnboardingLayout', () => {
   describe('hideInstructionsCopy', () => {
-    const COPY_FEATURE = 'onboarding-copy-setup-instructions-project-creation';
-
-    it('shows copy instructions button when feature flag is enabled', () => {
-      renderLayout(makeDocsConfig(), [COPY_FEATURE]);
+    it('shows copy instructions button', () => {
+      renderLayout(makeDocsConfig());
       expect(screen.getByRole('button', {name: 'Copy instructions'})).toBeInTheDocument();
     });
 
     it('hides copy instructions button when hideInstructionsCopy is set', () => {
-      renderLayout(makeDocsConfig({hideInstructionsCopy: true}), [COPY_FEATURE]);
-      expect(
-        screen.queryByRole('button', {name: 'Copy instructions'})
-      ).not.toBeInTheDocument();
-    });
-
-    it('hides copy instructions button when feature flag is not enabled', () => {
-      renderLayout(makeDocsConfig());
+      renderLayout(makeDocsConfig({hideInstructionsCopy: true}));
       expect(
         screen.queryByRole('button', {name: 'Copy instructions'})
       ).not.toBeInTheDocument();

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -15,10 +15,7 @@ import {
   NEXT_STEP_CLICKED_EVENT,
   resolveDocsFlowEvent,
 } from 'sentry/components/onboarding/gettingStartedDoc/docsFlowAnalytics';
-import {
-  OnboardingCopyMarkdownButton,
-  useCopySetupInstructionsProjectCreationEnabled,
-} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
+import {OnboardingCopyMarkdownButton} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
@@ -82,7 +79,6 @@ export function OnboardingLayout({
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsProjectCreationEnabled();
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
@@ -213,7 +209,7 @@ export function OnboardingLayout({
           <Divider withBottomMargin />
           <div>
             {steps.map((step, index) => {
-              const showCopy = copyEnabled && index === 0 && !hideInstructionsCopy;
+              const showCopy = index === 0 && !hideInstructionsCopy;
               const copyButton = showCopy ? (
                 <OnboardingCopyMarkdownButton
                   steps={steps}


### PR DESCRIPTION
Graduate `organizations:onboarding-copy-setup-instructions-project-creation`. This flag was rolled out to GA (100%) in the automator in getsentry/sentry-options-automator#6694 on 3/5/26 and hasn't been touched since. Defaults the project-creation copy-instructions button to always-on and drops the flag check.

The sibling `organizations:onboarding-copy-setup-instructions` flag is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ButQirEPzeR6gFnN61Lid3

---
_Generated by [Claude Code](https://claude.ai/code/session_01ButQirEPzeR6gFnN61Lid3)_