### PR TITLE
fix(notifications): log integration config errors at WARNING in notification action handlers

### DIFF
--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -3,6 +3,7 @@ import logging
 import sentry_sdk
 
 from sentry import features
+from sentry.exceptions import InvalidIdentity
 from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.grouptype import MetricIssue
 from sentry.integrations.metric_alerts import incident_attachment_info
@@ -24,6 +25,11 @@ from sentry.notifications.platform.templates.issue import (
 from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
 from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
 from sentry.options.rollout import in_random_rollout
+from sentry.shared_integrations.exceptions import (
+    ApiUnauthorized,
+    IntegrationConfigurationError,
+    IntegrationFormError,
+)
 from sentry.types.activity import ActivityType
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.types import ActionInvocation
@@ -111,6 +117,15 @@ def execute_via_issue_alert_handler(invocation: ActionInvocation) -> None:
             extra={"action_id": invocation.action.id, "detector_id": invocation.detector.id},
         )
         raise
+    except (IntegrationFormError, IntegrationConfigurationError, InvalidIdentity, ApiUnauthorized):
+        # These are expected user-configuration errors (e.g. invalid repo, revoked credentials).
+        # They are already tracked at WARNING level by the SLO system in the integration layer;
+        # logging them again at ERROR here would cause spurious Sentry captures.
+        logger.warning(
+            "Integration configuration error executing via issue alert handler",
+            extra={"action_id": invocation.action.id, "detector_id": invocation.detector.id},
+        )
+        raise
     except Exception:
         logger.exception(
             "Error executing via issue alert handler",
@@ -130,6 +145,15 @@ def execute_via_metric_alert_handler(invocation: ActionInvocation) -> None:
         logger.exception(
             "No notification handler found for action type: %s",
             invocation.action.type,
+            extra={"action_id": invocation.action.id, "detector_id": invocation.detector.id},
+        )
+        raise
+    except (IntegrationFormError, IntegrationConfigurationError, InvalidIdentity, ApiUnauthorized):
+        # These are expected user-configuration errors (e.g. invalid repo, revoked credentials).
+        # They are already tracked at WARNING level by the SLO system in the integration layer;
+        # logging them again at ERROR here would cause spurious Sentry captures.
+        logger.warning(
+            "Integration configuration error executing via metric alert handler",
             extra={"action_id": invocation.action.id, "detector_id": invocation.detector.id},
         )
         raise

--- a/tests/sentry/notifications/notification_action/test_utils.py
+++ b/tests/sentry/notifications/notification_action/test_utils.py
@@ -1,0 +1,142 @@
+import uuid
+from unittest import mock
+
+import pytest
+
+from sentry.exceptions import InvalidIdentity
+from sentry.notifications.notification_action.utils import (
+    execute_via_issue_alert_handler,
+    execute_via_metric_alert_handler,
+)
+from sentry.shared_integrations.exceptions import (
+    ApiUnauthorized,
+    IntegrationConfigurationError,
+    IntegrationFormError,
+)
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class ExecuteViaHandlerLoggingBase(BaseWorkflowTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
+        self.detector = self.create_detector(project=self.project)
+        self.workflow = self.create_workflow()
+        self.action = Action(type=Action.Type.DISCORD)
+        self.group, self.event, self.group_event = self.create_group_event()
+        self.event_data = WorkflowEventData(event=self.group_event, group=self.group)
+
+    def _make_invocation(self) -> ActionInvocation:
+        return ActionInvocation(
+            event_data=self.event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
+        )
+
+
+class TestExecuteViaIssueAlertHandlerLogging(ExecuteViaHandlerLoggingBase):
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            IntegrationFormError({"repo": "Given repository does not belong to this installation"}),
+            IntegrationConfigurationError("Invalid integration configuration"),
+            InvalidIdentity(),
+            ApiUnauthorized("Unauthorized"),
+        ],
+    )
+    @mock.patch("sentry.notifications.notification_action.utils.logger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get"
+    )
+    def test_integration_config_errors_logged_as_warning_not_exception(
+        self,
+        mock_registry_get: mock.MagicMock,
+        mock_logger: mock.MagicMock,
+        exc: Exception,
+    ) -> None:
+        """Integration config errors should be logged at WARNING, not ERROR, and re-raised."""
+        mock_handler = mock.Mock()
+        mock_handler.invoke_legacy_registry.side_effect = exc
+        mock_registry_get.return_value = mock_handler
+
+        with pytest.raises(type(exc)):
+            execute_via_issue_alert_handler(self._make_invocation())
+
+        mock_logger.warning.assert_called_once()
+        mock_logger.exception.assert_not_called()
+
+    @mock.patch("sentry.notifications.notification_action.utils.logger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.issue_alert_handler_registry.get"
+    )
+    def test_unexpected_errors_still_logged_as_exception(
+        self,
+        mock_registry_get: mock.MagicMock,
+        mock_logger: mock.MagicMock,
+    ) -> None:
+        """Unexpected errors should still be logged at ERROR level."""
+        mock_handler = mock.Mock()
+        mock_handler.invoke_legacy_registry.side_effect = RuntimeError("unexpected")
+        mock_registry_get.return_value = mock_handler
+
+        with pytest.raises(RuntimeError):
+            execute_via_issue_alert_handler(self._make_invocation())
+
+        mock_logger.exception.assert_called_once()
+        mock_logger.warning.assert_not_called()
+
+
+class TestExecuteViaMetricAlertHandlerLogging(ExecuteViaHandlerLoggingBase):
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            IntegrationFormError({"repo": "Given repository does not belong to this installation"}),
+            IntegrationConfigurationError("Invalid integration configuration"),
+            InvalidIdentity(),
+            ApiUnauthorized("Unauthorized"),
+        ],
+    )
+    @mock.patch("sentry.notifications.notification_action.utils.logger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
+    )
+    def test_integration_config_errors_logged_as_warning_not_exception(
+        self,
+        mock_registry_get: mock.MagicMock,
+        mock_logger: mock.MagicMock,
+        exc: Exception,
+    ) -> None:
+        """Integration config errors should be logged at WARNING, not ERROR, and re-raised."""
+        mock_handler = mock.Mock()
+        mock_handler.invoke_legacy_registry.side_effect = exc
+        mock_registry_get.return_value = mock_handler
+
+        with pytest.raises(type(exc)):
+            execute_via_metric_alert_handler(self._make_invocation())
+
+        mock_logger.warning.assert_called_once()
+        mock_logger.exception.assert_not_called()
+
+    @mock.patch("sentry.notifications.notification_action.utils.logger")
+    @mock.patch(
+        "sentry.notifications.notification_action.registry.metric_alert_handler_registry.get"
+    )
+    def test_unexpected_errors_still_logged_as_exception(
+        self,
+        mock_registry_get: mock.MagicMock,
+        mock_logger: mock.MagicMock,
+    ) -> None:
+        """Unexpected errors should still be logged at ERROR level."""
+        mock_handler = mock.Mock()
+        mock_handler.invoke_legacy_registry.side_effect = RuntimeError("unexpected")
+        mock_registry_get.return_value = mock_handler
+
+        with pytest.raises(RuntimeError):
+            execute_via_metric_alert_handler(self._make_invocation())
+
+        mock_logger.exception.assert_called_once()
+        mock_logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes spurious Sentry error captures from `execute_via_issue_alert_handler` and `execute_via_metric_alert_handler` when integration validation errors (expected user-configuration problems) bubble up and are logged as `ERROR`.

**Sentry issue**: https://sentry.io/organizations/sentry/issues/7430979215/

**Triage session**: https://claude.ai/code/session_01S82KC3TNcDCsP9GxxC4YGB

## Root-cause analysis

`IntegrationFormError`, `IntegrationConfigurationError`, `InvalidIdentity`, and `ApiUnauthorized` are **expected user-configuration errors** — things like "repo doesn't belong to this installation", revoked OAuth tokens, or misconfigured Jira field settings. They are not Sentry product defects.

These exceptions are already caught and recorded at **WARNING level** by the SLO system inside `src/sentry/rules/actions/integrations/create_ticket/utils.py` via `lifecycle.record_halt(e)`, which emits a `integrations.slo.halted` breadcrumb. The exception is then **re-raised**.

The re-raised exception propagates up the call stack to `execute_via_issue_alert_handler` (and `execute_via_metric_alert_handler`), where a blanket `except Exception: logger.exception(...)` block catches it and logs it at **ERROR** level a second time. `logger.exception` triggers a Sentry capture, creating a high-volume stream of error events for something that is ultimately the user's misconfiguration, not a system failure.

## What the fix does

Adds explicit `except (IntegrationFormError, IntegrationConfigurationError, InvalidIdentity, ApiUnauthorized)` clauses **before** the generic `except Exception` in both handler functions. These clauses:

1. Log at `logger.warning(...)` — no Sentry capture, appropriate severity
2. Still **re-raise** the exception so the caller knows the action failed
3. Leave the generic `except Exception: logger.exception(...)` path intact for genuine unexpected failures

The same pattern is applied to both `execute_via_issue_alert_handler` and `execute_via_metric_alert_handler` since they share the same structure and both sit above the SLO-tracked integration layer.

## What was ruled out

- **Swallowing the exception**: not done — callers need to know the action failed.
- **Removing the generic handler**: not done — real unexpected errors must still be captured at ERROR.
- **Fixing at the SLO layer**: the SLO layer already handles these correctly; the problem is the second logging further up the stack.
- **`IntegrationResourceNotFoundError` / `IntegrationProviderError`**: also caught in the SLO layer but not included here, as they were not observed in the Sentry issue and the scope of this fix is targeted.

## Test plan

- [ ] New test class `TestExecuteViaIssueAlertHandlerLogging` verifies each of the four exception types is logged at `WARNING` (not `exception`) and re-raised
- [ ] New test class `TestExecuteViaMetricAlertHandlerLogging` does the same for the metric alert path
- [ ] Existing tests in `test_group_type_notification_registry_handlers.py` continue to pass
- [ ] Run: `pytest -n3 -svv --reuse-db tests/sentry/notifications/notification_action/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01S82KC3TNcDCsP9GxxC4YGB)_