### PR TITLE
ref(pr-metrics): Gate the activity document on an org feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -204,6 +204,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:pr-lifecycle-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Write PullRequestActivity rows from GitHub PR lifecycle webhooks
     manager.add("organizations:pr-metrics-activity", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Fold PR activity into a single PullRequestActivityLog document instead of one row per event
+    manager.add("organizations:pr-metrics-activity-document", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Record PullRequestAttribution from webhook and seer.pr_created events
     manager.add("organizations:pr-metrics-attribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Emit the BigQuery row on a tracked PR's close/merge (PR Merge Live Metrics rollout)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -647,16 +647,6 @@ register(
     default=3600,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-# Cutover switch for the reduced per-PR activity document. When on, PR activity is
-# folded into a single PullRequestActivityLog JSON document at webhook time instead
-# of one PullRequestActivity row per event; routing is per-PR (a PR stays on
-# whichever store it started on). Flip this ON only AFTER the code is fully
-# deployed, so a mixed fleet never splits one PR's writes across both stores.
-register(
-    "pr_metrics.activity_document.enabled",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -580,9 +580,11 @@ def handle_activity(
         return
 
     # reopened/edited exist only on the document path; skip the whole path —
-    # including PR resolution — when the cutover option is off, so the legacy path
+    # including PR resolution — when the cutover flag is off, so the legacy path
     # is untouched.
-    if action in _DOC_ONLY_ACTIONS and not options.get("pr_metrics.activity_document.enabled"):
+    if action in _DOC_ONLY_ACTIONS and not features.has(
+        "organizations:pr-metrics-activity-document", organization
+    ):
         return
 
     pr = _get_pull_request(
@@ -595,9 +597,9 @@ def handle_activity(
     if pr is None:
         return
 
-    use_doc = _use_activity_document(pr)
+    use_doc = _use_activity_document(pr, organization)
     if action in _DOC_ONLY_ACTIONS and not use_doc:
-        # Option is on globally, but this PR is still on the legacy store.
+        # The flag is on for this org, but this PR is still on the legacy store.
         return
 
     # Terminal events (close/merge/reopen) on the document path must be recorded
@@ -607,7 +609,7 @@ def handle_activity(
         return
 
     webhook_id: str | None = kwargs.get("github_delivery_id")
-    _write_activity(pr, action, pull_request_data or {}, event, webhook_id, use_doc)
+    _write_activity(pr, organization, action, pull_request_data or {}, event, webhook_id, use_doc)
 
 
 def handle_comment(
@@ -667,7 +669,7 @@ def handle_comment(
         author_association=comment.get("author_association", "NONE"),
     )
     _record_activity_event(
-        pr, webhook_id, PullRequestActivityType.COMMENT_CREATED, asdict(payload_obj)
+        pr, organization, webhook_id, PullRequestActivityType.COMMENT_CREATED, asdict(payload_obj)
     )
 
 
@@ -733,7 +735,12 @@ def handle_review(
     if not webhook_id:
         return
     _record_activity_event(
-        pr, webhook_id, event_type, payload, event_at=extract_event_at(event_type, event)
+        pr,
+        organization,
+        webhook_id,
+        event_type,
+        payload,
+        event_at=extract_event_at(event_type, event),
     )
 
 
@@ -785,7 +792,7 @@ def handle_review_comment(
         review_id=comment.get("pull_request_review_id"),
     )
     _record_activity_event(
-        pr, webhook_id, PullRequestActivityType.COMMENT_CREATED, asdict(payload_obj)
+        pr, organization, webhook_id, PullRequestActivityType.COMMENT_CREATED, asdict(payload_obj)
     )
 
 
@@ -841,7 +848,12 @@ def handle_review_thread(
     if not webhook_id:
         return
     _record_activity_event(
-        pr, webhook_id, event_type, payload, event_at=extract_event_at(event_type, event)
+        pr,
+        organization,
+        webhook_id,
+        event_type,
+        payload,
+        event_at=extract_event_at(event_type, event),
     )
 
 
@@ -885,6 +897,7 @@ def handle_check_suite(
         if is_activity_tracking_enabled(organization, pr):
             _record_activity_event(
                 pr,
+                organization,
                 webhook_id,
                 PullRequestActivityType.CHECK_SUITE_COMPLETED,
                 payload,
@@ -932,6 +945,7 @@ def handle_check_run(
         if is_activity_tracking_enabled(organization, pr):
             _record_activity_event(
                 pr,
+                organization,
                 webhook_id,
                 PullRequestActivityType.CHECK_RUN_COMPLETED,
                 payload,
@@ -1368,16 +1382,16 @@ def _write_mcp_attribution(pr: PullRequest) -> None:
     )
 
 
-def _use_activity_document(pr: PullRequest) -> bool:
+def _use_activity_document(pr: PullRequest, organization: Organization) -> bool:
     """Whether this PR's activity writes go to the reduced JSON document.
 
-    Per-PR routing, consulted only when the cutover option is on: a PR stays on
-    whichever store it started on — an existing document wins, else pre-existing
-    legacy rows keep it on the old path, else (a new PR) it starts on the
-    document. The indexed 1:1 document lookup runs first; the legacy-rows EXISTS
-    only when there's no document.
+    Per-PR routing, consulted only when the cutover flag is on for the org: a PR
+    stays on whichever store it started on — an existing document wins, else
+    pre-existing legacy rows keep it on the old path, else (a new PR) it starts on
+    the document. The indexed 1:1 document lookup runs first; the legacy-rows
+    EXISTS only when there's no document.
     """
-    if not options.get("pr_metrics.activity_document.enabled"):
+    if not features.has("organizations:pr-metrics-activity-document", organization):
         return False
     if PullRequestActivityLog.objects.filter(pull_request=pr).exists():
         return True
@@ -1429,6 +1443,7 @@ def _apply_activity_into_doc(
 
 def _record_activity_event(
     pr: PullRequest,
+    organization: Organization,
     webhook_id: str,
     event_type: PullRequestActivityType,
     payload: dict[str, Any],
@@ -1448,7 +1463,7 @@ def _record_activity_event(
     computed here.
     """
     if use_doc is None:
-        use_doc = _use_activity_document(pr)
+        use_doc = _use_activity_document(pr, organization)
     if use_doc:
         _apply_activity_into_doc(
             pr,
@@ -1482,6 +1497,7 @@ def _write_activity_row(
 
 def _write_activity(
     pr: PullRequest,
+    organization: Organization,
     action: str,
     pull_request: Mapping[str, Any],
     event: Mapping[str, Any],
@@ -1509,6 +1525,7 @@ def _write_activity(
     payload = _build_activity_payload(action, pull_request, event, use_doc)
     _record_activity_event(
         pr,
+        organization,
         webhook_id,
         event_type,
         payload,

--- a/tests/sentry/pr_metrics/test_webhooks_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_webhooks_activity_doc.py
@@ -1,7 +1,7 @@
 """Write-path + routing tests for the reduced activity document (CORE-283 PR 2).
 
-These exercise the ``pr_metrics.activity_document.enabled`` cutover: with the
-option off every webhook keeps writing legacy ``PullRequestActivity`` rows
+These exercise the ``organizations:pr-metrics-activity-document`` cutover: with
+the flag off every webhook keeps writing legacy ``PullRequestActivity`` rows
 (covered by ``test_webhooks.py``); with it on, activity folds into the per-PR
 ``PullRequestActivityLog`` document per the routing rules.
 """
@@ -31,11 +31,11 @@ from sentry.pr_metrics.webhooks import (
     handle_review_thread,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import override_options, with_feature
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import cell_silo_test
 
 ACTIVITY_FLAG = "organizations:pr-metrics-activity"
-DOC_ON = {"pr_metrics.activity_document.enabled": True}
+DOC_FLAG = "organizations:pr-metrics-activity-document"
 
 
 @with_feature(ACTIVITY_FLAG)
@@ -265,20 +265,20 @@ class ActivityDocumentWritePathTest(TestCase):
 
     # --- routing ----------------------------------------------------------
 
-    def test_option_off_writes_legacy_row_only(self) -> None:
+    def test_flag_off_writes_legacy_row_only(self) -> None:
         self._activity(action="opened")
         assert self._doc_or_none() is None
         assert self._rows() == 1
 
-    def test_option_on_fresh_pr_writes_document_only(self) -> None:
-        with override_options(DOC_ON):
+    def test_flag_on_fresh_pr_writes_document_only(self) -> None:
+        with self.feature(DOC_FLAG):
             self._activity(action="opened")
         assert self._rows() == 0
         doc = self._doc()
         assert doc is not None
         assert [e["event_type"] for e in doc["events"]] == [PullRequestActivityType.OPENED]
 
-    def test_option_on_existing_legacy_rows_stay_on_legacy(self) -> None:
+    def test_flag_on_existing_legacy_rows_stay_on_legacy(self) -> None:
         # A PR that already has legacy rows keeps writing them (self-drains later).
         PullRequestActivity.objects.create(
             pull_request=self.pr,
@@ -286,12 +286,12 @@ class ActivityDocumentWritePathTest(TestCase):
             event_type=PullRequestActivityType.OPENED,
             payload={},
         )
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="synchronize", webhook_id="d2", before="a", after="b")
         assert self._doc_or_none() is None
         assert self._rows() == 2
 
-    def test_option_on_existing_document_stays_on_document(self) -> None:
+    def test_flag_on_existing_document_stays_on_document(self) -> None:
         PullRequestActivityLog.objects.create(
             pull_request=self.pr,
             data={
@@ -303,7 +303,7 @@ class ActivityDocumentWritePathTest(TestCase):
                 "events_dropped": 0,
             },
         )
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="synchronize", webhook_id="d2", before="a", after="b")
         assert self._rows() == 0
         doc = self._doc()
@@ -330,7 +330,7 @@ class ActivityDocumentWritePathTest(TestCase):
                 "events_dropped": 0,
             },
         )
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="synchronize", webhook_id="d2", before="a", after="b")
         assert self._rows() == 1  # unchanged legacy row
         doc = self._doc()
@@ -342,7 +342,7 @@ class ActivityDocumentWritePathTest(TestCase):
         # rolls the creation back too — no empty {} row is left behind to route later
         # events onto an all-zeros document. (Matches the legacy row insert, which
         # also leaves nothing on failure.)
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             with patch(
                 "sentry.pr_metrics.webhooks.apply_activity", side_effect=RuntimeError("boom")
             ):
@@ -354,7 +354,7 @@ class ActivityDocumentWritePathTest(TestCase):
     # --- entry writes -----------------------------------------------------
 
     def test_opened_entry_captures_payload_and_event_at(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="opened", webhook_id="d1")
         entry = self._doc()["events"][0]
         assert entry["event_type"] == PullRequestActivityType.OPENED
@@ -367,7 +367,7 @@ class ActivityDocumentWritePathTest(TestCase):
         assert "body" not in entry["payload"]
 
     def test_synchronize_entry_has_null_event_at(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="synchronize", webhook_id="d1", before="old", after="new")
         entry = self._doc()["events"][0]
         assert entry["event_type"] == PullRequestActivityType.SYNCHRONIZED
@@ -376,7 +376,7 @@ class ActivityDocumentWritePathTest(TestCase):
         assert entry["payload"]["after_sha"] == "new"
 
     def test_closed_and_merged_event_at_from_pr_fields(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(
                 action="closed",
                 webhook_id="close1",
@@ -392,7 +392,7 @@ class ActivityDocumentWritePathTest(TestCase):
         assert entry["event_at"] == "2026-07-10T11:30:00Z"  # merged_at
 
     def test_review_submitted_entry_uses_review_submitted_at(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._review(webhook_id="rv1")
         doc = self._doc()
         entry = doc["events"][0]
@@ -402,13 +402,13 @@ class ActivityDocumentWritePathTest(TestCase):
         assert doc["participants"] == {"reviewer": "User"}
 
     def test_review_thread_entry_recorded(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._review_thread(webhook_id="rt1")
         entry = self._doc()["events"][0]
         assert entry["event_type"] == PullRequestActivityType.REVIEW_THREAD_RESOLVED
 
     def test_entry_redelivery_deduped_in_document(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="synchronize", webhook_id="dup", before="a", after="b")
             self._activity(action="synchronize", webhook_id="dup", before="a", after="b")
         doc = self._doc()
@@ -418,7 +418,7 @@ class ActivityDocumentWritePathTest(TestCase):
     # --- comment writes (participants only) -------------------------------
 
     def test_comment_folds_participant_only(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._comment(webhook_id="c1", sender_login="commenter")
         assert self._rows() == 0
         doc = self._doc()
@@ -427,7 +427,7 @@ class ActivityDocumentWritePathTest(TestCase):
         assert doc["counts"] == {}
 
     def test_review_comment_folds_participant_only(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._review_comment(webhook_id="rc1", sender_login="inline-reviewer")
         doc = self._doc()
         assert doc["participants"] == {"inline-reviewer": "User"}
@@ -437,7 +437,7 @@ class ActivityDocumentWritePathTest(TestCase):
     # --- check writes (rollup) --------------------------------------------
 
     def test_check_suite_folds_into_rollup(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._check_suite(conclusion="failure", updated_at="2026-07-10T12:00:00Z")
         assert self._rows() == 0
         doc = self._doc()
@@ -451,7 +451,7 @@ class ActivityDocumentWritePathTest(TestCase):
         assert doc["events"] == []
 
     def test_check_run_failing_tracked_with_provider_completed_at(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._check_run(
                 check_name="unit", conclusion="failure", completed_at="2026-07-10T12:05:00Z"
             )
@@ -464,7 +464,7 @@ class ActivityDocumentWritePathTest(TestCase):
         }
 
     def test_check_run_green_not_retained(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._check_run(
                 check_name="lint", conclusion="success", completed_at="2026-07-10T12:05:00Z"
             )
@@ -474,14 +474,14 @@ class ActivityDocumentWritePathTest(TestCase):
     # --- new-path-only captures -------------------------------------------
 
     def test_reopened_recorded_on_document(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="reopened", webhook_id="ro1")
         entry = self._doc()["events"][0]
         assert entry["event_type"] == PullRequestActivityType.REOPENED
         assert entry["event_at"] is None
         assert entry["payload"]["sender_login"] == "author"
 
-    def test_reopened_ignored_when_option_off(self) -> None:
+    def test_reopened_ignored_when_flag_off(self) -> None:
         self._activity(action="reopened")
         assert self._doc_or_none() is None
         assert self._rows() == 0
@@ -495,13 +495,13 @@ class ActivityDocumentWritePathTest(TestCase):
             event_type=PullRequestActivityType.OPENED,
             payload={},
         )
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="reopened", webhook_id="ro1")
         assert self._doc_or_none() is None
         assert self._rows() == 1
 
     def test_edited_captures_changed_field_names_only(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(
                 action="edited",
                 webhook_id="ed1",
@@ -521,7 +521,7 @@ class ActivityDocumentWritePathTest(TestCase):
         PullRequestMetrics.objects.create(
             pull_request=self.pr, verdict=PullRequestVerdict.MERGED_UNCHANGED
         )
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(
                 action="closed",
                 webhook_id="close1",
@@ -535,14 +535,14 @@ class ActivityDocumentWritePathTest(TestCase):
         PullRequestMetrics.objects.create(
             pull_request=self.pr, verdict=PullRequestVerdict.MERGED_UNCHANGED
         )
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(action="synchronize", webhook_id="s1", before="a", after="b")
         assert self._doc_or_none() is None
 
     def test_comment_deletions_are_ignored(self) -> None:
         # Deliberately not captured on either store: without the deleted comment's
         # content, a sender+timestamp entry is too little signal to act on.
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._comment_deleted(webhook_id="cd1", sender={"login": "human", "type": "User"})
             self._review_comment_deleted(
                 webhook_id="rcd1", sender={"login": "human", "type": "User"}
@@ -551,12 +551,12 @@ class ActivityDocumentWritePathTest(TestCase):
         assert self._rows() == 0
 
     def test_check_group_keyed_on_head_sha(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._check_run(check_name="t", conclusion="failure", webhook_id="cr1")
         assert "headsha1|github-actions" in self._doc()["checks"]
 
     def test_check_groups_split_by_head_sha(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._check_suite(head_sha="headsha1", webhook_id="cs1")
             self._check_suite(head_sha="headsha2", webhook_id="cs2")
         assert set(self._doc()["checks"].keys()) == {
@@ -565,7 +565,7 @@ class ActivityDocumentWritePathTest(TestCase):
         }
 
     def test_auto_merge_enabled_captures_sender_on_document(self) -> None:
-        with override_options(DOC_ON):
+        with self.feature(DOC_FLAG):
             self._activity(
                 action="auto_merge_enabled",
                 webhook_id="am1",


### PR DESCRIPTION
## What

Swaps the PR-activity document cutover gate from the global option `pr_metrics.activity_document.enabled` to an organization feature flag, `organizations:pr-metrics-activity-document`.

- Registers the flag in `src/sentry/features/temporary.py` next to its siblings, matching them exactly: `OrganizationFeature`, `FeatureHandlerStrategy.FLAGPOLE`, `api_expose=False`.
- Replaces both read sites in `pr_metrics/webhooks.py` (the `_DOC_ONLY_ACTIONS` guard in `handle_activity`, and `_use_activity_document`) with `features.has(...)`.
- Threads `organization` down to `_use_activity_document` through `_write_activity` / `_record_activity_event`. Every webhook handler already has `organization` in scope, so nothing re-fetches it from `pr.organization_id`.
- Deletes the option and its comment block from `options/defaults.py`.
- Migrates `tests/sentry/pr_metrics/test_webhooks_activity_doc.py` from `override_options(DOC_ON)` to `self.feature(DOC_FLAG)`.

## Why a flag instead of an option

A global boolean is all-or-nothing — it can't scope the rollout to one org, so there's no way to canary the new write path on `getsentry` before every org processing PR webhooks gets it. Every other gate in this pipeline (`pr-metrics-activity`, `-attribution`, `-emit`, `-judge`) is already a flagpole flag with org targeting; this one was the odd one out.

## No migration needed

`pr_metrics.activity_document.enabled` has **never been enabled anywhere** — the automator PR that would set it ([sentry-options-automator#8640](https://github.com/getsentry/sentry-options-automator/pull/8640)) is still open and unmerged. There is no live value to preserve and no rolling-deploy concern from changing the gate: every org is off before this change and off after it. `rg 'pr_metrics.activity_document'` returns nothing across the repo now.

## Behavior

Per-PR sticky routing is untouched — existing document wins, else pre-existing legacy rows keep the PR on legacy, else a new PR starts on the document. Only the global gate in front of that routing changed.

## Follow-up

A flagpole config targeting `organization_slug=getsentry` to start the canary.

## Verification

- `pytest tests/sentry/pr_metrics/ -q` — **457 passed**, matching the pre-change baseline on `master` exactly (no tests added, removed, or skipped; 25 gate sites converted in place).
- `pytest tests/sentry/features/ tests/flagpole/ -q` — 133 passed.
- `mypy` on the three changed source files — `Success: no issues found in 3 source files`.
- `ruff check` + `ruff format` clean on changed files.