### PR TITLE
fix(github): handle null expires_at in GitHub access token refresh

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -4,7 +4,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from functools import cached_property
 from typing import Any, TypedDict
@@ -277,7 +277,15 @@ class GithubProxyClient(IntegrationProxyClient):
             api_request_type=GitHubApiRequestType.REFRESH_ACCESS_TOKEN,
         )
         access_token = data["token"]
-        expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
+        expires_at_raw = data.get("expires_at")
+        if expires_at_raw is not None:
+            expires_at = datetime.strptime(expires_at_raw, "%Y-%m-%dT%H:%M:%SZ").isoformat()
+        else:
+            # GitHub may return null for expires_at in some installation configurations.
+            # Fall back to a 1-hour expiry, consistent with GitHub's documented token lifetime.
+            expires_at = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
         permissions = data.get("permissions")
         integration.metadata.update(
             {

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -283,9 +283,12 @@ class GithubProxyClient(IntegrationProxyClient):
         else:
             # GitHub may return null for expires_at in some installation configurations.
             # Fall back to a 1-hour expiry, consistent with GitHub's documented token lifetime.
-            expires_at = (datetime.now(timezone.utc) + timedelta(hours=1)).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            )
+            # Match the naive-isoformat shape stored on the non-null path (get_access_token
+            # reads this back via datetime.fromisoformat().replace(tzinfo=None)).
+            fallback_expiry = datetime.now(timezone.utc).replace(
+                tzinfo=None, microsecond=0
+            ) + timedelta(hours=1)
+            expires_at = fallback_expiry.isoformat()
         permissions = data.get("permissions")
         integration.metadata.update(
             {

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -841,8 +841,8 @@ class GithubProxyClientTest(TestCase):
     def test__refresh_access_token_null_expires_at(self, mock_jwt) -> None:
         """GitHub can return null for expires_at; verify we fall back to a 1-hour default."""
         responses.replace(
-            method=responses.POST,
-            url=f"https://api.github.com/app/installations/{self.installation_id}/access_tokens",
+            responses.POST,
+            f"https://api.github.com/app/installations/{self.installation_id}/access_tokens",
             json={
                 "token": self.access_token,
                 "expires_at": None,

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -838,6 +838,36 @@ class GithubProxyClientTest(TestCase):
 
     @responses.activate
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
+    def test__refresh_access_token_null_expires_at(self, mock_jwt) -> None:
+        """GitHub can return null for expires_at; verify we fall back to a 1-hour default."""
+        responses.replace(
+            method=responses.POST,
+            url=f"https://api.github.com/app/installations/{self.installation_id}/access_tokens",
+            json={
+                "token": self.access_token,
+                "expires_at": None,
+                "permissions": {
+                    "administration": "read",
+                },
+                "repository_selection": "all",
+            },
+            status=200,
+        )
+
+        # Should not raise a TypeError
+        self.gh_client._refresh_access_token()
+
+        self.integration.refresh_from_db()
+        saved_expires_at = self.integration.metadata.get("expires_at")
+        # expires_at must be a non-empty string (not None) so get_access_token won't loop
+        assert saved_expires_at is not None
+        assert isinstance(saved_expires_at, str)
+        # It should be a parseable ISO-8601 datetime string in the future
+        parsed = datetime.fromisoformat(saved_expires_at)
+        assert parsed > datetime.utcnow()
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
     def test__get_token(self, mock_jwt) -> None:
         access_token_request = Request(
             url=f"{self.gh_client.base_url}/repos/test-repo/issues"


### PR DESCRIPTION
## Summary

- **Sentry issue**: https://sentry.io/organizations/sentry/issues/7569905613/
- **Triage session**: https://claude.ai/code/session_0181aUHScodPh4N4yan4vE2i

### Root cause

GitHub's `POST /app/installations/{id}/access_tokens` endpoint returned a `201 Created` with a valid `token` and full `permissions`, but with `expires_at: null`. `_refresh_access_token` in `src/sentry/integrations/github/client.py` called `datetime.strptime(data["expires_at"], ...)` unconditionally — when `data["expires_at"]` is `None` this raises `TypeError: strptime() argument 1 must be str, not None`, causing `sync_repos_for_org` to fail for the affected organization (its repo list is never synced).

### Why did GitHub return null `expires_at`?

A null `expires_at` from this endpoint is **undocumented** — GitHub's docs state installation access tokens always expire after 1 hour and always return the timestamp. Investigation points to a **transient, GitHub-side anomaly**, not a Sentry bug or a persistent integration misconfiguration:

- **It's rare and not reproducible by config**: the issue has only 2 occurrences over ~26 days, affecting a single installation. A persistent config problem would fire on every refresh for that install (hourly), not twice.
- **Not the new stateless-token format**: the captured response token is ~40 chars (classic opaque `ghs_` token), not the ~520-char self-describing stateless JWT GitHub began rolling out in Apr–May 2026. So this isn't "the token carries its own expiry, so the field was omitted" — it's a classic token that simply came back without its expiry.
- **Consistent with a degraded/partial response**: GitHub had installation-token incidents in this window caused by a caching-proxy component returning intermittent bad responses. A `201` carrying a token + permissions but a null `expires_at` matches that failure shape (partial serialization).

**Conclusion**: GitHub occasionally emits a malformed-but-successful token response. We can't prevent that server-side, so the client must tolerate it. Since the affected token is a classic 1-hour installation token, falling back to `now + 1h` is both safe and accurate.

### Fix

Guard against `None` in `_refresh_access_token`. When `expires_at` is null, fall back to a computed 1-hour expiry — consistent with GitHub's documented installation-token lifetime. The fallback produces the **same naive, second-resolution isoformat** shape as the non-null path (`get_access_token` reads it back via `datetime.fromisoformat(...).replace(tzinfo=None)`), avoiding an aware/naive mismatch. `datetime` and `timedelta` were already imported; added `timezone`.

### What was ruled out

- **Bare `try/except`**: hides the underlying problem and masks future regressions.
- **Storing `None` as `expires_at`**: `get_access_token` checks `not expires_at`, which is `True` for `None`, so storing `None` would cause every token request to trigger a refresh — an infinite refresh loop.
- **A Sentry-side cause (proxy/deserialization stripping the field)**: ruled out — the crash is a direct control-silo call to `api.github.com` (breadcrumb shows `201 Created`), `data["token"]` and `data["permissions"]` parsed fine, so the null came from GitHub's response body, not our parsing.

## Test plan

- Added `test__refresh_access_token_null_expires_at` to `GithubProxyClientTest` in `tests/sentry/integrations/github/test_client.py`.
- The test mocks the GitHub API to return `null` for `expires_at`, calls `_refresh_access_token()`, and asserts:
  1. No exception is raised.
  2. `integration.metadata["expires_at"]` is a non-`None` string (prevents the refresh loop).
  3. The stored datetime parses correctly and is in the future.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181aUHScodPh4N4yan4vE2i)_