### PR TITLE
feat(seer): route root-cause autofix through the RCA feature

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -228,6 +228,92 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
     return step_to_action_type[step][is_completed]
 
 
+def _handle_step_started_events(
+    group: Group,
+    step: AutofixStep,
+    run_id: int,
+    sentry_run_uuid: str,
+    referrer: AutofixReferrer,
+    activity_datetime: str,
+    iteration_index: int | None = None,
+    actor_user_id: int | None = None,
+) -> None:
+    config = STEP_CONFIGS[step]
+    if config.started_event is not None:
+        analytics.record(
+            config.started_event(
+                organization_id=group.organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                referrer=referrer.value,
+                run_id=run_id,
+                iteration_index=iteration_index,
+            )
+        )
+
+    payload: dict[str, Any] = {
+        "run_id": run_id,
+        "sentry_run_id": sentry_run_uuid,
+        "group_id": group.id,
+    }
+    if iteration_index is not None:
+        payload["iteration_index"] = iteration_index
+
+    webhook_action_type = get_step_webhook_action_type(step, is_completed=False)
+    event_name = webhook_action_type.value
+
+    event_type = f"seer.{event_name}"
+    try:
+        sentry_app_event_type = SentryAppEventType(event_type)
+        if SeerAutofixOperator.has_access(organization=group.organization):
+            task_kwargs: dict[str, Any] = {
+                "event_type": sentry_app_event_type,
+                "event_payload": payload,
+                "organization_id": group.organization.id,
+                "activity_datetime": activity_datetime,
+            }
+            if step == AutofixStep.PR_ITERATION:
+                activity_attribution: SeerActivityAttribution = {"referrer": referrer}
+                if actor_user_id is not None:
+                    activity_attribution["actor_user_id"] = actor_user_id
+                task_kwargs["activity_attribution"] = activity_attribution
+            process_autofix_updates.apply_async(kwargs=task_kwargs)
+    except ValueError:
+        logger.exception(
+            "autofix.trigger.webhook_invalid_event_type",
+            extra={"event_type": event_type},
+        )
+
+    try:
+        broadcast_webhooks_for_organization.delay(
+            resource_name="seer",
+            event_name=event_name,
+            organization_id=group.organization.id,
+            payload=payload,
+        )
+    except Exception:
+        logger.exception(
+            "autofix.trigger.webhook_failed",
+            extra={
+                "organization_id": group.organization.id,
+                "webhook_event": event_name,
+                "step": step.value,
+                "run_id": run_id,
+                "group_id": group.id,
+                "iteration_index": iteration_index,
+            },
+        )
+
+    metrics.incr(
+        "autofix.explorer.trigger",
+        tags={
+            "step": step.value,
+            "referrer": referrer.value,
+            "iteration_index": iteration_index,
+        },
+    )
+
+
 @dataclass(frozen=True)
 class Iteration:
     index: int
@@ -455,12 +541,13 @@ def trigger_autofix_agent(
             },
         )
 
-        handle_step_started_events(
+        _handle_step_started_events(
             group,
             AutofixStep.ROOT_CAUSE,
             feature_run_id,
             str(feature_run.uuid),
             referrer,
+            activity_datetime=timezone.now().isoformat(),
         )
         return feature_run
 
@@ -554,83 +641,15 @@ def trigger_autofix_agent(
 
     activity_datetime = timezone.now().isoformat()
 
-    # Emit the started event after run_id is resolved so it can be joined to
-    # downstream completed/PR events.
-    if config.started_event is not None:
-        analytics.record(
-            config.started_event(
-                organization_id=group.organization.id,
-                project_id=group.project_id,
-                group_id=group.id,
-                referrer=referrer.value,
-                run_id=run_id,
-                iteration_index=iteration_index,
-            )
-        )
-
-    payload: dict[str, Any] = {
-        "run_id": run_id,
-        "sentry_run_id": str(run.uuid),
-        "group_id": group.id,
-    }
-    if iteration_index is not None:
-        payload["iteration_index"] = iteration_index
-
-    webhook_action_type = get_step_webhook_action_type(step, is_completed=False)
-    event_name = webhook_action_type.value
-
-    event_type = f"seer.{event_name}"
-    try:
-        sentry_app_event_type = SentryAppEventType(event_type)
-        if SeerAutofixOperator.has_access(organization=group.organization):
-            task_kwargs: dict[str, Any] = {
-                "event_type": sentry_app_event_type,
-                "event_payload": payload,
-                "organization_id": group.organization.id,
-                "activity_datetime": activity_datetime,
-            }
-            if is_iteration_step:
-                activity_attribution: SeerActivityAttribution = {
-                    "referrer": referrer,
-                }
-                if actor_user_id is not None:
-                    activity_attribution["actor_user_id"] = actor_user_id
-                task_kwargs["activity_attribution"] = activity_attribution
-            process_autofix_updates.apply_async(kwargs=task_kwargs)
-    except ValueError:
-        logger.exception(
-            "autofix.trigger.webhook_invalid_event_type",
-            extra={"event_type": event_type},
-        )
-
-    # Send "started" webhook after we have the run_id
-    try:
-        broadcast_webhooks_for_organization.delay(
-            resource_name="seer",
-            event_name=event_name,
-            organization_id=group.organization.id,
-            payload=payload,
-        )
-    except Exception:
-        logger.exception(
-            "autofix.trigger.webhook_failed",
-            extra={
-                "organization_id": group.organization.id,
-                "webhook_event": event_name,
-                "step": step.value,
-                "run_id": run_id,
-                "group_id": group.id,
-                "iteration_index": iteration_index,
-            },
-        )
-
-    metrics.incr(
-        "autofix.explorer.trigger",
-        tags={
-            "step": step.value,
-            "referrer": referrer.value,
-            "iteration_index": iteration_index,
-        },
+    _handle_step_started_events(
+        group,
+        step,
+        run_id,
+        str(run.uuid),
+        referrer,
+        activity_datetime,
+        iteration_index,
+        actor_user_id,
     )
 
     return run

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -55,7 +55,7 @@ from sentry.seer.entrypoints.operator import (
     SeerAutofixOperator,
     process_autofix_updates,
 )
-from sentry.seer.models import SeerRepoDefinition
+from sentry.seer.models import SeerApiError, SeerRepoDefinition
 from sentry.seer.models.run import SeerRun
 from sentry.seer.models.seer_api_models import UNKNOWN_RUN_ID_FOR_GROUP, SeerPermissionError
 from sentry.sentry_apps.event_types import SentryAppEventType
@@ -426,6 +426,43 @@ def trigger_autofix_agent(
         )
         if not has_budget:
             raise NoSeerQuotaException()
+
+    use_seer_rca_feature = features.has(
+        "organizations:autofix-rca-in-seer", group.organization, actor=user
+    )
+    if step == AutofixStep.ROOT_CAUSE and run_id is None and use_seer_rca_feature:
+        # Local import avoids a circular import (dispatch imports this module).
+        from sentry.seer.autofix_rca.dispatch import trigger_autofix_rca_feature
+
+        feature_run = trigger_autofix_rca_feature(
+            group,
+            referrer=referrer,
+            user_context=user_context,
+            stopping_point=stopping_point,
+        )
+        feature_run_id = feature_run.seer_run_state_id
+        if feature_run_id is None:
+            # flush=True populates this on success; guard defensively.
+            raise SeerApiError("autofix_rca feature run has no run id", 500)
+
+        logger.info(
+            "autofix.trigger.routed_to_rca_feature",
+            extra={
+                "group_id": group.id,
+                "organization_id": group.organization.id,
+                "run_id": feature_run_id,
+                "referrer": referrer.value,
+            },
+        )
+
+        handle_step_started_events(
+            group,
+            AutofixStep.ROOT_CAUSE,
+            feature_run_id,
+            str(feature_run.uuid),
+            referrer,
+        )
+        return feature_run
 
     config = STEP_CONFIGS[step]
 

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -28,6 +28,7 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_push_changes,
 )
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
@@ -497,6 +498,136 @@ class TestTriggerAutofixAgent(TestCase):
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["project"] == self.group.project
         assert call_kwargs["group"] == self.group
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_root_cause_routes_to_rca_feature_when_flagged(
+        self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        """With the flag on, a new root-cause run dispatches the autofix_rca feature
+        instead of a legacy explorer run, still emits the started webhook, and
+        returns the feature run."""
+        feature_run = self.create_seer_run(
+            organization=self.group.organization, type="feature_run", seer_run_state_id=777
+        )
+        mock_feature.return_value = feature_run
+
+        with self.feature("organizations:autofix-rca-in-seer"):
+            result = trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
+
+        assert result == feature_run
+        mock_feature.assert_called_once()
+        assert mock_feature.call_args.args[0] == self.group
+        # legacy explorer run is not started for a flagged root-cause kickoff
+        mock_client_class.return_value.start_run.assert_not_called()
+        # the started webhook still fires, pointing at the feature run
+        mock_broadcast.assert_called_once()
+        payload = mock_broadcast.call_args.kwargs["payload"]
+        assert (
+            mock_broadcast.call_args.kwargs["event_name"] == SeerActionType.ROOT_CAUSE_STARTED.value
+        )
+        assert payload["run_id"] == 777
+        assert payload["sentry_run_id"] == str(feature_run.uuid)
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_rca_feature_receives_stopping_point(
+        self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        """The stopping point must reach the feature: delivery reads it back off the
+        run to decide whether to continue the pipeline past root cause."""
+        mock_feature.return_value = self.create_seer_run(
+            organization=self.group.organization, type="feature_run", seer_run_state_id=777
+        )
+
+        with self.feature("organizations:autofix-rca-in-seer"):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+                stopping_point=AutofixStoppingPoint.CODE_CHANGES,
+            )
+
+        assert mock_feature.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_solution_step_does_not_route_to_rca_feature(
+        self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
+    ):
+        """Only the root-cause step routes; solution kickoffs stay on the legacy flow."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = self.create_seer_run(
+            organization=self.group.organization, seer_run_state_id=5
+        )
+
+        with self.feature("organizations:autofix-rca-in-seer"):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.SOLUTION,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
+
+        mock_feature.assert_not_called()
+        mock_client.start_run.assert_called_once()
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_root_cause_uses_legacy_flow_without_flag(
+        self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
+    ):
+        """Without the flag, root-cause kickoffs use the legacy explorer run."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        seer_run = self.create_seer_run(organization=self.group.organization, seer_run_state_id=9)
+        mock_client.start_run.return_value = seer_run
+
+        result = trigger_autofix_agent(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
+
+        assert result == seer_run
+        mock_feature.assert_not_called()
+        mock_client.start_run.assert_called_once()
+
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
+    @patch("sentry.seer.autofix_rca.dispatch.trigger_autofix_rca_feature")
+    @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
+    def test_flagged_root_cause_still_enforces_quota(
+        self, mock_client_class, mock_feature, mock_check_quota
+    ):
+        """The upstream quota check runs before routing to the feature."""
+        with self.feature("organizations:autofix-rca-in-seer"):
+            with pytest.raises(NoSeerQuotaException):
+                trigger_autofix_agent(
+                    group=self.group,
+                    step=AutofixStep.ROOT_CAUSE,
+                    referrer=AutofixReferrer.UNKNOWN,
+                    run_id=None,
+                )
+
+        mock_feature.assert_not_called()
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)


### PR DESCRIPTION
Wires up the new seer-driven RCA flow. Leverages the `autofix-rca-in-seer` feature flagg added in #120104 to branch and use the new feature when enabled.