### PR TITLE
fix(gitlab): sanitize ANSI escape sequences from MR webhook author email/name

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import re
 from abc import ABC
 from collections.abc import Mapping
 from datetime import timezone
@@ -52,6 +53,45 @@ from sentry.utils import metrics
 logger = logging.getLogger("sentry.webhooks")
 
 PROVIDER_NAME = "integrations:gitlab"
+
+# Matches ANSI/VT100 CSI escape sequences such as \x1b[d or \x1b[0m, plus
+# any two-character escape sequence that starts with ESC but is not a CSI
+# introducer.  These sequences arrive in GitLab webhook payloads and consist
+# of a non-printable ESC byte followed by printable ASCII characters — so a
+# single-pass strip of non-printable bytes would leave the printable tail
+# ("[d", "[c", …) behind.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b(?:\[[0-9;]*[A-Za-z]|[^\[])")
+
+# After stripping ANSI sequences, remove any remaining character outside the
+# printable ASCII range (0x20–0x7E), e.g. lone ESC bytes or other control
+# characters.
+_NON_PRINTABLE_ASCII_RE = re.compile(r"[^\x20-\x7E]")
+
+
+def _sanitize_author_field(value: str | None, max_length: int) -> str | None:
+    """Strip non-printable and ANSI escape characters, then truncate to *max_length*.
+
+    GitLab webhook payloads can carry ANSI escape sequences or other control
+    characters inside author email/name fields.  Passing those values straight
+    to ``CommitAuthor.objects.get_or_create`` causes PostgreSQL to raise a
+    ``StringDataRightTruncation`` (Django ``DataError``) when the value
+    exceeds the column's ``varchar(N)`` limit.  Sanitizing at the extraction
+    point — before the value touches any model layer — is the correct fix.
+
+    Two-pass approach:
+    1. Remove full ANSI/VT100 escape sequences (e.g. ``\\x1b[d``, ``\\x1b[0m``).
+       These sequences contain printable ASCII characters (``[``, ``d``, …) that
+       the second pass would not remove on its own.
+    2. Remove any remaining non-printable ASCII characters (control chars, lone
+       ESC bytes, non-ASCII code points).
+    """
+    if value is None:
+        return None
+    value = _ANSI_ESCAPE_RE.sub("", value)
+    value = _NON_PRINTABLE_ASCII_RE.sub("", value)
+    return value[:max_length]
+
+
 GITLAB_WEBHOOK_SECRET_INVALID_ERROR = """Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/organization/integrations/integration-platform/public-integration/#refreshing-tokens."""
 
 
@@ -456,8 +496,12 @@ class MergeEventWebhook(GitlabWebhook):
             author_name = None
             head_commit_sha = None
             if last_commit:
-                author_email = last_commit["author"]["email"]
-                author_name = last_commit["author"]["name"]
+                author_email = _sanitize_author_field(
+                    last_commit["author"]["email"], max_length=200
+                )
+                author_name = _sanitize_author_field(
+                    last_commit["author"]["name"], max_length=128
+                )
                 head_commit_sha = last_commit.get("id")
 
             updated_at = event["object_attributes"].get("updated_at")
@@ -654,7 +698,8 @@ class PushEventWebhook(GitlabWebhook):
             if IntegrationRepositoryProvider.should_ignore_commit(commit["message"]):
                 continue
 
-            author_email = commit["author"]["email"]
+            author_email = _sanitize_author_field(commit["author"]["email"], max_length=200)
+            author_name = _sanitize_author_field(commit["author"]["name"], max_length=128)
 
             # TODO(dcramer): we need to deal with bad values here, but since
             # its optional, lets just throw it out for now
@@ -664,7 +709,7 @@ class PushEventWebhook(GitlabWebhook):
                 authors[author_email] = author = CommitAuthor.objects.get_or_create(
                     organization_id=organization.id,
                     email=author_email,
-                    defaults={"name": commit["author"]["name"]},
+                    defaults={"name": author_name},
                 )[0]
             else:
                 author = authors[author_email]

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -431,6 +431,42 @@ class WebhookTest(GitLabTestCase):
         self.assert_pull_request(pull, author)
         self.assert_group_link(group, pull)
 
+    def test_merge_event_author_email_with_ansi_sequences_is_sanitized(self) -> None:
+        # Regression test for SENTRY-5RKP: GitLab MR webhooks can carry ANSI
+        # escape sequences appended to the commit author email.  Passing the
+        # raw value to CommitAuthor.get_or_create caused PostgreSQL to raise a
+        # StringDataRightTruncation (DataError) when the value exceeded the
+        # email column's varchar(200) limit.  The fix strips all non-printable
+        # ASCII characters at the extraction point before any model layer is
+        # touched.
+        self.create_gitlab_repo("getsentry/sentry")
+        payload = orjson.loads(MERGE_REQUEST_OPENED_EVENT)
+
+        # Simulate the malformed email seen in production: a valid address
+        # followed by many ANSI cursor-movement escape sequences.
+        clean_email = "user@example.com"
+        ansi_suffix = "\x1b[d" * 34 + "\x1b[c" * 33  # 34 cursor-left + 33 cursor-right
+        dirty_email = clean_email + ansi_suffix
+        assert len(dirty_email) > 200  # would exceed varchar(200) without the fix
+
+        payload["object_attributes"]["last_commit"]["author"]["email"] = dirty_email
+        payload["object_attributes"]["last_commit"]["author"]["name"] = (
+            "Dev User\x1b[0m"  # also sanitize name
+        )
+
+        response = self.client.post(
+            self.url,
+            data=orjson.dumps(payload),
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Merge Request Hook",
+        )
+        assert response.status_code == 204
+
+        author = CommitAuthor.objects.get()
+        assert author.email == clean_email
+        assert author.name == "Dev User"
+
     def test_merge_event_update_pull_request(self) -> None:
         repo = self.create_gitlab_repo("getsentry/sentry")
         group = self.create_group(project=self.project, short_id=9)


### PR DESCRIPTION
## Summary

Fixes a production `DataError: value too long for type character varying(200)` crash in the GitLab webhook handler.

- **Sentry issue**: https://sentry.sentry.io/issues/SENTRY-5RKP
- **Triage session**: https://claude.ai/code/session_01Ma5RaV2qEq4QrWH3gakKs5

## Root Cause

A GitLab MR webhook arrived with ANSI terminal escape sequences appended to the commit author email field in the `last_commit.author.email` payload key — e.g. `user@example.com` followed by 34 cursor-left (`\x1b[d`) and 33 cursor-right (`\x1b[c`) sequences, totalling ~170 extra bytes and pushing the value well past 200 characters.

`MergeEventWebhook.__call__` extracted this value verbatim and passed it directly to `CommitAuthor.objects.get_or_create(email=<malformed_value>, ...)`. PostgreSQL's `varchar(200)` constraint on the `sentry_commitauthor.email` column rejected the insert with `StringDataRightTruncation`, which Django surfaced as `DataError`. The entire webhook request failed with a 500.

## What was ruled out

- **Widening the DB column**: wrong direction — the column is already generous at 200 chars; accommodating injected garbage is not the answer.
- **Catching `DataError` silently**: hides the bug, allows future similar injections to fail undetected, and does not store the author at all so the PR record ends up without an author.
- **Truncating blindly without stripping**: ANSI sequences like `\x1b[d` consist of a non-printable ESC byte (`\x1b`) followed by printable ASCII characters (`[d`). Stripping only non-printable bytes would leave `[d[d[d…` in the stored email, which is still wrong data.

## Fix

Add `_sanitize_author_field()` in `src/sentry/integrations/gitlab/webhooks.py` and apply it when extracting author email and name from MR and push webhook payloads, before they reach any model layer.

The sanitizer uses a two-pass regex approach:
1. **Strip complete ANSI/VT100 CSI sequences** (`\x1b[<params><letter>`) and two-character escape sequences — these contain printable ASCII characters that the second pass would not catch.
2. **Strip any remaining non-printable ASCII** characters (lone ESC bytes, other control characters, non-ASCII code points).
3. **Truncate** to the column's `max_length` as a belt-and-suspenders guard.

## Test plan

- [ ] New regression test `test_merge_event_author_email_with_ansi_sequences_is_sanitized` in `tests/sentry/integrations/gitlab/test_webhook.py` — injects a production-style malformed email (valid address + 67 ANSI escape sequences, length > 200) into the webhook payload, posts it through the full webhook handler, and asserts that the `CommitAuthor` is created with the clean email and name.
- [ ] Existing GitLab webhook tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ma5RaV2qEq4QrWH3gakKs5)_