### PR TITLE
fix(analytics): Attribute setup docs by project creation variant

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
 import {
+  docsFlowVariantParams,
   DSN_COPIED_EVENT,
   resolveDocsFlowEvent,
 } from 'sentry/components/onboarding/gettingStartedDoc/docsFlowAnalytics';
@@ -26,6 +27,7 @@ function CopyDsnField({params}: {params: DocsParams<any>}) {
           trackAnalytics(resolveDocsFlowEvent(DSN_COPIED_EVENT, params.docsFlow), {
             organization: params.organization,
             platform: params.platformKey,
+            ...docsFlowVariantParams(params.docsFlow),
           })
         }
       >

--- a/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.spec.tsx
@@ -1,8 +1,9 @@
 import {
   docsFlowGamingOrigin,
+  docsFlowMarkdownParams,
+  docsFlowVariantParams,
   DSN_COPIED_EVENT,
   JS_LOADER_NPM_DOCS_SHOWN_EVENT,
-  MARKDOWN_SOURCE_BY_FLOW,
   NEXT_STEP_CLICKED_EVENT,
   resolveDocsFlowEvent,
   SETUP_LOADER_DOCS_RENDERED_EVENT,
@@ -11,69 +12,114 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/docsFlowAnalytics';
 
 describe('docsFlowAnalytics', () => {
-  it('preserves the old two-way onboarding event branches', () => {
-    expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'onboarding')).toBe(
-      'onboarding.dsn-copied'
-    );
-    expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'onboarding-scm')).toBe(
-      'onboarding.scm_dsn_copied'
-    );
-    expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'project-creation')).toBe(
-      'onboarding.dsn-copied'
-    );
-    expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'project-creation-scm')).toBe(
-      'onboarding.dsn-copied'
-    );
-    expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, undefined)).toBe(
-      'onboarding.dsn-copied'
-    );
+  describe('resolveDocsFlowEvent', () => {
+    it('keeps distinct names for the onboarding arms', () => {
+      expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'onboarding')).toBe(
+        'onboarding.dsn-copied'
+      );
+      expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'onboarding-scm')).toBe(
+        'onboarding.scm_dsn_copied'
+      );
+    });
 
-    expect(resolveDocsFlowEvent(NEXT_STEP_CLICKED_EVENT, 'project-creation')).toBe(
-      'onboarding.next_step_clicked'
-    );
-    expect(resolveDocsFlowEvent(JS_LOADER_NPM_DOCS_SHOWN_EVENT, 'project-creation')).toBe(
-      'onboarding.js_loader_npm_docs_shown'
-    );
-    expect(
-      resolveDocsFlowEvent(SETUP_LOADER_DOCS_RENDERED_EVENT, 'project-creation')
-    ).toBe('onboarding.setup_loader_docs_rendered');
+    it('resolves BOTH project-creation arms to the same base name (SCM lives in variant)', () => {
+      expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'project-creation')).toBe(
+        'project_creation.dsn_copied'
+      );
+      expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, 'project-creation-scm')).toBe(
+        'project_creation.dsn_copied'
+      );
+      expect(
+        resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, 'project-creation-scm')
+      ).toBe('project_creation.source_maps_wizard_button_copy_clicked');
+      expect(
+        resolveDocsFlowEvent(JS_LOADER_NPM_DOCS_SHOWN_EVENT, 'project-creation-scm')
+      ).toBe('project_creation.js_loader_npm_docs_shown');
+    });
+
+    it('falls back to the legacy project-creation name when the flow is undefined', () => {
+      // Peripheral surfaces (e.g. updatedEmptyState) build DocsParams without a
+      // docsFlow; they must keep emitting the pre-enum project-creation names.
+      expect(resolveDocsFlowEvent(DSN_COPIED_EVENT, undefined)).toBe(
+        'project_creation.dsn_copied'
+      );
+      expect(resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, undefined)).toBe(
+        'project_creation.source_maps_wizard_button_copy_clicked'
+      );
+    });
+
+    it('reproduces the exact onboarding names for the regression-gated flows', () => {
+      expect(resolveDocsFlowEvent(NEXT_STEP_CLICKED_EVENT, 'onboarding')).toBe(
+        'onboarding.next_step_clicked'
+      );
+      expect(resolveDocsFlowEvent(NEXT_STEP_CLICKED_EVENT, 'onboarding-scm')).toBe(
+        'onboarding.scm_next_step_clicked'
+      );
+      expect(resolveDocsFlowEvent(JS_LOADER_NPM_DOCS_SHOWN_EVENT, 'onboarding')).toBe(
+        'onboarding.js_loader_npm_docs_shown'
+      );
+      expect(
+        resolveDocsFlowEvent(SETUP_LOADER_DOCS_RENDERED_EVENT, 'onboarding-scm')
+      ).toBe('onboarding.scm_setup_loader_docs_rendered');
+      expect(
+        resolveDocsFlowEvent(SOURCE_MAPS_SELECTED_AND_COPIED_EVENT, 'onboarding')
+      ).toBe('onboarding.source_maps_wizard_selected_and_copied');
+    });
   });
 
-  it('preserves the old three-way source-map event branches', () => {
-    expect(resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, 'onboarding')).toBe(
-      'onboarding.source_maps_wizard_button_copy_clicked'
-    );
-    expect(resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, 'onboarding-scm')).toBe(
-      'onboarding.scm_source_maps_wizard_button_copy_clicked'
-    );
-    expect(resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, 'project-creation')).toBe(
-      'project_creation.source_maps_wizard_button_copy_clicked'
-    );
-    expect(
-      resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, 'project-creation-scm')
-    ).toBe('project_creation.source_maps_wizard_button_copy_clicked');
-    expect(resolveDocsFlowEvent(SOURCE_MAPS_COPY_CLICKED_EVENT, undefined)).toBe(
-      'project_creation.source_maps_wizard_button_copy_clicked'
-    );
-    expect(resolveDocsFlowEvent(SOURCE_MAPS_SELECTED_AND_COPIED_EVENT, undefined)).toBe(
-      'project_creation.source_maps_wizard_selected_and_copied'
-    );
+  describe('docsFlowVariantParams', () => {
+    it('stamps the SCM/legacy variant only for the project-creation arms', () => {
+      expect(docsFlowVariantParams('project-creation-scm')).toEqual({variant: 'scm'});
+      expect(docsFlowVariantParams('project-creation')).toEqual({variant: 'legacy'});
+    });
+
+    it('omits variant for the onboarding arms (their events are onboarding.*)', () => {
+      expect(docsFlowVariantParams('onboarding')).toEqual({});
+      expect(docsFlowVariantParams('onboarding-scm')).toEqual({});
+    });
+
+    it('omits variant when project-creation origin is unmarked', () => {
+      expect(docsFlowVariantParams(undefined)).toEqual({});
+    });
   });
 
-  it('preserves copy-as-markdown source values', () => {
-    expect(MARKDOWN_SOURCE_BY_FLOW.onboarding).toBe('first_time_setup');
-    expect(MARKDOWN_SOURCE_BY_FLOW['onboarding-scm']).toBe('first_time_setup');
-    expect(MARKDOWN_SOURCE_BY_FLOW['project-creation']).toBe('project_getting_started');
-    expect(MARKDOWN_SOURCE_BY_FLOW['project-creation-scm']).toBe(
-      'project_getting_started'
-    );
+  describe('docsFlowMarkdownParams', () => {
+    it('sets source by flow and variant by SCM experience', () => {
+      expect(docsFlowMarkdownParams('onboarding')).toEqual({
+        source: 'first_time_setup',
+        variant: 'legacy',
+      });
+      expect(docsFlowMarkdownParams('onboarding-scm')).toEqual({
+        source: 'first_time_setup',
+        variant: 'scm',
+      });
+      expect(docsFlowMarkdownParams('project-creation')).toEqual({
+        source: 'project_getting_started',
+        variant: 'legacy',
+      });
+      expect(docsFlowMarkdownParams('project-creation-scm')).toEqual({
+        source: 'project_getting_started',
+        variant: 'scm',
+      });
+    });
+
+    it('keeps the project source but omits variant when origin is unmarked', () => {
+      expect(docsFlowMarkdownParams(undefined)).toEqual({
+        source: 'project_getting_started',
+      });
+    });
   });
 
-  it('preserves the two-value gaming origin taxonomy', () => {
-    expect(docsFlowGamingOrigin('onboarding')).toBe('onboarding');
-    expect(docsFlowGamingOrigin('onboarding-scm')).toBe('onboarding');
-    expect(docsFlowGamingOrigin('project-creation')).toBe('project-creation');
-    expect(docsFlowGamingOrigin('project-creation-scm')).toBe('project-creation');
-    expect(docsFlowGamingOrigin(undefined)).toBe('project-creation');
+  describe('docsFlowGamingOrigin', () => {
+    it('collapses onto the 2-value origin taxonomy (Q1: no SCM split)', () => {
+      expect(docsFlowGamingOrigin('onboarding')).toBe('onboarding');
+      expect(docsFlowGamingOrigin('onboarding-scm')).toBe('onboarding');
+      expect(docsFlowGamingOrigin('project-creation')).toBe('project-creation');
+      expect(docsFlowGamingOrigin('project-creation-scm')).toBe('project-creation');
+    });
+
+    it('defaults an undefined flow to project-creation', () => {
+      expect(docsFlowGamingOrigin(undefined)).toBe('project-creation');
+    });
   });
 });

--- a/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.ts
@@ -1,52 +1,73 @@
 import type {DocsFlow} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
 
 /**
- * Maps {@link DocsFlow} onto the existing analytics taxonomy without changing
- * behavior. The pre-refactor boolean branches did not all share a fallback:
- * DSN/next-step/loader events treated every non-SCM surface as onboarding,
- * while source-map events had an explicit project-creation arm. Each map keeps
- * its own `default` so callers that never supplied either boolean retain that
- * exact behavior.
+ * Maps a {@link DocsFlow} to the analytics event NAME for a setup-docs
+ * interaction. Onboarding and SCM onboarding keep distinct event names. The two
+ * project-creation arms (`project-creation`, `project-creation-scm`) resolve to
+ * the SAME base `project_creation.*` name — SCM vs legacy is carried in a
+ * `variant` param instead (see {@link docsFlowVariantParams}), so both variants
+ * keep incrementing one counter. Several of these fire from more than one file,
+ * so the taxonomy is centralized here to keep the names in sync.
  */
-type DocsFlowEventMap<T extends string = string> = Record<DocsFlow | 'default', T>;
+type DocsFlowEventMap<T extends string = string> = Record<DocsFlow, T>;
+
+// Legacy default: the pre-enum `!newOrg && !hasScmOnboarding` arm. Peripheral
+// surfaces that build DocsParams directly (e.g. updatedEmptyState) leave
+// docsFlow undefined and must keep emitting these project-creation names.
+const DEFAULT_FLOW: DocsFlow = 'project-creation';
 
 export function resolveDocsFlowEvent<T extends string>(
   map: DocsFlowEventMap<T>,
   flow: DocsFlow | undefined
 ): T {
-  return map[flow ?? 'default'];
+  return map[flow ?? DEFAULT_FLOW];
+}
+
+/**
+ * Params to spread onto setup-docs events. Only an explicit project-creation
+ * flow carries `variant`; unmarked/peripheral surfaces keep the canonical event
+ * name without being guessed as legacy.
+ */
+export function docsFlowVariantParams(flow: DocsFlow | undefined): {
+  variant?: ProjectCreationVariant;
+} {
+  switch (flow) {
+    case 'project-creation-scm':
+      return {variant: 'scm'};
+    case 'project-creation':
+      return {variant: 'legacy'};
+    default:
+      return {};
+  }
 }
 
 export const DSN_COPIED_EVENT = {
   onboarding: 'onboarding.dsn-copied',
   'onboarding-scm': 'onboarding.scm_dsn_copied',
-  'project-creation': 'onboarding.dsn-copied',
-  'project-creation-scm': 'onboarding.dsn-copied',
-  default: 'onboarding.dsn-copied',
+  'project-creation': 'project_creation.dsn_copied',
+  'project-creation-scm': 'project_creation.dsn_copied',
 } as const satisfies DocsFlowEventMap;
 
 export const NEXT_STEP_CLICKED_EVENT = {
   onboarding: 'onboarding.next_step_clicked',
   'onboarding-scm': 'onboarding.scm_next_step_clicked',
-  'project-creation': 'onboarding.next_step_clicked',
-  'project-creation-scm': 'onboarding.next_step_clicked',
-  default: 'onboarding.next_step_clicked',
+  'project-creation': 'project_creation.next_step_clicked',
+  'project-creation-scm': 'project_creation.next_step_clicked',
 } as const satisfies DocsFlowEventMap;
 
 export const JS_LOADER_NPM_DOCS_SHOWN_EVENT = {
   onboarding: 'onboarding.js_loader_npm_docs_shown',
   'onboarding-scm': 'onboarding.scm_js_loader_npm_docs_shown',
-  'project-creation': 'onboarding.js_loader_npm_docs_shown',
-  'project-creation-scm': 'onboarding.js_loader_npm_docs_shown',
-  default: 'onboarding.js_loader_npm_docs_shown',
+  'project-creation': 'project_creation.js_loader_npm_docs_shown',
+  'project-creation-scm': 'project_creation.js_loader_npm_docs_shown',
 } as const satisfies DocsFlowEventMap;
 
 export const SETUP_LOADER_DOCS_RENDERED_EVENT = {
   onboarding: 'onboarding.setup_loader_docs_rendered',
   'onboarding-scm': 'onboarding.scm_setup_loader_docs_rendered',
-  'project-creation': 'onboarding.setup_loader_docs_rendered',
-  'project-creation-scm': 'onboarding.setup_loader_docs_rendered',
-  default: 'onboarding.setup_loader_docs_rendered',
+  'project-creation': 'project_creation.setup_loader_docs_rendered',
+  'project-creation-scm': 'project_creation.setup_loader_docs_rendered',
 } as const satisfies DocsFlowEventMap;
 
 export const SOURCE_MAPS_COPY_CLICKED_EVENT = {
@@ -54,7 +75,6 @@ export const SOURCE_MAPS_COPY_CLICKED_EVENT = {
   'onboarding-scm': 'onboarding.scm_source_maps_wizard_button_copy_clicked',
   'project-creation': 'project_creation.source_maps_wizard_button_copy_clicked',
   'project-creation-scm': 'project_creation.source_maps_wizard_button_copy_clicked',
-  default: 'project_creation.source_maps_wizard_button_copy_clicked',
 } as const satisfies DocsFlowEventMap;
 
 export const SOURCE_MAPS_SELECTED_AND_COPIED_EVENT = {
@@ -62,22 +82,43 @@ export const SOURCE_MAPS_SELECTED_AND_COPIED_EVENT = {
   'onboarding-scm': 'onboarding.scm_source_maps_wizard_selected_and_copied',
   'project-creation': 'project_creation.source_maps_wizard_selected_and_copied',
   'project-creation-scm': 'project_creation.source_maps_wizard_selected_and_copied',
-  default: 'project_creation.source_maps_wizard_selected_and_copied',
 } as const satisfies DocsFlowEventMap;
 
-/** Copy-as-markdown `source` value, preserving the old `newOrg` split. */
-export const MARKDOWN_SOURCE_BY_FLOW: Record<DocsFlow, string> = {
-  onboarding: 'first_time_setup',
-  'onboarding-scm': 'first_time_setup',
-  'project-creation': 'project_getting_started',
-  'project-creation-scm': 'project_getting_started',
-};
+/**
+ * Copy-as-markdown analytics params per flow. `source` names only the flow (no
+ * `_scm` suffix); `variant` identifies the SCM or legacy experience. Unlike
+ * {@link docsFlowVariantParams} (which is empty for onboarding, since
+ * name-based onboarding events keep `onboarding.scm_*` names), this shared
+ * cross-flow event needs the variant for the onboarding arms too, so it maps
+ * all four flows.
+ */
+export function docsFlowMarkdownParams(flow: DocsFlow | undefined): {
+  source: string;
+  variant?: ProjectCreationVariant;
+} {
+  switch (flow) {
+    case 'onboarding':
+      return {source: 'first_time_setup', variant: 'legacy'};
+    case 'onboarding-scm':
+      return {source: 'first_time_setup', variant: 'scm'};
+    case 'project-creation':
+      return {source: 'project_getting_started', variant: 'legacy'};
+    case 'project-creation-scm':
+      return {source: 'project_getting_started', variant: 'scm'};
+    default:
+      return {source: 'project_getting_started'};
+  }
+}
 
-/** Gaming SDK-access origin, preserving the old two-value `newOrg` split. */
+/**
+ * Gaming SDK-access modal `origin` per flow (Q1: no SCM split; collapse onto the
+ * existing 2-value origin taxonomy). Fired from several gaming platform docs, so
+ * the collapse lives here to stay consistent.
+ */
 export function docsFlowGamingOrigin(
   flow: DocsFlow | undefined
 ): 'onboarding' | 'project-creation' {
-  return flow === 'onboarding' || flow === 'onboarding-scm'
+  return (flow ?? DEFAULT_FLOW) === 'onboarding' || flow === 'onboarding-scm'
     ? 'onboarding'
     : 'project-creation';
 }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -17,6 +17,8 @@ interface CopyMarkdownButtonProps {
   label?: string;
   onCopy?: () => void;
   title?: string;
+  /** Identifies the SCM or legacy experience for copy-as-markdown analytics. */
+  variant?: 'scm' | 'legacy';
 }
 
 /**
@@ -35,6 +37,7 @@ export function CopyMarkdownButton({
   onCopy,
   title,
   label,
+  variant,
 }: CopyMarkdownButtonProps) {
   return (
     <Tooltip
@@ -51,7 +54,7 @@ export function CopyMarkdownButton({
         icon={<IconCopy />}
         analyticsEventKey="setup_guide.copy_as_markdown"
         analyticsEventName="Setup Guide: Copy as Markdown"
-        analyticsParams={{format: 'markdown', source}}
+        analyticsParams={{format: 'markdown', source, ...(variant ? {variant} : {})}}
         onClick={() => {
           copyToClipboard(getMarkdown());
           onCopy?.();
@@ -76,6 +79,8 @@ interface OnboardingCopyMarkdownButtonProps {
    * not represented as onboarding steps.
    */
   postamble?: string;
+  /** Identifies the SCM or legacy experience for copy-as-markdown analytics. */
+  variant?: 'scm' | 'legacy';
 }
 
 /**
@@ -88,6 +93,7 @@ export function OnboardingCopyMarkdownButton({
   borderless,
   postamble,
   onCopy,
+  variant,
 }: OnboardingCopyMarkdownButtonProps) {
   const authToken = useAuthToken();
   const tabSelectionsMap = useTabSelectionsMap();
@@ -115,6 +121,7 @@ export function OnboardingCopyMarkdownButton({
       source={source}
       borderless={borderless}
       onCopy={onCopy}
+      variant={variant}
     />
   );
 }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -8,8 +8,9 @@ import {List} from 'sentry/components/list';
 import {ListItem} from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
+  docsFlowMarkdownParams,
+  docsFlowVariantParams,
   DSN_COPIED_EVENT,
-  MARKDOWN_SOURCE_BY_FLOW,
   NEXT_STEP_CLICKED_EVENT,
   resolveDocsFlowEvent,
 } from 'sentry/components/onboarding/gettingStartedDoc/docsFlowAnalytics';
@@ -140,6 +141,7 @@ export function OnboardingLayout({
             trackAnalytics(resolveDocsFlowEvent(DSN_COPIED_EVENT, docsFlow), {
               organization,
               platform: platformKey,
+              ...docsFlowVariantParams(docsFlow),
             });
           },
         }),
@@ -213,7 +215,7 @@ export function OnboardingLayout({
               const copyButton = showCopy ? (
                 <OnboardingCopyMarkdownButton
                   steps={steps}
-                  source={MARKDOWN_SOURCE_BY_FLOW[docsFlow ?? 'project-creation']}
+                  {...docsFlowMarkdownParams(docsFlow)}
                 />
               ) : null;
 
@@ -263,6 +265,7 @@ export function OnboardingLayout({
                               newOrg:
                                 docsFlow === 'onboarding' ||
                                 docsFlow === 'onboarding-scm',
+                              ...docsFlowVariantParams(docsFlow),
                             }
                           )
                         }

--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -4,6 +4,7 @@ import {Button} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
+  docsFlowVariantParams,
   resolveDocsFlowEvent,
   SOURCE_MAPS_COPY_CLICKED_EVENT,
   SOURCE_MAPS_SELECTED_AND_COPIED_EVENT,
@@ -37,6 +38,7 @@ export function getUploadSourceMapsStep({
       project_id: project.id,
       platform: platformKey,
       organization,
+      ...docsFlowVariantParams(docsFlow),
     });
   }
 

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -2,6 +2,7 @@ import {Link} from '@sentry/scraps/link';
 
 import {buildSdkConfig} from 'sentry/components/onboarding/gettingStartedDoc/buildSdkConfig';
 import {
+  docsFlowVariantParams,
   JS_LOADER_NPM_DOCS_SHOWN_EVENT,
   resolveDocsFlowEvent,
   SETUP_LOADER_DOCS_RENDERED_EVENT,
@@ -354,6 +355,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
           organization: params.organization,
           platform: params.platformKey,
           project_id: params.project.id,
+          ...docsFlowVariantParams(params.docsFlow),
         }
       );
     };
@@ -366,6 +368,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
           organization: params.organization,
           platform: params.platformKey,
           project_id: params.project.id,
+          ...docsFlowVariantParams(params.docsFlow),
         }
       );
     };
@@ -470,6 +473,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
           organization: params.organization,
           platform: params.platformKey,
           project_id: params.project.id,
+          ...docsFlowVariantParams(params.docsFlow),
         }
       );
     };
@@ -504,6 +508,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
           organization: params.organization,
           platform: params.platformKey,
           project_id: params.project.id,
+          ...docsFlowVariantParams(params.docsFlow),
         }
       );
     };

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -1,3 +1,11 @@
+/**
+ * Project-creation-flow variant. Encodes SCM vs legacy in a param instead of the
+ * event name so both variants keep incrementing the same `project_creation.*`
+ * counter (preserving absolute dashboard totals) while staying segmentable. See
+ * the setup-docs events below and the SCM cores that emit it.
+ */
+export type ProjectCreationVariant = 'scm' | 'legacy';
+
 export type ProjectCreationEventParameters = {
   'project_creation.back_button_clicked': Record<string, unknown>;
   'project_creation.data_removal_modal_confirm_button_clicked': {
@@ -10,6 +18,28 @@ export type ProjectCreationEventParameters = {
     date_created: string;
     platform: string;
     project_id: string;
+  };
+  // Setup-docs (getting-started) page events, mirroring onboarding.* /
+  // onboarding.scm_*. The non-scm_ keys fix a pollution bug where project
+  // creation previously emitted onboarding.* for these interactions. The
+  // optional `variant` splits SCM vs legacy project creation without a separate
+  // event name (see docsFlowAnalytics.ts / docsFlowVariantParams).
+  'project_creation.dsn_copied': {
+    platform: string;
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.js_loader_npm_docs_shown': {
+    platform: string;
+    project_id: string;
+    variant?: ProjectCreationVariant;
+  };
+  'project_creation.next_step_clicked': {
+    newOrg: boolean;
+    platform: string;
+    products: string[];
+    project_id: string;
+    step: string;
+    variant?: ProjectCreationVariant;
   };
   // SCM-first project creation flow (mirrors onboarding.scm_*)
   'project_creation.scm_connect_integration_selected': {
@@ -63,13 +93,20 @@ export type ProjectCreationEventParameters = {
   'project_creation.select_framework_modal_skip_button_clicked': {
     platform: string;
   };
+  'project_creation.setup_loader_docs_rendered': {
+    platform: string;
+    project_id: string;
+    variant?: ProjectCreationVariant;
+  };
   'project_creation.source_maps_wizard_button_copy_clicked': {
     platform: string;
     project_id: string;
+    variant?: ProjectCreationVariant;
   };
   'project_creation.source_maps_wizard_selected_and_copied': {
     platform: string;
     project_id: string;
+    variant?: ProjectCreationVariant;
   };
 };
 
@@ -122,4 +159,10 @@ export const projectCreationEventMap: Record<
     'Project Creation: Source Maps Wizard Button Copy Clicked',
   'project_creation.source_maps_wizard_selected_and_copied':
     'Project Creation: Source Maps Wizard Selected and Copied',
+  'project_creation.dsn_copied': 'Project Creation: DSN Copied',
+  'project_creation.next_step_clicked': 'Project Creation: Next Step Clicked',
+  'project_creation.js_loader_npm_docs_shown':
+    'Project Creation: JS Loader Switch to npm Instructions',
+  'project_creation.setup_loader_docs_rendered':
+    'Project Creation: Setup Loader Docs Rendered',
 };

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -410,7 +410,7 @@ describe('CreateProject', () => {
     });
     TeamStore.loadUserTeams([teamWithAccess]);
 
-    render(<CreateProject />, {
+    const {router} = render(<CreateProject />, {
       organization,
     });
 
@@ -422,6 +422,7 @@ describe('CreateProject', () => {
       1
     );
     expect(addSuccessMessage).toHaveBeenCalledWith('Created project testProj');
+    expect(router.location.query.projectCreationVariant).toBe('legacy');
   });
 
   it('should display error message on proj creation failure', async () => {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -326,14 +326,15 @@ export function CreateProject() {
           wasNameManuallyModified: hasUserModifiedProjectName.current,
         });
 
-        navigate(
-          normalizeUrl(
+        navigate({
+          pathname: normalizeUrl(
             makeProjectsPathname({
               path: `/${project.slug}/getting-started/`,
               organization,
             })
-          )
-        );
+          ),
+          query: {projectCreationVariant: 'legacy'},
+        });
       } catch (error: any) {
         addErrorMessage(t('Failed to create project %s', projectName));
 

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -9,7 +9,10 @@ import {Grid, type GridProps} from '@sentry/scraps/layout';
 import Feature from 'sentry/components/acl/feature';
 import {NotFound} from 'sentry/components/errors/notFound';
 import {SdkDocumentation} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
-import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {
+  DocsFlow,
+  ProductSolution,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {platformProductAvailability} from 'sentry/components/onboarding/productSelection';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {setPageFiltersStorage} from 'sentry/components/pageFilters/persistence';
@@ -19,7 +22,7 @@ import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {decodeList} from 'sentry/utils/queryString';
+import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -45,6 +48,17 @@ export function ProjectInstallPlatform({project, platform}: Props) {
   const isSelfHosted = ConfigStore.get('isSelfHosted');
 
   const onProductSelectionSync = useScmCreateProjectProductSync(project);
+
+  // Attribute setup-docs analytics from the flow that actually created this
+  // project. Experiment enrollment alone is insufficient: users can visit
+  // getting-started for older or unrelated projects while still enrolled.
+  const projectCreationVariant = decodeScalar(location.query.projectCreationVariant);
+  const docsFlow: DocsFlow | undefined =
+    projectCreationVariant === 'scm'
+      ? 'project-creation-scm'
+      : projectCreationVariant === 'legacy'
+        ? 'project-creation'
+        : undefined;
 
   const products = useMemo(
     () => decodeList(location.query.product ?? []) as ProductSolution[],
@@ -98,7 +112,7 @@ export function ProjectInstallPlatform({project, platform}: Props) {
           project={project}
           activeProductSelection={products}
           onProductSelectionSync={onProductSelectionSync}
-          docsFlow="project-creation"
+          docsFlow={docsFlow}
         />
       )}
       <div>

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -217,6 +217,7 @@ describe('ScmCreateProject', () => {
     await waitFor(() => {
       expect(router.location.pathname).toContain('/python/getting-started/');
     });
+    expect(router.location.query.projectCreationVariant).toBe('scm');
   });
 
   it('forwards the selected products to getting-started as the product query', async () => {
@@ -260,6 +261,7 @@ describe('ScmCreateProject', () => {
       ProductSolution.PERFORMANCE_MONITORING,
       ProductSolution.SESSION_REPLAY,
     ]);
+    expect(router.location.query.projectCreationVariant).toBe('scm');
   });
 
   it('forwards synced-back product selection to getting-started on the next project creation', async () => {

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -198,15 +198,15 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
           path: `/${project.slug}/getting-started/`,
           organization,
         }),
-        // Carry the upfront product selection into the setup docs so the
-        // instructions match what was chosen here; the getting-started page
-        // seeds its selection from the `product` query. Mirrors the SCM
-        // onboarding flow (ScmProjectDetails -> goNextStep). Classic
-        // createProject selects products on that page instead, so it forwards
-        // nothing.
-        query: wizardState.selectedFeatures
-          ? {product: wizardState.selectedFeatures}
-          : undefined,
+        // Carry both the creating flow and upfront product selection into the
+        // setup docs. The flow marker attributes analytics to the SCM variant;
+        // the product query seeds the selected instructions.
+        query: {
+          projectCreationVariant: 'scm',
+          ...(wizardState.selectedFeatures
+            ? {product: wizardState.selectedFeatures}
+            : {}),
+        },
       });
     },
     [wizardState, navigate, organization]


### PR DESCRIPTION
## TLDR

Moves project-creation setup-docs activity out of `onboarding.*` counters and onto shared `project_creation.*` events, segmented by `variant: 'scm' | 'legacy'` from an explicit creation-flow marker.

## Details

This PR is stacked on the behavior-preserving `docsFlow` refactor (#119937). It contains the analytics contract change separately so reviewers can evaluate event names, dimensions, and BI discontinuities without also reviewing the boolean-to-enum plumbing.

Legacy `CreateProject` and `ScmCreateProject` now forward `projectCreationVariant=legacy|scm` when navigating to the shared getting-started page. `ProjectInstallPlatform` derives `docsFlow` from that marker rather than from experiment enrollment: enrolled users can visit older or unrelated projects, so the experiment alone is not evidence that the current page came from SCM creation. Unmarked peripheral surfaces use the canonical project-creation event names without a guessed variant.

The two marked project-creation arms resolve to the same `project_creation.*` names for DSN copy, next step, JS-loader, setup-loader, source-map, and framework interactions. `docsFlowVariantParams` supplies the SCM/legacy split at each fire site; onboarding and SCM onboarding keep their existing distinct names and never receive the project-creation variant. The project-creation registry gains the missing base setup-docs events.

`setup_guide.copy_as_markdown` follows the shared-param model: `source` contains only the flow (`first_time_setup` or `project_getting_started`) and `variant` contains SCM-ness. This intentionally removes the `_scm` source values, including SCM onboarding; unmarked surfaces retain the project source without a variant. Gaming origin remains on its existing two-value taxonomy.

Coverage verifies the collapsed event maps, all four marked flow variants, unmarked behavior, and both create paths forwarding the correct marker while preserving SCM product-selection query parameters.

BI note: project-creation DSN/next-step/loader traffic leaves the polluted onboarding counters; copy-as-markdown `_scm` source values move to base source + `variant`.

Refs VDY-133
