### PR TITLE
feat(seer): Attribute agent actions to delegating users

### DIFF
--- a/src/sentry/issues/action_log/base.py
+++ b/src/sentry/issues/action_log/base.py
@@ -80,6 +80,9 @@ def resolve_action_actor(request: Request | HttpRequest) -> GroupActionActor:
             if auth.kind in ("org_auth_token", "api_key"):
                 if auth.organization_id is not None:
                     return GroupActionActor.org(auth.organization_id)
+            elif auth.kind == "agent_token":
+                if auth.user_id is not None:
+                    return GroupActionActor.user(auth.user_id)
             elif auth.kind == "api_token":
                 user = request.user
                 # Gate on is_sentry_app (the app's proxy user), not application_id: an OAuth client

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -46,7 +46,7 @@ def ViewerContextMiddleware(
         jwt_ctx = _viewer_context_from_jwt_header(request)
 
         if jwt_ctx is not None and request_ctx.user_id is not None:
-            # Authenticated user takes precedence.
+            # Direct user or agent authentication is authoritative when both are present.
             if (
                 jwt_ctx.organization_id is not None
                 and request_ctx.organization_id is not None

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
+from sentry.seer.agent_token import is_agent_auth
 from sentry.viewer_context import (
     ActorType,
     ViewerContext,
@@ -89,9 +90,17 @@ def _viewer_context_from_request(request: HttpRequest) -> ViewerContext:
     if auth is not None and hasattr(auth, "organization_id"):
         organization_id = auth.organization_id
 
+    # An agent token is a non-user actor: the request user is anonymous, so read the
+    # delegating user it acts on behalf of from the credential.
+    if auth is not None and is_agent_auth(auth):
+        actor_type = ActorType.AGENT
+        user_id = auth.user_id
+    else:
+        actor_type = ActorType.USER
+
     return ViewerContext(
         user_id=user_id,
         organization_id=organization_id,
-        actor_type=ActorType.USER,
+        actor_type=actor_type,
         token=auth,
     )

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -19,9 +19,11 @@ from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.organizations.services.organization.model import RpcAuditLogEntryActor
+from sentry.seer.agent_token import is_agent_auth
 from sentry.silo.base import cell_silo_function
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.users.services.user.service import user_service
 
 
 def create_audit_entry(
@@ -33,6 +35,12 @@ def create_audit_entry(
     **kwargs: Any,
 ) -> AuditLogEntry:
     user = kwargs.pop("actor", request.user if request.user.is_authenticated else None)
+    if user is None:
+        # An agent token acts on behalf of a member but authenticates as a non-user actor,
+        # so attribute the audit entry to the delegating user.
+        auth = getattr(request, "auth", None)
+        if auth is not None and is_agent_auth(auth) and auth.user_id is not None:
+            user = user_service.get_user(user_id=auth.user_id)
     api_key = get_api_key_for_audit_log(request)
     org_auth_token = get_org_auth_token_for_audit_log(request)
 

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -42,6 +42,7 @@ class ActorType(enum.StrEnum):
     USER = "user"
     SYSTEM = "system"
     INTEGRATION = "integration"
+    AGENT = "agent"
     UNKNOWN = "unknown"
 
 

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -160,6 +160,11 @@ class TestResolveActionActor(TestCase):
         request = self._request(auth=auth, user=self.user)
         assert resolve_action_actor(request) == GroupActionActor.user(self.user.id)
 
+    def test_agent_token(self) -> None:
+        auth = AuthenticatedToken(kind="agent_token", user_id=self.user.id)
+        request = self._request(auth=auth)
+        assert resolve_action_actor(request) == GroupActionActor.user(self.user.id)
+
     def test_org_auth_token(self) -> None:
         auth = AuthenticatedToken(kind="org_auth_token", organization_id=self.organization.id)
         request = self._request(auth=auth)

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory, override_settings
+from rest_framework.request import Request
 
 from sentry.auth.services.auth import AuthenticatedToken
+from sentry.middleware.auth import AuthenticationMiddleware
 from sentry.middleware.viewer_context import ViewerContextMiddleware, _viewer_context_from_request
+from sentry.seer import agent_token
 from sentry.testutils.cases import TestCase
 from sentry.viewer_context import (
     ActorType,
@@ -198,6 +202,38 @@ class ViewerContextMiddlewareTest(TestCase):
         assert ctx.user_id is None
         assert ctx.organization_id is None
         assert ctx.token is None
+
+    @override_settings(SENTRY_VIEWER_CONTEXT_ENABLED=True)
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_agent_token_sets_agent_context(self):
+        # Through the real chain: AuthenticationMiddleware resolves the agent bearer,
+        # then this middleware derives user + org + agent actor from it.
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            scopes=["org:read"],
+            session_id="s1",
+        )
+
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        request = self.factory.get("/api/0/organizations/", HTTP_AUTHORIZATION=f"Bearer {token}")
+        AuthenticationMiddleware(lambda r: MagicMock(status_code=200)).process_request(
+            cast(Request, request)
+        )
+        ViewerContextMiddleware(get_response)(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx is not None
+        assert ctx.user_id == self.user.id
+        assert ctx.organization_id == self.organization.id
+        assert ctx.actor_type is ActorType.AGENT
+        assert ctx.token is not None
 
     @override_settings(SENTRY_VIEWER_CONTEXT_ENABLED=True)
     @override_settings(SEER_API_SHARED_SECRET="test-secret")

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -222,9 +222,10 @@ class ViewerContextMiddlewareTest(TestCase):
             return MagicMock(status_code=200)
 
         request = self.factory.get("/api/0/organizations/", HTTP_AUTHORIZATION=f"Bearer {token}")
-        AuthenticationMiddleware(lambda r: MagicMock(status_code=200)).process_request(
-            cast(Request, request)
-        )
+        with self.feature(agent_token.FEATURE_FLAG):
+            AuthenticationMiddleware(lambda r: MagicMock(status_code=200)).process_request(
+                cast(Request, request)
+            )
         ViewerContextMiddleware(get_response)(request)
 
         assert len(captured) == 1

--- a/tests/sentry/utils/test_audit.py
+++ b/tests/sentry/utils/test_audit.py
@@ -56,6 +56,21 @@ class CreateAuditEntryTest(TestCase):
 
         self.assert_no_delete_log_created()
 
+    def test_audit_entry_agent_token_attributes_to_delegating_user(self) -> None:
+        from sentry.auth.services.auth import AuthenticatedToken
+
+        req = fake_http_request(AnonymousUser())
+        # An agent token authenticates as a non-user actor; the audit entry should still be
+        # attributed to the member it acts on behalf of.
+        req.auth = AuthenticatedToken(
+            kind="agent_token", user_id=self.user.id, organization_id=self.org.id
+        )
+
+        entry = create_audit_entry(req, organization_id=self.org.id, data={"thing": "to True"})
+        assert entry.actor_id == self.user.id
+
+        self.assert_no_delete_log_created()
+
     def test_audit_entry_frontend(self) -> None:
         org = self.create_organization()
 


### PR DESCRIPTION
This stacked PR adds attribution after the core token flow and release compatibility layers. Agent-authenticated audit entries and issue action logs are attributed to the delegating user, and propagated viewer context identifies the caller as an agent while preserving its user and organization.

Review order: #118539 for the core token/auth/grant behavior, then #120173 for release compatibility, then this PR. Access-log `delegated_user_id`/`agent_session_id` fields and agent-aware rate limiting can build on this attribution layer separately.
