### PR TITLE
fix(weekly-reports): Simplify outcomes query by removing redundant groupby

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -1,7 +1,6 @@
 import sentry_sdk
 
 from sentry import features
-from sentry.constants import DataCategory
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import TeamStatus
@@ -21,7 +20,6 @@ from sentry.tasks.summaries.utils import (
 from sentry.tasks.summaries.weekly_report_cache import read_project_metrics
 from sentry.types.group import GroupSubStatus
 from sentry.utils import metrics
-from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import parse_snuba_datetime
 from sentry.utils.tracing import start_span
 
@@ -125,13 +123,10 @@ class OrganizationReportContextFactory:
                     project_id = data["project_id"]
                     if project_id not in ctx.projects_context_map:
                         continue
-                    project_ctx = ctx.projects_context_map[project_id]
-                    total = data["total"]
-                    if data["outcome"] != Outcome.ACCEPTED:
+                    if project_id not in error_missed_project_ids:
                         continue
-                    if data["category"] in DataCategory.error_categories():
-                        if project_id in error_missed_project_ids:
-                            project_ctx.prev_week_accepted_error_count += total
+                    project_ctx = ctx.projects_context_map[project_id]
+                    project_ctx.prev_week_accepted_error_count += data["total"]
 
             if issue_missed_project_ids:
                 issue_data = organization_project_issue_summaries(

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -438,8 +438,6 @@ def project_event_counts_for_organization(start, end, ctx, referrer: str) -> lis
     query = Query(
         match=Entity("outcomes"),
         select=[
-            Column("outcome"),
-            Column("category"),
             Function("sum", [Column("quantity")], "total"),
         ],
         where=[
@@ -453,7 +451,7 @@ def project_event_counts_for_organization(start, end, ctx, referrer: str) -> lis
                 [*DataCategory.error_categories()],
             ),
         ],
-        groupby=[Column("outcome"), Column("category"), Column("project_id"), Column("time")],
+        groupby=[Column("project_id"), Column("time")],
         granularity=Granularity(ONE_DAY),
         orderby=[OrderBy(Column("time"), Direction.ASC)],
         limit=Limit(10000),


### PR DESCRIPTION
## Summary

Resolves 2/5 of [ID-1714](https://linear.app/getsentry/issue/ID-1714/improve-performance) --> improving performance of weekly report

- Removed `outcome` and `category` from `SELECT` and `GROUP BY` in the outcomes Snuba query — both are already filtered in `WHERE` (outcome=ACCEPTED, category IN error_categories)
- Removes dead Python-side checks on outcome/category in `_append_previous_week_counts`
- Reduces result set size, lowering Snuba query time and transfer overhead
- This query referrer (`reports.outcomes`) was responsible for 392 `SnubaError: Read timed out` events in the last 30 days (SENTRY-5JQZ)

## Test plan
- [ ] Existing `test_weekly_reports.py` tests pass
- [ ] Monitor SENTRY-5JQZ event count after deploy