### PR TITLE
feat(analytics): Attribute getting-started header actions by variant

### DIFF
--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -11,7 +11,9 @@ export type ProjectCreationEventParameters = {
     field: 'threshold' | 'metric' | 'interval';
     variant?: ProjectCreationVariant;
   };
-  'project_creation.back_button_clicked': Record<string, unknown>;
+  'project_creation.back_button_clicked': {
+    variant?: ProjectCreationVariant;
+  };
   // SCM-first project creation wizard steps. SCM vs legacy rides in `variant`
   // (see scmFlowVariantParams); these events are only emitted by the SCM cores
   // today, so `variant` is `scm` in practice, but stays optional so a future
@@ -31,13 +33,17 @@ export type ProjectCreationEventParameters = {
   'project_creation.data_removal_modal_confirm_button_clicked': {
     platform: string;
     project_id: string;
+    variant?: ProjectCreationVariant;
   };
+  // Defined but never fired — back-nav deletes directly with no modal. Left in
+  // the registry so historical dashboards don't lose the key; do not wire.
   'project_creation.data_removal_modal_dismissed': {platform: string; project_id: string};
   'project_creation.data_removal_modal_rendered': {platform: string; project_id: string};
   'project_creation.data_removed': {
     date_created: string;
     platform: string;
     project_id: string;
+    variant?: ProjectCreationVariant;
   };
   // Setup-docs (getting-started) page events, mirroring onboarding.* /
   // onboarding.scm_*. The non-scm_ keys fix a pollution bug where project

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -2,9 +2,10 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {ProjectKeysFixture} from 'sentry-fixture/projectKeys';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import * as useRecentCreatedProjectHook from 'sentry/components/onboarding/useRecentCreatedProject';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
@@ -65,7 +66,13 @@ function mockProjectApiResponses(projects: Array<Project | ProjectWithBadPlatfor
   });
 }
 
-function renderAnalyticsScenario(projectCreationVariant?: string) {
+function renderAnalyticsScenario(
+  projectCreationVariant?: string,
+  options: {
+    isProjectActive?: boolean;
+    mockRecentCreatedProject?: boolean;
+  } = {}
+) {
   const {organization, project} = initializeOrg({
     router: {params: {projectId: ProjectFixture().slug}},
   });
@@ -87,6 +94,19 @@ function renderAnalyticsScenario(projectCreationVariant?: string) {
 
   ProjectsStore.loadInitialData([projectWithPlatform]);
   mockProjectApiResponses([projectWithPlatform]);
+
+  if (options.mockRecentCreatedProject) {
+    jest.spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject').mockReturnValue({
+      project: projectWithPlatform,
+      isProjectActive: options.isProjectActive ?? false,
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${projectWithPlatform.slug}/`,
+      method: 'DELETE',
+      body: {},
+    });
+  }
+
   const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
   render(
     <RouteAnalyticsContext value={routeAnalytics}>
@@ -268,6 +288,97 @@ describe('ProjectInstallPlatform', () => {
     expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
       'project_creation.take_me_to_issues_clicked',
       expect.anything()
+    );
+  });
+
+  it.each(['scm', 'legacy'] as const)(
+    'attributes getting-started header back analytics to the %s variant',
+    async variant => {
+      const {organization, project, trackAnalyticsSpy} = renderAnalyticsScenario(
+        variant,
+        {mockRecentCreatedProject: true, isProjectActive: false}
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Back to Platform Selection'})
+      );
+
+      await waitFor(() => {
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+          'project_creation.back_button_clicked',
+          expect.objectContaining({organization, variant})
+        );
+      });
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'project_creation.data_removal_modal_confirm_button_clicked',
+        expect.objectContaining({
+          organization,
+          platform: project.slug,
+          project_id: project.id,
+          variant,
+        })
+      );
+      await waitFor(() => {
+        expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+          'project_creation.data_removed',
+          expect.objectContaining({
+            organization,
+            date_created: project.dateCreated,
+            platform: project.slug,
+            project_id: project.id,
+            variant,
+          })
+        );
+      });
+    }
+  );
+
+  it('fires header back analytics without a guessed variant when unmarked', async () => {
+    const {organization, project, trackAnalyticsSpy} = renderAnalyticsScenario(
+      undefined,
+      {mockRecentCreatedProject: true, isProjectActive: false}
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Back to Platform Selection'})
+    );
+
+    await waitFor(() => {
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'project_creation.back_button_clicked',
+        expect.objectContaining({organization})
+      );
+    });
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.back_button_clicked',
+      expect.not.objectContaining({variant: expect.anything()})
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.data_removal_modal_confirm_button_clicked',
+      expect.objectContaining({
+        organization,
+        platform: project.slug,
+        project_id: project.id,
+      })
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.data_removal_modal_confirm_button_clicked',
+      expect.not.objectContaining({variant: expect.anything()})
+    );
+    await waitFor(() => {
+      expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+        'project_creation.data_removed',
+        expect.objectContaining({
+          organization,
+          date_created: project.dateCreated,
+          platform: project.slug,
+          project_id: project.id,
+        })
+      );
+    });
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.data_removed',
+      expect.not.objectContaining({variant: expect.anything()})
     );
   });
 });

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -134,7 +134,11 @@ export function ProjectInstallPlatform({project, platform}: Props) {
       {!isSelfHosted && showDocsWithProductSelection && (
         <ProductUnavailableCTA organization={organization} />
       )}
-      <PlatformDocHeader projectSlug={project.slug} platform={platform} />
+      <PlatformDocHeader
+        projectSlug={project.slug}
+        platform={platform}
+        projectCreationVariant={projectCreationVariant}
+      />
       {platform.id === 'other' ? (
         <OtherPlatformsInfo
           projectSlug={project.slug}

--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -11,6 +11,7 @@ import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import type {PlatformIntegration, Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {ProjectCreationVariant} from 'sentry/utils/analytics/projectCreationAnalyticsEvents';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
@@ -21,10 +22,23 @@ import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 type Props = {
   platform: PlatformIntegration;
   projectSlug: Project['slug'];
+  /**
+   * When this getting-started page was reached from project creation, the
+   * create form stamps `?projectCreationVariant=scm|legacy`. Stamp that onto
+   * the three header events so abandonment can be segmented. Unmarked entry
+   * points (older projects, peripheral links) keep firing the same
+   * `project_creation.*` names without a variant guess.
+   */
+  projectCreationVariant?: ProjectCreationVariant;
   title?: string;
 };
 
-export function PlatformDocHeader({platform, projectSlug, title}: Props) {
+export function PlatformDocHeader({
+  platform,
+  projectSlug,
+  projectCreationVariant,
+  title,
+}: Props) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
   const navigate = useNavigate();
@@ -39,8 +53,11 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
       return;
     }
 
+    const variantParams = projectCreationVariant ? {variant: projectCreationVariant} : {};
+
     trackAnalytics('project_creation.back_button_clicked', {
       organization,
+      ...variantParams,
     });
 
     if (!isProjectActive) {
@@ -48,6 +65,7 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
         organization,
         platform: recentCreatedProject.slug,
         project_id: recentCreatedProject.id,
+        ...variantParams,
       });
 
       try {
@@ -63,6 +81,7 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
           date_created: recentCreatedProject.dateCreated,
           platform: recentCreatedProject.slug,
           project_id: recentCreatedProject.id,
+          ...variantParams,
         });
       } catch (error) {
         handleXhrErrorResponse(
@@ -80,7 +99,14 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
       }) + `?referrer=getting-started&project=${recentCreatedProject.id}`,
       {replace: true}
     );
-  }, [api, recentCreatedProject, organization, isProjectActive, navigate]);
+  }, [
+    api,
+    recentCreatedProject,
+    organization,
+    isProjectActive,
+    navigate,
+    projectCreationVariant,
+  ]);
 
   useBlocker(({historyAction}) => {
     if (historyAction === 'POP') {


### PR DESCRIPTION
## TLDR

The shared getting-started header’s back / silent-delete analytics now carry `variant: 'scm' | 'legacy'` when the page was reached from project creation, so abandonment can be segmented without new event names.

## Details

Stacked on the getting-started funnel PR (#120131), which already consumes the `?projectCreationVariant=` forward-nav marker on this page for the view event and “Take me to Issues”. This PR extends that marker into `PlatformDocHeader`, the abandonment surface on the same page.

`ProjectInstallPlatform` passes the validated marker into `PlatformDocHeader`. On back click the header still fires the three existing live counters — `project_creation.back_button_clicked`, `project_creation.data_removal_modal_confirm_button_clicked` (name is historical; there is no modal — back-nav deletes an inactive project directly), and `project_creation.data_removed` after a successful delete. When the marker is present each payload gains `variant`; when it is missing the same names fire without a variant, so peripheral entry points (older projects, non-creation links) are not guessed into SCM or legacy. The typed params gain optional `variant` to match. The two dead registry keys (`data_removal_modal_rendered` / `_dismissed`) stay unwired — flagged in a one-line comment only.

Coverage extends the existing getting-started analytics helper: both marked variants assert all three events carry the right `variant` through the inactive-project delete path, and the unmarked path asserts the same events fire without a `variant` field.

Refs VDY-133