### PR TITLE
feat(analytics): Attribute project getting-started funnel by variant

### DIFF
--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -137,6 +137,12 @@ export type ProjectCreationEventParameters = {
     project_id: string;
     variant?: ProjectCreationVariant;
   };
+  'project_creation.take_me_to_issues_clicked': {
+    platform: string;
+    products: string[];
+    project_id: string;
+    variant: ProjectCreationVariant;
+  };
 };
 
 export const projectCreationEventMap: Record<
@@ -196,4 +202,6 @@ export const projectCreationEventMap: Record<
     'Project Creation: JS Loader Switch to npm Instructions',
   'project_creation.setup_loader_docs_rendered':
     'Project Creation: Setup Loader Docs Rendered',
+  'project_creation.take_me_to_issues_clicked':
+    'Project Creation: Take Me to Issues Clicked',
 };

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -2,12 +2,15 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
+import * as analytics from 'sentry/utils/analytics';
 import {ProjectInstallPlatform} from 'sentry/views/projectInstall/platform';
+import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
 type ProjectWithBadPlatform = Omit<Project, 'platform'> & {
   platform: string;
@@ -62,10 +65,58 @@ function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatfor
   });
 }
 
+function renderAnalyticsScenario(projectCreationVariant?: string) {
+  const {organization, project} = initializeOrg({
+    router: {params: {projectId: ProjectFixture().slug}},
+  });
+  const platform: PlatformIntegration = {
+    id: 'other',
+    name: 'Other',
+    link: 'https://docs.sentry.io/platforms/',
+    type: 'language',
+    language: 'other',
+  };
+  const projectWithPlatform = {...project, platform: platform.id};
+  const routeAnalytics = {
+    previousUrl: '',
+    setDisableRouteAnalytics: jest.fn(),
+    setEventNames: jest.fn(),
+    setOrganization: jest.fn(),
+    setRouteAnalyticsParams: jest.fn(),
+  };
+
+  ProjectsStore.loadInitialData([projectWithPlatform]);
+  mockProjectApiResponses([projectWithPlatform]);
+  const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+  render(
+    <RouteAnalyticsContext value={routeAnalytics}>
+      <ProjectInstallPlatform project={projectWithPlatform} platform={platform} />
+    </RouteAnalyticsContext>,
+    {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/projects/${project.slug}/getting-started/`,
+          query: {
+            product: [ProductSolution.PERFORMANCE_MONITORING],
+            ...(projectCreationVariant ? {projectCreationVariant} : {}),
+          },
+        },
+      },
+    }
+  );
+
+  return {organization, project: projectWithPlatform, routeAnalytics, trackAnalyticsSpy};
+}
+
 describe('ProjectInstallPlatform', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     ConfigStore.init();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should render NotFound if no matching integration/platform', async () => {
@@ -158,5 +209,65 @@ describe('ProjectInstallPlatform', () => {
     ).toBeInTheDocument();
 
     expect(screen.getByText('Take me to Issues')).toBeInTheDocument();
+  });
+
+  it.each(['scm', 'legacy'] as const)(
+    'attributes getting-started analytics to the %s project-creation variant',
+    async variant => {
+      const {organization, project, routeAnalytics, trackAnalyticsSpy} =
+        renderAnalyticsScenario(variant);
+
+      expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
+        'project_creation.getting_started_viewed',
+        'Project Creation: Getting Started Viewed'
+      );
+      expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+        platform: 'Other',
+        products: [ProductSolution.PERFORMANCE_MONITORING],
+        project_id: project.id,
+        variant,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: 'Take me to Issues'}));
+
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'project_creation.take_me_to_issues_clicked',
+        {
+          organization,
+          platform: 'Other',
+          products: [ProductSolution.PERFORMANCE_MONITORING],
+          project_id: project.id,
+          variant,
+        }
+      );
+      expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+        'onboarding.take_me_to_issues_clicked',
+        expect.anything()
+      );
+    }
+  );
+
+  it('keeps unmarked getting-started clicks in the onboarding counter', async () => {
+    const {organization, project, routeAnalytics, trackAnalyticsSpy} =
+      renderAnalyticsScenario();
+
+    expect(routeAnalytics.setEventNames).not.toHaveBeenCalled();
+    expect(routeAnalytics.setRouteAnalyticsParams).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Take me to Issues'}));
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.take_me_to_issues_clicked',
+      {
+        organization,
+        platform: 'Other',
+        products: [ProductSolution.PERFORMANCE_MONITORING],
+        project_id: project.id,
+      }
+    );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'project_creation.take_me_to_issues_clicked',
+      expect.anything()
+    );
   });
 });

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -22,7 +22,10 @@ import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
+import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -40,10 +43,35 @@ type Props = {
   project: Project;
 };
 
+type ProjectCreationGettingStartedAnalyticsProps = {
+  platform: string;
+  products: ProductSolution[];
+  projectId: string;
+  variant: ProjectCreationVariant;
+};
+
+function ProjectCreationGettingStartedAnalytics({
+  platform,
+  products,
+  projectId,
+  variant,
+}: ProjectCreationGettingStartedAnalyticsProps) {
+  useRouteAnalyticsEventNames(
+    'project_creation.getting_started_viewed',
+    'Project Creation: Getting Started Viewed'
+  );
+  useRouteAnalyticsParams({platform, products, project_id: projectId, variant});
+
+  return null;
+}
+
 export function ProjectInstallPlatform({project, platform}: Props) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
+  const variantQuery = decodeScalar(location.query.projectCreationVariant);
+  const projectCreationVariant =
+    variantQuery === 'scm' || variantQuery === 'legacy' ? variantQuery : undefined;
 
   const isSelfHosted = ConfigStore.get('isSelfHosted');
 
@@ -52,7 +80,6 @@ export function ProjectInstallPlatform({project, platform}: Props) {
   // Attribute setup-docs analytics from the flow that actually created this
   // project. Experiment enrollment alone is insufficient: users can visit
   // getting-started for older or unrelated projects while still enrolled.
-  const projectCreationVariant = decodeScalar(location.query.projectCreationVariant);
   const docsFlow: DocsFlow | undefined =
     projectCreationVariant === 'scm'
       ? 'project-creation-scm'
@@ -96,6 +123,14 @@ export function ProjectInstallPlatform({project, platform}: Props) {
 
   return (
     <Fragment>
+      {projectCreationVariant && (
+        <ProjectCreationGettingStartedAnalytics
+          platform={platform.name ?? 'unknown'}
+          products={products}
+          projectId={project.id}
+          variant={projectCreationVariant}
+        />
+      )}
       {!isSelfHosted && showDocsWithProductSelection && (
         <ProductUnavailableCTA organization={organization} />
       )}
@@ -141,12 +176,20 @@ export function ProjectInstallPlatform({project, platform}: Props) {
           <Button
             variant="primary"
             onClick={() => {
-              trackAnalytics('onboarding.take_me_to_issues_clicked', {
+              const analyticsParams = {
                 organization,
                 platform: platform.name ?? 'unknown',
                 project_id: project.id,
                 products,
-              });
+              };
+              if (projectCreationVariant) {
+                trackAnalytics('project_creation.take_me_to_issues_clicked', {
+                  ...analyticsParams,
+                  variant: projectCreationVariant,
+                });
+              } else {
+                trackAnalytics('onboarding.take_me_to_issues_clicked', analyticsParams);
+              }
               redirectWithProjectSelection({
                 pathname: issueStreamLink,
               });

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -202,8 +202,8 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
           organization,
         }),
         // Carry both the creating flow and upfront product selection into the
-        // setup docs. The flow marker attributes analytics to the SCM variant;
-        // the product query seeds the selected instructions.
+        // setup-docs and getting-started analytics to the SCM variant; the
+        // product query seeds the selected instructions.
         query: {
           projectCreationVariant: 'scm',
           ...(wizardState.selectedFeatures


### PR DESCRIPTION
## TLDR

Attributes the shared project getting-started page and its “Take me to Issues” action to one `project_creation.*` funnel with `variant: 'scm' | 'legacy'`, while leaving unrelated entry points in the existing onboarding counter.

## Details

This PR is stacked above the setup-docs attribution PR (#120143), which establishes the explicit `projectCreationVariant=legacy|scm` forward-navigation marker. This PR consumes that marker for the getting-started funnel rather than owning the navigation plumbing.

`ProjectInstallPlatform` validates the marker before registering `project_creation.getting_started_viewed` through route analytics or firing `project_creation.take_me_to_issues_clicked`. Both events carry the platform, project, products, and variant. Missing or invalid markers deliberately keep the existing `onboarding.take_me_to_issues_clicked` behavior, which avoids relabeling peripheral traffic and ensures each click emits exactly one event.

The component coverage exercises both marked variants and the unmarked fallback, including route-event parameters and explicit assertions that marked clicks do not also fire the onboarding event. The new click event is registered in the project-creation analytics map; the route event remains page-local.

Refs VDY-133
