### PR TITLE
fix(explore): Remove trace links from aggregate table

### DIFF
--- a/static/app/views/explore/tables/aggregatesTable.spec.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.spec.tsx
@@ -210,6 +210,49 @@ describe('AggregatesTable', () => {
     ).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['id', 'span-id'],
+    ['trace', 'trace-id'],
+  ])('does not link aggregate %s values', (field, value) => {
+    const eventView = EventView.fromLocation(
+      LocationFixture({query: {field: [field, 'count()']}})
+    );
+
+    render(
+      <AggregatesTableWithParamsProvider
+        aggregatesTableResult={createAggregatesTableResult({
+          eventView,
+          result: {
+            data: [{[field]: value, 'count()': 1}],
+            meta: {
+              fields: {
+                [field]: FieldValueType.STRING,
+                'count()': FieldValueType.INTEGER,
+              },
+              units: {},
+            },
+          },
+        })}
+      />,
+      {
+        initialRouterConfig: {
+          ...initialRouterConfig,
+          location: {
+            ...initialRouterConfig.location,
+            query: {
+              ...initialRouterConfig.location.query,
+              groupBy: field,
+            },
+          },
+        },
+        organization,
+      }
+    );
+
+    expect(screen.getByText(value)).toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: value})).not.toBeInTheDocument();
+  });
+
   it('uses validated field types when aggregate metadata is missing', async () => {
     const eventView = EventView.fromLocation(
       LocationFixture({

--- a/static/app/views/explore/tables/aggregatesTable.tsx
+++ b/static/app/views/explore/tables/aggregatesTable.tsx
@@ -290,6 +290,7 @@ export function AggregatesTable({
                         <FieldRenderer
                           column={columns[field]}
                           data={row}
+                          disableTraceLinks
                           unit={meta?.units?.[field]}
                           meta={meta}
                         />

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -58,6 +58,7 @@ interface FieldProps {
   meta: MetaType;
   allowActions?: Actions[];
   column?: TableColumn<keyof TableDataRow>;
+  disableTraceLinks?: boolean;
   extraMenuItems?: MenuItemProps[];
   unit?: string;
   usePortalOnDropdown?: boolean;
@@ -69,6 +70,7 @@ export function FieldRenderer({
   unit,
   column,
   allowActions,
+  disableTraceLinks,
   extraMenuItems,
   usePortalOnDropdown,
 }: FieldProps) {
@@ -82,6 +84,7 @@ export function FieldRenderer({
       unit={unit}
       column={column}
       allowActions={allowActions}
+      disableTraceLinks={disableTraceLinks}
       extraMenuItems={extraMenuItems}
       userQuery={userQuery}
       setUserQuery={setUserQuery}
@@ -130,6 +133,7 @@ function BaseExploreFieldRenderer({
   unit,
   column,
   allowActions,
+  disableTraceLinks,
   extraMenuItems,
   userQuery,
   setUserQuery,
@@ -174,7 +178,7 @@ function BaseExploreFieldRenderer({
     rendered = <StyledTimeSince unitStyle="short" date={date} tooltipShowSeconds />;
   }
 
-  if (field === 'trace') {
+  if (field === 'trace' && !disableTraceLinks) {
     if (isPartialSpanOrTraceData(data.timestamp)) {
       const queryString = new MutableSearch('');
 
@@ -233,7 +237,7 @@ function BaseExploreFieldRenderer({
     }
   }
 
-  if (['id', 'span_id', 'transaction.id'].includes(field)) {
+  if (!disableTraceLinks && ['id', 'span_id', 'transaction.id'].includes(field)) {
     const spanId = field === 'transaction.id' ? undefined : (data.span_id ?? data.id);
 
     if (isPartialSpanOrTraceData(data.timestamp)) {
@@ -295,10 +299,10 @@ function BaseExploreFieldRenderer({
 
       rendered = <Link to={target}>{rendered}</Link>;
     }
+  }
 
-    if (field === 'id') {
-      return rendered;
-    }
+  if (field === 'id') {
+    return rendered;
   }
 
   return (


### PR DESCRIPTION
Explore aggregate tables now render grouped span and trace IDs as plain values instead of linking them to trace details. Sample tables retain their existing trace-navigation links, and regression coverage protects both aggregate group-by cases.
