### PR TITLE
feat(search): Register agentic triage sort feature flag and options

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -44,6 +44,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Organization scoped features that are in development or in customer trials. #
     ###############################################################################
 
+    # Enable agentic triage sort for night shift candidate selection
+    manager.add("organizations:agentic-triage-sort", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables alert creation on indexed events in UI (use for PoC/testing only)
     manager.add("organizations:alert-allow-indexed", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-based issue detection for an organization

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -906,31 +906,26 @@ register(
 )
 
 # Agentic triage sort: purpose-built for night shift candidate ranking.
-# Each factor weight defaults to 0.20 (equal weighting across 5 factors).
+# Each factor weight defaults to 0.25 (equal weighting across 4 factors).
 # Set a weight to 0 to skip that factor's aggregation entirely.
 register(
     "snuba.search.agentic-triage.recency-weight",
-    default=0.20,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "snuba.search.agentic-triage.severity-weight",
-    default=0.20,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "snuba.search.agentic-triage.user-impact-weight",
-    default=0.20,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
     "snuba.search.agentic-triage.event-volume-weight",
-    default=0.20,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "snuba.search.agentic-triage.fixability-weight",
-    default=0.20,
+    default=0.25,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Lookback window in seconds for Snuba aggregation (default: 2 days).

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -905,6 +905,41 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Agentic triage sort: purpose-built for night shift candidate ranking.
+# Each factor weight defaults to 0.20 (equal weighting across 5 factors).
+# Set a weight to 0 to skip that factor's aggregation entirely.
+register(
+    "snuba.search.agentic-triage.recency-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "snuba.search.agentic-triage.severity-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "snuba.search.agentic-triage.user-impact-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "snuba.search.agentic-triage.event-volume-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "snuba.search.agentic-triage.fixability-weight",
+    default=0.20,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Lookback window in seconds for Snuba aggregation (default: 2 days).
+register(
+    "snuba.search.agentic-triage.lookback-seconds",
+    default=172800,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
 register(
     "snuba.tagstore.cache-tagkeys-rate",


### PR DESCRIPTION
+ Add `organizations:agentic-triage-sort` FlagPole feature flag and register configurable weight options for the new agentic triage sort (recency, severity, user impact, event volume — all default 0.25) plus a lookback window option (default 2 days).
+ First PR for agentic triage sort so we can move away from recommended sort. 
