### PR TITLE
fix(traces): Preserve logs when trace metadata fails

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.spec.tsx
@@ -304,15 +304,7 @@ describe('useTraceMeta', () => {
     await waitFor(() => expect(result.current.status === 'pending').toBe(false));
 
     expect(result.current).toEqual({
-      data: {
-        errors: 0,
-        performance_issues: 0,
-        projects: 0,
-        transactions: 0,
-        transaction_child_count_map: {},
-        span_count: 0,
-        span_count_map: {},
-      },
+      data: undefined,
       errors: [expect.any(Error), expect.any(Error), expect.any(Error)],
       isLoading: false,
       status: 'error',
@@ -321,6 +313,33 @@ describe('useTraceMeta', () => {
     expect(mockRequest1).toHaveBeenCalled();
     expect(mockRequest2).toHaveBeenCalled();
     expect(mockRequest3).toHaveBeenCalled();
+  });
+
+  it('EAP - does not return zero-filled metadata when the request fails', async () => {
+    const org = OrganizationFixture({features: ['trace-spans-format']});
+    const trace = {traceSlug: 'slug1', timestamp: 1};
+
+    jest.mocked(useSyncedLocalStorageState).mockReturnValue(['eap', jest.fn()]);
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/trace-meta/slug1/',
+      statusCode: 408,
+    });
+
+    const {result} = renderHookWithProviders(useTraceMeta, {
+      organization: org,
+      initialProps: trace,
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+
+    expect(result.current).toEqual({
+      data: undefined,
+      errors: [expect.any(Error)],
+      isLoading: false,
+      status: 'error',
+    });
   });
 
   it('Retries with 90d when initial 14d response has no data', async () => {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -411,10 +411,12 @@ export function useTraceMeta(options: UseTraceMetaOptions): TraceMetaQueryResult
     };
   }
 
+  const allRequestsFailed = data?.apiErrors.length === traces.length;
+
   return {
-    data: data?.meta,
+    data: allRequestsFailed ? undefined : data?.meta,
     errors: data?.apiErrors ?? [],
-    status: data?.apiErrors?.length === traces.length ? 'error' : status,
+    status: allRequestsFailed ? 'error' : status,
     isLoading,
   };
 }

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
@@ -77,6 +77,20 @@ describe('useTraceContextSections', () => {
     expect(result.current.hasAiSpans).toBe(true);
   });
 
+  it('uses loaded logs when trace metadata is unavailable', () => {
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree(),
+        logs: [{}] as unknown as OurLogsResponseItem[],
+        metrics: undefined,
+        meta: undefined,
+      })
+    );
+
+    expect(result.current.hasLogs).toBe(true);
+    expect(result.current.hasTraceEvents).toBe(false);
+  });
+
   it('falls back to tree data for AI spans when EAP trace meta has no gen_ai span op count', () => {
     const {result} = renderHook(() =>
       useTraceContextSections({


### PR DESCRIPTION
Trace details now treats a complete trace metadata request failure as unavailable metadata instead of exposing the zero-initialized accumulator. Logs that loaded independently therefore remain recognized, so the Logs tab no longer disappears in favor of an empty Waterfall after a metadata timeout.

Successful zero counts remain authoritative, and partial multi-trace metadata results continue to aggregate normally. Regression coverage includes legacy and EAP request failures plus the loaded-logs fallback.

Fixes EXP-1107
