### PR TITLE
fix: use TopBar.Slot instead of manual h1 heading

### DIFF
--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -9,7 +9,7 @@ import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DateTime} from 'sentry/components/dateTime';
@@ -42,6 +42,7 @@ import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {TopBar} from 'sentry/views/navigation/topBar';
 import {getRelativeExplorerUrl} from 'sentry/views/seerExplorer/utils';
 import {
   CATEGORY_LABELS,
@@ -233,7 +234,7 @@ function SeerWorkflows() {
     <SentryDocumentTitle title={t('Sentry Workflows')} orgSlug={organization.slug}>
       <Stack gap="lg" padding="xl">
         <Stack gap="2xs">
-          <Heading as="h1">{t('Sentry Workflows')}</Heading>
+          <TopBar.Slot name="title">{t('Sentry Workflows')}</TopBar.Slot>
           <Text as="p" variant="muted">
             {t('Historical runs of Sentry workflows for this organization.')}
           </Text>


### PR DESCRIPTION
| before | after |
|--------|--------|
| <img width="1214" height="188" alt="Screenshot 2026-07-20 at 13 40 33" src="https://github.com/user-attachments/assets/45be91d6-0bb1-418c-aead-69f7755ce2af" /> | <img width="1213" height="159" alt="Screenshot 2026-07-20 at 13 40 15" src="https://github.com/user-attachments/assets/4f54ee61-fdd3-49a7-9636-5f1f2e6f85a2" /> |