### PR TITLE
feat(analytics): Instrument SCM connect + messaging-install for project creation

### DIFF
--- a/static/app/components/onboarding/scm/scmAlertFrequencySection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmAlertFrequencySection.spec.tsx
@@ -1,7 +1,15 @@
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
 
+import * as integrationUtil from 'sentry/utils/integrationUtil';
+import {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 import {
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
@@ -14,6 +22,8 @@ import {
 import {ScmAlertFrequencySection} from './scmAlertFrequencySection';
 
 type Props = React.ComponentProps<typeof ScmAlertFrequencySection>;
+
+const organization = OrganizationFixture();
 
 const notificationProps: IssueAlertNotificationProps = {
   actions: [MultipleCheckboxOptions.EMAIL],
@@ -39,11 +49,15 @@ function renderSection(overrides: Partial<Props> = {}) {
     ...overrides,
   };
 
-  render(<ScmAlertFrequencySection {...props} />, {organization: OrganizationFixture()});
+  render(<ScmAlertFrequencySection {...props} />, {organization});
   return props;
 }
 
 describe('ScmAlertFrequencySection', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
+  });
   it('makes the alert-frequency section a collapsible toggle in project creation', async () => {
     renderSection({analyticsFlow: 'project-creation'});
 
@@ -96,6 +110,55 @@ describe('ScmAlertFrequencySection', () => {
       MultipleCheckboxOptions.INTEGRATION,
     ]);
   });
+
+  it.each([
+    ['onboarding', MessagingIntegrationAnalyticsView.ONBOARDING],
+    ['project-creation', MessagingIntegrationAnalyticsView.PROJECT_CREATION],
+  ] as const)(
+    'attributes SCM messaging installs to the %s flow',
+    async (analyticsFlow, expectedView) => {
+      for (const providerKey of ['slack', 'discord', 'msteams']) {
+        MockApiClient.addMockResponse({
+          url: `/organizations/${organization.slug}/config/integrations/`,
+          body: {providers: [GitHubIntegrationProviderFixture({key: providerKey})]},
+          match: [MockApiClient.matchQuery({provider_key: providerKey})],
+        });
+      }
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/integrations/`,
+        body: [],
+        match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/pipeline/integration_pipeline/`,
+        method: 'POST',
+        body: {},
+      });
+      const trackIntegrationSpy = jest.spyOn(
+        integrationUtil,
+        'trackIntegrationAnalytics'
+      );
+
+      renderGlobalModal();
+      renderSection({
+        analyticsFlow,
+        notificationProps: {...notificationProps, shouldRenderSetupButton: true},
+      });
+      if (analyticsFlow === 'project-creation') {
+        await userEvent.click(screen.getByRole('button', {name: 'Alert frequency'}));
+      }
+      await userEvent.click(
+        await screen.findByRole('button', {name: /connect to messaging/i})
+      );
+      const addButtons = await screen.findAllByRole('button', {name: /add integration/i});
+      await userEvent.click(addButtons[0]!);
+
+      expect(trackIntegrationSpy).toHaveBeenCalledWith(
+        'integrations.installation_start',
+        expect.objectContaining({view: expectedView, variant: 'scm'})
+      );
+    }
+  );
 
   it('hides the notification options when alerts are turned off', () => {
     renderSection({

--- a/static/app/components/onboarding/scm/scmAlertFrequencySection.tsx
+++ b/static/app/components/onboarding/scm/scmAlertFrequencySection.tsx
@@ -52,7 +52,10 @@ export function ScmAlertFrequencySection({
     <ScmCollapsibleReveal
       open={alertRuleConfig.alertSetting !== RuleAction.CREATE_ALERT_LATER}
     >
-      <ScmIssueAlertNotificationOptions {...notificationProps} />
+      <ScmIssueAlertNotificationOptions
+        {...notificationProps}
+        analyticsFlow={analyticsFlow}
+      />
     </ScmCollapsibleReveal>
   );
 

--- a/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationConnect.tsx
@@ -212,6 +212,7 @@ export function ScmIntegrationConnect({
         />
         {allowIntegrationSwitching ? (
           <ScmIntegrationSelect
+            analyticsFlow={analyticsFlow}
             integrations={activeIntegrations}
             selectedIntegration={effectiveIntegration}
             onChange={handleIntegrationSelect}

--- a/static/app/components/onboarding/scm/scmIntegrationSelect.spec.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationSelect.spec.tsx
@@ -3,6 +3,8 @@ import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegr
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import * as analytics from 'sentry/utils/analytics';
+
 import {ScmIntegrationSelect} from './scmIntegrationSelect';
 
 const githubGetsentry = OrganizationIntegrationsFixture({
@@ -41,6 +43,7 @@ describe('ScmIntegrationSelect', () => {
   it('renders the selected integration name in the trigger', async () => {
     render(
       <ScmIntegrationSelect
+        analyticsFlow="project-creation"
         integrations={[githubGetsentry, gitlabAcme]}
         selectedIntegration={githubGetsentry}
         onChange={jest.fn()}
@@ -55,6 +58,7 @@ describe('ScmIntegrationSelect', () => {
     const onChange = jest.fn();
     render(
       <ScmIntegrationSelect
+        analyticsFlow="project-creation"
         integrations={[githubGetsentry, gitlabAcme]}
         selectedIntegration={githubGetsentry}
         onChange={onChange}
@@ -75,6 +79,7 @@ describe('ScmIntegrationSelect', () => {
   it('links the Manage providers footer to SCM integration settings', async () => {
     render(
       <ScmIntegrationSelect
+        analyticsFlow="project-creation"
         integrations={[githubGetsentry]}
         selectedIntegration={githubGetsentry}
         onChange={jest.fn()}
@@ -87,6 +92,27 @@ describe('ScmIntegrationSelect', () => {
     expect(await screen.findByRole('button', {name: 'Manage providers'})).toHaveAttribute(
       'href',
       '/settings/org-slug/integrations/?category=source%20code%20management'
+    );
+  });
+
+  it('fires manage_providers_clicked with the flow variant on footer click', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    render(
+      <ScmIntegrationSelect
+        analyticsFlow="project-creation"
+        integrations={[githubGetsentry]}
+        selectedIntegration={githubGetsentry}
+        onChange={jest.fn()}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /getsentry/}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Manage providers'}));
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.manage_providers_clicked',
+      expect.objectContaining({variant: 'scm'})
     );
   });
 });

--- a/static/app/components/onboarding/scm/scmIntegrationSelect.tsx
+++ b/static/app/components/onboarding/scm/scmIntegrationSelect.tsx
@@ -4,10 +4,14 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {type ScmAnalyticsFlow, scmFlowVariantParams} from './scmAnalyticsFlow';
+
 interface ScmIntegrationSelectProps {
+  analyticsFlow: ScmAnalyticsFlow;
   integrations: Integration[];
   onChange: (integration: Integration) => void;
   selectedIntegration: Integration;
@@ -21,6 +25,7 @@ interface ScmIntegrationSelectProps {
  * footer.
  */
 export function ScmIntegrationSelect({
+  analyticsFlow,
   integrations,
   onChange,
   selectedIntegration,
@@ -59,7 +64,13 @@ export function ScmIntegrationSelect({
         <MenuComponents.CTALinkButton
           icon={<IconSettings />}
           to={`/settings/${organization.slug}/integrations/?category=source%20code%20management`}
-          onClick={closeOverlay}
+          onClick={() => {
+            trackAnalytics('project_creation.manage_providers_clicked', {
+              organization,
+              ...scmFlowVariantParams(analyticsFlow),
+            });
+            closeOverlay();
+          }}
         >
           {t('Manage providers')}
         </MenuComponents.CTALinkButton>

--- a/static/app/components/onboarding/scm/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/components/onboarding/scm/scmIssueAlertNotificationOptions.tsx
@@ -15,6 +15,7 @@ import {
   useIssueAlertNotificationOptions,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
 import {ScmCollapsibleReveal} from './scmCollapsibleReveal';
 import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
 
@@ -25,7 +26,11 @@ import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRu
  * renders the messaging rule stacked (`ScmMessagingIntegrationAlertRule`)
  * instead of the classic inline card.
  */
-export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationProps) {
+type Props = IssueAlertNotificationProps & {
+  analyticsFlow: ScmAnalyticsFlow;
+};
+
+export function ScmIssueAlertNotificationOptions({analyticsFlow, ...props}: Props) {
   const {actions, setActions} = props;
   const {querySuccess, shouldRenderNotificationConfigs, shouldRenderSetupButton} =
     useIssueAlertNotificationOptions(props);
@@ -73,7 +78,12 @@ export function ScmIssueAlertNotificationOptions(props: IssueAlertNotificationPr
       </Stack>
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
-          analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
+          analyticsView={
+            analyticsFlow === 'project-creation'
+              ? MessagingIntegrationAnalyticsView.PROJECT_CREATION
+              : MessagingIntegrationAnalyticsView.ONBOARDING
+          }
+          variant="scm"
         />
       )}
     </Stack>

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -49,6 +49,9 @@ export type ProjectCreationEventParameters = {
     project_id: string;
     variant?: ProjectCreationVariant;
   };
+  'project_creation.manage_providers_clicked': {
+    variant?: ProjectCreationVariant;
+  };
   'project_creation.next_step_clicked': {
     newOrg: boolean;
     platform: string;
@@ -162,6 +165,8 @@ export const projectCreationEventMap: Record<
     'Project Creation: Source Maps Wizard Selected and Copied',
   'project_creation.dsn_copied': 'Project Creation: DSN Copied',
   'project_creation.next_step_clicked': 'Project Creation: Next Step Clicked',
+  'project_creation.manage_providers_clicked':
+    'Project Creation: Manage Providers Clicked',
   'project_creation.js_loader_npm_docs_shown':
     'Project Creation: JS Loader Switch to npm Instructions',
   'project_creation.setup_loader_docs_rendered':

--- a/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
+++ b/static/app/views/alerts/rules/issue/messagingIntegrationModal.tsx
@@ -14,6 +14,9 @@ type Props = ModalRenderProps & {
   providers: IntegrationProvider[];
   bodyContent?: React.ReactNode;
   onAddIntegration?: () => void;
+  // `analyticsView` identifies the install flow; `variant` identifies the SCM or
+  // legacy project-creation experience.
+  variant?: 'scm' | 'legacy';
 };
 
 export function MessagingIntegrationModal({
@@ -25,6 +28,7 @@ export function MessagingIntegrationModal({
   providers,
   onAddIntegration,
   analyticsView,
+  variant,
 }: Props) {
   return (
     <Fragment>
@@ -45,6 +49,7 @@ export function MessagingIntegrationModal({
                   analyticsParams: {
                     already_installed: false,
                     view: analyticsView,
+                    ...(variant ? {variant} : {}),
                   },
                   onAddIntegration,
                 }}

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -17,15 +17,23 @@ import {MessagingIntegrationModal} from 'sentry/views/alerts/rules/issue/messagi
 
 export enum MessagingIntegrationAnalyticsView {
   ALERT_RULE_CREATION = 'alert_rule_creation_messaging_integration_onboarding',
+  ONBOARDING = 'onboarding',
   PROJECT_CREATION = 'project_creation_messaging_integration_onboarding',
 }
 
 type Props = {
   analyticsView: MessagingIntegrationAnalyticsView;
   refetchConfigs?: () => void;
+  // `analyticsView` identifies the flow; `variant` identifies the SCM or legacy
+  // project-creation experience. Alert-rule creation leaves `variant` undefined.
+  variant?: 'scm' | 'legacy';
 };
 
-export function SetupMessagingIntegrationButton({refetchConfigs, analyticsView}: Props) {
+export function SetupMessagingIntegrationButton({
+  refetchConfigs,
+  analyticsView,
+  variant,
+}: Props) {
   const {openModal} = useModal();
 
   const providerKeys = ['slack', 'discord', 'msteams'];
@@ -123,6 +131,7 @@ export function SetupMessagingIntegrationButton({refetchConfigs, analyticsView}:
                     providers={integrationProvidersQuery.providers}
                     onAddIntegration={onAddIntegration}
                     analyticsView={analyticsView}
+                    variant={variant}
                   />
                 ),
                 {

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -379,6 +379,7 @@ export function IssueAlertNotificationOptions(
       {shouldRenderSetupButton && (
         <SetupMessagingIntegrationButton
           analyticsView={MessagingIntegrationAnalyticsView.PROJECT_CREATION}
+          variant="legacy"
         />
       )}
     </Fragment>


### PR DESCRIPTION
## TLDR

Adds the SCM manage-providers funnel event and makes messaging-integration installs segmentable by SCM versus legacy without mislabeling SCM onboarding as project creation.

## Details

This PR is stacked on the platform-selection parity PR (#120115). `ScmIntegrationSelect` now fires `project_creation.manage_providers_clicked` with the project-creation SCM variant when its integration-settings footer is used.

Messaging installs continue using one flow value plus `variant`. Legacy project creation passes the project-creation messaging view with `variant:'legacy'`. The SCM alert-frequency section now threads its existing `analyticsFlow` into `ScmIssueAlertNotificationOptions`: SCM project creation uses the project-creation messaging view, while SCM onboarding uses `view:'onboarding'`; both carry `variant:'scm'`. The shared alert-rule-creation caller remains on its existing view with no variant.

The flow-aware mapping fixes the previous cross-flow leak where the shared SCM alert-frequency UI labeled onboarding messaging installs as project creation. End-to-end coverage opens the setup modal and starts an install from both SCM flows, asserting the emitted `view` and `variant`; the manage-providers click remains covered separately.

Refs VDY-133
