### PR TITLE
feat(trace-items): Filter metrics to those with context via context_only

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -51,6 +51,14 @@ _GROUPING_ORDER = [METRIC_NAME_ALIAS, METRIC_TYPE_ALIAS, METRIC_UNIT_ALIAS]
 MAX_METRICS_PER_PAGE = 1000
 
 
+def _metric_names_filter(names: list[str]) -> str:
+    """A search clause matching ``metric.name`` against any of the given names."""
+    clauses = [
+        'metric.name:"' + name.replace("\\", "\\\\").replace('"', '\\"') + '"' for name in names
+    ]
+    return "(" + " OR ".join(clauses) + ")"
+
+
 class TraceMetricContext(TypedDict):
     brief: NotRequired[str]
     additionalContext: NotRequired[str]
@@ -114,11 +122,33 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
         snuba_params.end = adjusted_end
 
         query_string = serialized.get("query", "")
-        # Authored context is joined from TraceItemAttributeValueContext, gated
+        # Authored context lives in TraceItemAttributeValueContext and is gated
         # behind the feature; conventions don't apply to custom metrics.
-        include_context = "context" in serialized.get("expand", set()) and features.has(
+        has_context_feature = features.has(
             "organizations:data-browsing-attribute-context", organization, actor=request.user
         )
+        # context_only restricts results to metrics that have authored context.
+        context_only = serialized.get("context_only", False) and has_context_feature
+        include_context = has_context_feature and (
+            "context" in serialized.get("expand", set()) or context_only
+        )
+
+        if context_only:
+            context_names = list(
+                TraceItemAttributeValueContext.objects.filter(
+                    organization=organization,
+                    item_type=TraceItemTypes.TRACEMETRICS,
+                    attribute_name=METRIC_NAME_ALIAS,
+                )
+                .values_list("attribute_value", flat=True)
+                .distinct()
+            )
+            if not context_names:
+                return self.paginate(request=request, paginator=ChainPaginator([]))
+            # Restrict the metrics query to names that have context, so count,
+            # sort, and pagination all operate on the filtered set.
+            name_filter = _metric_names_filter(context_names)
+            query_string = f"{query_string} {name_filter}".strip()
 
         # Resolve the requested sort to a query orderby, always appending the
         # grouping key so pagination has a stable total order.

--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -29,7 +29,6 @@ from sentry.search.eap.constants import (
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.trace_metrics import TraceMetrics
-from sentry.utils import json
 
 _COUNT_ALIAS = f"count({METRIC_NAME_ALIAS})"
 _LAST_SEEN_ALIAS = "max(timestamp_precise)"
@@ -52,10 +51,17 @@ _GROUPING_ORDER = [METRIC_NAME_ALIAS, METRIC_TYPE_ALIAS, METRIC_UNIT_ALIAS]
 MAX_METRICS_PER_PAGE = 1000
 
 
+def _quote_search_value(value: str) -> str:
+    # Wrap in double quotes, escaping backslashes and quotes. Unlike json.dumps,
+    # this leaves non-ASCII characters literal (the search grammar doesn't decode
+    # `\uXXXX`), so unicode metric names still match.
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def _metric_names_filter(names: list[str]) -> str:
     """An `IN` search clause matching ``metric.name`` against any of the given names."""
-    # json.dumps gives us a correctly quoted + escaped string literal per name.
-    quoted = ", ".join(json.dumps(name) for name in names)
+    quoted = ", ".join(_quote_search_value(name) for name in names)
     return f"metric.name:[{quoted}]"
 
 

--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -190,6 +190,10 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
             ]
             if include_context:
                 self._attach_context(metrics, organization)
+            if context_only:
+                # The query filters by name only, but context is keyed by
+                # (name, type) — drop rows whose specific type has no context.
+                metrics = [metric for metric in metrics if "context" in metric]
             return metrics
 
         return self.paginate(

--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -29,6 +29,7 @@ from sentry.search.eap.constants import (
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.trace_metrics import TraceMetrics
+from sentry.utils import json
 
 _COUNT_ALIAS = f"count({METRIC_NAME_ALIAS})"
 _LAST_SEEN_ALIAS = "max(timestamp_precise)"
@@ -53,7 +54,8 @@ MAX_METRICS_PER_PAGE = 1000
 
 def _metric_names_filter(names: list[str]) -> str:
     """An `IN` search clause matching ``metric.name`` against any of the given names."""
-    quoted = ", ".join('"' + name.replace("\\", "\\\\").replace('"', '\\"') + '"' for name in names)
+    # json.dumps gives us a correctly quoted + escaped string literal per name.
+    quoted = ", ".join(json.dumps(name) for name in names)
     return f"metric.name:[{quoted}]"
 
 

--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -52,11 +52,9 @@ MAX_METRICS_PER_PAGE = 1000
 
 
 def _metric_names_filter(names: list[str]) -> str:
-    """A search clause matching ``metric.name`` against any of the given names."""
-    clauses = [
-        'metric.name:"' + name.replace("\\", "\\\\").replace('"', '\\"') + '"' for name in names
-    ]
-    return "(" + " OR ".join(clauses) + ")"
+    """An `IN` search clause matching ``metric.name`` against any of the given names."""
+    quoted = ", ".join('"' + name.replace("\\", "\\\\").replace('"', '\\"') + '"' for name in names)
+    return f"metric.name:[{quoted}]"
 
 
 class TraceMetricContext(TypedDict):

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -142,6 +142,20 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         assert response.status_code == 200, response.data
         assert response.data == []
 
+    def test_context_only_drops_type_without_context(self) -> None:
+        # Same name exists as counter and gauge, but only the counter has context.
+        # The name filter returns both; the gauge (no context) must be dropped.
+        self.store_metric("checkout.requests", "counter")
+        self.store_metric("checkout.requests", "gauge")
+        self.create_context(
+            "checkout.requests", metric_type=TraceMetricTypes.COUNTER, project=None, brief="Counter"
+        )
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert [(row["type"], "context" in row) for row in response.data] == [("counter", True)]
+
     def test_context_only_ignored_without_feature(self) -> None:
         self.store_metric("has.context", "counter")
         self.store_metric("no.context", "counter")

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -142,6 +142,17 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         assert response.status_code == 200, response.data
         assert response.data == []
 
+    def test_context_only_matches_unicode_name(self) -> None:
+        # A unicode metric name must still match the IN filter (regression: json
+        # escaping would emit \uXXXX, which the search grammar doesn't decode).
+        self.store_metric("café.requests", "counter")
+        self.create_context("café.requests", project=None, brief="Café")
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert [row["name"] for row in response.data] == ["café.requests"]
+
     def test_context_only_drops_type_without_context(self) -> None:
         # Same name exists as counter and gauge, but only the counter has context.
         # The name filter returns both; the gauge (no context) must be dropped.

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -123,15 +123,40 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         assert response.status_code == 400, response.data
         assert "sort" in response.data
 
-    def test_accepts_context_only(self) -> None:
-        # context_only is accepted (behavior wired up separately) and doesn't
-        # change the result yet.
-        self.store_metric("checkout.requests", "counter")
+    def test_context_only_filters_to_metrics_with_context(self) -> None:
+        self.store_metric("has.context", "counter")
+        self.store_metric("no.context", "counter")
+        self.create_context("has.context", project=None, brief="Described")
 
         response = self.do_request(query={"project": self.project.id, "context_only": "1"})
 
         assert response.status_code == 200, response.data
-        assert [row["name"] for row in response.data] == ["checkout.requests"]
+        assert [row["name"] for row in response.data] == ["has.context"]
+        assert response.data[0]["context"] == {"brief": "Described"}
+
+    def test_context_only_empty_when_no_context(self) -> None:
+        self.store_metric("no.context", "counter")
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert response.data == []
+
+    def test_context_only_ignored_without_feature(self) -> None:
+        self.store_metric("has.context", "counter")
+        self.store_metric("no.context", "counter")
+        self.create_context("has.context", project=None, brief="Described")
+
+        response = self.do_request(
+            query={"project": self.project.id, "context_only": "1"},
+            features={
+                "organizations:visibility-explore-view": True,
+                "organizations:tracemetrics-enabled": True,
+            },
+        )
+
+        assert response.status_code == 200, response.data
+        assert {row["name"] for row in response.data} == {"has.context", "no.context"}
 
     def test_expand_context(self) -> None:
         self.store_metric("checkout.requests", "counter")


### PR DESCRIPTION
Implements the `context_only` behavior on the metrics list endpoint: when `context_only=true`, only metrics that have authored context are returned.

## How it works

The set of metric names with context is read from `TraceItemAttributeValueContext` (org-level, `item_type=tracemetrics`, `attribute_name=metric.name`) and applied as a `metric.name:(...)` filter on the EAP query. Doing the filter in-query (rather than post-filtering the page) means **count, sort, and pagination all operate on the filtered set** — so a low-count metric with context isn't dropped by count-ranked truncation.

- Gated behind `data-browsing-attribute-context`; a no-op when the feature is off.
- Returns an empty page when no metrics have context.
- Context is attached to the results (since we're filtering to context-having metrics).

## Note on base branch

Based on `dominikbuszowiecki/dain-1796-...` (#120076), which adds the `context_only` **param** this PR gives behavior to. It'll auto-retarget to master once #120076 merges.

Backend-only.