### PR TITLE
feat(sentry-apps): indicate custom formatting applied to routines

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -200,6 +200,29 @@ describe('Sentry Application Details', () => {
         screen.queryByRole('textbox', {name: 'Redirect URL'})
       ).not.toBeInTheDocument();
     });
+
+    it('notes the payload transform when the URL fires a Claude routine', async () => {
+      render(<SentryApplicationDetails />, {
+        initialRouterConfig,
+        organization: OrganizationFixture({
+          features: ['sentry-apps-claude-routine-webhooks'],
+        }),
+      });
+
+      const webhookInput = screen.getByRole('textbox', {name: 'Webhook URL'});
+      await userEvent.type(
+        webhookInput,
+        'https://api.anthropic.com/v1/claude_code/routines/trig_123/fire'
+      );
+
+      await userEvent.hover(screen.getByText('Claude routine'));
+      expect(
+        await screen.findByText(/automatically format your webhook payloads/)
+      ).toBeInTheDocument();
+
+      await userEvent.type(webhookInput, '/extra');
+      expect(screen.queryByText('Claude routine')).not.toBeInTheDocument();
+    });
   });
 
   describe('Renders public app', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -4,6 +4,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
 import {Flex} from '@sentry/scraps/layout';
@@ -85,6 +86,11 @@ const AVATAR_STYLES = {
     ),
   },
 };
+
+// Mirrors CLAUDE_ROUTINE_URL_RE in src/sentry/utils/sentry_apps/webhooks.py;
+// payloads sent to matching URLs get a plain-text prompt added.
+const CLAUDE_ROUTINE_URL_REGEX =
+  /^https:\/\/api\.anthropic\.com\/v1\/claude_code\/routines\/[^/?#]+\/fire\/?$/;
 
 const sentryAppFormSchema = z
   .object({
@@ -706,6 +712,18 @@ function SentryApplicationForm({
                 value={field.state.value}
                 onChange={field.handleChange}
                 placeholder={t('e.g. https://example.com/sentry/webhook/')}
+                trailingItems={
+                  organization.features.includes('sentry-apps-claude-routine-webhooks') &&
+                  CLAUDE_ROUTINE_URL_REGEX.test(field.state.value) ? (
+                    <Tooltip
+                      title={t(
+                        'Sentry will automatically format your webhook payloads to be compatible with Claude Routines.'
+                      )}
+                    >
+                      <Tag variant="info">{t('Claude routine')}</Tag>
+                    </Tooltip>
+                  ) : null
+                }
               />
             </field.Layout.Row>
           )}


### PR DESCRIPTION
Add a tag to the custom integration webhook field that pops up when entering a claude routine-like url. Looks like this:
<img width="618" height="139" alt="Screenshot 2026-07-20 at 4 31 14 PM" src="https://github.com/user-attachments/assets/72079438-941b-405e-b7bd-9489b202db64" />
