### PR TITLE
fix(seer): Fix autofix prompt key and register it

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -23,6 +23,7 @@ DEFAULT_PROMPTS: dict[str, _PromptConfig] = {
     "metric_alert_ignore_archived_issues": {"required_fields": ["organization_id", "project_id"]},
     "releases": {"required_fields": ["organization_id", "project_id"]},
     "seer_autofix_setup_acknowledged": {"required_fields": ["organization_id"]},
+    "seer_autofix_sw_notification": {"required_fields": ["organization_id"]},
     "stacktrace_link": {"required_fields": ["organization_id", "project_id"]},
     "user_snooze_deprecation": {"required_fields": ["organization_id", "project_id"]},
     "workflow_engine_onboarding_banner": {"required_fields": ["organization_id"]},

--- a/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
+++ b/static/app/components/events/autofix/v3/seerEnableNotifications.tsx
@@ -19,7 +19,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 const SUCCESS_VISIBLE_DURATION_MS = 25_000;
-const PROMPT_FEATURE = 'autofix-sw-notification';
+const PROMPT_FEATURE = 'seer_autofix_sw_notification';
 
 interface Props {
   status: undefined | ExplorerAutofixState['status'];


### PR DESCRIPTION
Currently when we try to read the old key we're getting a lot of 400 responses with `{detail: "Invalid feature name autofix-sw-notification"}` as the payload.

I need to register the key. derp. Also I renamed the key so it fits existing conventions. 

this is a frontend+backend change, but the frontend is already (silently) broken, so we can combine into one commit without creating more issues. 

Follows:
- https://github.com/getsentry/sentry/pull/119772
- https://github.com/getsentry/sentry/pull/119753
- https://github.com/getsentry/sentry/pull/119364
