### PR TITLE
chore: remove unused Seer RPC record_pr_attribution function

### DIFF
--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -1240,9 +1240,8 @@ def _detect_delegated_agent(
     Filter PRs that could have been delegated by Autofix to external coding agents,
     and fire the matching request to Seer if it's a candidate.
 
-    Seer resolves the match either synchronously (a ``200`` with the match body,
-    recorded in-process here) or asynchronously (a ``202``, followed later by the
-    "record_pr_attribution" RPC callback writing the attribution row).
+    Seer returns ``200`` when a match is found (with the match body recorded
+    in-process here) or ``202`` when a match is not found.
     """
     group_ids = resolved_group_ids(pr)
     if not group_ids:
@@ -1317,8 +1316,7 @@ def _send_seer_delegated_agent_match(
         return
 
     if response.status != 200:
-        # 202: Seer enqueued the match asynchronously and will call back via the
-        # record_pr_attribution RPC once it resolves.
+        # 202: Seer did not find a match.
         _record_delegated_candidate(provider_hint, "sent")
         return
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -247,9 +247,9 @@ def make_match_coding_agent_pr_request(
 class DelegatedAgentMatch(BaseModel):
     """A match resolved synchronously by ``/v1/pr-metrics/delegated-agent-match``.
 
-    Returned as a ``200`` body instead of the async ``202`` + ``record_pr_attribution``
-    RPC callback. ``match_path`` isn't consumed on the Sentry side today; it's kept
-    here to mirror the full wire contract.
+    Returned as a ``200`` body when a match is found. Seer returns ``202`` when
+    a match is not found. ``match_path`` isn't consumed on the Sentry side today;
+    it's kept here to mirror the full wire contract.
     """
 
     run_id: int

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -55,18 +55,8 @@ from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import MONITORING_PROVIDERS, IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
-from sentry.models.pullrequest import (
-    PullRequest,
-    PullRequestAttributionSignalType,
-    PullRequestAttributionSource,
-)
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
-from sentry.pr_metrics.attribution import (
-    DELEGATED_SIGNAL_TYPES,
-    DelegatedAgentSignalDetails,
-    record_attribution_signal,
-)
 from sentry.pr_metrics.judge import update_pr_metrics
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
@@ -146,7 +136,6 @@ from sentry.seer.sentry_data_models import (
     OrganizationProjectDetail,
     OrganizationProjectsResponse,
     OrganizationSlugResponse,
-    PrAttributionResponse,
     RefreshMonitoringProviderTokenErrorResponse,
     RefreshMonitoringProviderTokenSuccessResponse,
     SendSeerWebhookErrorResponse,
@@ -942,83 +931,6 @@ def refresh_monitoring_provider_token(
     )
 
 
-def record_pr_attribution(
-    *,
-    organization_id: int,
-    pull_request_id: int,
-    signal_type: str,
-    signal_details: dict[str, Any] | None = None,
-) -> PrAttributionResponse:
-    """Record a PR attribution signal on behalf of Seer.
-
-    Idempotent via the unique constraint on
-    PullRequestAttribution(pull_request, signal_type, source).
-
-    Args:
-        organization_id: Sentry organization that owns the PR.
-        pull_request_id: Sentry-internal PullRequest.id.
-        signal_type: A PullRequestAttributionSignalType value.
-        signal_details: Arbitrary provider-specific metadata to store on the row.
-
-    Returns:
-        {"attribution_id": int} on success, or {"attribution_id": None} when the
-        pr-metrics-attribution feature is disabled for the org.
-    """
-    try:
-        signal = PullRequestAttributionSignalType(signal_type)
-    except ValueError:
-        raise ParseError(detail=f"Unknown signal_type: {signal_type!r}")
-
-    try:
-        organization = Organization.objects.get(
-            id=organization_id, status=OrganizationStatus.ACTIVE
-        )
-    except Organization.DoesNotExist:
-        raise ObjectDoesNotExist(f"Organization {organization_id} not found or inactive")
-
-    if not features.has("organizations:pr-metrics-attribution", organization):
-        logger.info(
-            "seer.record_pr_attribution.feature_disabled",
-            extra={"organization_id": organization_id, "pull_request_id": pull_request_id},
-        )
-        return PrAttributionResponse(attribution_id=None)
-
-    try:
-        pull_request = PullRequest.objects.get(
-            id=pull_request_id,
-            organization_id=organization_id,
-        )
-    except PullRequest.DoesNotExist:
-        raise ObjectDoesNotExist(
-            f"PullRequest {pull_request_id} not found in org {organization_id}"
-        )
-
-    if signal in DELEGATED_SIGNAL_TYPES:
-        try:
-            signal_details = DelegatedAgentSignalDetails.parse_obj(signal_details or {}).dict()
-        except Exception:
-            raise ParseError(
-                detail="signal_details does not match DelegatedAgentSignalDetails schema"
-            )
-
-    attribution = record_attribution_signal(
-        pull_request=pull_request,
-        signal_type=signal,
-        source=PullRequestAttributionSource.SEER_DATA,
-        signal_details=signal_details,
-    )
-    logger.info(
-        "seer.record_pr_attribution.recorded",
-        extra={
-            "organization_id": organization_id,
-            "pull_request_id": pull_request_id,
-            "signal_type": signal_type,
-            "attribution_id": attribution.id,
-        },
-    )
-    return PrAttributionResponse(attribution_id=attribution.id)
-
-
 # Every value below MUST be a function returning a `pydantic.BaseModel` (or
 # a union of `BaseModel` subclasses, optionally with `None`). Two complementary
 # guards enforce this:
@@ -1088,7 +1000,6 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     "call_custom_tool": seer_rpc(call_custom_tool),
     "call_on_completion_hook": seer_rpc(call_on_completion_hook),
     "deliver_feature_result": seer_rpc(deliver_feature_result),
-    "record_pr_attribution": seer_rpc(record_pr_attribution),
     "get_log_attributes_for_trace": seer_rpc(get_log_attributes_for_trace),
     "get_metric_attributes_for_trace": seer_rpc(get_metric_attributes_for_trace),
     "get_baseline_tag_distribution": seer_rpc(get_baseline_tag_distribution),

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -551,13 +551,6 @@ class TransactionsForProjectResponse(BaseModel):
     transactions: list[Transaction]
 
 
-class PrAttributionResponse(BaseModel):
-    """`record_pr_attribution` returns `{"attribution_id": <id or null>}`. None
-    is emitted when the pr-metrics-attribution feature is disabled for the org."""
-
-    attribution_id: int | None
-
-
 class UpdatePrMetricsSuccessResponse(BaseModel):
     """`update_pr_metrics` success: `{"success": true}`. The `success` literal is
     the discriminator against the error shape below."""

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -18,7 +18,6 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.models.project import Project
 from sentry.models.projectrepository import ProjectRepository, ProjectRepositorySource
-from sentry.models.pullrequest import PullRequestAttribution, PullRequestAttributionSignalType
 from sentry.models.repository import Repository
 from sentry.seer.endpoints.seer_rpc import (
     generate_request_signature,
@@ -29,13 +28,11 @@ from sentry.seer.endpoints.seer_rpc import (
     get_project_preferences,
     get_repo_installation_id,
     has_repo_code_mappings,
-    record_pr_attribution,
     refresh_monitoring_provider_token,
 )
 from sentry.seer.sentry_data_models import (
     GitHubEnterpriseConfigErrorResponse,
     GitHubEnterpriseConfigSuccessResponse,
-    PrAttributionResponse,
     SendSeerWebhookSuccessResponse,
 )
 from sentry.sentry_apps.event_types import SentryAppEventType
@@ -1064,131 +1061,6 @@ class TestRefreshMonitoringProviderToken(APITestCase):
         result = refresh_monitoring_provider_token(identity_id=pat_identity.id)
 
         assert result == {"error": "refresh_not_supported"}
-
-
-@with_feature("organizations:pr-metrics-attribution")
-@cell_silo_test
-class TestRecordPrAttribution(APITestCase):
-    def setUp(self) -> None:
-        self.project = self.create_project(organization=self.organization)
-        self.repo = self.create_repo(self.project, provider="integrations:github", external_id="1")
-        self.pr = self.create_pull_request(
-            repository_id=self.repo.id,
-            organization_id=self.organization.id,
-            key="10",
-        )
-
-    _DEFAULT_PR_URL = "https://github.com/getsentry/sentry/pull/99"
-
-    def _call(self, **overrides: Any) -> PrAttributionResponse:
-        kwargs: dict[str, Any] = {
-            "organization_id": self.organization.id,
-            "pull_request_id": self.pr.id,
-            "signal_type": PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
-            "signal_details": {"pr_url": self._DEFAULT_PR_URL},
-        }
-        kwargs.update(overrides)
-        return record_pr_attribution(**kwargs)
-
-    def test_creates_attribution(self) -> None:
-        result = self._call()
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.signal_type == PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE
-        assert attr.is_valid is True
-        assert result.attribution_id == attr.id
-
-    def test_stores_typed_signal_details_for_delegated_signals(self) -> None:
-        self._call(
-            signal_details={
-                "agent_id": "agent-abc-123",
-                "pr_url": self._DEFAULT_PR_URL,
-                "run_id": 42,
-            }
-        )
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.signal_details == {
-            "agent_id": "agent-abc-123",
-            "pr_url": self._DEFAULT_PR_URL,
-            "run_id": 42,
-            "group_ids": [],
-        }
-
-    def test_delegated_signal_details_defaults_nullable_fields(self) -> None:
-        self._call(signal_details={"pr_url": self._DEFAULT_PR_URL})
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.signal_details == {
-            "agent_id": None,
-            "pr_url": self._DEFAULT_PR_URL,
-            "run_id": None,
-            "group_ids": [],
-        }
-
-    def test_invalid_delegated_signal_details_raises(self) -> None:
-        from rest_framework.exceptions import ParseError
-
-        with pytest.raises(ParseError):
-            self._call(signal_details={"agent_id": "x"})  # missing required pr_url
-
-    def test_no_signal_details_for_non_delegated_type_leaves_null(self) -> None:
-        self._call(
-            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
-            signal_details=None,
-        )
-
-        attr = PullRequestAttribution.objects.get(pull_request=self.pr)
-        assert attr.signal_details is None
-
-    def test_idempotent_on_repeat_call(self) -> None:
-        result1 = self._call()
-        result2 = self._call()
-
-        assert result1 == result2
-        assert PullRequestAttribution.objects.filter(pull_request=self.pr).count() == 1
-
-    def test_invalid_signal_type_raises(self) -> None:
-        from rest_framework.exceptions import ParseError
-
-        with pytest.raises(ParseError):
-            self._call(signal_type="not_a_real_signal")
-
-    def test_org_not_found_raises(self) -> None:
-        from django.core.exceptions import ObjectDoesNotExist
-
-        with pytest.raises(ObjectDoesNotExist):
-            self._call(organization_id=999999)
-
-    def test_pr_not_found_raises(self) -> None:
-        from django.core.exceptions import ObjectDoesNotExist
-
-        with pytest.raises(ObjectDoesNotExist):
-            self._call(pull_request_id=999999)
-
-    def test_pr_from_different_org_raises(self) -> None:
-        from django.core.exceptions import ObjectDoesNotExist
-
-        other_org = self.create_organization()
-        other_project = self.create_project(organization=other_org)
-        other_repo = self.create_repo(
-            other_project, provider="integrations:github", external_id="2"
-        )
-        other_pr = self.create_pull_request(
-            repository_id=other_repo.id,
-            organization_id=other_org.id,
-            key="20",
-        )
-
-        with pytest.raises(ObjectDoesNotExist):
-            self._call(pull_request_id=other_pr.id)
-
-    def test_feature_disabled_returns_null_attribution_id(self) -> None:
-        with self.feature({"organizations:pr-metrics-attribution": False}):
-            result = self._call()
-
-        assert result == {"attribution_id": None}
-        assert not PullRequestAttribution.objects.filter(pull_request=self.pr).exists()
 
 
 @override_settings(SEER_RPC_SHARED_SECRET=["a-long-value-that-is-hard-to-guess"])


### PR DESCRIPTION
Remove the unused `record_pr_attribution` Seer RPC function and its associated test infrastructure. This function was originally designed to handle asynchronous PR attribution callbacks from Seer, but is no longer used since Seer now calls `record_attribution_signal` directly instead of going through the RPC layer.

The removal includes:
- The `record_pr_attribution` RPC function definition
- The `TestRecordPrAttribution` test class with 9 test methods  
- The `PrAttributionResponse` data model that was only used by this function
- Updates to comments that referenced the deprecated async callback mechanism

Comments now accurately reflect the current behavior where Seer returns HTTP 200 when a match is found and HTTP 202 when no match is found, rather than the old async pattern of 202 + callback.

Fixes CW-1679