### PR TITLE
feat(action_log): Require GroupActions to opt-in to be considered user-visible.

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 from enum import IntEnum, StrEnum
-from typing import Any, Literal, NotRequired, Optional, TypedDict
+from typing import Any, ClassVar, Literal, NotRequired, Optional, TypedDict
 
 from pydantic import BaseModel
 
@@ -154,7 +154,10 @@ class ActionSource(StrEnum):
 class GroupAction(BaseModel, abc.ABC):
     """Typed payload for a group action log entry. Frozen after construction."""
 
-    _registry: dict[GroupActionType, type[GroupAction]] = {}
+    _registry: ClassVar[dict[GroupActionType, type[GroupAction]]] = {}
+    _user_visible_types: ClassVar[set[GroupActionType]] = set()
+
+    user_visible: ClassVar[bool] = False
 
     class Config:
         frozen = True
@@ -170,6 +173,8 @@ class GroupAction(BaseModel, abc.ABC):
                     f"{cls.__name__} conflicts with {existing.__name__}"
                 )
             cls._registry[action_type] = cls
+            if cls.user_visible:
+                cls._user_visible_types.add(action_type)
 
     @classmethod
     @abc.abstractmethod
@@ -179,6 +184,10 @@ class GroupAction(BaseModel, abc.ABC):
     def by_type(cls, action_type: GroupActionType) -> type[GroupAction] | None:
         return cls._registry.get(action_type)
 
+    @classmethod
+    def get_user_visible_types(cls) -> frozenset[GroupActionType]:
+        return frozenset(cls._user_visible_types)
+
 
 class ViewAction(GroupAction):
     @classmethod
@@ -187,12 +196,15 @@ class ViewAction(GroupAction):
 
 
 class ResolveAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.RESOLVE
 
 
 class UnresolveAction(GroupAction):
+    user_visible = True
     event_id: Optional[str] = None
 
     @classmethod
@@ -201,6 +213,7 @@ class UnresolveAction(GroupAction):
 
 
 class ArchiveAction(GroupAction):
+    user_visible = True
     ignore_count: Optional[int] = None
     ignore_duration: Optional[int] = None
     ignore_until: Optional[str] = None
@@ -215,6 +228,7 @@ class ArchiveAction(GroupAction):
 
 
 class AssignAction(GroupAction):
+    user_visible = True
     assignee: Optional[str] = None
     assignee_email: Optional[str] = None
     assignee_name: Optional[str] = None
@@ -228,12 +242,15 @@ class AssignAction(GroupAction):
 
 
 class UnassignAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.UNASSIGN
 
 
 class SetPriorityAction(GroupAction):
+    user_visible = True
     priority: str
     reason: Optional[str] = None
 
@@ -243,6 +260,7 @@ class SetPriorityAction(GroupAction):
 
 
 class MergeIntoOtherAction(GroupAction):
+    user_visible = True
     counterpart_group_id: int
 
     @classmethod
@@ -251,6 +269,7 @@ class MergeIntoOtherAction(GroupAction):
 
 
 class MergeFromOtherAction(GroupAction):
+    user_visible = True
     counterpart_group_ids: list[int]
 
     @classmethod
@@ -259,12 +278,16 @@ class MergeFromOtherAction(GroupAction):
 
 
 class DeleteAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.DELETE
 
 
 class BookmarkAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.BOOKMARK
@@ -277,6 +300,7 @@ class SentryActorRef(BaseModel):
 
 
 class CommentAction(GroupAction):
+    user_visible = True
     comment_id: int
     text: Optional[str] = None
     mentions: Optional[list[SentryActorRef]] = None
@@ -287,6 +311,7 @@ class CommentAction(GroupAction):
 
 
 class CommentEditAction(GroupAction):
+    user_visible = True
     comment_id: int
 
     @classmethod
@@ -295,6 +320,7 @@ class CommentEditAction(GroupAction):
 
 
 class CommentDeleteAction(GroupAction):
+    user_visible = True
     comment_id: int
 
     @classmethod
@@ -303,30 +329,39 @@ class CommentDeleteAction(GroupAction):
 
 
 class SubscribeAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.SUBSCRIBE
 
 
 class UnsubscribeAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.UNSUBSCRIBE
 
 
 class MarkReviewedAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.MARK_REVIEWED
 
 
 class TriggerAutofixAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.TRIGGER_AUTOFIX
 
 
 class CreateExternalIssueAction(GroupAction):
+    user_visible = True
     provider: str
     external_issue_key: str
 
@@ -336,6 +371,7 @@ class CreateExternalIssueAction(GroupAction):
 
 
 class LinkExternalIssueAction(GroupAction):
+    user_visible = True
     provider: str
     external_issue_key: str
 
@@ -345,6 +381,7 @@ class LinkExternalIssueAction(GroupAction):
 
 
 class UnlinkExternalIssueAction(GroupAction):
+    user_visible = True
     provider: str
     external_issue_key: str
 
@@ -354,6 +391,7 @@ class UnlinkExternalIssueAction(GroupAction):
 
 
 class CreatePlatformExternalIssueAction(GroupAction):
+    user_visible = True
     service_type: str
     display_name: str
     web_url: str
@@ -364,6 +402,7 @@ class CreatePlatformExternalIssueAction(GroupAction):
 
 
 class LinkPlatformExternalIssueAction(GroupAction):
+    user_visible = True
     service_type: str
     display_name: str
     web_url: str
@@ -374,6 +413,7 @@ class LinkPlatformExternalIssueAction(GroupAction):
 
 
 class UnlinkPlatformExternalIssueAction(GroupAction):
+    user_visible = True
     service_type: str
     display_name: str
     web_url: str
@@ -384,6 +424,7 @@ class UnlinkPlatformExternalIssueAction(GroupAction):
 
 
 class AutofixPrCreatedAction(GroupAction):
+    user_visible = True
     run_id: str | None = None
     pull_requests: list[dict[str, object]]
 
@@ -393,6 +434,7 @@ class AutofixPrCreatedAction(GroupAction):
 
 
 class ResolvedInPullRequestAction(GroupAction):
+    user_visible = True
     pull_request: Optional[int] = None  # PullRequest model ID
 
     @classmethod
@@ -402,6 +444,8 @@ class ResolvedInPullRequestAction(GroupAction):
 
 class RootCauseIdentifiedAction(GroupAction):
     """Seer (or a human) identified the root cause of an issue."""
+
+    user_visible = True
 
     run_id: str | None = None
     summary: str | None = None
@@ -414,6 +458,8 @@ class RootCauseIdentifiedAction(GroupAction):
 class AutofixCodingCompleteAction(GroupAction):
     """Seer finished writing a fix (code ready, PR not yet created)."""
 
+    user_visible = True
+
     run_id: str | None = None
 
     @classmethod
@@ -422,6 +468,7 @@ class AutofixCodingCompleteAction(GroupAction):
 
 
 class SetRegressedAction(GroupAction):
+    user_visible = True
     event_id: Optional[str] = None
     version: Optional[str] = None
 
@@ -431,6 +478,7 @@ class SetRegressedAction(GroupAction):
 
 
 class PullRequestClosedAction(GroupAction):
+    user_visible = True
     pull_request: Optional[int | str] = None  # PullRequest model ID
     # Whether the issue has other linked PRs still open when this one closed
     has_other_open_prs: Optional[bool] = None
@@ -441,6 +489,7 @@ class PullRequestClosedAction(GroupAction):
 
 
 class PullRequestReopenedAction(GroupAction):
+    user_visible = True
     pull_request: int
 
     @classmethod
@@ -449,6 +498,7 @@ class PullRequestReopenedAction(GroupAction):
 
 
 class PullRequestMergedAction(GroupAction):
+    user_visible = True
     pull_request: int
     has_other_open_prs: Optional[bool] = None
 
@@ -458,6 +508,7 @@ class PullRequestMergedAction(GroupAction):
 
 
 class PullRequestUnlinkedAction(GroupAction):
+    user_visible = True
     pull_request: int
     has_other_open_prs: Optional[bool] = None
 
@@ -481,6 +532,7 @@ class GroupActionLogPayload(TypedDict):
 
 
 class SetPublicAction(GroupAction):
+    user_visible = True
     # No activity data.
 
     @classmethod
@@ -489,6 +541,7 @@ class SetPublicAction(GroupAction):
 
 
 class SetPrivateAction(GroupAction):
+    user_visible = True
     # No activity data.
 
     @classmethod
@@ -497,6 +550,7 @@ class SetPrivateAction(GroupAction):
 
 
 class CreateIssueAction(GroupAction):
+    user_visible = True
     title: str
     provider: str
     location: str
@@ -509,6 +563,7 @@ class CreateIssueAction(GroupAction):
 
 
 class SetResolvedInReleaseAction(GroupAction):
+    user_visible = True
     version: Optional[str] = None
 
     @classmethod
@@ -517,6 +572,7 @@ class SetResolvedInReleaseAction(GroupAction):
 
 
 class SetResolvedByAgeAction(GroupAction):
+    user_visible = True
     auto_resolve_age_threshold: Optional[int] = None
 
     @classmethod
@@ -525,6 +581,7 @@ class SetResolvedByAgeAction(GroupAction):
 
 
 class SetResolvedInCommitAction(GroupAction):
+    user_visible = True
     commit: Optional[int] = None
 
     @classmethod
@@ -533,6 +590,7 @@ class SetResolvedInCommitAction(GroupAction):
 
 
 class DeployAction(GroupAction):
+    user_visible = True
     deploy_id: int
     version: str
     environment: str
@@ -543,6 +601,7 @@ class DeployAction(GroupAction):
 
 
 class NewProcessingIssuesAction(GroupAction):
+    user_visible = True
     reprocessing_active: bool
     # TODO Break out as separate model?
     issues: list[dict[str, str | dict[str, str]]]
@@ -553,6 +612,7 @@ class NewProcessingIssuesAction(GroupAction):
 
 
 class UnmergeSourceAction(GroupAction):
+    user_visible = True
     destination_id: int
     fingerprints: list[str]
 
@@ -562,6 +622,7 @@ class UnmergeSourceAction(GroupAction):
 
 
 class UnmergeDestinationAction(GroupAction):
+    user_visible = True
     source_id: int
     fingerprints: list[str]
 
@@ -571,6 +632,7 @@ class UnmergeDestinationAction(GroupAction):
 
 
 class ReprocessAction(GroupAction):
+    user_visible = True
     event_count: Optional[int] = None
     old_group_id: Optional[int] = None
     new_group_id: Optional[int] = None
@@ -581,6 +643,7 @@ class ReprocessAction(GroupAction):
 
 
 class AutoSetOngoingAction(GroupAction):
+    user_visible = True
     after_days: Optional[int] = None
 
     @classmethod
@@ -589,6 +652,7 @@ class AutoSetOngoingAction(GroupAction):
 
 
 class SetEscalatingAction(GroupAction):
+    user_visible = True
     event_id: Optional[str] = None
     forecast: Optional[int] = None
     expired_snooze: Optional[dict[str, int | str | None]] = None
@@ -599,6 +663,7 @@ class SetEscalatingAction(GroupAction):
 
 
 class DeletedAttachmentAction(GroupAction):
+    user_visible = True
     # No activity data.
 
     @classmethod
@@ -607,6 +672,7 @@ class DeletedAttachmentAction(GroupAction):
 
 
 class ReferencedInCommitAction(GroupAction):
+    user_visible = True
     commit: int
 
     @classmethod
@@ -615,6 +681,7 @@ class ReferencedInCommitAction(GroupAction):
 
 
 class SeerRCAStartedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int] = None
 
     @classmethod
@@ -623,6 +690,7 @@ class SeerRCAStartedAction(GroupAction):
 
 
 class SeerRCACompletedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int | str] = None
     summary: Optional[str] = None
     # TODO Break out as separate model?
@@ -634,6 +702,7 @@ class SeerRCACompletedAction(GroupAction):
 
 
 class SeerSolutionStartedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int] = None
 
     @classmethod
@@ -642,6 +711,7 @@ class SeerSolutionStartedAction(GroupAction):
 
 
 class SeerSolutionCompletedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int] = None
     # TODO Break out as separate model?
     solution: Optional[dict[str, str | list[dict[str, str]]]] = None
@@ -653,6 +723,7 @@ class SeerSolutionCompletedAction(GroupAction):
 
 
 class SeerCodingStartedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int] = None
 
     @classmethod
@@ -661,6 +732,7 @@ class SeerCodingStartedAction(GroupAction):
 
 
 class SeerCodingCompletedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int] = None
     changes: Optional[list[dict[str, str | int]]] = None
 
@@ -670,6 +742,7 @@ class SeerCodingCompletedAction(GroupAction):
 
 
 class SeerPRCreatedAction(GroupAction):
+    user_visible = True
     run_id: Optional[int] = None
     # TODO Break out as separate model?
     pull_requests: Optional[list[dict[str, str | dict[str, str | int]]]] = None
@@ -680,12 +753,16 @@ class SeerPRCreatedAction(GroupAction):
 
 
 class SeerIterationStartedAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.SEER_ITERATION_STARTED
 
 
 class SeerIterationCompletedAction(GroupAction):
+    user_visible = True
+
     @classmethod
     def get_type(cls) -> GroupActionType:
         return GroupActionType.SEER_ITERATION_COMPLETED

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -16,6 +16,11 @@ from sentry.db.models import (
 from sentry.issues.action_log.types import GroupAction, GroupActionType, GroupActorType
 
 
+class GroupActionLogEntryManager(models.Manager["GroupActionLogEntry"]):
+    def user_visible(self) -> models.QuerySet[GroupActionLogEntry]:
+        return self.filter(type__in=GroupAction.get_user_visible_types())
+
+
 @cell_silo_model
 class GroupActionLogEntry(Model):
     """
@@ -27,6 +32,8 @@ class GroupActionLogEntry(Model):
     **Do not create or update rows directly.** Use the helpers in
     ``sentry.issues.action_log`` instead.
     """
+
+    objects: GroupActionLogEntryManager = GroupActionLogEntryManager()
 
     __relocation_scope__ = RelocationScope.Excluded
 

--- a/src/sentry/issues/models/groupactionlogentry.py
+++ b/src/sentry/issues/models/groupactionlogentry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+from typing import ClassVar
 
 from django.db import models
 from django.db.models.functions import Now
@@ -13,10 +14,11 @@ from sentry.db.models import (
     cell_silo_model,
     sane_repr,
 )
+from sentry.db.models.manager.base import BaseManager
 from sentry.issues.action_log.types import GroupAction, GroupActionType, GroupActorType
 
 
-class GroupActionLogEntryManager(models.Manager["GroupActionLogEntry"]):
+class GroupActionLogEntryManager(BaseManager["GroupActionLogEntry"]):
     def user_visible(self) -> models.QuerySet[GroupActionLogEntry]:
         return self.filter(type__in=GroupAction.get_user_visible_types())
 
@@ -33,7 +35,7 @@ class GroupActionLogEntry(Model):
     ``sentry.issues.action_log`` instead.
     """
 
-    objects: GroupActionLogEntryManager = GroupActionLogEntryManager()
+    objects: ClassVar[GroupActionLogEntryManager] = GroupActionLogEntryManager()
 
     __relocation_scope__ = RelocationScope.Excluded
 

--- a/tests/sentry/issues/models/test_groupactionlogentry.py
+++ b/tests/sentry/issues/models/test_groupactionlogentry.py
@@ -31,3 +31,34 @@ class GroupActionLogEntryActionPropertyTest(TestCase):
         loaded = GroupActionLogEntry.objects.get(id=entry.id)
 
         assert loaded.action is loaded.action
+
+
+class GroupActionLogEntryManagerTest(TestCase):
+    def test_user_visible_excludes_non_visible_types(self) -> None:
+        visible = self.create_group_action_log_entry(
+            type=GroupActionType.ASSIGN,
+            data={"assignee": "user:1", "assignee_type": "user"},
+        )
+        # VIEW is not user-visible
+        self.create_group_action_log_entry(type=GroupActionType.VIEW)
+        # RECONCILE_STATUS is not user-visible
+        self.create_group_action_log_entry(
+            type=GroupActionType.RECONCILE_STATUS,
+            data={"status": "open"},
+        )
+
+        qs = GroupActionLogEntry.objects.user_visible()
+        assert list(qs.values_list("id", flat=True)) == [visible.id]
+
+    def test_user_visible_chains_with_other_filters(self) -> None:
+        group2 = self.create_group()
+        self.create_group_action_log_entry(
+            type=GroupActionType.RESOLVE,
+        )
+        entry = self.create_group_action_log_entry(
+            group=group2,
+            type=GroupActionType.RESOLVE,
+        )
+
+        qs = GroupActionLogEntry.objects.user_visible().filter(group_id=group2.id)
+        assert list(qs.values_list("id", flat=True)) == [entry.id]


### PR DESCRIPTION
Some GroupActions aren't of interest to users; this adds a standard way for marking actions user-relevant, and a simple query helper for retrieving only user-visible entries.

Fixes ISWF-3056.
