### PR TITLE
feat(analytics): Instrument SCM + legacy alert & notification for project creation

### DIFF
--- a/static/app/components/onboarding/scm/scmAlertFrequencySection.spec.tsx
+++ b/static/app/components/onboarding/scm/scmAlertFrequencySection.spec.tsx
@@ -8,6 +8,7 @@ import {
   userEvent,
 } from 'sentry-test/reactTestingLibrary';
 
+import * as analytics from 'sentry/utils/analytics';
 import * as integrationUtil from 'sentry/utils/integrationUtil';
 import {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 import {
@@ -91,6 +92,7 @@ describe('ScmAlertFrequencySection', () => {
   });
 
   it('adds the integration action when the Integration checkbox is clicked', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const setActions = jest.fn();
     renderSection({
       analyticsFlow: 'onboarding',
@@ -109,6 +111,27 @@ describe('ScmAlertFrequencySection', () => {
       MultipleCheckboxOptions.EMAIL,
       MultipleCheckboxOptions.INTEGRATION,
     ]);
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.notify_integration_toggled',
+      expect.anything()
+    );
+  });
+
+  it('tracks integration toggles in project creation', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    renderSection({analyticsFlow: 'project-creation'});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Alert frequency'}));
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Integration (Slack, Discord, MS Teams, etc.)',
+      })
+    );
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.notify_integration_toggled',
+      expect.objectContaining({enabled: true, variant: 'scm'})
+    );
   });
 
   it.each([

--- a/static/app/components/onboarding/scm/scmIssueAlertNotificationOptions.tsx
+++ b/static/app/components/onboarding/scm/scmIssueAlertNotificationOptions.tsx
@@ -5,6 +5,8 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   MessagingIntegrationAnalyticsView,
   SetupMessagingIntegrationButton,
@@ -32,6 +34,7 @@ type Props = IssueAlertNotificationProps & {
 
 export function ScmIssueAlertNotificationOptions({analyticsFlow, ...props}: Props) {
   const {actions, setActions} = props;
+  const organization = useOrganization();
   const {querySuccess, shouldRenderNotificationConfigs, shouldRenderSetupButton} =
     useIssueAlertNotificationOptions(props);
 
@@ -54,13 +57,20 @@ export function ScmIssueAlertNotificationOptions({analyticsFlow, ...props}: Prop
             <Flex as="label" align="start" gap="md">
               <Checkbox
                 checked={actions.includes(MultipleCheckboxOptions.INTEGRATION)}
-                onChange={e =>
+                onChange={e => {
                   setActions(
                     e.target.checked
                       ? [...actions, MultipleCheckboxOptions.INTEGRATION]
                       : actions.filter(a => a !== MultipleCheckboxOptions.INTEGRATION)
-                  )
-                }
+                  );
+                  if (analyticsFlow === 'project-creation') {
+                    trackAnalytics('project_creation.notify_integration_toggled', {
+                      organization,
+                      enabled: e.target.checked,
+                      variant: 'scm',
+                    });
+                  }
+                }}
               />
               <Text bold={false} ellipsis>
                 {t('Integration (Slack, Discord, MS Teams, etc.)')}
@@ -72,7 +82,7 @@ export function ScmIssueAlertNotificationOptions({analyticsFlow, ...props}: Prop
           open={!shouldRenderSetupButton && shouldRenderNotificationConfigs}
         >
           <IndentedRule>
-            <ScmMessagingIntegrationAlertRule {...props} />
+            <ScmMessagingIntegrationAlertRule {...props} analyticsFlow={analyticsFlow} />
           </IndentedRule>
         </ScmCollapsibleReveal>
       </Stack>

--- a/static/app/components/onboarding/scm/scmMessagingIntegrationAlertRule.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingIntegrationAlertRule.spec.tsx
@@ -2,7 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
 
+import * as analytics from 'sentry/utils/analytics';
 import type {IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
 import {ScmMessagingIntegrationAlertRule} from './scmMessagingIntegrationAlertRule';
@@ -12,13 +14,19 @@ describe('ScmMessagingIntegrationAlertRule', () => {
   const slackIntegrations = [
     OrganizationIntegrationsFixture({name: "Moo Deng's Workspace"}),
   ];
+  const discordIntegrations = [
+    OrganizationIntegrationsFixture({name: "Moo Deng's Server"}),
+  ];
 
   const notificationProps: IssueAlertNotificationProps = {
     actions: [],
     channel: {label: 'channel', value: 'channel'},
     integration: slackIntegrations[0],
     provider: 'slack',
-    providersToIntegrations: {slack: slackIntegrations},
+    providersToIntegrations: {
+      slack: slackIntegrations,
+      discord: discordIntegrations,
+    },
     queryError: false,
     querySuccess: true,
     shouldRenderSetupButton: false,
@@ -35,8 +43,19 @@ describe('ScmMessagingIntegrationAlertRule', () => {
     });
   });
 
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
+  });
+
   it('renders the reused provider sentence with its three controls', () => {
-    render(<ScmMessagingIntegrationAlertRule {...notificationProps} />, {organization});
+    render(
+      <ScmMessagingIntegrationAlertRule
+        {...notificationProps}
+        analyticsFlow="project-creation"
+      />,
+      {organization}
+    );
 
     // The same three controls as the classic rule render.
     expect(screen.getByLabelText('provider')).toBeInTheDocument();
@@ -48,4 +67,35 @@ describe('ScmMessagingIntegrationAlertRule', () => {
     // ("Send [provider] notification to the [integration] workspace to [channel]").
     expect(screen.getByText('Send notification to the workspace to')).toBeInTheDocument();
   });
+
+  it.each([
+    ['project-creation', true],
+    ['onboarding', false],
+  ] as const)(
+    'tracks provider changes only in the project-creation flow (%s)',
+    async (analyticsFlow, shouldTrack) => {
+      const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+      render(
+        <ScmMessagingIntegrationAlertRule
+          {...notificationProps}
+          analyticsFlow={analyticsFlow}
+        />,
+        {organization}
+      );
+
+      await selectEvent.select(screen.getByLabelText('provider'), 'Discord');
+
+      if (shouldTrack) {
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+          'project_creation.notify_provider_changed',
+          expect.objectContaining({provider: 'discord', variant: 'scm'})
+        );
+      } else {
+        expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+          'project_creation.notify_provider_changed',
+          expect.anything()
+        );
+      }
+    }
+  );
 });

--- a/static/app/components/onboarding/scm/scmMessagingIntegrationAlertRule.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingIntegrationAlertRule.tsx
@@ -14,6 +14,8 @@ import {
   useMessagingIntegrationAlertRule,
 } from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
 
+import type {ScmAnalyticsFlow} from './scmAnalyticsFlow';
+
 /**
  * SCM-styled variant of `MessagingIntegrationAlertRule`. Instead of the classic
  * inline sentence inside a grey card, the provider sentence is rendered into a
@@ -27,7 +29,11 @@ import {
  * option lists) and the same provider sentence as the classic layout, so copy
  * and behavior stay in lockstep; only the presentation differs.
  */
-export function ScmMessagingIntegrationAlertRule(props: IssueAlertNotificationProps) {
+type Props = IssueAlertNotificationProps & {
+  analyticsFlow: ScmAnalyticsFlow;
+};
+
+export function ScmMessagingIntegrationAlertRule({analyticsFlow, ...props}: Props) {
   const {
     provider,
     integration,
@@ -43,7 +49,10 @@ export function ScmMessagingIntegrationAlertRule(props: IssueAlertNotificationPr
     onIntegrationChange,
     onChannelChange,
     onCreateChannel,
-  } = useMessagingIntegrationAlertRule(props);
+  } = useMessagingIntegrationAlertRule(
+    props,
+    analyticsFlow === 'project-creation' ? 'scm' : undefined
+  );
 
   if (!provider) {
     return null;

--- a/static/app/components/onboarding/scm/useScmProjectDetails.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.spec.tsx
@@ -9,6 +9,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import {IssueAlertActionType} from 'sentry/types/alerts';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import * as analytics from 'sentry/utils/analytics';
 import {MultipleCheckboxOptions} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
@@ -104,7 +105,33 @@ describe('useScmProjectDetails', () => {
   afterEach(() => {
     TeamStore.reset();
     MockApiClient.clearMockResponses();
+    jest.restoreAllMocks();
   });
+
+  it.each([
+    ['project-creation', true],
+    ['onboarding', false],
+  ] as const)(
+    'tracks threshold edits only in the project-creation flow (%s)',
+    (analyticsFlow, shouldTrack) => {
+      const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+      const {result} = renderDetails({analyticsFlow});
+
+      act(() => result.current.onAlertChange('threshold', '10'));
+
+      if (shouldTrack) {
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+          'project_creation.alert_threshold_edited',
+          expect.objectContaining({field: 'threshold', variant: 'scm'})
+        );
+      } else {
+        expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+          'project_creation.alert_threshold_edited',
+          expect.anything()
+        );
+      }
+    }
+  );
 
   it('requires an integration channel when notifying via integration', () => {
     TeamStore.loadInitialData([adminTeam]);

--- a/static/app/components/onboarding/scm/useScmProjectDetails.ts
+++ b/static/app/components/onboarding/scm/useScmProjectDetails.ts
@@ -276,6 +276,15 @@ export function useScmProjectDetails({
           option: optionMap[value as number] ?? String(value),
           ...scmFlowVariantParams(analyticsFlow),
         });
+      } else if (
+        analyticsFlow === 'project-creation' &&
+        (key === 'threshold' || key === 'metric' || key === 'interval')
+      ) {
+        trackAnalytics('project_creation.alert_threshold_edited', {
+          organization,
+          field: key,
+          ...scmFlowVariantParams(analyticsFlow),
+        });
       }
     },
     [

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -7,6 +7,10 @@
 export type ProjectCreationVariant = 'scm' | 'legacy';
 
 export type ProjectCreationEventParameters = {
+  'project_creation.alert_threshold_edited': {
+    field: 'threshold' | 'metric' | 'interval';
+    variant?: ProjectCreationVariant;
+  };
   'project_creation.back_button_clicked': Record<string, unknown>;
   // SCM-first project creation wizard steps. SCM vs legacy rides in `variant`
   // (see scmFlowVariantParams); these events are only emitted by the SCM cores
@@ -58,6 +62,20 @@ export type ProjectCreationEventParameters = {
     products: string[];
     project_id: string;
     step: string;
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.notify_channel_changed': {
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.notify_integration_changed': {
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.notify_integration_toggled': {
+    enabled: boolean;
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.notify_provider_changed': {
+    provider: string;
     variant?: ProjectCreationVariant;
   };
   'project_creation.platform_change_platform_clicked': {
@@ -141,6 +159,13 @@ export const projectCreationEventMap: Record<
     'Project Creation: Data Removal Modal Rendered',
   'project_creation.data_removed': 'Project Creation: Data Removed',
   'project_creation.back_button_clicked': 'Project Creation: Back Button Clicked',
+  'project_creation.alert_threshold_edited': 'Project Creation: Alert Threshold Edited',
+  'project_creation.notify_integration_toggled':
+    'Project Creation: Notify Integration Toggled',
+  'project_creation.notify_provider_changed': 'Project Creation: Notify Provider Changed',
+  'project_creation.notify_integration_changed':
+    'Project Creation: Notify Integration Changed',
+  'project_creation.notify_channel_changed': 'Project Creation: Notify Channel Changed',
   'project_creation.connect_integration_selected':
     'Project Creation: Connect Integration Selected',
   'project_creation.connect_repo_selected': 'Project Creation: Connect Repo Selected',

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -783,6 +783,30 @@ describe('CreateProject', () => {
       );
     });
 
+    it('does not fire alert_threshold_edited unless custom alerts are selected', async () => {
+      renderFrameworkModalMockRequests({
+        organization,
+        teamSlug: teamWithAccess.slug,
+      });
+      const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
+      render(<CreateProject />, {organization});
+
+      // Default is high-priority. Metric/interval Selects stay interactive while
+      // the custom radio is unselected (their wrappers call preventDefault), so
+      // an edit must not count as a custom-threshold change.
+      await selectEvent.select(screen.getByText('occurrences of'), /users affected/);
+
+      expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+        'project_creation.alert_threshold_edited',
+        expect.anything()
+      );
+      expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+        'project_creation.project_details_alert_selected',
+        expect.objectContaining({option: 'custom'})
+      );
+    });
+
     it('should disable submit button when channel validation fails and integration is selected', async () => {
       renderFrameworkModalMockRequests({
         organization,

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -17,6 +17,7 @@ import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicato
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
+import * as analytics from 'sentry/utils/analytics';
 import {CreateProject} from 'sentry/views/projectInstall/createProject';
 import * as useValidateChannelModule from 'sentry/views/projectInstall/useValidateChannel';
 
@@ -755,6 +756,31 @@ describe('CreateProject', () => {
 
       await userEvent.click(getSubmitButton());
       expect(projectCreationMockRequest).toHaveBeenCalled();
+    });
+
+    it('fires alert_selected and alert_threshold_edited with variant=legacy', async () => {
+      renderFrameworkModalMockRequests({
+        organization,
+        teamSlug: teamWithAccess.slug,
+      });
+      const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+
+      render(<CreateProject />, {organization});
+
+      // Switch to custom alerts: fires the alert-selected event, and reveals the
+      // threshold input.
+      await userEvent.click(screen.getByText(/When there are more than/));
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'project_creation.project_details_alert_selected',
+        expect.objectContaining({option: 'custom', variant: 'legacy'})
+      );
+
+      // Edit the threshold: fires the threshold-edited event.
+      await userEvent.type(screen.getByTestId('range-input'), '5');
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'project_creation.alert_threshold_edited',
+        expect.objectContaining({field: 'threshold', variant: 'legacy'})
+      );
     });
 
     it('should disable submit button when channel validation fails and integration is selected', async () => {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -53,6 +53,7 @@ import type {
 import {
   getRequestDataFragment,
   IssueAlertOptions,
+  RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
 import {useValidateChannel} from 'sentry/views/projectInstall/useValidateChannel';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
@@ -518,6 +519,24 @@ export function CreateProject() {
                 ...formData.alertRule,
                 [field]: value,
               });
+              if (field === 'alertSetting') {
+                const optionMap: Record<number, string> = {
+                  [RuleAction.DEFAULT_ALERT]: 'high_priority',
+                  [RuleAction.CUSTOMIZED_ALERTS]: 'custom',
+                  [RuleAction.CREATE_ALERT_LATER]: 'create_later',
+                };
+                trackAnalytics('project_creation.project_details_alert_selected', {
+                  organization,
+                  option: optionMap[value as number] ?? String(value),
+                  variant: 'legacy',
+                });
+              } else {
+                trackAnalytics('project_creation.alert_threshold_edited', {
+                  organization,
+                  field,
+                  variant: 'legacy',
+                });
+              }
             }}
           />
           <StyledListItem>

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -530,7 +530,10 @@ export function CreateProject() {
                   option: optionMap[value as number] ?? String(value),
                   variant: 'legacy',
                 });
-              } else {
+              } else if (
+                (field === 'threshold' || field === 'metric' || field === 'interval') &&
+                formData.alertRule?.alertSetting === RuleAction.CUSTOMIZED_ALERTS
+              ) {
                 trackAnalytics('project_creation.alert_threshold_edited', {
                   organization,
                   field,

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -19,6 +19,7 @@ import {
   type IssueAlertRuleAction,
 } from 'sentry/types/alerts';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -346,6 +347,7 @@ export function IssueAlertNotificationOptions(
   notificationProps: IssueAlertNotificationProps
 ) {
   const {actions, setActions} = notificationProps;
+  const organization = useOrganization();
   const {querySuccess, shouldRenderNotificationConfigs, shouldRenderSetupButton} =
     useIssueAlertNotificationOptions(notificationProps);
 
@@ -358,7 +360,18 @@ export function IssueAlertNotificationOptions(
       <MultipleCheckbox
         name="notification"
         value={actions}
-        onChange={values => setActions(values)}
+        onChange={values => {
+          const wasEnabled = actions.includes(MultipleCheckboxOptions.INTEGRATION);
+          const isEnabled = values.includes(MultipleCheckboxOptions.INTEGRATION);
+          setActions(values);
+          if (wasEnabled !== isEnabled) {
+            trackAnalytics('project_creation.notify_integration_toggled', {
+              organization,
+              enabled: isEnabled,
+              variant: 'legacy',
+            });
+          }
+        }}
       >
         <Stack gap="md">
           <MultipleCheckbox.Item value={MultipleCheckboxOptions.EMAIL} disabled>

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -562,6 +562,18 @@ describe('useMessagingIntegrationAlertRule change analytics', () => {
     );
   });
 
+  it('tracks custom channel creation with the variant', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const {result} = renderRule('legacy');
+
+    result.current.onCreateChannel('#custom-channel');
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.notify_channel_changed',
+      expect.objectContaining({variant: 'legacy'})
+    );
+  });
+
   it('fires nothing when variant is undefined (shared alerts rule-creation caller)', () => {
     const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const {result} = renderRule(undefined);
@@ -573,6 +585,18 @@ describe('useMessagingIntegrationAlertRule change analytics', () => {
       'project_creation.notify_provider_changed',
       expect.anything()
     );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.notify_channel_changed',
+      expect.anything()
+    );
+  });
+
+  it('does not track custom channel creation without a variant', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const {result} = renderRule(undefined);
+
+    result.current.onCreateChannel('#custom-channel');
+
     expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
       'project_creation.notify_channel_changed',
       expect.anything()

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
+import * as analytics from 'sentry/utils/analytics';
 import type {IssueAlertNotificationProps} from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   MessagingIntegrationAlertRule,
@@ -500,5 +501,81 @@ describe('useMessagingIntegrationAlertRule channel label reconciliation', () => 
 
     await waitFor(() => expect(result.current.channelOptions).toBeDefined());
     expect(mockSetChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe('useMessagingIntegrationAlertRule change analytics', () => {
+  const organization = OrganizationFixture();
+  const slackA = OrganizationIntegrationsFixture({name: "Moo Deng's Workspace"});
+  const slackB = OrganizationIntegrationsFixture({name: "Moo Waan's Workspace"});
+  const discord = OrganizationIntegrationsFixture({name: "Moo Deng's Server"});
+
+  function renderRule(variant?: 'scm' | 'legacy') {
+    return renderHookWithProviders(
+      () =>
+        useMessagingIntegrationAlertRule(
+          {
+            actions: [],
+            integration: slackA,
+            provider: 'slack',
+            providersToIntegrations: {slack: [slackA, slackB], discord: [discord]},
+            queryError: false,
+            querySuccess: true,
+            shouldRenderSetupButton: false,
+            setActions: jest.fn(),
+            setChannel: jest.fn(),
+            setIntegration: jest.fn(),
+            setProvider: jest.fn(),
+          } as IssueAlertNotificationProps,
+          variant
+        ),
+      {organization}
+    );
+  }
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${slackA.id}/channels/`,
+      body: {results: []},
+    });
+  });
+
+  it('fires notify_*_changed with the variant when set', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const {result} = renderRule('scm');
+
+    result.current.onProviderChange({value: 'discord'});
+    result.current.onIntegrationChange({value: slackB});
+    result.current.onChannelChange({label: '#general', value: '1'});
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.notify_provider_changed',
+      expect.objectContaining({provider: 'discord', variant: 'scm'})
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.notify_integration_changed',
+      expect.objectContaining({variant: 'scm'})
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.notify_channel_changed',
+      expect.objectContaining({variant: 'scm'})
+    );
+  });
+
+  it('fires nothing when variant is undefined (shared alerts rule-creation caller)', () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    const {result} = renderRule(undefined);
+
+    result.current.onProviderChange({value: 'discord'});
+    result.current.onChannelChange({label: '#general', value: '1'});
+
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.notify_provider_changed',
+      expect.anything()
+    );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.notify_channel_changed',
+      expect.anything()
+    );
   });
 });

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -5,6 +5,7 @@ import {Select, SelectOption} from '@sentry/scraps/select';
 
 import {FormField} from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -36,15 +37,20 @@ type ChannelListResponse = {
  *
  * @public Consumed by the SCM layout in a downstream PR.
  */
-export function useMessagingIntegrationAlertRule({
-  channel,
-  integration,
-  provider,
-  setChannel,
-  setIntegration,
-  setProvider,
-  providersToIntegrations,
-}: IssueAlertNotificationProps) {
+export function useMessagingIntegrationAlertRule(
+  {
+    channel,
+    integration,
+    provider,
+    setChannel,
+    setIntegration,
+    setProvider,
+    providersToIntegrations,
+  }: IssueAlertNotificationProps,
+  // Project-creation SCM/legacy split for the change events (VDY-133 §7.5).
+  // When undefined (e.g. the alerts rule-creation flow), no analytics fire.
+  variant?: 'scm' | 'legacy'
+) {
   const organization = useOrganization();
 
   const {data: channels, isPending} = useApiQuery<ChannelListResponse>(
@@ -130,17 +136,36 @@ export function useMessagingIntegrationAlertRule({
       setIntegration(providersToIntegrations[option.value]![0]);
       setChannel(undefined);
       validateChannel.clear();
+      if (variant) {
+        trackAnalytics('project_creation.notify_provider_changed', {
+          organization,
+          provider: option.value,
+          variant,
+        });
+      }
     },
     onIntegrationChange: (option: any) => {
       setIntegration(option.value);
       setChannel(undefined);
       validateChannel.clear();
+      if (variant) {
+        trackAnalytics('project_creation.notify_integration_changed', {
+          organization,
+          variant,
+        });
+      }
     },
     onChannelChange: (option: {label: React.ReactNode; value: string} | null) => {
       setChannel(
         option ? {value: option.value, label: option.label, new: false} : undefined
       );
       validateChannel.clear();
+      if (variant) {
+        trackAnalytics('project_creation.notify_channel_changed', {
+          organization,
+          variant,
+        });
+      }
     },
     onCreateChannel: (newOption: string) => {
       setChannel({value: newOption, label: newOption, new: true});
@@ -224,7 +249,7 @@ export function MessagingIntegrationAlertRule(props: IssueAlertNotificationProps
     onIntegrationChange,
     onChannelChange,
     onCreateChannel,
-  } = useMessagingIntegrationAlertRule(props);
+  } = useMessagingIntegrationAlertRule(props, 'legacy');
 
   if (!provider) {
     return null;

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.tsx
@@ -47,8 +47,8 @@ export function useMessagingIntegrationAlertRule(
     setProvider,
     providersToIntegrations,
   }: IssueAlertNotificationProps,
-  // Project-creation SCM/legacy split for the change events (VDY-133 §7.5).
-  // When undefined (e.g. the alerts rule-creation flow), no analytics fire.
+  // For project creation, `variant` identifies the SCM or legacy experience.
+  // Other flows leave it undefined and do not emit these change events.
   variant?: 'scm' | 'legacy'
 ) {
   const organization = useOrganization();
@@ -169,6 +169,12 @@ export function useMessagingIntegrationAlertRule(
     },
     onCreateChannel: (newOption: string) => {
       setChannel({value: newOption, label: newOption, new: true});
+      if (variant) {
+        trackAnalytics('project_creation.notify_channel_changed', {
+          organization,
+          variant,
+        });
+      }
     },
   };
 }


### PR DESCRIPTION
## TLDR

Instruments project-creation alert-frequency and notification interactions for both variants while keeping the shared SCM onboarding surface out of every new `project_creation.*` counter.

## Details

This PR is stacked on the connect and messaging-install PR (#120119). The SCM alert-frequency components are shared by SCM onboarding and SCM project creation, so each new emitter now follows `analyticsFlow` instead of treating every SCM render as project creation.

The integration checkbox emits `project_creation.notify_integration_toggled` only in project creation. Provider, integration, and channel changes pass `variant:'scm'` to `useMessagingIntegrationAlertRule` only in project creation; onboarding passes no variant, so the shared hook emits none of those project events. Threshold, metric, and interval edits likewise emit `project_creation.alert_threshold_edited` only in project creation. Existing onboarding alert-selection events remain unchanged.

Legacy `CreateProject` continues emitting the same base notification and threshold events with `variant:'legacy'`, including the alert-selection parity event. Focused cross-flow coverage exercises project creation and onboarding for the integration checkbox, provider changes, and threshold edits, asserting both the positive SCM payloads and onboarding silence.

Refs VDY-133
