### PR TITLE
fix(pr-metrics): Stop aborted check reruns from erasing a recorded verdict

### DIFF
--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -112,6 +112,31 @@ def is_failing_conclusion(conclusion: str | None) -> bool:
     return conclusion not in NON_FAILING_CONCLUSIONS and conclusion not in ABORTED_CONCLUSIONS
 
 
+def has_verdict(conclusion: str | None) -> bool:
+    """Whether a conclusion reports an outcome at all — a pass or a failure.
+
+    ``cancelled``/``stale`` and an empty conclusion are the *absence* of a result,
+    not a result: the run was abandoned before CI decided anything.
+    """
+    return bool(conclusion) and conclusion not in ABORTED_CONCLUSIONS
+
+
+def _wins_conclusion(candidate: str | None, current: str | None) -> bool:
+    """Whether a newer conclusion may replace the stored one.
+
+    Latest-wins is the right rule only between verdicts. A rerun that was cancelled
+    reports nothing, so it must not erase what CI already decided: a check that
+    failed and whose rerun was then cancelled is still failing, and letting the
+    cancellation win drops it from ``failing_check_names`` — and, where the app
+    emits no suite event, flips the whole group to ``success``.
+
+    A no-verdict conclusion is still recorded when there is nothing to erase, so a
+    run that only ever aborted (a PR closed mid-CI) reads as aborted rather than
+    silently deriving a pass.
+    """
+    return has_verdict(candidate) or not has_verdict(current)
+
+
 def new_document() -> ActivityDoc:
     """An empty activity document at the current version."""
     return {
@@ -291,15 +316,18 @@ def _apply_check_suite(
 ) -> None:
     """Fold a completed ``check_suite`` into its ``(head_sha, app_slug)`` group.
 
-    The suite carries the aggregate conclusion (latest wins on ``updated_at``) and
-    the run count (``max`` of ``latest_check_runs_count``). A failing suite also
-    lowers ``first_failure_at`` so the signal survives even for CI apps that only
-    emit suite events.
+    The suite carries the aggregate conclusion (latest verdict wins on
+    ``updated_at`` — see :func:`_wins_conclusion` for why an aborted suite does not
+    count) and the run count (``max`` of ``latest_check_runs_count``). A failing
+    suite also lowers ``first_failure_at`` so the signal survives even for CI apps
+    that only emit suite events.
     """
     group = _get_or_create_group(doc, payload)
 
     conclusion = payload.get("conclusion") or ""
-    if _is_newer(suite_updated_at, group.get("suite_updated_at")):
+    if _is_newer(suite_updated_at, group.get("suite_updated_at")) and _wins_conclusion(
+        conclusion, group.get("suite_conclusion")
+    ):
         group["suite_conclusion"] = conclusion
         group["suite_updated_at"] = suite_updated_at
     group["check_runs_count"] = max(
@@ -319,7 +347,9 @@ def _apply_check_run(
     its entry (``failed_attempts`` += 1) and lowers ``first_failure_at``; a
     non-failing run updates an existing (previously-failing) entry in place so a
     fail→rerun-green at the same head reads as recovered rather than vanishing.
-    Latest-wins on ``completed_at`` keeps out-of-order deliveries convergent.
+    Latest-*verdict*-wins on ``completed_at`` keeps out-of-order deliveries
+    convergent while leaving a stored result intact when a rerun aborts without
+    reaching one (see :func:`_wins_conclusion`).
     Redelivery-safe without ``webhook_id`` dedup: a redelivered failing event
     double counts only the magnitude signal, which is accepted.
     """
@@ -338,7 +368,9 @@ def _apply_check_run(
     if entry is not None:
         if failing:
             entry["failed_attempts"] = entry.get("failed_attempts", 0) + 1
-        if _is_newer(completed_at, entry.get("completed_at")):
+        if _is_newer(completed_at, entry.get("completed_at")) and _wins_conclusion(
+            conclusion, entry.get("conclusion")
+        ):
             entry["conclusion"] = conclusion
             entry["completed_at"] = completed_at
     elif failing:

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -977,6 +977,59 @@ def test_timeline_suite_conclusion_derived_from_runs_when_absent() -> None:
     assert events[0]["payload"]["conclusion"] == "failure"  # derived from the failing run
 
 
+def test_cancelled_rerun_does_not_erase_a_failure() -> None:
+    # A check fails, is rerun, and the rerun is cancelled. The cancellation reports
+    # no verdict, so the failure stands — otherwise the check silently drops out of
+    # failing_check_names while CI never said it passed.
+    doc = new_document()
+    _run(doc, check_name="unit", conclusion="failure", completed_at="2026-07-10T12:00:00Z")
+    _run(doc, check_name="unit", conclusion="cancelled", completed_at="2026-07-10T12:05:00Z")
+
+    assert _group(doc)["runs"]["unit"]["conclusion"] == "failure"
+    assert timeline_events_from_doc(doc)[0]["payload"]["failing_check_names"] == ["unit"]
+
+
+def test_cancelled_rerun_does_not_flip_a_failing_group_to_success() -> None:
+    # The sharper consequence: with no suite event the group conclusion is derived
+    # from the runs, so letting the cancellation win reported a green CI run that
+    # never happened.
+    doc = new_document()
+    _run(doc, check_name="unit", conclusion="failure", completed_at="2026-07-10T12:00:00Z")
+    _run(doc, check_name="unit", conclusion="cancelled", completed_at="2026-07-10T12:05:00Z")
+
+    assert timeline_events_from_doc(doc)[0]["payload"]["conclusion"] == "failure"
+
+
+def test_cancelled_suite_does_not_erase_a_failing_suite_conclusion() -> None:
+    doc = new_document()
+    _suite(doc, conclusion="failure", updated_at="2026-07-10T12:00:00Z")
+    _suite(doc, conclusion="cancelled", updated_at="2026-07-10T12:05:00Z")
+
+    assert _group(doc)["suite_conclusion"] == "failure"
+
+
+def test_a_real_verdict_after_an_abort_still_wins() -> None:
+    # The guard must not freeze the entry: a genuine green after the cancellation
+    # is a verdict and supersedes the failure as usual.
+    doc = new_document()
+    _run(doc, check_name="unit", conclusion="failure", completed_at="2026-07-10T12:00:00Z")
+    _run(doc, check_name="unit", conclusion="cancelled", completed_at="2026-07-10T12:05:00Z")
+    _run(doc, check_name="unit", conclusion="success", completed_at="2026-07-10T12:10:00Z")
+
+    assert _group(doc)["runs"]["unit"]["conclusion"] == "success"
+    assert timeline_events_from_doc(doc)[0]["payload"]["failing_check_names"] == []
+
+
+def test_abort_only_group_still_reads_as_aborted() -> None:
+    # Nothing to erase, so the abort is recorded — a PR closed mid-CI must not
+    # derive a pass out of a suite that only ever cancelled.
+    doc = new_document()
+    _suite(doc, conclusion="cancelled", updated_at="2026-07-10T12:00:00Z")
+
+    assert _group(doc)["suite_conclusion"] == "cancelled"
+    assert timeline_events_from_doc(doc)[0]["payload"]["conclusion"] == "cancelled"
+
+
 def test_timeline_recovered_run_excluded_from_failing_names() -> None:
     doc = new_document()
     _run(doc, check_name="flaky", conclusion="failure", completed_at="2026-07-10T12:00:00Z")


### PR DESCRIPTION
The checks rollup applied latest-wins on the raw conclusion, so a **cancelled rerun overwrote whatever CI had already decided**. A check that failed and was then cancelled — an author aborting a rerun, or a concurrency `cancel-in-progress` — stops counting as failing.

```python
# before: any newer event wins, verdict or not
if _is_newer(completed_at, entry.get("completed_at")):
    entry["conclusion"] = conclusion
```

Two consequences on live data:

* The check drops out of `failing_check_names`, so the judge is no longer told what failed.
* Worse, for a CI app that emits **no suite event**, `_synthesized_suite_conclusion` derives the group conclusion from the runs — with the only failing check now reading `cancelled`, the group flips to `success`. That is a green CI result that never happened, and it also feeds `ci_failing_at_close` on the no-judge close path.

Latest-wins is only the right rule *between verdicts*. `cancelled`/`stale` and an empty conclusion report no outcome — the run was abandoned before CI decided anything — so they no longer replace a stored result.

The guard is deliberately not "never store an abort". A no-verdict conclusion is still recorded when there is nothing to erase, so a PR closed mid-CI still reads as `cancelled` rather than falling through to a derived pass. And a genuine verdict arriving after an abort supersedes as normal, so a fail → cancel → green sequence still ends green.

This is a bug in the existing rollup rather than anything new: `is_failing_conclusion`'s own docstring already describes `cancelled`/`stale` as "aborted without a verdict", the reducer just didn't honor that when overwriting.

**Not blocked on anything.** It only makes fields Seer already reads more accurate, so it needs no coordinated deploy — unlike #120113, which is stacked behind a Seer reader and touches a different function in this file. It does resolve a wart noted there: a failed-then-cancelled check that appeared in neither the failing nor the recovered list now correctly appears as failing.

Refs CW-1656
