### PR TITLE
fix(search): Make ctrl/cmd+delete in search delete to the cursor

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -81,6 +81,14 @@ type DeleteTokensAction = {
   focusOverride?: FocusOverride;
 };
 
+type DeleteToCursorAction = {
+  cursorPosition: number;
+  direction: 'before' | 'after';
+  inputValue: string;
+  token: ParseResultToken;
+  type: 'DELETE_TO_CURSOR';
+};
+
 type UpdateFreeTextActionOnSelect = {
   shouldCommitQuery: boolean;
   text: string;
@@ -236,6 +244,7 @@ export type QueryBuilderActions =
   | ResetFocusOverrideAction
   | DeleteTokenAction
   | DeleteTokensAction
+  | DeleteToCursorAction
   | UpdateFreeTextActionOnSelect
   | UpdateFreeTextActionOnBlur
   | UpdateFreeTextActionOnCommit
@@ -283,6 +292,39 @@ function deleteQueryTokens(
     ...state,
     query: removeQueryTokensFromQuery(state.query, action.tokens),
     focusOverride: action.focusOverride ?? null,
+  };
+}
+
+function deleteToCursor(
+  state: QueryBuilderState,
+  action: DeleteToCursorAction,
+  parseQuery: (query: string) => ParseResult | null
+): QueryBuilderState {
+  const {token, cursorPosition, inputValue, direction} = action;
+  const deleteBefore = direction === 'before';
+
+  const newQuery = deleteBefore
+    ? removeExcessWhitespaceFromParts(
+        inputValue.slice(cursorPosition),
+        state.query.substring(token.location.end.offset)
+      )
+    : removeExcessWhitespaceFromParts(
+        state.query.substring(0, token.location.start.offset),
+        inputValue.slice(0, cursorPosition)
+      );
+
+  const newParsedQuery = parseQuery(newQuery);
+  const focusedToken = deleteBefore
+    ? newParsedQuery?.find(t => t.type === Token.FREE_TEXT)
+    : newParsedQuery?.findLast(t => t.type === Token.FREE_TEXT);
+
+  return {
+    ...state,
+    query: newQuery,
+    committedQuery: newQuery,
+    focusOverride: focusedToken
+      ? {itemKey: makeTokenKey(focusedToken, newParsedQuery)}
+      : {itemKey: `${Token.FREE_TEXT}:0`},
   };
 }
 
@@ -1146,6 +1188,12 @@ export function useQueryBuilderState({
         case 'DELETE_TOKENS': {
           return {
             ...deleteQueryTokens(state, action),
+            clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
+          };
+        }
+        case 'DELETE_TO_CURSOR': {
+          return {
+            ...deleteToCursor(state, action, parseQuery),
             clearAskSeerFeedback: displayAskSeerFeedback ? true : false,
           };
         }

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -583,24 +583,57 @@ describe('SearchQueryBuilder', () => {
       }
     );
 
-    it('clears uncommitted free text repeatedly with Cmd+Delete', async () => {
-      render(<SearchQueryBuilder {...defaultProps} initialQuery="" />);
+    it('deletes everything before the cursor with Ctrl+Backspace, keeping what is after', async () => {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
 
-      const input = screen.getByRole('combobox', {name: 'Add a search term'});
+      await userEvent.type(getLastInput(), 'abcdef');
+      await userEvent.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
+      await userEvent.keyboard('{Control>}{Backspace}{/Control}');
 
-      await userEvent.type(input, 'first');
+      await waitFor(() => {
+        expect(getLastInput()).toHaveValue('def');
+      });
+      expect(
+        screen.queryByRole('row', {name: 'browser.name:firefox'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('deletes everything after the cursor with Ctrl+Delete, keeping what is before', async () => {
+      render(
+        <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+      );
+
+      await userEvent.type(getLastInput(), 'abcdef');
+      await userEvent.keyboard('{ArrowLeft}{ArrowLeft}{ArrowLeft}');
       await userEvent.keyboard('{Control>}{Delete}{/Control}');
 
       await waitFor(() => {
-        expect(input).toHaveValue('');
+        expect(getLastInput()).toHaveValue('abc');
       });
+      expect(screen.getByRole('row', {name: 'browser.name:firefox'})).toBeInTheDocument();
+    });
 
-      await userEvent.type(input, 'second');
-      await userEvent.keyboard('{Control>}{Delete}{/Control}');
+    it('clears the query with Ctrl+Backspace from an empty trailing input', async () => {
+      const mockOnSearch = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          initialQuery="browser.name:firefox"
+          onSearch={mockOnSearch}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{Control>}{Backspace}{/Control}');
 
       await waitFor(() => {
-        expect(input).toHaveValue('');
+        expect(
+          screen.queryByRole('row', {name: 'browser.name:firefox'})
+        ).not.toBeInTheDocument();
       });
+      expect(mockOnSearch).toHaveBeenCalledWith('', expect.anything());
     });
 
     it('is hidden at small sizes', async () => {

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -42,7 +42,7 @@ import {
   findItemInSections,
   itemIsSection,
 } from 'sentry/components/searchQueryBuilder/tokens/utils';
-import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
+import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 import {defined} from 'sentry/utils/defined';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -382,6 +382,7 @@ export function SearchQueryBuilderCombobox<
   children,
   description,
   items,
+  token,
   inputValue,
   filterValue = inputValue,
   placeholder,
@@ -412,7 +413,7 @@ export function SearchQueryBuilderCombobox<
   ['data-test-id']: dataTestId,
   ref,
 }: SearchQueryBuilderComboboxProps<T>) {
-  const {clearSearchQuery} = useSearchQueryBuilderState();
+  const {clearSearchQuery, dispatch} = useSearchQueryBuilderState();
   const {disabled} = useSearchQueryBuilderConfig();
   const {portalTarget, wrapperRef} = useSearchQueryBuilderLayout();
   const {enableAISearch} = useSearchQueryBuilderAI();
@@ -664,12 +665,28 @@ export function SearchQueryBuilderCombobox<
         disabled={disabled}
         onKeyDownCapture={e => {
           if (isCtrlKeyPressed(e) && (e.key === 'Backspace' || e.key === 'Delete')) {
-            e.preventDefault();
-            e.stopPropagation();
-            onSearchQueryClear?.();
-            state.close();
-            clearSearchQuery({reopenDropdown: true});
-            return;
+            if (token.type === Token.FREE_TEXT) {
+              e.preventDefault();
+              e.stopPropagation();
+              state.close();
+              dispatch({
+                type: 'DELETE_TO_CURSOR',
+                token,
+                cursorPosition: e.currentTarget.selectionStart ?? 0,
+                inputValue,
+                direction: e.key === 'Backspace' ? 'before' : 'after',
+              });
+              return;
+            }
+
+            if (!inputValue) {
+              e.preventDefault();
+              e.stopPropagation();
+              onSearchQueryClear?.();
+              state.close();
+              clearSearchQuery({reopenDropdown: true});
+              return;
+            }
           }
 
           onKeyDownCapture?.(e, {state});


### PR DESCRIPTION
Pressing <kbd>Ctrl</kbd>+<kbd>Backspace</kbd> (<kbd>Cmd</kbd>+<kbd>Backspace</kbd> on Mac) in the search field previously cleared the **entire** query. That's not how OS line inputs generally work: it's supposed to be that...

- <kbd>Ctrl/Cmd</kbd>+<kbd>Backspace</kbd> deletes everything **before** the cursor (the text on that side plus any tokens beyond it), keeping everything after.
- <kbd>Ctrl/Cmd</kbd>+<kbd>Delete</kbd> deletes everything **after** the cursor, keeping everything before.

This PR adds a new `DELETE_TO_CURSOR` reducer action that applies that behavior.

💁 Quick repro link with a few query chips: https://sentry-2vwia8n4m.sentry.dev/explore/logs?logsFields=timestamp&logsFields=message&logsQuery=%21message%3A%EF%80%8DContains%EF%80%8Dapi.access%20%21message%3A%EF%80%8DContains%EF%80%8Dviewer_context.missing%20severity%3Ainfo&logsSortBys=-timestamp

Closes LOGS-923.