### PR TITLE
chore(control): actually drop OrganizationMemberTeamReplica 

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -33,7 +33,7 @@ replays: 0001_squashed_0007_organizationmember_replay_access
 
 seer: 0029_add_agent_write_grant
 
-sentry: 1144_add_dashboard_last_visited_by_user
+sentry: 1145_delete_organizationmemberteamreplica
 
 social_auth: 0001_squashed_0003_social_auth_json_field
 

--- a/src/sentry/migrations/1145_delete_organizationmemberteamreplica.py
+++ b/src/sentry/migrations/1145_delete_organizationmemberteamreplica.py
@@ -1,0 +1,30 @@
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.new_migrations.monkey.models import SafeDeleteModel
+from sentry.new_migrations.monkey.state import DeletionAction
+
+
+class Migration(CheckedMigration):
+    # This flag is used to mark that a migration shouldn't be automatically run in production.
+    # This should only be used for operations where it's safe to run the migration after your
+    # code has deployed. So this should not be used for most operations that alter the schema
+    # of a table.
+    # Here are some things that make sense to mark as post deployment:
+    # - Large data migrations. Typically we want these to be run manually so that they can be
+    #   monitored and not block the deploy for a long period of time while they run.
+    # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
+    #   run this outside deployments so that we don't block them. Note that while adding an index
+    #   is a schema change, it's completely safe to run the operation after the code has deployed.
+    # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
+
+    is_post_deployment = False
+
+    dependencies = [
+        ("sentry", "1144_add_dashboard_last_visited_by_user"),
+    ]
+
+    operations = [
+        SafeDeleteModel(
+            name="OrganizationMemberTeamReplica",
+            deletion_action=DeletionAction.DELETE,
+        ),
+    ]


### PR DESCRIPTION
Step 5 of 5, the final change tearing out the dead `TeamReplica` table. Now that the table has been moved to pending-deletion state (Step 4), this actually drops it.

Refs INFRENG-369