### PR TITLE
fix(ourlogs): scope Open in Explore link to the whole trace

### DIFF
--- a/static/app/components/events/ourlogs/ourlogsDrawer.tsx
+++ b/static/app/components/events/ourlogs/ourlogsDrawer.tsx
@@ -87,7 +87,7 @@ export function OurlogsDrawer({
     [event, propAdditionalData?.scrollToDisabled]
   );
 
-  const exploreUrl = useEventLogsUrl(event, project);
+  const exploreUrl = useEventLogsUrl(event);
 
   return (
     <SearchQueryBuilderProvider {...searchQueryBuilderProps}>

--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -441,7 +441,7 @@ describe('OurlogsSection', () => {
 
     const href = openInExploreButton.getAttribute('href');
     expect(href).toBe(
-      '/organizations/org-slug/explore/logs/?end=2019-03-21T00%3A00%3A00&environment=dev&logsQuery=trace%3A00000000000000000000000000000000&project=2&start=2019-03-19T00%3A00%3A00'
+      '/organizations/org-slug/explore/logs/?end=2019-03-21T00%3A00%3A00&logsQuery=trace%3A00000000000000000000000000000000&project=-1&start=2019-03-19T00%3A00%3A00'
     );
   });
 });

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -247,7 +247,6 @@ function OurlogsSectionContent({
             <LinkButton
               analyticsEventKey="issue_details.logs_open_in_explore_action_button_clicked"
               analyticsEventName="Issue Details: Logs Open in Explore Action Button Clicked"
-              openInNewTab
               size="xs"
               to={logsUrl}
             >

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -146,7 +146,7 @@ function OurlogsSectionContent({
   const {openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
   const sharedHoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const logsUrl = useEventLogsUrl(event, project);
+  const logsUrl = useEventLogsUrl(event);
 
   const onOpenLogsDrawer = useCallback(
     (e: React.MouseEvent, expandedLogId?: string) => {

--- a/static/app/components/events/ourlogs/useEventLogsUrl.spec.tsx
+++ b/static/app/components/events/ourlogs/useEventLogsUrl.spec.tsx
@@ -1,11 +1,8 @@
 import {EventFixture} from 'sentry-fixture/event';
-import {ProjectFixture} from 'sentry-fixture/project';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {useEventLogsUrl} from 'sentry/components/events/ourlogs/useEventLogsUrl';
-
-const project = ProjectFixture();
 
 describe('useEventLogsUrl', () => {
   it('returns null when there is no context trace_id', () => {
@@ -14,7 +11,7 @@ describe('useEventLogsUrl', () => {
       dateCreated: '12-21-2024',
     });
 
-    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event));
 
     expect(result.current).toBeNull();
   });
@@ -30,12 +27,12 @@ describe('useEventLogsUrl', () => {
       dateReceived: null,
     });
 
-    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event));
 
     expect(result.current).toBeNull();
   });
 
-  it('returns the logs url with empty environment when the environment does not exist', () => {
+  it('returns the logs url scoped to all projects with empty environment when the environment does not exist', () => {
     const event = EventFixture({
       contexts: {
         trace: {
@@ -45,14 +42,14 @@ describe('useEventLogsUrl', () => {
       dateCreated: '12-21-2024',
     });
 
-    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event));
 
     expect(result.current).toMatchInlineSnapshot(
-      `"/organizations/org-slug/explore/logs/?end=2024-12-22T05%3A00%3A00&logsQuery=trace%3Atrace-abc-123&project=2&start=2024-12-20T05%3A00%3A00"`
+      `"/organizations/org-slug/explore/logs/?end=2024-12-22T05%3A00%3A00&logsQuery=trace%3Atrace-abc-123&project=-1&start=2024-12-20T05%3A00%3A00"`
     );
   });
 
-  it('returns the logs url with an environment when the environment exists', () => {
+  it('returns the logs url without an environment filter even when the event has an environment', () => {
     const event = EventFixture({
       contexts: {
         trace: {
@@ -68,10 +65,10 @@ describe('useEventLogsUrl', () => {
       ],
     });
 
-    const {result} = renderHookWithProviders(() => useEventLogsUrl(event, project));
+    const {result} = renderHookWithProviders(() => useEventLogsUrl(event));
 
     expect(result.current).toMatchInlineSnapshot(
-      `"/organizations/org-slug/explore/logs/?end=2024-12-22T05%3A00%3A00&environment=environment-abc-123&logsQuery=trace%3Atrace-abc-123&project=2&start=2024-12-20T05%3A00%3A00"`
+      `"/organizations/org-slug/explore/logs/?end=2024-12-22T05%3A00%3A00&logsQuery=trace%3Atrace-abc-123&project=-1&start=2024-12-20T05%3A00%3A00"`
     );
   });
 });

--- a/static/app/components/events/ourlogs/useEventLogsUrl.tsx
+++ b/static/app/components/events/ourlogs/useEventLogsUrl.tsx
@@ -1,14 +1,13 @@
 import moment from 'moment-timezone';
 
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import type {Event} from 'sentry/types/event';
-import type {Project} from 'sentry/types/project';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
-import {getEventEnvironment} from 'sentry/views/issueDetails/utils';
 
-export function useEventLogsUrl(event: Event, project: Project) {
+export function useEventLogsUrl(event: Event) {
   const organization = useOrganization();
   const traceId = event.contexts.trace?.trace_id;
   if (!traceId) {
@@ -23,13 +22,12 @@ export function useEventLogsUrl(event: Event, project: Project) {
   const eventMoment = moment(eventTimestamp);
   const start = getUtcDateString(eventMoment.clone().subtract(1, 'day'));
   const end = getUtcDateString(eventMoment.clone().add(1, 'day'));
-  const environment = getEventEnvironment(event);
 
   return getLogsUrl({
     organization,
     selection: {
-      projects: [parseInt(project.id, 10)],
-      environments: environment ? [environment] : [],
+      projects: [ALL_ACCESS_PROJECTS],
+      environments: [],
       datetime: {
         start,
         end,

--- a/static/app/views/explore/replays/detail/ourlogs/openInLogsButton.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/openInLogsButton.tsx
@@ -33,7 +33,7 @@ export function OpenInLogsButton({replayId}: Props) {
   });
 
   return (
-    <LinkButton size="md" to={url} openInNewTab>
+    <LinkButton size="md" to={url}>
       {t('Open in Logs')}
     </LinkButton>
   );


### PR DESCRIPTION
The Logs section's _Open in Explore_ link scoped its query to the event's single project and environment. When an issue's trace carries logs from multiple projects or environments (eg. a frontend event whose trace also has backend logs), that isn't right. So this removes the environment and project filters from links.

Also fixes a couple of links in this area to _not_ `openInNewTab`.

Closes LOGS-922
