### PR TITLE
fix(detectors): Handle invalid body size values in large payload detector

### DIFF
--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -13,6 +13,7 @@ from ..detectors.utils import (
     get_notification_attachment_body,
     get_span_duration,
     get_span_evidence_value,
+    log_invalid_span_data,
 )
 from ..performance_problem import PerformanceProblem
 from ..types import Span
@@ -56,7 +57,18 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         payload_size_threshold = self.settings["payload_size_threshold"]
 
         if isinstance(encoded_body_size, str):
-            encoded_body_size = int(encoded_body_size)
+            try:
+                encoded_body_size = int(encoded_body_size)
+            except (ValueError, OverflowError) as err:
+                # Track instances of this happening so we know if it's a widespread problem
+                log_invalid_span_data(
+                    span,
+                    detector="large_http_payload",
+                    key="http.response_content_length",
+                    value=encoded_body_size,
+                    error=err,
+                )
+                return
 
         if encoded_body_size > payload_size_threshold:
             self._store_performance_problem(span)

--- a/src/sentry/issue_detection/detectors/utils.py
+++ b/src/sentry/issue_detection/detectors/utils.py
@@ -1,10 +1,14 @@
 import hashlib
+import logging
 import re
 from datetime import timedelta
-from typing import TypedDict
+from typing import Any, TypedDict
 from urllib.parse import parse_qs, urlparse
 
 from ..types import Span
+
+logger = logging.getLogger("issue_detectors")
+
 
 FILTERED_KEYWORDS = [
     "[Filtered]",
@@ -313,3 +317,38 @@ def total_span_time(span_list: list[Span]) -> float:
     # Add the remaining duration
     total_duration += current_max - current_min
     return total_duration * 1000
+
+
+def log_invalid_span_data(
+    span: Span,
+    detector: str,
+    key: str,
+    value: Any,
+    error: Exception | None = None,
+    extra_data: dict[str, Any] | None = None,
+) -> None:
+    """
+    Track instances of detectors encountering data they're not expecting, so we can consider
+    updating them to handle it.
+
+    Logs an `issue_detectors.invalid_data` warning tagged with:
+        - span, trace, project, and org ids,
+        - the detector name,
+        - the bad value,
+        - the error the bad data would have caused (optional), and
+        - any other data passed in the `extra_data` parameter (also optional).
+    """
+    logger.warning(
+        "issue_detectors.invalid_data",
+        extra={
+            "detector": detector,
+            "span_id": span.get("span_id"),
+            "trace_id": span.get("trace_id"),
+            "project_id": span.get("project_id"),
+            "org_id": span.get("organization_id"),
+            "key": key,
+            "value": value,
+            "error": repr(error),  # We use `repr` over `str` to also get error type
+            **(extra_data or {}),
+        },
+    )

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -250,7 +251,7 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         event = create_event(spans)
         assert self.find_problems(event) == []
 
-    def test_handles_string_payload_size_threshold(self) -> None:
+    def test_handles_valid_string_payload_size(self) -> None:
         spans = [
             create_span(
                 "http.client",
@@ -284,6 +285,31 @@ class LargeHTTPPayloadDetectorTest(TestCase):
                 evidence_display=[],
             )
         ]
+
+    @patch("sentry.issue_detection.detectors.utils.logger.warning")
+    def test_handles_invalid_string_payload_size(self, mock_logger_warning: MagicMock) -> None:
+        span = create_span("http.client", 1000, "GET /api/0/organizations/endpoint1", "hash2")
+        span["project_id"] = self.project.id
+        span["organization_id"] = self.project.organization.id
+        event = create_event([span])
+
+        for invalid_value in ["NaN", "[Filtered]", "dogs are great"]:
+            event["spans"][0]["data"] = {"http.response_content_length": invalid_value}
+
+            assert self.find_problems(event) == []  # No problem found, but also no crash
+            mock_logger_warning.assert_called_with(
+                "issue_detectors.invalid_data",
+                extra={
+                    "detector": "large_http_payload",
+                    "span_id": span["span_id"],
+                    "trace_id": span["trace_id"],
+                    "project_id": span["project_id"],
+                    "org_id": span["organization_id"],
+                    "key": "http.response_content_length",
+                    "value": invalid_value,
+                    "error": f"ValueError(\"invalid literal for int() with base 10: '{invalid_value}'\")",
+                },
+            )
 
     def test_does_not_trigger_detection_for_prefetch_spans(self) -> None:
         spans = [


### PR DESCRIPTION
This updates our large HTTP payload detector to handle invalid payload size values - rather than crashing, the detector will now just log the invalid data and move on. Because the need to log invalid data isn't unique to that detector, this PR does it via a new utility function, `log_invalid_span_data`.

Fixes https://sentry.sentry.io/issues/7598692991