### PR TITLE
perf(jest): Mock root ECharts imports

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -276,7 +276,7 @@ const config: Config.InitialOptions = {
 
     // Disable echarts in test, since they're very slow and take time to
     // transform
-    '^echarts/(.*)': '<rootDir>/tests/js/sentry-test/mocks/echartsMock.js',
+    '^echarts(?:/.*)?$': '<rootDir>/tests/js/sentry-test/mocks/echartsMock.js',
     '^zrender/(.*)': '<rootDir>/tests/js/sentry-test/mocks/echartsMock.js',
 
     // @sentry/sqlish is ESM-only with `exports` that only define `import`

--- a/tests/js/sentry-test/mocks/echartsMock.js
+++ b/tests/js/sentry-test/mocks/echartsMock.js
@@ -1,4 +1,11 @@
 'use strict';
 // empty stub file for echarts with jest
 
-module.exports = {default: {id: 'echarts'}, use: () => {}};
+module.exports = {
+  __esModule: true,
+  connect: () => {},
+  default: {id: 'echarts'},
+  disconnect: () => {},
+  getInstanceByDom: () => {},
+  use: () => {},
+};


### PR DESCRIPTION
The ECharts Jest mapper only matched subpaths, so root imports still loaded and transformed the real package. Match both the package root and subpaths to the lightweight mock, and expose the small root API surface tests use.

Benchmarking `useChartXRangeSelection.spec.tsx` over five cache-disabled runs:

| Before | After | Improvement |
|---:|---:|---:|
| 4.530s median | 4.125s median | 405ms / 8.9% |

This helps any Jest suite that reaches a root ECharts import by avoiding the real module work.