### PR TITLE
deps(api-docs): Replace js-yaml with yaml

### DIFF
--- a/api-docs/index.ts
+++ b/api-docs/index.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import yaml from 'js-yaml';
 import JsonRefs from 'json-refs';
+import {parse} from 'yaml';
 
 function dictToString(dict) {
   const res: string[] = [];
@@ -13,16 +13,14 @@ function dictToString(dict) {
 }
 
 function bundle(originalFile) {
-  // @ts-expect-error: Types do not match the version of js-yaml installed
-  const root = yaml.safeLoad(fs.readFileSync(originalFile, 'utf8'));
+  const root = parse(fs.readFileSync(originalFile, 'utf8'));
   const options = {
     filter: ['relative', 'remote', 'local'],
     resolveCirculars: true,
     location: originalFile,
     loaderOptions: {
       processContent: function (res, callback) {
-        // @ts-expect-error: Types do not match the version of js-yaml installed
-        callback(undefined, yaml.safeLoad(res.text));
+        callback(undefined, parse(res.text));
       },
     },
   };

--- a/api-docs/openapi-diff.ts
+++ b/api-docs/openapi-diff.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import https from 'node:https';
 
-import yaml from 'js-yaml';
 import jsonDiff from 'json-diff';
+import {parse} from 'yaml';
 
 async function main() {
   const openApiData = await new Promise((resolve, reject) =>
@@ -24,8 +24,7 @@ async function main() {
   );
 
   const readFile = fs.readFileSync('tests/apidocs/openapi-derefed.json', 'utf8');
-  // @ts-expect-error: Types do not match the version of js-yaml installed
-  const target = yaml.safeLoad(readFile);
+  const target = parse(readFile);
 
   // eslint-disable-next-line no-console
   console.log(jsonDiff.diffString(openApiData, target));

--- a/api-docs/package.json
+++ b/api-docs/package.json
@@ -12,14 +12,13 @@
   "author": "sentry.io",
   "license": "UNLICENSED",
   "dependencies": {
-    "js-yaml": "^3.15.0",
     "json-diff": "^0.7.1",
     "json-refs": "^3.0.15",
     "openapi-examples-validator": "^6.0.2",
-    "sane": "^5.0.1"
+    "sane": "^5.0.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@types/js-yaml": "^4.0.5",
     "@types/json-diff": "^0.7.0"
   },
   "pnpm": {

--- a/api-docs/pnpm-lock.yaml
+++ b/api-docs/pnpm-lock.yaml
@@ -13,9 +13,6 @@ importers:
 
   .:
     dependencies:
-      js-yaml:
-        specifier: ^3.15.0
-        version: 3.15.0
       json-diff:
         specifier: ^0.7.1
         version: 0.7.4
@@ -28,10 +25,10 @@ importers:
       sane:
         specifier: ^5.0.1
         version: 5.0.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
-      '@types/js-yaml':
-        specifier: ^4.0.5
-        version: 4.0.9
       '@types/json-diff':
         specifier: ^0.7.0
         version: 0.7.0
@@ -60,9 +57,6 @@ packages:
     engines: {node: '>= 10.16.0'}
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
-
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-diff@0.7.0':
     resolution: {integrity: sha512-20IJqupGHywtIaE6fS30iygh3dVqVdzmsnrYn/VFuRaQKxLx/RGH5K9hhCfctVxgN7KzJlnD7gYFAOrNwiCgtA==}
@@ -639,9 +633,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
 snapshots:
@@ -667,8 +661,6 @@ snapshots:
   '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
     dependencies:
       jsep: 1.4.0
-
-  '@types/js-yaml@4.0.9': {}
 
   '@types/json-diff@0.7.0': {}
 
@@ -1150,7 +1142,7 @@ snapshots:
       lodash.flatmap: 4.5.0
       lodash.flatten: 4.4.0
       lodash.merge: 4.6.2
-      yaml: 2.7.1
+      yaml: 2.9.0
 
   path-key@3.1.1: {}
 
@@ -1283,4 +1275,4 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  yaml@2.7.1: {}
+  yaml@2.9.0: {}


### PR DESCRIPTION
Replace the unmaintained js-yaml package with yaml in the API docs tooling. We're already using `yaml` in the sentry repo.

https://e18e.dev/docs/replacements/js-yaml