### PR TITLE
ref(dashboards): Remove `dashboards-ai-generate` feature flag (backend)

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -9,7 +9,6 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -159,11 +158,6 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDashboardGeneratePermission,)
 
     def post(self, request: Request, organization: Organization) -> Response:
-        if not features.has(
-            "organizations:dashboards-ai-generate", organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
-
         has_access, error = has_seer_access_with_detail(organization, request.user)
         if not has_access:
             raise PermissionDenied(error)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -79,8 +79,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-details-widget", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Insights to Dashboards UI migration
     manager.add("organizations:insights-to-dashboards-ui-rollout", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable AI-powered dashboard generation via Seer
-    manager.add("organizations:dashboards-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-powered dashboard editing via Seer
     manager.add("organizations:dashboards-ai-generate-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables starred dashboards functionality

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -178,11 +178,8 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
 
         has_seer_access, _ = has_seer_access_with_detail(organization, request.user)
-        has_dashboards_ai_generate_access = has_seer_access and features.has(
-            "organizations:dashboards-ai-generate", organization, actor=request.user
-        )
 
-        if not has_access and not has_dashboards_ai_generate_access:
+        if not has_access and not has_seer_access:
             raise PermissionDenied(error)
 
         if not run_id:
@@ -231,13 +228,8 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
         has_access, error = has_seer_agent_access_with_detail(organization, request.user)
 
         has_seer_access, _ = has_seer_access_with_detail(organization, request.user)
-        has_dashboards_ai_generate_access = has_seer_access and features.has(
-            "organizations:dashboards-ai-generate", organization, actor=request.user
-        )
-        # Orgs with dashboards AI generate access can continue existing dashboard generate runs, but cannot start new runs from this endpoint.
-        can_continue_dashboards_generate_run = (
-            has_dashboards_ai_generate_access and run_id is not None
-        )
+        # Orgs with Seer access can continue existing dashboard generate runs, but cannot start new runs from this endpoint.
+        can_continue_dashboards_generate_run = has_seer_access and run_id is not None
 
         if not has_access and not can_continue_dashboards_generate_run:
             raise PermissionDenied(error)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -10,7 +10,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
 
-@with_feature("organizations:dashboards-ai-generate")
 @with_feature("organizations:gen-ai-features")
 class OrganizationDashboardGenerateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-dashboards-generate"
@@ -54,12 +53,6 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         call_kwargs = mock_client.start_run.call_args[1]
         assert "Show me error rates by project" in call_kwargs["prompt"]
         assert call_kwargs["artifact_key"] == "dashboard"
-
-    @with_feature({"organizations:dashboards-ai-generate": False})
-    def test_post_without_feature_flag_returns_403(self) -> None:
-        data = {"prompt": "Show me error rates"}
-        response = self.client.post(self.url, data, format="json")
-        assert response.status_code == 403
 
     @patch(
         "sentry.dashboards.endpoints.organization_dashboard_generate.has_seer_access_with_detail"

--- a/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_agent_chat.py
@@ -305,7 +305,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
     def test_get_run_allowed_with_dashboards_ai_generate_flag(
         self, mock_client_class: MagicMock
     ) -> None:
-        """GET with run_id should succeed with dashboards-ai-generate flag even without seer-explorer."""
+        """GET with run_id should succeed for orgs with Seer access even without seer-explorer."""
         mock_state = SeerRunState(
             run_id=123,
             blocks=[],
@@ -316,12 +316,7 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
         mock_client.get_run.return_value = mock_state
         mock_client_class.return_value = mock_client
 
-        with self.feature(
-            {
-                "organizations:seer-explorer": False,
-                "organizations:dashboards-ai-generate": True,
-            }
-        ):
+        with self.feature({"organizations:seer-explorer": False}):
             response = self.client.get(f"{self.url}123/")
 
         assert response.status_code == 200
@@ -331,42 +326,32 @@ class OrganizationSeerAgentChatEndpointTest(APITestCase):
     def test_continue_run_allowed_with_dashboards_ai_generate_flag(
         self, mock_client_class: MagicMock
     ) -> None:
-        """POST with run_id should succeed with dashboards-ai-generate flag."""
+        """POST with run_id should succeed for orgs with Seer access even without seer-explorer."""
         mock_client = MagicMock()
         mock_client.continue_run.return_value = 789
         mock_client_class.return_value = mock_client
 
         data = {"query": "Follow up question"}
-        with self.feature(
-            {
-                "organizations:seer-explorer": False,
-                "organizations:dashboards-ai-generate": True,
-            }
-        ):
+        with self.feature({"organizations:seer-explorer": False}):
             response = self.client.post(f"{self.url}789/", data, format="json")
 
         assert response.status_code == 200
         assert response.data == {"run_id": 789, "sentry_run_id": None}
 
     def test_new_run_denied_without_seer_explorer_flag(self) -> None:
-        """POST without run_id should be denied with only dashboards-ai-generate flag."""
+        """POST without run_id should be denied for orgs without seer-explorer, even with Seer access."""
         data = {"query": "Start a new conversation"}
-        with self.feature(
-            {
-                "organizations:seer-explorer": False,
-                "organizations:dashboards-ai-generate": True,
-            }
-        ):
+        with self.feature({"organizations:seer-explorer": False}):
             response = self.client.post(self.url, data, format="json")
 
         assert response.status_code == 403
 
-    def test_get_denied_without_either_flag(self) -> None:
-        """GET should be denied without seer-explorer or dashboards-ai-generate."""
+    def test_get_denied_without_seer_access(self) -> None:
+        """GET should be denied when the org has neither seer-explorer nor base Seer access."""
         with self.feature(
             {
                 "organizations:seer-explorer": False,
-                "organizations:dashboards-ai-generate": False,
+                "organizations:gen-ai-features": False,
             }
         ):
             response = self.client.get(self.url)


### PR DESCRIPTION
Remove `organizations:dashboards-ai-generate`. This flag was fully rolled out to GA in the automator in [#7130](https://github.com/getsentry/sentry-options-automator/pull/7130) on 4/7, and hasn't been touched since.

Removes the flag registration and all backend checks, defaulting the behavior to enabled. Frontend changes are split into a separate PR (backend/frontend are not atomically deployed); the frontend PR should merge first so the feature UI is not gated on the removed flag exposure.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tiEMhiwz4faSBkVG9jWZb)_