### PR TITLE
fix(issues): Handle invalid release resolution searches

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -1,3 +1,4 @@
+import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 
 import {
@@ -11,6 +12,8 @@ import {
 import {ResolveActions} from 'sentry/components/actions/resolve';
 
 describe('ResolveActions', () => {
+  const project = ProjectFixture({id: '1', slug: 'proj-1'});
+  const releaseProject = ProjectFixture({id: '2', slug: 'project-slug'});
   const spy = jest.fn();
   afterEach(() => {
     spy.mockClear();
@@ -25,7 +28,7 @@ describe('ResolveActions', () => {
           onUpdate={spy}
           disabled
           hasRelease={false}
-          projectSlug="proj-1"
+          project={project}
         />
       );
       const button = screen.getByRole('button', {name: 'Resolve'});
@@ -43,7 +46,7 @@ describe('ResolveActions', () => {
           onUpdate={spy}
           disableDropdown
           hasRelease={false}
-          projectSlug="proj-1"
+          project={project}
         />
       );
 
@@ -65,7 +68,7 @@ describe('ResolveActions', () => {
           onUpdate={spy}
           disabled
           hasRelease={false}
-          projectSlug="proj-1"
+          project={project}
           isResolved
         />
       );
@@ -91,7 +94,7 @@ describe('ResolveActions', () => {
           onUpdate={spy}
           disabled
           hasRelease={false}
-          projectSlug="proj-1"
+          project={project}
           isResolved
           isAutoResolved
         />
@@ -109,7 +112,7 @@ describe('ResolveActions', () => {
           hasSemverReleaseFeature={false}
           onUpdate={spy}
           hasRelease={false}
-          projectSlug="proj-1"
+          project={project}
         />
       );
       await userEvent.click(screen.getByRole('button', {name: 'Resolve'}));
@@ -129,7 +132,7 @@ describe('ResolveActions', () => {
           hasSemverReleaseFeature={false}
           onUpdate={spy}
           hasRelease={false}
-          projectSlug="proj-1"
+          project={project}
           shouldConfirm
           confirmMessage="Are you sure???"
         />
@@ -159,7 +162,7 @@ describe('ResolveActions', () => {
       <ResolveActions
         hasSemverReleaseFeature={false}
         hasRelease
-        projectSlug="project-slug"
+        project={releaseProject}
         onUpdate={onUpdate}
       />
     );
@@ -190,7 +193,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease
-        projectSlug="proj-1"
+        project={project}
         latestRelease={{version: 'frontend@1.2.3'}}
       />
     );
@@ -212,7 +215,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature
         onUpdate={spy}
         hasRelease
-        projectSlug="proj-1"
+        project={project}
       />
     );
 
@@ -233,7 +236,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature
         onUpdate={spy}
         hasRelease
-        projectSlug="proj-1"
+        project={project}
         latestRelease={{version: 'frontend@abc123def'}}
       />
     );
@@ -251,7 +254,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
-        projectSlug="proj-1"
+        project={project}
       />
     );
 
@@ -265,7 +268,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
-        projectSlug="proj-1"
+        project={project}
         multipleProjectsSelected
       />
     );
@@ -285,7 +288,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
-        projectSlug="proj-1"
+        project={project}
         disableResolveInRelease={false}
       />
     );
@@ -298,7 +301,7 @@ describe('ResolveActions', () => {
         hasSemverReleaseFeature={false}
         onUpdate={spy}
         hasRelease={false}
-        projectSlug="proj-1"
+        project={project}
         disableResolveInRelease
       />
     );
@@ -315,7 +318,7 @@ describe('ResolveActions', () => {
       <ResolveActions
         hasSemverReleaseFeature={false}
         hasRelease
-        projectSlug="project-slug"
+        project={releaseProject}
         onUpdate={onUpdate}
       />
     );

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -155,7 +155,7 @@ describe('ResolveActions', () => {
   it('can resolve in "another version"', async () => {
     const onUpdate = jest.fn();
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
+      url: '/organizations/org-slug/releases/',
       body: [ReleaseFixture()],
     });
     render(
@@ -311,7 +311,7 @@ describe('ResolveActions', () => {
   it('does render next release option with subtitle', async () => {
     const onUpdate = jest.fn();
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
+      url: '/organizations/org-slug/releases/',
       body: [ReleaseFixture()],
     });
     render(

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -53,6 +53,7 @@ interface ResolveActionsProps {
   hasRelease: boolean;
   hasSemverReleaseFeature: boolean;
   onUpdate: (data: GroupStatusResolution) => void;
+  project: Project | undefined;
   confirmLabel?: string;
   confirmMessage?: React.ReactNode;
   disableDropdown?: boolean;
@@ -64,7 +65,6 @@ interface ResolveActionsProps {
   multipleProjectsSelected?: boolean;
   priority?: 'primary';
   projectFetchError?: boolean;
-  projectSlug?: string;
   shouldConfirm?: boolean;
   size?: 'xs' | 'sm';
 }
@@ -74,7 +74,7 @@ export function ResolveActions({
   isResolved = false,
   isAutoResolved = false,
   confirmLabel = t('Resolve'),
-  projectSlug,
+  project,
   hasRelease,
   latestRelease,
   confirmMessage,
@@ -89,6 +89,7 @@ export function ResolveActions({
   onUpdate,
 }: ResolveActionsProps) {
   const {openModal} = useModal();
+  const projectSlug = project?.slug;
 
   const organization = useOrganization();
 
@@ -333,13 +334,17 @@ export function ResolveActions({
   }
 
   function openCustomReleaseModal() {
+    if (!project) {
+      return;
+    }
+
     openModal(deps => (
       <CustomResolutionModal
         {...deps}
         onSelected={(statusDetails: ResolvedStatusDetails) =>
           handleAnotherExistingReleaseResolution(statusDetails)
         }
-        projectSlug={projectSlug}
+        project={project}
       />
     ));
   }

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -334,10 +334,6 @@ export function ResolveActions({
   }
 
   function openCustomReleaseModal() {
-    if (!project) {
-      return;
-    }
-
     openModal(deps => (
       <CustomResolutionModal
         {...deps}

--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -16,7 +16,7 @@ describe('CustomResolutionModal', () => {
   beforeEach(() => {
     ConfigStore.init();
     releasesMock = MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
+      url: '/organizations/org-slug/releases/',
       body: [ReleaseFixture({authors: [UserFixture()]})],
     });
   });
@@ -40,7 +40,10 @@ describe('CustomResolutionModal', () => {
         CloseButton={makeCloseButton(() => null)}
       />
     );
-    expect(releasesMock).toHaveBeenCalled();
+    expect(releasesMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({query: {project: '1', query: ''}})
+    );
 
     const trigger = screen.getByRole('button', {name: /version/i});
     await userEvent.click(trigger);
@@ -56,6 +59,27 @@ describe('CustomResolutionModal', () => {
     expect(onSelected).toHaveBeenCalledWith({
       inRelease: 'sentry-android-shop@1.2.0',
     });
+  });
+
+  it('queries organization releases without a project', async () => {
+    render(
+      <CustomResolutionModal
+        Header={p => <span>{p.children}</span>}
+        Body={wrapper()}
+        Footer={wrapper()}
+        project={undefined}
+        onSelected={jest.fn()}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(() => null)}
+      />
+    );
+
+    await waitFor(() =>
+      expect(releasesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({query: {query: ''}})
+      )
+    );
   });
 
   it('indicates which releases had commits from the user', async () => {
@@ -81,7 +105,7 @@ describe('CustomResolutionModal', () => {
 
   it('indicates if the release is semver or timestamp', async () => {
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
+      url: '/organizations/org-slug/releases/',
       body: [
         // Timestamp release
         ReleaseFixture({
@@ -134,7 +158,7 @@ describe('CustomResolutionModal', () => {
 
   it('treats a release without version info as non-semver', async () => {
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/releases/',
+      url: '/organizations/org-slug/releases/',
       body: [
         ReleaseFixture({
           version: 'legacy-release',

--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -10,6 +11,7 @@ import {CustomResolutionModal} from 'sentry/components/customResolutionModal';
 import {ConfigStore} from 'sentry/stores/configStore';
 
 describe('CustomResolutionModal', () => {
+  const project = ProjectFixture({id: '1', slug: 'project-slug'});
   let releasesMock: any;
   beforeEach(() => {
     ConfigStore.init();
@@ -32,7 +34,7 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        projectSlug="project-slug"
+        project={project}
         onSelected={onSelected}
         closeModal={jest.fn()}
         CloseButton={makeCloseButton(() => null)}
@@ -44,6 +46,11 @@ describe('CustomResolutionModal', () => {
     await userEvent.click(trigger);
     const option = await screen.findByRole('option', {name: /1\.2\.0/});
     await userEvent.click(option);
+
+    expect(screen.getByRole('link', {name: /view release/i})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/releases/sentry-android-shop%401.2.0/?project=1'
+    );
 
     await userEvent.click(screen.getByText('Resolve'));
     expect(onSelected).toHaveBeenCalledWith({
@@ -59,7 +66,7 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        projectSlug="project-slug"
+        project={project}
         onSelected={jest.fn()}
         closeModal={jest.fn()}
         CloseButton={makeCloseButton(() => null)}
@@ -110,7 +117,7 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        projectSlug="project-slug"
+        project={project}
         onSelected={jest.fn()}
         closeModal={jest.fn()}
         CloseButton={makeCloseButton(() => null)}
@@ -125,6 +132,64 @@ describe('CustomResolutionModal', () => {
     expect(screen.getByRole('option', {name: '1.2.3 (semver)'})).toBeInTheDocument();
   });
 
+  it('treats a release without version info as non-semver', async () => {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/releases/',
+      body: [
+        ReleaseFixture({
+          version: 'legacy-release',
+          versionInfo: null,
+        }),
+      ],
+    });
+
+    render(
+      <CustomResolutionModal
+        Header={p => <span>{p.children}</span>}
+        Body={wrapper()}
+        Footer={wrapper()}
+        project={project}
+        onSelected={jest.fn()}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(() => null)}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /version/i}));
+
+    expect(
+      await screen.findByRole('option', {name: 'legacy-release (non-semver)'})
+    ).toBeInTheDocument();
+  });
+
+  it('ignores a collection response from an exact release lookup', async () => {
+    const exactReleaseMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/.0/',
+      body: [ReleaseFixture({version: 'unexpected-collection-release'})],
+    });
+
+    render(
+      <CustomResolutionModal
+        Header={p => <span>{p.children}</span>}
+        Body={wrapper()}
+        Footer={wrapper()}
+        project={project}
+        onSelected={jest.fn()}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(() => null)}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: /version/i}));
+    const searchInput = await screen.findByRole('textbox');
+    await userEvent.click(searchInput);
+    await userEvent.paste('.0');
+
+    await waitFor(() => expect(exactReleaseMock).toHaveBeenCalled());
+    expect(await screen.findByRole('option', {name: /1\.2\.0/})).toBeInTheDocument();
+    expect(screen.queryByText('unexpected-collection-release')).not.toBeInTheDocument();
+  });
+
   it('shows an inline error when submitting with no selection', async () => {
     const onSelected = jest.fn();
     render(
@@ -132,7 +197,7 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        projectSlug="project-slug"
+        project={project}
         onSelected={onSelected}
         closeModal={jest.fn()}
         CloseButton={makeCloseButton(() => null)}
@@ -167,7 +232,7 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        projectSlug="project-slug"
+        project={project}
         onSelected={jest.fn()}
         closeModal={jest.fn()}
         CloseButton={makeCloseButton(() => null)}
@@ -212,7 +277,7 @@ describe('CustomResolutionModal', () => {
         Header={p => <span>{p.children}</span>}
         Body={wrapper()}
         Footer={wrapper()}
-        projectSlug="project-slug"
+        project={project}
         onSelected={jest.fn()}
         closeModal={jest.fn()}
         CloseButton={makeCloseButton(() => null)}

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import {useQuery} from '@tanstack/react-query';
+import {skipToken, useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
@@ -14,20 +14,28 @@ import {Version} from 'sentry/components/version';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
+import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {isVersionInfoSemver} from 'sentry/views/explore/releases/utils';
+import {makeReleasesPathname} from 'sentry/views/explore/releases/utils/pathnames';
+
+function canLookupExactRelease(version: string): boolean {
+  return version.length > 0 && !/^\.\.?$/.test(version);
+}
 
 function makeReleaseOption(
   release: Release,
-  currentUserEmail?: string
+  currentUserEmail: string | undefined
 ): SelectOption<string> {
   const isAuthor = release.authors?.some(
     author => author.email && author.email === currentUserEmail
   );
+  const isSemver = release.versionInfo
+    ? isVersionInfoSemver(release.versionInfo.version)
+    : false;
 
   return {
     value: release.version,
@@ -37,14 +45,10 @@ function makeReleaseOption(
           <Fragment>{release.versionInfo.package}@</Fragment>
         )}
         <Version version={release.version} anchor={false} />{' '}
-        {isVersionInfoSemver(release.versionInfo.version)
-          ? t('(semver)')
-          : t('(non-semver)')}
+        {isSemver ? t('(semver)') : t('(non-semver)')}
       </span>
     ),
-    textValue: release.versionInfo?.package
-      ? `${release.versionInfo.package}@${release.version}`
-      : release.version,
+    textValue: release.version,
     details: (
       <span>
         {t('Created')} <TimeSince date={release.dateCreated} />
@@ -69,79 +73,82 @@ function getUniqueReleases(releases: Array<Release | null | undefined>): Release
 
 interface CustomResolutionModalProps extends ModalRenderProps {
   onSelected: (change: {inRelease: string}) => void;
-  projectSlug: string | undefined;
+  project: Project;
 }
 
 export function CustomResolutionModal(props: CustomResolutionModalProps) {
   const organization = useOrganization();
-  const [version, setVersion] = useState('');
   const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearch = useDebouncedValue(searchQuery);
   const currentUser = ConfigStore.get('user');
   const [selectionError, setSelectionError] = useState<string | null>(null);
 
-  const releaseListOptions = props.projectSlug
-    ? apiOptions.as<Release[]>()(
-        '/projects/$organizationIdOrSlug/$projectIdOrSlug/releases/',
-        {
-          path: {
-            organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: props.projectSlug,
-          },
-          query: {query: debouncedSearch},
-          staleTime: 60_000,
-        }
-      )
-    : apiOptions.as<Release[]>()('/organizations/$organizationIdOrSlug/releases/', {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {query: debouncedSearch},
-        staleTime: 60_000,
-      });
+  const releaseListOptions = apiOptions.as<Release[]>()(
+    '/projects/$organizationIdOrSlug/$projectIdOrSlug/releases/',
+    {
+      path: {
+        organizationIdOrSlug: organization.slug,
+        projectIdOrSlug: props.project.slug,
+      },
+      query: {query: debouncedSearch},
+      staleTime: 60_000,
+    }
+  );
 
   const {data: releases = [], isFetching} = useQuery({
     ...releaseListOptions,
     retry: false,
   });
 
-  const shouldLookupExact = debouncedSearch.trim().length > 0;
+  const exactSearch = debouncedSearch.trim();
+  const shouldLookupExact = canLookupExactRelease(exactSearch);
 
   // Attempt to find the exact release, the list is capped at the most recent 100 releases
-  const {data: exactRelease} = useQuery({
-    ...apiOptions.as<Release>()(
+  const {data: exactReleaseResponse} = useQuery({
+    ...apiOptions.as<Release | Release[]>()(
       '/organizations/$organizationIdOrSlug/releases/$version/',
       {
-        path: {
-          organizationIdOrSlug: organization.slug,
-          version: debouncedSearch.trim(),
-        },
+        path: shouldLookupExact
+          ? {
+              organizationIdOrSlug: organization.slug,
+              version: exactSearch,
+            }
+          : skipToken,
         staleTime: 30_000,
       }
     ),
-    enabled: shouldLookupExact,
     retry: false,
   });
+  // Guard against intermediaries normalizing the detail URL to the releases collection.
+  const exactRelease = Array.isArray(exactReleaseResponse)
+    ? undefined
+    : exactReleaseResponse;
 
-  const options = useMemo((): Array<SelectOption<string>> => {
-    const prioritizedReleases = debouncedSearch.trim()
-      ? [exactRelease, ...releases]
-      : [selectedRelease, ...releases];
+  const visibleReleases = useMemo(
+    () =>
+      getUniqueReleases(
+        exactSearch ? [exactRelease, ...releases] : [selectedRelease, ...releases]
+      ),
+    [exactRelease, exactSearch, releases, selectedRelease]
+  );
 
-    return getUniqueReleases(prioritizedReleases).map(release =>
-      makeReleaseOption(release, currentUser?.email)
-    );
-  }, [currentUser?.email, debouncedSearch, exactRelease, releases, selectedRelease]);
+  const options = useMemo(
+    (): Array<SelectOption<string>> =>
+      visibleReleases.map(release => makeReleaseOption(release, currentUser?.email)),
+    [currentUser?.email, visibleReleases]
+  );
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!version) {
+    if (!selectedRelease) {
       setSelectionError(t('Please select a release.'));
       return;
     }
 
     setSearchQuery('');
     setSelectionError(null);
-    props.onSelected({inRelease: version});
+    props.onSelected({inRelease: selectedRelease.version});
     props.closeModal();
   };
   const {Header, Body, Footer} = props;
@@ -161,16 +168,14 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
             onChange: setSearchQuery,
           }}
           options={options}
-          value={version}
+          value={selectedRelease?.version ?? ''}
           loading={isFetching}
           emptyMessage={isFetching ? t('Loading releases\u2026') : t('No releases found')}
           onChange={option => {
             const selectedVersion = option?.value ? String(option.value) : '';
-            const visibleReleases = getUniqueReleases([exactRelease, ...releases]);
             const release =
               visibleReleases.find(item => item.version === selectedVersion) ?? null;
 
-            setVersion(selectedVersion);
             setSelectedRelease(release);
             setSelectionError(null);
             setSearchQuery('');
@@ -183,7 +188,7 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
               prefix={t('Version')}
               aria-label={t('Version')}
             >
-              {version
+              {selectedRelease
                 ? triggerProps.children
                 : isFetching
                   ? t('Loading\u2026')
@@ -194,14 +199,13 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
         />
         {selectionError ? <ErrorText role="alert">{selectionError}</ErrorText> : null}
         <Container marginTop="md">
-          {version ? (
+          {selectedRelease ? (
             // Open release in new tab to avoid closing the modal
             <ExternalLink
-              href={normalizeUrl(
-                `/organizations/${organization.slug}/releases/${encodeURIComponent(version)}/${
-                  props.projectSlug ? `?project=${props.projectSlug}` : ''
-                }`
-              )}
+              href={`${makeReleasesPathname({
+                organization,
+                path: `/${encodeURIComponent(selectedRelease.version)}/`,
+              })}?project=${props.project.id}`}
               openInNewTab
             >
               <Flex align="center" gap="xs">

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -73,7 +73,7 @@ function getUniqueReleases(releases: Array<Release | null | undefined>): Release
 
 interface CustomResolutionModalProps extends ModalRenderProps {
   onSelected: (change: {inRelease: string}) => void;
-  project: Project;
+  project: Project | undefined;
 }
 
 export function CustomResolutionModal(props: CustomResolutionModalProps) {
@@ -84,20 +84,12 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
   const currentUser = ConfigStore.get('user');
   const [selectionError, setSelectionError] = useState<string | null>(null);
 
-  const releaseListOptions = apiOptions.as<Release[]>()(
-    '/projects/$organizationIdOrSlug/$projectIdOrSlug/releases/',
-    {
-      path: {
-        organizationIdOrSlug: organization.slug,
-        projectIdOrSlug: props.project.slug,
-      },
-      query: {query: debouncedSearch},
-      staleTime: 60_000,
-    }
-  );
-
   const {data: releases = [], isFetching} = useQuery({
-    ...releaseListOptions,
+    ...apiOptions.as<Release[]>()('/organizations/$organizationIdOrSlug/releases/', {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {project: props.project?.id, query: debouncedSearch},
+      staleTime: 60_000,
+    }),
     retry: false,
   });
 
@@ -205,7 +197,7 @@ export function CustomResolutionModal(props: CustomResolutionModalProps) {
               href={`${makeReleasesPathname({
                 organization,
                 path: `/${encodeURIComponent(selectedRelease.version)}/`,
-              })}?project=${props.project.id}`}
+              })}${props.project ? `?project=${props.project.id}` : ''}`}
               openInNewTab
             >
               <Flex align="center" gap="xs">

--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -93,7 +93,7 @@ interface ReleaseData {
   lastEvent: string;
   // TODO(ts)
   newGroups: number;
-  versionInfo: VersionInfo;
+  versionInfo: VersionInfo | null;
   adoptionStages?: Record<
     string,
     {
@@ -138,7 +138,7 @@ export type ReleaseMeta = {
   releaseFileCount: number;
   released: string;
   version: string;
-  versionInfo: VersionInfo;
+  versionInfo: VersionInfo | null;
 };
 
 /**

--- a/static/app/views/explore/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/explore/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -138,13 +138,15 @@ export function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
                 </Tooltip>
               </Flex>
             }
-            value={isVersionInfoSemver(versionInfo.version) ? t('Yes') : t('No')}
+            value={
+              versionInfo && isVersionInfoSemver(versionInfo.version) ? t('Yes') : t('No')
+            }
           />
           <KeyValueTableRow
             keyName={t('Package')}
             value={
               <StyledTextOverflow ellipsisDirection="left">
-                {versionInfo.package ?? '\u2014'}
+                {versionInfo?.package ?? '\u2014'}
               </StyledTextOverflow>
             }
           />

--- a/static/app/views/explore/releases/drawer/generalCard.tsx
+++ b/static/app/views/explore/releases/drawer/generalCard.tsx
@@ -53,6 +53,7 @@ export function GeneralCard({
         key: t('Semver'),
         subject: t('Semver'),
         value: releaseDetails ? (
+          releaseDetails.versionInfo &&
           isVersionInfoSemver(releaseDetails.versionInfo.version) ? (
             t('Yes')
           ) : (
@@ -68,7 +69,7 @@ export function GeneralCard({
         key: t('Package'),
         subject: t('Package'),
         value: releaseDetails ? (
-          (releaseDetails.versionInfo.package ?? '\u2014')
+          (releaseDetails.versionInfo?.package ?? '\u2014')
         ) : (
           <TinyPlaceholder />
         ),

--- a/static/app/views/explore/releases/drawer/newIssues.tsx
+++ b/static/app/views/explore/releases/drawer/newIssues.tsx
@@ -40,7 +40,9 @@ export function NewIssues({release, projectId, withChart = false}: Props) {
       queryParams={queryParams}
       query={
         releaseDetails
-          ? `release:"${escapeDoubleQuotes(releaseDetails?.versionInfo.version.raw)}"`
+          ? `release:"${escapeDoubleQuotes(
+              releaseDetails.versionInfo?.version.raw ?? releaseDetails.version
+            )}"`
           : ''
       }
       canSelectGroups={false}

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -525,7 +525,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                 latestRelease={project.latestRelease}
                 hasSemverReleaseFeature={hasSemverReleaseFeature}
                 onUpdate={onUpdate}
-                projectSlug={project.slug}
+                project={project}
                 isResolved={isResolved}
                 isAutoResolved={isAutoResolved}
                 size="sm"

--- a/static/app/views/issueList/actions/resolveActions.tsx
+++ b/static/app/views/issueList/actions/resolveActions.tsx
@@ -55,7 +55,7 @@ export function ResolveActionsContainer({
       hasRelease={hasRelease}
       multipleProjectsSelected={!selectedProjectSlug}
       latestRelease={latestRelease}
-      projectSlug={project?.slug}
+      project={project ?? undefined}
       onUpdate={onUpdate}
       shouldConfirm={onShouldConfirm(ConfirmAction.RESOLVE)}
       confirmMessage={confirm({action: ConfirmAction.RESOLVE, canBeUndone: true})}


### PR DESCRIPTION
Typing `.` in the resolved-in release modal could normalize the exact release request to the releases collection and crash when the response was treated as a single release.

Skip URL dot segments, guard the response shape, and handle nullable version info. Also keeps the selected release as the single source of truth and fixes the Explore release link to use the project id.

fixes JAVASCRIPT-39MQ
fixes #119995