### PR TITLE
fix(searchQueryBuilder): always render ActionButtons

### DIFF
--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -292,7 +292,7 @@ function SearchQueryBuilderUI({
   onChange,
 }: SearchQueryBuilderProps) {
   const {parsedQuery, query, dispatch} = useSearchQueryBuilderState();
-  const {wrapperRef, actionBarRef, size} = useSearchQueryBuilderLayout();
+  const {wrapperRef, actionBarRef} = useSearchQueryBuilderLayout();
 
   useOnChange({onChange});
   useLayoutEffect(() => {
@@ -324,9 +324,7 @@ function SearchQueryBuilderUI({
             actionBarWidth={actionBarWidth}
           />
         )}
-        {size !== 'small' && (
-          <ActionButtons ref={actionBarRef} trailingItems={trailingItems} />
-        )}
+        <ActionButtons ref={actionBarRef} trailingItems={trailingItems} />
       </PanelProvider>
     </Wrapper>
   );


### PR DESCRIPTION
I noticed the `X` button is disappearing from the search box in the issue list input box and I can’t see why we would do that. This got more visible when the persistent seer sidebar is open because it moves the searchQueryBuilder into “small” sizing per default

| before | after |
|--------|--------|
| <img width="1109" height="113" alt="Screenshot 2026-07-21 at 10 44 08" src="https://github.com/user-attachments/assets/e76d5b94-1dc7-4a2e-8bdc-174f4464ef72" /> | <img width="1114" height="117" alt="Screenshot 2026-07-21 at 10 45 01" src="https://github.com/user-attachments/assets/d6c70198-097e-4c17-afe8-41aefd5a12c7" /> | 

