### PR TITLE
ref(issues): Remove virtual auto-resolve UI

### DIFF
--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -86,25 +86,6 @@ describe('ResolveActions', () => {
     });
   });
 
-  describe('auto resolved', () => {
-    it('cannot be unresolved manually', async () => {
-      render(
-        <ResolveActions
-          hasSemverReleaseFeature={false}
-          onUpdate={spy}
-          disabled
-          hasRelease={false}
-          project={project}
-          isResolved
-          isAutoResolved
-        />
-      );
-
-      await userEvent.click(screen.getByRole('button', {name: 'Unresolve'}));
-      expect(spy).not.toHaveBeenCalled();
-    });
-  });
-
   describe('without confirmation', () => {
     it('calls spy with resolved status when clicked', async () => {
       render(

--- a/static/app/components/actions/resolve.spec.tsx
+++ b/static/app/components/actions/resolve.spec.tsx
@@ -60,32 +60,6 @@ describe('ResolveActions', () => {
     });
   });
 
-  describe('resolved', () => {
-    it('calls onUpdate with unresolved status when clicked', async () => {
-      render(
-        <ResolveActions
-          hasSemverReleaseFeature={false}
-          onUpdate={spy}
-          disabled
-          hasRelease={false}
-          project={project}
-          isResolved
-        />
-      );
-
-      const button = screen.getByRole('button', {name: 'Unresolve'});
-      expect(button).toBeInTheDocument();
-      expect(button).toHaveTextContent('');
-
-      await userEvent.click(button);
-      expect(spy).toHaveBeenCalledWith({
-        status: 'unresolved',
-        statusDetails: {},
-        substatus: 'ongoing',
-      });
-    });
-  });
-
   describe('without confirmation', () => {
     it('calls spy with resolved status when clicked', async () => {
       render(

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -15,7 +15,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconChevron, IconReleases} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {GroupStatusResolution, ResolvedStatusDetails} from 'sentry/types/group';
-import {GroupStatus, GroupSubstatus} from 'sentry/types/group';
+import {GroupStatus} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -59,7 +59,6 @@ interface ResolveActionsProps {
   disableDropdown?: boolean;
   disableResolveInRelease?: boolean;
   disabled?: boolean;
-  isResolved?: boolean;
   latestRelease?: Project['latestRelease'];
   multipleProjectsSelected?: boolean;
   priority?: 'primary';
@@ -70,7 +69,6 @@ interface ResolveActionsProps {
 
 export function ResolveActions({
   size = 'xs',
-  isResolved = false,
   confirmLabel = t('Resolve'),
   project,
   hasRelease,
@@ -163,30 +161,7 @@ export function ResolveActions({
     });
   }
 
-  function renderResolved() {
-    return (
-      <Tooltip title={t('Unresolve')}>
-        <Button
-          variant="primary"
-          size="xs"
-          aria-label={t('Unresolve')}
-          onClick={() =>
-            onUpdate({
-              status: GroupStatus.UNRESOLVED,
-              statusDetails: {},
-              substatus: GroupSubstatus.ONGOING,
-            })
-          }
-        />
-      </Tooltip>
-    );
-  }
-
   function renderDropdownMenu() {
-    if (isResolved) {
-      return renderResolved();
-    }
-
     const shouldDisplayCta = !hasRelease && !multipleProjectsSelected;
     const actionTitle = shouldDisplayCta
       ? t('Set up release tracking in order to use this feature.')
@@ -332,10 +307,6 @@ export function ResolveActions({
         project={project}
       />
     ));
-  }
-
-  if (isResolved) {
-    return renderResolved();
   }
 
   return (

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -59,7 +59,6 @@ interface ResolveActionsProps {
   disableDropdown?: boolean;
   disableResolveInRelease?: boolean;
   disabled?: boolean;
-  isAutoResolved?: boolean;
   isResolved?: boolean;
   latestRelease?: Project['latestRelease'];
   multipleProjectsSelected?: boolean;
@@ -72,7 +71,6 @@ interface ResolveActionsProps {
 export function ResolveActions({
   size = 'xs',
   isResolved = false,
-  isAutoResolved = false,
   confirmLabel = t('Resolve'),
   project,
   hasRelease,
@@ -167,20 +165,11 @@ export function ResolveActions({
 
   function renderResolved() {
     return (
-      <Tooltip
-        title={
-          isAutoResolved
-            ? t(
-                'This event is resolved due to the Auto Resolve configuration for this project'
-              )
-            : t('Unresolve')
-        }
-      >
+      <Tooltip title={t('Unresolve')}>
         <Button
           variant="primary"
           size="xs"
           aria-label={t('Unresolve')}
-          disabled={isAutoResolved}
           onClick={() =>
             onUpdate({
               status: GroupStatus.UNRESOLVED,

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -1101,7 +1101,6 @@ export interface IgnoredStatusDetails {
 }
 export interface ResolvedStatusDetails {
   actor?: AvatarUser;
-  autoResolved?: boolean;
   inCommit?: {
     commit?: string;
     dateCreated?: string;

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -133,8 +133,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
 
   const isResolved = group.status === 'resolved';
   const isIgnored = group.status === 'ignored';
-  const isAutoResolved =
-    group.status === 'resolved' ? group.statusDetails.autoResolved : undefined;
   const hasDeleteAccess = organization.access.includes('event:admin');
 
   const config = useMemo(() => getConfigForIssueType(group, project), [group, project]);
@@ -429,7 +427,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                 }
               />
             )}
-            {isResolved && resolveCap.enabled && !isAutoResolved && (
+            {isResolved && resolveCap.enabled && (
               <CMDKAction
                 display={{label: t('Unresolve'), icon: <IconCheckmark />}}
                 onAction={() =>
@@ -486,7 +484,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
             {resolveCap.enabled && isResolved && (
               <Button
                 size="sm"
-                disabled={disabled || isAutoResolved}
+                disabled={disabled}
                 onClick={() =>
                   onUpdate({
                     status: GroupStatus.UNRESOLVED,
@@ -501,7 +499,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
             {isIgnored && (
               <Button
                 size="sm"
-                disabled={disabled || isAutoResolved}
+                disabled={disabled}
                 onClick={() =>
                   onUpdate({
                     status: GroupStatus.UNRESOLVED,
@@ -527,7 +525,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                 onUpdate={onUpdate}
                 project={project}
                 isResolved={isResolved}
-                isAutoResolved={isAutoResolved}
                 size="sm"
                 priority="primary"
               />

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -524,7 +524,6 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                 hasSemverReleaseFeature={hasSemverReleaseFeature}
                 onUpdate={onUpdate}
                 project={project}
-                isResolved={isResolved}
                 size="sm"
                 priority="primary"
               />


### PR DESCRIPTION
Remove the old `statusDetails.autoResolved` type and UI branches that hid or disabled unresolve for virtual auto-resolution.

Persisted auto-resolved issues use the normal resolved controls. Follows #120153, which removes the backend field and inferred status.

Refs https://linear.app/getsentry/issue/ID-1710