### PR TITLE
feat(seer): Add agentic triage scoring for night shift candidate selection

### DIFF
--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -335,19 +335,22 @@ def _fetch_and_score_agentic(
     without_data = [g for g in candidates if g.id not in factors]
     scores = _agentic_triage_score([g.id for g in with_data], factors)
     with_data.sort(key=lambda g: scores.get(g.id, 0.0), reverse=True)
-    top = (with_data + without_data)[:max_candidates]
 
-    # Step 4: Re-rank by fixability (descending, nulls last). Drop issues
-    # with fixability below the threshold — same filter as the recommended path.
-    top.sort(
+    # Step 4: Filter by fixability threshold BEFORE truncating, so below-threshold
+    # issues don't consume slots. Then re-rank by fixability and take top N.
+    eligible = [
+        g
+        for g in with_data + without_data
+        if g.seer_fixability_score is None or g.seer_fixability_score >= FIXABILITY_SCORE_THRESHOLD
+    ]
+    eligible.sort(
         key=lambda g: (g.seer_fixability_score is not None, g.seer_fixability_score or 0.0),
         reverse=True,
     )
 
     return [
         ScoredCandidate(group=g, fixability=g.seer_fixability_score, times_seen=g.times_seen)
-        for g in top
-        if g.seer_fixability_score is None or g.seer_fixability_score >= FIXABILITY_SCORE_THRESHOLD
+        for g in eligible[:max_candidates]
     ]
 
 

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -336,11 +336,10 @@ def _fetch_and_score_agentic(
     scores = _agentic_triage_score([g.id for g in with_data], factors)
     with_data.sort(key=lambda g: scores.get(g.id, 0.0), reverse=True)
 
-    # Step 4: Filter by fixability threshold BEFORE truncating, so below-threshold
-    # issues don't consume slots. Then re-rank by fixability and take top N.
+    # Step 4: Take the top 10 issues each from the scored and unscored groups and re-rank by fixability.
     eligible = [
         g
-        for g in with_data + without_data
+        for g in with_data[:10] + without_data[:10]
         if g.seer_fixability_score is None or g.seer_fixability_score >= FIXABILITY_SCORE_THRESHOLD
     ]
     eligible.sort(

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -3,22 +3,33 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import timedelta
 
 import sentry_sdk
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+from snuba_sdk import Request
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.entity import Entity
+from snuba_sdk.function import Function
+from snuba_sdk.query import Limit, Query
 
-from sentry import search
+from sentry import features, options, search
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.issues.search import group_types_from
-from sentry.models.group import GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.models.project import Project
 from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
 from sentry.seer.autofix.utils import is_issue_category_eligible
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
 from sentry.tasks.seer.night_shift.skip_cache import recently_skipped
 from sentry.types.group import PriorityLevel
 from sentry.utils.cursors import Cursor
+from sentry.utils.snuba import raw_snql_query
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
@@ -49,6 +60,10 @@ def fixability_score_strategy(
 ) -> list[ScoredCandidate]:
     """Scores candidates across all projects combined — a busy project can eat
     the whole max_candidates budget. See fixability_score_strategy_per_project."""
+    if features.has(
+        "organizations:agentic-triage-sort", projects[0].organization
+    ):  # Assume all projects are in the same org
+        return _fetch_and_score_agentic(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
     return _fetch_and_score(projects, max_candidates, NIGHT_SHIFT_ISSUE_FETCH_LIMIT)
 
 
@@ -63,8 +78,94 @@ def fixability_score_strategy_per_project(
     )
     selected: list[ScoredCandidate] = []
     for project in projects:
-        selected.extend(_fetch_and_score([project], max_candidates, fetch_limit))
+        if features.has("organizations:agentic-triage-sort", project.organization):
+            selected.extend(_fetch_and_score_agentic([project], max_candidates, fetch_limit))
+        else:
+            selected.extend(_fetch_and_score([project], max_candidates, fetch_limit))
     return selected
+
+
+def _agentic_triage_snuba_factors(
+    group_ids: Sequence[int],
+    project_ids: Sequence[int],
+    organization_id: int,
+) -> dict[int, dict[str, float]]:
+    """Single Snuba query returning 4 raw factor values per group over the lookback window."""
+    lookback = options.get("snuba.search.agentic-triage.lookback-seconds")
+    now = timezone.now()
+    start = now - timedelta(seconds=lookback)
+
+    select: list[Column | Function] = [
+        Column("group_id"),
+        Function("max", [Column("timestamp")], alias="max_timestamp"),
+        Function("max", [Column("level")], alias="max_level"),
+        Function("count", [], alias="event_count"),
+    ]
+    # uniq(user) is expensive — only include if weight is non-zero.
+    if options.get("snuba.search.agentic-triage.user-impact-weight"):
+        select.append(Function("uniq", [Column("tags[sentry:user]")], alias="unique_users"))
+
+    query = Query(
+        match=Entity("events"),
+        select=select,
+        where=[
+            Condition(Column("group_id"), Op.IN, list(group_ids)),
+            Condition(Column("project_id"), Op.IN, list(project_ids)),
+            Condition(Column("timestamp"), Op.GTE, start),
+            Condition(Column("timestamp"), Op.LT, now),
+        ],
+        groupby=[Column("group_id")],
+        limit=Limit(len(group_ids)),
+    )
+    request = Request(
+        dataset=Dataset.Events.value,
+        app_id="night_shift",
+        query=query,
+        tenant_ids={"organization_id": organization_id},
+    )
+    rows = raw_snql_query(
+        request, referrer=Referrer.SEER_NIGHT_SHIFT_FIXABILITY_SCORE_STRATEGY.value
+    )["data"]
+    result: dict[int, dict[str, float]] = {}
+    for row in rows:
+        factors = dict(row)
+        # Convert timestamp string to epoch float for scoring.
+        ts = factors.get("max_timestamp")
+        if isinstance(ts, str):
+            dt = parse_datetime(ts)
+            factors["max_timestamp"] = dt.timestamp() if dt else 0.0
+        result[factors.pop("group_id")] = factors
+    return result
+
+
+AGENTIC_TRIAGE_FACTORS = [
+    ("max_timestamp", "snuba.search.agentic-triage.recency-weight"),
+    ("max_level", "snuba.search.agentic-triage.severity-weight"),
+    ("unique_users", "snuba.search.agentic-triage.user-impact-weight"),
+    ("event_count", "snuba.search.agentic-triage.event-volume-weight"),
+]
+
+
+def _agentic_triage_score(
+    group_ids: Sequence[int],
+    snuba_factors: dict[int, dict[str, float]],
+) -> dict[int, float]:
+    """Min-max normalize Snuba factors and return {group_id: weighted_score}."""
+    active = [(k, options.get(opt)) for k, opt in AGENTIC_TRIAGE_FACTORS if options.get(opt)]
+    if not active or not group_ids:
+        return {gid: 0.0 for gid in group_ids}
+
+    # Build raw arrays in group_ids order.
+    raw = {k: [float(snuba_factors.get(gid, {}).get(k, 0)) for gid in group_ids] for k, _ in active}
+
+    # Min-max normalize each factor.
+    normed: dict[str, list[float]] = {}
+    for k, vals in raw.items():
+        mn, mx = min(vals), max(vals)
+        rng = mx - mn
+        normed[k] = [(v - mn) / rng if rng else 0.0 for v in vals]
+
+    return {gid: sum(w * normed[k][i] for k, w in active) for i, gid in enumerate(group_ids)}
 
 
 def _fetch_and_score(
@@ -138,9 +239,6 @@ def _fetch_and_score(
             elif candidate.fixability >= FIXABILITY_SCORE_THRESHOLD:
                 scored.append(candidate)
 
-        # We're aiming to collect a full page of non-skipped results.
-        # If that happens in a single query that's ideal - if not we
-        # continue till we've looked at NIGHT_SHIFT_MAX_SEARCH_PAGES.
         if kept >= fetch_limit or not result.next:
             break
 
@@ -154,6 +252,71 @@ def _fetch_and_score(
             sentry_sdk.metrics.distribution("night_shift.fixability_score", c.fixability)
 
     return selected
+
+
+def _fetch_and_score_agentic(
+    projects: Sequence[Project],
+    max_candidates: int,
+    fetch_limit: int,
+) -> list[ScoredCandidate]:
+    """Agentic triage path: Postgres for eligible groups, Snuba for scoring factors,
+    min-max normalize, then re-rank by fixability."""
+
+    # Step 1: Get eligible group IDs from Postgres with pagination.
+    # Mirrors the search.backend.query filters: unresolved, un-triaged, eligible types.
+    type_ids = sorted(group_types_from([]) | {LowValueSpanConfigurationType.type_id})
+    base_qs = Group.objects.filter(
+        project__in=projects,
+        status=GroupStatus.UNRESOLVED,
+        seer_explorer_autofix_last_triggered__isnull=True,
+        type__in=type_ids,
+    ).order_by("-last_seen")
+
+    # Page through to collect enough non-skipped candidates, same pattern as the
+    # recommended path. Skip filtering happens in Python so one page may not yield
+    # enough usable candidates.
+    candidates: list[Group] = []
+    offset = 0
+    for _page in range(NIGHT_SHIFT_MAX_SEARCH_PAGES):
+        batch = list(base_qs[offset : offset + fetch_limit])
+        if not batch:
+            break
+
+        skipped_ids = recently_skipped(g.id for g in batch)
+        for group in batch:
+            if group.id in skipped_ids:
+                continue
+            if not is_issue_category_eligible(group):
+                continue
+            candidates.append(group)
+
+        offset += fetch_limit
+        if len(candidates) >= fetch_limit:
+            break
+
+    if not candidates:
+        return []
+
+    # Step 2: One Snuba query for all 4 scoring factors on these groups.
+    group_ids = [g.id for g in candidates]
+    project_ids = [p.id for p in projects]
+    factors = _agentic_triage_snuba_factors(group_ids, project_ids, projects[0].organization_id)
+
+    # Step 3: Min-max normalize and compute weighted scores, take top N.
+    scores = _agentic_triage_score(group_ids, factors)
+    candidates.sort(key=lambda g: scores.get(g.id, 0.0), reverse=True)
+    top = candidates[:max_candidates]
+
+    # Step 4: Re-rank top candidates by fixability (descending, nulls last).
+    top.sort(
+        key=lambda g: (g.seer_fixability_score is not None, g.seer_fixability_score or 0.0),
+        reverse=True,
+    )
+
+    return [
+        ScoredCandidate(group=g, fixability=g.seer_fixability_score, times_seen=g.times_seen)
+        for g in top
+    ]
 
 
 def priority_label(priority: int | None) -> str | None:

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -98,7 +98,27 @@ def _agentic_triage_snuba_factors(
     select: list[Column | Function] = [
         Column("group_id"),
         Function("max", [Column("timestamp")], alias="max_timestamp"),
-        Function("max", [Column("level")], alias="max_level"),
+        # level is a string in Snuba — map to integer so max() is numeric.
+        Function(
+            "max",
+            [
+                Function(
+                    "multiIf",
+                    [
+                        Function("equals", [Column("level"), "fatal"]),
+                        4,
+                        Function("equals", [Column("level"), "error"]),
+                        3,
+                        Function("equals", [Column("level"), "warning"]),
+                        2,
+                        Function("equals", [Column("level"), "info"]),
+                        1,
+                        0,
+                    ],
+                )
+            ],
+            alias="max_level",
+        ),
         Function("count", [], alias="event_count"),
     ]
     # uniq(user) is expensive — only include if weight is non-zero.
@@ -265,12 +285,18 @@ def _fetch_and_score_agentic(
     # Step 1: Get eligible group IDs from Postgres with pagination.
     # Mirrors the search.backend.query filters: unresolved, un-triaged, eligible types.
     type_ids = sorted(group_types_from([]) | {LowValueSpanConfigurationType.type_id})
-    base_qs = Group.objects.filter(
-        project__in=projects,
-        status=GroupStatus.UNRESOLVED,
-        seer_explorer_autofix_last_triggered__isnull=True,
-        type__in=type_ids,
-    ).order_by("-last_seen")
+    # Exclude groups Seer ran on within the last 30 days (matching the
+    # RecentDateCondition used by the recommended path's search filter).
+    seer_recency_cutoff = timezone.now() - timedelta(days=30)
+    base_qs = (
+        Group.objects.filter(
+            project__in=projects,
+            status=GroupStatus.UNRESOLVED,
+            type__in=type_ids,
+        )
+        .exclude(seer_explorer_autofix_last_triggered__gte=seer_recency_cutoff)
+        .order_by("-last_seen")
+    )
 
     # Page through to collect enough non-skipped candidates, same pattern as the
     # recommended path. Skip filtering happens in Python so one page may not yield
@@ -302,12 +328,17 @@ def _fetch_and_score_agentic(
     project_ids = [p.id for p in projects]
     factors = _agentic_triage_snuba_factors(group_ids, project_ids, projects[0].organization_id)
 
-    # Step 3: Min-max normalize and compute weighted scores, take top N.
-    scores = _agentic_triage_score(group_ids, factors)
-    candidates.sort(key=lambda g: scores.get(g.id, 0.0), reverse=True)
-    top = candidates[:max_candidates]
+    # Step 3: Only score groups that got Snuba results. Non-error types
+    # (issue-platform) won't have rows in the events entity — append them
+    # after scored groups so they don't distort min-max normalization.
+    with_data = [g for g in candidates if g.id in factors]
+    without_data = [g for g in candidates if g.id not in factors]
+    scores = _agentic_triage_score([g.id for g in with_data], factors)
+    with_data.sort(key=lambda g: scores.get(g.id, 0.0), reverse=True)
+    top = (with_data + without_data)[:max_candidates]
 
-    # Step 4: Re-rank top candidates by fixability (descending, nulls last).
+    # Step 4: Re-rank by fixability (descending, nulls last). Drop issues
+    # with fixability below the threshold — same filter as the recommended path.
     top.sort(
         key=lambda g: (g.seer_fixability_score is not None, g.seer_fixability_score or 0.0),
         reverse=True,
@@ -316,6 +347,7 @@ def _fetch_and_score_agentic(
     return [
         ScoredCandidate(group=g, fixability=g.seer_fixability_score, times_seen=g.times_seen)
         for g in top
+        if g.seer_fixability_score is None or g.seer_fixability_score >= FIXABILITY_SCORE_THRESHOLD
     ]
 
 

--- a/tests/sentry/tasks/seer/night_shift/test_simple_triage.py
+++ b/tests/sentry/tasks/seer/night_shift/test_simple_triage.py
@@ -1,0 +1,71 @@
+from sentry.tasks.seer.night_shift.simple_triage import _agentic_triage_score
+from sentry.testutils.cases import TestCase
+
+
+class TestAgenticTriageScore(TestCase):
+    """Tests for _agentic_triage_score — min-max normalization and weighted sum."""
+
+    def test_varying_values(self):
+        """Candidates with different factor values get different scores."""
+        factors = {
+            1: {"max_timestamp": 100.0, "max_level": 3, "unique_users": 10, "event_count": 500},
+            2: {"max_timestamp": 200.0, "max_level": 1, "unique_users": 50, "event_count": 5},
+            3: {"max_timestamp": 300.0, "max_level": 4, "unique_users": 1, "event_count": 50},
+        }
+        scores = _agentic_triage_score([1, 2, 3], factors)
+
+        # All scores should be between 0 and 1 (4 factors × 0.25 max each).
+        for gid in [1, 2, 3]:
+            assert 0.0 <= scores[gid] <= 1.0
+
+        # Group 3 has highest recency and severity, should score well.
+        # Group 2 has most users. Group 1 has most events.
+        # No single group dominates all factors, so scores should differ.
+        assert len(set(scores.values())) == 3
+
+    def test_all_identical(self):
+        """When all candidates have the same values, all scores are 0."""
+        factors = {
+            1: {"max_timestamp": 100.0, "max_level": 3, "unique_users": 10, "event_count": 50},
+            2: {"max_timestamp": 100.0, "max_level": 3, "unique_users": 10, "event_count": 50},
+        }
+        scores = _agentic_triage_score([1, 2], factors)
+        assert scores[1] == 0.0
+        assert scores[2] == 0.0
+
+    def test_single_candidate(self):
+        """A single candidate gets score 0 (min == max for all factors)."""
+        factors = {
+            1: {"max_timestamp": 100.0, "max_level": 3, "unique_users": 10, "event_count": 50},
+        }
+        scores = _agentic_triage_score([1], factors)
+        assert scores[1] == 0.0
+
+    def test_missing_group_in_snuba(self):
+        """A group not returned by Snuba gets 0 for all factors."""
+        factors = {
+            1: {"max_timestamp": 200.0, "max_level": 4, "unique_users": 100, "event_count": 500},
+        }
+        scores = _agentic_triage_score([1, 2], factors)
+        # Group 1 has max values, group 2 has 0 — group 1 should score higher.
+        assert scores[1] > scores[2]
+        assert scores[2] == 0.0
+
+    def test_zero_weight_factor_skipped(self):
+        """Factors with weight=0 are excluded from the score."""
+        factors = {
+            1: {"max_timestamp": 100.0, "max_level": 3, "unique_users": 999, "event_count": 50},
+            2: {"max_timestamp": 200.0, "max_level": 3, "unique_users": 1, "event_count": 50},
+        }
+        # Zero out user-impact weight — unique_users difference shouldn't matter.
+        with self.options({"snuba.search.agentic-triage.user-impact-weight": 0}):
+            scores = _agentic_triage_score([1, 2], factors)
+
+        # Only recency differs (severity and volume are identical).
+        # Group 2 has higher recency so it should score higher.
+        assert scores[2] > scores[1]
+
+    def test_empty_inputs(self):
+        """Empty group_ids or factors returns all zeros."""
+        assert _agentic_triage_score([], {}) == {}
+        assert _agentic_triage_score([1, 2], {}) == {1: 0.0, 2: 0.0}


### PR DESCRIPTION
+ Behind the `organizations:agentic-triage-sort` feature flag, night shift uses a direct Snuba query to fetch 4 raw factors (recency, severity, user impact, event volume), applies min-max normalization, and re-ranks by fixability. This replaces the recommended sort which is optimized for human users and unsuitable for the agentic triage usecase.
+ If tried to keep the logic simple and created a new fetch function _fetch_and_score_agentic to cleanly separate it from fetch_and_score

