### PR TITLE
feat(integrations): add action-row layout to the create-integration modal

### DIFF
--- a/static/app/components/modals/createNewIntegrationModal.spec.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.spec.tsx
@@ -1,0 +1,46 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import CreateNewIntegrationModal from 'sentry/components/modals/createNewIntegrationModal';
+
+describe('CreateNewIntegrationModal', () => {
+  it('chooses the integration type with radios by default', () => {
+    renderGlobalModal();
+
+    act(() => openModal(modalProps => <CreateNewIntegrationModal {...modalProps} />));
+
+    expect(screen.getByText('Internal Integration')).toBeInTheDocument();
+    expect(screen.getByText('Public Integration')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+
+    expect(screen.getByRole('button', {name: 'Next'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/developer-settings/new-internal/'
+    );
+  });
+
+  it('offers starting from scratch', () => {
+    renderGlobalModal({
+      organization: OrganizationFixture({
+        features: ['sentry-apps-creation-templates'],
+      }),
+    });
+
+    act(() => openModal(modalProps => <CreateNewIntegrationModal {...modalProps} />));
+
+    expect(screen.getByText('Internal Integration')).toBeInTheDocument();
+    expect(screen.getByText('Public Integration')).toBeInTheDocument();
+
+    const buttons = screen.getAllByRole('button', {name: 'Get started'});
+    expect(buttons[0]).toHaveAttribute(
+      'href',
+      '/settings/org-slug/developer-settings/new-internal/'
+    );
+    expect(buttons[1]).toHaveAttribute(
+      'href',
+      '/settings/org-slug/developer-settings/new-public/'
+    );
+  });
+});

--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -5,8 +5,9 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
@@ -24,7 +25,11 @@ const analyticsView = 'new_integration_modal';
 function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRenderProps) {
   const theme = useTheme();
   const organization = useOrganization();
+  const hasCreationTemplates = organization.features.includes(
+    'sentry-apps-creation-templates'
+  );
   const [option, selectOption] = useState('internal');
+  const baseUrl = `/settings/${organization.slug}/developer-settings/`;
   const choices = [
     [
       'internal',
@@ -99,43 +104,150 @@ function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRend
             )}
           </Alert>
         </Alert.Container>
-        <StyledRadioGroup
-          choices={choices}
-          label={t('Avatar Type')}
-          onChange={value => selectOption(value)}
-          value={option}
-        />
+        {hasCreationTemplates ? (
+          <Stack gap="xl">
+            <Stack gap="sm">
+              <Text bold>{t('Start from scratch')}</Text>
+              <Stack border="primary" radius="md">
+                <ChoiceRow
+                  title={t('Internal Integration')}
+                  description={tct(
+                    'Internal integrations are meant for custom integrations unique to your organization. See more info on [docsLink].',
+                    {
+                      docsLink: (
+                        <ExternalLink
+                          href={platformEventLinkMap[PlatformEvents.INTERNAL_DOCS]}
+                          onClick={() => {
+                            trackIntegrationAnalytics(PlatformEvents.INTERNAL_DOCS, {
+                              organization,
+                              view: analyticsView,
+                            });
+                          }}
+                        >
+                          {t('Internal Integrations')}
+                        </ExternalLink>
+                      ),
+                    }
+                  )}
+                  action={
+                    <LinkButton
+                      variant="secondary"
+                      size="sm"
+                      to={`${baseUrl}new-internal/`}
+                      onClick={() => {
+                        trackIntegrationAnalytics(PlatformEvents.CHOSE_INTERNAL, {
+                          organization,
+                          view: analyticsView,
+                        });
+                        closeModal();
+                      }}
+                    >
+                      {t('Get started')}
+                    </LinkButton>
+                  }
+                />
+                <Stack.Separator />
+                <ChoiceRow
+                  title={t('Public Integration')}
+                  description={tct(
+                    'A public integration will be available for all Sentry users for installation. See more info on [docsLink].',
+                    {
+                      docsLink: (
+                        <ExternalLink
+                          href={platformEventLinkMap[PlatformEvents.PUBLIC_DOCS]}
+                          onClick={() => {
+                            trackIntegrationAnalytics(PlatformEvents.PUBLIC_DOCS, {
+                              organization,
+                              view: analyticsView,
+                            });
+                          }}
+                        >
+                          {t('Public Integrations')}
+                        </ExternalLink>
+                      ),
+                    }
+                  )}
+                  action={
+                    <LinkButton
+                      variant="secondary"
+                      size="sm"
+                      to={`${baseUrl}new-public/`}
+                      onClick={() => {
+                        trackIntegrationAnalytics(PlatformEvents.CHOSE_PUBLIC, {
+                          organization,
+                          view: analyticsView,
+                        });
+                        closeModal();
+                      }}
+                    >
+                      {t('Get started')}
+                    </LinkButton>
+                  }
+                />
+              </Stack>
+            </Stack>
+          </Stack>
+        ) : (
+          <StyledRadioGroup
+            choices={choices}
+            label={t('Integration Type')}
+            onChange={value => selectOption(value)}
+            value={option}
+          />
+        )}
       </Body>
       <Footer>
         <Button
           size="sm"
           onClick={() => closeModal()}
-          style={{marginRight: theme.space.md}}
+          style={hasCreationTemplates ? undefined : {marginRight: theme.space.md}}
         >
           {t('Cancel')}
         </Button>
-        <LinkButton
-          variant="primary"
-          size="sm"
-          to={`/settings/${organization.slug}/developer-settings/${
-            option === 'public' ? 'new-public' : 'new-internal'
-          }/`}
-          onClick={() => {
-            trackIntegrationAnalytics(
-              option === 'public'
-                ? PlatformEvents.CHOSE_PUBLIC
-                : PlatformEvents.CHOSE_INTERNAL,
-              {
-                organization,
-                view: analyticsView,
-              }
-            );
-          }}
-        >
-          {t('Next')}
-        </LinkButton>
+        {!hasCreationTemplates && (
+          <LinkButton
+            variant="primary"
+            size="sm"
+            to={`${baseUrl}${option === 'public' ? 'new-public' : 'new-internal'}/`}
+            onClick={() => {
+              trackIntegrationAnalytics(
+                option === 'public'
+                  ? PlatformEvents.CHOSE_PUBLIC
+                  : PlatformEvents.CHOSE_INTERNAL,
+                {
+                  organization,
+                  view: analyticsView,
+                }
+              );
+            }}
+          >
+            {t('Next')}
+          </LinkButton>
+        )}
       </Footer>
     </Fragment>
+  );
+}
+
+function ChoiceRow({
+  title,
+  description,
+  action,
+}: {
+  action: ReactNode;
+  description: ReactNode;
+  title: ReactNode;
+}) {
+  return (
+    <Flex justify="between" align="center" gap="xl" padding="md lg">
+      <Stack gap="2xs">
+        <Text bold>{title}</Text>
+        <Text variant="muted" size="sm">
+          {description}
+        </Text>
+      </Stack>
+      {action}
+    </Flex>
   );
 }
 
@@ -145,6 +257,7 @@ const StyledRadioGroup = styled(RadioGroup)`
     padding-bottom: ${p => p.theme.space.md};
   }
 `;
+
 const RadioChoiceHeader = styled('h6')`
   margin: 0;
 `;


### PR DESCRIPTION
Restyle the 'create custom integration' modal in preparation of supporting templates. It (will) look like this:
<img width="1192" height="1084" alt="image" src="https://github.com/user-attachments/assets/21ad8541-97fd-48f0-ae03-6a353e2d7540" />

This particular change moves us from radio buttons to this action button layout.
