### PR TITLE
ref(detectors): Refactor `get_span_evidence_value` and strip whitespace

### DIFF
--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -187,9 +187,7 @@ def get_span_evidence_value(span: Span | None = None, include_op: bool = True) -
     elif not desc and op:
         value = op
     elif op and desc:
-        value = f"{op} - {desc}"
-        if not include_op:
-            value = desc
+        value = f"{op} - {desc}" if include_op else desc
 
     return value
 

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -179,14 +179,14 @@ def get_span_evidence_value(span: Span | None = None, include_op: bool = True) -
     if not span:
         return value
 
-    op = span.get("op")
-    desc = span.get("description")
+    op = span.get("op") or ""
+    desc = span.get("description") or ""
 
-    if not op and desc and isinstance(desc, str):
+    if not op and desc:
         value = desc
-    elif not desc and op and isinstance(op, str):
+    elif not desc and op:
         value = op
-    elif op and isinstance(op, str) and desc and isinstance(desc, str):
+    elif op and desc:
         value = f"{op} - {desc}"
         if not include_op:
             value = desc

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -179,8 +179,8 @@ def get_span_evidence_value(span: Span | None = None, include_op: bool = True) -
     if not span:
         return value
 
-    op = span.get("op") or ""
-    desc = span.get("description") or ""
+    op = (span.get("op") or "").strip()
+    desc = (span.get("description") or "").strip()
 
     if not op and desc:
         value = desc

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -178,8 +178,10 @@ def get_span_evidence_value(span: Span | None = None, include_op: bool = True) -
     value = "no value"
     if not span:
         return value
+
     op = span.get("op")
     desc = span.get("description")
+
     if not op and desc and isinstance(desc, str):
         value = desc
     elif not desc and op and isinstance(op, str):
@@ -188,6 +190,7 @@ def get_span_evidence_value(span: Span | None = None, include_op: bool = True) -
         value = f"{op} - {desc}"
         if not include_op:
             value = desc
+
     return value
 
 


### PR DESCRIPTION
This is a small refactor of the `get_span_evidence_value` issue detector utility function, mostly just to simplify the code a bit, but also to add whitespace stripping to both the `op` and `description` values. (The fact that whitespace isn't stripped is causing a false-positive mismatch in our existing-vs-span-first-detectors experiment.)