### PR TITLE
ref(dashboards): Remove `dashboards-ai-generate` feature flag (frontend)

### DIFF
--- a/static/app/views/dashboards/createFromSeer.spec.tsx
+++ b/static/app/views/dashboards/createFromSeer.spec.tsx
@@ -69,7 +69,7 @@ const MOCKED_PROCESSING_SESSION = {
 
 describe('CreateFromSeer', () => {
   const organization = OrganizationFixture({
-    features: ['dashboards-edit', 'dashboards-ai-generate'],
+    features: ['dashboards-edit'],
   });
 
   beforeEach(() => {

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -26,9 +26,7 @@ export default function CreateFromSeer() {
   const location = useLocation();
 
   const seerRunId = location.query?.seerRunId ? Number(location.query.seerRunId) : null;
-  const hasFeature =
-    organization.features.includes('dashboards-edit') &&
-    organization.features.includes('dashboards-ai-generate');
+  const hasFeature = organization.features.includes('dashboards-edit');
 
   const [dashboard, setDashboard] = useState(EMPTY_DASHBOARD);
 

--- a/static/app/views/dashboards/dashboardEditSeerChat.tsx
+++ b/static/app/views/dashboards/dashboardEditSeerChat.tsx
@@ -20,9 +20,7 @@ export function DashboardEditSeerChat({
 }: DashboardEditSeerChatProps) {
   const organization = useOrganization();
 
-  const hasFeature =
-    organization.features.includes('dashboards-edit') &&
-    organization.features.includes('dashboards-ai-generate');
+  const hasFeature = organization.features.includes('dashboards-edit');
 
   const handleDashboardUpdate = useCallback(
     (data: {title: string; widgets: Widget[]}, seerRunId: number | null) => {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1403,9 +1403,6 @@ class DashboardDetail extends Component<Props, State> {
                             {dashboardState === DashboardState.EDIT &&
                               organization.features.includes(
                                 'dashboards-ai-generate-edit'
-                              ) &&
-                              organization.features.includes(
-                                'dashboards-ai-generate'
                               ) && (
                                 <DashboardEditSeerChat
                                   dashboard={modifiedDashboard ?? dashboard}

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -385,79 +385,75 @@ function ManageDashboards() {
           position="bottom-end"
           data-test-id="sort-by-select"
         />
-        <Feature features={['dashboards-ai-generate']}>
-          {({hasFeature: hasAiGenerate}) =>
-            hasAiGenerate && areAiFeaturesAllowed ? (
-              <DashboardCreateLimitWrapper>
-                {({
-                  hasReachedDashboardLimit,
-                  isLoading: isLoadingDashboardsLimit,
-                  limitMessage,
-                }) => (
-                  <DropdownMenu
-                    items={[
-                      {
-                        key: 'create-dashboard',
-                        label: t('Create dashboard manually'),
-                        onAction: () => onCreate(),
-                        disabled: hasReachedDashboardLimit || isLoadingDashboardsLimit,
-                        details: limitMessage,
-                      },
-                      {
-                        key: 'create-dashboard-agent',
-                        textValue: t('Generate dashboard'),
-                        label: (
-                          <Flex gap="sm" align="center" as="span">
-                            {t('Generate dashboard')}
-                            <FeatureBadge type="beta" />
-                          </Flex>
-                        ),
-                        onAction: () => onGenerateDashboard(),
-                        disabled: hasReachedDashboardLimit || isLoadingDashboardsLimit,
-                        details: limitMessage,
-                      },
-                    ]}
-                    trigger={triggerProps => (
-                      <Button
-                        {...triggerProps}
-                        data-test-id="dashboard-create"
-                        variant="primary"
-                        icon={<IconAdd />}
-                      >
-                        {t('Create Dashboard')}
-                      </Button>
-                    )}
-                  />
-                )}
-              </DashboardCreateLimitWrapper>
-            ) : (
-              <DashboardCreateLimitWrapper>
-                {({
-                  hasReachedDashboardLimit,
-                  isLoading: isLoadingDashboardsLimit,
-                  limitMessage,
-                }) => (
+        {areAiFeaturesAllowed ? (
+          <DashboardCreateLimitWrapper>
+            {({
+              hasReachedDashboardLimit,
+              isLoading: isLoadingDashboardsLimit,
+              limitMessage,
+            }) => (
+              <DropdownMenu
+                items={[
+                  {
+                    key: 'create-dashboard',
+                    label: t('Create dashboard manually'),
+                    onAction: () => onCreate(),
+                    disabled: hasReachedDashboardLimit || isLoadingDashboardsLimit,
+                    details: limitMessage,
+                  },
+                  {
+                    key: 'create-dashboard-agent',
+                    textValue: t('Generate dashboard'),
+                    label: (
+                      <Flex gap="sm" align="center" as="span">
+                        {t('Generate dashboard')}
+                        <FeatureBadge type="beta" />
+                      </Flex>
+                    ),
+                    onAction: () => onGenerateDashboard(),
+                    disabled: hasReachedDashboardLimit || isLoadingDashboardsLimit,
+                    details: limitMessage,
+                  },
+                ]}
+                trigger={triggerProps => (
                   <Button
+                    {...triggerProps}
                     data-test-id="dashboard-create"
-                    onClick={event => {
-                      event.preventDefault();
-                      onCreate();
-                    }}
                     variant="primary"
                     icon={<IconAdd />}
-                    disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
-                    tooltipProps={{
-                      isHoverable: true,
-                      title: limitMessage,
-                    }}
                   >
                     {t('Create Dashboard')}
                   </Button>
                 )}
-              </DashboardCreateLimitWrapper>
-            )
-          }
-        </Feature>
+              />
+            )}
+          </DashboardCreateLimitWrapper>
+        ) : (
+          <DashboardCreateLimitWrapper>
+            {({
+              hasReachedDashboardLimit,
+              isLoading: isLoadingDashboardsLimit,
+              limitMessage,
+            }) => (
+              <Button
+                data-test-id="dashboard-create"
+                onClick={event => {
+                  event.preventDefault();
+                  onCreate();
+                }}
+                variant="primary"
+                icon={<IconAdd />}
+                disabled={hasReachedDashboardLimit || isLoadingDashboardsLimit}
+                tooltipProps={{
+                  isHoverable: true,
+                  title: limitMessage,
+                }}
+              >
+                {t('Create Dashboard')}
+              </Button>
+            )}
+          </DashboardCreateLimitWrapper>
+        )}
       </StyledActions>
     );
   }


### PR DESCRIPTION
Remove `organizations:dashboards-ai-generate`. This flag was fully rolled out to GA in the automator in [#7130](https://github.com/getsentry/sentry-options-automator/pull/7130) on 4/7, and hasn't been touched since.

Removes the frontend feature checks, defaulting the behavior to enabled. Backend changes (flag registration + API checks) are in #120134. This frontend PR should merge first, before the backend removes the flag's `api_expose` registration.

---
_Generated by [Claude Code](https://claude.ai/code/session_018tiEMhiwz4faSBkVG9jWZb)_