### PR TITLE
feat(issues): Remove fake auto-resolution

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -92,7 +92,6 @@ class GroupAnnotation(TypedDict):
 
 
 class GroupStatusDetailsResponseOptional(TypedDict, total=False):
-    autoResolved: bool
     ignoreCount: int
     ignoreUntil: datetime
     ignoreUserCount: int
@@ -523,16 +522,6 @@ class GroupSerializerBase(Serializer, ABC):
                 )
             else:
                 status = GroupStatus.UNRESOLVED
-        # If the issue is UNRESOLVED but has resolved_at set, it means the user manually
-        # unresolved it after it was resolved. We should respect that and not override
-        # the status back to RESOLVED.
-        if status == GroupStatus.UNRESOLVED and obj.is_over_resolve_age() and not obj.resolved_at:
-            # When an issue is over the auto-resolve age but the task has not yet run
-            # Only show as auto-resolved if this group type has auto-resolve enabled
-            if obj.issue_type.enable_auto_resolve:
-                status = GroupStatus.RESOLVED
-                status_details["autoResolved"] = True
-
         status_label: GroupStatusStr
         if status == GroupStatus.RESOLVED:
             status_label = "resolved"

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1730,7 +1730,7 @@ def _handle_regression(
             id=group.id,
             # ensure we can't update things if the status has been set to
             # ignored
-            status__in=[GroupStatus.RESOLVED, GroupStatus.UNRESOLVED],
+            status=GroupStatus.RESOLVED,
         )
         .exclude(
             # add to the regression window to account for races here
@@ -1738,8 +1738,6 @@ def _handle_regression(
         )
         .update(
             active_at=date,
-            # explicitly set last_seen here as ``is_resolved()`` looks
-            # at the value
             last_seen=date,
             status=GroupStatus.UNRESOLVED,
             substatus=GroupSubStatus.REGRESSED,

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -60,12 +60,11 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ALLOWED_FUTURE_DELTA, DEFAULT_SORT_OPTION
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
-from sentry.models.group import QUERY_STATUS_LOOKUP, Group, GroupStatus
+from sentry.models.group import Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupinbox import GroupInbox
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
 from sentry.utils.cursors import Cursor, CursorResult
@@ -259,18 +258,6 @@ def search_and_serialize_issues(
         ),
         request=request,
     )
-
-    # HACK: remove auto resolved entries
-    # TODO: We should try to integrate this into the search backend, since
-    # this can cause us to arbitrarily return fewer results than requested.
-    status = [
-        search_filter
-        for search_filter in query_kwargs.get("search_filters", [])
-        if search_filter.key.name == "status" and search_filter.operator in EQUALITY_OPERATORS
-    ]
-    if status and (GroupStatus.UNRESOLVED in status[0].value.raw_value):
-        status_labels = {QUERY_STATUS_LOOKUP[s] for s in status[0].value.raw_value}
-        rows = [r for r in rows if "status" not in r or r["status"] in status_labels]
 
     return rows, cursor_result, query_kwargs
 

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -32,11 +32,10 @@ from sentry.apidocs.parameters import (
 )
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.environment import Environment
-from sentry.models.group import QUERY_STATUS_LOOKUP, Group, GroupStatus
+from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.services import eventstore
 from sentry.signals import advanced_search
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -211,18 +210,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
         results = list(cursor_result)
 
         context = serialize(results, request.user, serializer)
-
-        # HACK: remove auto resolved entries
-        # TODO: We should try to integrate this into the search backend, since
-        # this can cause us to arbitrarily return fewer results than requested.
-        status = [
-            search_filter
-            for search_filter in query_kwargs.get("search_filters", [])
-            if search_filter.key.name == "status" and search_filter.operator in EQUALITY_OPERATORS
-        ]
-        if status and (GroupStatus.UNRESOLVED in status[0].value.raw_value):
-            status_labels = {QUERY_STATUS_LOOKUP[s] for s in status[0].value.raw_value}
-            context = [r for r in context if "status" not in r or r["status"] in status_labels]
 
         response = Response(context)
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -818,12 +818,6 @@ class Group(Model):
         if self.short_id is not None:
             return f"{self.project.slug.upper()}-{base32_encode(self.short_id)}"
 
-    def is_over_resolve_age(self):
-        resolve_age = self.project.get_option("sentry:resolve_age", None)
-        if not resolve_age:
-            return False
-        return self.last_seen < timezone.now() - timedelta(hours=int(resolve_age))
-
     def is_ignored(self):
         return self.get_status() == GroupStatus.IGNORED
 
@@ -909,14 +903,6 @@ class Group(Model):
             else:
                 if not snooze.is_valid(group=self):
                     status = GroupStatus.UNRESOLVED
-
-        # If the issue is UNRESOLVED but has resolved_at set, it means the user manually
-        # unresolved it after it was resolved. We should respect that and not override
-        # the status back to RESOLVED.
-        if status == GroupStatus.UNRESOLVED and self.is_over_resolve_age() and not self.resolved_at:
-            # Only auto-resolve if this group type has auto-resolve enabled
-            if self.issue_type.enable_auto_resolve:
-                return GroupStatus.RESOLVED
 
         return status
 

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -78,21 +78,6 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         assert result["status"] == "ignored"
         assert result["statusDetails"]["actor"]["id"] == str(user.id)
 
-    def test_auto_resolve_not_yet_resolved(self) -> None:
-        now = timezone.now()
-        self.project.update_option("sentry:resolve_age", 168)  # 7 days
-
-        user = self.create_user()
-        group = self.create_group(
-            status=GroupStatus.UNRESOLVED,
-            last_seen=now - timedelta(days=10),  # Last seen 10 days ago (past auto-resolve age)
-        )
-        assert group.resolved_at is None
-
-        result = serialize(group, user)
-        assert result["status"] == "unresolved"
-        assert result["statusDetails"] == {}
-
     def test_resolved_in_next_release(self) -> None:
         release = self.create_release(project=self.project, version="a")
         user = self.create_user()

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -1,13 +1,10 @@
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import GroupSerializer, SimpleGroupSerializer
-from sentry.grouping.grouptype import ErrorGroupType
 from sentry.integrations.types import ExternalProviderEnum
-from sentry.issues.grouptype import FeedbackGroup
 from sentry.issues.progress_state import IssueProgressState
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouplink import GroupLink
@@ -81,23 +78,6 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         assert result["status"] == "ignored"
         assert result["statusDetails"]["actor"]["id"] == str(user.id)
 
-    def test_manually_unresolved_after_auto_resolve(self) -> None:
-        now = timezone.now()
-        self.project.update_option("sentry:resolve_age", 168)  # 7 days
-
-        user = self.create_user()
-        group = self.create_group(
-            status=GroupStatus.UNRESOLVED,
-            last_seen=now - timedelta(days=10),  # Last seen 10 days ago (past auto-resolve age)
-        )
-
-        group.resolved_at = now - timedelta(days=1)
-        group.save()
-
-        result = serialize(group, user)
-        assert result["status"] == "unresolved"
-        assert result["statusDetails"] == {}
-
     def test_auto_resolve_not_yet_resolved(self) -> None:
         now = timezone.now()
         self.project.update_option("sentry:resolve_age", 168)  # 7 days
@@ -110,8 +90,8 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         assert group.resolved_at is None
 
         result = serialize(group, user)
-        assert result["status"] == "resolved"
-        assert result["statusDetails"]["autoResolved"] is True
+        assert result["status"] == "unresolved"
+        assert result["statusDetails"] == {}
 
     def test_resolved_in_next_release(self) -> None:
         release = self.create_release(project=self.project, version="a")
@@ -165,40 +145,6 @@ class GroupSerializerTest(TestCase, PerformanceIssueTestCase):
         result = serialize(group, user)
         assert result["status"] == "resolved"
         assert result["statusDetails"]["inCommit"]["id"] == commit.key
-
-    @patch("sentry.models.Group.is_over_resolve_age")
-    def test_auto_resolved(self, mock_is_over_resolve_age: MagicMock) -> None:
-        mock_is_over_resolve_age.return_value = True
-
-        user = self.create_user()
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        result = serialize(group, user)
-        assert result["status"] == "resolved"
-        assert result["statusDetails"] == {"autoResolved": True}
-
-    @patch("sentry.models.Group.is_over_resolve_age")
-    def test_auto_resolved_respects_enable_auto_resolve_flag(
-        self, mock_is_over_resolve_age: MagicMock
-    ) -> None:
-        mock_is_over_resolve_age.return_value = True
-
-        user = self.create_user()
-
-        # Test with a group type that has auto-resolve enabled
-        error_type_id = ErrorGroupType.type_id
-        group_error = self.create_group(status=GroupStatus.UNRESOLVED, type=error_type_id)
-        result_error = serialize(group_error, user)
-        assert result_error["status"] == "resolved"
-        assert result_error["statusDetails"] == {"autoResolved": True}
-
-        # Test with a group type that has auto-resolve disabled (feedback)
-        feedback_type_id = FeedbackGroup.type_id
-        group_feedback = self.create_group(status=GroupStatus.UNRESOLVED, type=feedback_type_id)
-
-        result_feedback = serialize(group_feedback, user)
-        assert result_feedback["status"] == "unresolved"
-        assert "autoResolved" not in result_feedback.get("statusDetails", {})
 
     def test_subscribed(self) -> None:
         user = self.create_user()

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1325,39 +1325,6 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
 
         assert Group.objects.get(id=group.id).status == GroupStatus.UNRESOLVED
 
-    @mock.patch("sentry.models.Group.is_resolved")
-    def test_unresolves_group_with_auto_resolve(self, mock_is_resolved: mock.MagicMock) -> None:
-        ts = before_now(minutes=5).isoformat()
-        mock_is_resolved.return_value = False
-        manager = EventManager(make_event(event_id="a" * 32, checksum="a" * 32, timestamp=ts))
-        with self.tasks():
-            event = manager.save(self.project.id)
-        assert event.group is not None
-
-        resolved_at = before_now(minutes=4)
-        Activity.objects.create(
-            group=event.group,
-            project=event.group.project,
-            type=ActivityType.SET_RESOLVED.value,
-            datetime=resolved_at,
-        )
-
-        mock_is_resolved.return_value = True
-        manager = EventManager(
-            make_event(
-                event_id="b" * 32, checksum="a" * 32, timestamp=before_now(minutes=3).isoformat()
-            )
-        )
-        with self.tasks():
-            event2 = manager.save(self.project.id)
-        assert event2.group is not None
-        assert event.group_id == event2.group_id
-
-        group = Group.objects.get(id=event.group.id)
-        assert group.active_at
-        assert group.active_at.replace(second=0) == event2.datetime.replace(second=0)
-        assert group.active_at.replace(second=0) != event.datetime.replace(second=0)
-
     def test_invalid_transaction(self) -> None:
         dict_input = {"messages": "foo"}
         manager = EventManager(make_event(transaction=dict_input))

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -564,31 +564,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_success_response(query=f"project:{project.slug}")
         assert len(response.data) == 1
 
-    def test_unresolved_includes_groups_pending_auto_resolution(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
-        old_event = self.store_event(
-            data={
-                "fingerprint": ["old-group"],
-                "timestamp": before_now(days=1).isoformat(),
-            },
-            project_id=project.id,
-        )
-        recent_event = self.store_event(
-            data={
-                "fingerprint": ["recent-group"],
-                "timestamp": before_now(seconds=1).isoformat(),
-            },
-            project_id=project.id,
-        )
-
-        self.login_as(user=self.user)
-        response = self.get_success_response()
-        assert {row["id"] for row in response.data} == {
-            str(old_event.group.id),
-            str(recent_event.group.id),
-        }
-
     def test_perf_issue(self) -> None:
         event = self.store_event(
             data={
@@ -678,8 +653,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         }
 
     def test_lookup_by_event_id(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
         event_id = "c" * 32
         event = self.store_event(
             data={"event_id": event_id, "timestamp": self.min_ago.isoformat()},
@@ -717,8 +690,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["matchingEventId"] == event_id
 
     def test_lookup_by_event_id_with_whitespace(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
         event_id = "c" * 32
         event = self.store_event(
             data={"event_id": event_id, "timestamp": self.min_ago.isoformat()},
@@ -733,8 +704,6 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["matchingEventId"] == event_id
 
     def test_lookup_by_unknown_event_id(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
         self.create_group()
         self.create_group()
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -564,23 +564,30 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         response = self.get_success_response(query=f"project:{project.slug}")
         assert len(response.data) == 1
 
-    def test_auto_resolved(self) -> None:
+    def test_unresolved_includes_groups_pending_auto_resolution(self) -> None:
         project = self.project
         project.update_option("sentry:resolve_age", 1)
-        self.store_event(
-            data={"event_id": "a" * 32, "timestamp": before_now(seconds=1).isoformat()},
+        old_event = self.store_event(
+            data={
+                "fingerprint": ["old-group"],
+                "timestamp": before_now(days=1).isoformat(),
+            },
             project_id=project.id,
         )
-        event2 = self.store_event(
-            data={"event_id": "b" * 32, "timestamp": before_now(seconds=1).isoformat()},
+        recent_event = self.store_event(
+            data={
+                "fingerprint": ["recent-group"],
+                "timestamp": before_now(seconds=1).isoformat(),
+            },
             project_id=project.id,
         )
-        group2 = event2.group
 
         self.login_as(user=self.user)
         response = self.get_success_response()
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(group2.id)
+        assert {row["id"] for row in response.data} == {
+            str(old_event.group.id),
+            str(recent_event.group.id),
+        }
 
     def test_perf_issue(self) -> None:
         event = self.store_event(

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -44,16 +44,6 @@ class GroupTest(TestCase, SnubaTestCase):
         group.status = GroupStatus.UNRESOLVED
         assert not group.is_resolved()
 
-        group.last_seen = timezone.now() - timedelta(hours=12)
-
-        group.project.update_option("sentry:resolve_age", 24)
-
-        assert not group.is_resolved()
-
-        group.project.update_option("sentry:resolve_age", 1)
-
-        assert not group.is_resolved()
-
     def test_is_ignored_with_expired_snooze(self) -> None:
         group = self.create_group(status=GroupStatus.IGNORED)
         GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(minutes=1))

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from django.db.models import ProtectedError
 from django.utils import timezone
 
-from sentry.issues.grouptype import FeedbackGroup, ProfileFileIOGroupType, ReplayHydrationErrorType
+from sentry.issues.grouptype import FeedbackGroup, ProfileFileIOGroupType
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus, get_group_with_redirect
 from sentry.models.groupopenperiod import GroupOpenPeriod
@@ -52,7 +52,7 @@ class GroupTest(TestCase, SnubaTestCase):
 
         group.project.update_option("sentry:resolve_age", 1)
 
-        assert group.is_resolved()
+        assert not group.is_resolved()
 
     def test_is_ignored_with_expired_snooze(self) -> None:
         group = self.create_group(status=GroupStatus.IGNORED)
@@ -451,39 +451,6 @@ class GroupTest(TestCase, SnubaTestCase):
         for status, substatus in desired_status_substatus_pairs:
             group = self.create_group(status=status, substatus=substatus)
             assert group.substatus is substatus
-
-
-class GroupIsOverResolveAgeTest(TestCase):
-    def test_simple(self) -> None:
-        group = self.group
-        group.last_seen = timezone.now() - timedelta(hours=2)
-        group.project.update_option("sentry:resolve_age", 1)  # 1 hour
-        assert group.is_over_resolve_age() is True
-        group.last_seen = timezone.now()
-        assert group.is_over_resolve_age() is False
-
-    def test_respects_enable_auto_resolve_flag(self) -> None:
-        # Create a group and make it old enough to auto-resolve
-        group = self.group
-        group.last_seen = timezone.now() - timedelta(hours=2)
-        group.project.update_option("sentry:resolve_age", 1)  # 1 hour
-
-        # Test with a group type that has auto-resolve enabled
-        group.type = ReplayHydrationErrorType.type_id
-        group.save()
-
-        # Verify it would be auto-resolved
-        assert group.is_over_resolve_age() is True
-        assert group.get_status() == GroupStatus.RESOLVED
-
-        # Test with a group type that has auto-resolve disabled
-        group.type = FeedbackGroup.type_id
-        group.status = GroupStatus.UNRESOLVED  # Reset status
-        group.save()
-
-        # Verify it would NOT be auto-resolved, even though is_over_resolve_age is True
-        assert group.is_over_resolve_age() is True
-        assert group.get_status() == GroupStatus.UNRESOLVED
 
 
 class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -174,17 +174,19 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
-    def test_auto_resolved(self) -> None:
+    def test_unresolved_includes_groups_pending_auto_resolution(self) -> None:
         project = self.project
         project.update_option("sentry:resolve_age", 1)
-        self.create_group(last_seen=before_now(days=1))
-        group2 = self.create_group(last_seen=timezone.now())
+        old_group = self.create_group(last_seen=before_now(days=1))
+        recent_group = self.create_group(last_seen=timezone.now())
 
         self.login_as(user=self.user)
         response = self.client.get(self.path + "?query=is:unresolved", format="json")
         assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(group2.id)
+        assert {row["id"] for row in response.data} == {
+            str(old_group.id),
+            str(recent_group.id),
+        }
 
     def test_lookup_by_event_id(self) -> None:
         project = self.project

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -174,23 +174,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert len(response.data) == 0
 
-    def test_unresolved_includes_groups_pending_auto_resolution(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
-        old_group = self.create_group(last_seen=before_now(days=1))
-        recent_group = self.create_group(last_seen=timezone.now())
-
-        self.login_as(user=self.user)
-        response = self.client.get(self.path + "?query=is:unresolved", format="json")
-        assert response.status_code == 200
-        assert {row["id"] for row in response.data} == {
-            str(old_group.id),
-            str(recent_group.id),
-        }
-
     def test_lookup_by_event_id(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
         event_id = "c" * 32
         event = self.store_event(
             data={"event_id": event_id, "timestamp": self.min_ago.isoformat()},
@@ -206,7 +190,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_lookup_by_event_with_matching_environment(self) -> None:
         project = self.project
-        project.update_option("sentry:resolve_age", 1)
         self.create_environment(name="test", project=project)
 
         event = self.store_event(
@@ -226,8 +209,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["matchingEventEnvironment"] == "test"
 
     def test_lookup_by_event_id_with_whitespace(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
         event = self.store_event(
             data={"event_id": "c" * 32, "timestamp": self.min_ago.isoformat()},
             project_id=self.project.id,
@@ -241,8 +222,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["id"] == str(event.group.id)
 
     def test_lookup_by_unknown_event_id(self) -> None:
-        project = self.project
-        project.update_option("sentry:resolve_age", 1)
         self.create_group()
         self.create_group()
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -250,17 +250,6 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         assert result["status"] == "resolved"
         assert result["statusDetails"]["inCommit"]["id"] == commit.key
 
-    @mock.patch("sentry.models.Group.is_over_resolve_age")
-    def test_auto_resolved(self, mock_is_over_resolve_age: mock.MagicMock) -> None:
-        mock_is_over_resolve_age.return_value = True
-
-        user = self.create_user()
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        result = serialize(group, user, serializer=GroupSerializerSnuba())
-        assert result["status"] == "resolved"
-        assert result["statusDetails"] == {"autoResolved": True}
-
     def test_subscribed(self) -> None:
         user = self.create_user()
         group = self.create_group()


### PR DESCRIPTION
Remove the fake read-time auto-resolution status and the workarounds it required. Issues pending auto-resolution now stay unresolved until the background task persists the transition. The auto-resolution task is being adjusted from 1 hour intervals to 10 minutes in #120149

some history:

- Before 2016, auto-resolution was not persisted. The model and serializer inferred it from `last_seen` and the project's resolve age, returning `resolved` while the database row was still unresolved.
- [`statusDetails.autoResolved`](https://github.com/getsentry/sentry/commit/10f06d04fbff11cd7c706b07bdb6bccc70721b66) was added in 2015 for [#2341](https://github.com/getsentry/sentry/issues/2341) so the UI could explain why unresolve did not stick and disable that action.
- The persisted [auto-resolve task](https://github.com/getsentry/sentry/commit/41c2d77c7cbd564ee47f63e442c792a6ee7efac2) arrived in 2016 with the stated goal of removing the obscure magic from the code and UI.
- The fake path stayed around alongside the task, requiring extra filtering after issue serialization and special regression handling. [#102160](https://github.com/getsentry/sentry/pull/102160) added another exception in 2025 after manually unresolved issues were immediately shown as resolved again.

Refs https://linear.app/getsentry/issue/ID-1710