### PR TITLE
chore(control): stop regions from replicating OrganizationMemberTeam

### DIFF
--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any, ClassVar, Self
 
 from django.db import models
@@ -48,27 +47,6 @@ class OrganizationMemberTeam(ReplicatedCellModel):
                 if shard_identifier is None
                 else shard_identifier
             )
-        )
-
-    def handle_async_replication(self, shard_identifier: int) -> None:
-        from sentry.hybridcloud.services.replica.service import control_replica_service
-        from sentry.organizations.services.organization.serial import (
-            serialize_rpc_organization_member_team,
-        )
-
-        control_replica_service.upsert_replicated_organization_member_team(
-            omt=serialize_rpc_organization_member_team(self)
-        )
-
-    @classmethod
-    def handle_async_deletion(
-        cls, identifier: int, shard_identifier: int, payload: Mapping[str, Any] | None
-    ) -> None:
-        from sentry.hybridcloud.services.replica.service import control_replica_service
-
-        control_replica_service.remove_replicated_organization_member_team(
-            organization_id=shard_identifier,
-            organization_member_team_id=identifier,
         )
 
     def get_audit_log_data(self) -> dict[str, Any]:

--- a/src/sentry/organizations/services/organization/serial.py
+++ b/src/sentry/organizations/services/organization/serial.py
@@ -16,7 +16,6 @@ from sentry.organizations.services.organization import (
     RpcOrganizationMember,
     RpcOrganizationMemberFlags,
     RpcOrganizationMemberSummary,
-    RpcOrganizationMemberTeam,
     RpcOrganizationSummary,
     RpcTeam,
     RpcTeamMember,
@@ -151,16 +150,3 @@ def serialize_rpc_organization(
         rpc_org.teams.extend(serialize_rpc_team(team) for team in teams)
 
     return rpc_org
-
-
-def serialize_rpc_organization_member_team(
-    omt: OrganizationMemberTeam,
-) -> RpcOrganizationMemberTeam:
-    return RpcOrganizationMemberTeam(
-        id=omt.id,
-        team_id=omt.team_id,
-        organizationmember_id=omt.organizationmember_id,
-        organization_id=omt.organizationmember.organization_id,
-        is_active=omt.is_active,
-        role=omt.role,
-    )

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -21,13 +21,12 @@ from sentry.hybridcloud.tasks.deliver_from_outbox import enqueue_outbox_jobs
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
-from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.cell import Cell, get_local_cell
 from sentry.users.models.user import User
 
@@ -561,13 +560,9 @@ class TestOutboxesManager(TestCase):
         with outbox_runner():
             assert CellOutbox.objects.count() == 10
             assert OrganizationMemberTeam.objects.count() == 11
-            with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-                assert OrganizationMemberTeamReplica.objects.count() == 1
 
         assert CellOutbox.objects.count() == 0
         assert OrganizationMemberTeam.objects.count() == 11
-        with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-            assert OrganizationMemberTeamReplica.objects.count() == 11
 
         existing = OrganizationMemberTeam.objects.all().exclude(id=do_not_touch.id).all()
         for obj in existing:
@@ -576,24 +571,18 @@ class TestOutboxesManager(TestCase):
 
         with outbox_runner():
             assert CellOutbox.objects.count() == 10
-            with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-                assert OrganizationMemberTeamReplica.objects.filter(role="cow").count() == 0
 
         assert CellOutbox.objects.count() == 0
-        with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-            assert OrganizationMemberTeamReplica.objects.filter(role="cow").count() == 10
+        assert OrganizationMemberTeam.objects.filter(role="cow").count() == 10
 
         OrganizationMemberTeam.objects.bulk_delete(existing)
 
         with outbox_runner():
             assert CellOutbox.objects.count() == 10
             assert OrganizationMemberTeam.objects.count() == 1
-            with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-                assert OrganizationMemberTeamReplica.objects.count() == 11
 
         assert CellOutbox.objects.count() == 0
-        with assume_test_silo_mode_of(OrganizationMemberTeamReplica):
-            assert OrganizationMemberTeamReplica.objects.count() == 1
+        assert OrganizationMemberTeam.objects.count() == 1
 
 
 @control_silo_test

--- a/tests/sentry/hybridcloud/test_replica.py
+++ b/tests/sentry/hybridcloud/test_replica.py
@@ -6,7 +6,6 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authidentityreplica import AuthIdentityReplica
 from sentry.models.authprovider import AuthProvider
 from sentry.models.authproviderreplica import AuthProviderReplica
-from sentry.models.organizationmemberteamreplica import OrganizationMemberTeamReplica
 from sentry.silo.base import SiloMode
 from sentry.testutils.factories import Factories
 from sentry.testutils.outbox import outbox_runner
@@ -147,35 +146,3 @@ def test_replicate_auth_identity() -> None:
         with assume_test_silo_mode(SiloMode.CELL):
             for ai, next_ident in zip(auth_identities, [*auth_idents[1:], auth_idents[0]]):
                 assert AuthIdentityReplica.objects.get(auth_identity_id=ai.id).ident == next_ident
-
-
-@django_db_all(transaction=True)
-@all_silo_test
-def test_replicate_organization_member_team() -> None:
-    org = Factories.create_organization()
-    team = Factories.create_team(org)
-    user = Factories.create_user()
-    member = Factories.create_member(organization=org, user=user)
-    with assume_test_silo_mode(SiloMode.CONTROL):
-        assert OrganizationMemberTeamReplica.objects.count() == 0
-
-    omt = Factories.create_team_membership(team=team, member=member)
-
-    with assume_test_silo_mode(SiloMode.CONTROL):
-        replicated = OrganizationMemberTeamReplica.objects.get(organizationmemberteam_id=omt.id)
-
-    assert replicated.organization_id == omt.organizationmember.organization_id
-    assert replicated.team_id == omt.team_id
-    assert replicated.organizationmember_id == omt.organizationmember_id
-    assert replicated.organizationmemberteam_id == omt.id
-    assert replicated.is_active == omt.is_active
-    assert replicated.role == omt.role
-
-    with assume_test_silo_mode(SiloMode.CELL):
-        omt.role = "boo"
-        omt.save()
-
-    with assume_test_silo_mode(SiloMode.CONTROL):
-        replicated = OrganizationMemberTeamReplica.objects.get(organizationmemberteam_id=omt.id)
-
-    assert replicated.role == "boo"


### PR DESCRIPTION
Step 2 of 5 in tearing out the dead `OrganizationMemberTeamReplica` table: stop the regions from calling the replication RPC. This follows the recent TeamReplica teardown (#119646), where `Team` — also a `ReplicatedCellModel` — kept its base class/manager/category and only shed the handler + RPC.

Stacked on Step 1 (#120155)

Refs INFRENG-369