### PR TITLE
ref(taskbroker): Add raw-named namespaces for profiles/events ingest tasks

### DIFF
--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -12,7 +12,7 @@ from sentry.ingest.types import ConsumerType
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import ingest_events_passthrough_tasks, ingest_events_raw_tasks
+from sentry.taskworker.namespaces import ingest_events_raw_tasks
 from sentry.utils import metrics
 
 from .processors import IngestMessage, Retriable, process_event
@@ -82,7 +82,25 @@ def process_simple_event_message(
         raise InvalidMessage(raw_value.partition, raw_value.offset) from exc
 
 
-def _process_event_from_kafka(message_bytes: bytes) -> None:
+@instrumented_task(
+    name="sentry.ingest.consumer.simple_event.process_event_from_kafka",
+    namespace=ingest_events_raw_tasks,
+    processing_deadline_duration=150,
+    retry=Retry(times=2, delay=5, on=(Retriable,)),
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+)
+def process_event_from_kafka(message_bytes: bytes) -> None:
+    """Process an event from raw Kafka message bytes.
+
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it,
+    instead taskbroker itself is configured to consume a topic (in infra
+    templates) and spawns tasks for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination.
+    """
     metrics.distribution(
         "ingest_consumer.payload_size",
         len(message_bytes),
@@ -112,56 +130,3 @@ def _process_event_from_kafka(message_bytes: bytes) -> None:
         inline_save_event=options.get(INLINE_SAVE_EVENT_OPTION),
         inline_save_event_transaction=options.get(INLINE_SAVE_EVENT_TRANSACTION_OPTION),
     )
-
-
-@instrumented_task(
-    name="sentry.ingest.consumer.simple_event.process_event_from_kafka",
-    namespace=ingest_events_passthrough_tasks,
-    processing_deadline_duration=150,
-    retry=Retry(times=2, delay=5, on=(Retriable,)),
-    compression_type=CompressionType.ZSTD,
-    silo_mode=SiloMode.CELL,
-)
-def process_event_from_kafka(message_bytes: bytes) -> None:
-    """Process an event from raw Kafka message bytes.
-
-    This task is directly spawned from taskbroker in "raw mode". You won't find
-    any application code that calls apply_async or delay directly on it,
-    instead taskbroker itself is configured to consume a topic (in infra
-    templates) and spawns tasks for each message.
-
-    As such, the task signature, name and namespace cannot be changed without
-    coordination.
-
-    This is a duplicate of `process_event_from_kafka_raw`, registered under
-    the `ingest.events.passthrough` namespace instead of `ingest.events.raw`
-    (STREAM-1191). Delete this task once infra no longer routes anything to
-    `ingest.events.passthrough`.
-    """
-    return _process_event_from_kafka(message_bytes)
-
-
-@instrumented_task(
-    name="sentry.ingest.consumer.simple_event.process_event_from_kafka_raw",
-    namespace=ingest_events_raw_tasks,
-    processing_deadline_duration=150,
-    retry=Retry(times=2, delay=5, on=(Retriable,)),
-    compression_type=CompressionType.ZSTD,
-    silo_mode=SiloMode.CELL,
-)
-def process_event_from_kafka_raw(message_bytes: bytes) -> None:
-    """Process an event from raw Kafka message bytes.
-
-    This task is directly spawned from taskbroker in "raw mode". You won't find
-    any application code that calls apply_async or delay directly on it,
-    instead taskbroker itself is configured to consume a topic (in infra
-    templates) and spawns tasks for each message.
-
-    As such, the task signature, name and namespace cannot be changed without
-    coordination.
-
-    This is a duplicate of `process_event_from_kafka`, registered under the
-    `ingest.events.raw` namespace instead of `ingest.events.passthrough`
-    (STREAM-1191).
-    """
-    return _process_event_from_kafka(message_bytes)

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -12,7 +12,7 @@ from sentry.ingest.types import ConsumerType
 from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import ingest_events_passthrough_tasks
+from sentry.taskworker.namespaces import ingest_events_passthrough_tasks, ingest_events_raw_tasks
 from sentry.utils import metrics
 
 from .processors import IngestMessage, Retriable, process_event
@@ -82,25 +82,7 @@ def process_simple_event_message(
         raise InvalidMessage(raw_value.partition, raw_value.offset) from exc
 
 
-@instrumented_task(
-    name="sentry.ingest.consumer.simple_event.process_event_from_kafka",
-    namespace=ingest_events_passthrough_tasks,
-    processing_deadline_duration=150,
-    retry=Retry(times=2, delay=5, on=(Retriable,)),
-    compression_type=CompressionType.ZSTD,
-    silo_mode=SiloMode.CELL,
-)
-def process_event_from_kafka(message_bytes: bytes) -> None:
-    """Process an event from raw Kafka message bytes.
-
-    This task is directly spawned from taskbroker in "raw mode". You won't find
-    any application code that calls apply_async or delay directly on it,
-    instead taskbroker itself is configured to consume a topic (in infra
-    templates) and spawns tasks for each message.
-
-    As such, the task signature, name and namespace cannot be changed without
-    coordination.
-    """
+def _process_event_from_kafka(message_bytes: bytes) -> None:
     metrics.distribution(
         "ingest_consumer.payload_size",
         len(message_bytes),
@@ -130,3 +112,56 @@ def process_event_from_kafka(message_bytes: bytes) -> None:
         inline_save_event=options.get(INLINE_SAVE_EVENT_OPTION),
         inline_save_event_transaction=options.get(INLINE_SAVE_EVENT_TRANSACTION_OPTION),
     )
+
+
+@instrumented_task(
+    name="sentry.ingest.consumer.simple_event.process_event_from_kafka",
+    namespace=ingest_events_passthrough_tasks,
+    processing_deadline_duration=150,
+    retry=Retry(times=2, delay=5, on=(Retriable,)),
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+)
+def process_event_from_kafka(message_bytes: bytes) -> None:
+    """Process an event from raw Kafka message bytes.
+
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it,
+    instead taskbroker itself is configured to consume a topic (in infra
+    templates) and spawns tasks for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination.
+
+    This is a duplicate of `process_event_from_kafka_raw`, registered under
+    the `ingest.events.passthrough` namespace instead of `ingest.events.raw`
+    (STREAM-1191). Delete this task once infra no longer routes anything to
+    `ingest.events.passthrough`.
+    """
+    return _process_event_from_kafka(message_bytes)
+
+
+@instrumented_task(
+    name="sentry.ingest.consumer.simple_event.process_event_from_kafka_raw",
+    namespace=ingest_events_raw_tasks,
+    processing_deadline_duration=150,
+    retry=Retry(times=2, delay=5, on=(Retriable,)),
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+)
+def process_event_from_kafka_raw(message_bytes: bytes) -> None:
+    """Process an event from raw Kafka message bytes.
+
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it,
+    instead taskbroker itself is configured to consume a topic (in infra
+    templates) and spawns tasks for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination.
+
+    This is a duplicate of `process_event_from_kafka`, registered under the
+    `ingest.events.raw` namespace instead of `ingest.events.passthrough`
+    (STREAM-1191).
+    """
+    return _process_event_from_kafka(message_bytes)

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -230,7 +230,8 @@ ALL_KILLSWITCH_OPTIONS = {
     ),
     "profiling.killswitch.ingest-profiles": KillswitchInfo(
         description="""
-        Drop profiles in the sentry.profiles.task.process_profile_from_kafka task.
+        Drop profiles in the sentry.profiles.task.process_profile_from_kafka and
+        sentry.profiles.task.process_profile_from_kafka_raw tasks.
 
         This happens after relay produces profiles to the topic but before a task
         is started to process/ingest to profile.

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -68,7 +68,10 @@ from sentry.search.utils import DEVICE_CLASS
 from sentry.signals import first_profile_received
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import ingest_profiling_passthrough_tasks
+from sentry.taskworker.namespaces import (
+    ingest_profiling_passthrough_tasks,
+    ingest_profiling_raw_tasks,
+)
 from sentry.taskworker.producer import get_task_producer
 from sentry.utils import json, metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
@@ -160,6 +163,18 @@ eap_task_producer = get_task_producer(
 logger = logging.getLogger(__name__)
 
 
+def _process_profile_from_kafka(message_bytes: bytes, headers: dict[str, str]) -> None:
+    if _should_drop(headers):
+        return
+
+    sampled = _is_sampled(headers)
+
+    if not sampled and not options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
+        return
+
+    process_profile_task(payload=message_bytes, sampled=sampled)
+
+
 @instrumented_task(
     name="sentry.profiles.task.process_profile_from_kafka",
     namespace=ingest_profiling_passthrough_tasks,
@@ -182,16 +197,43 @@ def process_profile_from_kafka(
 
     As such, the task signature, name and namespace cannot be changed without
     coordination.
+
+    This is a duplicate of `process_profile_from_kafka_raw`, registered under
+    the `ingest.profiling.passthrough` namespace instead of
+    `ingest.profiling.raw` (STREAM-1191). Delete this task once infra no
+    longer routes anything to `ingest.profiling.passthrough`.
     """
-    if _should_drop(headers):
-        return
+    _process_profile_from_kafka(message_bytes, headers)
 
-    sampled = _is_sampled(headers)
 
-    if not sampled and not options.get("profiling.profile_metrics.unsampled_profiles.enabled"):
-        return
+@instrumented_task(
+    name="sentry.profiles.task.process_profile_from_kafka_raw",
+    namespace=ingest_profiling_raw_tasks,
+    processing_deadline_duration=80,
+    retry=Retry(times=2, delay=5),
+    compression_type=CompressionType.ZSTD,
+    silo_mode=SiloMode.CELL,
+    pass_headers=True,
+)
+def process_profile_from_kafka_raw(
+    message_bytes: bytes,
+    headers: dict[str, str],
+) -> None:
+    """Process a profile from raw Kafka message bytes.
 
-    process_profile_task(payload=message_bytes, sampled=sampled)
+    This task is directly spawned from taskbroker in "raw mode". You won't find
+    any application code that calls apply_async or delay directly on it,
+    instead taskbroker itself is configured to consume a topic (in infra
+    templates) and spawns tasks for each message.
+
+    As such, the task signature, name and namespace cannot be changed without
+    coordination.
+
+    This is a duplicate of `process_profile_from_kafka`, registered under the
+    `ingest.profiling.raw` namespace instead of `ingest.profiling.passthrough`
+    (STREAM-1191).
+    """
+    _process_profile_from_kafka(message_bytes, headers)
 
 
 def _is_sampled(headers: dict[str, str]) -> bool:

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -82,8 +82,15 @@ hybridcloud_control_tasks = app.taskregistry.create_namespace(
     app_feature="hybrid_cloud",
 )
 
+# TODO(STREAM-1191): remove once infra has fully migrated to
+# ingest_profiling_raw_tasks below.
 ingest_profiling_passthrough_tasks = app.taskregistry.create_namespace(
     "ingest.profiling.passthrough",
+    app_feature="profiles",
+)
+
+ingest_profiling_raw_tasks = app.taskregistry.create_namespace(
+    "ingest.profiling.raw",
     app_feature="profiles",
 )
 
@@ -102,8 +109,15 @@ ingest_attachments_tasks = app.taskregistry.create_namespace(
     app_feature="attachments",
 )
 
+# TODO(STREAM-1191): remove once infra has fully migrated to
+# ingest_events_raw_tasks below.
 ingest_events_passthrough_tasks = app.taskregistry.create_namespace(
     "ingest.events.passthrough",
+    app_feature="errors",
+)
+
+ingest_events_raw_tasks = app.taskregistry.create_namespace(
+    "ingest.events.raw",
     app_feature="errors",
 )
 

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -109,13 +109,6 @@ ingest_attachments_tasks = app.taskregistry.create_namespace(
     app_feature="attachments",
 )
 
-# TODO(STREAM-1191): remove once infra has fully migrated to
-# ingest_events_raw_tasks below.
-ingest_events_passthrough_tasks = app.taskregistry.create_namespace(
-    "ingest.events.passthrough",
-    app_feature="errors",
-)
-
 ingest_events_raw_tasks = app.taskregistry.create_namespace(
     "ingest.events.raw",
     app_feature="errors",


### PR DESCRIPTION
## Summary
- **Profiling** (`process_profile_from_kafka`, live in prod): registered under a new `ingest.profiling.raw` namespace *in addition to* the existing `ingest.profiling.passthrough` one (extracted the shared logic into a `_process_profile_from_kafka` helper so both stay in sync). A task's namespace can't be changed without coordinating with infra, so this duplicates rather than renames -- once infra is repointed at `ingest.profiling.raw`, the passthrough task/namespace can be deleted.
- **Events** (`process_event_from_kafka`): this one isn't live in raw/taskbroker mode yet -- `devservices/config/taskbroker.yml` has a `raw:` topic mapping for `ingest.profiling.passthrough`, but no equivalent entry for events; the `ingest-events` topic there still runs through the old Arroyo consumer command. Since nothing is routing to `ingest.events.passthrough` yet, no infra coordination is needed and this is a hard cutover -- the task now points straight at `ingest.events.raw`, and the `ingest.events.passthrough` namespace is removed rather than kept around as a duplicate.
- The `.raw` naming matches the convention already used by subscriptions (`snuba.subscriptions.*.raw`) and replays (`replays.raw`); the `.passthrough` naming on profiles/events just predates that convention.

ref STREAM-1191

## Test plan
- [x] `ruff` / `mypy` pass on the changed files
- [ ] `pytest` for `tests/sentry/profiles/test_task.py` and `tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py` (blocked locally by an unrelated pre-existing environment issue; these tests call the task functions directly and are unaffected by the namespace changes)