### PR TITLE
fix(taskworker): handle closed Kafka producer gracefully during shutdown

### DIFF
--- a/src/sentry/scm/private/stream_producer.py
+++ b/src/sentry/scm/private/stream_producer.py
@@ -6,6 +6,7 @@ from sentry.scm.private.helpers import record_count_metric, report_error_to_sent
 from sentry.scm.private.ipc import PRODUCE_TO_LISTENER, produce_to_listener, produce_to_listeners
 from sentry.scm.types import HybridCloudSilo, SubscriptionEvent
 from sentry.scm.utils import check_rollout_option
+from sentry.utils.arroyo_producer import ProducerClosedError
 
 logger = logging.getLogger("sentry.scm")
 PREFIX = "sentry.scm.produce_event_to_scm_stream"
@@ -37,6 +38,15 @@ def produce_event_to_scm_stream(
         record_count(f"{PREFIX}.success", 1, {})
         if is_dev:
             logger.info(f"Successfully processed SCM webhook event: {event['event_type_hint']}.")
+    except ProducerClosedError:
+        # The Kafka producer was shut down while this request was still in flight.
+        # This is expected during rolling deployments when Granian starts draining
+        # connections and the atexit handler closes the producer before all webhook
+        # handlers finish. Record a metric but do not report to Sentry — this is
+        # not an actionable error.
+        record_count(f"{PREFIX}.failed", 1, {"reason": "producer-closed"})
+        if is_dev:
+            logger.warning("SCM webhook event dropped: Kafka producer shut down (process shutting down).")
     except SCMProviderNotSupported:
         record_count(
             f"{PREFIX}.failed", 1, {"reason": "provider-not-supported", "provider": event["type"]}

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -16,6 +16,16 @@ from sentry.utils.kafka_config import get_kafka_producer_cluster_options, get_to
 _ProducerFuture = ProducerFuture[BrokerValue[KafkaPayload]]
 
 
+class ProducerClosedError(Exception):
+    """Raised when produce() is called after the SingletonProducer has been shut down.
+
+    During rolling deployments the process atexit handler closes the underlying
+    Kafka producer while in-flight requests may still try to dispatch tasks.
+    Callers that expect this during shutdown should catch this exception
+    separately from unexpected errors so it is not reported to Sentry.
+    """
+
+
 class SingletonProducer:
     """
     A Kafka producer that can be instantiated as a global
@@ -32,6 +42,7 @@ class SingletonProducer:
         self._factory = kafka_producer_factory
         self._futures: deque[_ProducerFuture] = deque()
         self.max_futures = max_futures
+        self._closed = False
 
         # This fixes a shutdown-ordering bug with OutcomeAggregator, which
         # flushes buffered outcomes into a producer from its own atexit handler.
@@ -46,7 +57,20 @@ class SingletonProducer:
     def produce(
         self, destination: ArroyoTopic | Partition, payload: KafkaPayload
     ) -> _ProducerFuture:
-        future = self._get().produce(destination, payload)
+        # Fast path: check the closed flag before attempting to produce.
+        # _shutdown() sets this flag before closing the underlying producer,
+        # so we can detect the common case without catching a RuntimeError.
+        if self._closed:
+            raise ProducerClosedError("SingletonProducer has been shut down")
+        try:
+            future = self._get().produce(destination, payload)
+        except RuntimeError as e:
+            # Handle the race condition where _shutdown() closed the producer
+            # between our flag check above and the actual produce() call.
+            # Arroyo raises RuntimeError("producer has been closed") in this case.
+            if "producer has been closed" in str(e):
+                raise ProducerClosedError("SingletonProducer has been shut down") from e
+            raise
         self._track_futures(future)
         return future
 
@@ -67,6 +91,11 @@ class SingletonProducer:
                 future.result()
 
     def _shutdown(self) -> None:
+        # Mark as closed before flushing/closing so that concurrent produce()
+        # calls made on other threads see the flag and raise ProducerClosedError
+        # instead of hitting a RuntimeError from the underlying Kafka producer.
+        self._closed = True
+
         for future in self._futures:
             try:
                 future.result()

--- a/tests/sentry/scm/unit/test_stream_producer.py
+++ b/tests/sentry/scm/unit/test_stream_producer.py
@@ -3,6 +3,7 @@ import msgspec
 from fixtures.github import PULL_REQUEST_OPENED_EVENT_EXAMPLE
 from sentry.scm.private.stream_producer import produce_event_to_scm_stream
 from sentry.scm.types import SubscriptionEvent
+from sentry.utils.arroyo_producer import ProducerClosedError
 
 
 def test_produce_to_scm_stream() -> None:
@@ -90,6 +91,46 @@ def test_produce_to_scm_stream_invalid_payload() -> None:
     assert metrics == [
         ("sentry.scm.produce_event_to_scm_stream.failed", 1, {"reason": "processing"})
     ]
+
+
+def test_produce_to_scm_stream_producer_closed() -> None:
+    # When the Kafka producer is shut down during a rolling deployment,
+    # produce_to_listener raises ProducerClosedError. This must be recorded
+    # as a metric but must NOT be reported to Sentry as an error.
+    metrics = []
+    reported_exception = None
+
+    def record_count(k, a, t):
+        metrics.append((k, a, t))
+
+    def report_error(e):
+        nonlocal reported_exception
+        reported_exception = e
+
+    event: SubscriptionEvent = {
+        "event": PULL_REQUEST_OPENED_EVENT_EXAMPLE.decode("utf-8"),
+        "event_type_hint": "pull_request",
+        "extra": {},
+        "received_at": 0,
+        "sentry_meta": [],
+        "type": "github",
+    }
+    def raise_producer_closed(listener_name, message, event_type_hint, silo):
+        raise ProducerClosedError("shutdown")
+
+    produce_event_to_scm_stream(
+        event,
+        "control",
+        produce_to_listener=raise_producer_closed,
+        record_count=record_count,
+        report_error=report_error,
+        rollout_enabled=lambda _: True,
+    )
+
+    # Must record a metric for observability.
+    assert metrics == [("sentry.scm.produce_event_to_scm_stream.failed", 1, {"reason": "producer-closed"})]
+    # Must NOT report to Sentry — this is expected during shutdown.
+    assert reported_exception is None
 
 
 def test_produce_to_scm_stream_rollout_disabled() -> None:

--- a/tests/sentry/utils/test_arroyo_producer.py
+++ b/tests/sentry/utils/test_arroyo_producer.py
@@ -1,10 +1,11 @@
+import pytest
 from unittest.mock import Mock, patch
 
 from arroyo.backends.kafka import KafkaProducer
 
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.testutils.helpers.options import override_options
-from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
+from sentry.utils.arroyo_producer import ProducerClosedError, SingletonProducer, get_arroyo_producer
 
 
 def test_registers_shutdown_at_construction() -> None:
@@ -26,6 +27,54 @@ def test_shutdown_is_noop_without_producer() -> None:
 
     producer = SingletonProducer(dummy_producer)
     producer._shutdown()
+
+
+def test_produce_after_shutdown_raises_producer_closed_error() -> None:
+    # Calling produce() after _shutdown() has run must raise ProducerClosedError,
+    # not the raw RuntimeError from the underlying Kafka producer.
+    mock_kafka = Mock(spec=KafkaProducer)
+
+    def dummy_producer() -> KafkaProducer:
+        return mock_kafka
+
+    producer = SingletonProducer(dummy_producer)
+    producer._shutdown()
+
+    with pytest.raises(ProducerClosedError):
+        producer.produce(Mock(), Mock())
+
+    # The underlying producer must not have been called.
+    mock_kafka.produce.assert_not_called()
+
+
+def test_produce_raises_producer_closed_error_on_underlying_runtime_error() -> None:
+    # If the underlying Kafka producer raises RuntimeError("producer has been closed")
+    # (e.g. due to a race between _shutdown and produce), SingletonProducer must
+    # wrap it in ProducerClosedError so callers can distinguish shutdown from bugs.
+    mock_kafka = Mock(spec=KafkaProducer)
+    mock_kafka.produce.side_effect = RuntimeError("producer has been closed")
+
+    def dummy_producer() -> KafkaProducer:
+        return mock_kafka
+
+    producer = SingletonProducer(dummy_producer)
+
+    with pytest.raises(ProducerClosedError):
+        producer.produce(Mock(), Mock())
+
+
+def test_produce_reraises_unrelated_runtime_error() -> None:
+    # RuntimeErrors that are NOT about a closed producer must propagate unchanged.
+    mock_kafka = Mock(spec=KafkaProducer)
+    mock_kafka.produce.side_effect = RuntimeError("some other error")
+
+    def dummy_producer() -> KafkaProducer:
+        return mock_kafka
+
+    producer = SingletonProducer(dummy_producer)
+
+    with pytest.raises(RuntimeError, match="some other error"):
+        producer.produce(Mock(), Mock())
 
 
 def test_track_futures() -> None:


### PR DESCRIPTION
## Summary

Fixes `RuntimeError: producer has been closed` noise in Sentry during rolling deployments.

- **Sentry issue**: https://sentry.io/organizations/sentry/issues/7477709919/
- **Triage session**: https://claude.ai/code/session_01NCzH6oK1BUWm9gh2wSqScb

## Root cause

During rolling deployments, Granian starts draining connections and the process `atexit` handler closes the Arroyo `KafkaProducer` (via `SingletonProducer._shutdown()`). In-flight webhook requests that are still executing call `produce()` after the producer has been closed. The underlying arroyo library checks `self.__shutdown_requested.is_set()` and raises `RuntimeError("producer has been closed")`.

That exception propagates up through:

```
arroyo_producer.py:produce()
  → taskbroker_client.delay()
    → ipc.py:produce_to_listener()
      → ipc.py:produce_to_listeners()
        → stream_producer.py:produce_event_to_scm_stream()
```

The generic `except Exception as e` in `produce_event_to_scm_stream` catches it and calls `report_error_to_sentry(e)`, creating Sentry errors for a normal shutdown condition that is not actionable.

## What the fix does

**`src/sentry/utils/arroyo_producer.py`** (root cause fix):

- Adds `ProducerClosedError(Exception)` — a distinct exception type for this lifecycle condition.
- Adds a `_closed: bool` flag to `SingletonProducer`.
- `_shutdown()` sets `_closed = True` **before** closing the underlying producer, so concurrent `produce()` calls on other threads see the flag immediately.
- `produce()` checks `_closed` first (fast path), and also catches `RuntimeError("producer has been closed")` from the underlying arroyo producer (handles the race window between the flag check and the actual Kafka call), re-raising both cases as `ProducerClosedError`.

**`src/sentry/scm/private/stream_producer.py`** (caller fix):

- Catches `ProducerClosedError` before the generic `except Exception`, records a `producer-closed` metric for observability, and skips `report_error_to_sentry`. Shutdown-time message drops are expected and not actionable.

## What was ruled out

- **Swallowing the error silently in `produce()`**: Callers need to know the producer is unavailable so they can decide whether to retry, log, or metric it. A specific exception type preserves that signal without hitting Sentry.
- **Re-initializing the producer after shutdown**: This would fight the process lifecycle and could produce messages after flush guarantees no longer hold.
- **Catching only in `stream_producer.py` without fixing `arroyo_producer.py`**: That would leave the raw `RuntimeError` leaking to all other `SingletonProducer` callers in the codebase (outcomes, spans, monitors, etc.) if they encounter the same race.

## Tests

- `test_produce_after_shutdown_raises_producer_closed_error` — flag-based fast path
- `test_produce_raises_producer_closed_error_on_underlying_runtime_error` — race-condition path (underlying Kafka raises RuntimeError)
- `test_produce_reraises_unrelated_runtime_error` — unrelated RuntimeErrors still propagate
- `test_produce_to_scm_stream_producer_closed` — verifies metric is recorded and Sentry is **not** called

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCzH6oK1BUWm9gh2wSqScb)_