### PR TITLE
fix(analytics): Unify project platform selection in growth event

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -18,6 +18,7 @@ import {ProjectCreationErrorAlert} from 'sentry/components/onboarding/projectCre
 import {
   type ScmAnalyticsFlow,
   scmFlowVariantParams,
+  trackScmPlatformSelected,
 } from 'sentry/components/onboarding/scm/scmAnalyticsFlow';
 import {
   useCreateProjectAndRulesError,
@@ -49,10 +50,6 @@ export enum SupportedLanguages {
 const SCM_FRAMEWORK_MODAL_RENDERED_EVENT = {
   onboarding: 'onboarding.scm_select_framework_modal_rendered',
   'project-creation': 'project_creation.select_framework_modal_rendered',
-} as const;
-const SCM_PLATFORM_SELECTED_EVENT = {
-  onboarding: 'onboarding.scm_platform_selected',
-  'project-creation': 'project_creation.platform_selected',
 } as const;
 
 const topGoFrameworks: PlatformKey[] = [
@@ -246,12 +243,12 @@ export function FrameworkSuggestionModal({
     }
 
     if (hasScmOnboarding) {
-      trackAnalytics(SCM_PLATFORM_SELECTED_EVENT[analyticsFlow], {
+      trackScmPlatformSelected(
+        analyticsFlow,
         organization,
-        platform: selectedFramework.key,
-        source: 'manual',
-        ...scmFlowVariantParams(analyticsFlow),
-      });
+        selectedFramework.key,
+        'manual'
+      );
     } else {
       trackAnalytics(
         newOrg
@@ -278,12 +275,12 @@ export function FrameworkSuggestionModal({
 
   const handleSkip = useCallback(() => {
     if (hasScmOnboarding) {
-      trackAnalytics(SCM_PLATFORM_SELECTED_EVENT[analyticsFlow], {
+      trackScmPlatformSelected(
+        analyticsFlow,
         organization,
-        platform: selectedPlatform.key,
-        source: 'manual',
-        ...scmFlowVariantParams(analyticsFlow),
-      });
+        selectedPlatform.key,
+        'manual'
+      );
     } else {
       trackAnalytics(
         newOrg

--- a/static/app/components/onboarding/scm/scmAnalyticsFlow.ts
+++ b/static/app/components/onboarding/scm/scmAnalyticsFlow.ts
@@ -1,3 +1,6 @@
+import type {Organization} from 'sentry/types/organization';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import type {PlatformSelectionSource} from 'sentry/utils/analytics/growthAnalyticsEvents';
 import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
 
 /**
@@ -19,4 +22,34 @@ export function scmFlowVariantParams(flow: ScmAnalyticsFlow): {
   variant?: ProjectCreationVariant;
 } {
   return flow === 'project-creation' ? {variant: 'scm'} : {};
+}
+
+/**
+ * Route one SCM platform selection to the flow's canonical event. Onboarding
+ * keeps its existing name and payload; project creation reuses the legacy
+ * `growth.select_platform` counter with separate flow, variant, and selection-source
+ * dimensions.
+ */
+export function trackScmPlatformSelected(
+  flow: ScmAnalyticsFlow,
+  organization: Organization,
+  platformKey: string,
+  selectionSource: PlatformSelectionSource
+) {
+  if (flow === 'onboarding') {
+    trackAnalytics('onboarding.scm_platform_selected', {
+      organization,
+      platform: platformKey,
+      source: selectionSource,
+    });
+    return;
+  }
+
+  trackAnalytics('growth.select_platform', {
+    organization,
+    platform_id: platformKey,
+    selection_source: selectionSource,
+    source: 'project-creation',
+    variant: 'scm',
+  });
 }

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
@@ -109,6 +109,79 @@ describe('ScmPlatformFeaturesCore', () => {
     );
   });
 
+  it('fires only growth.select_platform for the project-creation SCM flow', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {platforms: [DetectedPlatformFixture({platform: 'python'})]},
+    });
+
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedRepository: repository,
+          selectedPlatform: undefined,
+        })}
+      />,
+      {organization}
+    );
+
+    await waitFor(() =>
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'growth.select_platform',
+        expect.objectContaining({
+          platform_id: 'python',
+          selection_source: 'detected',
+          source: 'project-creation',
+          variant: 'scm',
+        })
+      )
+    );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.platform_selected',
+      expect.anything()
+    );
+  });
+
+  it('keeps the onboarding SCM platform-selection event', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const repository = RepositoryFixture({
+      id: '123',
+      provider: {id: 'integrations:github', name: 'GitHub'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/${repository.id}/platforms/`,
+      body: {platforms: [DetectedPlatformFixture({platform: 'python'})]},
+    });
+
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          analyticsFlow: 'onboarding',
+          selectedRepository: repository,
+          selectedPlatform: undefined,
+        })}
+      />,
+      {organization}
+    );
+
+    await waitFor(() =>
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'onboarding.scm_platform_selected',
+        expect.objectContaining({platform: 'python', source: 'detected'})
+      )
+    );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'growth.select_platform',
+      expect.anything()
+    );
+  });
+
   it('clears the selected platform from the manual picker', async () => {
     const onPlatformChange = jest.fn();
     const onFeaturesChange = jest.fn();

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -20,7 +20,11 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
+import {
+  type ScmAnalyticsFlow,
+  scmFlowVariantParams,
+  trackScmPlatformSelected,
+} from './scmAnalyticsFlow';
 import {ScmPlatformCard} from './scmPlatformCard';
 import {
   DEFAULT_SCM_FEATURES,
@@ -33,10 +37,6 @@ import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
 import {useScmResolvedPlatform} from './useScmResolvedPlatform';
 
-const PLATFORM_SELECTED_EVENT = {
-  onboarding: 'onboarding.scm_platform_selected',
-  'project-creation': 'project_creation.platform_selected',
-} as const;
 const CHANGE_PLATFORM_CLICKED_EVENT = {
   onboarding: 'onboarding.scm_platform_change_platform_clicked',
   'project-creation': 'project_creation.platform_change_platform_clicked',
@@ -147,12 +147,12 @@ export function ScmPlatformFeaturesCore({
     }
     autoDetectionTrackedRef.current = true;
     setPlatform(detectedPlatformKey);
-    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
+    trackScmPlatformSelected(
+      analyticsFlow,
       organization,
-      platform: detectedPlatformKey,
-      source: 'detected',
-      ...scmFlowVariantParams(analyticsFlow),
-    });
+      detectedPlatformKey,
+      'detected'
+    );
   }, [
     detectedPlatformKey,
     selectedPlatform?.key,
@@ -245,12 +245,7 @@ export function ScmPlatformFeaturesCore({
     onFeaturesChange(DEFAULT_SCM_FEATURES);
     onClearProjectDetailsForm();
 
-    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
-      organization,
-      platform: platformKey,
-      source: 'manual',
-      ...scmFlowVariantParams(analyticsFlow),
-    });
+    trackScmPlatformSelected(analyticsFlow, organization, platformKey, 'manual');
   };
 
   const handleSelectDetectedPlatform = (platformKey: PlatformKey) => {
@@ -261,12 +256,7 @@ export function ScmPlatformFeaturesCore({
     onFeaturesChange(DEFAULT_SCM_FEATURES);
     onClearProjectDetailsForm();
 
-    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
-      organization,
-      platform: platformKey,
-      source: 'detected',
-      ...scmFlowVariantParams(analyticsFlow),
-    });
+    trackScmPlatformSelected(analyticsFlow, organization, platformKey, 'detected');
   };
 
   function handleChangePlatformClick() {
@@ -309,12 +299,12 @@ export function ScmPlatformFeaturesCore({
     // selection, so record it as the detected source (mirrors the auto-adopt
     // path and handleSelectDetectedPlatform, which were the only detected-source
     // emitters before).
-    trackAnalytics(PLATFORM_SELECTED_EVENT[analyticsFlow], {
+    trackScmPlatformSelected(
+      analyticsFlow,
       organization,
-      platform: detectedPlatformKey,
-      source: 'detected',
-      ...scmFlowVariantParams(analyticsFlow),
-    });
+      detectedPlatformKey,
+      'detected'
+    );
   }
 
   // Shared by both manual-picker variants. A null option is the clear action,

--- a/static/app/components/platformPicker.spec.tsx
+++ b/static/app/components/platformPicker.spec.tsx
@@ -56,6 +56,20 @@ describe('PlatformPicker', () => {
     );
   });
 
+  it('records picker selections as manual', async () => {
+    render(<PlatformPicker {...baseProps} defaultCategory="all" />);
+
+    await userEvent.click(screen.getByTestId('platform-python'));
+
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'growth.select_platform',
+      expect.objectContaining({
+        platform_id: 'python',
+        selection_source: 'manual',
+      })
+    );
+  });
+
   it('should clear the platform when clear is clicked', async () => {
     const props = {
       ...baseProps,

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -67,6 +67,11 @@ interface PlatformPickerProps {
   showOther?: boolean;
   source?: string;
   /**
+   * For project-creation picker events, `source` identifies the flow and `variant`
+   * identifies the SCM or legacy experience.
+   */
+  variant?: 'scm' | 'legacy';
+  /**
    * When `false`, hides the close button and does not display a custom background color.
    */
   visibleSelection?: boolean;
@@ -82,6 +87,7 @@ export function PlatformPicker({
   navClassName,
   organization,
   source,
+  variant,
   visibleSelection = true,
   loading = false,
   showFilterBar = true,
@@ -155,12 +161,20 @@ export function PlatformPicker({
     filter,
     platformList,
     source,
+    variant,
     organization,
     category,
   });
 
   useEffect(() => {
-    latestValuesRef.current = {filter, platformList, source, organization, category};
+    latestValuesRef.current = {
+      filter,
+      platformList,
+      source,
+      variant,
+      organization,
+      category,
+    };
   });
 
   const debounceSearch = useRef(
@@ -169,6 +183,7 @@ export function PlatformPicker({
         filter: currentFilter,
         platformList: currentPlatformList,
         source: currentSource,
+        variant: currentVariant,
         organization: currentOrganization,
         category: currentCategory,
       } = latestValuesRef.current;
@@ -180,6 +195,7 @@ export function PlatformPicker({
         search: currentFilter.toLowerCase(),
         num_results: currentPlatformList.length,
         source: currentSource,
+        variant: currentVariant,
         organization: currentOrganization ?? null,
       });
 
@@ -209,6 +225,7 @@ export function PlatformPicker({
               trackAnalytics('growth.platformpicker_category', {
                 category: val,
                 source,
+                variant,
                 organization: organization ?? null,
               });
               setCategory(val);
@@ -251,7 +268,9 @@ export function PlatformPicker({
                 onClick={() => {
                   trackAnalytics('growth.select_platform', {
                     platform_id: item.id,
+                    selection_source: 'manual',
                     source,
+                    variant,
                     organization: organization ?? null,
                   });
 

--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -1,5 +1,7 @@
 import type {PlatformKey} from 'sentry/types/platform';
 
+export type PlatformSelectionSource = 'detected' | 'manual';
+
 type MobilePromptBannerParams = {
   matchedUserAgentString: string;
 };
@@ -11,17 +13,22 @@ type PlatformParam = {
 type PlatformCategory = {
   category: string;
   source?: string;
+  // For project creation, `source` identifies the flow and `variant` the experience.
+  variant?: 'scm' | 'legacy';
 };
 
 type PlatformPickerParam = {
   platform_id: string;
+  selection_source?: PlatformSelectionSource;
   source?: string;
+  variant?: 'scm' | 'legacy';
 };
 
 type PlatformSearchParam = {
   num_results: number;
   search: string;
   source?: string;
+  variant?: 'scm' | 'legacy';
 };
 
 type SampleEventParam = {

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -66,11 +66,6 @@ export type ProjectCreationEventParameters = {
     platform: string;
     variant?: ProjectCreationVariant;
   };
-  'project_creation.platform_selected': {
-    platform: string;
-    source: 'detected' | 'manual';
-    variant?: ProjectCreationVariant;
-  };
   'project_creation.project_details_alert_selected': {
     option: string;
     variant?: ProjectCreationVariant;
@@ -150,7 +145,6 @@ export const projectCreationEventMap: Record<
     'Project Creation: Platform Change Platform Clicked',
   'project_creation.platform_feature_toggled':
     'Project Creation: Platform Feature Toggled',
-  'project_creation.platform_selected': 'Project Creation: Platform Selected',
   'project_creation.project_details_alert_selected':
     'Project Creation: Project Details Alert Selected',
   'project_creation.project_details_create_clicked':

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -501,6 +501,8 @@ export function CreateProject() {
             defaultCategory={defaultCategory}
             setPlatform={handlePlatformChange}
             organization={organization}
+            source="project-creation"
+            variant="legacy"
             showOther
             noAutoFilter
           />


### PR DESCRIPTION
## TLDR

Uses `growth.select_platform` as the single project-creation platform-selection event for both legacy and SCM, distinguished by `variant` and by `selection_source: 'detected' | 'manual'`.

## Details

Stacked on the core-wizard `variant` PR (#120080). Legacy `CreateProject` already selects through `<PlatformPicker>`, whose live `growth.select_platform` counter is the continuity anchor; keeping a second `project_creation.platform_selected` signal for SCM would permanently emit two events for one selection.

Legacy now passes `source="project-creation"` and `variant="legacy"` into `<PlatformPicker>`. The picker stamps `selection_source:'manual'` on card clicks and continues threading source/variant into its selection, search, and category events.

SCM platform commitments route through `trackScmPlatformSelected`. Its project-creation arm emits only `growth.select_platform` with `source:'project-creation'`, `variant:'scm'`, and the detected/manual selection source supplied by the caller. Its onboarding arm preserves `onboarding.scm_platform_selected` unchanged, so SCM onboarding does not enter the project-creation growth bucket. The obsolete `project_creation.platform_selected` registry entry is removed.

The component coverage verifies that SCM project creation emits only the growth event with detected attribution, SCM onboarding keeps its prior event, and ordinary `<PlatformPicker>` selections report manual attribution. The broader project-install and SCM suites guard the shared call sites and framework modal routing.

BI note: live SCM traffic moves from `project_creation.scm_platform_selected` into `growth.select_platform`; legacy `growth.select_platform.source` moves from undefined to `project-creation`. The existing Amplitude event name remains unchanged to preserve that counter.

Refs VDY-133

