### PR TITLE
fix(seer): Support agent tokens in release endpoints

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -40,6 +40,7 @@ from sentry.organizations.services.organization import (
     RpcUserOrganizationContext,
     organization_service,
 )
+from sentry.seer.agent_token import is_agent_auth
 from sentry.types.cell import subdomain_is_locality
 from sentry.utils import auth
 from sentry.utils.hashlib import hash_values
@@ -812,8 +813,15 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
             is_api_token_auth(request.auth) and request.access.has_scope("project:releases")
         )
 
+        agent_auth = request.auth if is_agent_auth(request.auth) else None
+        has_valid_agent_auth = (
+            agent_auth is not None and agent_auth.organization_id == organization.id
+        )
+
         if not (
-            has_valid_api_key or (getattr(request, "user", None) and request.user.is_authenticated)
+            has_valid_api_key
+            or has_valid_agent_auth
+            or (getattr(request, "user", None) and request.user.is_authenticated)
         ):
             return []
 
@@ -847,13 +855,14 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         via has_global_access.
 
         Results are cached for 60s per actor/org/release/effective-project-scope/mode.
+        Agent requests bypass the cache so every call rechecks live project membership.
         """
         actor_id = None
         has_perms = None
         key = None
         if request.user.is_authenticated:
             actor_id = "user:%s" % request.user.id
-        elif request.auth is not None:
+        elif request.auth is not None and not is_agent_auth(request.auth):
             actor_id = "apikey:%s" % request.auth.entity_id
         if actor_id is not None:
             if project_ids:

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -1195,6 +1195,19 @@ def from_rpc_member(
 def from_auth(auth: AuthenticatedToken, organization: Organization) -> Access:
     if is_system_auth(auth):
         return SystemAccess()
+    if is_agent_auth(auth):
+        access: Access = DEFAULT
+        if auth.user_id is not None and auth.organization_id == organization.id:
+            try:
+                member = OrganizationMember.objects.get(
+                    user_id=auth.user_id, organization_id=organization.id
+                )
+            except OrganizationMember.DoesNotExist:
+                pass
+            else:
+                member.organization = organization
+                access = from_member(member, scopes=auth.get_scopes())
+        return access
     auth_organization_id = auth.organization_id
     if auth_organization_id is not None and auth_organization_id == organization.id:
         return OrganizationGlobalAccess(

--- a/tests/sentry/seer/test_agent_token.py
+++ b/tests/sentry/seer/test_agent_token.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 from django.contrib.sessions.backends.base import SessionBase
+from django.core.cache import cache
 from django.test import RequestFactory, override_settings
 from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
@@ -14,8 +15,8 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from sentry.api.authentication import AgentTokenAuthentication, UserAuthTokenAuthentication
-from sentry.api.bases.organization import OrganizationPermission
-from sentry.auth.access import Access
+from sentry.api.bases.organization import OrganizationPermission, OrganizationReleasesBaseEndpoint
+from sentry.auth.access import Access, from_auth
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer import agent_token
 from sentry.seer.models.agent_write_grant import SeerAgentWriteGrant
@@ -264,6 +265,40 @@ class AgentTokenAuthAndGateTest(TestCase):
 
         assert access.has_project_access(member_project)
         assert not access.has_project_access(other_project)
+
+        release_projects = OrganizationReleasesBaseEndpoint().get_projects(request, self.org)
+        assert release_projects == [member_project]
+
+    def test_from_auth_preserves_member_and_token_scope_caps(self) -> None:
+        request = self._agent_request(self.member, ["org:read", "org:write"], method="GET")
+        assert request.auth is not None
+
+        resolved_access = from_auth(request.auth, self.org)
+
+        assert resolved_access.has_scope("org:read")
+        assert not resolved_access.has_scope("org:write")
+
+    def test_release_permission_rechecks_live_agent_membership(self) -> None:
+        cache.clear()
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+        team = self.create_team(organization=self.org)
+        membership = self.create_team_membership(user=self.member, team=team)
+        self.create_project(organization=self.org, teams=[team])
+        endpoint = OrganizationReleasesBaseEndpoint()
+
+        member_request = self._agent_request(
+            self.member, ["org:read", "project:read"], method="GET"
+        )
+        self._access_for(member_request)
+        assert endpoint.has_release_permission(member_request, self.org)
+
+        membership.delete()
+        member_request = self._agent_request(
+            self.member, ["org:read", "project:read"], method="GET"
+        )
+        self._access_for(member_request)
+        assert not endpoint.has_release_permission(member_request, self.org)
 
     def test_agent_denied_after_member_is_removed(self) -> None:
         # Ephemeral tokens re-derive authority from live membership on each request, so


### PR DESCRIPTION
This stacked PR keeps the core capability-token change focused while adding compatibility for Sentry's release-specific access paths. Agent credentials can resolve only the delegating member's release projects, release permission checks re-evaluate live membership instead of using credential-row caching, and the legacy `from_auth` path preserves member and token scope caps.

This is stacked on `greg/agent-write-token-flow`; review #118539 first.
