### PR TITLE
fix(weekly-reports): Eliminate expensive JOIN in issue summaries query

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -477,7 +477,7 @@ def organization_project_issue_summaries(
     """
     return list(
         Group.objects.filter(
-            project__organization_id=ctx.organization.id,
+            project_id__in=list(ctx.projects_context_map.keys()),
             last_seen__gte=start,
             last_seen__lt=end,
             status=GroupStatus.UNRESOLVED,


### PR DESCRIPTION
## Summary

Resolves 1/5 of [ID-1714](https://linear.app/getsentry/issue/ID-1714/improve-performance) --> improve performance of weekly report

- Replaced `project__organization_id` filter with `project_id__in` using IDs already in the report context
- Eliminates `INNER JOIN sentry_project` from the SQL query, allowing Postgres to use a direct index on `(project_id, status, last_seen)`
- This query was responsible for 251 `OperationalError: canceling statement due to user request` events + 75 `NoRetriesRemainingError` events in the last 30 days (SENTRY-5RDV, SENTRY-440X)

## Test plan
- [ ] Existing `test_weekly_reports.py` tests pass
- [ ] Monitor SENTRY-5RDV and SENTRY-440X event counts after deploy