### PR TITLE
fix(discover): adjust max pickable days options to mirror spans

### DIFF
--- a/static/app/utils/useMaxPickableDays.tsx
+++ b/static/app/utils/useMaxPickableDays.tsx
@@ -103,7 +103,8 @@ export function getMaxPickableDays(
 ): MaxPickableDaysOptions {
   switch (dataCategory) {
     case DataCategory.SPANS:
-    case DataCategory.SPANS_INDEXED: {
+    case DataCategory.SPANS_INDEXED:
+    case DataCategory.ERRORS: {
       const maxPickableDays = organization.features.includes(
         'visibility-explore-range-high'
       )
@@ -112,7 +113,8 @@ export function getMaxPickableDays(
       return {
         maxPickableDays,
         maxUpgradableDays: MAX_PICKABLE_DAYS,
-        upsellFooter: SpansUpsellFooter,
+        upsellFooter:
+          dataCategory === DataCategory.ERRORS ? ErrorsUpsellFooter : SpansUpsellFooter,
       };
     }
     case DataCategory.TRACE_METRICS:
@@ -147,4 +149,8 @@ const UpsellFooterHook = OverrideOrDefault({
 
 export const SpansUpsellFooter = (
   <UpsellFooterHook description={DESCRIPTION} source="spans" />
+);
+
+export const ErrorsUpsellFooter = (
+  <UpsellFooterHook description={DESCRIPTION} source="errors" />
 );

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -14,6 +14,7 @@ import {
   AiQueryProvider,
   useAiQueryContext,
 } from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
+import {DataCategory} from 'sentry/types/dataCategory';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -21,6 +22,7 @@ import {EventView} from 'sentry/utils/discover/eventView';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
@@ -140,8 +142,14 @@ function Homepage() {
 }
 
 export default function HomepageContainer() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.ERRORS],
+  });
   return (
-    <PageFiltersContainer skipInitializeUrlParams>
+    <PageFiltersContainer
+      skipInitializeUrlParams
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
       <AiQueryProvider>
         <Homepage />
       </AiQueryProvider>

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -28,6 +28,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {useGlobalAlerts} from 'sentry/views/app/globalAlerts';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
+import {getDiscoverDeprecation} from 'sentry/views/discover/utils';
 
 import {Results} from './results';
 
@@ -142,13 +143,16 @@ function Homepage() {
 }
 
 export default function HomepageContainer() {
+  const organization = useOrganization();
   const maxPickableDays = useMaxPickableDays({
     dataCategories: [DataCategory.ERRORS],
   });
   return (
     <PageFiltersContainer
       skipInitializeUrlParams
-      maxPickableDays={maxPickableDays.maxPickableDays}
+      maxPickableDays={
+        getDiscoverDeprecation(organization) ? maxPickableDays.maxPickableDays : undefined
+      }
     >
       <AiQueryProvider>
         <Homepage />

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -47,7 +47,7 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconEllipsis} from 'sentry/icons';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tct, tctCode} from 'sentry/locale';
-import type {PageFilters} from 'sentry/types/core';
+import {DataCategory, type PageFilters} from 'sentry/types/core';
 import {SavedSearchType} from 'sentry/types/group';
 import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -75,6 +75,7 @@ import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -1396,6 +1397,10 @@ function DiscoverPageFilters({
   isHomepage?: boolean;
 }) {
   const {projects} = useProjects();
+  // use the same data category as spans so the time period options across discover and traces are the same
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.ERRORS],
+  });
 
   const currentDataset = getDatasetFromLocationOrSavedQueryDataset(
     location,
@@ -1431,7 +1436,7 @@ function DiscoverPageFilters({
       <PageFilterBar condensed>
         <ProjectPageFilter />
         <EnvironmentPageFilter />
-        <DatePageFilter />
+        <DatePageFilter maxPickableDays={maxPickableDays.maxPickableDays} />
       </PageFilterBar>
       <Flex gap="md" align="center">
         {!shouldHideCreateAlert && (

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -106,6 +106,7 @@ import {
 import Table from 'sentry/views/discover/table';
 import {
   generateTitle,
+  getDiscoverDeprecation,
   getTransactionsDeprecation,
   handleAddQueryToDashboard,
   SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
@@ -1436,7 +1437,13 @@ function DiscoverPageFilters({
       <PageFilterBar condensed>
         <ProjectPageFilter />
         <EnvironmentPageFilter />
-        <DatePageFilter maxPickableDays={maxPickableDays.maxPickableDays} />
+        <DatePageFilter
+          maxPickableDays={
+            getDiscoverDeprecation(organization)
+              ? maxPickableDays.maxPickableDays
+              : undefined
+          }
+        />
       </PageFilterBar>
       <Flex gap="md" align="center">
         {!shouldHideCreateAlert && (

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -1576,6 +1576,9 @@ export default function ResultsContainer() {
   const location = useLocation();
   const navigate = useNavigate();
   const {addAlert} = useGlobalAlerts();
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.ERRORS],
+  });
 
   /**
    * Block `<Results>` from mounting until GSH is ready since there are API
@@ -1592,6 +1595,9 @@ export default function ResultsContainer() {
     <PageFiltersContainer
       disablePersistence={
         organization.features.includes('discover-query') && !!location.query.id
+      }
+      maxPickableDays={
+        getDiscoverDeprecation(organization) ? maxPickableDays.maxPickableDays : undefined
       }
       skipLoadLastUsed={false}
       // The Discover Results component will manage URL params, including page filters state

--- a/static/gsApp/overrides/useMaxPickableDays.tsx
+++ b/static/gsApp/overrides/useMaxPickableDays.tsx
@@ -5,6 +5,7 @@ import {MAX_PICKABLE_DAYS} from 'sentry/constants';
 import {DataCategory} from 'sentry/types/core';
 import {defined} from 'sentry/utils/defined';
 import {
+  ErrorsUpsellFooter,
   getBestMaxPickableDays,
   getMaxPickableDays,
   SpansUpsellFooter,
@@ -115,6 +116,13 @@ function getMaxPickableDaysBySubscription(
       return {
         maxPickableDays: subscription?.planDetails?.retentionDays ?? MAX_PICKABLE_DAYS,
         maxUpgradableDays: MAX_PICKABLE_DAYS,
+      };
+    case DataCategory.ERRORS:
+      return {
+        // we're trying to emulate the spans behavior which uses 30 as a default
+        maxPickableDays: subscription?.planDetails?.retentionDays ?? 30,
+        maxUpgradableDays: MAX_PICKABLE_DAYS,
+        upsellFooter: ErrorsUpsellFooter,
       };
     default:
       return undefined;


### PR DESCRIPTION
In an effort to deprecate discover and surface errors, we wanted to adjust the max pickable days in the date page filter selector. In general we're going to allow full discover functionality on all plan types but will limit by time range selection, just like we do in all other Explore surfaces.

following [these retention periods](https://docs.sentry.io/security-legal-pii/security/data-retention-periods/#default-data-retention-by-plan) in the docs