### PR TITLE
fix(integrations): Allow rotating token-only app secrets

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_rotate_secret.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_rotate_secret.py
@@ -11,6 +11,7 @@ from sentry.api.base import control_silo_endpoint
 from sentry.api.permissions import DemoSafePermission
 from sentry.api.serializers import serialize
 from sentry.auth.superuser import superuser_has_permission
+from sentry.conf.server import SENTRY_TOKEN_ONLY_SCOPES
 from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import generate_token
 from sentry.organizations.services.organization import organization_service
@@ -61,6 +62,11 @@ class SentryAppRotateSecretPermission(DemoSafePermission):
             raise Http404
 
         for scope in sentry_app.scope_list:
+            # Token-only scopes are intentionally grantable to integrations but unavailable
+            # to user roles. Rotating a secret does not grant new scopes, and the requester
+            # must still belong to the owning organization and have org:write or org:admin.
+            if scope in SENTRY_TOKEN_ONLY_SCOPES:
+                continue
             if not request.access.has_scope(scope):
                 raise SentryAppError(
                     message=f"Requested permission of {scope} exceeds requester's permission. Please contact an owner to make the requested change.",

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_rotate_secret.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_rotate_secret.py
@@ -90,6 +90,21 @@ class SentryAppRotateSecretTest(APITestCase):
         assert len(new_secret) == len(old_secret)
         assert new_secret != old_secret
 
+    def test_owner_can_rotate_secret_with_token_only_scopes(self) -> None:
+        # Regression test for #92019's scope check after #113394 made org:ci token-only.
+        self.sentry_app.update(scope_list=("org:ci", "project:distribution"))
+        self.login_as(self.user)
+        assert self.sentry_app.application is not None
+        old_secret = self.sentry_app.application.client_secret
+        assert old_secret is not None
+
+        response = self.client.post(self.url)
+
+        assert response.status_code == 200
+        new_secret = response.data["clientSecret"]
+        assert len(new_secret) == len(old_secret)
+        assert new_secret != old_secret
+
     def test_superuser_has_access(self) -> None:
         superuser = self.create_user(is_superuser=True)
         self.login_as(user=superuser, superuser=True)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_rotate_secret.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_rotate_secret.py
@@ -91,7 +91,6 @@ class SentryAppRotateSecretTest(APITestCase):
         assert new_secret != old_secret
 
     def test_owner_can_rotate_secret_with_token_only_scopes(self) -> None:
-        # Regression test for #92019's scope check after #113394 made org:ci token-only.
         self.sentry_app.update(scope_list=("org:ci", "project:distribution"))
         self.login_as(self.user)
         assert self.sentry_app.application is not None


### PR DESCRIPTION
Rotating a Sentry App secret fails for integrations with `org:ci` because token-only scopes are intentionally unavailable to user roles.

Ignore token-only scopes during rotation while keeping the organization membership, `org:write`, and privileged scope checks. Adds regression coverage for the behavior introduced in #92019 after #113394 made `org:ci` token-only.