### PR TITLE
fix(weekly-reports): Reduce key error issues chunk size from 100 to 25

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -129,7 +129,7 @@ def user_project_ownership(ctx: OrganizationReportContext) -> None:
             ctx.project_ownership.setdefault(user_id, set()).add(project_id)
 
 
-_KEY_ERROR_ISSUES_CHUNK_SIZE = 100
+_KEY_ERROR_ISSUES_CHUNK_SIZE = 25
 
 
 def _org_key_error_issues_chunk(

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -129,7 +129,7 @@ def user_project_ownership(ctx: OrganizationReportContext) -> None:
             ctx.project_ownership.setdefault(user_id, set()).add(project_id)
 
 
-_KEY_ERROR_ISSUES_CHUNK_SIZE = 25
+_KEY_ERROR_ISSUES_PROJECT_CHUNK_SIZE = 25
 
 
 def _org_key_error_issues_chunk(
@@ -210,8 +210,8 @@ def org_key_error_issues(
             return {}
 
         results: dict[int, list[dict[str, Any]]] = {}
-        for i in range(0, len(project_ids), _KEY_ERROR_ISSUES_CHUNK_SIZE):
-            chunk = project_ids[i : i + _KEY_ERROR_ISSUES_CHUNK_SIZE]
+        for i in range(0, len(project_ids), _KEY_ERROR_ISSUES_PROJECT_CHUNK_SIZE):
+            chunk = project_ids[i : i + _KEY_ERROR_ISSUES_PROJECT_CHUNK_SIZE]
             chunk_results = _org_key_error_issues_chunk(ctx, chunk, referrer, per_project_limit)
             results.update(chunk_results)
 


### PR DESCRIPTION
## Summary
- Reduced `_KEY_ERROR_ISSUES_PROJECT_CHUNK_SIZE` from 100 to 25
- The `events JOIN group_attributes` Snuba query chunks projects and runs one query per chunk. At 100 projects, each chunk scans a large volume of events and frequently hits the 30s Snuba timeout
- Smaller chunks mean more queries but each is 4x smaller and faster
- This referrer (`reports.key_errors.batched`) had 113 `SnubaError: Read timed out` events in the last 30 days ([SENTRY-5JQZ](https://sentry.sentry.io/issues/SENTRY-5JQZ))

## Test plan 
- [ ] Existing `test_weekly_reports.py` tests pass
- [ ] Monitor `reports.key_errors.batched` referrer timeout rate after deploy