### PR TITLE
fix(analytics): Carry SCM project-creation wizard events in a variant param

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -15,7 +15,10 @@ import {RadioLineItem} from 'sentry/components/forms/controls/radioGroup';
 import {List} from 'sentry/components/list';
 import {ListItem} from 'sentry/components/list/listItem';
 import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCreationErrorAlert';
-import type {ScmAnalyticsFlow} from 'sentry/components/onboarding/scm/scmAnalyticsFlow';
+import {
+  type ScmAnalyticsFlow,
+  scmFlowVariantParams,
+} from 'sentry/components/onboarding/scm/scmAnalyticsFlow';
 import {
   useCreateProjectAndRulesError,
   useIsCreatingProjectAndRules,
@@ -45,11 +48,11 @@ export enum SupportedLanguages {
 // the active flow (new-org onboarding vs SCM-first project creation).
 const SCM_FRAMEWORK_MODAL_RENDERED_EVENT = {
   onboarding: 'onboarding.scm_select_framework_modal_rendered',
-  'project-creation': 'project_creation.scm_select_framework_modal_rendered',
+  'project-creation': 'project_creation.select_framework_modal_rendered',
 } as const;
 const SCM_PLATFORM_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_platform_selected',
-  'project-creation': 'project_creation.scm_platform_selected',
+  'project-creation': 'project_creation.platform_selected',
 } as const;
 
 const topGoFrameworks: PlatformKey[] = [
@@ -213,17 +216,28 @@ export function FrameworkSuggestionModal({
   });
 
   useEffect(() => {
-    trackAnalytics(
-      hasScmOnboarding
-        ? SCM_FRAMEWORK_MODAL_RENDERED_EVENT[analyticsFlow]
-        : newOrg
-          ? 'onboarding.select_framework_modal_rendered'
-          : 'project_creation.select_framework_modal_rendered',
-      {
+    if (hasScmOnboarding) {
+      trackAnalytics(SCM_FRAMEWORK_MODAL_RENDERED_EVENT[analyticsFlow], {
         platform: selectedPlatform.key,
         organization,
-      }
-    );
+        ...scmFlowVariantParams(analyticsFlow),
+      });
+    } else if (newOrg) {
+      trackAnalytics('onboarding.select_framework_modal_rendered', {
+        platform: selectedPlatform.key,
+        organization,
+      });
+    } else {
+      // Legacy project-creation variant shares the base
+      // project_creation.select_framework_modal_rendered name with the SCM
+      // variant above; stamp variant:'legacy' so it isn't dropped from
+      // variant-filtered queries.
+      trackAnalytics('project_creation.select_framework_modal_rendered', {
+        platform: selectedPlatform.key,
+        organization,
+        variant: 'legacy',
+      });
+    }
   }, [selectedPlatform.key, organization, newOrg, hasScmOnboarding, analyticsFlow]);
 
   const handleConfigure = useCallback(() => {
@@ -236,6 +250,7 @@ export function FrameworkSuggestionModal({
         organization,
         platform: selectedFramework.key,
         source: 'manual',
+        ...scmFlowVariantParams(analyticsFlow),
       });
     } else {
       trackAnalytics(
@@ -267,6 +282,7 @@ export function FrameworkSuggestionModal({
         organization,
         platform: selectedPlatform.key,
         source: 'manual',
+        ...scmFlowVariantParams(analyticsFlow),
       });
     } else {
       trackAnalytics(

--- a/static/app/components/onboarding/scm/scmAnalyticsFlow.ts
+++ b/static/app/components/onboarding/scm/scmAnalyticsFlow.ts
@@ -1,6 +1,22 @@
+import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
+
 /**
  * Which flow is hosting the SCM step components. Used to pick which
  * `*.scm_*` analytics event names the components fire (onboarding for
  * new-org onboarding, project-creation for the project creation wizard).
  */
 export type ScmAnalyticsFlow = 'onboarding' | 'project-creation';
+
+/**
+ * Params to spread onto a project-creation analytics event so the SCM vs legacy
+ * variant rides in a `variant` param instead of a distinct `scm_` event name
+ * (VDY-133). Returns `{}` for the onboarding flow — those events keep their
+ * distinct `onboarding.scm_*` names and must NOT carry a project-creation
+ * `variant`. The SCM cores only ever run in the SCM variant of project
+ * creation, so the `project-creation` flow always maps to `variant: 'scm'`.
+ */
+export function scmFlowVariantParams(flow: ScmAnalyticsFlow): {
+  variant?: ProjectCreationVariant;
+} {
+  return flow === 'project-creation' ? {variant: 'scm'} : {};
+}

--- a/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
+++ b/static/app/components/onboarding/scm/scmFeatureSelectionPanel.tsx
@@ -18,7 +18,7 @@ import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
 import {ScmFeatureInfoCards} from './scmFeatureInfoCards';
 import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
 import {
@@ -31,7 +31,7 @@ import {useScmResolvedPlatform} from './useScmResolvedPlatform';
 
 const FEATURE_TOGGLED_EVENT = {
   onboarding: 'onboarding.scm_platform_feature_toggled',
-  'project-creation': 'project_creation.scm_platform_feature_toggled',
+  'project-creation': 'project_creation.platform_feature_toggled',
 } as const;
 
 interface ScmFeatureSelectionPanelProps {
@@ -154,6 +154,7 @@ export function ScmFeatureSelectionPanel({
         feature,
         enabled: !wasEnabled,
         platform: currentPlatformKey ?? '',
+        ...scmFlowVariantParams(analyticsFlow),
       });
     },
     [

--- a/static/app/components/onboarding/scm/scmIntegrationConnect.spec.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationConnect.spec.tsx
@@ -138,8 +138,8 @@ describe('ScmIntegrationConnect', () => {
 
     await waitFor(() =>
       expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-        'project_creation.scm_connect_integration_selected',
-        expect.objectContaining({provider: 'github', source: 'default'})
+        'project_creation.connect_integration_selected',
+        expect.objectContaining({provider: 'github', source: 'default', variant: 'scm'})
       )
     );
   });
@@ -169,8 +169,8 @@ describe('ScmIntegrationConnect', () => {
 
     await waitFor(() =>
       expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-        'project_creation.scm_connect_integration_selected',
-        expect.objectContaining({provider: 'gitlab', source: 'manual'})
+        'project_creation.connect_integration_selected',
+        expect.objectContaining({provider: 'gitlab', source: 'manual', variant: 'scm'})
       )
     );
   });
@@ -195,7 +195,7 @@ describe('ScmIntegrationConnect', () => {
     expect(onClearDerivedState).not.toHaveBeenCalled();
 
     const integrationSelectedCalls = trackAnalyticsSpy.mock.calls.filter(
-      ([event]) => event === 'project_creation.scm_connect_integration_selected'
+      ([event]) => event === 'project_creation.connect_integration_selected'
     );
     expect(integrationSelectedCalls).toHaveLength(1);
     expect(integrationSelectedCalls[0]![1]).toEqual(

--- a/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
@@ -11,7 +11,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
-import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
 import {ScmIntegrationSelect} from './scmIntegrationSelect';
 import {ScmProviderPills} from './scmProviderPills';
 import {ScmRepoSelector} from './scmRepoSelector';
@@ -20,7 +20,7 @@ import {useScmProviders} from './useScmProviders';
 
 const INTEGRATION_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_connect_integration_selected',
-  'project-creation': 'project_creation.scm_connect_integration_selected',
+  'project-creation': 'project_creation.connect_integration_selected',
 } as const;
 
 interface ScmIntegrationConnectProps {
@@ -114,6 +114,7 @@ export function ScmIntegrationConnect({
       organization,
       provider: effectiveIntegration.provider.key,
       source: 'default',
+      ...scmFlowVariantParams(analyticsFlow),
     });
   }, [
     allowIntegrationSwitching,
@@ -149,6 +150,7 @@ export function ScmIntegrationConnect({
         organization,
         provider: integration.provider.key,
         source: 'manual',
+        ...scmFlowVariantParams(analyticsFlow),
       });
     },
     [

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -20,7 +20,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
 import {ScmPlatformCard} from './scmPlatformCard';
 import {
   DEFAULT_SCM_FEATURES,
@@ -35,15 +35,15 @@ import {useScmResolvedPlatform} from './useScmResolvedPlatform';
 
 const PLATFORM_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_platform_selected',
-  'project-creation': 'project_creation.scm_platform_selected',
+  'project-creation': 'project_creation.platform_selected',
 } as const;
 const CHANGE_PLATFORM_CLICKED_EVENT = {
   onboarding: 'onboarding.scm_platform_change_platform_clicked',
-  'project-creation': 'project_creation.scm_platform_change_platform_clicked',
+  'project-creation': 'project_creation.platform_change_platform_clicked',
 } as const;
 const SKIP_DETECTION_CLICKED_EVENT = {
   onboarding: 'onboarding.scm_skip_detection_clicked',
-  'project-creation': 'project_creation.scm_skip_detection_clicked',
+  'project-creation': 'project_creation.skip_detection_clicked',
 } as const;
 
 interface ScmPlatformFeaturesCoreProps {
@@ -151,6 +151,7 @@ export function ScmPlatformFeaturesCore({
       organization,
       platform: detectedPlatformKey,
       source: 'detected',
+      ...scmFlowVariantParams(analyticsFlow),
     });
   }, [
     detectedPlatformKey,
@@ -248,6 +249,7 @@ export function ScmPlatformFeaturesCore({
       organization,
       platform: platformKey,
       source: 'manual',
+      ...scmFlowVariantParams(analyticsFlow),
     });
   };
 
@@ -263,6 +265,7 @@ export function ScmPlatformFeaturesCore({
       organization,
       platform: platformKey,
       source: 'detected',
+      ...scmFlowVariantParams(analyticsFlow),
     });
   };
 
@@ -273,10 +276,12 @@ export function ScmPlatformFeaturesCore({
     if (isDetecting) {
       trackAnalytics(SKIP_DETECTION_CLICKED_EVENT[analyticsFlow], {
         organization,
+        ...scmFlowVariantParams(analyticsFlow),
       });
     } else {
       trackAnalytics(CHANGE_PLATFORM_CLICKED_EVENT[analyticsFlow], {
         organization,
+        ...scmFlowVariantParams(analyticsFlow),
       });
     }
   }
@@ -308,6 +313,7 @@ export function ScmPlatformFeaturesCore({
       organization,
       platform: detectedPlatformKey,
       source: 'detected',
+      ...scmFlowVariantParams(analyticsFlow),
     });
   }
 

--- a/static/app/components/onboarding/scm/scmRepoSelector.spec.tsx
+++ b/static/app/components/onboarding/scm/scmRepoSelector.spec.tsx
@@ -207,7 +207,7 @@ describe('ScmRepoSelector', () => {
     expect(onRepositoryChange).toHaveBeenCalled();
   });
 
-  it('fires project_creation.scm_connect_repo_selected when analyticsFlow=project-creation', async () => {
+  it('fires project_creation.connect_repo_selected when analyticsFlow=project-creation', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {
@@ -244,10 +244,11 @@ describe('ScmRepoSelector', () => {
     await userEvent.click(await screen.findByRole('menuitemradio', {name: 'sentry'}));
 
     expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-      'project_creation.scm_connect_repo_selected',
+      'project_creation.connect_repo_selected',
       expect.objectContaining({
         provider: mockIntegration.provider.key,
         repo: 'sentry',
+        variant: 'scm',
       })
     );
     expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(

--- a/static/app/components/onboarding/scm/scmRepoSelector.tsx
+++ b/static/app/components/onboarding/scm/scmRepoSelector.tsx
@@ -7,7 +7,7 @@ import type {Integration, Repository} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
 import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
 import {useScmRepos} from './useScmRepos';
@@ -15,7 +15,7 @@ import {useScmRepoSelection} from './useScmRepoSelection';
 
 const REPO_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_connect_repo_selected',
-  'project-creation': 'project_creation.scm_connect_repo_selected',
+  'project-creation': 'project_creation.connect_repo_selected',
 } as const;
 
 interface ScmRepoSelectorProps {
@@ -80,6 +80,7 @@ export function ScmRepoSelector({
           organization,
           provider: integration.provider.key,
           repo: repo.name,
+          ...scmFlowVariantParams(analyticsFlow),
         });
       }
       handleSelect(option);

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -4,7 +4,10 @@ import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboardingContext';
-import type {ScmAnalyticsFlow} from 'sentry/components/onboarding/scm/scmAnalyticsFlow';
+import {
+  type ScmAnalyticsFlow,
+  scmFlowVariantParams,
+} from 'sentry/components/onboarding/scm/scmAnalyticsFlow';
 import {useCreateProjectAndRules} from 'sentry/components/onboarding/useCreateProjectAndRules';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
@@ -32,32 +35,36 @@ import {
 } from 'sentry/views/projectInstall/issueAlertOptions';
 
 // The project-details analytics events, routed by the active flow (new-org
-// onboarding vs SCM-first project creation). The project_creation.* events are
-// registered in projectCreationAnalyticsEvents.tsx. STEP_VIEWED is fired by the
-// presentational component when the step is rendered, not here.
+// onboarding vs SCM-first project creation). Onboarding keeps its distinct
+// `onboarding.scm_*` names; the project-creation arm fires the base
+// `project_creation.*` name and carries the SCM/legacy split in a `variant`
+// param (see scmFlowVariantParams) so it shares the counter with the legacy
+// flow. STEP_VIEWED is fired by the presentational component when the step is
+// rendered, not here.
 const NAME_EDITED_EVENT = {
   onboarding: 'onboarding.scm_project_details_name_edited',
-  'project-creation': 'project_creation.scm_project_details_name_edited',
+  'project-creation': 'project_creation.project_details_name_edited',
 } as const;
 const TEAM_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_project_details_team_selected',
-  'project-creation': 'project_creation.scm_project_details_team_selected',
+  'project-creation': 'project_creation.project_details_team_selected',
 } as const;
 const ALERT_SELECTED_EVENT = {
   onboarding: 'onboarding.scm_project_details_alert_selected',
-  'project-creation': 'project_creation.scm_project_details_alert_selected',
+  'project-creation': 'project_creation.project_details_alert_selected',
 } as const;
 const CREATE_CLICKED_EVENT = {
   onboarding: 'onboarding.scm_project_details_create_clicked',
-  'project-creation': 'project_creation.scm_project_details_create_clicked',
+  'project-creation': 'project_creation.project_details_create_clicked',
 } as const;
-const CREATE_SUCCEEDED_EVENT = {
-  onboarding: 'onboarding.scm_project_details_create_succeeded',
-  'project-creation': 'project_creation.scm_project_details_create_succeeded',
-} as const;
+// Create-succeeded diverges by flow (different payloads), so it is fired via an
+// explicit branch in `submit` rather than a routing map: onboarding keeps
+// `onboarding.scm_project_details_create_succeeded` ({project_slug}); the
+// project-creation arm reuses the legacy `project_creation_page.created` counter
+// ({project_id, platform, variant:'scm'}) so absolute creation counts stay whole.
 const CREATE_FAILED_EVENT = {
   onboarding: 'onboarding.scm_project_details_create_failed',
-  'project-creation': 'project_creation.scm_project_details_create_failed',
+  'project-creation': 'project_creation.project_details_create_failed',
 } as const;
 
 export function getSubmitTooltipText({
@@ -235,6 +242,7 @@ export function useScmProjectDetails({
       trackAnalytics(NAME_EDITED_EVENT[analyticsFlow], {
         organization,
         custom: projectDetailsForm.projectName !== defaultName,
+        ...scmFlowVariantParams(analyticsFlow),
       });
     }
   }, [projectDetailsForm?.projectName, defaultName, organization, analyticsFlow]);
@@ -242,7 +250,11 @@ export function useScmProjectDetails({
   const onTeamChange = useCallback(
     ({value}: {value: string}) => {
       onProjectDetailsFormChange({...projectDetailsForm, teamSlug: value});
-      trackAnalytics(TEAM_SELECTED_EVENT[analyticsFlow], {organization, team: value});
+      trackAnalytics(TEAM_SELECTED_EVENT[analyticsFlow], {
+        organization,
+        team: value,
+        ...scmFlowVariantParams(analyticsFlow),
+      });
     },
     [onProjectDetailsFormChange, projectDetailsForm, organization, analyticsFlow]
   );
@@ -262,6 +274,7 @@ export function useScmProjectDetails({
         trackAnalytics(ALERT_SELECTED_EVENT[analyticsFlow], {
           organization,
           option: optionMap[value as number] ?? String(value),
+          ...scmFlowVariantParams(analyticsFlow),
         });
       }
     },
@@ -375,7 +388,10 @@ export function useScmProjectDetails({
     isCompletingRef.current = true;
     setIsCompleting(true);
 
-    trackAnalytics(CREATE_CLICKED_EVENT[analyticsFlow], {organization});
+    trackAnalytics(CREATE_CLICKED_EVENT[analyticsFlow], {
+      organization,
+      ...scmFlowVariantParams(analyticsFlow),
+    });
 
     const notificationAction = hasNotificationAction
       ? buildIntegrationAction(notificationProps)
@@ -386,27 +402,53 @@ export function useScmProjectDetails({
       alertRuleConfig,
       notificationAction,
     };
+    // Mirror the legacy project_creation_page.created `issue_alert` breakdown
+    // (see createProject.tsx): Custom > Default > No Rule, derived from the
+    // configured alert setting.
+    const issueAlert =
+      alertRuleConfig.alertSetting === RuleAction.CUSTOMIZED_ALERTS
+        ? 'Custom'
+        : alertRuleConfig.alertSetting === RuleAction.CREATE_ALERT_LATER
+          ? 'No Rule'
+          : 'Default';
 
     try {
       // User navigated back and clicked Create without changing anything; skip
       // to completion without creating a duplicate. Any actual change abandons
       // the previous project and creates a new one, matching legacy onboarding.
       if (existingProject && nothingChanged) {
-        trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
-          organization,
-          project_slug: existingProject.slug,
-        });
+        if (analyticsFlow === 'onboarding') {
+          trackAnalytics('onboarding.scm_project_details_create_succeeded', {
+            organization,
+            project_slug: existingProject.slug,
+          });
+        } else {
+          // Back-nav "nothing changed" path: no project or rules were created
+          // this pass, so the rule breakdown reflects "nothing new created now"
+          // while issue_alert echoes the configured setting (matches legacy
+          // payload shape; variant discriminates SCM).
+          trackAnalytics('project_creation_page.created', {
+            organization,
+            project_id: existingProject.id,
+            platform: selectedPlatform.key,
+            issue_alert: issueAlert,
+            notification_rule_created: false,
+            rule_ids: [],
+            variant: 'scm',
+          });
+        }
         onComplete({project: existingProject, projectDetailsForm: submittedForm});
         return;
       }
 
-      const {project} = await createProjectAndRules.mutateAsync({
-        projectName: projectNameResolved,
-        platform: selectedPlatform,
-        team: isOrgMemberWithNoAccess ? undefined : teamSlugResolved,
-        alertRuleConfig: getRequestDataFragment(alertRuleConfig),
-        createNotificationAction,
-      });
+      const {project, ruleIds, notificationRule} =
+        await createProjectAndRules.mutateAsync({
+          projectName: projectNameResolved,
+          platform: selectedPlatform,
+          team: isOrgMemberWithNoAccess ? undefined : teamSlugResolved,
+          alertRuleConfig: getRequestDataFragment(alertRuleConfig),
+          createNotificationAction,
+        });
 
       if (selectedRepository?.id) {
         try {
@@ -420,14 +462,29 @@ export function useScmProjectDetails({
         }
       }
 
-      trackAnalytics(CREATE_SUCCEEDED_EVENT[analyticsFlow], {
-        organization,
-        project_slug: project.slug,
-      });
+      if (analyticsFlow === 'onboarding') {
+        trackAnalytics('onboarding.scm_project_details_create_succeeded', {
+          organization,
+          project_slug: project.slug,
+        });
+      } else {
+        trackAnalytics('project_creation_page.created', {
+          organization,
+          project_id: project.id,
+          platform: selectedPlatform.key,
+          issue_alert: issueAlert,
+          notification_rule_created: !!notificationRule,
+          rule_ids: ruleIds,
+          variant: 'scm',
+        });
+      }
 
       onComplete({project, projectDetailsForm: submittedForm});
     } catch (error) {
-      trackAnalytics(CREATE_FAILED_EVENT[analyticsFlow], {organization});
+      trackAnalytics(CREATE_FAILED_EVENT[analyticsFlow], {
+        organization,
+        ...scmFlowVariantParams(analyticsFlow),
+      });
       addErrorMessage(t('Failed to create project'));
       Sentry.captureException(error);
     } finally {

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -8,6 +8,22 @@ export type ProjectCreationVariant = 'scm' | 'legacy';
 
 export type ProjectCreationEventParameters = {
   'project_creation.back_button_clicked': Record<string, unknown>;
+  // SCM-first project creation wizard steps. SCM vs legacy rides in `variant`
+  // (see scmFlowVariantParams); these events are only emitted by the SCM cores
+  // today, so `variant` is `scm` in practice, but stays optional so a future
+  // legacy sibling can share the name.
+  'project_creation.connect_integration_selected': {
+    provider: string;
+    // 'default' when the integration was auto-selected on entry, 'manual' when
+    // the user explicitly switched via the selector.
+    source: 'default' | 'manual';
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.connect_repo_selected': {
+    provider: string;
+    repo: string;
+    variant?: ProjectCreationVariant;
+  };
   'project_creation.data_removal_modal_confirm_button_clicked': {
     platform: string;
     project_id: string;
@@ -41,45 +57,38 @@ export type ProjectCreationEventParameters = {
     step: string;
     variant?: ProjectCreationVariant;
   };
-  // SCM-first project creation flow (mirrors onboarding.scm_*)
-  'project_creation.scm_connect_integration_selected': {
-    provider: string;
-    // 'default' when the integration was auto-selected on entry, 'manual' when
-    // the user explicitly switched via the selector.
-    source: 'default' | 'manual';
+  'project_creation.platform_change_platform_clicked': {
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_connect_repo_selected': {
-    provider: string;
-    repo: string;
-  };
-  'project_creation.scm_platform_change_platform_clicked': Record<string, unknown>;
-  'project_creation.scm_platform_feature_toggled': {
+  'project_creation.platform_feature_toggled': {
     enabled: boolean;
     feature: string;
     platform: string;
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_platform_selected': {
+  'project_creation.platform_selected': {
     platform: string;
     source: 'detected' | 'manual';
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_project_details_alert_selected': {
+  'project_creation.project_details_alert_selected': {
     option: string;
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_project_details_create_clicked': Record<string, unknown>;
-  'project_creation.scm_project_details_create_failed': Record<string, unknown>;
-  'project_creation.scm_project_details_create_succeeded': {
-    project_slug: string;
+  'project_creation.project_details_create_clicked': {
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_project_details_name_edited': {
+  'project_creation.project_details_create_failed': {
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.project_details_name_edited': {
     custom: boolean;
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_project_details_team_selected': {
+  'project_creation.project_details_team_selected': {
     team: string;
+    variant?: ProjectCreationVariant;
   };
-  'project_creation.scm_select_framework_modal_rendered': {
-    platform: string;
-  };
-  'project_creation.scm_skip_detection_clicked': Record<string, unknown>;
   'project_creation.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -89,6 +98,7 @@ export type ProjectCreationEventParameters = {
   };
   'project_creation.select_framework_modal_rendered': {
     platform: string;
+    variant?: ProjectCreationVariant;
   };
   'project_creation.select_framework_modal_skip_button_clicked': {
     platform: string;
@@ -96,6 +106,9 @@ export type ProjectCreationEventParameters = {
   'project_creation.setup_loader_docs_rendered': {
     platform: string;
     project_id: string;
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.skip_detection_clicked': {
     variant?: ProjectCreationVariant;
   };
   'project_creation.source_maps_wizard_button_copy_clicked': {
@@ -130,31 +143,25 @@ export const projectCreationEventMap: Record<
     'Project Creation: Data Removal Modal Rendered',
   'project_creation.data_removed': 'Project Creation: Data Removed',
   'project_creation.back_button_clicked': 'Project Creation: Back Button Clicked',
-  'project_creation.scm_connect_integration_selected':
-    'Project Creation: SCM Connect Integration Selected',
-  'project_creation.scm_connect_repo_selected':
-    'Project Creation: SCM Connect Repo Selected',
-  'project_creation.scm_platform_change_platform_clicked':
-    'Project Creation: SCM Platform Change Platform Clicked',
-  'project_creation.scm_platform_feature_toggled':
-    'Project Creation: SCM Platform Feature Toggled',
-  'project_creation.scm_platform_selected': 'Project Creation: SCM Platform Selected',
-  'project_creation.scm_project_details_alert_selected':
-    'Project Creation: SCM Project Details Alert Selected',
-  'project_creation.scm_project_details_create_clicked':
-    'Project Creation: SCM Project Details Create Clicked',
-  'project_creation.scm_project_details_create_failed':
-    'Project Creation: SCM Project Details Create Failed',
-  'project_creation.scm_project_details_create_succeeded':
-    'Project Creation: SCM Project Details Create Succeeded',
-  'project_creation.scm_project_details_name_edited':
-    'Project Creation: SCM Project Details Name Edited',
-  'project_creation.scm_project_details_team_selected':
-    'Project Creation: SCM Project Details Team Selected',
-  'project_creation.scm_select_framework_modal_rendered':
-    'Project Creation: SCM Framework Modal Rendered',
-  'project_creation.scm_skip_detection_clicked':
-    'Project Creation: SCM Skip Detection Clicked',
+  'project_creation.connect_integration_selected':
+    'Project Creation: Connect Integration Selected',
+  'project_creation.connect_repo_selected': 'Project Creation: Connect Repo Selected',
+  'project_creation.platform_change_platform_clicked':
+    'Project Creation: Platform Change Platform Clicked',
+  'project_creation.platform_feature_toggled':
+    'Project Creation: Platform Feature Toggled',
+  'project_creation.platform_selected': 'Project Creation: Platform Selected',
+  'project_creation.project_details_alert_selected':
+    'Project Creation: Project Details Alert Selected',
+  'project_creation.project_details_create_clicked':
+    'Project Creation: Project Details Create Clicked',
+  'project_creation.project_details_create_failed':
+    'Project Creation: Project Details Create Failed',
+  'project_creation.project_details_name_edited':
+    'Project Creation: Project Details Name Edited',
+  'project_creation.project_details_team_selected':
+    'Project Creation: Project Details Team Selected',
+  'project_creation.skip_detection_clicked': 'Project Creation: Skip Detection Clicked',
   'project_creation.source_maps_wizard_button_copy_clicked':
     'Project Creation: Source Maps Wizard Button Copy Clicked',
   'project_creation.source_maps_wizard_selected_and_copied':

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -1,4 +1,5 @@
 import type {GroupStatus} from 'sentry/types/group';
+import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
 import type {CommonGroupAnalyticsData} from 'sentry/utils/events';
 import type {Tab} from 'sentry/views/issueDetails/types';
 
@@ -168,6 +169,9 @@ export type TeamInsightsEventParameters = {
     platform: string;
     project_id: string;
     rule_ids: string[];
+    // 'legacy' from CreateProject, 'scm' from the SCM wizard. Both variants
+    // populate the same payload; only this discriminator differs.
+    variant?: ProjectCreationVariant;
   };
   'project_detail.change_chart': {chart_index: number; metric: string};
   'project_detail.open_anr_issues': Record<string, unknown>;

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -32,6 +32,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {slugify} from 'sentry/utils/slugify';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
@@ -274,6 +275,7 @@ export function CreateProject() {
     'project_creation_page.viewed',
     'Project Create: Creation page viewed'
   );
+  useRouteAnalyticsParams({variant: 'legacy'});
 
   const configurePlatform = useCallback(
     async ({
@@ -308,6 +310,7 @@ export function CreateProject() {
           platform: selectedPlatform.key,
           rule_ids: ruleIds,
           notification_rule_created: !!notificationRule,
+          variant: 'legacy',
         });
 
         addSuccessMessage(

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -32,6 +32,7 @@ import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useCanCreateProject} from 'sentry/utils/useCanCreateProject';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -63,12 +64,14 @@ export function ScmCreateProject() {
   // Single page-viewed event for the whole flow. Unlike onboarding's discrete
   // steps, every section renders at once here, so the per-section step_viewed
   // events the shared cores fire in onboarding are intentionally suppressed in
-  // this flow. Uses an SCM-specific event (not the classic
-  // project_creation_page.viewed) so the SCM-first funnel stays separable.
+  // this flow. Reuses the classic project_creation_page.viewed counter (shared
+  // with the legacy CreateProject flow) and carries variant:'scm' so the SCM
+  // funnel stays separable without splitting the absolute page-view count.
   useRouteAnalyticsEventNames(
-    'project_creation.scm_create_project_viewed',
-    'Project Creation: SCM Create Project Viewed'
+    'project_creation_page.viewed',
+    'Project Create: Creation page viewed'
   );
+  useRouteAnalyticsParams({variant: 'scm'});
 
   // Snapshot of the last completed wizard session, written when a project is
   // created (see handleComplete in the wizard). Restored when this mount is a


### PR DESCRIPTION
## TLDR

The SCM project-creation wizard's 13 analytics events (connect integration/repo, platform select/change/skip, feature toggle, framework modal, project-details name/team/alert/create/succeeded, page view) stop firing distinct `project_creation.scm_*` names and instead fire the base `project_creation.*` name carrying `variant: 'scm'`. Both project-creation variants now increment one counter per interaction, so absolute dashboard totals stay whole while remaining segmentable by `variant`.

## Details

Stacked on the setup-docs `variant` work. Frontend-only. This is a **relabel of live events** — the `project_creation.scm_*` core-wizard keys ship in `master` today — so BI dashboards keying on those names will see them stop and the base `project_creation.*` names pick up the SCM traffic (filter `variant == 'scm'` to recover the SCM cohort).

The motivation is absolute-count continuity: a distinct `project_creation.scm_*` name splits SCM traffic off the established `project_creation.*` counters, stepping those dashboards down as the `onboarding-scm-project-creation-experiment` ramps. Encoding SCM in a `variant` param instead keeps each counter whole. Onboarding is deliberately untouched: the shared SCM cores (`scmIntegrationConnect`, `scmRepoSelector`, `scmPlatformFeaturesCore`, `scmFeatureSelectionPanel`, `useScmProjectDetails`, `frameworkSuggestionModal`) route by `analyticsFlow`, and only the `project-creation` arm changes — the `onboarding` arm keeps its distinct `onboarding.scm_*` names. That is an accepted asymmetry (SCM encoded in the event name for onboarding, in a param for project creation); each `EVENT` lookup notes it.

A single `scmFlowVariantParams(flow)` helper (next to `ScmAnalyticsFlow`) returns `{variant: 'scm'}` for the `project-creation` flow and `{}` for `onboarding`, and is spread onto every project-creation fire site. Keeping it a small shared function (rather than an inline ternary at ~15 call sites) guarantees the onboarding arm never accidentally carries a project-creation `variant`.

Two events reuse an existing legacy counter rather than a new base name, because a `project_creation.*` sibling already exists for them:

- **Page view.** `scmCreateProject` switches its `useRouteAnalyticsEventNames` from `project_creation.scm_create_project_viewed` to the classic `project_creation_page.viewed` and adds `useRouteAnalyticsParams({variant: 'scm'})`; legacy `createProject` gets `variant: 'legacy'`. These are route events (free-form params), so no registry change.
- **Create succeeded.** `useScmProjectDetails`'s create hook serves both SCM onboarding and SCM project creation, so it branches explicitly: onboarding keeps `onboarding.scm_project_details_create_succeeded` (`{project_slug}`), while project creation reuses the legacy `project_creation_page.created` counter. Because the new SCM `created` payload was never consumed, it is aligned to the full legacy payload — `issue_alert` (derived from the alert setting exactly as `createProject` does), `notification_rule_created`, `rule_ids` from the mutation result — plus `variant: 'scm'`, rather than loosening the event type. The back-navigation "nothing changed" path has no freshly created rules, so it reports `notification_rule_created: false` / `rule_ids: []` with `issue_alert` echoing the configured setting. Legacy `createProject.created` gains `variant: 'legacy'`.

The remaining eleven wizard interactions become net-new base `project_creation.*` names (`connect_integration_selected`, `connect_repo_selected`, `platform_selected`, `platform_change_platform_clicked`, `skip_detection_clicked`, `platform_feature_toggled`, `project_details_{name_edited,team_selected,alert_selected,create_clicked,create_failed}`), each with optional `variant`. `select_framework_modal_rendered` and `platform_selected` are shared through `frameworkSuggestionModal`, whose rendered-effect is restructured into explicit branches so the SCM arm carries `variant: 'scm'`, the legacy project-creation arm carries `variant: 'legacy'`, and the new-org onboarding arm stays variant-free.

Existing onboarding specs (`scmPlatformFeatures`, `scmProjectDetails`) are the regression gate — they assert the `onboarding.scm_*` names with no `variant`, and stay green because `scmFlowVariantParams` returns `{}` for onboarding. The two SCM-flow specs that asserted `project_creation.scm_*` names now assert the base name plus `variant: 'scm'`.

Refs VDY-133

