### PR TITLE
fix(seer): Restore issue summary generation for seat-based orgs

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1509,14 +1509,23 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
+    from sentry.seer.autofix.issue_summary import get_issue_summary_cache_key
     from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
     from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
-    from sentry.tasks.seer.autofix import generate_summary_and_run_automation
+    from sentry.tasks.seer.autofix import (
+        generate_issue_summary_only,
+        generate_summary_and_run_automation,
+    )
 
     event = job["event"]
     group = event.group
 
     if is_seer_seat_based_tier_enabled(group.organization):
+        # Generate issue summary and fixability score if it doesn't exist and then return.
+        # Agentic Triage handles automations for seat based orgs but it still needs summary and fixability score.
+        cache_key = get_issue_summary_cache_key(group.id)
+        if cache.get(cache_key) is None:
+            generate_issue_summary_only.delay(group.id)
         return
 
     skip_reason = get_default_seer_automation_skip_reason(group, locks)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1509,7 +1509,10 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
-    from sentry.seer.autofix.issue_summary import get_issue_summary_cache_key
+    from sentry.seer.autofix.issue_summary import (
+        get_issue_summary_cache_key,
+        get_issue_summary_lock_key,
+    )
     from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
     from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
     from sentry.tasks.seer.autofix import (
@@ -1525,7 +1528,10 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
         # Agentic Triage handles automations for seat based orgs but it still needs summary and fixability score.
         cache_key = get_issue_summary_cache_key(group.id)
         if cache.get(cache_key) is None:
-            generate_issue_summary_only.delay(group.id)
+            lock_key, lock_name = get_issue_summary_lock_key(group.id)
+            lock = locks.get(lock_key, duration=1, name=lock_name)
+            if not lock.locked():
+                generate_issue_summary_only.delay(group.id)
         return
 
     skip_reason = get_default_seer_automation_skip_reason(group, locks)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3204,9 +3204,9 @@ class SeatBasedSeerAutomationTestMixin(BasePostProcessGroupMixin):
             event=event,
         )
 
-        # Nothing is kicked off from post-process for seat-based orgs.
+        # Seat-based orgs skip automation but still generate summary + fixability score.
         mock_generate_summary_and_run_automation.assert_not_called()
-        mock_generate_summary_only.assert_not_called()
+        mock_generate_summary_only.assert_called_once_with(event.group.id)
         mock_run_automation.assert_not_called()
 
 


### PR DESCRIPTION
+ PR #119811 added an early return in kick_off_seer_automation for seat-based orgs, which inadvertently stopped generating issue summaries and fixability scores for those orgs.

+ For seat-based orgs, generate the issue summary and fixability score (via generate_issue_summary_only) when no cached summary exists, then return without triggering automation. Agentic Triage handles automations for seat-based orgs but still needs the summary and fixability score.