### PR TITLE
feat(search): Show Ask Seer results directly

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -280,6 +280,7 @@ describe('AskSeerComboBox', () => {
 
     const filter = await screen.findByText('Filter');
     expect(filter).toBeInTheDocument();
+    expect(screen.getByText('Do any of these look right to you?')).toBeInTheDocument();
     expect(screen.queryByText('Time Range')).not.toBeInTheDocument();
   });
 
@@ -308,6 +309,9 @@ describe('AskSeerComboBox', () => {
     await userEvent.type(input, 'test{Enter}');
 
     expect(await screen.findByText('Filter')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Do any of these look right to you?')
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole('option', {name: 'None of these'})).not.toBeInTheDocument();
   });
 

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -485,7 +485,9 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
             </Stack>
           ) : data?.queries && (data?.queries?.length ?? 0) > 0 ? (
             <Stack flex="1" onMouseLeave={onMouseLeave}>
-              <AskSeerSearchHeader title={t('Do any of these look right to you?')} />
+              {hasAskSeerUxRework ? null : (
+                <AskSeerSearchHeader title={t('Do any of these look right to you?')} />
+              )}
               <AskSeerSearchListBox
                 {...listBoxProps}
                 listBoxRef={listBoxRef}

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.spec.tsx
@@ -108,6 +108,31 @@ describe('AskSeerPollingComboBox results', () => {
     MockApiClient.clearMockResponses();
   });
 
+  it('preserves the results prompt when the rework is disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/search-agent/start/',
+      method: 'POST',
+      body: {run_id: 123},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/search-agent/state/123/',
+      body: {
+        session: {
+          status: 'completed',
+          current_step: null,
+          completed_steps: [],
+          final_response: {query: 'span.duration:>30s'},
+        },
+      },
+    });
+    renderPollingComboBox(['gen-ai-features']);
+
+    await submitQuery();
+
+    expect(await screen.findByText('Filter')).toBeInTheDocument();
+    expect(screen.getByText('Do any of these look right to you?')).toBeInTheDocument();
+  });
+
   it('regenerates results when feedback is unavailable', async () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const startRequest = MockApiClient.addMockResponse({
@@ -136,6 +161,10 @@ describe('AskSeerPollingComboBox results', () => {
       name: 'Generate again',
     });
     expect(regenerateButton).toBeEnabled();
+    expect(screen.getByText('Filter')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Do any of these look right to you?')
+    ).not.toBeInTheDocument();
 
     const input = screen.getByRole('combobox', {
       name: 'Ask Seer with Natural Language',

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -151,7 +151,9 @@ function AskSeerPollingPopoverContent({
   if (hasResults) {
     return (
       <SeerContent onMouseLeave={onMouseLeave}>
-        <AskSeerSearchHeader title={t('Do any of these look right to you?')} />
+        {hasAskSeerUxRework ? null : (
+          <AskSeerSearchHeader title={t('Do any of these look right to you?')} />
+        )}
         <AskSeerSearchListBox {...listBoxProps} listBoxRef={listBoxRef} state={state} />
       </SeerContent>
     );

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox.tsx
@@ -54,7 +54,10 @@ const StyledUl = styled('ul')`
   outline: none;
   margin: 0;
   padding: 0;
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
+
+  &:not(:first-child) {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  }
 
   & > :not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.tokens.border.primary};


### PR DESCRIPTION
When `gen-ai-ask-seer-ux-rework` is enabled, Ask Seer now presents the generated result directly in both polling and mutation flows instead of preceding it with the results prompt. Organizations outside the rollout retain the existing prompt.

The result list draws its top separator only when content precedes it, avoiding a double border against the popover frame in the reworked layout while preserving the legacy separator.

Closes BROWSE-639
