### PR TITLE
fix(GAL): Add missing context to gitlab webhooks

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -31,6 +31,7 @@ from sentry.integrations.utils.metrics import IntegrationWebhookEvent, Integrati
 from sentry.integrations.utils.scope import clear_organization_info
 from sentry.integrations.utils.sync import sync_group_assignee_inbound_by_external_actor
 from sentry.integrations.utils.webhook_viewer_context import webhook_viewer_context
+from sentry.issues.action_log import ActionSource, action_context_scope, resolve_action_actor
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
@@ -713,7 +714,8 @@ class GitlabWebhookEndpoint(Endpoint):
         if request.method != "POST":
             return HttpResponse(status=405, reason="HTTP method not supported.")
 
-        return super().dispatch(request, *args, **kwargs)
+        with action_context_scope(ActionSource.GITLAB, resolve_action_actor(request)):
+            return super().dispatch(request, *args, **kwargs)
 
     def post(self, request: HttpRequest) -> HttpResponse:
         clear_organization_info()


### PR DESCRIPTION
Addresses SENTRY-5RK1
