### PR TITLE
fix(detectors): Use correct key for transaction name

### DIFF
--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -71,7 +71,7 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
             "cause_span_ids": [],
             "offender_span_ids": [offender_span_id],
             "op": "http",
-            "transaction_name": self._event.get("description", ""),
+            "transaction_name": self._event.get("transaction", ""),
             "repeating_spans": get_span_evidence_value(span),
             "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
             "num_repeating_spans": 1,

--- a/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
+++ b/src/sentry/issue_detection/detectors/render_blocking_asset_span_detector.py
@@ -69,7 +69,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
                     "parent_span_ids": [],
                     "cause_span_ids": [],
                     "offender_span_ids": [span_id],
-                    "transaction_name": self.event().get("description", ""),
+                    "transaction_name": self.event().get("transaction", ""),
                     "slow_span_description": span.get("description", ""),
                     "slow_span_duration": self._get_duration(span),
                     "transaction_duration": self._get_duration(self._event),

--- a/src/sentry/issue_detection/detectors/slow_db_query_detector.py
+++ b/src/sentry/issue_detection/detectors/slow_db_query_detector.py
@@ -68,7 +68,7 @@ class SlowDBQueryDetector(PerformanceDetector):
                 "cause_span_ids": [],
                 "parent_span_ids": [],
                 "offender_span_ids": spans_involved,
-                "transaction_name": self._event.get("description", ""),
+                "transaction_name": self._event.get("transaction", ""),
                 "repeating_spans": get_span_evidence_value(span)[:MAX_EVIDENCE_VALUE_LENGTH],
                 "repeating_spans_compact": get_span_evidence_value(span, include_op=False)[
                     :MAX_EVIDENCE_VALUE_LENGTH

--- a/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
+++ b/src/sentry/issue_detection/detectors/uncompressed_asset_detector.py
@@ -108,7 +108,7 @@ class UncompressedAssetSpanDetector(PerformanceDetector):
                 "parent_span_ids": [],
                 "cause_span_ids": [],
                 "offender_span_ids": [span_id],
-                "transaction_name": self._event.get("description", ""),
+                "transaction_name": self._event.get("transaction", ""),
                 "repeating_spans": get_span_evidence_value(span),
                 "repeating_spans_compact": get_span_evidence_value(span, include_op=False),
                 "num_repeating_spans": str(len(span_id)),


### PR DESCRIPTION
This fixes a bug in a few of the existing issue detectors which is causing a false positive mismatch in the existing-vs-span-first-detectors experiment. In most of the existing detectors, we correctly look at `event["transaction"]` to get the value for `evidence_data.transaction_name`, but in a few we instead look at `event["description"]`, even though events have never had a top-level `description` field. (The fact that this mistake is replicated across four detectors appears to just be copy-pasta.)