### PR TITLE
fix(weekly-reports): Scope previous-week outcomes query to missed projects

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -120,6 +120,7 @@ class OrganizationReportContextFactory:
                     end=prev_end,
                     ctx=ctx,
                     referrer=Referrer.REPORTS_OUTCOMES.value,
+                    project_ids=list(error_missed_project_ids),
                 )
                 for data in event_counts:
                     project_id = data["project_id"]

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -430,10 +430,26 @@ def fetch_key_performance_issues(ctx: OrganizationReportContext):
         ]
 
 
-def project_event_counts_for_organization(start, end, ctx, referrer: str) -> list[dict[str, Any]]:
+def project_event_counts_for_organization(
+    start, end, ctx, referrer: str, project_ids: Sequence[int] | None = None
+) -> list[dict[str, Any]]:
     """
     Populates context.projects which is { project_id: ProjectContext }
     """
+
+    where = [
+        Condition(Column("timestamp"), Op.GTE, start),
+        Condition(Column("timestamp"), Op.LT, end),
+        Condition(Column("org_id"), Op.EQ, ctx.organization.id),
+        Condition(Column("outcome"), Op.EQ, Outcome.ACCEPTED),
+        Condition(
+            Column("category"),
+            Op.IN,
+            [*DataCategory.error_categories()],
+        ),
+    ]
+    if project_ids:
+        where.append(Condition(Column("project_id"), Op.IN, project_ids))
 
     query = Query(
         match=Entity("outcomes"),
@@ -442,17 +458,7 @@ def project_event_counts_for_organization(start, end, ctx, referrer: str) -> lis
             Column("category"),
             Function("sum", [Column("quantity")], "total"),
         ],
-        where=[
-            Condition(Column("timestamp"), Op.GTE, start),
-            Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column("org_id"), Op.EQ, ctx.organization.id),
-            Condition(Column("outcome"), Op.EQ, Outcome.ACCEPTED),
-            Condition(
-                Column("category"),
-                Op.IN,
-                [*DataCategory.error_categories()],
-            ),
-        ],
+        where=where,
         groupby=[Column("outcome"), Column("category"), Column("project_id"), Column("time")],
         granularity=Granularity(ONE_DAY),
         orderby=[OrderBy(Column("time"), Direction.ASC)],


### PR DESCRIPTION
_Keep in draft until we rollout WoW changes to all orgs and wait a week._

_Reasoning: when we turn on the FF for all orgs,  the cache is still empty --> there will be a cache miss for every project. This PR would cause us to run a separate query for every project in the org. Use per-project previous week querying for when the cache hit rate for all orgs is >90% e.g. there are only a few cache misses per org per week._ 

## Summary
- Added optional `project_ids` parameter to `project_event_counts_for_organization`
- Previous-week cache-miss fallback now passes only the missed project IDs, avoiding a full org-wide Snuba scan
- Previously, even a single project cache miss triggered a query across all org projects for the prior week

## Test plan
- [ ] Existing `test_weekly_reports.py` tests pass
- [ ] Monitor `reports.outcomes` referrer timeout rate after deploy