### PR TITLE
chore(seer-infra-telemetry): Set up temporary code to provide Seer with GCP integration internally…

### DIFF
--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -132,6 +132,30 @@ def _get_personal_monitoring_connections(
     return connections
 
 
+# TEMPORARY: hardcoded GCP MCP connections for the Sentry org for internal dogfooding.
+# Remove when the full GcpIntegrationProvider + setup UI is built.
+_SENTRY_ORG_GCP_PROJECT_IDS = ["internal-sentry"]
+
+_GCP_MCP_CONNECTIONS = [
+    ("gcp_logging", "https://logging.googleapis.com/mcp"),
+    ("gcp_monitoring", "https://monitoring.googleapis.com/mcp"),
+    ("gcp_trace", "https://cloudtrace.googleapis.com/mcp"),
+]
+
+
+def _get_gcp_connections_for_sentry_org() -> list[MonitoringProviderConnectionData]:
+    return [
+        MonitoringProviderConnectionData(
+            provider_key=provider_key,
+            url=url,
+            auth_method="gcp_adc",
+            refreshable=False,
+            gcp_project_ids=_SENTRY_ORG_GCP_PROJECT_IDS,
+        )
+        for provider_key, url in _GCP_MCP_CONNECTIONS
+    ]
+
+
 def get_monitoring_provider_connections(
     organization: Organization, user_id: int | None
 ) -> list[MonitoringProviderConnectionData]:
@@ -153,4 +177,11 @@ def get_monitoring_provider_connections(
         if provider_family(connection.provider_key) not in connected_families
     ]
 
-    return personal_connections + org_connections
+    all_connections = personal_connections + org_connections
+
+    # TEMPORARY: hardcoded GCP MCP connections for the Sentry org (id=1) for internal dogfooding.
+    # Remove when the full GcpIntegrationProvider + setup UI is built.
+    if organization.id == 1:
+        all_connections.extend(_get_gcp_connections_for_sentry_org())
+
+    return all_connections

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -867,6 +867,7 @@ class MonitoringProviderConnectionData(BaseModel):
     identity_id: int | None = None
     auth_method: str
     refreshable: bool = True
+    gcp_project_ids: list[str] | None = None
 
     def __getitem__(self, key: str) -> Any:
         return self.dict()[key]


### PR DESCRIPTION
Setting up some temporary code to provide the GCP provider connection to Seer only internally for the Sentry org.

Only for the short-term to allow for dogfooding internally, will be torn down in favor of the proper approach.