### PR TITLE
feat(analytics): Tag project-creation page views by sticky org origin

### DIFF
--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -91,7 +91,7 @@ describe('OrganizationCreate', () => {
     });
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      '/organizations/org-slug/projects/new/?referrer=org-creation'
+      '/organizations/org-slug/projects/new/?projectCreationOrigin=org_creation'
     );
   });
 
@@ -128,7 +128,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
+      'https://org-slug.sentry.io/projects/new/?projectCreationOrigin=org_creation'
     );
   });
 
@@ -176,7 +176,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
+      'https://org-slug.sentry.io/projects/new/?projectCreationOrigin=org_creation'
     );
   });
 
@@ -213,7 +213,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
+      'https://org-slug.sentry.io/projects/new/?projectCreationOrigin=org_creation'
     );
   });
 
@@ -245,7 +245,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
+      'https://org-slug.sentry.io/projects/new/?projectCreationOrigin=org_creation'
     );
   });
 
@@ -291,7 +291,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
+      'https://org-slug.sentry.io/projects/new/?projectCreationOrigin=org_creation'
     );
   });
 });

--- a/static/app/views/organizationCreate/index.spec.tsx
+++ b/static/app/views/organizationCreate/index.spec.tsx
@@ -91,7 +91,7 @@ describe('OrganizationCreate', () => {
     });
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      '/organizations/org-slug/projects/new/'
+      '/organizations/org-slug/projects/new/?referrer=org-creation'
     );
   });
 
@@ -128,7 +128,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/'
+      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
     );
   });
 
@@ -176,7 +176,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/'
+      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
     );
   });
 
@@ -213,7 +213,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/'
+      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
     );
   });
 
@@ -245,7 +245,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/'
+      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
     );
   });
 
@@ -291,7 +291,7 @@ describe('OrganizationCreate', () => {
 
     expect(testableWindowLocation.assign).toHaveBeenCalledTimes(1);
     expect(testableWindowLocation.assign).toHaveBeenCalledWith(
-      'https://org-slug.sentry.io/projects/new/'
+      'https://org-slug.sentry.io/projects/new/?referrer=org-creation'
     );
   });
 });

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -83,8 +83,13 @@ function OrganizationCreate() {
           onSubmitSuccess={(createdOrg: OrganizationSummary) => {
             const hasCustomerDomain =
               ConfigStore.get('features').has('system:multi-region');
+            // Marker for project-creation page-view analytics: distinguishes
+            // brand-new org activation from adding a project to an existing
+            // org. Must ride on the URL — this redirect is a full page reload
+            // (testableWindowLocation.assign), so location.state does not
+            // survive. Orthogonal to `?referrer=getting-started` (autofill).
             let nextUrl = normalizeUrl(
-              `/organizations/${createdOrg.slug}/projects/new/`,
+              `/organizations/${createdOrg.slug}/projects/new/?referrer=org-creation`,
               {forceCustomerDomain: hasCustomerDomain}
             );
             if (hasCustomerDomain) {

--- a/static/app/views/organizationCreate/index.tsx
+++ b/static/app/views/organizationCreate/index.tsx
@@ -20,6 +20,10 @@ import {getSignupLocalities} from 'sentry/utils/cells';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
+import {
+  PROJECT_CREATION_ORIGIN_ORG_CREATION,
+  PROJECT_CREATION_ORIGIN_QUERY_KEY,
+} from 'sentry/views/projectInstall/projectCreationOrigin';
 
 export const DATA_STORAGE_DOCS_LINK =
   'https://docs.sentry.io/product/accounts/choose-your-data-center';
@@ -83,13 +87,14 @@ function OrganizationCreate() {
           onSubmitSuccess={(createdOrg: OrganizationSummary) => {
             const hasCustomerDomain =
               ConfigStore.get('features').has('system:multi-region');
-            // Marker for project-creation page-view analytics: distinguishes
-            // brand-new org activation from adding a project to an existing
-            // org. Must ride on the URL — this redirect is a full page reload
-            // (testableWindowLocation.assign), so location.state does not
-            // survive. Orthogonal to `?referrer=getting-started` (autofill).
+            // One-shot seed for sticky journey origin on /projects/new/. Must
+            // ride on the URL: this redirect is a full page reload
+            // (testableWindowLocation.assign), often onto a customer-domain
+            // host, so sessionStorage set here would not survive. Dedicated
+            // query key — not `referrer`, which getting-started back uses for
+            // autofill and would clobber this mid-journey.
             let nextUrl = normalizeUrl(
-              `/organizations/${createdOrg.slug}/projects/new/?referrer=org-creation`,
+              `/organizations/${createdOrg.slug}/projects/new/?${PROJECT_CREATION_ORIGIN_QUERY_KEY}=${PROJECT_CREATION_ORIGIN_ORG_CREATION}`,
               {forceCustomerDomain: hasCustomerDomain}
             );
             if (hasCustomerDomain) {

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -20,6 +20,7 @@ import type {Organization} from 'sentry/types/organization';
 import * as analytics from 'sentry/utils/analytics';
 import {CreateProject} from 'sentry/views/projectInstall/createProject';
 import * as useValidateChannelModule from 'sentry/views/projectInstall/useValidateChannel';
+import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
 jest.mock('sentry/actionCreators/indicator');
 
@@ -107,6 +108,57 @@ describe('CreateProject', () => {
   afterEach(() => {
     MockApiClient.clearMockResponses();
   });
+
+  it.each([
+    {referrer: undefined, origin: 'existing_org'},
+    {referrer: 'org-creation', origin: 'org_creation'},
+    // Autofill return path — orthogonal marker; still counts as existing-org.
+    {referrer: 'getting-started', origin: 'existing_org'},
+  ] as const)(
+    'sets project-creation page-view origin to $origin when referrer is $referrer',
+    ({referrer, origin}) => {
+      const organization = OrganizationFixture({
+        access: ['project:read', 'project:write', 'project:admin'],
+      });
+      TeamStore.loadUserTeams([teamWithAccess]);
+      renderFrameworkModalMockRequests({
+        organization,
+        teamSlug: teamWithAccess.slug,
+      });
+
+      const routeAnalytics = {
+        previousUrl: '',
+        setDisableRouteAnalytics: jest.fn(),
+        setEventNames: jest.fn(),
+        setOrganization: jest.fn(),
+        setRouteAnalyticsParams: jest.fn(),
+      };
+
+      render(
+        <RouteAnalyticsContext value={routeAnalytics}>
+          <CreateProject />
+        </RouteAnalyticsContext>,
+        {
+          organization,
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/projects/new/',
+              query: referrer ? {referrer} : {},
+            },
+          },
+        }
+      );
+
+      expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
+        'project_creation_page.viewed',
+        'Project Create: Creation page viewed'
+      );
+      expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+        variant: 'legacy',
+        origin,
+      });
+    }
+  );
 
   it('should block if you have access to no teams without team-roles', () => {
     const organization = OrganizationFixture({

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -107,58 +107,95 @@ describe('CreateProject', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    window.sessionStorage.clear();
   });
 
-  it.each([
-    {referrer: undefined, origin: 'existing_org'},
-    {referrer: 'org-creation', origin: 'org_creation'},
-    // Autofill return path — orthogonal marker; still counts as existing-org.
-    {referrer: 'getting-started', origin: 'existing_org'},
-  ] as const)(
-    'sets project-creation page-view origin to $origin when referrer is $referrer',
-    ({referrer, origin}) => {
-      const organization = OrganizationFixture({
-        access: ['project:read', 'project:write', 'project:admin'],
-      });
-      TeamStore.loadUserTeams([teamWithAccess]);
-      renderFrameworkModalMockRequests({
+  function renderCreateWithOriginQuery(query: Record<string, string> = {}) {
+    const organization = OrganizationFixture({
+      access: ['project:read', 'project:write', 'project:admin'],
+    });
+    TeamStore.loadUserTeams([teamWithAccess]);
+    renderFrameworkModalMockRequests({
+      organization,
+      teamSlug: teamWithAccess.slug,
+    });
+
+    const routeAnalytics = {
+      previousUrl: '',
+      setDisableRouteAnalytics: jest.fn(),
+      setEventNames: jest.fn(),
+      setOrganization: jest.fn(),
+      setRouteAnalyticsParams: jest.fn(),
+    };
+
+    render(
+      <RouteAnalyticsContext value={routeAnalytics}>
+        <CreateProject />
+      </RouteAnalyticsContext>,
+      {
         organization,
-        teamSlug: teamWithAccess.slug,
-      });
-
-      const routeAnalytics = {
-        previousUrl: '',
-        setDisableRouteAnalytics: jest.fn(),
-        setEventNames: jest.fn(),
-        setOrganization: jest.fn(),
-        setRouteAnalyticsParams: jest.fn(),
-      };
-
-      render(
-        <RouteAnalyticsContext value={routeAnalytics}>
-          <CreateProject />
-        </RouteAnalyticsContext>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: '/organizations/org-slug/projects/new/',
-              query: referrer ? {referrer} : {},
-            },
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/projects/new/',
+            query,
           },
-        }
-      );
+        },
+      }
+    );
 
-      expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
-        'project_creation_page.viewed',
-        'Project Create: Creation page viewed'
-      );
-      expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
-        variant: 'legacy',
-        origin,
-      });
-    }
-  );
+    return {organization, routeAnalytics};
+  }
+
+  it('sets page-view origin to org_creation from the org-create seed param', () => {
+    const {routeAnalytics} = renderCreateWithOriginQuery({
+      projectCreationOrigin: 'org_creation',
+    });
+
+    expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
+      'project_creation_page.viewed',
+      'Project Create: Creation page viewed'
+    );
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'legacy',
+      origin: 'org_creation',
+    });
+  });
+
+  it('keeps org_creation origin sticky after getting-started autofill return', () => {
+    // Prior org-create land already wrote sticky origin for this org.
+    window.sessionStorage.setItem('project-creation-origin:org-slug', 'org_creation');
+
+    // Back from instructions only brings autofill referrer; journey origin sticks.
+    const {routeAnalytics} = renderCreateWithOriginQuery({
+      referrer: 'getting-started',
+      project: '123',
+    });
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'legacy',
+      origin: 'org_creation',
+    });
+  });
+
+  it('defaults page-view origin to existing_org without a seed', () => {
+    const {routeAnalytics} = renderCreateWithOriginQuery();
+
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'legacy',
+      origin: 'existing_org',
+    });
+  });
+
+  it('does not treat getting-started referrer alone as org creation', () => {
+    const {routeAnalytics} = renderCreateWithOriginQuery({
+      referrer: 'getting-started',
+      project: '123',
+    });
+
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'legacy',
+      origin: 'existing_org',
+    });
+  });
 
   it('should block if you have access to no teams without team-roles', () => {
     const organization = OrganizationFixture({

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -276,7 +276,14 @@ export function CreateProject() {
     'project_creation_page.viewed',
     'Project Create: Creation page viewed'
   );
-  useRouteAnalyticsParams({variant: 'legacy'});
+  // `origin` is orthogonal to `variant`: org-create success redirects here with
+  // `?referrer=org-creation` (full-page reload), everything else is existing-org.
+  // `referrer=getting-started` is the autofill path and never coexists with
+  // org-creation, so it correctly lands as existing_org.
+  useRouteAnalyticsParams({
+    variant: 'legacy',
+    origin: referrer === 'org-creation' ? 'org_creation' : 'existing_org',
+  });
 
   const configurePlatform = useCallback(
     async ({

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -55,7 +55,7 @@ import {
   IssueAlertOptions,
   RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
-import {resolveProjectCreationPageOrigin} from 'sentry/views/projectInstall/projectCreationOrigin';
+import {useProjectCreationPageOrigin} from 'sentry/views/projectInstall/projectCreationOrigin';
 import {useValidateChannel} from 'sentry/views/projectInstall/useValidateChannel';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
@@ -281,13 +281,7 @@ export function CreateProject() {
   // ?projectCreationOrigin=org_creation from org-create). Orthogonal to
   // `variant` and to `referrer=getting-started` autofill — back-from-docs
   // must not reclassify an org-activation visit as existing_org.
-  useRouteAnalyticsParams({
-    variant: 'legacy',
-    origin: resolveProjectCreationPageOrigin({
-      orgSlug: organization.slug,
-      queryValue: decodeScalar(location.query.projectCreationOrigin),
-    }),
-  });
+  useRouteAnalyticsParams({variant: 'legacy', origin: useProjectCreationPageOrigin()});
 
   const configurePlatform = useCallback(
     async ({

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -55,6 +55,7 @@ import {
   IssueAlertOptions,
   RuleAction,
 } from 'sentry/views/projectInstall/issueAlertOptions';
+import {resolveProjectCreationPageOrigin} from 'sentry/views/projectInstall/projectCreationOrigin';
 import {useValidateChannel} from 'sentry/views/projectInstall/useValidateChannel';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
@@ -276,13 +277,16 @@ export function CreateProject() {
     'project_creation_page.viewed',
     'Project Create: Creation page viewed'
   );
-  // `origin` is orthogonal to `variant`: org-create success redirects here with
-  // `?referrer=org-creation` (full-page reload), everything else is existing-org.
-  // `referrer=getting-started` is the autofill path and never coexists with
-  // org-creation, so it correctly lands as existing_org.
+  // Journey origin is sticky (sessionStorage seeded by
+  // ?projectCreationOrigin=org_creation from org-create). Orthogonal to
+  // `variant` and to `referrer=getting-started` autofill — back-from-docs
+  // must not reclassify an org-activation visit as existing_org.
   useRouteAnalyticsParams({
     variant: 'legacy',
-    origin: referrer === 'org-creation' ? 'org_creation' : 'existing_org',
+    origin: resolveProjectCreationPageOrigin({
+      orgSlug: organization.slug,
+      queryValue: decodeScalar(location.query.projectCreationOrigin),
+    }),
   });
 
   const configurePlatform = useCallback(

--- a/static/app/views/projectInstall/projectCreationOrigin.spec.tsx
+++ b/static/app/views/projectInstall/projectCreationOrigin.spec.tsx
@@ -1,8 +1,13 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 import {
   PROJECT_CREATION_ORIGIN_ORG_CREATION,
   PROJECT_CREATION_ORIGIN_QUERY_KEY,
   resolveProjectCreationPageOrigin,
+  useProjectCreationPageOrigin,
 } from 'sentry/views/projectInstall/projectCreationOrigin';
 
 describe('resolveProjectCreationPageOrigin', () => {
@@ -10,7 +15,8 @@ describe('resolveProjectCreationPageOrigin', () => {
     sessionStorageWrapper.clear();
   });
 
-  it('seeds storage and returns org_creation from the query param', () => {
+  it('returns org_creation from the query seed without writing storage', () => {
+    // Pure read: the sticky write lives in the hook, not the resolver.
     expect(
       resolveProjectCreationPageOrigin({
         orgSlug: 'acme',
@@ -18,60 +24,96 @@ describe('resolveProjectCreationPageOrigin', () => {
       })
     ).toBe('org_creation');
 
-    expect(sessionStorageWrapper.getItem('project-creation-origin:acme')).toBe(
-      PROJECT_CREATION_ORIGIN_ORG_CREATION
-    );
+    expect(sessionStorageWrapper.getItem('project-creation-origin:acme')).toBeNull();
   });
 
-  it('returns sticky org_creation after the seed is gone (e.g. autofill back)', () => {
-    resolveProjectCreationPageOrigin({
-      orgSlug: 'acme',
-      queryValue: PROJECT_CREATION_ORIGIN_ORG_CREATION,
-    });
+  it('returns sticky org_creation from storage when the seed is gone', () => {
+    // Simulates the getting-started autofill return: storage set on a prior
+    // land, URL now only carries referrer (no origin seed).
+    sessionStorageWrapper.setItem(
+      'project-creation-origin:acme',
+      PROJECT_CREATION_ORIGIN_ORG_CREATION
+    );
 
     expect(
-      resolveProjectCreationPageOrigin({
-        orgSlug: 'acme',
-        // Getting-started back only sets referrer — no origin seed.
-        queryValue: undefined,
-      })
+      resolveProjectCreationPageOrigin({orgSlug: 'acme', queryValue: undefined})
     ).toBe('org_creation');
   });
 
   it('defaults to existing_org with no seed and empty storage', () => {
     expect(
-      resolveProjectCreationPageOrigin({
-        orgSlug: 'acme',
-        queryValue: undefined,
-      })
+      resolveProjectCreationPageOrigin({orgSlug: 'acme', queryValue: undefined})
     ).toBe('existing_org');
   });
 
   it('does not treat other query values as org creation', () => {
     expect(
-      resolveProjectCreationPageOrigin({
-        orgSlug: 'acme',
-        queryValue: 'getting-started',
-      })
+      resolveProjectCreationPageOrigin({orgSlug: 'acme', queryValue: 'getting-started'})
     ).toBe('existing_org');
   });
 
   it('scopes sticky origin per org slug', () => {
-    resolveProjectCreationPageOrigin({
-      orgSlug: 'acme',
-      queryValue: PROJECT_CREATION_ORIGIN_ORG_CREATION,
-    });
+    sessionStorageWrapper.setItem(
+      'project-creation-origin:acme',
+      PROJECT_CREATION_ORIGIN_ORG_CREATION
+    );
 
     expect(
-      resolveProjectCreationPageOrigin({
-        orgSlug: 'other-org',
-        queryValue: undefined,
-      })
+      resolveProjectCreationPageOrigin({orgSlug: 'other-org', queryValue: undefined})
     ).toBe('existing_org');
   });
 
   it('exports the query key used by org-create redirect', () => {
     // Guard against silent drift between the redirect builder and the reader.
     expect(PROJECT_CREATION_ORIGIN_QUERY_KEY).toBe('projectCreationOrigin');
+  });
+});
+
+describe('useProjectCreationPageOrigin', () => {
+  const organization = OrganizationFixture({slug: 'acme'});
+
+  beforeEach(() => {
+    sessionStorageWrapper.clear();
+  });
+
+  function renderOrigin(query: Record<string, string> = {}) {
+    return renderHookWithProviders(useProjectCreationPageOrigin, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/organizations/acme/projects/new/', query},
+      },
+    });
+  }
+
+  it('stickies the seed into sessionStorage and returns org_creation', async () => {
+    const {result} = renderOrigin({
+      [PROJECT_CREATION_ORIGIN_QUERY_KEY]: PROJECT_CREATION_ORIGIN_ORG_CREATION,
+    });
+
+    expect(result.current).toBe('org_creation');
+    await waitFor(() => {
+      expect(sessionStorageWrapper.getItem('project-creation-origin:acme')).toBe(
+        PROJECT_CREATION_ORIGIN_ORG_CREATION
+      );
+    });
+  });
+
+  it('keeps org_creation sticky on a bare autofill return', () => {
+    // Prior land already stickied origin for this org.
+    sessionStorageWrapper.setItem(
+      'project-creation-origin:acme',
+      PROJECT_CREATION_ORIGIN_ORG_CREATION
+    );
+
+    const {result} = renderOrigin({referrer: 'getting-started', project: '123'});
+
+    expect(result.current).toBe('org_creation');
+  });
+
+  it('defaults to existing_org and writes nothing without a seed', () => {
+    const {result} = renderOrigin();
+
+    expect(result.current).toBe('existing_org');
+    expect(sessionStorageWrapper.getItem('project-creation-origin:acme')).toBeNull();
   });
 });

--- a/static/app/views/projectInstall/projectCreationOrigin.spec.tsx
+++ b/static/app/views/projectInstall/projectCreationOrigin.spec.tsx
@@ -1,0 +1,77 @@
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+import {
+  PROJECT_CREATION_ORIGIN_ORG_CREATION,
+  PROJECT_CREATION_ORIGIN_QUERY_KEY,
+  resolveProjectCreationPageOrigin,
+} from 'sentry/views/projectInstall/projectCreationOrigin';
+
+describe('resolveProjectCreationPageOrigin', () => {
+  beforeEach(() => {
+    sessionStorageWrapper.clear();
+  });
+
+  it('seeds storage and returns org_creation from the query param', () => {
+    expect(
+      resolveProjectCreationPageOrigin({
+        orgSlug: 'acme',
+        queryValue: PROJECT_CREATION_ORIGIN_ORG_CREATION,
+      })
+    ).toBe('org_creation');
+
+    expect(sessionStorageWrapper.getItem('project-creation-origin:acme')).toBe(
+      PROJECT_CREATION_ORIGIN_ORG_CREATION
+    );
+  });
+
+  it('returns sticky org_creation after the seed is gone (e.g. autofill back)', () => {
+    resolveProjectCreationPageOrigin({
+      orgSlug: 'acme',
+      queryValue: PROJECT_CREATION_ORIGIN_ORG_CREATION,
+    });
+
+    expect(
+      resolveProjectCreationPageOrigin({
+        orgSlug: 'acme',
+        // Getting-started back only sets referrer — no origin seed.
+        queryValue: undefined,
+      })
+    ).toBe('org_creation');
+  });
+
+  it('defaults to existing_org with no seed and empty storage', () => {
+    expect(
+      resolveProjectCreationPageOrigin({
+        orgSlug: 'acme',
+        queryValue: undefined,
+      })
+    ).toBe('existing_org');
+  });
+
+  it('does not treat other query values as org creation', () => {
+    expect(
+      resolveProjectCreationPageOrigin({
+        orgSlug: 'acme',
+        queryValue: 'getting-started',
+      })
+    ).toBe('existing_org');
+  });
+
+  it('scopes sticky origin per org slug', () => {
+    resolveProjectCreationPageOrigin({
+      orgSlug: 'acme',
+      queryValue: PROJECT_CREATION_ORIGIN_ORG_CREATION,
+    });
+
+    expect(
+      resolveProjectCreationPageOrigin({
+        orgSlug: 'other-org',
+        queryValue: undefined,
+      })
+    ).toBe('existing_org');
+  });
+
+  it('exports the query key used by org-create redirect', () => {
+    // Guard against silent drift between the redirect builder and the reader.
+    expect(PROJECT_CREATION_ORIGIN_QUERY_KEY).toBe('projectCreationOrigin');
+  });
+});

--- a/static/app/views/projectInstall/projectCreationOrigin.ts
+++ b/static/app/views/projectInstall/projectCreationOrigin.ts
@@ -1,0 +1,54 @@
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+
+/**
+ * Top-of-funnel attribution for /projects/new/: how the *journey* started,
+ * orthogonal to SCM/legacy `variant` and to the back-nav `referrer` autofill
+ * marker. Sticky for the browser tab so back-from-getting-started does not
+ * reclassify an org-activation visit as existing-org.
+ *
+ * Seed: org-create redirects with `?projectCreationOrigin=org_creation` (must
+ * be a URL param — full page reload, often cross-subdomain onto a customer
+ * domain, so storage set on the signup host would not survive). On first
+ * create-page paint we copy the seed into sessionStorage on *this* origin.
+ * Subsequent create mounts (including autofill returns) read storage.
+ */
+export type ProjectCreationPageOrigin = 'org_creation' | 'existing_org';
+
+/** Query key used only as a one-shot seed on the org-create → create hop. */
+export const PROJECT_CREATION_ORIGIN_QUERY_KEY = 'projectCreationOrigin';
+
+/** Only seed value we write today. Absent / anything else → existing_org. */
+export const PROJECT_CREATION_ORIGIN_ORG_CREATION = 'org_creation';
+
+/**
+ * Resolve journey origin for project-creation page-view analytics.
+ * Side effect: when the URL seed is present, stickies it into sessionStorage.
+ */
+export function resolveProjectCreationPageOrigin({
+  orgSlug,
+  queryValue,
+}: {
+  orgSlug: string;
+  queryValue: string | undefined;
+}): ProjectCreationPageOrigin {
+  const key = `project-creation-origin:${orgSlug}`;
+
+  if (queryValue === PROJECT_CREATION_ORIGIN_ORG_CREATION) {
+    try {
+      sessionStorageWrapper.setItem(key, PROJECT_CREATION_ORIGIN_ORG_CREATION);
+    } catch {
+      // Best-effort sticky; still report org_creation for this paint.
+    }
+    return 'org_creation';
+  }
+
+  try {
+    if (sessionStorageWrapper.getItem(key) === PROJECT_CREATION_ORIGIN_ORG_CREATION) {
+      return 'org_creation';
+    }
+  } catch {
+    // Fall through to existing_org.
+  }
+
+  return 'existing_org';
+}

--- a/static/app/views/projectInstall/projectCreationOrigin.ts
+++ b/static/app/views/projectInstall/projectCreationOrigin.ts
@@ -1,4 +1,9 @@
+import {useEffect} from 'react';
+
+import {decodeScalar} from 'sentry/utils/queryString';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 /**
  * Top-of-funnel attribution for /projects/new/: how the *journey* started,
@@ -21,8 +26,10 @@ export const PROJECT_CREATION_ORIGIN_QUERY_KEY = 'projectCreationOrigin';
 export const PROJECT_CREATION_ORIGIN_ORG_CREATION = 'org_creation';
 
 /**
- * Resolve journey origin for project-creation page-view analytics.
- * Side effect: when the URL seed is present, stickies it into sessionStorage.
+ * Pure read: resolve journey origin from the seed query value, falling back to
+ * the sticky sessionStorage value, then `existing_org`. No side effects — the
+ * sticky write lives in {@link useProjectCreationPageOrigin} so render stays
+ * pure. Safe to call during render.
  */
 export function resolveProjectCreationPageOrigin({
   orgSlug,
@@ -31,19 +38,13 @@ export function resolveProjectCreationPageOrigin({
   orgSlug: string;
   queryValue: string | undefined;
 }): ProjectCreationPageOrigin {
-  const key = `project-creation-origin:${orgSlug}`;
-
   if (queryValue === PROJECT_CREATION_ORIGIN_ORG_CREATION) {
-    try {
-      sessionStorageWrapper.setItem(key, PROJECT_CREATION_ORIGIN_ORG_CREATION);
-    } catch {
-      // Best-effort sticky; still report org_creation for this paint.
-    }
     return 'org_creation';
   }
 
   try {
-    if (sessionStorageWrapper.getItem(key) === PROJECT_CREATION_ORIGIN_ORG_CREATION) {
+    const sticky = sessionStorageWrapper.getItem(`project-creation-origin:${orgSlug}`);
+    if (sticky === PROJECT_CREATION_ORIGIN_ORG_CREATION) {
       return 'org_creation';
     }
   } catch {
@@ -51,4 +52,34 @@ export function resolveProjectCreationPageOrigin({
   }
 
   return 'existing_org';
+}
+
+/**
+ * Resolve the sticky project-creation journey origin for page-view analytics.
+ * Reads the org-create seed, stickies it into tab sessionStorage in an effect
+ * (keeping render pure and avoiding a StrictMode double-write), and resolves
+ * seed → storage → `existing_org`. A back-from-getting-started visit that only
+ * carries `referrer=getting-started` therefore keeps the org-activation origin.
+ */
+export function useProjectCreationPageOrigin(): ProjectCreationPageOrigin {
+  const organization = useOrganization();
+  const location = useLocation();
+  const orgSlug = organization.slug;
+  const queryValue = decodeScalar(location.query[PROJECT_CREATION_ORIGIN_QUERY_KEY]);
+
+  useEffect(() => {
+    if (queryValue !== PROJECT_CREATION_ORIGIN_ORG_CREATION) {
+      return;
+    }
+    try {
+      sessionStorageWrapper.setItem(
+        `project-creation-origin:${orgSlug}`,
+        PROJECT_CREATION_ORIGIN_ORG_CREATION
+      );
+    } catch {
+      // Best-effort sticky; this paint still reports org_creation from the seed.
+    }
+  }, [orgSlug, queryValue]);
+
+  return resolveProjectCreationPageOrigin({orgSlug, queryValue});
 }

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -100,47 +100,81 @@ describe('ScmCreateProject', () => {
     jest.clearAllMocks();
   });
 
-  it.each([
-    {referrer: undefined, origin: 'existing_org'},
-    {referrer: 'org-creation', origin: 'org_creation'},
-    // Autofill return path — orthogonal marker; still counts as existing-org.
-    {referrer: 'getting-started', origin: 'existing_org'},
-  ] as const)(
-    'sets project-creation page-view origin to $origin when referrer is $referrer',
-    ({referrer, origin}) => {
-      const routeAnalytics = {
-        previousUrl: '',
-        setDisableRouteAnalytics: jest.fn(),
-        setEventNames: jest.fn(),
-        setOrganization: jest.fn(),
-        setRouteAnalyticsParams: jest.fn(),
-      };
+  function renderScmWithOriginQuery(query: Record<string, string> = {}) {
+    const routeAnalytics = {
+      previousUrl: '',
+      setDisableRouteAnalytics: jest.fn(),
+      setEventNames: jest.fn(),
+      setOrganization: jest.fn(),
+      setRouteAnalyticsParams: jest.fn(),
+    };
 
-      render(
-        <RouteAnalyticsContext value={routeAnalytics}>
-          <ScmCreateProject />
-        </RouteAnalyticsContext>,
-        {
-          organization,
-          initialRouterConfig: {
-            location: {
-              pathname: '/organizations/org-slug/projects/new/',
-              query: referrer ? {referrer, project: CREATED_PROJECT_ID} : {},
-            },
+    render(
+      <RouteAnalyticsContext value={routeAnalytics}>
+        <ScmCreateProject />
+      </RouteAnalyticsContext>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/projects/new/',
+            query,
           },
-        }
-      );
+        },
+      }
+    );
 
-      expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
-        'project_creation_page.viewed',
-        'Project Create: Creation page viewed'
-      );
-      expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
-        variant: 'scm',
-        origin,
-      });
-    }
-  );
+    return {routeAnalytics};
+  }
+
+  it('sets page-view origin to org_creation from the org-create seed param', () => {
+    const {routeAnalytics} = renderScmWithOriginQuery({
+      projectCreationOrigin: 'org_creation',
+    });
+
+    expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
+      'project_creation_page.viewed',
+      'Project Create: Creation page viewed'
+    );
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'scm',
+      origin: 'org_creation',
+    });
+  });
+
+  it('keeps org_creation origin sticky after getting-started autofill return', () => {
+    window.sessionStorage.setItem('project-creation-origin:org-slug', 'org_creation');
+
+    const {routeAnalytics} = renderScmWithOriginQuery({
+      referrer: 'getting-started',
+      project: CREATED_PROJECT_ID,
+    });
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'scm',
+      origin: 'org_creation',
+    });
+  });
+
+  it('defaults page-view origin to existing_org without a seed', () => {
+    const {routeAnalytics} = renderScmWithOriginQuery();
+
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'scm',
+      origin: 'existing_org',
+    });
+  });
+
+  it('does not treat getting-started referrer alone as org creation', () => {
+    const {routeAnalytics} = renderScmWithOriginQuery({
+      referrer: 'getting-started',
+      project: CREATED_PROJECT_ID,
+    });
+
+    expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+      variant: 'scm',
+      origin: 'existing_org',
+    });
+  });
   it('shows all steps with the Create CTA disabled on a fresh visit', async () => {
     render(<ScmCreateProject />, {organization});
 

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -10,6 +10,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import {DEFAULT_ISSUE_ALERT_OPTIONS_VALUES} from 'sentry/views/projectInstall/issueAlertOptions';
+import {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 
 import {ScmCreateProject} from './scmCreateProject';
 
@@ -99,6 +100,47 @@ describe('ScmCreateProject', () => {
     jest.clearAllMocks();
   });
 
+  it.each([
+    {referrer: undefined, origin: 'existing_org'},
+    {referrer: 'org-creation', origin: 'org_creation'},
+    // Autofill return path — orthogonal marker; still counts as existing-org.
+    {referrer: 'getting-started', origin: 'existing_org'},
+  ] as const)(
+    'sets project-creation page-view origin to $origin when referrer is $referrer',
+    ({referrer, origin}) => {
+      const routeAnalytics = {
+        previousUrl: '',
+        setDisableRouteAnalytics: jest.fn(),
+        setEventNames: jest.fn(),
+        setOrganization: jest.fn(),
+        setRouteAnalyticsParams: jest.fn(),
+      };
+
+      render(
+        <RouteAnalyticsContext value={routeAnalytics}>
+          <ScmCreateProject />
+        </RouteAnalyticsContext>,
+        {
+          organization,
+          initialRouterConfig: {
+            location: {
+              pathname: '/organizations/org-slug/projects/new/',
+              query: referrer ? {referrer, project: CREATED_PROJECT_ID} : {},
+            },
+          },
+        }
+      );
+
+      expect(routeAnalytics.setEventNames).toHaveBeenCalledWith(
+        'project_creation_page.viewed',
+        'Project Create: Creation page viewed'
+      );
+      expect(routeAnalytics.setRouteAnalyticsParams).toHaveBeenCalledWith({
+        variant: 'scm',
+        origin,
+      });
+    }
+  );
   it('shows all steps with the Create CTA disabled on a fresh visit', async () => {
     render(<ScmCreateProject />, {organization});
 

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -38,7 +38,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage, writeStorageValue} from 'sentry/utils/useSessionStorage';
-import {resolveProjectCreationPageOrigin} from 'sentry/views/projectInstall/projectCreationOrigin';
+import {useProjectCreationPageOrigin} from 'sentry/views/projectInstall/projectCreationOrigin';
 import {
   WIZARD_STORAGE_KEY,
   type WizardState,
@@ -58,7 +58,6 @@ const INITIAL_STATE: WizardState = {
 };
 
 export function ScmCreateProject() {
-  const organization = useOrganization();
   const location = useLocation();
   const referrer = decodeScalar(location.query.referrer);
   const projectId = decodeScalar(location.query.project);
@@ -77,13 +76,7 @@ export function ScmCreateProject() {
   // ?projectCreationOrigin=org_creation from org-create). Orthogonal to
   // `variant` and to `referrer=getting-started` autofill — back-from-docs
   // must not reclassify an org-activation visit as existing_org.
-  useRouteAnalyticsParams({
-    variant: 'scm',
-    origin: resolveProjectCreationPageOrigin({
-      orgSlug: organization.slug,
-      queryValue: decodeScalar(location.query.projectCreationOrigin),
-    }),
-  });
+  useRouteAnalyticsParams({variant: 'scm', origin: useProjectCreationPageOrigin()});
 
   // Snapshot of the last completed wizard session, written when a project is
   // created (see handleComplete in the wizard). Restored when this mount is a

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -38,6 +38,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage, writeStorageValue} from 'sentry/utils/useSessionStorage';
+import {resolveProjectCreationPageOrigin} from 'sentry/views/projectInstall/projectCreationOrigin';
 import {
   WIZARD_STORAGE_KEY,
   type WizardState,
@@ -57,6 +58,7 @@ const INITIAL_STATE: WizardState = {
 };
 
 export function ScmCreateProject() {
+  const organization = useOrganization();
   const location = useLocation();
   const referrer = decodeScalar(location.query.referrer);
   const projectId = decodeScalar(location.query.project);
@@ -71,13 +73,16 @@ export function ScmCreateProject() {
     'project_creation_page.viewed',
     'Project Create: Creation page viewed'
   );
-  // `origin` is orthogonal to `variant`: org-create success redirects here with
-  // `?referrer=org-creation` (full-page reload), everything else is existing-org.
-  // `referrer=getting-started` is the autofill path and never coexists with
-  // org-creation, so it correctly lands as existing_org.
+  // Journey origin is sticky (sessionStorage seeded by
+  // ?projectCreationOrigin=org_creation from org-create). Orthogonal to
+  // `variant` and to `referrer=getting-started` autofill — back-from-docs
+  // must not reclassify an org-activation visit as existing_org.
   useRouteAnalyticsParams({
     variant: 'scm',
-    origin: referrer === 'org-creation' ? 'org_creation' : 'existing_org',
+    origin: resolveProjectCreationPageOrigin({
+      orgSlug: organization.slug,
+      queryValue: decodeScalar(location.query.projectCreationOrigin),
+    }),
   });
 
   // Snapshot of the last completed wizard session, written when a project is

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -71,7 +71,14 @@ export function ScmCreateProject() {
     'project_creation_page.viewed',
     'Project Create: Creation page viewed'
   );
-  useRouteAnalyticsParams({variant: 'scm'});
+  // `origin` is orthogonal to `variant`: org-create success redirects here with
+  // `?referrer=org-creation` (full-page reload), everything else is existing-org.
+  // `referrer=getting-started` is the autofill path and never coexists with
+  // org-creation, so it correctly lands as existing_org.
+  useRouteAnalyticsParams({
+    variant: 'scm',
+    origin: referrer === 'org-creation' ? 'org_creation' : 'existing_org',
+  });
 
   // Snapshot of the last completed wizard session, written when a project is
   // created (see handleComplete in the wizard). Restored when this mount is a


### PR DESCRIPTION
## TLDR

`project_creation_page.viewed` now carries a sticky `origin: 'org_creation' | 'existing_org'` for the whole create journey, so back-from-instructions does not reclassify an org-activation visit as existing-org.

## Details

Stacked on the getting-started header PR (#120147). Orthogonal to SCM/legacy `variant`. Earlier draft used `?referrer=org-creation`, but `referrer` is already the getting-started autofill hop marker — back-nav hard-sets `referrer=getting-started` and would flip origin mid-journey.

Org-create still needs a **URL seed** on the first hop: the redirect is a full `testableWindowLocation.assign`, often onto a customer-domain host, so storage written on the signup host would not survive. The seed is a dedicated query key (`projectCreationOrigin=org_creation`), not `referrer`. `organizationCreate/index.tsx` appends it to `nextUrl` while preserving the `forceCustomerDomain` composition.

`projectCreationOrigin.ts` exposes two functions. `resolveProjectCreationPageOrigin` is a **pure read**: seed query value → per-org sticky in `sessionStorage` → `existing_org`, no side effect, safe to call during render. `useProjectCreationPageOrigin` wraps it — it reads `useOrganization`/`useLocation`, resolves the value for the current paint, and performs the sticky `sessionStorage` write inside a `useEffect` keyed on `[orgSlug, queryValue]`. The write lives in the effect rather than in render so the seed paint stays pure (no StrictMode double-write, no per-render write) while still reporting `origin: 'org_creation'` synchronously from the seed on that first paint. Subsequent create mounts — including autofill returns that only carry `referrer=getting-started` — read the sticky and keep `org_creation`; no seed and empty storage resolve to `existing_org`.

Both `CreateProject` and `ScmCreateProject` stamp the resolved origin next to `variant` on the shared `project_creation_page.viewed` route event via a single `useRouteAnalyticsParams({variant, origin: useProjectCreationPageOrigin()})` call. Autofill / wizard restore continue to own `referrer` exclusively. No registry change (route params are free-form). Additive only — no BI count discontinuity.

Coverage: `resolveProjectCreationPageOrigin` unit tests assert the pure read paths (seed with no write, sticky-from-storage, default, non-`org_creation` values, per-org scoping) plus a query-key drift guard; `useProjectCreationPageOrigin` tests assert the effect-backed sticky write, sticky-after-autofill return, and the write-nothing default. Org-create redirect assertions cover the dedicated query key across the customer-domain permutations; both create UIs assert seed → `org_creation`, sticky-after-autofill, default → `existing_org`, and that bare `getting-started` is not org creation.

Refs VDY-133
