### PR TITLE
fix(formatting): unblock CI for llmFormat response types

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
-from typing import Any, NotRequired
+from typing import Any, TypedDict, cast
 
 from django.contrib.auth.models import AnonymousUser
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -127,9 +127,15 @@ def issue_search_query_to_conditions(
     return snql_conditions, resolved_legacy_conditions
 
 
-class GroupEventDetailsFormattedResponse(GroupEventDetailsResponse):
+class _GroupEventDetailsFormattedResponseOptional(TypedDict, total=False):
     # present only when ``?llmFormat`` is requested and the formatter option is on
-    formatted: NotRequired[FormattedResponse]
+    formatted: FormattedResponse
+
+
+class GroupEventDetailsFormattedResponse(
+    GroupEventDetailsResponse, _GroupEventDetailsFormattedResponseOptional
+):
+    pass
 
 
 @extend_schema(tags=["Events"])
@@ -292,4 +298,4 @@ class GroupEventDetailsEndpoint(FormattableResponseMixin, GroupEndpoint):
         )
         if data is None:
             return Response({"detail": "Failed to load event"}, status=500)
-        return Response(data)
+        return Response(cast(GroupEventDetailsFormattedResponse, data))

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, NotRequired, TypedDict, Union
+from typing import Annotated, Any, Literal, TypedDict, Union
 
 from pydantic import BaseModel, Field
 
@@ -38,9 +38,12 @@ class AutofixHandoffResponse(TypedDict):
     failures: list[dict[str, Any]]
 
 
-class AutofixStateResponse(TypedDict):
+class _AutofixStateResponseOptional(TypedDict, total=False):
+    # present only when ``?llmFormat`` is requested and the formatter option is on
+    formatted: FormattedResponse
+
+
+class AutofixStateResponse(_AutofixStateResponseOptional):
     """Response type for the GET endpoint"""
 
     autofix: dict[str, Any] | None
-    # present only when ``?llmFormat`` is requested and the formatter option is on
-    formatted: NotRequired[FormattedResponse]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the CI failures on #119545 (`backend typing` + `api docs test`).

### Root causes
1. **api docs**: `NotRequired[...]` on TypedDict fields is ignored when the module has `from __future__ import annotations`, so OpenAPI marked `formatted` as required and example validation failed.
2. **mypy**: `wrap_event_response` returns `GroupEventDetailsResponse`, which didn't match the annotated `Response[GroupEventDetailsFormattedResponse]`.

### Fix
- Use `total=False` TypedDict mixins for the optional `formatted` field (same pattern used elsewhere in serializers).
- Cast the event details payload to `GroupEventDetailsFormattedResponse` on return.

### Test plan
- [x] `prek` mypy on changed files
- [x] Confirmed `formatted` is in `__optional_keys__` for both response TypedDicts
- [ ] CI: `backend typing` and `api docs test` pass on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e00c5eb-00d2-477c-b40d-7cada0d3f69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e00c5eb-00d2-477c-b40d-7cada0d3f69e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

