### PR TITLE
fix(autofix): no-op PR iteration when Seer run is missing

### DIFF
--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -53,9 +53,11 @@ from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 
-# Posted when someone ``@sentry``-iterates a PR that isn't backed by an Autofix
-# explorer run with ``repo_pr_states`` — including coding-agent-handoff PRs and
-# unrelated human PRs. We can't reliably tell those apart at comment time.
+# Posted when someone ``@sentry``-iterates a PR that Seer associates with a run
+# that has no Autofix-created ``repo_pr_states`` — mainly coding-agent-handoff
+# PRs. We intentionally do *not* post this when Seer returns no run at all:
+# GitHub webhooks fan out to every region, so a missing run often just means
+# this region is not the one that owns the Autofix session.
 INELIGIBLE_PR_ITERATION_COMMENT = (
     "PR iteration only works on pull requests created by Seer's Autofix agent. "
     "PRs that the Autofix Agent didn't create aren't eligible. This includes PRs "
@@ -426,11 +428,29 @@ def trigger_pr_iteration_from_comment(
         return None
 
     agent_state = get_agent_state_from_pr_id(organization_id, repo.provider, pr_id)
-    if agent_state is None or not agent_state.repo_pr_states:
+    if agent_state is None:
+        # No-op: missing runs are expected on regions that don't own the session
+        # when webhooks are fanned out everywhere. Do not react/comment as
+        # ineligible — that would false-positive against the region that does
+        # own the Autofix run and is iterating successfully.
         metrics.incr("autofix.pr_iteration.comment_trigger.no_run")
         logger.info(
             "autofix.pr_iteration.comment_trigger.no_run",
             extra={"organization_id": organization_id, "pr_id": pr_id},
+        )
+        return None
+
+    if not agent_state.repo_pr_states:
+        # Found a Seer run for this PR, but it wasn't created by Autofix
+        # (coding-agent handoff is the main case). Explain ineligibility.
+        metrics.incr("autofix.pr_iteration.comment_trigger.ineligible_run")
+        logger.info(
+            "autofix.pr_iteration.comment_trigger.ineligible_run",
+            extra={
+                "organization_id": organization_id,
+                "pr_id": pr_id,
+                "run_id": agent_state.run_id,
+            },
         )
         _comment_pr_iteration_ineligible(
             client,

--- a/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_webhook.py
@@ -300,6 +300,8 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue.assert_not_called()
         mock_consume.assert_not_called()
 
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm")
     @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
     @patch(f"{TASK_PATH}.consume_queued_autofix_feedback.apply_async")
     @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback")
@@ -312,8 +314,12 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_enqueue: MagicMock,
         mock_consume: MagicMock,
         mock_has_access: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
     ) -> None:
-        mock_get_integration.return_value = self._mock_integration()
+        # Multi-region fan-out: missing run must no-op without reacting.
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
         mock_get_state.return_value = None
 
         self._call()
@@ -321,6 +327,9 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_has_access.assert_not_called()
         mock_enqueue.assert_not_called()
         mock_consume.assert_not_called()
+        mock_reaction.assert_not_called()
+        mock_make_scm.assert_not_called()
+        mock_integration.get_installation.return_value.get_client.return_value.create_comment.assert_not_called()
 
     @patch(f"{TASK_PATH}._add_comment_reaction")
     @patch(f"{TASK_PATH}.make_scm")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -169,9 +169,55 @@ class TriggerPrIterationFromCommentTest(TestCase):
         mock_make_scm: MagicMock,
         mock_reaction: MagicMock,
     ) -> None:
+        # Missing runs must no-op: webhooks fan out to every region, so the
+        # region that doesn't own the Autofix session must not react/comment
+        # as if the PR were ineligible.
         mock_integration = self._mock_integration()
         mock_get_integration.return_value = mock_integration
         mock_get_state.return_value = None
+
+        self._call()
+
+        mock_has_access.assert_not_called()
+        mock_enqueue.assert_not_called()
+        mock_trigger_consume.assert_not_called()
+        mock_reaction.assert_not_called()
+        mock_make_scm.assert_not_called()
+        mock_integration.get_installation.return_value.get_client.return_value.create_comment.assert_not_called()
+        mock_cache.get.assert_not_called()
+        mock_cache.set.assert_not_called()
+
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}.make_scm")
+    @patch(f"{TASK_PATH}.default_cache")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access")
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{TASK_PATH}.integration_service.get_integration")
+    def test_comments_ineligible_when_run_has_no_repo_pr_states(
+        self,
+        mock_get_integration: MagicMock,
+        mock_get_state: MagicMock,
+        mock_enqueue: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_cache: MagicMock,
+        mock_make_scm: MagicMock,
+        mock_reaction: MagicMock,
+    ) -> None:
+        # Found a Seer run (e.g. coding-agent handoff) but no Autofix PRs —
+        # this is the case where we still explain ineligibility.
+        mock_integration = self._mock_integration()
+        mock_get_integration.return_value = mock_integration
+        mock_get_state.return_value = SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={},
+            metadata={"group_id": self.group.id},
+        )
         mock_cache.get.return_value = None
 
         self._call()
@@ -214,7 +260,14 @@ class TriggerPrIterationFromCommentTest(TestCase):
     ) -> None:
         mock_integration = self._mock_integration()
         mock_get_integration.return_value = mock_integration
-        mock_get_state.return_value = None
+        mock_get_state.return_value = SeerRunState(
+            run_id=67890,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={},
+            metadata={"group_id": self.group.id},
+        )
         mock_cache.get.return_value = True
 
         self._call()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a user `@sentry`-iterates on an Autofix PR, GitHub webhooks fan out to every region. Regions that don't own the Autofix session look up the Seer run, get nothing, and previously posted the "ineligible" reaction/comment — even while the owning region successfully ran iteration.

**Short-term fix:** only post the ineligible reaction/comment when we *find* a Seer run for the PR but it has no Autofix `repo_pr_states` (mainly coding-agent handoff). If Seer returns no run, no-op.

### Before
```
agent_state = get_agent_state_from_pr_id(...)
if agent_state is None or not agent_state.repo_pr_states:
    react/comment ineligible
run_iteration
```

### After
```
agent_state = get_agent_state_from_pr_id(...)
if agent_state is None:
    return  # no-op (expected on non-owning regions)
if not agent_state.repo_pr_states:
    react/comment ineligible  # handoff / non-Autofix PR
run_iteration
```

Longer-term options (not in this PR): store Autofix PR → region routing in control silo so webhooks only hit the owning region, or attach metadata telling other regions to skip the Seer handler.