### PR TITLE
feat(seer-agent): Allow use of bash mode in seer agent

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -267,6 +267,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-structured-context-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine experimental contexts
     manager.add("organizations:context-engine-experiments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable frontend override for bash mode
+    manager.add("organizations:seer-explorer-allow-bash-mode", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable frontend override for context engine (only for AI/ML/Reasoning platform team)
     manager.add("organizations:seer-explorer-context-engine-allow-fe-override", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable frontend override UI component for context engine (only for AI/ML/Reasoning platform team)

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -380,6 +380,7 @@ class SeerAgentClient:
         artifact_schema: type[BaseModel] | None = None,
         metadata: dict[str, Any] | None = None,
         request: Request | None = None,
+        override_bash_mode_enabled: bool = False,
         override_ce_enable: bool = True,
         ui_tools: str | None = None,
     ) -> SeerRun:
@@ -472,7 +473,10 @@ class SeerAgentClient:
             chat_body["ui_tools"] = ui_tools
 
         agent_run_options.update(
-            self._build_agent_run_options(override_ce_enable=override_ce_enable)
+            self._build_agent_run_options(
+                override_bash_mode_enabled=override_bash_mode_enabled,
+                override_ce_enable=override_ce_enable,
+            )
         )
 
         user_id = (
@@ -570,13 +574,25 @@ class SeerAgentClient:
             flush=flush,
         )
 
-    def _build_agent_run_options(self, override_ce_enable: bool = True) -> dict[str, Any]:
+    def _build_agent_run_options(
+        self,
+        *,
+        override_bash_mode_enabled: bool = False,
+        override_ce_enable: bool = True,
+    ) -> dict[str, Any]:
         """Resolve org-flag-driven agent run options, shared by start_run and start_feature_run."""
         opts: dict[str, Any] = {}
 
         if _has_context_engine(self.organization, self.user):
             if random.random() < options.get("seer.explorer.context-engine-rollout"):
                 opts["is_context_engine_enabled"] = True
+
+        if features.has(
+            "organizations:seer-explorer-allow-bash-mode",
+            self.organization,
+            actor=self.user,
+        ):
+            opts["enable_bash_mode"] = override_bash_mode_enabled
 
         if features.has(
             "organizations:seer-explorer-context-engine-allow-fe-override",

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -98,6 +98,11 @@ class SeerAgentChatSerializer(serializers.Serializer):
         default=None,
         help_text="The UI page name where the request originated (e.g., route string).",
     )
+    override_bash_mode_enabled = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Override bash mode tools.",
+    )
     override_ce_enable = serializers.BooleanField(
         required=False,
         default=True,
@@ -251,6 +256,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         insert_index = validated_data.get("insert_index")
         on_page_context = validated_data.get("on_page_context")
         page_name = validated_data.get("page_name")
+        override_bash_mode_enabled = validated_data["override_bash_mode_enabled"]
         override_ce_enable = validated_data["override_ce_enable"]
         override_code_mode_enable = validated_data.get("override_code_mode_enable")
         ui_tools = (
@@ -317,6 +323,7 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 on_page_context=on_page_context,
                 page_name=page_name,
                 ui_tools=ui_tools,
+                override_bash_mode_enabled=override_bash_mode_enabled,
                 override_ce_enable=override_ce_enable,
                 request=request,
             )

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -126,6 +126,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
             on_page_context=None,
             page_name=None,
             ui_tools=None,
+            override_bash_mode_enabled=False,
             override_ce_enable=True,
             request=ANY,
         )


### PR DESCRIPTION
This adds the option to enable bash mode in the seer agent chat endpoint