### PR TITLE
feat(issues): Run auto-resolve every 10 minutes

### DIFF
--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -25,8 +25,7 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.types.activity import ActivityType
 
-AUTO_RESOLVE_FREQUENCY = 10 * 60
-AUTO_RESOLVE_TASK_EXPIRY = 60 * 60
+TEN_MINUTES = 10 * 60
 
 
 @instrumented_task(
@@ -43,7 +42,7 @@ def schedule_auto_resolution():
     for opt in options_qs:
         opts_by_project[opt.project_id][opt.key] = opt.value
 
-    cutoff = time() - AUTO_RESOLVE_FREQUENCY
+    cutoff = time() - TEN_MINUTES
     for project_id, options in opts_by_project.items():
         if not options.get("sentry:resolve_age"):
             # kill the option to avoid it coming up in the future
@@ -57,7 +56,7 @@ def schedule_auto_resolution():
 
         auto_resolve_project_issues.apply_async(
             args=[project_id],
-            expires=AUTO_RESOLVE_TASK_EXPIRY,
+            expires=TEN_MINUTES,
             headers={"sentry-propagate-traces": False},
         )
 
@@ -164,6 +163,6 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
         auto_resolve_project_issues.apply_async(
             args=[project_id],
             kwargs={"cutoff": int(cutoff.strftime("%s")), "chunk_size": chunk_size},
-            expires=AUTO_RESOLVE_TASK_EXPIRY,
+            expires=TEN_MINUTES,
             headers={"sentry-propagate-traces": False},
         )

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -25,7 +25,8 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.types.activity import ActivityType
 
-ONE_HOUR = 3600
+AUTO_RESOLVE_FREQUENCY = 10 * 60
+AUTO_RESOLVE_TASK_EXPIRY = 60 * 60
 
 
 @instrumented_task(
@@ -42,7 +43,7 @@ def schedule_auto_resolution():
     for opt in options_qs:
         opts_by_project[opt.project_id][opt.key] = opt.value
 
-    cutoff = time() - ONE_HOUR
+    cutoff = time() - AUTO_RESOLVE_FREQUENCY
     for project_id, options in opts_by_project.items():
         if not options.get("sentry:resolve_age"):
             # kill the option to avoid it coming up in the future
@@ -56,7 +57,7 @@ def schedule_auto_resolution():
 
         auto_resolve_project_issues.apply_async(
             args=[project_id],
-            expires=ONE_HOUR,
+            expires=AUTO_RESOLVE_TASK_EXPIRY,
             headers={"sentry-propagate-traces": False},
         )
 
@@ -163,6 +164,6 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
         auto_resolve_project_issues.apply_async(
             args=[project_id],
             kwargs={"cutoff": int(cutoff.strftime("%s")), "chunk_size": chunk_size},
-            expires=ONE_HOUR,
+            expires=AUTO_RESOLVE_TASK_EXPIRY,
             headers={"sentry-propagate-traces": False},
         )

--- a/tests/sentry/tasks/test_auto_resolve_issues.py
+++ b/tests/sentry/tasks/test_auto_resolve_issues.py
@@ -11,7 +11,7 @@ from sentry.issues.grouptype import (
     PerformanceSlowDBQueryGroupType,
 )
 from sentry.models.group import Group, GroupStatus
-from sentry.tasks.auto_resolve_issues import schedule_auto_resolution
+from sentry.tasks.auto_resolve_issues import AUTO_RESOLVE_FREQUENCY, schedule_auto_resolution
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 
@@ -19,6 +19,32 @@ from sentry.testutils.helpers.analytics import assert_any_analytics_event
 class ScheduleAutoResolutionTest(TestCase):
     def test_task_persistent_name(self) -> None:
         assert schedule_auto_resolution.name == "sentry.tasks.schedule_auto_resolution"
+
+    def test_schedules_projects_every_ten_minutes(self) -> None:
+        current_ts = 1_000_000
+        due_project = self.create_project()
+        recent_project = self.create_project()
+
+        due_project.update_option("sentry:resolve_age", 1)
+        due_project.update_option("sentry:_last_auto_resolve", current_ts - AUTO_RESOLVE_FREQUENCY)
+        recent_project.update_option("sentry:resolve_age", 1)
+        recent_project.update_option(
+            "sentry:_last_auto_resolve", current_ts - AUTO_RESOLVE_FREQUENCY + 1
+        )
+
+        with (
+            patch("sentry.tasks.auto_resolve_issues.time", return_value=current_ts),
+            patch(
+                "sentry.tasks.auto_resolve_issues.auto_resolve_project_issues.apply_async"
+            ) as mock_apply_async,
+        ):
+            schedule_auto_resolution()
+
+        mock_apply_async.assert_called_once_with(
+            args=[due_project.id],
+            expires=60 * 60,
+            headers={"sentry-propagate-traces": False},
+        )
 
     @patch("sentry.analytics.record")
     @patch("sentry.tasks.auto_resolve_issues.kick_off_status_syncs")

--- a/tests/sentry/tasks/test_auto_resolve_issues.py
+++ b/tests/sentry/tasks/test_auto_resolve_issues.py
@@ -11,7 +11,7 @@ from sentry.issues.grouptype import (
     PerformanceSlowDBQueryGroupType,
 )
 from sentry.models.group import Group, GroupStatus
-from sentry.tasks.auto_resolve_issues import AUTO_RESOLVE_FREQUENCY, schedule_auto_resolution
+from sentry.tasks.auto_resolve_issues import schedule_auto_resolution
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 
@@ -19,32 +19,6 @@ from sentry.testutils.helpers.analytics import assert_any_analytics_event
 class ScheduleAutoResolutionTest(TestCase):
     def test_task_persistent_name(self) -> None:
         assert schedule_auto_resolution.name == "sentry.tasks.schedule_auto_resolution"
-
-    def test_schedules_projects_every_ten_minutes(self) -> None:
-        current_ts = 1_000_000
-        due_project = self.create_project()
-        recent_project = self.create_project()
-
-        due_project.update_option("sentry:resolve_age", 1)
-        due_project.update_option("sentry:_last_auto_resolve", current_ts - AUTO_RESOLVE_FREQUENCY)
-        recent_project.update_option("sentry:resolve_age", 1)
-        recent_project.update_option(
-            "sentry:_last_auto_resolve", current_ts - AUTO_RESOLVE_FREQUENCY + 1
-        )
-
-        with (
-            patch("sentry.tasks.auto_resolve_issues.time", return_value=current_ts),
-            patch(
-                "sentry.tasks.auto_resolve_issues.auto_resolve_project_issues.apply_async"
-            ) as mock_apply_async,
-        ):
-            schedule_auto_resolution()
-
-        mock_apply_async.assert_called_once_with(
-            args=[due_project.id],
-            expires=60 * 60,
-            headers={"sentry-propagate-traces": False},
-        )
 
     @patch("sentry.analytics.record")
     @patch("sentry.tasks.auto_resolve_issues.kick_off_status_syncs")


### PR DESCRIPTION
The scheduler already wakes every 10 minutes, but the per-project throttle only allows auto-resolve to run hourly. Match the throttle and task expiry to the schedule so projects resolve sooner and stale work does not survive newer scheduler ticks.

Task execution duration is well below the new interval in [Datadog](https://app.datadoghq.com/metric/explorer?graph_layout=stacked&start=1783981091028&end=1784585891028&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgIGBoA1mBu9ToAdE3aLdqtcMRwmQSSIk5QeNqeQ60AnFOKWXAiEmhwwBjy8mgQmRNSyFqLcQAEAIIAcgAih5G+8hjZyBAaGmYaJxeHtQ3XcIcAkqeHAAU+wKWFan3qGlaGkybFGyycGAIOCcdhwaEGUgoILi4LqkNaSIQKLRaAqcCc8m0OAAVv0EE5Hs9NABKHiHABGWEOwBxWFRcBgQwoEO+PFa1LQGPkgI8xAohwAzAA2AAMqpZIB4AF0qK53HhMKFwvrVIaMDFSvEtbqQBo5MsZCBbssEAgckkcDAnJkjRotok3AJtE4ucoKhgMQEQJsRBS5IplOlNlBErGKfQmMoRG4PGgtfxHhtsE4Ex70zaeHw7RtxABhKTCGAoESGtA8IA).

Refs https://linear.app/getsentry/issue/ID-1710