### PR TITLE
fix(conversations): Prevent blank message bubbles in the transcript

### DIFF
--- a/static/app/utils/marked/marked.spec.tsx
+++ b/static/app/utils/marked/marked.spec.tsx
@@ -2,12 +2,40 @@
 
 import {
   asyncSanitizedMarked,
+  markdownRendersVisibleContent,
   sanitizedMarked,
   singleLineRenderer,
 } from 'sentry/utils/marked/marked';
 import {loadPrismLanguage} from 'sentry/utils/prism';
 
 jest.unmock('prismjs');
+
+describe('markdownRendersVisibleContent', () => {
+  it.each([
+    '',
+    '   ',
+    '\n\n',
+    '```',
+    '```\n```',
+    '```js\n```',
+    // Images are stripped by `sanitizeHtml`, so image-only content renders
+    // nothing and must be treated as blank.
+    '![alt](img.png)',
+  ])('returns false for content that renders nothing: %j', text => {
+    expect(markdownRendersVisibleContent(text)).toBe(false);
+  });
+
+  it.each([
+    'hello',
+    '**bold**',
+    '# heading',
+    '```\nconst x = 1;\n```',
+    '- item',
+    '| a |\n|---|\n| 1 |',
+  ])('returns true for content that renders something: %j', text => {
+    expect(markdownRendersVisibleContent(text)).toBe(true);
+  });
+});
 
 function expectMarkdown(test: any) {
   expect(sanitizedMarked(test[0])).toEqual('<p>' + test[1] + '</p>\n');

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -187,3 +187,46 @@ export const singleLineRenderer = (text: string): string => {
     renderer: new NoParagraphRenderer(),
   });
 };
+
+/**
+ * Whether markdown renders any output a reader can see. Some valid markdown
+ * collapses to nothing — most commonly a bare or empty code fence (```), which
+ * renders an empty `<pre><code>` box. Callers can fall back to showing the raw
+ * text so the content isn't swallowed into a blank space. See TET-2670.
+ */
+export function markdownRendersVisibleContent(text: string): boolean {
+  if (text.trim().length === 0) {
+    return false;
+  }
+  return MarkedLexer.lex(text).some(hasVisibleToken);
+}
+
+// A token renders something visible if it is a rule/image/table, or it (or a
+// descendant) carries non-whitespace text. An empty code fence and bare
+// whitespace are the notable tokens that carry none.
+function hasVisibleToken(token: Token): boolean {
+  switch (token.type) {
+    case 'space':
+      return false;
+    // Images render nothing in this app: `sanitizeHtml` strips `<img>` (not in
+    // ALLOWED_TAGS), and its `alt` is dropped along with it. So image-only
+    // content must fall back to raw text, not count as visible. This needs an
+    // explicit case ahead of `default` — an image token carries its alt as
+    // child text tokens, which the default branch would otherwise treat as
+    // visible text.
+    case 'image':
+      return false;
+    case 'hr':
+    case 'table':
+      return true;
+    case 'list':
+      return token.items.some(hasVisibleToken);
+    default:
+      if ('tokens' in token && token.tokens && token.tokens.length > 0) {
+        return token.tokens.some(hasVisibleToken);
+      }
+      return 'text' in token && typeof token.text === 'string'
+        ? token.text.trim().length > 0
+        : false;
+  }
+}

--- a/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.spec.ts
@@ -542,6 +542,23 @@ describe('conversationMessages utilities', () => {
       expect(turns[1]?.toolCalls).toHaveLength(1);
       expect(turns[1]?.toolCalls[0]?.name).toBe('search');
     });
+
+    it('treats whitespace-only content as absent so no blank bubble renders', () => {
+      const requestMessages = JSON.stringify([{role: 'user', content: '   '}]);
+      const genNode = createMockNode({
+        id: 'gen-1',
+        startTimestamp: 1000,
+        attributes: {
+          [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+          [SpanFields.GEN_AI_RESPONSE_TEXT]: '\n\n',
+        },
+      });
+
+      const turns = buildConversationTurns([genNode as any], []);
+
+      expect(turns[0]?.userContent).toBeNull();
+      expect(turns[0]?.assistantContent).toBeNull();
+    });
   });
 
   describe('mergeEmptyTurns', () => {

--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -18,6 +18,21 @@ import {SpanFields} from 'sentry/views/insights/types';
 
 const FILTERED = '[Filtered]';
 
+/**
+ * Content that is empty or only whitespace has nothing to render, so we treat
+ * it as absent (`null`). This is the single guard that keeps blank message
+ * bubbles — a small empty "cylinder" in the transcript — out of every consumer
+ * of `extractMessagesFromNodes`. See TET-2670. Note `EMPTY_TEXT_CONTENT`
+ * (`'(no value)'`) is a deliberate placeholder, not blank, so it is preserved.
+ *
+ * Content that is non-blank but renders to nothing as markdown (e.g. a bare
+ * `\`\`\`` fence) is handled downstream by `AIContentRenderer`, which falls
+ * back to the raw text rather than an empty bubble.
+ */
+function blankToNull(content: string | null): string | null {
+  return content && content.trim().length > 0 ? content : null;
+}
+
 export interface ToolCall {
   hasError: boolean;
   name: string;
@@ -132,11 +147,11 @@ export function buildConversationTurns(
       generation: node,
       toolCalls,
       toolSpanNodes: toolCallSpans,
-      userContent: parseUserContent(node),
+      userContent: blankToNull(parseUserContent(node)),
       hasInputHistory: inputStats.totalMessageCount > 1,
       userMessageCount: inputStats.userMessageCount,
-      assistantContent,
-      reasoning,
+      assistantContent: blankToNull(assistantContent),
+      reasoning: blankToNull(reasoning),
       userEmail,
     });
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection.spec.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection.spec.ts
@@ -65,6 +65,14 @@ describe('detectAIContentType', () => {
     expect(detectAIContentType('Just some regular text here.').type).toBe('plain-text');
   });
 
+  it('treats markdown that renders nothing as plain text', () => {
+    // A bare/empty code fence looks like markdown but produces an empty
+    // <pre><code> box, so it is shown as raw text instead. See TET-2670.
+    expect(detectAIContentType('```').type).toBe('plain-text');
+    expect(detectAIContentType('```\n```').type).toBe('plain-text');
+    expect(detectAIContentType('```js\n```').type).toBe('plain-text');
+  });
+
   it('handles empty and whitespace strings', () => {
     expect(detectAIContentType('').type).toBe('plain-text');
     expect(detectAIContentType('   ').type).toBe('plain-text');

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection.ts
@@ -1,3 +1,4 @@
+import {markdownRendersVisibleContent} from 'sentry/utils/marked/marked';
 import {parseJsonWithFix} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 type AIContentType =
@@ -138,7 +139,12 @@ export function detectAIContentType(text: string): AIContentDetectionResult {
   }
 
   if (MARKDOWN_INDICATORS.some(re => re.test(trimmed))) {
-    return {type: 'markdown'};
+    // Some markdown renders to nothing (e.g. a bare/empty ``` fence). Treat it
+    // as plain text so the raw source is shown instead of a blank bubble.
+    // See TET-2670.
+    return markdownRendersVisibleContent(trimmed)
+      ? {type: 'markdown'}
+      : {type: 'plain-text'};
   }
 
   return {type: 'plain-text'};

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
@@ -76,4 +76,19 @@ describe('AIContentRenderer', () => {
     expect(screen.getByText('inner')).toBeInTheDocument();
     expect(screen.getByText('nested content')).toBeInTheDocument();
   });
+
+  it('falls back to raw text when markdown renders nothing (empty code fence)', () => {
+    render(<AIContentRenderer text="```" inline />);
+    expect(screen.getByText('```')).toBeInTheDocument();
+  });
+
+  it('falls back to raw text for non-inline empty markdown (span Output "Pretty")', () => {
+    render(<AIContentRenderer text="```" />);
+    expect(screen.getByText('```')).toBeInTheDocument();
+  });
+
+  it('still renders a code fence that has real content', async () => {
+    render(<AIContentRenderer text={'```\nconst x = 1;\n```'} inline />);
+    expect(await screen.findByText(/const x = 1;/)).toBeInTheDocument();
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -53,6 +53,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getDuration} from 'sentry/utils/duration/getDuration';
+import {markdownRendersVisibleContent} from 'sentry/utils/marked/marked';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -1164,6 +1165,14 @@ function MultilineText({
   const {hoverProps, isHovered} = useHover({});
   const theme = useTheme();
 
+  // Without a custom formatter we render `children` as markdown, but some
+  // markdown (e.g. a bare/empty ``` fence) renders to nothing — leaving the
+  // "Pretty" view blank. Fall back to the raw text in that case. See TET-2670.
+  const defaultFormattingIsBlank = useMemo(
+    () => !renderFormatted && !markdownRendersVisibleContent(children),
+    [renderFormatted, children]
+  );
+
   const content = (
     <MultilineTextWrapper {...hoverProps}>
       <Container position="absolute" top={theme.space.xs} right={theme.space.xs}>
@@ -1178,7 +1187,7 @@ function MultilineText({
           </SegmentedControl>
         )}
       </Container>
-      {showRaw
+      {showRaw || defaultFormattingIsBlank
         ? children.trim()
         : (renderFormatted?.(children) ?? (
             <MarkedText as={MarkdownContainer} text={children} />


### PR DESCRIPTION
Some agent turns arrived with no real content to show, yet the transcript still drew a message for them - an empty message bubble that read as a stray icon and left people wondering what it was. The same empty output appeared in the span detail Output tab, where the "Pretty" view could show nothing at all.

Now a turn with nothing to say produces no bubble, and a turn whose content can't be displayed (e.g. ` ``` `) shows its actual text instead of an empty box.
Fixes TET-2670
