### PR TITLE
fix(routing): Move legacy event redirect into `OrganizationContext` tree

### DIFF
--- a/static/app/router/routes.spec.tsx
+++ b/static/app/router/routes.spec.tsx
@@ -139,4 +139,19 @@ describe('buildRoutes()', () => {
       expect(matchedPaths).toContain(':catchAll/*');
     });
   });
+
+  it('matches legacy project event redirects under the organization layout', () => {
+    const matchedPaths = getMatchedPaths(
+      buildRoutes(),
+      '/test-org/test-project/events/test-event/'
+    );
+
+    expect(matchedPaths).toEqual([
+      '(layout)',
+      '/',
+      '(layout)',
+      '/:orgId/:projectId/',
+      'events/:eventId/',
+    ]);
+  });
 });

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2754,6 +2754,10 @@ function buildRoutes(): RouteObject[] {
         )
       ),
     },
+    {
+      path: 'events/:eventId/',
+      component: errorHandler(ProjectEventRedirect),
+    },
   ];
   const legacyOrgRedirects: SentryRouteObject = {
     path: '/:orgId/:projectId/',
@@ -2913,10 +2917,6 @@ function buildRoutes(): RouteObject[] {
       {
         path: ':projectId/issues/:groupId/merged/',
         redirectTo: '/organizations/:orgId/issues/:groupId/merged/',
-      },
-      {
-        path: ':projectId/events/:eventId/',
-        component: errorHandler(ProjectEventRedirect),
       },
     ],
   };


### PR DESCRIPTION
Resolves [JAVASCRIPT-367D](https://sentry.sentry.io/issues/7176039804?project=11276).

The legacy route (`/:orgId/:projectId/events/:eventId/`) rendered `ProjectEventRedirect` directly, but it was defined inside `legacyRedirectRoutes` which sits outside of the `OrganizationContext` provider tree. This caused the `useOrganization` call in the component to throw the error on the Sentry issue ("useOrganization called but organization is not set").

This fix moves that route into `legacyOrgRedirectChildren`, where the org context is available when `ProjectEventRedirect` renders.

This fix was created to replace the suboptimal Seer-generated fix [here](https://github.com/getsentry/sentry/pull/119987). 