### PR TITLE
ref(onboarding): Remove onboarding-copy-setup-instructions-project-creation registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -166,8 +166,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable copy setup instructions button on onboarding surfaces
     manager.add("organizations:onboarding-copy-setup-instructions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable copy setup instructions button on project creation getting-started page
-    manager.add("organizations:onboarding-copy-setup-instructions-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new onboarding welcome and SDK setup UI
     manager.add("organizations:onboarding-new-welcome-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable SCM-first onboarding flow with provider connection, platform detection, and feature selection steps

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -178,8 +178,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the agentic setup interstitial on the onboarding welcome step
     manager.add("organizations:onboarding-agentic-setup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable copy setup instructions button on project creation getting-started page
-    manager.add("organizations:onboarding-copy-setup-instructions-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable SCM-first onboarding flow with provider connection, platform detection, and feature selection steps
     manager.add("organizations:onboarding-scm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM onboarding A/B test measuring conversion impact


### PR DESCRIPTION
Removes the `organizations:onboarding-copy-setup-instructions-project-creation` feature registration. This flag was rolled out to GA (100%) in the automator in getsentry/sentry-options-automator#6694 on 3/5/26 and hasn't been touched since.

Flag references were removed in #120011 (land that first). Split from the frontend change because `static/` and `src/` are not atomically deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ButQirEPzeR6gFnN61Lid3

---
_Generated by [Claude Code](https://claude.ai/code/session_01ButQirEPzeR6gFnN61Lid3)_