### PR TITLE
ref(integrations): Remove integrations-github-platform-detection flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -124,7 +124,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Starfish: extract metrics from the spans
     manager.add("organizations:indexed-spans-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-multi-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-vercel-upsert-env-var", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
@@ -36,13 +36,6 @@ class OrganizationRepositoryPlatformsEndpoint(OrganizationRepositoryEndpoint):
     }
 
     def get(self, request: Request, organization: Organization, repo: Repository) -> Response:
-        if not features.has(
-            "organizations:integrations-github-platform-detection",
-            organization,
-            actor=request.user,
-        ):
-            return Response(status=404)
-
         if (
             not repo.integration_id
             or repo.provider != f"integrations:{IntegrationProviderSlug.GITHUB}"

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -133,7 +133,6 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 {
                     "organizations:onboarding-scm-experiment": True,
                     "organizations:onboarding-scm-project-details-experiment": True,
-                    "organizations:integrations-github-platform-detection": True,
                 }
             ),
             mock.patch(
@@ -214,7 +213,6 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 {
                     "organizations:onboarding-scm-experiment": True,
                     "organizations:onboarding-scm-project-details-experiment": True,
-                    "organizations:integrations-github-platform-detection": True,
                 }
             ),
             mock.patch(
@@ -310,7 +308,6 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 {
                     "organizations:onboarding-scm-experiment": True,
                     "organizations:onboarding-scm-project-details-experiment": True,
-                    "organizations:integrations-github-platform-detection": True,
                 }
             ),
             mock.patch(
@@ -452,7 +449,6 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 {
                     "organizations:onboarding-scm-experiment": True,
                     "organizations:onboarding-scm-project-details-experiment": True,
-                    "organizations:integrations-github-platform-detection": True,
                 }
             ),
             mock.patch(
@@ -588,7 +584,6 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 {
                     "organizations:onboarding-scm-experiment": True,
                     "organizations:onboarding-scm-project-details-experiment": True,
-                    "organizations:integrations-github-platform-detection": True,
                 }
             ),
             mock.patch(
@@ -859,7 +854,6 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 {
                     "organizations:onboarding-scm-experiment": True,
                     "organizations:onboarding-scm-project-details-experiment": False,
-                    "organizations:integrations-github-platform-detection": True,
                 }
             ),
             mock.patch(

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
 
-FEATURE_FLAG = "organizations:integrations-github-platform-detection"
 MULTI_FLAG = "organizations:integrations-github-multi-platform-detection"
 ENDPOINT_MODULE = "sentry.integrations.api.endpoints.organization_repository_platforms"
 
@@ -42,10 +41,6 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             integration_id=self.integration.id,
         )
 
-    def test_feature_flag_required(self) -> None:
-        response = self.get_response(self.organization.slug, self.repo.id)
-        assert response.status_code == 404
-
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_detects_platforms(self, get_jwt: mock.MagicMock) -> None:
@@ -63,10 +58,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             status=200,
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_success_response(
-                self.organization.slug, self.repo.id, status_code=200
-            )
+        response = self.get_success_response(self.organization.slug, self.repo.id, status_code=200)
 
         # Only the top language by bytes is returned
         assert response.data == {
@@ -106,10 +98,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             status=200,
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_success_response(
-                self.organization.slug, self.repo.id, status_code=200
-            )
+        response = self.get_success_response(self.organization.slug, self.repo.id, status_code=200)
 
         assert response.data == {
             "platforms": [
@@ -138,8 +127,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
         }
 
     def test_repo_not_found(self) -> None:
-        with self.feature(FEATURE_FLAG):
-            response = self.get_response(self.organization.slug, 99999)
+        response = self.get_response(self.organization.slug, 99999)
         assert response.status_code == 404
 
     def test_non_github_repo(self) -> None:
@@ -150,8 +138,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             external_id="456",
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_response(self.organization.slug, repo.id)
+        response = self.get_response(self.organization.slug, repo.id)
         assert response.status_code == 400
         assert "only supported for GitHub" in response.data["detail"]
 
@@ -164,8 +151,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             integration_id=self.integration.id,
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_response(self.organization.slug, repo.id)
+        response = self.get_response(self.organization.slug, repo.id)
         assert response.status_code == 400
         assert "only supported for GitHub" in response.data["detail"]
 
@@ -178,8 +164,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             integration_id=None,
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_response(self.organization.slug, repo.id)
+        response = self.get_response(self.organization.slug, repo.id)
         assert response.status_code == 400
 
     def test_other_orgs_repo_not_accessible(self) -> None:
@@ -192,8 +177,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             integration_id=self.integration.id,
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_response(self.organization.slug, other_repo.id)
+        response = self.get_response(self.organization.slug, other_repo.id)
         assert response.status_code == 404
 
     @mock.patch(f"{ENDPOINT_MODULE}.sentry_sdk")
@@ -209,8 +193,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             status=500,
         )
 
-        with self.feature(FEATURE_FLAG):
-            response = self.get_response(self.organization.slug, self.repo.id)
+        response = self.get_response(self.organization.slug, self.repo.id)
         assert response.status_code == 502
         assert "Failed to detect" in response.data["detail"]
         assert mock_sentry_sdk.capture_exception.called
@@ -221,7 +204,7 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
 
 
 class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
-    """Tests for the multi-platform detector path (both flags enabled)."""
+    """Tests for the multi-platform detector path (multi flag enabled)."""
 
     endpoint = "sentry-api-0-organization-repository-platforms"
 
@@ -269,7 +252,7 @@ class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
             status=200,
         )
 
-        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+        with self.feature(MULTI_FLAG):
             response = self.get_success_response(
                 self.organization.slug, self.repo.id, status_code=200
             )
@@ -299,7 +282,7 @@ class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
             status=409,
         )
 
-        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+        with self.feature(MULTI_FLAG):
             response = self.get_success_response(
                 self.organization.slug, self.repo.id, status_code=200
             )
@@ -325,7 +308,7 @@ class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
             status=500,
         )
 
-        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+        with self.feature(MULTI_FLAG):
             response = self.get_response(self.organization.slug, self.repo.id)
 
         assert response.status_code == 502
@@ -360,7 +343,7 @@ class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
             status=200,
         )
 
-        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+        with self.feature(MULTI_FLAG):
             response = self.get_success_response(
                 self.organization.slug, self.repo.id, status_code=200
             )
@@ -408,7 +391,7 @@ class OrganizationRepositoryPlatformsMultiGetTest(APITestCase):
             status=200,
         )
 
-        with self.feature({FEATURE_FLAG: True, MULTI_FLAG: True}):
+        with self.feature(MULTI_FLAG):
             response = self.get_success_response(
                 self.organization.slug, self.repo.id, status_code=200
             )


### PR DESCRIPTION
Remove `organizations:integrations-github-platform-detection`. This flag was fully rolled out to 100% GA in the automator in [#7306](https://github.com/getsentry/sentry-options-automator/pull/7306) on 4/16 and hasn't been touched since.

Defaults the repository platforms endpoint (feature gate added in #109699) to always-on, drops the flag registration, and updates tests. The related `integrations-github-multi-platform-detection` flag is unaffected.

Companion PRs remove the config from the automator and the schema snapshot from getsentry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyvhXbHM6wg47YU4XZiYLh)_