### PR TITLE
feat(releases): Add enable-release-creation feature to remaining release auto-creation paths

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -75,6 +75,7 @@ from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.releases.util import ReleaseQuerySet, SemverFilter
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.releases.auto_creation import should_auto_create_releases
 from sentry.releases.use_cases.release import serialize as release_serializer
 from sentry.search.events.constants import (
     OPERATOR_TO_DJANGO,
@@ -90,6 +91,7 @@ from sentry.signals import release_created
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.types.activity import ActivityType
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.dates import deprecated_utcnow
@@ -307,9 +309,16 @@ def debounce_update_release_health_data(organization, project_ids: list[int]):
             # happen if the release only had health data so far.  For these cases
             # we want to create the release the first time we observed it on the
             # health side.
+            project.set_cached_field_value("organization", organization)
             release = Release.get_or_create(
-                project=project, version=version, date_added=dates.get((project_id, version))
+                project=project,
+                version=version,
+                date_added=dates.get((project_id, version)),
+                create=should_auto_create_releases(project),
             )
+            if release is None:
+                metrics.incr("organization_releases.release_autocreation_skipped")
+                continue
 
             # Make sure that the release knows about this project.  Like we had before
             # the project might not have been associated with this release yet.

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -118,6 +118,7 @@ from sentry.net.http import connection_from_url
 from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
 from sentry.receivers.onboarding import record_release_received
+from sentry.releases.auto_creation import should_auto_create_releases
 from sentry.reprocessing2 import is_reprocessed_event
 from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.services.eventstore.processing import event_processing_store
@@ -731,12 +732,7 @@ def _get_or_create_release_many(jobs: Sequence[Job], projects: ProjectsMapping) 
         project = projects[job["project_id"]]
         date = job["event"].datetime
 
-        # When the org has the feature flag and the project has disabled
-        # auto-creation, we only associate with releases that already exist
-        # (e.g. created via the CLI) and never create new ones from telemetry.
-        create_release = not features.has(
-            "organizations:auto-release-creation", project.organization
-        ) or project.get_option("sentry:enable_auto_release_creation")
+        create_release = should_auto_create_releases(project)
 
         try:
             release = Release.get_or_create(

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from sentry_sdk import capture_exception
 from taskbroker_client.retry import Retry
 
-from sentry import features, options
+from sentry import options
 from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.models.release import Release, ReleaseStatus
@@ -18,6 +18,7 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.release_health import release_monitor
 from sentry.release_health.release_monitor.base import Totals
+from sentry.releases.auto_creation import should_auto_create_releases
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import release_health_tasks
 from sentry.utils import metrics
@@ -196,12 +197,7 @@ def _handle_release_adoption(
         metrics.incr("sentry.tasks.process_projects_with_sessions.creating_rpe")
         try:
             project = Project.objects.get(id=project_id)
-            # When the org has the feature flag and the project has disabled
-            # auto-creation, only associate with releases that already exist
-            # (e.g. created via the CLI) and never create new ones from telemetry.
-            create_release = not features.has(
-                "organizations:auto-release-creation", project.organization
-            ) or project.get_option("sentry:enable_auto_release_creation")
+            create_release = should_auto_create_releases(project)
 
             env = Environment.objects.get_or_create(name=environment_name, organization_id=org_id)[
                 0

--- a/src/sentry/releases/auto_creation.py
+++ b/src/sentry/releases/auto_creation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sentry import features
+
+if TYPE_CHECKING:
+    from sentry.models.project import Project
+
+
+def should_auto_create_releases(project: Project) -> bool:
+    """
+    Whether releases may be created as a side effect of telemetry (events, spans,
+    session health data) for this project. When the org has the feature flag and the
+    project has disabled auto-creation, telemetry may only associate with releases
+    that already exist (e.g. created via the CLI), never create new ones.
+    """
+    return not features.has("organizations:auto-release-creation", project.organization) or bool(
+        project.get_option("sentry:enable_auto_release_creation")
+    )

--- a/src/sentry/releases/endpoints/project_release_stats.py
+++ b/src/sentry/releases/endpoints/project_release_stats.py
@@ -23,6 +23,8 @@ from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.release import Release
 from sentry.release_health.base import is_overview_stat
+from sentry.releases.auto_creation import should_auto_create_releases
+from sentry.utils import metrics
 from sentry.utils.dates import get_rollup_from_request
 
 
@@ -52,13 +54,20 @@ def upsert_missing_release(project, version) -> datetime | None:
         )
     except Release.DoesNotExist:
         rows = release_health.backend.get_oldest_health_data_for_releases([(project.id, version)])
-        if rows:
-            oldest = next(iter(rows.values()))
-            release = Release.get_or_create(project=project, version=version, date_added=oldest)
-            release.add_project(project)
-            return release.date_added
-        else:
+        if not rows:
             return None
+        oldest = next(iter(rows.values()))
+        release = Release.get_or_create(
+            project=project,
+            version=version,
+            date_added=oldest,
+            create=should_auto_create_releases(project),
+        )
+        if release is None:
+            metrics.incr("project_release_stats.release_autocreation_skipped")
+            return None
+        release.add_project(project)
+        return release.date_added
 
 
 @extend_schema(tags=["Releases"])

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -39,6 +39,7 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.receivers.features import record_generic_event_processed
 from sentry.receivers.onboarding import record_release_received
+from sentry.releases.auto_creation import should_auto_create_releases
 from sentry.signals import first_insight_span_received, first_transaction_received
 from sentry.spans.consumers.process_segments.enrichment import TreeEnricher, compute_breakdowns
 from sentry.spans.consumers.process_segments.shim import build_shim_event_data, make_compatible
@@ -266,13 +267,22 @@ def _create_models(
         return
 
     try:
-        release = Release.get_or_create(project=project, version=release_name, date_added=date)
+        release = Release.get_or_create(
+            project=project,
+            version=release_name,
+            date_added=date,
+            create=should_auto_create_releases(project),
+        )
     except ValidationError:
         # Avoid catching a stacktrace here, the codepath is very hot
         logger.warning(
             "Failed creating Release due to ValidationError",
             extra={"project": project, "version": release_name},
         )
+        return
+
+    if release is None:
+        metrics.incr("spans.consumers.process_segments.release_autocreation_skipped")
         return
 
     if dist_name:
@@ -459,8 +469,17 @@ def _bump_release_last_seen(
     environment = Environment.get_or_create(project=project, name=environment_name)
 
     try:
-        release = Release.get_or_create(project=project, version=release_name, date_added=date)
+        release = Release.get_or_create(
+            project=project,
+            version=release_name,
+            date_added=date,
+            create=should_auto_create_releases(project),
+        )
     except ValidationError:
+        return
+
+    if release is None:
+        metrics.incr("spans.consumers.process_segments.release_autocreation_skipped")
         return
 
     # Bumps release-environment last-seen.

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -8,7 +8,10 @@ from django.urls import reverse
 from django.utils import timezone
 
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
-from sentry.api.endpoints.organization_releases import ReleaseSerializerWithProjects
+from sentry.api.endpoints.organization_releases import (
+    ReleaseSerializerWithProjects,
+    debounce_update_release_health_data,
+)
 from sentry.api.release_search import FINALIZED_KEY, RELEASE_CREATED_KEY
 from sentry.api.serializers.rest_framework.release import ReleaseHeadCommitSerializer
 from sentry.auth import access
@@ -3124,3 +3127,46 @@ class OrganizationReleasesBaseEndpointGetProjectsTest(TestCase):
 
         # Should return the project since user is a member
         assert project in projects
+
+
+class DebounceUpdateReleaseHealthDataTest(TestCase):
+    def run_with_health_data(self, project, version="1.0"):
+        with patch(
+            "sentry.api.endpoints.organization_releases.release_health"
+        ) as mock_release_health:
+            mock_release_health.backend.get_changed_project_release_model_adoptions.return_value = [
+                (project.id, version)
+            ]
+            mock_release_health.backend.get_oldest_health_data_for_releases.return_value = {
+                (project.id, version): timezone.now()
+            }
+            debounce_update_release_health_data(project.organization, [project.id])
+
+    def test_creates_release_from_health_data(self) -> None:
+        project = self.create_project()
+
+        self.run_with_health_data(project)
+
+        release = Release.objects.get(organization_id=project.organization_id, version="1.0")
+        assert ReleaseProject.objects.filter(release=release, project=project).exists()
+
+    def test_auto_creation_disabled_skips_creation(self) -> None:
+        project = self.create_project()
+        project.update_option("sentry:enable_auto_release_creation", False)
+
+        with self.feature("organizations:auto-release-creation"):
+            self.run_with_health_data(project)
+
+        assert not Release.objects.filter(organization_id=project.organization_id).exists()
+
+    def test_auto_creation_disabled_associates_existing_release(self) -> None:
+        # A release created out-of-band (e.g. via the CLI) is still associated even
+        # when auto-creation is disabled.
+        project = self.create_project()
+        project.update_option("sentry:enable_auto_release_creation", False)
+        release = Release.objects.create(organization_id=project.organization_id, version="1.0")
+
+        with self.feature("organizations:auto-release-creation"):
+            self.run_with_health_data(project)
+
+        assert ReleaseProject.objects.filter(release=release, project=project).exists()

--- a/tests/sentry/releases/endpoints/test_project_release_stats.py
+++ b/tests/sentry/releases/endpoints/test_project_release_stats.py
@@ -1,10 +1,14 @@
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 
 from sentry.models.release import Release
-from sentry.testutils.cases import APITestCase
+from sentry.models.releases.release_project import ReleaseProject
+from sentry.releases.endpoints.project_release_stats import upsert_missing_release
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
@@ -51,3 +55,45 @@ class ProjectReleaseStatsTest(APITestCase):
         )
         response = self.client.get(url, format="json")
         assert response.status_code == 404, response.content
+
+
+class UpsertMissingReleaseTest(TestCase):
+    def upsert_with_health_data(self, project, version="1.0"):
+        with patch(
+            "sentry.releases.endpoints.project_release_stats.release_health"
+        ) as mock_release_health:
+            mock_release_health.backend.get_oldest_health_data_for_releases.return_value = {
+                (project.id, version): timezone.now()
+            }
+            return upsert_missing_release(project, version)
+
+    def test_creates_release_from_health_data(self) -> None:
+        project = self.create_project()
+
+        date_added = self.upsert_with_health_data(project)
+
+        release = Release.objects.get(organization_id=project.organization_id, version="1.0")
+        assert date_added == release.date_added
+        assert ReleaseProject.objects.filter(release=release, project=project).exists()
+
+    def test_auto_creation_disabled_returns_none(self) -> None:
+        project = self.create_project()
+        project.update_option("sentry:enable_auto_release_creation", False)
+
+        with self.feature("organizations:auto-release-creation"):
+            assert self.upsert_with_health_data(project) is None
+
+        assert not Release.objects.filter(organization_id=project.organization_id).exists()
+
+    def test_auto_creation_disabled_associates_existing_release(self) -> None:
+        # A release created out-of-band (e.g. via the CLI) is still associated even
+        # when auto-creation is disabled.
+        project = self.create_project()
+        project.update_option("sentry:enable_auto_release_creation", False)
+        release = Release.objects.create(organization_id=project.organization_id, version="1.0")
+
+        with self.feature("organizations:auto-release-creation"):
+            date_added = self.upsert_with_health_data(project)
+
+        assert date_added == release.date_added
+        assert ReleaseProject.objects.filter(release=release, project=project).exists()

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -4,12 +4,19 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from django.utils import timezone
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
 from sentry.models.environment import Environment
 from sentry.models.release import Release
+from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+from sentry.models.releases.release_project import ReleaseProject
 from sentry.spans.consumers.process_segments import message as message_module
-from sentry.spans.consumers.process_segments.message import _verify_compatibility, process_segment
+from sentry.spans.consumers.process_segments.message import (
+    _bump_release_last_seen,
+    _verify_compatibility,
+    process_segment,
+)
 from sentry.spans.consumers.process_segments.shim import build_shim_event_data
 from sentry.spans.consumers.process_segments.types import attribute_value
 from sentry.testutils.cases import TestCase
@@ -22,6 +29,10 @@ from tests.sentry.spans.consumers.process import build_mock_span
 class TestSpansTask(TestCase):
     def setUp(self) -> None:
         self.project = self.create_project()
+        message_module.cache = None
+
+    def tearDown(self) -> None:
+        message_module.cache = None
 
     def generate_basic_spans(self):
         segment_span = build_mock_span(
@@ -152,6 +163,49 @@ class TestSpansTask(TestCase):
             organization_id=self.organization.id,
             name="a" * 64,
         )
+
+    def test_create_models_auto_creation_disabled(self) -> None:
+        self.project.update_option("sentry:enable_auto_release_creation", False)
+        spans = self.generate_basic_spans()
+
+        with self.feature("organizations:auto-release-creation"):
+            assert process_segment(spans)
+
+        Environment.objects.get(organization_id=self.organization.id, name="development")
+        assert not Release.objects.filter(organization_id=self.organization.id).exists()
+
+    def test_create_models_auto_creation_disabled_associates_existing_release(self) -> None:
+        # A release created out-of-band (e.g. via the CLI) is still associated even
+        # when auto-creation is disabled.
+        self.project.update_option("sentry:enable_auto_release_creation", False)
+        release = Release.objects.create(
+            organization_id=self.organization.id,
+            version="backend@24.2.0.dev0+699ce0cd1281cc3c7275d0a474a595375c769ae8",
+        )
+        spans = self.generate_basic_spans()
+
+        with self.feature("organizations:auto-release-creation"):
+            assert process_segment(spans)
+
+        assert ReleaseProject.objects.filter(release=release, project=self.project).exists()
+        assert ReleaseProjectEnvironment.objects.filter(
+            release_id=release.id, project_id=self.project.id
+        ).exists()
+
+    def test_create_models_auto_creation_disabled_without_feature_flag(self) -> None:
+        self.project.update_option("sentry:enable_auto_release_creation", False)
+        spans = self.generate_basic_spans()
+        assert process_segment(spans)
+
+        assert Release.objects.filter(organization_id=self.organization.id).exists()
+
+    def test_bump_release_last_seen_auto_creation_disabled(self) -> None:
+        self.project.update_option("sentry:enable_auto_release_creation", False)
+
+        with self.feature("organizations:auto-release-creation"):
+            _bump_release_last_seen(self.project, "development", "1.0", timezone.now())
+
+        assert not Release.objects.filter(organization_id=self.organization.id).exists()
 
     @override_options({"spans.process-segments.detect-performance-problems.enable": True})
     @mock.patch("sentry.issues.ingest.send_issue_occurrence_to_eventstream")


### PR DESCRIPTION
- Extract the `organizations:auto-release-creation` / `sentry:enable_auto_release_creation` check into a shared `should_auto_create_releases` helper
- Add check to the remaining telemetry-driven creation paths:
  - spans consumer `_create_models` / `_bump_release_last_seen` (standalone spans/EAP ingest)
  - `debounce_update_release_health_data` (release list flushing health data to postgres)
  - `upsert_missing_release` (project release stats endpoint; returns 404 instead of creating)

Contributes to TET-2505