### PR TITLE
fix(gitlab): prevent ProcessingDeadlineExceeded on large release ranges

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("sentry.integrations.gitlab")
 
+# GitLab does not include diffs in the compare/commit-list response, so
+# _format_commits must make one additional API call per commit to build the
+# patch set (see _get_patchset).  With many commits this becomes O(N)
+# sequential HTTP requests and can push the fetch_commits task past its
+# processing deadline.  When the commit count exceeds this threshold we skip
+# patchset fetching entirely and return an empty list for every commit instead.
+GITLAB_MAX_COMMITS_FOR_PATCHSET = 100
+
 
 class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"]):
     name = "Gitlab"
@@ -124,6 +132,31 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
 
     def _format_commits(self, client, repo, commit_list):
         """Convert GitLab commits into our internal format"""
+        if len(commit_list) > GITLAB_MAX_COMMITS_FOR_PATCHSET:
+            # Fetching one diff per commit would generate too many sequential
+            # HTTP requests for large release ranges and push the task past its
+            # processing deadline.  Skip patchset fetching for all commits so
+            # the task completes in time; commit metadata is still recorded.
+            logger.warning(
+                "gitlab.repository.patchset_fetch_skipped",
+                extra={
+                    "repository": repo.name,
+                    "num_commits": len(commit_list),
+                    "max_commits": GITLAB_MAX_COMMITS_FOR_PATCHSET,
+                },
+            )
+            return [
+                {
+                    "id": c["id"],
+                    "repository": repo.name,
+                    "author_email": c["author_email"],
+                    "author_name": c["author_name"],
+                    "message": c["title"],
+                    "timestamp": self.format_date(c["created_at"]),
+                    "patch_set": [],
+                }
+                for c in commit_list
+            ]
         return [
             {
                 "id": c["id"],

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -39,8 +39,15 @@ from sentry.utils.tracing import get_current_span
 logger = logging.getLogger(__name__)
 
 GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS = 3600
-GITHUB_CACHEABLE_REPOSITORY_PROVIDERS = frozenset(
-    ("integrations:github", "integrations:github_enterprise")
+# Providers whose compare-commits results are safe to cache.  Caching avoids
+# re-fetching the full commit list (including per-commit diffs for GitLab) on
+# every task retry for the same SHA range.
+CACHEABLE_REPOSITORY_PROVIDERS = frozenset(
+    (
+        "integrations:github",
+        "integrations:github_enterprise",
+        "integrations:gitlab",
+    )
 )
 
 
@@ -90,7 +97,7 @@ def fetch_commits_for_compare_range(
     user: RpcUser | None,
 ) -> list[dict[str, Any]]:
     cache_enabled = (
-        isinstance(repo.provider, str) and repo.provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
+        isinstance(repo.provider, str) and repo.provider in CACHEABLE_REPOSITORY_PROVIDERS
     )
     set_tag("compare_commits_cache_enabled", cache_enabled)
     sentry_sdk.set_attribute("compare_commits_cache_enabled", cache_enabled)

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,11 +1,15 @@
 from functools import cached_property
+from unittest.mock import MagicMock
 
 import orjson
 import pytest
 import responses
 
 from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_RESPONSE
-from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
+from sentry.integrations.gitlab.repository import (
+    GITLAB_MAX_COMMITS_FOR_PATCHSET,
+    GitlabRepositoryProvider,
+)
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -328,3 +332,50 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         repo = self.get_repository(pk=response.data["id"])
         result = self.provider.repository_external_slug(repo)
         assert result == repo.config["project_id"]
+
+    def _make_fake_commits(self, count: int) -> list[dict[str, str]]:
+        return [
+            {
+                "id": f"a{i:039x}",
+                "author_name": "Author",
+                "author_email": "author@example.com",
+                "title": f"Commit {i}",
+                "created_at": "2014-02-27T10:27:00+02:00",
+            }
+            for i in range(count)
+        ]
+
+    @responses.activate
+    def test_format_commits_skips_patchset_when_commit_count_exceeds_limit(self) -> None:
+        """When the commit count exceeds GITLAB_MAX_COMMITS_FOR_PATCHSET, patchsets are
+        skipped to prevent O(N) sequential HTTP requests from timing out the task."""
+        commit_count = GITLAB_MAX_COMMITS_FOR_PATCHSET + 1
+        commits = self._make_fake_commits(commit_count)
+
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = self.get_repository(pk=response.data["id"])
+
+        # client=None is intentional: if _get_patchset were called it would
+        # raise AttributeError, which would make the test fail.
+        result = self.provider._format_commits(None, repo, commits)
+
+        assert len(result) == commit_count
+        assert all(c["patch_set"] == [] for c in result)
+
+    @responses.activate
+    def test_format_commits_fetches_patchset_when_within_limit(self) -> None:
+        """When the commit count is at or below the limit, patchsets are fetched normally."""
+        commit_count = GITLAB_MAX_COMMITS_FOR_PATCHSET
+        commits = self._make_fake_commits(commit_count)
+
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = self.get_repository(pk=response.data["id"])
+
+        mock_client = MagicMock()
+        mock_client.get_diff.return_value = []
+
+        result = self.provider._format_commits(mock_client, repo, commits)
+
+        assert len(result) == commit_count
+        assert mock_client.get_diff.call_count == commit_count
+        assert all(c["patch_set"] == [] for c in result)

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -18,6 +18,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.commits import (
     GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS,
     fetch_commits,
+    fetch_commits_for_compare_range,
     get_github_compare_commits_cache_key,
     handle_invalid_identity,
 )
@@ -278,6 +279,41 @@ class FetchCommitsTest(TestCase):
             and call.args[2] == GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS
             for call in mock_cache_set.call_args_list
         )
+
+    def test_gitlab_compare_commits_cache_enabled(self, mock_record: MagicMock) -> None:
+        """GitLab repositories use the task-level result cache, so a second call
+        for the same SHA range uses the cached result rather than re-fetching."""
+        org = self.create_organization(owner=self.user, name="gitlab-org")
+        repo = Repository.objects.create(
+            name="example",
+            provider="integrations:gitlab",
+            organization_id=org.id,
+        )
+        cache.clear()
+
+        mock_provider = MagicMock()
+        mock_provider.fetch_commits_for_compare_range.return_value = [
+            {"id": "abc123", "repository": repo.name}
+        ]
+
+        result1 = fetch_commits_for_compare_range(
+            repo=repo,
+            provider=mock_provider,
+            start_sha="a" * 40,
+            end_sha="b" * 40,
+            user=None,
+        )
+        result2 = fetch_commits_for_compare_range(
+            repo=repo,
+            provider=mock_provider,
+            start_sha="a" * 40,
+            end_sha="b" * 40,
+            user=None,
+        )
+
+        # The provider should only be called once; the second call hits the cache.
+        assert mock_provider.fetch_commits_for_compare_range.call_count == 1
+        assert result1 == result2
 
     def test_release_locked(self, mock_record_event: MagicMock) -> None:
         self.login_as(user=self.user)


### PR DESCRIPTION
## Summary

Fixes repeated `ProcessingDeadlineExceeded` noise on the `sentry.tasks.commits.fetch_commits` task for GitLab integrations with high-commit-count release ranges.

**Sentry issue**: https://sentry.sentry.io/issues/SENTRY-5HBP
**Linear**: ISWF-2125 "Reduce noise ProcessingDeadlineExceeded"
**Triggering event ID**: `6866dc6870ad4b208e74f4efef001571`

---

## Root-cause analysis

The call chain is:

```
fetch_commits
  → fetch_commits_for_compare_range
    → GitlabRepositoryProvider.compare_commits
      → _format_commits
        → _get_patchset (per commit)
          → client.get_diff(project_id, sha)   ← one HTTP request per commit
```

Unlike GitHub, GitLab's compare/commit-list API does not include file diffs in its response. `_format_commits` compensates by calling `_get_patchset` (and thus `client.get_diff`) once per commit. For a release range spanning hundreds of commits this creates a long sequential chain of HTTP requests (~0.7–1.5 s each), and the task exceeds its 905-second processing deadline.

Compounding the issue: `fetch_commits_for_compare_range` (in `tasks/commits.py`) maintains a task-level result cache to avoid re-fetching on retries, but it was gated behind `GITHUB_CACHEABLE_REPOSITORY_PROVIDERS` which only covered GitHub — so every retry for a GitLab repo re-fetched all diffs from scratch.

### What was ruled out

- **Silencing the error / raising the timeout**: not appropriate — hides a real problem.
- **Per-SHA `functools.lru_cache` in `_get_patchset`**: wouldn't help; commits within a single range each have unique SHAs.
- **Fixing the cache alone**: the task-level cache only helps on *retries* for the same SHA range; the first invocation with many commits still generates all requests and can timeout before the cache is populated.

---

## Fix

Two complementary changes:

### 1. Commit-count cap in `_format_commits` (`gitlab/repository.py`)

Add `GITLAB_MAX_COMMITS_FOR_PATCHSET = 100`. When a release range contains more than 100 commits, patchset fetching is skipped for all commits and each returns `patch_set: []`. Commit metadata (id, author, message, timestamp) is still recorded. A `WARNING` log (`gitlab.repository.patchset_fetch_skipped`) is emitted to make the skip observable in production.

This directly fixes the timeout: at 1.5 s per request, 100 commits ≈ 150 s — well within the 905-second task deadline.

### 2. Extend the result cache to GitLab (`tasks/commits.py`)

Add `"integrations:gitlab"` to the (renamed) `CACHEABLE_REPOSITORY_PROVIDERS` frozenset. This means the `compare_commits_cache_enabled` tag will now be `True` for GitLab repos, and the cached result (including the capped commit list) is reused on task retries for the same SHA range instead of re-fetching.

---

## Test plan

- [ ] `tests/sentry/integrations/gitlab/test_repository.py::GitLabRepositoryProviderTest::test_format_commits_skips_patchset_when_commit_count_exceeds_limit` — verifies that when `len(commit_list) > GITLAB_MAX_COMMITS_FOR_PATCHSET`, `_format_commits` returns commits with empty `patch_set` without calling the client at all.
- [ ] `tests/sentry/integrations/gitlab/test_repository.py::GitLabRepositoryProviderTest::test_format_commits_fetches_patchset_when_within_limit` — verifies that for ≤ 100 commits, `_get_patchset` is called once per commit as before.
- [ ] `tests/sentry/tasks/test_commits.py::FetchCommitsTest::test_gitlab_compare_commits_cache_enabled` — verifies that the task-level cache is active for GitLab repos, so a second call for the same SHA range hits the cache and does not call the provider again.
- [ ] Existing GitHub cache tests continue to pass (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nfvwwmgaxtnj4cWQqc1jJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nfvwwmgaxtnj4cWQqc1jJW)_