### PR TITLE
feat(seer): Show skip reason on the workflows page Skipped tag

### DIFF
--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -212,6 +212,39 @@ describe('SeerWorkflows', () => {
     ).toBeInTheDocument();
   });
 
+  it('appends the skip reason to the Skipped tag when one was recorded', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              groupTitle: 'ValueError: something broke',
+              action: 'skip',
+              skipReason: 'insufficient_info',
+              seerRunId: null,
+              pullRequests: [],
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Expand run'}));
+
+    expect(screen.getByText('Skipped: insufficient info')).toBeInTheDocument();
+  });
+
   it('shows nothing extra when no reason is recorded for an issue', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -47,7 +47,6 @@ import {
   CATEGORY_LABELS,
   CATEGORY_ORDER,
   getActionLabel,
-  getSkipReasonLabel,
   STRATEGY_META,
 } from 'sentry/views/seerWorkflows/strategies';
 import type {
@@ -796,7 +795,7 @@ function IssueStatusTag({issue}: {issue: SeerNightShiftRunIssue}) {
   const actionLabel = getActionLabel(issue.action);
   const label =
     issue.action === 'skip' && issue.skipReason
-      ? `${actionLabel}: ${getSkipReasonLabel(issue.skipReason)}`
+      ? `${actionLabel}: ${issue.skipReason.replaceAll('_', ' ')}`
       : actionLabel;
   const variant = ACTION_TAG_VARIANT[issue.action] ?? 'muted';
   if (!issue.seerRunId) {

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -47,6 +47,7 @@ import {
   CATEGORY_LABELS,
   CATEGORY_ORDER,
   getActionLabel,
+  getSkipReasonLabel,
   STRATEGY_META,
 } from 'sentry/views/seerWorkflows/strategies';
 import type {
@@ -792,7 +793,11 @@ const ACTION_TAG_VARIANT: Record<string, TagVariant> = {
 };
 
 function IssueStatusTag({issue}: {issue: SeerNightShiftRunIssue}) {
-  const label = getActionLabel(issue.action);
+  const actionLabel = getActionLabel(issue.action);
+  const label =
+    issue.action === 'skip' && issue.skipReason
+      ? `${actionLabel}: ${getSkipReasonLabel(issue.skipReason)}`
+      : actionLabel;
   const variant = ACTION_TAG_VARIANT[issue.action] ?? 'muted';
   if (!issue.seerRunId) {
     return <Tag variant={variant}>{label}</Tag>;

--- a/static/app/views/seerWorkflows/strategies.tsx
+++ b/static/app/views/seerWorkflows/strategies.tsx
@@ -54,3 +54,18 @@ const ACTION_LABELS: Record<string, string> = {
 export function getActionLabel(action: string): string {
   return ACTION_LABELS[action] ?? action;
 }
+
+// Maps the skip_reason categories Seer sends to display labels. skip_reason is
+// an open passthrough string, so unknown values get their underscores
+// humanized rather than dropped.
+const SKIP_REASON_LABELS: Record<string, string> = {
+  duplicate: 'duplicate',
+  insufficient_info: 'insufficient info',
+  environmental: 'environmental',
+  ambiguous_root_cause: 'ambiguous root cause',
+  other: 'other',
+};
+
+export function getSkipReasonLabel(skipReason: string): string {
+  return SKIP_REASON_LABELS[skipReason] ?? skipReason.replaceAll('_', ' ');
+}

--- a/static/app/views/seerWorkflows/strategies.tsx
+++ b/static/app/views/seerWorkflows/strategies.tsx
@@ -54,18 +54,3 @@ const ACTION_LABELS: Record<string, string> = {
 export function getActionLabel(action: string): string {
   return ACTION_LABELS[action] ?? action;
 }
-
-// Maps the skip_reason categories Seer sends to display labels. skip_reason is
-// an open passthrough string, so unknown values get their underscores
-// humanized rather than dropped.
-const SKIP_REASON_LABELS: Record<string, string> = {
-  duplicate: 'duplicate',
-  insufficient_info: 'insufficient info',
-  environmental: 'environmental',
-  ambiguous_root_cause: 'ambiguous root cause',
-  other: 'other',
-};
-
-export function getSkipReasonLabel(skipReason: string): string {
-  return SKIP_REASON_LABELS[skipReason] ?? skipReason.replaceAll('_', ' ');
-}


### PR DESCRIPTION
Seer recently started returning a categorical `skip_reason` for night-shift triage skip verdicts, and the workflows API already exposes it (`skipReason` on each issue), but the UI only surfaced it in the employee-only debug table. This appends the reason to the `Skipped` tag on the workflows page, e.g. **Skipped: insufficient info**, so users can see why an issue was skipped without expanding debug internals.

Since `skip_reason` is an open passthrough string on the Sentry side, the label just humanizes the snake_case value — new Seer categories render without a Sentry deploy, and runs recorded before the field existed keep the plain `Skipped` tag. Frontend-only; no API changes.