### PR TITLE
feat(seer): Back get_metric_metadata with the metrics endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -27,7 +27,7 @@ from sentry.search.eap.constants import (
     METRIC_UNIT_ALIAS,
 )
 from sentry.search.eap.types import SearchResolverConfig
-from sentry.snuba.referrer import Referrer
+from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.trace_metrics import TraceMetrics
 
 _COUNT_ALIAS = f"count({METRIC_NAME_ALIAS})"
@@ -73,6 +73,10 @@ class OrganizationTraceItemMetricsSerializer(serializers.Serializer[Never]):
     # A response field to sort by, optionally prefixed with `-` for descending
     # (e.g. `-count`). Defaults to metric name.
     sort = serializers.CharField(required=False)
+    # Overrides the referrer attached to the underlying query so callers (e.g.
+    # Seer tools) remain distinguishable in query analytics. Falls back to the
+    # endpoint default when absent or not a recognized referrer.
+    referrer = serializers.CharField(required=False)
 
     def validate_sort(self, value: str) -> str:
         field = value[1:] if value.startswith("-") else value
@@ -111,6 +115,12 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
         snuba_params.start = adjusted_start
         snuba_params.end = adjusted_end
 
+        # Allowlist the caller-supplied referrer; fall back to the endpoint
+        # default when absent or unrecognized so query analytics stay clean.
+        referrer = serialized.get("referrer")
+        if not referrer or not is_valid_referrer(referrer):
+            referrer = Referrer.API_EXPLORE_TRACEMETRICS_METRICS_LIST.value
+
         query_string = serialized.get("query", "")
         # Authored context is joined from TraceItemAttributeValueContext, gated
         # behind the feature; conventions don't apply to custom metrics.
@@ -144,7 +154,7 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
                     orderby=orderby,
                     offset=offset,
                     limit=limit,
-                    referrer=Referrer.API_EXPLORE_TRACEMETRICS_METRICS_LIST.value,
+                    referrer=referrer,
                     config=SearchResolverConfig(),
                     sampling_mode=snuba_params.sampling_mode,
                 )

--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -33,6 +33,20 @@ from sentry.snuba.trace_metrics import TraceMetrics
 _COUNT_ALIAS = f"count({METRIC_NAME_ALIAS})"
 _LAST_SEEN_ALIAS = "max(timestamp_precise)"
 
+# Sortable response fields mapped to their underlying query aliases. Keeps the
+# public `sort` param decoupled from the internal aggregate expressions.
+_SORT_FIELDS = {
+    "name": METRIC_NAME_ALIAS,
+    "type": METRIC_TYPE_ALIAS,
+    "unit": METRIC_UNIT_ALIAS,
+    "count": _COUNT_ALIAS,
+    "lastSeen": _LAST_SEEN_ALIAS,
+}
+
+# The full grouping key — appended after any sort so pagination always has a
+# stable total order (a single field like count isn't unique across rows).
+_GROUPING_ORDER = [METRIC_NAME_ALIAS, METRIC_TYPE_ALIAS, METRIC_UNIT_ALIAS]
+
 # Metrics count is small; a generous cap avoids paginating in practice.
 MAX_METRICS_PER_PAGE = 1000
 
@@ -56,6 +70,17 @@ class TraceMetricItem(TypedDict):
 class OrganizationTraceItemMetricsSerializer(serializers.Serializer[Never]):
     query = serializers.CharField(required=False)
     expand = serializers.MultipleChoiceField(choices=["context"], required=False)
+    # A response field to sort by, optionally prefixed with `-` for descending
+    # (e.g. `-count`). Defaults to metric name.
+    sort = serializers.CharField(required=False)
+
+    def validate_sort(self, value: str) -> str:
+        field = value[1:] if value.startswith("-") else value
+        if field not in _SORT_FIELDS:
+            raise serializers.ValidationError(
+                f"Invalid sort field `{field}`. Must be one of: {', '.join(_SORT_FIELDS)}."
+            )
+        return value
 
 
 @cell_silo_endpoint
@@ -93,6 +118,17 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
             "organizations:data-browsing-attribute-context", organization, actor=request.user
         )
 
+        # Resolve the requested sort to a query orderby, always appending the
+        # grouping key so pagination has a stable total order.
+        sort = serialized.get("sort")
+        if sort:
+            descending = sort.startswith("-")
+            sort_alias = _SORT_FIELDS[sort.lstrip("-")]
+            sort_column = ("-" if descending else "") + sort_alias
+            orderby = [sort_column] + [column for column in _GROUPING_ORDER if column != sort_alias]
+        else:
+            orderby = list(_GROUPING_ORDER)
+
         def data_fn(offset: int, limit: int) -> list[TraceMetricItem]:
             with handle_query_errors():
                 results = TraceMetrics.run_table_query(
@@ -105,9 +141,7 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
                         _COUNT_ALIAS,
                         _LAST_SEEN_ALIAS,
                     ],
-                    # Order by the full grouping key so pagination has a stable
-                    # total order (a name alone isn't unique across type/unit).
-                    orderby=[METRIC_NAME_ALIAS, METRIC_TYPE_ALIAS, METRIC_UNIT_ALIAS],
+                    orderby=orderby,
                     offset=offset,
                     limit=limit,
                     referrer=Referrer.API_EXPLORE_TRACEMETRICS_METRICS_LIST.value,

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -110,6 +110,11 @@ def get_metric_metadata(
             params=params,
         )
     except ApiError as e:
+        # A 404 means the org lacks the (feature-gated) trace-items metrics
+        # endpoint — there are no metrics to describe, so return an empty result
+        # rather than a failure (the events-backed version degraded gracefully here).
+        if getattr(e, "status_code", None) == 404:
+            return MetricMetadataSuccessResponse(candidates=[], has_more=False)
         # Surface status + body prefix in log extras so prod flakes are debuggable
         # without a new deploy. Keep the return `error` code stable for callers.
         logger.exception(

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -10,6 +10,7 @@ from sentry.seer.sentry_data_models import (
     MetricMetadataRow,
     MetricMetadataSuccessResponse,
 )
+from sentry.snuba.referrer import Referrer
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,7 @@ def get_metric_metadata(
         "per_page": per_page,
         "statsPeriod": stats_period,
         "project": project_ids or [ALL_ACCESS_PROJECT_ID],
+        "referrer": Referrer.SEER_EXPLORER_TOOLS,
     }
 
     try:

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -10,7 +10,6 @@ from sentry.seer.sentry_data_models import (
     MetricMetadataRow,
     MetricMetadataSuccessResponse,
 )
-from sentry.snuba.referrer import Referrer
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +69,7 @@ def get_metric_metadata(
             "candidates": [{"name", "type", "unit", "count"}, ...],
             "has_more": bool,
             "error": str,  # present only on handler-side failure (e.g.
-                           # "organization_not_found", "events_query_failed").
+                           # "organization_not_found", "metrics_query_failed").
                            # Callers should treat a non-empty error as a tool
                            # failure rather than an empty result set.
         }
@@ -95,32 +94,26 @@ def get_metric_metadata(
     per_page = max(1, limit) + 1
 
     params: dict[str, Any] = {
-        "dataset": "tracemetrics",
-        # Selecting metric.name/type/unit plus count(value) groups by the selected
-        # non-aggregate fields, giving us distinct tuples with event counts.
-        # tracemetrics requires count() to take an attribute argument — zero-arg
-        # count() parse-fails at the events layer.
-        "field": ["metric.name", "metric.type", "metric.unit", "count(value)"],
         "query": query,
-        "sort": "-count(value)",
+        # Highest-count metrics first.
+        "sort": "-count",
         "per_page": per_page,
         "statsPeriod": stats_period,
         "project": project_ids or [ALL_ACCESS_PROJECT_ID],
-        "referrer": Referrer.SEER_EXPLORER_TOOLS,
     }
 
     try:
         resp = ApiClient().get(
             auth=ApiKey(organization_id=organization.id, scope_list=API_KEY_SCOPES),
             user=None,
-            path=f"/organizations/{organization.slug}/events/",
+            path=f"/organizations/{organization.slug}/trace-items/metrics/",
             params=params,
         )
     except ApiError as e:
         # Surface status + body prefix in log extras so prod flakes are debuggable
         # without a new deploy. Keep the return `error` code stable for callers.
         logger.exception(
-            "get_metric_metadata: events query failed",
+            "get_metric_metadata: metrics query failed",
             extra={
                 "org_id": org_id,
                 "project_ids": project_ids,
@@ -129,10 +122,12 @@ def get_metric_metadata(
             },
         )
         return MetricMetadataErrorResponse(
-            candidates=[], has_more=False, error="events_query_failed"
+            candidates=[], has_more=False, error="metrics_query_failed"
         )
 
-    raw_rows = (resp.data or {}).get("data") or []
+    # The metrics endpoint returns a bare list of {name, type, unit, count, ...},
+    # already ordered by count descending via the sort param above.
+    raw_rows = resp.data or []
 
     # We over-fetch by 1 (per_page = limit + 1) specifically to detect whether
     # Sentry has more matches than the caller asked for. That signal must be
@@ -143,22 +138,16 @@ def get_metric_metadata(
 
     candidates: list[MetricMetadataRow] = []
     for row in raw_rows:
-        name = row.get("metric.name")
-        mtype = row.get("metric.type")
-        munit = row.get("metric.unit") or "none"
+        name = row.get("name")
+        mtype = row.get("type")
         if not name or not mtype:
             continue
-        # count(value) may come back under the full function key or the bare name
-        # depending on the dataset shape.
-        count = row.get("count(value)")
-        if count is None:
-            count = row.get("count", 0)
         candidates.append(
             MetricMetadataRow(
                 name=str(name),
                 type=str(mtype),
-                unit=str(munit),
-                count=int(count or 0),
+                unit=str(row.get("unit") or "none"),
+                count=int(row.get("count") or 0),
             )
         )
 

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -180,6 +180,20 @@ class TestGetMetricMetadata(TestCase):
         assert result.candidates[0].unit == "none"
 
     @patch("sentry.seer.assisted_query.metrics_tools.ApiClient")
+    def test_feature_gated_404_returns_empty(self, mock_client_cls: MagicMock) -> None:
+        # Org lacks the feature-gated metrics endpoint → empty result, not a failure.
+        mock_client = mock_client_cls.return_value
+        mock_client.get.side_effect = ApiError(404, None)
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["foo"],
+        )
+
+        assert result.dict() == {"candidates": [], "has_more": False}
+
+    @patch("sentry.seer.assisted_query.metrics_tools.ApiClient")
     def test_organization_not_found_returns_error(self, mock_client_cls: MagicMock) -> None:
         mock_client = mock_client_cls.return_value
         """Missing organization must surface as an explicit error code, not a silent

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -41,22 +41,20 @@ class TestGetMetricMetadata(TestCase):
     def test_returns_distinct_tuples_with_count(self, mock_client_cls: MagicMock) -> None:
         mock_client = mock_client_cls.return_value
         response = MagicMock()
-        response.data = {
-            "data": [
-                {
-                    "metric.name": "http.request.duration",
-                    "metric.type": "distribution",
-                    "metric.unit": "millisecond",
-                    "count(value)": 1200,
-                },
-                {
-                    "metric.name": "api.request.count",
-                    "metric.type": "counter",
-                    "metric.unit": "none",
-                    "count(value)": 800,
-                },
-            ]
-        }
+        response.data = [
+            {
+                "name": "http.request.duration",
+                "type": "distribution",
+                "unit": "millisecond",
+                "count": 1200,
+            },
+            {
+                "name": "api.request.count",
+                "type": "counter",
+                "unit": "none",
+                "count": 800,
+            },
+        ]
         mock_client.get.return_value = response
 
         result = get_metric_metadata(
@@ -75,20 +73,17 @@ class TestGetMetricMetadata(TestCase):
         assert dist.unit == "millisecond"
         assert dist.count == 1200
 
-        # Assert query params carry the expected shape.
+        # Assert we hit the metrics endpoint with the expected params.
         _args, kwargs = mock_client.get.call_args
+        assert kwargs["path"] == f"/organizations/{self.org.slug}/trace-items/metrics/"
         params = kwargs["params"]
-        assert params["dataset"] == "tracemetrics"
-        assert params["field"] == [
-            "metric.name",
-            "metric.type",
-            "metric.unit",
-            "count(value)",
-        ]
-        assert params["sort"] == "-count(value)"
+        assert params["sort"] == "-count"
         assert params["query"] == '(metric.name:"*http*" OR metric.name:"*api*")'
         # over-fetch by 1 to detect has_more
         assert params["per_page"] == 11
+        # No events-layer params leak through.
+        assert "dataset" not in params
+        assert "field" not in params
 
     @patch("sentry.seer.assisted_query.metrics_tools.ApiClient")
     def test_empty_substrings_short_circuits(self, mock_client_cls: MagicMock) -> None:
@@ -106,17 +101,10 @@ class TestGetMetricMetadata(TestCase):
         mock_client = mock_client_cls.return_value
         # Asking for limit=2 means we over-fetch 3. If we actually see 3, has_more=True.
         response = MagicMock()
-        response.data = {
-            "data": [
-                {
-                    "metric.name": f"m.{i}",
-                    "metric.type": "counter",
-                    "metric.unit": "none",
-                    "count(value)": 100 - i,
-                }
-                for i in range(3)
-            ]
-        }
+        response.data = [
+            {"name": f"m.{i}", "type": "counter", "unit": "none", "count": 100 - i}
+            for i in range(3)
+        ]
         mock_client.get.return_value = response
 
         result = get_metric_metadata(
@@ -139,26 +127,13 @@ class TestGetMetricMetadata(TestCase):
         malformed row shouldn't hide that signal from the caller."""
         # limit=2, per_page=3. Return 3 rows where one is malformed.
         # Post-filter: 2 candidates (== limit). Pre-filter: 3 rows (> limit).
-        # has_more must be True because Sentry had 3 matches, caller asked for 2.
         response = MagicMock()
-        response.data = {
-            "data": [
-                {
-                    "metric.name": "a",
-                    "metric.type": "counter",
-                    "metric.unit": "none",
-                    "count(value)": 30,
-                },
-                # Malformed — will be filtered out locally.
-                {"metric.name": None, "metric.type": "counter", "metric.unit": "none"},
-                {
-                    "metric.name": "b",
-                    "metric.type": "counter",
-                    "metric.unit": "none",
-                    "count(value)": 20,
-                },
-            ]
-        }
+        response.data = [
+            {"name": "a", "type": "counter", "unit": "none", "count": 30},
+            # Malformed — will be filtered out locally.
+            {"name": None, "type": "counter", "unit": "none"},
+            {"name": "b", "type": "counter", "unit": "none", "count": 20},
+        ]
         mock_client.get.return_value = response
 
         result = get_metric_metadata(
@@ -175,18 +150,11 @@ class TestGetMetricMetadata(TestCase):
     def test_skips_rows_missing_name_or_type(self, mock_client_cls: MagicMock) -> None:
         mock_client = mock_client_cls.return_value
         response = MagicMock()
-        response.data = {
-            "data": [
-                {
-                    "metric.name": "good",
-                    "metric.type": "counter",
-                    "metric.unit": "none",
-                    "count(value)": 10,
-                },
-                {"metric.name": "", "metric.type": "counter", "metric.unit": "none"},
-                {"metric.name": "no-type", "metric.type": None, "metric.unit": "none"},
-            ]
-        }
+        response.data = [
+            {"name": "good", "type": "counter", "unit": "none", "count": 10},
+            {"name": "", "type": "counter", "unit": "none"},
+            {"name": "no-type", "type": None, "unit": "none"},
+        ]
         mock_client.get.return_value = response
 
         result = get_metric_metadata(
@@ -201,16 +169,7 @@ class TestGetMetricMetadata(TestCase):
     def test_missing_unit_defaults_to_none(self, mock_client_cls: MagicMock) -> None:
         mock_client = mock_client_cls.return_value
         response = MagicMock()
-        response.data = {
-            "data": [
-                {
-                    "metric.name": "foo",
-                    "metric.type": "counter",
-                    "metric.unit": None,
-                    "count(value)": 5,
-                }
-            ]
-        }
+        response.data = [{"name": "foo", "type": "counter", "unit": None, "count": 5}]
         mock_client.get.return_value = response
 
         result = get_metric_metadata(
@@ -238,12 +197,12 @@ class TestGetMetricMetadata(TestCase):
             "has_more": False,
             "error": "organization_not_found",
         }
-        # No events query should be attempted.
+        # No metrics query should be attempted.
         mock_client.get.assert_not_called()
 
     @patch("sentry.seer.assisted_query.metrics_tools.ApiClient")
-    def test_events_query_failure_returns_error(self, mock_client_cls: MagicMock) -> None:
-        """When the underlying events API raises ApiError, return an explicit
+    def test_metrics_query_failure_returns_error(self, mock_client_cls: MagicMock) -> None:
+        """When the underlying metrics API raises ApiError, return an explicit
         error code rather than a silent empty result."""
         mock_client = mock_client_cls.return_value
         mock_client.get.side_effect = ApiError(500, "snuba exploded")
@@ -257,18 +216,18 @@ class TestGetMetricMetadata(TestCase):
         assert result.dict() == {
             "candidates": [],
             "has_more": False,
-            "error": "events_query_failed",
+            "error": "metrics_query_failed",
         }
         mock_client.get.assert_called_once()
 
 
 class TestGetMetricMetadataIntegration(APITransactionTestCase, SnubaTestCase, TraceMetricsTestCase):
-    """End-to-end test against the real tracemetrics parser.
+    """End-to-end test against the real trace-items metrics endpoint.
 
-    The mock-based tests above never exercised the events-layer query parser,
-    which masked that zero-arg count() parse-fails on tracemetrics. This class
-    persists real TraceItems and lets the handler's in-process client.get call
-    hit the actual parser, so a regression in the aggregate shape surfaces here.
+    The mock-based tests above never exercise the metrics endpoint's query
+    parser. This class persists real TraceItems and lets the handler's
+    in-process client.get call hit the actual endpoint, so a regression in the
+    query/aggregate shape surfaces here.
     """
 
     def setUp(self) -> None:
@@ -300,14 +259,20 @@ class TestGetMetricMetadataIntegration(APITransactionTestCase, SnubaTestCase, Tr
         )
 
     def test_returns_candidates_matching_substring(self) -> None:
-        result = get_metric_metadata(
-            org_id=self.organization.id,
-            project_ids=[self.project.id],
-            name_substrings=["http"],
-            stats_period="1h",
-        )
+        with self.feature(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:tracemetrics-enabled": True,
+            }
+        ):
+            result = get_metric_metadata(
+                org_id=self.organization.id,
+                project_ids=[self.project.id],
+                name_substrings=["http"],
+                stats_period="1h",
+            )
 
-        # A broken aggregate would short-circuit into events_query_failed.
+        # A broken query would short-circuit into metrics_query_failed.
         assert isinstance(result, MetricMetadataSuccessResponse), result
         names = {c.name for c in result.candidates}
         assert "http.request.duration" in names

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -102,6 +102,27 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         assert response.status_code == 200, response.data
         assert [row["name"] for row in response.data] == ["checkout.requests"]
 
+    def test_sort_by_count(self) -> None:
+        self.store_metric("low.count", "counter")
+        for _ in range(3):
+            self.store_metric("high.count", "counter")
+
+        desc = self.do_request(query={"project": self.project.id, "sort": "-count"})
+        assert desc.status_code == 200, desc.data
+        assert [row["name"] for row in desc.data] == ["high.count", "low.count"]
+
+        asc = self.do_request(query={"project": self.project.id, "sort": "count"})
+        assert asc.status_code == 200, asc.data
+        assert [row["name"] for row in asc.data] == ["low.count", "high.count"]
+
+    def test_rejects_invalid_sort(self) -> None:
+        self.store_metric("checkout.requests", "counter")
+
+        response = self.do_request(query={"project": self.project.id, "sort": "bogus"})
+
+        assert response.status_code == 400, response.data
+        assert "sort" in response.data
+
     def test_expand_context(self) -> None:
         self.store_metric("checkout.requests", "counter")
         self.create_context(


### PR DESCRIPTION
Straight refactor of the `get_metric_metadata` RPC to query the new trace-items metrics endpoint (`/organizations/{org}/trace-items/metrics/`) instead of the events endpoint (`/events/?dataset=tracemetrics`). Both run the same query on the same trace-metrics dataset under the hood, so **behavior is unchanged** — substring filtering, count-descending order, and `has_more` all work the same.

## Changes

- **Tool:** swap the endpoint path + params (drop `dataset`/`field`; parse the metrics endpoint's `{name, type, unit, count}` rows); `sort` becomes `-count`. Same short-circuits (no substrings, or all substrings unusable → empty).
- **Endpoint:** add a `sort` param (mapped response field, optional `-` for descending) — needed so the tool can request count-descending order, which the events endpoint provided via `sort=-count(value)`.

Deliberately scoped: **no context features** (no `expand=context`, no `context_only`). Those are follow-ups (#120076 and #120096).

Backend-only. Refs DAIN-1796.