### PR TITLE
feat(preprod): Add git SHAs to default preprod search attributes

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -112,7 +112,9 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'build_number',
   'build_version',
   'git_base_ref',
+  'git_base_sha',
   'git_head_ref',
+  'git_head_sha',
   'platform_name',
   'snapshot_status',
 ];


### PR DESCRIPTION
## Summary

Adds `git_head_sha` and `git_base_sha` to `SENTRY_PREPROD_STRING_TAGS`, the static default attribute list for preprod trace items. This makes both SHAs always available as searchable keys in the search bar on the releases explore **Snapshots** and **Mobile Builds** tabs, consistent with the existing `git_head_ref` / `git_base_ref` fields.

## Background

The preprod search bar's suggested keys are the intersection of a tab's allowed-key list with `(static attribute floor ∪ attributes returned by the EAP /attribute endpoint)`.

Both SHAs were already present in `SNAPSHOT_ALLOWED_KEYS` and `MOBILE_BUILDS_ALLOWED_KEYS`, and both are written to EAP (`src/sentry/preprod/eap/write.py`) whenever an artifact has a commit comparison. But because they were missing from the static floor (`SENTRY_PREPROD_STRING_TAGS`), they only surfaced when the `/attribute` endpoint happened to return them for the selected projects and time range — so they would intermittently disappear from the search bar. Adding them to the floor guarantees they always show, like the git ref fields do.

## Changes

- `static/app/views/explore/constants.tsx`: add `git_base_sha` and `git_head_sha` to `SENTRY_PREPROD_STRING_TAGS`.