### PR TITLE
chore(control): remove last/test-only reader of OrganizationMemberTeamReplica

### DIFF
--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -5,11 +5,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, MutableMapping
 from typing import TYPE_CHECKING, Any, TypedDict, TypeGuard
 
-from django.db.models import Subquery
-
 from sentry.integrations.types import ExternalProviderEnum
-from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.notifications.defaults import (
     DEFAULT_ENABLED_PROVIDERS_VALUES,
     NOTIFICATION_SETTINGS_TYPE_DEFAULTS,
@@ -21,7 +17,7 @@ from sentry.notifications.types import (
     NotificationSettingEnum,
     NotificationSettingsOptionEnum,
 )
-from sentry.types.actor import Actor, ActorType
+from sentry.types.actor import Actor
 from sentry.users.services.user.model import RpcUser
 
 if TYPE_CHECKING:
@@ -128,34 +124,3 @@ def recipient_is_team(recipient: Actor | Team | RpcUser | User) -> TypeGuard[Act
     if isinstance(recipient, Actor) and recipient.is_team:
         return True
     return isinstance(recipient, Team)
-
-
-def get_team_members(team: Team | Actor) -> list[Actor]:
-    if recipient_is_team(team):  # handles type error below
-        team_id = team.id
-    else:  # team is either Team or Actor, so if recipient_is_team returns false it is because Actor has a different type
-        raise Exception(
-            "Actor team has ActorType %s, expected ActorType Team",
-            team.actor_type,  # type: ignore[union-attr]
-        )
-
-    # get organization member IDs of all members in the team
-    team_members = OrganizationMemberTeamReplica.objects.filter(team_id=team_id)
-
-    # use the first member to get the org id + determine if there are any members to begin with
-    first_member = team_members.first()
-    if not first_member:
-        return []
-    org_id = first_member.organization_id
-
-    # get user IDs for all members in the team
-    members = OrganizationMemberMapping.objects.filter(
-        organization_id=org_id,
-        organizationmember_id__in=Subquery(team_members.values("organizationmember_id")),
-    )
-
-    return [
-        Actor(id=user_id, actor_type=ActorType.USER)
-        for user_id in members.values_list("user_id", flat=True)
-        if user_id
-    ]

--- a/tests/sentry/notifications/test_helpers.py
+++ b/tests/sentry/notifications/test_helpers.py
@@ -1,11 +1,9 @@
 from urllib.parse import parse_qs, urlparse
 
-from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.models.rule import Rule
 from sentry.notifications.helpers import (
     collect_groups_by_project,
     get_subscription_from_attributes,
-    get_team_members,
     validate,
 )
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
@@ -17,8 +15,7 @@ from sentry.notifications.utils.links import (
 )
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of
-from sentry.types.actor import Actor
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 class NotificationHelpersTest(TestCase):
@@ -129,17 +126,3 @@ class NotificationHelpersTest(TestCase):
             }
             for rule_detail in rule_details
         }
-
-    def test_get_team_members(self) -> None:
-        user1 = self.create_user()
-        user2 = self.create_user()
-        team1 = self.create_team()
-        team2 = self.create_team()
-        team3 = self.create_team()
-        self.create_member(organization=self.organization, teams=[team1], user=user1)
-        self.create_member(organization=self.organization, teams=[team2], user=user2)
-
-        with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-            assert get_team_members(team1) == [Actor.from_object(user1)]
-            assert get_team_members(team2) == [Actor.from_object(user2)]
-            assert get_team_members(team3) == []


### PR DESCRIPTION
Step 1 of 5 in tearing out the dead `OrganizationMemberTeamReplica` table.

`get_team_members()` in `notifications/helpers.py` was the only production code still reading the replica — and it was itself dead, called only by its own test. (Not to be confused with the live `get_team_members` in `seer/agent/tools.py`, which is unrelated and doesn't touch the replica.) This removes the function, its test, and the imports that only existed to support them. No schema changes.

Next: Step 2 stops the regions from writing/replicating (#120156), stacked on this.

Refs INFRENG-369