### PR TITLE
feat(ingest): add option to reprocess events not in nodestore

### DIFF
--- a/src/sentry/consumers/__init__.py
+++ b/src/sentry/consumers/__init__.py
@@ -224,15 +224,27 @@ def ingest_events_options() -> list[click.Option]:
     """
     Options for the "events"-like consumers: `events`, `attachments`, `transactions`.
 
-    This adds a `--reprocess-only-stuck-events`option. If that option is specified, *only* events
-    that were already persisted in the `processing_store` will be processed.
-    Events that never made it to the store, and ones that already made it out of the store are skipped,
-    same as attachments (which are not idempotent, and we would rather not duplicate them).
+    Options added:
+        `--reprocess-only-stuck-events`: *only* events that were already persisted in the `processing_store`
+        will be processed. Events that never made it to the store, and ones that already made it out of the store are skipped,
+        same as attachments (which are not idempotent, and we would rather not duplicate them).
+
+        `--reprocess-only-events-not-in-nodestore`: *only* events whose payload is missing from `nodestore` are processed.
+        This works similarly to `--reprocess-only-stuck-events`, but can be used to reprocess events that were stuck
+        in redis, but then purged.
     """
     options = multiprocessing_options(default_max_batch_size=100)
     options.append(
         click.Option(
             ["--reprocess-only-stuck-events", "reprocess_only_stuck_events"],
+            type=bool,
+            is_flag=True,
+            default=False,
+        )
+    )
+    options.append(
+        click.Option(
+            ["--reprocess-only-events-not-in-nodestore", "reprocess_only_events_not_in_nodestore"],
             type=bool,
             is_flag=True,
             default=False,

--- a/src/sentry/ingest/consumer/attachment_event.py
+++ b/src/sentry/ingest/consumer/attachment_event.py
@@ -45,6 +45,9 @@ def decode_and_process_chunks(
         message: IngestMessage = msgpack.unpackb(raw_payload, use_list=False)
 
         if message["type"] == "attachment_chunk":
+            # Stuck events already have their chunks assembled in the cache, so we skip re-storing
+            # them. When reprocessing events missing from nodestore however, we *do* need to store
+            # the chunks again, as the (re)processed event depends on them being present.
             if not reprocess_only_stuck_events:
                 process_attachment_chunk(message)
             return None
@@ -61,7 +64,9 @@ def decode_and_process_chunks(
 
 
 def process_attachments_and_events(
-    raw_message: Message[IngestMessage], reprocess_only_stuck_events: bool
+    raw_message: Message[IngestMessage],
+    reprocess_only_stuck_events: bool,
+    reprocess_only_events_not_in_nodestore: bool,
 ) -> None:
     """
     The second pass for the `attachments` topic processes *individual* `attachments`
@@ -88,7 +93,9 @@ def process_attachments_and_events(
 
     try:
         if message_type == "attachment":
-            if not reprocess_only_stuck_events:
+            # Individual attachments are not idempotent, so we skip them in either reprocessing
+            # mode to avoid duplicating attachments for events that were already handled.
+            if not reprocess_only_stuck_events and not reprocess_only_events_not_in_nodestore:
                 process_individual_attachment(message, project)
         elif message_type == "event":
             process_event(
@@ -96,6 +103,7 @@ def process_attachments_and_events(
                 message,
                 project,
                 reprocess_only_stuck_events,
+                reprocess_only_events_not_in_nodestore,
             )
         elif message_type == "user_report":
             process_userreport(message, project)

--- a/src/sentry/ingest/consumer/factory.py
+++ b/src/sentry/ingest/consumer/factory.py
@@ -63,6 +63,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         self,
         consumer_type: str,
         reprocess_only_stuck_events: bool,
+        reprocess_only_events_not_in_nodestore: bool,
         stop_at_timestamp: int | None,
         num_processes: int,
         max_batch_size: int,
@@ -70,9 +71,15 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         input_block_size: int | None,
         output_block_size: int | None,
     ):
+        if reprocess_only_stuck_events and reprocess_only_events_not_in_nodestore:
+            raise ValueError(
+                "`reprocess_only_stuck_events` and `reprocess_only_events_not_in_nodestore` "
+                "are mutually exclusive"
+            )
         self.consumer_type = consumer_type
         self.is_attachment_topic = consumer_type == ConsumerType.Attachments
         self.reprocess_only_stuck_events = reprocess_only_stuck_events
+        self.reprocess_only_events_not_in_nodestore = reprocess_only_events_not_in_nodestore
         self.stop_at_timestamp = stop_at_timestamp
 
         self.multi_process = None
@@ -105,6 +112,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
                 process_simple_event_message,
                 consumer_type=self.consumer_type,
                 reprocess_only_stuck_events=self.reprocess_only_stuck_events,
+                reprocess_only_events_not_in_nodestore=self.reprocess_only_events_not_in_nodestore,
             )
             next_step = maybe_multiprocess_step(mp, event_function, final_step, self._pool)
             return create_backpressure_step(health_checker=self.health_checker, next_step=next_step)
@@ -123,6 +131,7 @@ class IngestStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         processing_function = partial(
             process_attachments_and_events,
             reprocess_only_stuck_events=self.reprocess_only_stuck_events,
+            reprocess_only_events_not_in_nodestore=self.reprocess_only_events_not_in_nodestore,
         )
         step_2 = maybe_multiprocess_step(
             mp, processing_function, final_step, self._attachments_pool
@@ -170,6 +179,7 @@ class IngestTransactionsStrategyFactory(ProcessingStrategyFactory[KafkaPayload])
     def __init__(
         self,
         reprocess_only_stuck_events: bool,
+        reprocess_only_events_not_in_nodestore: bool,
         stop_at_timestamp: int | None,
         num_processes: int,
         max_batch_size: int,
@@ -177,8 +187,14 @@ class IngestTransactionsStrategyFactory(ProcessingStrategyFactory[KafkaPayload])
         input_block_size: int | None,
         output_block_size: int | None,
     ):
+        if reprocess_only_stuck_events and reprocess_only_events_not_in_nodestore:
+            raise ValueError(
+                "`reprocess_only_stuck_events` and `reprocess_only_events_not_in_nodestore` "
+                "are mutually exclusive"
+            )
         self.consumer_type = ConsumerType.Transactions
         self.reprocess_only_stuck_events = reprocess_only_stuck_events
+        self.reprocess_only_events_not_in_nodestore = reprocess_only_events_not_in_nodestore
         self.stop_at_timestamp = stop_at_timestamp
 
         self.multi_process = None
@@ -204,6 +220,7 @@ class IngestTransactionsStrategyFactory(ProcessingStrategyFactory[KafkaPayload])
             process_simple_event_message,
             consumer_type=self.consumer_type,
             reprocess_only_stuck_events=self.reprocess_only_stuck_events,
+            reprocess_only_events_not_in_nodestore=self.reprocess_only_events_not_in_nodestore,
         )
         next_step = maybe_multiprocess_step(mp, event_function, final_step, self._pool)
         return create_backpressure_step(health_checker=self.health_checker, next_step=next_step)

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.cache import cache
 from usageaccountant import UsageUnit
 
-from sentry import features
+from sentry import features, nodestore
 from sentry.attachments import CachedAttachment, attachment_cache, store_attachments_for_event
 from sentry.constants import DataCategory
 from sentry.event_manager import save_attachment
@@ -21,6 +21,7 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.services import eventstore
+from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.processing import (
     event_processing_store,
     transaction_processing_store,
@@ -80,6 +81,7 @@ def process_event(
     message: IngestMessage,
     project: Project,
     reprocess_only_stuck_events: bool = False,
+    reprocess_only_events_not_in_nodestore: bool = False,
     inline_save_event: bool = False,
     inline_save_event_transaction: bool = False,
 ) -> None:
@@ -183,6 +185,14 @@ def process_event(
                 op="event_processing_store.exists", name="event_processing_store.exists"
             ):
                 if not processing_store.exists(data):
+                    return
+
+        # If we only want to reprocess events that never made it into `nodestore`, we check whether the event body has
+        # already been persisted. We only continue here if the event is *not* present.
+        if reprocess_only_events_not_in_nodestore:
+            with start_span(op="nodestore.exists", name="nodestore.exists"):
+                node_id = Event.generate_node_id(project_id, event_id)
+                if nodestore.backend.get(node_id) is not None:
                     return
 
         attachment_objects = [

--- a/src/sentry/ingest/consumer/simple_event.py
+++ b/src/sentry/ingest/consumer/simple_event.py
@@ -27,6 +27,7 @@ def process_simple_event_message(
     raw_message: Message[KafkaPayload],
     consumer_type: str,
     reprocess_only_stuck_events: bool,
+    reprocess_only_events_not_in_nodestore: bool,
 ) -> None:
     """
     Processes a single Kafka Message containing a "simple" Event payload.
@@ -70,6 +71,7 @@ def process_simple_event_message(
             message,
             project,
             reprocess_only_stuck_events,
+            reprocess_only_events_not_in_nodestore,
         )
 
     except Exception as exc:

--- a/tests/sentry/ingest/ingest_consumer/test_dlq.py
+++ b/tests/sentry/ingest/ingest_consumer/test_dlq.py
@@ -71,6 +71,7 @@ def test_dlq_invalid_messages(factories, topic_name: str, consumer_type: Consume
     factory = IngestStrategyFactory(
         consumer_type,
         reprocess_only_stuck_events=False,
+        reprocess_only_events_not_in_nodestore=False,
         stop_at_timestamp=False,
         num_processes=1,
         max_batch_size=1,

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -8,10 +8,12 @@ import orjson
 import pytest
 from django.conf import settings
 
+from sentry import nodestore
 from sentry.conf.types.kafka_definition import Topic
 from sentry.consumers import get_stream_processor
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.services.eventstore.models import Event
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_kafka, requires_snuba
@@ -184,4 +186,69 @@ def test_ingest_consumer_gets_event_unstuck(
     assert message.data["extra"]["the_id"] == event_id2
 
     # the first event was never "stuck", so we expect it to be skipped
+    assert not eventstore.backend.get_event_by_id(default_project.id, event_id1)
+
+
+@django_db_all(transaction=True)
+def test_ingest_consumer_reprocesses_events_not_in_nodestore(
+    task_runner,
+    kafka_producer,
+    kafka_admin,
+    default_project,
+    get_test_message,
+    random_group_id,
+):
+    topic = Topic.INGEST_EVENTS
+    topic_event_name = get_topic_definition(topic)["real_topic_name"]
+
+    admin = kafka_admin(settings)
+    admin.delete_topic(topic_event_name)
+    producer = kafka_producer(settings)
+
+    create_topics("default", [topic_event_name])
+
+    message1, event_id1 = get_test_message(type="event")
+    producer.produce(topic_event_name, message1)
+
+    message2, event_id2 = get_test_message(type="event")
+    producer.produce(topic_event_name, message2)
+
+    # the first event already made it to `nodestore`, so lets fake that:
+    nodestore.backend.set(
+        Event.generate_node_id(default_project.id, event_id1),
+        {"event_id": event_id1, "project": default_project.id, "timestamp": time.time()},
+    )
+
+    consumer = get_stream_processor(
+        "ingest-events",
+        consumer_args=[
+            "--max-batch-size=2",
+            "--max-batch-time-ms=5000",
+            "--processes=10",
+            "--reprocess-only-events-not-in-nodestore",
+        ],
+        topic=None,
+        group_id=random_group_id,
+        auto_offset_reset="earliest",
+        strict_offset_reset=False,
+        enforce_schema=True,
+    )
+
+    with task_runner():
+        i = 0
+        while i < MAX_POLL_ITERATIONS:
+            message = eventstore.backend.get_event_by_id(default_project.id, event_id2)
+
+            if message:
+                break
+
+            consumer._run_once()
+            i += 1
+
+    # the second event was missing from `nodestore`, so we expect it to be processed
+    assert message is not None
+    assert message.data["event_id"] == event_id2
+    assert message.data["extra"]["the_id"] == event_id2
+
+    # the first event was already in `nodestore`, so we expect it to be skipped
     assert not eventstore.backend.get_event_by_id(default_project.id, event_id1)

--- a/tests/sentry/processing/backpressure/test_checking.py
+++ b/tests/sentry/processing/backpressure/test_checking.py
@@ -72,6 +72,7 @@ def process_one_message(payload: str) -> None:
     processing_strategy = IngestStrategyFactory(
         consumer_type=ConsumerType.Events,
         reprocess_only_stuck_events=False,
+        reprocess_only_events_not_in_nodestore=False,
         stop_at_timestamp=None,
         num_processes=1,
         max_batch_size=10,


### PR DESCRIPTION
This PR adds a `--reprocess-only-events-not-in-nodestore` flag to our ingest consumers, which works like `--reprocess-only-stuck-events`, but reprocesses events which are _not_ in nodestore (vs events that _are_ stuck in processing redis).

The purpose of this is to reprocess events which were previously stuck in processing redis (due to failing during `save_*`), and then were deleted from processing redis (meaning other reprocess flag won't work).