### PR TITLE
feat(pr-metrics): Forward per-check recovery detail on the judge wire

### DIFF
--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -569,6 +569,20 @@ def _synthesized_check_suite_payload(group: CheckGroup) -> dict[str, Any]:
             name for name, run in runs.items() if is_failing_conclusion(run.get("conclusion"))
         ),
         "first_failure_at": group.get("first_failure_at"),
+        # Every check that has EVER failed in this group, with its current
+        # conclusion and failure count. `failing_check_names` above is the
+        # currently-failing subset; the rest are checks that went red and came back
+        # green at the same SHA — flaky CI, which the collapse would otherwise
+        # destroy (the group reads plain "success"). `completed_at` is deliberately
+        # not forwarded: the judge orders by the group's own timestamp and has no
+        # use for per-run times.
+        "check_runs": {
+            name: {
+                "conclusion": run.get("conclusion") or "",
+                "failed_attempts": run.get("failed_attempts", 0),
+            }
+            for name, run in runs.items()
+        },
     }
 
 

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -984,3 +984,35 @@ def test_timeline_recovered_run_excluded_from_failing_names() -> None:
     suite = timeline_events_from_doc(doc)[0]
     # The run recovered (latest conclusion success), so it isn't a failing name.
     assert suite["payload"]["failing_check_names"] == []
+    # …but the failure it recovered from still reaches the judge via check_runs,
+    # which is the whole point: the group reads plain "success" otherwise, and the
+    # flakiness is unrecoverable downstream.
+    assert suite["payload"]["check_runs"] == {
+        "flaky": {"conclusion": "success", "failed_attempts": 1}
+    }
+
+
+def test_timeline_check_runs_carries_failure_counts_alongside_failing_names() -> None:
+    doc = new_document()
+    # `broken` is a live failure; `flaky` failed twice and came back green.
+    _run(doc, check_name="broken", conclusion="failure", completed_at="2026-07-10T12:00:00Z")
+    _run(doc, check_name="flaky", conclusion="failure", completed_at="2026-07-10T12:01:00Z")
+    _run(doc, check_name="flaky", conclusion="failure", completed_at="2026-07-10T12:02:00Z")
+    _run(doc, check_name="flaky", conclusion="success", completed_at="2026-07-10T12:05:00Z")
+
+    payload = timeline_events_from_doc(doc)[0]["payload"]
+
+    assert payload["failing_check_names"] == ["broken"]
+    assert payload["check_runs"] == {
+        "broken": {"conclusion": "failure", "failed_attempts": 1},
+        "flaky": {"conclusion": "success", "failed_attempts": 2},
+    }
+
+
+def test_timeline_check_runs_is_empty_when_nothing_ever_failed() -> None:
+    # Only ever-failed checks are tracked, so an all-green group forwards no
+    # recovery detail — the common case costs nothing on the wire.
+    doc = new_document()
+    _suite(doc, conclusion="success", updated_at="2026-07-10T12:06:00Z")
+
+    assert timeline_events_from_doc(doc)[0]["payload"]["check_runs"] == {}


### PR DESCRIPTION
> **Merge order:** this must land only after getsentry/seer#7437 deploys. That PR teaches the judge to read the key added here; until it does, the key is simply ignored. Same inert-reader-first pattern used for the CW-1656 stack.

The synthesized `check_suite_completed` payload carries only the *currently*-failing check names, so a check that failed and was re-run green at the same SHA leaves no trace on the wire — the group projects as plain `success`. Group-level flakiness survives via `first_failure_at` (a `success` conclusion with a non-null first failure reads as "was red, recovered"), but the judge can't name the flaky check or see how many attempts it took.

The document already holds exactly this: `runs` keeps every check that has *ever* failed and updates it in place when a re-run goes green, with a `failed_attempts` counter. This forwards that map as a `check_runs` key:

```json
"check_runs": {"flaky":  {"conclusion": "success", "failed_attempts": 2},
               "broken": {"conclusion": "failure", "failed_attempts": 1}}
```

`failing_check_names` is unchanged and remains the currently-failing subset; `check_runs` is the superset that also carries the recovered ones. `completed_at` is deliberately dropped — the judge orders by the group's own timestamp and has no use for per-run times. Empty `{}` when nothing ever failed, which is the common case, so this costs nothing on a green PR.

Additive key on an open payload dict, so the wire contract is unchanged and no `PrActivityEvent` field-set change is needed.

Related: #120123 fixes a bug in the same rollup where a cancelled rerun overwrote a recorded verdict. That one is unblocked and should land first — without it, a check that failed and was then cancelled sits in this `check_runs` map at `conclusion: cancelled`, appearing in neither `failing_check_names` nor the recovered set.

This is the CW-1600 decision on the second of the three candidate gaps. The judge-side rendering and the matching eval-corpus builder change are both in getsentry/seer#7437.

Refs CW-1600
