### PR TITLE
feat(preprod): Expose size PR comment options in project API

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1193,6 +1193,12 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_size_status_checks_rules": options.get(
                 "sentry:preprod_size_status_checks_rules"
             ),
+            "sentry:preprod_size_pr_comments_enabled": options.get(
+                "sentry:preprod_size_pr_comments_enabled", False
+            ),
+            "sentry:preprod_size_pr_comments_rules": options.get(
+                "sentry:preprod_size_pr_comments_rules"
+            ),
             "sentry:preprod_snapshot_status_checks_enabled": options.get(
                 "sentry:preprod_snapshot_status_checks_enabled", True
             ),

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -118,6 +118,11 @@ class ProjectMemberSerializer(serializers.Serializer):
         required=False,
     )
     preprodSizeStatusChecksRules = serializers.JSONField(required=False)
+    preprodSizePrCommentsEnabled = serializers.BooleanField(
+        help_text="Enable preprod size PR comments. Can be updated with **`project:read`** permission.",
+        required=False,
+    )
+    preprodSizePrCommentsRules = serializers.JSONField(required=False)
     preprodSnapshotStatusChecksEnabled = serializers.BooleanField(required=False)
     preprodSnapshotStatusChecksFailOnAdded = serializers.BooleanField(required=False)
     preprodSnapshotStatusChecksFailOnRemoved = serializers.BooleanField(required=False)
@@ -180,6 +185,8 @@ class ProjectMemberSerializer(serializers.Serializer):
         "debugFilesRole",
         "preprodSizeStatusChecksEnabled",
         "preprodSizeStatusChecksRules",
+        "preprodSizePrCommentsEnabled",
+        "preprodSizePrCommentsRules",
         "preprodSizeEnabledQuery",
         "preprodDistributionEnabledQuery",
         "preprodSizeEnabledByCustomer",
@@ -626,6 +633,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         Note that solely having the **`project:read`** scope restricts updatable settings to
         `isBookmarked`, `autofixAutomationTuning`, `seerScannerAutomation`,
         `preprodSizeStatusChecksEnabled`, `preprodSizeStatusChecksRules`,
+        `preprodSizePrCommentsEnabled`, `preprodSizePrCommentsRules`,
         `preprodSizeEnabledQuery`, `preprodDistributionEnabledQuery`,
         `preprodSizeEnabledByCustomer`, `preprodDistributionEnabledByCustomer`,
         and `preprodDistributionPrCommentsEnabledByCustomer`.
@@ -868,6 +876,22 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:preprod_size_status_checks_rules"] = result[
                     "preprodSizeStatusChecksRules"
+                ]
+        if result.get("preprodSizePrCommentsEnabled") is not None:
+            if project.update_option(
+                "sentry:preprod_size_pr_comments_enabled",
+                result["preprodSizePrCommentsEnabled"],
+            ):
+                changed_proj_settings["sentry:preprod_size_pr_comments_enabled"] = result[
+                    "preprodSizePrCommentsEnabled"
+                ]
+        if result.get("preprodSizePrCommentsRules") is not None:
+            if project.update_option(
+                "sentry:preprod_size_pr_comments_rules",
+                result["preprodSizePrCommentsRules"],
+            ):
+                changed_proj_settings["sentry:preprod_size_pr_comments_rules"] = result[
+                    "preprodSizePrCommentsRules"
                 ]
 
         if "preprodSizeEnabledByCustomer" in result:

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -72,6 +72,8 @@ OPTION_KEYS = frozenset(
         "sentry:debug_files_role",
         "sentry:preprod_size_status_checks_enabled",
         "sentry:preprod_size_status_checks_rules",
+        "sentry:preprod_size_pr_comments_enabled",
+        "sentry:preprod_size_pr_comments_rules",
         "sentry:preprod_size_enabled_query",
         "sentry:preprod_distribution_enabled_query",
         "sentry:preprod_size_enabled_by_customer",

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -270,6 +270,11 @@ class ProjectDetailsTest(APITestCase):
         assert resp.data["options"]["filters:log_messages"] == "Updated*\n*.sentry.io"
         assert resp.data["options"]["filters:trace_metric_names"] == "counter.*\n*.duration"
 
+    def test_preprod_size_pr_comments_defaults(self) -> None:
+        resp = self.get_success_response(self.project.organization.slug, self.project.slug)
+        assert resp.data["options"]["sentry:preprod_size_pr_comments_enabled"] is False
+        assert resp.data["options"]["sentry:preprod_size_pr_comments_rules"] is None
+
 
 class ProjectUpdateTestTokenAuthenticated(APITestCase):
     endpoint = "sentry-api-0-project-details"
@@ -819,6 +824,26 @@ class ProjectUpdateTest(APITestCase):
         )
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:preprod_snapshot_pr_comments_post_on_renamed") is True
+
+    def test_preprod_size_pr_comments_enabled_option(self) -> None:
+        self.get_success_response(self.org_slug, self.proj_slug, preprodSizePrCommentsEnabled=True)
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_size_pr_comments_enabled") is True
+
+    def test_preprod_size_pr_comments_rules_option(self) -> None:
+        rules = [
+            {
+                "id": "r1",
+                "metric": "install_size",
+                "measurement": "absolute",
+                "value": 1000000,
+                "artifactType": "main_artifact",
+                "filterQuery": "",
+            }
+        ]
+        self.get_success_response(self.org_slug, self.proj_slug, preprodSizePrCommentsRules=rules)
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_size_pr_comments_rules") == rules
 
     def test_bookmarks(self) -> None:
         self.get_success_response(self.org_slug, self.proj_slug, isBookmarked="false")


### PR DESCRIPTION
The project API now reads and writes the two size PR-comment options,
`sentry:preprod_size_pr_comments_enabled` and
`sentry:preprod_size_pr_comments_rules`. EME-938 added the backend task that
*consumes* these options, but nothing exposed them on the project API — the
GET serializer never emitted them and the PUT endpoint rejected them — so a
settings UI could neither read the current values nor persist changes. This
closes that gap.

The wiring mirrors the existing size status-check options at all four
touchpoints: the option allowlist, the GET serializer (`options` dict), and
the PUT endpoint (serializer fields + schema exclusion + option-mapping). The
new PUT fields live on `ProjectMemberSerializer`, so they are updatable with
`project:read`, matching `preprodSizeStatusChecks*`.

One deliberate difference from status checks: `...enabled` defaults to
**`false`** (per its registration in `projectoptions/defaults.py`), whereas
status checks default to `true`. The GET serializer reflects this, and the
`rules` key stays unregistered — read with an inline default — consistent with
`...status_checks_rules`.

This is the backend half of the size PR-comment settings work and must land
before the frontend panel, since the two do not deploy atomically. No data
migration: both options already existed and were consumed; this only makes
them reachable through the API.

Refs EME-938
