### PR TITLE
fix(dynamic-sampling): Only query transaction volumes for projects that need balancing

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -293,7 +293,14 @@ def get_eap_transaction_volumes(
     time_interval: timedelta = timedelta(hours=1),
     order_by_volume: Literal["asc", "desc"] = "asc",
     max_transactions: int = 100,
+    root_projects: Sequence[Project] | None = None,
 ) -> list[ProjectTransactionCounts]:
+    # Spans rooted in one project can be owned by any project in the org, so the query
+    # scope stays config.projects; root_projects only narrows which root projects
+    # (dsc.project_id) are counted.
+    if root_projects is None:
+        root_projects = config.projects
+
     end_time = datetime.now(UTC)
     start_time = end_time - time_interval
     transaction_counts_by_project: defaultdict[int, list[tuple[str, float]]] = defaultdict(list)
@@ -309,7 +316,7 @@ def get_eap_transaction_volumes(
         DynamicSamplingQueryFields.DSC_TRANSACTION,
     ]
 
-    root_project_filter = ",".join(str(project.id) for project in config.projects)
+    root_project_filter = ",".join(str(project.id) for project in root_projects)
     result = Spans.run_table_query(
         params=SnubaParams(
             start=start_time,

--- a/src/sentry/dynamic_sampling/per_org/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/scheduler.py
@@ -90,7 +90,16 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> DynamicSamplingStat
         except Exception as exc:
             sentry_sdk.capture_exception(exc)
 
-    transaction_volumes = get_eap_transaction_volumes(config)
+    # run_transaction_balancing skips projects at a 100% rate (legacy parity), so their
+    # transaction volumes are never used — leave them out of the query.
+    sample_rates = config.get_project_sample_rates()
+    projects_to_balance = [
+        project for project in config.projects if sample_rates.get(project.id) != 1.0
+    ]
+    if not projects_to_balance:
+        return DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
+
+    transaction_volumes = get_eap_transaction_volumes(config, root_projects=projects_to_balance)
     if not transaction_volumes:
         return DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
 

--- a/src/sentry/dynamic_sampling/per_org/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/telemetry.py
@@ -26,6 +26,7 @@ SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
 
 
 class DynamicSamplingStatus(StrEnum):
+    ALL_PROJECTS_AT_FULL_SAMPLE_RATE = "all_projects_at_full_sample_rate"
     COMPLETED = "completed"
     DISPATCHED = "dispatched"
     FAILED = "failed"

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -477,6 +477,59 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
             ),
         ]
 
+    def test_get_eap_transaction_volumes_filters_by_root_projects(self) -> None:
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        other_project = self.create_project(organization=organization)
+        timestamp = before_now(minutes=15)
+
+        self.store_spans(
+            [
+                # Rooted at `project` but owned by `other_project` — must still be counted
+                # even though `other_project` is not in root_projects.
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "sentry_tags": {
+                            "transaction": "checkout",
+                            "dsc.transaction": "checkout",
+                            "dsc.project_id": str(project.id),
+                        },
+                    },
+                    organization=organization,
+                    project=other_project,
+                    start_ts=timestamp,
+                ),
+                # Rooted at `other_project` — excluded by root_projects.
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "sentry_tags": {
+                            "transaction": "landing",
+                            "dsc.transaction": "landing",
+                            "dsc.project_id": str(other_project.id),
+                        },
+                    },
+                    organization=organization,
+                    project=other_project,
+                    start_ts=timestamp + timedelta(seconds=1),
+                ),
+            ]
+        )
+
+        volumes = get_eap_transaction_volumes(
+            self.get_config(organization),
+            root_projects=[project],
+        )
+
+        assert volumes == [
+            ProjectTransactionCounts(
+                org_id=organization.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 1)],
+            )
+        ]
+
     def test_get_eap_transaction_volumes_without_projects(self) -> None:
         organization = self.create_organization()
 

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -93,7 +93,7 @@ class RunCalculationsPerOrgTest(TestCase):
         get_project_volumes.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_continues_with_traffic(self) -> None:
+    def test_run_calculations_per_org_skips_transaction_volumes_at_full_sample_rate(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
@@ -126,23 +126,15 @@ class RunCalculationsPerOrgTest(TestCase):
                 "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
             ) as compare_rebalanced_projects,
             patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
-                    ProjectTransactionCounts(
-                        org_id=org.id,
-                        project_id=project.id,
-                        transaction_counts=[("checkout", 1.0)],
-                    )
-                ],
+                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes"
             ) as get_transaction_volumes,
             patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
+                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing"
             ) as transaction_balancing,
         ):
             result = run_calculations_per_org_task(org.id)
 
-        assert result is None
+        assert result == DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
         _assert_called_once_with_config(get_volume, org.id)
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
         project_config = _assert_called_once_with_config(get_project_volumes, org.id)
@@ -151,10 +143,8 @@ class RunCalculationsPerOrgTest(TestCase):
         compare_rebalanced_projects.assert_called_once_with(
             project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
-        )
+        get_transaction_volumes.assert_not_called()
+        transaction_balancing.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
     def test_run_calculations_per_org_returns_no_volume_without_project_volumes(self) -> None:
@@ -198,7 +188,7 @@ class RunCalculationsPerOrgTest(TestCase):
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
+        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
 
         with (
@@ -302,7 +292,7 @@ class RunCalculationsPerOrgTest(TestCase):
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
+        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
 
         with (
@@ -391,7 +381,7 @@ class RunCalculationsPerOrgTest(TestCase):
         project = self.create_project(organization=org)
         org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
+        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
         cached_sample_rates: dict[int, float | None] = {}
 
         with (
@@ -445,6 +435,9 @@ class RunCalculationsPerOrgTest(TestCase):
             project_config, rebalanced_projects, cached_sample_rates, project_volumes
         )
         transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
+        assert [p.id for p in get_transaction_volumes.call_args.kwargs["root_projects"]] == [
+            project.id
+        ]
         transaction_balancing.assert_called_once_with(
             transaction_config, project_volumes, get_transaction_volumes.return_value
         )


### PR DESCRIPTION
- `run_transaction_balancing` currently skips projects at a 100% sample rate since #119907, but their transaction volumes were still queried - which is what we wanted to prevent. This PR makes sure we only query transaction volumes when necessary

Contributes to TET-2721