### PR TITLE
feat(sentry-apps): allow webhook subscriptions before the url is set

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -29,12 +29,10 @@ type Props = {
   onEventsChange?: (events: WebhookSubscription[]) => void;
   onScopesChange?: (scopes: Scope[]) => void;
   permissionErrors?: Partial<Record<PermissionResource, string>>;
-  webhookDisabled?: boolean;
 };
 
 export function PermissionsObserver({
   appPublished = false,
-  webhookDisabled = false,
   events: initialEvents,
   newApp,
   scopes,
@@ -124,7 +122,6 @@ export function PermissionsObserver({
             permissions={permissions}
             events={events}
             onChange={handleEventChange}
-            webhookDisabled={webhookDisabled}
           />
         </PanelBody>
       </Panel>

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -25,26 +25,14 @@ type Props = {
   events: WebhookSubscription[];
   onChange: (events: WebhookSubscription[]) => void;
   permissions: Permissions;
-  webhookDisabled?: boolean;
 };
 
-export function Subscriptions({
-  events,
-  onChange,
-  permissions,
-  webhookDisabled = false,
-}: Props) {
+export function Subscriptions({events, onChange, permissions}: Props) {
   const organization = useOrganization();
   const granular = organization.features.includes('sentry-apps-granular-events');
 
-  // Keep the subscription consistent with the rest of the form: webhooks
-  // disabled means no events, and every event needs its backing permission.
+  // Every event needs its backing permission.
   useEffect(() => {
-    if (webhookDisabled && events.length) {
-      onChange([]);
-      return;
-    }
-
     const permitted = new Set<string>(
       EVENT_CHOICES.filter(
         resource => permissions[PERMISSIONS_MAP[resource]] !== 'no-access'
@@ -55,7 +43,7 @@ export function Subscriptions({
     if (JSON.stringify(events) !== JSON.stringify(permittedEvents)) {
       onChange(permittedEvents);
     }
-  }, [webhookDisabled, permissions, events, onChange]);
+  }, [permissions, events, onChange]);
 
   const handleResourceChange = (resource: Resource, checked: boolean) => {
     const owned = new Set<string>([resource, ...RESOURCE_EVENTS[resource]]);
@@ -98,7 +86,6 @@ export function Subscriptions({
       <SubscriptionBox
         key={choice}
         disabledFromPermissions={disabledFromPermissions}
-        webhookDisabled={webhookDisabled}
         checked={checked}
         selectedEvents={selectedEvents}
         resource={choice}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -201,6 +201,29 @@ describe('Sentry Application Details', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('requires a webhook URL to save enabled subscriptions', async () => {
+      createAppRequest = MockApiClient.addMockResponse({
+        url: '/sentry-apps/',
+        method: 'POST',
+        body: [],
+      });
+
+      renderComponent();
+
+      await userEvent.type(screen.getByRole('textbox', {name: 'Name'}), 'Test App');
+      await selectEvent.select(
+        screen.getByRole('textbox', {name: 'Issue & Event'}),
+        'Read'
+      );
+      await userEvent.click(screen.getByRole('checkbox', {name: 'issue'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+      expect(
+        await screen.findByText('This field is required when webhook events are enabled')
+      ).toBeInTheDocument();
+      expect(createAppRequest).not.toHaveBeenCalled();
+    });
+
     it('notes the payload transform when the URL fires a Claude routine', async () => {
       render(<SentryApplicationDetails />, {
         initialRouterConfig,

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -128,12 +128,21 @@ const sentryAppFormSchema = z
       });
     }
 
-    if (!data.isInternal && !data.webhookUrl.trim()) {
-      ctx.addIssue({
-        code: 'custom',
-        message: t('This field is required'),
-        path: ['webhookUrl'],
-      });
+    if (!data.webhookUrl.trim()) {
+      if (!data.isInternal) {
+        ctx.addIssue({
+          code: 'custom',
+          message: t('This field is required'),
+          path: ['webhookUrl'],
+        });
+      } else if (data.events.length > 0) {
+        // Mirrors the backend's events-require-a-webhook-URL rule.
+        ctx.addIssue({
+          code: 'custom',
+          message: t('This field is required when webhook events are enabled'),
+          path: ['webhookUrl'],
+        });
+      }
     }
 
     if (data.schema.trim()) {
@@ -868,21 +877,16 @@ function SentryApplicationForm({
       {getAvatarChooser(true)}
       {getAvatarChooser(false)}
 
-      <form.Subscribe selector={state => isInternal && !state.values.webhookUrl}>
-        {webhookDisabled => (
-          <PermissionsObserver
-            webhookDisabled={webhookDisabled}
-            appPublished={app ? app.status === 'published' : false}
-            scopes={app ? [...app.scopes] : []}
-            events={initialEvents}
-            newApp={!app}
-            permissionErrors={scopeErrors.permissions}
-            continuousIntegrationError={scopeErrors.continuousIntegration}
-            onScopesChange={scopes => form.setFieldValue('scopes', scopes)}
-            onEventsChange={events => form.setFieldValue('events', events)}
-          />
-        )}
-      </form.Subscribe>
+      <PermissionsObserver
+        appPublished={app ? app.status === 'published' : false}
+        scopes={app ? [...app.scopes] : []}
+        events={initialEvents}
+        newApp={!app}
+        permissionErrors={scopeErrors.permissions}
+        continuousIntegrationError={scopeErrors.continuousIntegration}
+        onScopesChange={scopes => form.setFieldValue('scopes', scopes)}
+        onEventsChange={events => form.setFieldValue('events', events)}
+      />
 
       {app?.status === 'internal' && (
         <PanelTable

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -78,19 +78,6 @@ describe('SubscriptionBox', () => {
     });
   });
 
-  it('disables checkbox when webhookDisabled=true', async () => {
-    renderComponent({resource: 'error', webhookDisabled: true});
-
-    expect(screen.getByRole('checkbox')).toBeDisabled();
-
-    await userEvent.hover(screen.getByRole('checkbox'));
-    expect(
-      await screen.findByText(
-        'Cannot enable webhook subscription without specifying a webhook url'
-      )
-    ).toBeInTheDocument();
-  });
-
   describe('granular event subscriptions', () => {
     const organization = OrganizationFixture({
       features: ['sentry-apps-granular-events'],

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -29,7 +29,6 @@ type Props = {
   onEventChange: (event: WebhookGranularEvent, checked: boolean) => void;
   resource: Resource;
   selectedEvents: WebhookGranularEvent[];
-  webhookDisabled?: boolean;
 };
 
 export function SubscriptionBox({
@@ -40,7 +39,6 @@ export function SubscriptionBox({
   onEventChange,
   resource,
   selectedEvents,
-  webhookDisabled = false,
 }: Props) {
   const {features} = useOrganization();
 
@@ -51,7 +49,7 @@ export function SubscriptionBox({
     return null;
   }
 
-  let disabled = disabledFromPermissions || webhookDisabled;
+  let disabled = disabledFromPermissions;
   let message = t(
     "Must have at least 'Read' permissions enabled for %s",
     PERMISSIONS_MAP[resource]
@@ -62,10 +60,6 @@ export function SubscriptionBox({
     message = t(
       'Your organization does not have access to the error subscription resource.'
     );
-  }
-
-  if (webhookDisabled) {
-    message = t('Cannot enable webhook subscription without specifying a webhook url');
   }
 
   const granular = features.includes('sentry-apps-granular-events');


### PR DESCRIPTION
To support app templates, we want to pre-fill certain webhook subscriptions before a webhook URL is entered by the user. So, instead of checking whether we have a webhook URL before allowing the user to modify webhook event subscriptions, check after attempting to save.