### PR TITLE
fix(release-thresholds): apply the status endpoint's release prefetches

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -215,11 +215,13 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
             )
             .order_by("-date")
             .distinct()
+            # prefetch the release_thresholds via the projects model
+            .prefetch_related(
+                "projects__release_thresholds__environment",
+                "releaseprojectenvironment_set",
+                "deploy_set",
+            )
         )
-        # prefetching the release_thresholds via the projects model
-        queryset.prefetch_related("projects__release_thresholds__environment")
-        queryset.prefetch_related("releaseprojectenvironment_set")
-        queryset.prefetch_related("deploy_set")
 
         logger.info(
             "Fetched releases",


### PR DESCRIPTION
It seems like `prefetch_related` returns a new queryset rather than mutating in place, which was leading to an N+1 in this releases endopint.