### PR TITLE
chore(external-mcp): Rename datadog integration

### DIFF
--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -170,8 +170,6 @@ class DatadogIntegration(IntegrationInstallation):
 
 class DatadogIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.DATADOG.value
-    # Distinct from the legacy "Datadog" data-forwarding card in the integration directory;
-    # this is the org-level API-key integration that lets Seer pull Datadog telemetry.
     name = "Datadog (Seer)"
     metadata = metadata
     integration_cls = DatadogIntegration

--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -170,7 +170,9 @@ class DatadogIntegration(IntegrationInstallation):
 
 class DatadogIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.DATADOG.value
-    name = "Datadog"
+    # Distinct from the legacy "Datadog" data-forwarding card in the integration directory;
+    # this is the org-level API-key integration that lets Seer pull Datadog telemetry.
+    name = "Datadog (Seer)"
     metadata = metadata
     integration_cls = DatadogIntegration
     features = frozenset([IntegrationFeatures.MONITORING])

--- a/tests/sentry/integrations/datadog/test_integration.py
+++ b/tests/sentry/integrations/datadog/test_integration.py
@@ -203,7 +203,6 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
     def test_provider_is_single_install_and_flagged(self) -> None:
         provider = self.provider()
         assert provider.key == "datadog"
-        # Distinct directory label so it doesn't collide with the legacy Datadog card.
         assert provider.name == "Datadog (Seer)"
         assert provider.allow_multiple is False
         assert provider.requires_feature_flag is True

--- a/tests/sentry/integrations/datadog/test_integration.py
+++ b/tests/sentry/integrations/datadog/test_integration.py
@@ -203,5 +203,7 @@ class DatadogIntegrationProviderTest(IntegrationTestCase):
     def test_provider_is_single_install_and_flagged(self) -> None:
         provider = self.provider()
         assert provider.key == "datadog"
+        # Distinct directory label so it doesn't collide with the legacy Datadog card.
+        assert provider.name == "Datadog (Seer)"
         assert provider.allow_multiple is False
         assert provider.requires_feature_flag is True


### PR DESCRIPTION
We already have a docs integration for datadog, so renaming the version that integrates with Seer.

<!-- Describe your PR here. -->