### PR TITLE
fix(view-hierarchy): Make windows optional in ViewHierarchyData type

### DIFF
--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -77,8 +77,8 @@ export type ViewHierarchyWindow = {
 
 export type ViewHierarchyData = {
   rendering_system: string;
-  windows: ViewHierarchyWindow[];
   positioning?: 'absolute' | 'relative';
+  windows?: ViewHierarchyWindow[];
 };
 
 export type ViewHierarchyNodeField = 'type' | 'name';
@@ -102,11 +102,11 @@ function ViewHierarchy({
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(
     null
   );
-  const [selectedNode, setSelectedNode] = useState(viewHierarchy?.windows?.[0]);
+  const [selectedNode, setSelectedNode] = useState(viewHierarchy.windows?.[0]);
   const [userHasSelected, setUserHasSelected] = useState(false);
   const hierarchy = useMemo(() => {
-    return viewHierarchy?.windows ?? [];
-  }, [viewHierarchy?.windows]);
+    return viewHierarchy.windows ?? [];
+  }, [viewHierarchy.windows]);
 
   const renderRow: UseVirtualizedTreeProps<ViewHierarchyWindow>['renderRow'] = (
     r,


### PR DESCRIPTION
Follow-up to #120006.

That PR added optional-chaining guards (`windows?.[0]`, `windows ?? []`) to handle a `ViewHierarchyData` attachment that has no `windows` key, but left the type declaring `windows` as **required** — so the type no longer matched the runtime behavior the guards were protecting against.

### Changes

- Mark `windows` as optional (`windows?: ViewHierarchyWindow[]`) in the `ViewHierarchyData` type, aligning it with runtime reality.
- Drop the redundant optional chaining on `viewHierarchy` itself (`viewHierarchy?.windows` → `viewHierarchy.windows`). The `viewHierarchy` prop is typed as non-optional `ViewHierarchyData`; only `windows` can be missing.