### PR TITLE
fix: serialize deep JVM view hierarchies

### DIFF
--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -10,6 +10,7 @@ from sentry.attachments import (
 )
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
 from sentry.models.project import Project
+from sentry.utils import json
 
 
 class ViewHierarchies:
@@ -76,8 +77,8 @@ def _serialize_view_hierarchy(view_hierarchy: Any) -> bytes:
         return orjson.dumps(view_hierarchy)
     except orjson.JSONEncodeError:
         # orjson cannot serialize documents nested beyond 255 levels. View hierarchies
-        # can be deeper, so preserve them with the standard library encoder instead.
-        return json.dumps(view_hierarchy, ensure_ascii=False, separators=(",", ":")).encode()
+        # can be deeper, so preserve them with Sentry's JSON encoder instead.
+        return json.dumps(view_hierarchy).encode()
 
 
 def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]):

--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import orjson
@@ -60,7 +61,7 @@ class ViewHierarchies:
                     type=attachment.type,
                     name=attachment.name,
                     content_type=attachment.content_type,
-                    data=orjson.dumps(view_hierarchy),
+                    data=_serialize_view_hierarchy(view_hierarchy),
                     chunks=None,
                     stored_id=attachment.stored_id,
                 )
@@ -68,6 +69,15 @@ class ViewHierarchies:
 
         attachments = self._other_attachments + new_attachments
         store_attachments_for_event(self._project, self._event, attachments, timeout=CACHE_TIMEOUT)
+
+
+def _serialize_view_hierarchy(view_hierarchy: Any) -> bytes:
+    try:
+        return orjson.dumps(view_hierarchy)
+    except orjson.JSONEncodeError:
+        # orjson cannot serialize documents nested beyond 255 levels. View hierarchies
+        # can be deeper, so preserve them with the standard library encoder instead.
+        return json.dumps(view_hierarchy, ensure_ascii=False, separators=(",", ":")).encode()
 
 
 def _deobfuscate_view_hierarchy(view_hierarchy: Any, class_names: dict[str, str]):

--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import orjson

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -1,7 +1,7 @@
-import json
 from typing import Any
 
 from sentry.lang.java.view_hierarchies import _serialize_view_hierarchy
+from sentry.utils import json
 
 
 def test_serialize_deep_view_hierarchy() -> None:

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -1,0 +1,16 @@
+import json
+from typing import Any
+
+from sentry.lang.java.view_hierarchies import _serialize_view_hierarchy
+
+
+def test_serialize_deep_view_hierarchy() -> None:
+    window: dict[str, Any] = {"type": "com.example.View"}
+    view_hierarchy = {"windows": [window]}
+
+    for _ in range(300):
+        child = {"type": "com.example.View"}
+        window["children"] = [child]
+        window = child
+
+    assert json.loads(_serialize_view_hierarchy(view_hierarchy)) == view_hierarchy

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+import orjson
+import pytest
+
 from sentry.lang.java.view_hierarchies import _serialize_view_hierarchy
 from sentry.utils import json
 
@@ -13,4 +16,10 @@ def test_serialize_deep_view_hierarchy() -> None:
         window["children"] = [child]
         window = child
 
-    assert json.loads(_serialize_view_hierarchy(view_hierarchy)) == view_hierarchy
+    raw_attachment = json.dumps(view_hierarchy).encode()
+    parsed_view_hierarchy = orjson.loads(raw_attachment)
+
+    with pytest.raises(orjson.JSONEncodeError):
+        orjson.dumps(parsed_view_hierarchy)
+
+    assert json.loads(_serialize_view_hierarchy(parsed_view_hierarchy)) == view_hierarchy


### PR DESCRIPTION
## Summary

* Fall back to compact standard-library JSON when `orjson` cannot serialize a deeply nested JVM view hierarchy.
* Add regression coverage for a hierarchy deeper than `orjson`'s 255-level recursion limit.

## Root cause

`ViewHierarchies.deobfuscate_and_save` serialized each updated attachment with `orjson.dumps`. That encoder rejects values nested beyond 255 levels, causing view-hierarchy deobfuscation to fail.

## Testing

* `.venv/bin/pytest -n0 -q tests/sentry/lang/java/test_view_hierarchies.py`
* `.venv/bin/prek run -q`
* `make test-selective` could not run because this environment does not have the Google Cloud CLI required by Sentry's coverage fetcher.

Fixes getsentry/sentry#78685