### PR TITLE
fix(weekly-reports): isolate failures in create_context steps

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -263,17 +263,37 @@ class OrganizationReportContextFactory:
 
         with metrics.timer("weekly_report.create_context.duration"):
             self._append_user_project_ownership(ctx)
-            self._append_project_event_counts(ctx)
-            self._append_organization_project_issue_summaries(ctx)
+
+            try:
+                self._append_project_event_counts(ctx)
+            except Exception:
+                sentry_sdk.capture_exception()
+
+            try:
+                self._append_organization_project_issue_summaries(ctx)
+            except Exception:
+                sentry_sdk.capture_exception()
+
             if features.has("organizations:weekly-report-week-over-week-metric", self.organization):
-                self._append_previous_week_counts(ctx)
+                try:
+                    self._append_previous_week_counts(ctx)
+                except Exception:
+                    sentry_sdk.capture_exception()
 
             # Enhanced privacy flag hides issue titles, transaction names, and source details
             if not self.organization.flags.enhanced_privacy:
-                self._append_project_key_issues(ctx)
+                try:
+                    self._append_project_key_issues(ctx)
+                except Exception:
+                    sentry_sdk.capture_exception()
+
                 self._hydrate_key_error_issues(ctx)
                 self._hydrate_key_performance_issues(ctx)
+
                 if features.has("organizations:weekly-report-past-issues", self.organization):
-                    self._append_project_past_resolved_issues(ctx)
+                    try:
+                        self._append_project_past_resolved_issues(ctx)
+                    except Exception:
+                        sentry_sdk.capture_exception()
 
         return ctx


### PR DESCRIPTION
_Keep in draft until other PRs are merged and processed. This is just a fallback for when "all else" fails, but there seem to be some easy wins for improving performance of individual sections first._ 

Resolves [ID-1714](https://linear.app/getsentry/issue/ID-1714/improve-performance)

## Summary
- Wrapped each data-fetching step in `create_context` with try/except + `sentry_sdk.capture_exception()`
- A Snuba timeout in one step (e.g., event counts) no longer prevents the remaining steps (e.g., key issues) from executing
- Reports may be partial (missing some sections) but will still be generated and delivered
- Prevents cascading `ProcessingDeadlineExceeded` errors (25 events in last 30 days)

## Test plan
- [ ] Existing `test_weekly_reports.py` tests pass
- [ ] Monitor `ProcessingDeadlineExceeded` event count after deploy