### PR TITLE
fix(view-hierarchy): Handle null hierarchy from failed JSON parsing

### DIFF
--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -67,7 +67,7 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
 
   // Memoize the JSON parsing because downstream hooks depend on
   // referential equality of objects in the data
-  const hierarchy = useMemo<ViewHierarchyData | null>(() => {
+  const hierarchy = useMemo(() => {
     if (!data) {
       return null;
     }
@@ -77,7 +77,7 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
     }
 
     try {
-      return JSON.parse(data);
+      return JSON.parse(data) as ViewHierarchyData;
     } catch (err) {
       Sentry.captureException(err);
       return null;

--- a/static/app/components/events/eventViewHierarchy.tsx
+++ b/static/app/components/events/eventViewHierarchy.tsx
@@ -67,7 +67,7 @@ function EventViewHierarchyContent({event, project, disableCollapsePersistence}:
 
   // Memoize the JSON parsing because downstream hooks depend on
   // referential equality of objects in the data
-  const hierarchy = useMemo<ViewHierarchyData>(() => {
+  const hierarchy = useMemo<ViewHierarchyData | null>(() => {
     if (!data) {
       return null;
     }

--- a/static/app/components/events/viewHierarchy/index.tsx
+++ b/static/app/components/events/viewHierarchy/index.tsx
@@ -87,7 +87,7 @@ type ViewHierarchyProps = {
   emptyMessage: string;
   nodeField: ViewHierarchyNodeField;
   showWireframe: boolean;
-  viewHierarchy: ViewHierarchyData;
+  viewHierarchy: ViewHierarchyData | null;
   platform?: string;
 };
 
@@ -102,11 +102,11 @@ function ViewHierarchy({
   const [scrollContainerRef, setScrollContainerRef] = useState<HTMLDivElement | null>(
     null
   );
-  const [selectedNode, setSelectedNode] = useState(viewHierarchy.windows?.[0]);
+  const [selectedNode, setSelectedNode] = useState(viewHierarchy?.windows?.[0]);
   const [userHasSelected, setUserHasSelected] = useState(false);
   const hierarchy = useMemo(() => {
-    return viewHierarchy.windows ?? [];
-  }, [viewHierarchy.windows]);
+    return viewHierarchy?.windows ?? [];
+  }, [viewHierarchy?.windows]);
 
   const renderRow: UseVirtualizedTreeProps<ViewHierarchyWindow>['renderRow'] = (
     r,
@@ -205,7 +205,7 @@ function ViewHierarchy({
 
   const viewHierarchyContent = (
     <Fragment>
-      <RenderingSystem platform={platform} system={viewHierarchy.rendering_system} />
+      <RenderingSystem platform={platform} system={viewHierarchy?.rendering_system} />
       <Flex gap="md" height="700px">
         <Left hasRight={showWireframe}>
           <TreeContainer>
@@ -233,7 +233,7 @@ function ViewHierarchy({
               selectedNode={userHasSelected ? selectedNode : undefined}
               onNodeSelect={onWireframeNodeSelect}
               platform={platform}
-              positioning={viewHierarchy.positioning}
+              positioning={viewHierarchy?.positioning}
             />
           </Right>
         )}


### PR DESCRIPTION
The View Hierarchy panel crashed with `Cannot read properties of null (reading 'windows')` when the attachment body was a malformed JSON string, since parsing returns `null` but the pre-render guard only checked the raw response. `ViewHierarchy` now accepts a nullable `viewHierarchy` prop and uses optional chaining, so it renders the empty state instead of throwing.
