### PR TITLE
test(dynamic-sampling): Improve per-org dynamic sampling tests

### DIFF
--- a/tests/sentry/dynamic_sampling/per_org/test_calculations.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_calculations.py
@@ -6,7 +6,6 @@ import orjson
 import pytest
 
 from sentry.dynamic_sampling.models.common import RebalancedItem
-from sentry.dynamic_sampling.models.projects_rebalancing import ProjectsRebalancingInput
 from sentry.dynamic_sampling.per_org.calculations import (
     apply_project_sample_rate_overrides,
     compare_rebalanced_projects_with_cache,
@@ -38,44 +37,30 @@ class ProjectBalancingCalculationsTest(TestCase):
         super().setUp()
         self.redis = get_redis_client_for_ds()
 
-    def test_run_project_balancing_returns_rebalanced_projects(self) -> None:
+    def test_run_project_balancing_balances_org_projects(self) -> None:
         org = self.create_organization()
         project_with_volume = self.create_project(organization=org)
         project_without_volume = self.create_project(organization=org)
-        other_project = self.create_project()
+        other_org_project = self.create_project()
         config = Mock()
         config.organization = org
         config.projects = [project_with_volume, project_without_volume]
         config.get_sample_rate.return_value = 0.5
-        rebalanced_projects = [
-            RebalancedItem(id=project_with_volume.id, count=100, new_sample_rate=0.25),
-        ]
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.ProjectsRebalancingModel.run",
-            return_value=rebalanced_projects,
-        ) as model_run:
-            result = run_project_balancing(
-                config,
-                [
-                    _project_volume(project_with_volume.id),
-                    _project_volume(project_without_volume.id, total=0, keep=0),
-                    _project_volume(other_project.id),
-                ],
-            )
+        result = run_project_balancing(
+            config,
+            [
+                _project_volume(project_with_volume.id, total=100),
+                _project_volume(project_without_volume.id, total=0, keep=0),
+                _project_volume(other_org_project.id),
+            ],
+        )
 
-        model_run.assert_called_once()
-        model_input = model_run.call_args.args[-1]
-        assert isinstance(model_input, ProjectsRebalancingInput)
-        assert model_input.sample_rate == 0.5
-        # Every project of the org is passed to the model; the one without volume is
-        # included with a count of 0 so it receives a 100% sample rate. The project from
-        # another org is excluded.
-        assert model_input.classes == [
-            RebalancedItem(id=project_with_volume.id, count=100),
-            RebalancedItem(id=project_without_volume.id, count=0),
-        ]
-        assert result == rebalanced_projects
+        rates_by_id = {int(item.id): item.new_sample_rate for item in result}
+        assert set(rates_by_id) == {project_with_volume.id, project_without_volume.id}
+        assert rates_by_id[project_without_volume.id] == 1.0
+        kept_volume = sum(item.count * item.new_sample_rate for item in result)
+        assert kept_volume == pytest.approx(100 * 0.5)
 
     def test_run_project_balancing_full_sample_rate_returns_all_projects_at_100_percent(
         self,
@@ -88,41 +73,15 @@ class ProjectBalancingCalculationsTest(TestCase):
         config.projects = [busy, idle]
         config.get_sample_rate.return_value = 1.0
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.calculations.ProjectsRebalancingModel.run"
-        ) as model_run:
-            result = run_project_balancing(
-                config,
-                [_project_volume(busy.id, total=1000), _project_volume(idle.id, total=0, keep=0)],
-            )
+        result = run_project_balancing(
+            config,
+            [_project_volume(busy.id, total=1000), _project_volume(idle.id, total=0, keep=0)],
+        )
 
-        # Mirrors legacy serving: a 100% org rate gives every project 100% and the balancing
-        # model never runs.
-        model_run.assert_not_called()
         assert {int(item.id): item.new_sample_rate for item in result} == {
             busy.id: 1.0,
             idle.id: 1.0,
         }
-
-    def test_run_project_balancing_assigns_full_sample_rate_to_zero_volume_projects(self) -> None:
-        org = self.create_organization()
-        project_with_volume = self.create_project(organization=org)
-        project_without_volume = self.create_project(organization=org)
-        config = Mock()
-        config.organization = org
-        config.projects = [project_with_volume, project_without_volume]
-        config.get_sample_rate.return_value = 0.5
-
-        result = run_project_balancing(
-            config,
-            [
-                _project_volume(project_with_volume.id, total=100),
-                _project_volume(project_without_volume.id, total=0, keep=0),
-            ],
-        )
-
-        rates_by_id = {int(item.id): item.new_sample_rate for item in result}
-        assert rates_by_id[project_without_volume.id] == 1.0
 
     def test_run_project_balancing_returns_empty_when_no_volume(self) -> None:
         org = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/test_configuration.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_configuration.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from datetime import timedelta
-from typing import NamedTuple
 from unittest.mock import patch
 
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
 
+from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import (
     AutomaticDynamicSamplingConfiguration,
     CustomDynamicSamplingOrganizationConfiguration,
@@ -25,46 +24,74 @@ from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
 
-SpanOrgIds = Callable[[Organization], list[int]]
-
-
-class MeasureOptionCase(NamedTuple):
-    name: str
-    check_span_feature_flag: bool
-    span_org_ids: SpanOrgIds
-    expected_measure: SamplingMeasure
-
-
-def _include_org(organization: Organization) -> list[int]:
-    return [organization.id]
-
-
-def _exclude_org(organization: Organization) -> list[int]:
-    return []
-
-
-MEASURE_OPTION_CASES = (
-    MeasureOptionCase("span-option-disabled", False, _include_org, SamplingMeasure.SEGMENTS),
-    MeasureOptionCase("org-not-in-span-option", True, _exclude_org, SamplingMeasure.SEGMENTS),
-    MeasureOptionCase("org-in-span-option", True, _include_org, SamplingMeasure.SPANS),
+GET_BLENDED_SAMPLE_RATE = (
+    "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
 )
+
+
+class SamplingMeasureSelectionTest(TestCase):
+    """The measure is shared base-class logic; it is tested once here instead of in
+    every configuration test."""
+
+    def _get_configuration(self, org: Organization) -> AutomaticDynamicSamplingConfiguration:
+        with patch(GET_BLENDED_SAMPLE_RATE, return_value=1.0):
+            configuration = get_configuration(org.id)
+        assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
+        return configuration
+
+    def test_defaults_to_segments_when_span_option_disabled(self) -> None:
+        org = self.create_organization()
+
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": False,
+                "dynamic-sampling.measure.spans": [org.id],
+            }
+        ):
+            configuration = self._get_configuration(org)
+
+        assert configuration.measure == SamplingMeasure.SEGMENTS
+        assert configuration.is_segment_based
+        assert not configuration.is_span_based
+
+    def test_segments_when_org_not_in_span_option(self) -> None:
+        org = self.create_organization()
+
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [],
+            }
+        ):
+            configuration = self._get_configuration(org)
+
+        assert configuration.measure == SamplingMeasure.SEGMENTS
+
+    def test_spans_when_org_in_span_option(self) -> None:
+        org = self.create_organization()
+
+        with self.options(
+            {
+                "dynamic-sampling.check_span_feature_flag": True,
+                "dynamic-sampling.measure.spans": [org.id],
+            }
+        ):
+            configuration = self._get_configuration(org)
+
+        assert configuration.measure == SamplingMeasure.SPANS
+        assert configuration.is_span_based
+        assert not configuration.is_segment_based
 
 
 class DynamicSamplingOrgConfigurationTest(TestCase):
     def test_subscription_backed_org_uses_blended_sample_rate(self) -> None:
         org = self.create_organization()
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ) as get_blended_sample_rate:
+        with patch(GET_BLENDED_SAMPLE_RATE, return_value=0.5) as get_blended_sample_rate:
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.is_enabled
-        assert configuration.measure == SamplingMeasure.SEGMENTS
-        assert configuration.is_segment_based
-        assert not configuration.is_span_based
         assert configuration.sample_rate == 0.5
         assert configuration.project_sample_rates == {}
         get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
@@ -76,10 +103,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=0.5,
-            ),
+            patch(GET_BLENDED_SAMPLE_RATE, return_value=0.5),
             patch(
                 "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
                 return_value=sliding_window_volume,
@@ -112,10 +136,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         sliding_window_volume = OrganizationDataVolume(org_id=org.id, total=1000, indexed=250)
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ),
+            patch(GET_BLENDED_SAMPLE_RATE, return_value=1.0),
             patch(
                 "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
                 return_value=sliding_window_volume,
@@ -141,10 +162,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=0.5,
-            ),
+            patch(GET_BLENDED_SAMPLE_RATE, return_value=0.5),
             patch(
                 "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
                 return_value=None,
@@ -164,10 +182,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         self.create_project(organization=org)
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=None,
-            ),
+            patch(GET_BLENDED_SAMPLE_RATE, return_value=None),
             patch(
                 "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
             ) as get_volume,
@@ -176,20 +191,14 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
 
         assert isinstance(configuration, NoDynamicSamplingConfiguration)
         assert not configuration.is_enabled
+        assert configuration.get_sample_rate() is None
         get_volume.assert_not_called()
-        with pytest.raises(AttributeError):
-            getattr(configuration, "measure")
-        with pytest.raises(AttributeError):
-            getattr(configuration, "sample_rate")
 
     def test_subscription_backed_org_without_subscription_bubbles_terminal_status(self) -> None:
         org = self.create_organization()
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                side_effect=ObjectDoesNotExist,
-            ),
+            patch(GET_BLENDED_SAMPLE_RATE, side_effect=ObjectDoesNotExist),
             pytest.raises(DynamicSamplingException) as exc_info,
         ):
             get_configuration(org.id)
@@ -200,10 +209,7 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         org = self.create_organization()
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ):
+        with patch(GET_BLENDED_SAMPLE_RATE, return_value=0.5):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
@@ -211,160 +217,68 @@ class DynamicSamplingOrgConfigurationTest(TestCase):
         assert configuration.project_sample_rates == {}
 
     def test_org_mode_custom_dynamic_sampling_uses_org_target_sample_rate(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
-                org = self.create_organization()
-                org.update_option("sentry:target_sample_rate", 0.3)
+        org = self.create_organization()
+        org.update_option("sentry:target_sample_rate", 0.3)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                    patch(
-                        "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-                    ) as get_blended_sample_rate,
-                ):
-                    configuration = get_configuration(org.id)
+        with (
+            self.feature("organizations:dynamic-sampling-custom"),
+            patch(GET_BLENDED_SAMPLE_RATE) as get_blended_sample_rate,
+        ):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
-                assert configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.is_span_based == (
-                    measure_case.expected_measure == SamplingMeasure.SPANS
-                )
-                assert configuration.is_segment_based == (
-                    measure_case.expected_measure == SamplingMeasure.SEGMENTS
-                )
-                assert configuration.sample_rate == 0.3
-                assert configuration.get_sample_rate() == 0.3
-                assert configuration.project_sample_rates == {}
-                get_blended_sample_rate.assert_not_called()
+        assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
+        assert configuration.is_enabled
+        assert configuration.sample_rate == 0.3
+        assert configuration.get_sample_rate() == 0.3
+        assert configuration.get_project_sample_rates() == {}
+        get_blended_sample_rate.assert_not_called()
 
     def test_project_mode_custom_dynamic_sampling_stores_project_sample_rates(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
-                org = self.create_organization()
-                project = self.create_project(organization=org)
-                project_without_rate = self.create_project(organization=org)
-                org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-                project.update_option("sentry:target_sample_rate", 0.2)
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        project_without_rate = self.create_project(organization=org)
+        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        project.update_option("sentry:target_sample_rate", 0.2)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                    patch(
-                        "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-                    ) as get_blended_sample_rate,
-                ):
-                    configuration = get_configuration(org.id)
+        with (
+            self.feature("organizations:dynamic-sampling-custom"),
+            patch(GET_BLENDED_SAMPLE_RATE) as get_blended_sample_rate,
+        ):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-                assert configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.is_span_based == (
-                    measure_case.expected_measure == SamplingMeasure.SPANS
-                )
-                assert configuration.is_segment_based == (
-                    measure_case.expected_measure == SamplingMeasure.SEGMENTS
-                )
-                assert configuration.project_sample_rates == {
-                    project.id: 0.2,
-                    project_without_rate.id: None,
-                }
-                assert configuration.get_sample_rate() is None
-                with pytest.raises(AttributeError):
-                    getattr(configuration, "sample_rate")
-                get_blended_sample_rate.assert_not_called()
+        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
+        assert configuration.is_enabled
+        assert configuration.get_project_sample_rates() == {
+            project.id: 0.2,
+            project_without_rate.id: None,
+        }
+        assert configuration.get_sample_rate() is None
+        get_blended_sample_rate.assert_not_called()
 
     def test_project_mode_custom_dynamic_sampling_without_project_rates_is_disabled(
         self,
     ) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
-                org = self.create_organization()
-                project = self.create_project(organization=org)
-                org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                ):
-                    configuration = get_configuration(org.id)
+        with self.feature("organizations:dynamic-sampling-custom"):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-                assert not configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.project_sample_rates == {project.id: None}
-                with pytest.raises(AttributeError):
-                    getattr(configuration, "sample_rate")
+        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
+        assert not configuration.is_enabled
+        assert configuration.get_project_sample_rates() == {project.id: None}
 
     def test_project_mode_custom_dynamic_sampling_without_projects_is_disabled(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
-                org = self.create_organization()
-                org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
+        org = self.create_organization()
+        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
-                with (
-                    self.feature("organizations:dynamic-sampling-custom"),
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                ):
-                    configuration = get_configuration(org.id)
+        with self.feature("organizations:dynamic-sampling-custom"):
+            configuration = get_configuration(org.id)
 
-                assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-                assert not configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.project_sample_rates == {}
-                with pytest.raises(AttributeError):
-                    getattr(configuration, "sample_rate")
-
-    def test_subscription_backed_org_uses_measure_options(self) -> None:
-        for measure_case in MEASURE_OPTION_CASES:
-            with self.subTest(measure_case=measure_case.name):
-                org = self.create_organization()
-
-                with (
-                    self.options(
-                        {
-                            "dynamic-sampling.check_span_feature_flag": measure_case.check_span_feature_flag,
-                            "dynamic-sampling.measure.spans": measure_case.span_org_ids(org),
-                        }
-                    ),
-                    patch(
-                        "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                        return_value=1.0,
-                    ),
-                ):
-                    configuration = get_configuration(org.id)
-
-                assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
-                assert configuration.is_enabled
-                assert configuration.measure == measure_case.expected_measure
-                assert configuration.is_span_based == (
-                    measure_case.expected_measure == SamplingMeasure.SPANS
-                )
-                assert configuration.is_segment_based == (
-                    measure_case.expected_measure == SamplingMeasure.SEGMENTS
-                )
-                assert configuration.sample_rate == 1.0
+        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
+        assert not configuration.is_enabled
+        assert configuration.get_project_sample_rates() == {}
 
 
 class GetProjectSampleRatesTest(TestCase):
@@ -373,25 +287,7 @@ class GetProjectSampleRatesTest(TestCase):
 
         assert configuration.get_project_sample_rates() == {}
 
-    def test_project_mode_returns_target_sample_rates(self) -> None:
-        org = self.create_organization()
-        project_a = self.create_project(organization=org)
-        project_b = self.create_project(organization=org)
-        org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
-        project_a.update_option("sentry:target_sample_rate", 0.2)
-
-        with self.feature("organizations:dynamic-sampling-custom"):
-            configuration = get_configuration(org.id)
-
-        assert isinstance(configuration, CustomDynamicSamplingProjectConfiguration)
-        assert configuration.get_project_sample_rates() == {
-            project_a.id: 0.2,
-            project_b.id: None,
-        }
-
-    def test_org_mode_uses_rebalanced_project_rates(self) -> None:
-        from sentry.dynamic_sampling.models.common import RebalancedItem
-
+    def test_rebalanced_project_rates_round_trip(self) -> None:
         org = self.create_organization()
         project_a = self.create_project(organization=org)
         project_b = self.create_project(organization=org)
@@ -413,7 +309,7 @@ class GetProjectSampleRatesTest(TestCase):
             project_b.id: 0.9,
         }
 
-    def test_org_mode_does_not_fall_back_to_org_sample_rate(self) -> None:
+    def test_does_not_fall_back_to_org_sample_rate_without_rebalancing(self) -> None:
         org = self.create_organization()
         self.create_project(organization=org)
         self.create_project(organization=org)
@@ -424,41 +320,6 @@ class GetProjectSampleRatesTest(TestCase):
             configuration = get_configuration(org.id)
 
         assert isinstance(configuration, CustomDynamicSamplingOrganizationConfiguration)
-        assert configuration.get_sample_rate() == 0.5
-        # Without rebalancing, project sample rates must stay empty rather than
-        # falling back to the org-wide sample rate.
-        assert configuration.get_project_sample_rates() == {}
-
-    def test_automatic_mode_uses_rebalanced_project_rates(self) -> None:
-        from sentry.dynamic_sampling.models.common import RebalancedItem
-
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ):
-            configuration = get_configuration(org.id)
-
-        assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
-        configuration.set_rebalanced_project_sample_rates(
-            [RebalancedItem(id=project.id, count=100, new_sample_rate=0.4)]
-        )
-        assert configuration.get_project_sample_rates() == {project.id: 0.4}
-
-    def test_automatic_mode_does_not_fall_back_to_org_sample_rate(self) -> None:
-        org = self.create_organization()
-        self.create_project(organization=org)
-        self.create_project(organization=org)
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=0.5,
-        ):
-            configuration = get_configuration(org.id)
-
-        assert isinstance(configuration, AutomaticDynamicSamplingConfiguration)
         assert configuration.get_sample_rate() == 0.5
         # Without rebalancing, project sample rates must stay empty rather than
         # falling back to the org-wide sample rate.

--- a/tests/sentry/dynamic_sampling/per_org/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_queries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -12,7 +12,6 @@ from sentry.dynamic_sampling.per_org.configuration import (
     get_configuration,
 )
 from sentry.dynamic_sampling.per_org.queries import (
-    DynamicSamplingQueryFields,
     DynamicSamplingQueryFilters,
     ProjectTransactionCounts,
     ProjectVolume,
@@ -30,6 +29,10 @@ from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
+
+GET_BLENDED_SAMPLE_RATE = (
+    "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
+)
 
 
 class EAPSpansTableQueryChunkingTest(TestCase, SnubaTestCase, SpanTestCase):
@@ -89,10 +92,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         organization: Organization,
     ) -> BaseDynamicSamplingConfiguration:
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ),
+            patch(GET_BLENDED_SAMPLE_RATE, return_value=1.0),
             patch(
                 "sentry.dynamic_sampling.per_org.configuration.get_outcomes_organization_volume",
                 return_value=None,
@@ -100,47 +100,44 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
         ):
             return get_configuration(organization.id)
 
-    def test_get_eap_organization_volume_existing_org(self) -> None:
+    def test_get_eap_organization_volume_counts_extrapolated_and_raw(self) -> None:
         organization = self.create_organization()
         project = self.create_project(organization=organization)
+        timestamp = before_now(minutes=15)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.Spans.run_table_query",
-            return_value={"data": [{DynamicSamplingQueryFields.COUNT: 2, "count_sample()": 2}]},
-        ) as run_table_query:
-            org_volume = get_eap_organization_volume(
-                self.get_config(organization), time_interval=timedelta(hours=1)
-            )
-
-        assert org_volume == OrganizationDataVolume(org_id=organization.id, total=2, indexed=2)
-        run_table_query.assert_called_once()
-        assert run_table_query.call_args.kwargs["params"].projects == [project]
-        assert (
-            run_table_query.call_args.kwargs["query_string"]
-            == DynamicSamplingQueryFilters.IS_SEGMENT
+        self.store_spans(
+            [
+                self.create_span(
+                    {"is_segment": True},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+                # sampled at 50% → extrapolates to 2 in count(), stays 1 in count_sample()
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "measurements": {"server_sample_rate": {"value": 0.5}},
+                    },
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp + timedelta(seconds=1),
+                ),
+                # non-segment spans are excluded
+                self.create_span(
+                    {"is_segment": False},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp + timedelta(seconds=2),
+                ),
+            ]
         )
-        assert run_table_query.call_args.kwargs["selected_columns"] == [
-            DynamicSamplingQueryFields.COUNT,
-            DynamicSamplingQueryFields.COUNT_SAMPLE,
-        ]
-        assert (
-            run_table_query.call_args.kwargs["referrer"]
-            == Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_ORG_VOLUME.value
+
+        org_volume = get_eap_organization_volume(
+            self.get_config(organization), time_interval=timedelta(hours=1)
         )
 
-    def test_get_eap_organization_volume_returns_raw_and_extrapolated_counts(self) -> None:
-        organization = self.create_organization()
-        self.create_project(organization=organization)
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.Spans.run_table_query",
-            return_value={"data": [{"count()": 10, DynamicSamplingQueryFields.COUNT_SAMPLE: 1}]},
-        ):
-            org_volume = get_eap_organization_volume(
-                self.get_config(organization), time_interval=timedelta(hours=1)
-            )
-
-        assert org_volume == OrganizationDataVolume(org_id=organization.id, total=10, indexed=1)
+        assert org_volume == OrganizationDataVolume(org_id=organization.id, total=3, indexed=2)
 
     def test_get_eap_organization_volume_without_traffic(self) -> None:
         organization = self.create_organization()
@@ -152,150 +149,89 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
         assert org_volume is None
 
-    def test_get_eap_organization_volume_without_projects(self) -> None:
-        organization = self.create_organization()
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.Spans.run_table_query",
-            return_value={"data": []},
-        ) as run_table_query:
-            org_volume = get_eap_organization_volume(
-                self.get_config(organization), time_interval=timedelta(hours=1)
-            )
-
-        assert org_volume is None
-        run_table_query.assert_called_once()
-        assert run_table_query.call_args.kwargs["params"].projects == []
-
-    def test_get_eap_project_volumes_existing_org(self) -> None:
+    def test_get_eap_project_volumes_counts_by_root_project(self) -> None:
         organization = self.create_organization()
         project = self.create_project(organization=organization)
         other_project = self.create_project(organization=organization)
-        other_organization = self.create_organization()
-        self.create_project(organization=other_organization)
+        timestamp = before_now(minutes=15)
 
-        received = (datetime.now(UTC) - timedelta(seconds=120)).timestamp()
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
-            return_value=[
-                {
-                    "sentry.dsc.project_id": project.id,
-                    "count()": 2,
-                    "count_sample()": 2,
-                    "count_unique(sentry.dsc.transaction)": 7,
-                    "max(received)": received,
-                },
-                {
-                    "sentry.dsc.project_id": other_project.id,
-                    "count()": 1,
-                    "count_sample()": 1,
-                    "count_unique(sentry.dsc.transaction)": 1,
-                },
-            ],
-        ) as run_table_query:
-            project_volumes = get_eap_project_volumes(
-                self.get_config(organization), time_interval=timedelta(hours=1)
-            )
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "sentry_tags": {
+                            "dsc.transaction": "checkout",
+                            "dsc.project_id": str(project.id),
+                        },
+                    },
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+                # sampled at 50% → extrapolates to 2 in count(), stays 1 in count_sample()
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "sentry_tags": {
+                            "dsc.transaction": "cart",
+                            "dsc.project_id": str(project.id),
+                        },
+                        "measurements": {"server_sample_rate": {"value": 0.5}},
+                    },
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp + timedelta(seconds=1),
+                ),
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "sentry_tags": {
+                            "dsc.transaction": "checkout",
+                            "dsc.project_id": str(other_project.id),
+                        },
+                    },
+                    organization=organization,
+                    project=other_project,
+                    start_ts=timestamp + timedelta(seconds=2),
+                ),
+                # missing dsc.project_id — grouped under a null root project and skipped
+                self.create_span(
+                    {"is_segment": True},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp + timedelta(seconds=3),
+                ),
+            ]
+        )
 
-        volumes_by_id = {volume.project_id: volume for volume in project_volumes}
+        project_volumes = get_eap_project_volumes(
+            self.get_config(organization), time_interval=timedelta(hours=1)
+        )
+
         assert [
             replace(volume, seconds_since_last_item=None) for volume in sorted(project_volumes)
         ] == [
             ProjectVolume(
-                project_id=project.id, total=2, keep=2, drop=0, num_distinct_transactions=7
+                project_id=project.id, total=3, keep=2, drop=1, num_distinct_transactions=2
             ),
             ProjectVolume(
                 project_id=other_project.id, total=1, keep=1, drop=0, num_distinct_transactions=1
             ),
         ]
-        project_seconds = volumes_by_id[project.id].seconds_since_last_item
-        assert project_seconds is not None and project_seconds > 100
-        assert volumes_by_id[other_project.id].seconds_since_last_item is None
-        run_table_query.assert_called_once()
-        query = run_table_query.call_args.args[0]
-        assert sorted(query["params"].projects, key=lambda p: p.id) == [
-            project,
-            other_project,
-        ]
-        assert query["query_string"] == DynamicSamplingQueryFilters.IS_SEGMENT
-        assert query["selected_columns"] == [
-            DynamicSamplingQueryFields.DSC_PROJECT_ID,
-            DynamicSamplingQueryFields.COUNT,
-            DynamicSamplingQueryFields.COUNT_SAMPLE,
-            DynamicSamplingQueryFields.COUNT_UNIQUE_TRANSACTIONS,
-            DynamicSamplingQueryFields.MAX_RECEIVED,
-        ]
-        assert query["orderby"] == [DynamicSamplingQueryFields.DSC_PROJECT_ID]
-        assert query["referrer"] == Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_PROJECT_VOLUMES.value
+        for volume in project_volumes:
+            assert volume.seconds_since_last_item is not None
+            assert volume.seconds_since_last_item > 0
 
     def test_get_eap_project_volumes_without_traffic(self) -> None:
         organization = self.create_organization()
         self.create_project(organization=organization)
 
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
-            return_value=[],
-        ):
-            project_volumes = get_eap_project_volumes(
-                self.get_config(organization), time_interval=timedelta(hours=1)
-            )
+        project_volumes = get_eap_project_volumes(
+            self.get_config(organization), time_interval=timedelta(hours=1)
+        )
 
         assert project_volumes == []
-
-    def test_get_eap_project_volumes_handles_missing_aggregate_values(self) -> None:
-        organization = self.create_organization()
-        project = self.create_project(organization=organization)
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
-            return_value=[
-                {
-                    "sentry.dsc.project_id": project.id,
-                }
-            ],
-        ):
-            project_volumes = get_eap_project_volumes(self.get_config(organization))
-
-        assert project_volumes == [ProjectVolume(project_id=project.id, total=0, keep=0, drop=0)]
-
-    def test_get_eap_project_volumes_skips_rows_without_dsc_project_id(self) -> None:
-        organization = self.create_organization()
-        project = self.create_project(organization=organization)
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
-            return_value=[
-                {
-                    "sentry.dsc.project_id": None,
-                    "count()": 3,
-                    "count_sample()": 1,
-                },
-                {
-                    "sentry.dsc.project_id": project.id,
-                    "count()": 2,
-                    "count_sample()": 1,
-                },
-            ],
-        ):
-            project_volumes = get_eap_project_volumes(self.get_config(organization))
-
-        assert project_volumes == [ProjectVolume(project_id=project.id, total=2, keep=1, drop=1)]
-
-    def test_get_eap_project_volumes_without_projects(self) -> None:
-        organization = self.create_organization()
-
-        with patch(
-            "sentry.dynamic_sampling.per_org.queries.run_eap_spans_table_query_in_chunks",
-            return_value=[],
-        ) as run_table_query:
-            project_volumes = get_eap_project_volumes(
-                self.get_config(organization), time_interval=timedelta(hours=1)
-            )
-
-        assert project_volumes == []
-        run_table_query.assert_called_once()
-        query = run_table_query.call_args.args[0]
-        assert query["params"].projects == []
 
     def test_get_outcomes_organization_volume_existing_org(self) -> None:
         organization = self.create_organization()
@@ -330,10 +266,7 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
 class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
     def get_config(self, organization: Organization) -> BaseDynamicSamplingConfiguration:
-        with patch(
-            "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-            return_value=1.0,
-        ):
+        with patch(GET_BLENDED_SAMPLE_RATE, return_value=1.0):
             return get_configuration(organization.id)
 
     def test_get_eap_transaction_volumes(self) -> None:
@@ -537,41 +470,6 @@ class EAPTransactionVolumesTest(TestCase, SnubaTestCase, SpanTestCase):
         volumes = get_eap_transaction_volumes(self.get_config(organization))
 
         assert volumes == []
-
-    def test_get_eap_transaction_volumes_attributes_to_originating_project(self) -> None:
-        organization = self.create_organization()
-        originating_project = self.create_project(organization=organization)
-        downstream_project = self.create_project(organization=organization)
-        timestamp = before_now(minutes=15)
-
-        self.store_spans(
-            [
-                # Owned by `downstream_project` but originated in `originating_project`.
-                self.create_span(
-                    {
-                        "is_segment": True,
-                        "sentry_tags": {
-                            "transaction": "checkout",
-                            "dsc.transaction": "checkout",
-                            "dsc.project_id": str(originating_project.id),
-                        },
-                    },
-                    organization=organization,
-                    project=downstream_project,
-                    start_ts=timestamp,
-                ),
-            ]
-        )
-
-        volumes = get_eap_transaction_volumes(self.get_config(organization))
-
-        assert volumes == [
-            ProjectTransactionCounts(
-                org_id=organization.id,
-                project_id=originating_project.id,
-                transaction_counts=[("checkout", 1)],
-            )
-        ]
 
     def test_get_eap_transaction_volumes_with_max_transactions_caps_total_rows(self) -> None:
         organization = self.create_organization()

--- a/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_scheduler.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -7,7 +10,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from sentry.constants import ObjectStatus
 from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org.configuration import BaseDynamicSamplingConfiguration
-from sentry.dynamic_sampling.per_org.gate import is_org_in_rollout
 from sentry.dynamic_sampling.per_org.queries import ProjectTransactionCounts, ProjectVolume
 from sentry.dynamic_sampling.per_org.scheduler import (
     run_calculations_per_org_task,
@@ -16,8 +18,14 @@ from sentry.dynamic_sampling.per_org.scheduler import (
 from sentry.dynamic_sampling.per_org.telemetry import DynamicSamplingStatus
 from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+
+SCHEDULER = "sentry.dynamic_sampling.per_org.scheduler"
+GET_BLENDED_SAMPLE_RATE = (
+    "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
+)
 
 
 def _assert_called_once_with_config(
@@ -35,6 +43,44 @@ def _project_volume(project_id: int, total: int = 100, keep: int = 25) -> Projec
     return ProjectVolume(project_id=project_id, total=total, keep=keep, drop=max(total - keep, 0))
 
 
+@contextmanager
+def _mock_pipeline(
+    blended_sample_rate: float | None = None,
+    org_volume: OrganizationDataVolume | None = None,
+    project_volumes: list[ProjectVolume] | None = None,
+    rebalanced_projects: list[RebalancedItem] | None = None,
+    transaction_volumes: list[ProjectTransactionCounts] | None = None,
+) -> Iterator[SimpleNamespace]:
+    with (
+        patch(GET_BLENDED_SAMPLE_RATE, return_value=blended_sample_rate) as get_blended_sample_rate,
+        patch(f"{SCHEDULER}.get_eap_organization_volume", return_value=org_volume) as get_volume,
+        patch(
+            f"{SCHEDULER}.get_eap_project_volumes", return_value=project_volumes or []
+        ) as get_project_volumes,
+        patch(
+            f"{SCHEDULER}.run_project_balancing", return_value=rebalanced_projects or []
+        ) as project_balancing,
+        patch(
+            f"{SCHEDULER}.get_cached_rebalanced_project_sample_rates", return_value={}
+        ) as get_cached_sample_rates,
+        patch(f"{SCHEDULER}.compare_rebalanced_projects_with_cache") as compare_rebalanced_projects,
+        patch(
+            f"{SCHEDULER}.get_eap_transaction_volumes", return_value=transaction_volumes or []
+        ) as get_transaction_volumes,
+        patch(f"{SCHEDULER}.run_transaction_balancing", return_value={}) as transaction_balancing,
+    ):
+        yield SimpleNamespace(
+            get_blended_sample_rate=get_blended_sample_rate,
+            get_volume=get_volume,
+            get_project_volumes=get_project_volumes,
+            project_balancing=project_balancing,
+            get_cached_sample_rates=get_cached_sample_rates,
+            compare_rebalanced_projects=compare_rebalanced_projects,
+            get_transaction_volumes=get_transaction_volumes,
+            transaction_balancing=transaction_balancing,
+        )
+
+
 class SchedulePerOrgCalculationsTest(TestCase):
     """Tests for the scheduling wrapper: rollout gating and active-org filtering."""
 
@@ -44,10 +90,10 @@ class SchedulePerOrgCalculationsTest(TestCase):
         self.create_project(organization=active)
         pending_deletion = self.create_organization()
         self.create_project(organization=pending_deletion)
-        pending_deletion.status = 1  # PENDING_DELETION
+        pending_deletion.status = OrganizationStatus.PENDING_DELETION
         pending_deletion.save()
 
-        with patch("sentry.dynamic_sampling.per_org.scheduler.CursoredScheduler") as MockScheduler:
+        with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:
             mock_instance = MockScheduler.return_value
             mock_instance.tick.return_value = False
             schedule_per_org_calculations()
@@ -68,7 +114,7 @@ class SchedulePerOrgCalculationsTest(TestCase):
         inactive_project.status = ObjectStatus.PENDING_DELETION
         inactive_project.save()
 
-        with patch("sentry.dynamic_sampling.per_org.scheduler.CursoredScheduler") as MockScheduler:
+        with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:
             mock_instance = MockScheduler.return_value
             mock_instance.tick.return_value = False
             schedule_per_org_calculations()
@@ -81,441 +127,245 @@ class SchedulePerOrgCalculationsTest(TestCase):
         assert org_with_inactive_project.id not in org_ids
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_org_in_rollout_is_dispatched(self) -> None:
+    def test_rollout_gate_filters_orgs(self) -> None:
         org = self.create_organization()
-        assert is_org_in_rollout(org.id) is True
+        self.create_project(organization=org)
 
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 0.0})
-    def test_org_not_in_rollout_is_skipped(self) -> None:
-        org = self.create_organization()
-        assert is_org_in_rollout(org.id) is False
+        with patch(f"{SCHEDULER}.CursoredScheduler") as MockScheduler:
+            MockScheduler.return_value.tick.return_value = False
+            schedule_per_org_calculations()
+            validate_item = MockScheduler.call_args.kwargs["validate_item"]
+
+        assert validate_item(org.id) is True
+        with override_options({"dynamic-sampling.per_org.rollout-rate": 0.0}):
+            assert validate_item(org.id) is False
 
 
 class RunCalculationsPerOrgTest(TestCase):
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_returns_no_volume_without_traffic(self) -> None:
-        org = self.create_organization()
-        self.create_project(organization=org)
-
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=None,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
-            ) as get_project_volumes,
-        ):
-            result = run_calculations_per_org_task(org.id)
-
-        assert result == DynamicSamplingStatus.NO_ORG_VOLUME
-        _assert_called_once_with_config(get_volume, org.id)
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        get_project_volumes.assert_not_called()
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_transaction_volumes_at_full_sample_rate(self) -> None:
+    def test_am2_happy_path_runs_full_pipeline(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)]
-        cached_sample_rates: dict[int, float | None] = {}
+        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
+        transaction_volumes = [
+            ProjectTransactionCounts(
+                org_id=org.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 1.0)],
+            )
+        ]
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes"
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing"
-            ) as transaction_balancing,
-        ):
+        with _mock_pipeline(
+            blended_sample_rate=1.0,
+            org_volume=OrganizationDataVolume(org_id=org.id, total=100, indexed=25),
+            project_volumes=project_volumes,
+            rebalanced_projects=rebalanced_projects,
+            transaction_volumes=transaction_volumes,
+        ) as pipeline:
+            result = run_calculations_per_org_task(org.id)
+
+        assert result is None
+        pipeline.get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
+        _assert_called_once_with_config(pipeline.get_volume, org.id)
+        project_config = _assert_called_once_with_config(pipeline.get_project_volumes, org.id)
+        pipeline.project_balancing.assert_called_once_with(project_config, project_volumes)
+        pipeline.get_cached_sample_rates.assert_called_once_with(org.id)
+        pipeline.compare_rebalanced_projects.assert_called_once_with(
+            project_config, rebalanced_projects, {}, project_volumes
+        )
+        transaction_config = _assert_called_once_with_config(
+            pipeline.get_transaction_volumes, org.id
+        )
+        assert [
+            p.id for p in pipeline.get_transaction_volumes.call_args.kwargs["root_projects"]
+        ] == [project.id]
+        pipeline.transaction_balancing.assert_called_once_with(
+            transaction_config, project_volumes, transaction_volumes
+        )
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_all_projects_at_full_sample_rate_skips_transaction_step(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        with _mock_pipeline(
+            blended_sample_rate=1.0,
+            org_volume=OrganizationDataVolume(org_id=org.id, total=100, indexed=25),
+            project_volumes=[_project_volume(project.id)],
+            rebalanced_projects=[RebalancedItem(id=project.id, count=100, new_sample_rate=1.0)],
+        ) as pipeline:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ALL_PROJECTS_AT_FULL_SAMPLE_RATE
-        _assert_called_once_with_config(get_volume, org.id)
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
-        )
-        get_transaction_volumes.assert_not_called()
-        transaction_balancing.assert_not_called()
+        pipeline.project_balancing.assert_called_once()
+        pipeline.get_transaction_volumes.assert_not_called()
+        pipeline.transaction_balancing.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_returns_no_volume_without_project_volumes(self) -> None:
+    def test_no_org_volume_short_circuits(self) -> None:
         org = self.create_organization()
         self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=[],
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes"
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=None,
-            ) as project_balancing,
-        ):
+        with _mock_pipeline(blended_sample_rate=1.0, org_volume=None) as pipeline:
+            result = run_calculations_per_org_task(org.id)
+
+        assert result == DynamicSamplingStatus.NO_ORG_VOLUME
+        _assert_called_once_with_config(pipeline.get_volume, org.id)
+        pipeline.get_project_volumes.assert_not_called()
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_no_project_volumes_short_circuits(self) -> None:
+        org = self.create_organization()
+        self.create_project(organization=org)
+
+        with _mock_pipeline(
+            blended_sample_rate=1.0,
+            org_volume=OrganizationDataVolume(org_id=org.id, total=100, indexed=25),
+            project_volumes=[],
+        ) as pipeline:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_PROJECT_VOLUMES
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(get_volume, org.id)
-        _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_not_called()
-        get_transaction_volumes.assert_not_called()
+        _assert_called_once_with_config(pipeline.get_project_volumes, org.id)
+        pipeline.project_balancing.assert_not_called()
+        pipeline.get_transaction_volumes.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_returns_no_volume_without_transaction_volumes(self) -> None:
+    def test_no_transaction_volumes_short_circuits(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
         rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
-        cached_sample_rates: dict[int, float | None] = {}
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[],
-            ) as get_transaction_volumes,
-        ):
+        with _mock_pipeline(
+            blended_sample_rate=1.0,
+            org_volume=OrganizationDataVolume(org_id=org.id, total=100, indexed=25),
+            project_volumes=project_volumes,
+            rebalanced_projects=rebalanced_projects,
+            transaction_volumes=[],
+        ) as pipeline:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.NO_TRANSACTION_VOLUMES
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(get_volume, org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
+        project_config = _assert_called_once_with_config(pipeline.get_project_volumes, org.id)
+        pipeline.project_balancing.assert_called_once_with(project_config, project_volumes)
+        pipeline.compare_rebalanced_projects.assert_called_once_with(
+            project_config, rebalanced_projects, {}, project_volumes
         )
-        _assert_called_once_with_config(get_transaction_volumes, org.id)
+        _assert_called_once_with_config(pipeline.get_transaction_volumes, org.id)
+        pipeline.transaction_balancing.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_project_balancing_for_project_mode(self) -> None:
+    def test_project_mode_skips_project_balancing(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
         project.update_option("sentry:target_sample_rate", 0.2)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
+        transaction_volumes = [
+            ProjectTransactionCounts(
+                org_id=org.id,
+                project_id=project.id,
+                transaction_counts=[("checkout", 1.0)],
+            )
+        ]
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
-                    ProjectTransactionCounts(
-                        org_id=org.id,
-                        project_id=project.id,
-                        transaction_counts=[("checkout", 1.0)],
-                    )
-                ],
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
-            ) as transaction_balancing,
+            _mock_pipeline(
+                org_volume=OrganizationDataVolume(org_id=org.id, total=100, indexed=25),
+                project_volumes=project_volumes,
+                transaction_volumes=transaction_volumes,
+            ) as pipeline,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result is None
-        get_blended_sample_rate.assert_not_called()
-        _assert_called_once_with_config(get_volume, org.id)
-        _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_not_called()
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
+        pipeline.get_blended_sample_rate.assert_not_called()
+        pipeline.project_balancing.assert_not_called()
+        pipeline.compare_rebalanced_projects.assert_not_called()
+        transaction_config = _assert_called_once_with_config(
+            pipeline.get_transaction_volumes, org.id
+        )
+        pipeline.transaction_balancing.assert_called_once_with(
+            transaction_config, project_volumes, transaction_volumes
         )
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_queries_projects_for_am3_org_mode(self) -> None:
+    def test_am3_org_mode_balances_projects(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.ORGANIZATION)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
         project_volumes = [_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
-        cached_sample_rates: dict[int, float | None] = {}
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
+            _mock_pipeline(
+                org_volume=OrganizationDataVolume(org_id=org.id, total=100, indexed=25),
+                project_volumes=project_volumes,
+                rebalanced_projects=[RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)],
+                transaction_volumes=[
                     ProjectTransactionCounts(
                         org_id=org.id,
                         project_id=project.id,
                         transaction_counts=[("checkout", 1.0)],
                     )
                 ],
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
-            ) as transaction_balancing,
+            ) as pipeline,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result is None
-        get_blended_sample_rate.assert_not_called()
-        _assert_called_once_with_config(get_volume, org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
-        )
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
-        )
+        pipeline.get_blended_sample_rate.assert_not_called()
+        project_config = _assert_called_once_with_config(pipeline.get_project_volumes, org.id)
+        pipeline.project_balancing.assert_called_once_with(project_config, project_volumes)
+        pipeline.transaction_balancing.assert_called_once()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_project_mode_without_project_rates(self) -> None:
+    def test_project_mode_without_project_rates_is_skipped(self) -> None:
         org = self.create_organization()
         self.create_project(organization=org)
         org.update_option("sentry:sampling_mode", DynamicSamplingMode.PROJECT)
 
         with (
             self.feature("organizations:dynamic-sampling-custom"),
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate"
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes"
-            ) as get_project_volumes,
+            _mock_pipeline() as pipeline,
         ):
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        get_blended_sample_rate.assert_not_called()
-        get_volume.assert_not_called()
-        get_project_volumes.assert_not_called()
+        pipeline.get_blended_sample_rate.assert_not_called()
+        pipeline.get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_queries_projects_for_am2(self) -> None:
-        org = self.create_organization()
-        project = self.create_project(organization=org)
-        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
-        project_volumes = [_project_volume(project.id)]
-        rebalanced_projects = [RebalancedItem(id=project.id, count=100, new_sample_rate=0.5)]
-        cached_sample_rates: dict[int, float | None] = {}
-
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume",
-                return_value=org_volume,
-            ) as get_volume,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_project_volumes",
-                return_value=project_volumes,
-            ) as get_project_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_project_balancing",
-                return_value=rebalanced_projects,
-            ) as project_balancing,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_cached_rebalanced_project_sample_rates",
-                return_value=cached_sample_rates,
-            ) as get_cached_sample_rates,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.compare_rebalanced_projects_with_cache"
-            ) as compare_rebalanced_projects,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_transaction_volumes",
-                return_value=[
-                    ProjectTransactionCounts(
-                        org_id=org.id,
-                        project_id=project.id,
-                        transaction_counts=[("checkout", 1.0)],
-                    )
-                ],
-            ) as get_transaction_volumes,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.run_transaction_balancing",
-                return_value={},
-            ) as transaction_balancing,
-        ):
-            result = run_calculations_per_org_task(org.id)
-
-        assert result is None
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        _assert_called_once_with_config(get_volume, org.id)
-        project_config = _assert_called_once_with_config(get_project_volumes, org.id)
-        project_balancing.assert_called_once_with(project_config, project_volumes)
-        get_cached_sample_rates.assert_called_once_with(org.id)
-        compare_rebalanced_projects.assert_called_once_with(
-            project_config, rebalanced_projects, cached_sample_rates, project_volumes
-        )
-        transaction_config = _assert_called_once_with_config(get_transaction_volumes, org.id)
-        assert [p.id for p in get_transaction_volumes.call_args.kwargs["root_projects"]] == [
-            project.id
-        ]
-        transaction_balancing.assert_called_once_with(
-            transaction_config, project_volumes, get_transaction_volumes.return_value
-        )
-
-    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_org_without_transaction_sample_rate(self) -> None:
+    def test_org_without_sample_rate_is_skipped(self) -> None:
         org = self.create_organization()
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=None,
-            ) as get_blended_sample_rate,
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
-        ):
+        with _mock_pipeline(blended_sample_rate=None) as pipeline:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
-        get_volume.assert_not_called()
+        pipeline.get_blended_sample_rate.assert_called_once_with(organization_id=org.id)
+        pipeline.get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_org_without_projects(self) -> None:
+    def test_org_without_projects_is_skipped(self) -> None:
         org = self.create_organization()
 
-        with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                return_value=1.0,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
-        ):
+        with _mock_pipeline(blended_sample_rate=1.0) as pipeline:
             result = run_calculations_per_org_task(org.id)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_PROJECTS
-        get_volume.assert_not_called()
+        pipeline.get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_org_without_subscription(self) -> None:
+    def test_org_without_subscription_is_skipped(self) -> None:
         org = self.create_organization()
 
         with (
-            patch(
-                "sentry.dynamic_sampling.per_org.configuration.quotas.backend.get_blended_sample_rate",
-                side_effect=ObjectDoesNotExist,
-            ),
-            patch(
-                "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-            ) as get_volume,
+            patch(GET_BLENDED_SAMPLE_RATE, side_effect=ObjectDoesNotExist),
+            patch(f"{SCHEDULER}.get_eap_organization_volume") as get_volume,
         ):
             result = run_calculations_per_org_task(org.id)
 
@@ -523,11 +373,9 @@ class RunCalculationsPerOrgTest(TestCase):
         get_volume.assert_not_called()
 
     @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
-    def test_run_calculations_per_org_skips_missing_org(self) -> None:
-        with patch(
-            "sentry.dynamic_sampling.per_org.scheduler.get_eap_organization_volume"
-        ) as get_volume:
+    def test_missing_org_is_skipped(self) -> None:
+        with _mock_pipeline() as pipeline:
             result = run_calculations_per_org_task(99999999)
 
         assert result == DynamicSamplingStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
-        get_volume.assert_not_called()
+        pipeline.get_volume.assert_not_called()

--- a/tests/sentry/dynamic_sampling/per_org/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_telemetry.py
@@ -60,6 +60,36 @@ def test_reraises_and_emits_error_status(
     emit.assert_called_once_with("dynamic_sampling.boom.status", expected_status)
 
 
+@pytest.mark.parametrize(
+    ("gate_overrides", "expected_status"),
+    [
+        ({"dynamic-sampling.per_org.killswitch": True}, DynamicSamplingStatus.KILLSWITCHED),
+        ({"dynamic-sampling.per_org.rollout-rate": 0.0}, DynamicSamplingStatus.ROLLOUT_DISABLED),
+    ],
+)
+def test_gate_short_circuits_without_calling_function(
+    gate_overrides: dict[str, object], expected_status: DynamicSamplingStatus
+) -> None:
+    calls = []
+
+    @track_dynamic_sampling
+    def gated() -> None:
+        calls.append(1)
+
+    timer, timer_tags = _capture_timer_tags()
+    with (
+        override_options({**_GATE_OPTIONS, **gate_overrides}),
+        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
+        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
+    ):
+        mock_metrics.timer.side_effect = timer
+        assert gated() == expected_status
+
+    assert calls == []
+    assert timer_tags["status"] == expected_status.value
+    emit.assert_called_once_with("dynamic_sampling.gated.status", expected_status)
+
+
 @override_options(_GATE_OPTIONS)
 def test_passes_result_through_and_emits_completed_on_success() -> None:
     @track_dynamic_sampling

--- a/tests/sentry/dynamic_sampling/per_org/test_telemetry.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_telemetry.py
@@ -30,10 +30,18 @@ def _capture_timer_tags() -> tuple[object, dict[str, str]]:
     return timer, tags
 
 
+@pytest.mark.parametrize(
+    ("error", "expected_status"),
+    [
+        (ValueError("nope"), DynamicSamplingStatus.FAILED),
+        (SnubaRPCTimeout("timed out"), DynamicSamplingStatus.SNUBA_TIMEOUT),
+        (SnubaRPCError("snuba failed"), DynamicSamplingStatus.SNUBA_ERROR),
+    ],
+)
 @override_options(_GATE_OPTIONS)
-def test_records_duration_and_reraises_with_failed_status_on_exception() -> None:
-    error = ValueError("nope")
-
+def test_reraises_and_emits_error_status(
+    error: Exception, expected_status: DynamicSamplingStatus
+) -> None:
     @track_dynamic_sampling
     def boom() -> None:
         raise error
@@ -43,59 +51,13 @@ def test_records_duration_and_reraises_with_failed_status_on_exception() -> None
     with (
         patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
         patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-        pytest.raises(ValueError),
+        pytest.raises(type(error)),
     ):
         mock_metrics.timer.side_effect = timer
         boom()
 
     assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", DynamicSamplingStatus.FAILED)
-
-
-@override_options(_GATE_OPTIONS)
-def test_reraises_snuba_timeout_and_emits_timeout_status() -> None:
-    error = SnubaRPCTimeout("timed out")
-
-    @track_dynamic_sampling
-    def boom() -> None:
-        raise error
-
-    timer, timer_tags = _capture_timer_tags()
-
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-        pytest.raises(SnubaRPCTimeout),
-    ):
-        mock_metrics.timer.side_effect = timer
-        boom()
-
-    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
-    emit.assert_called_once_with(
-        "dynamic_sampling.boom.status", DynamicSamplingStatus.SNUBA_TIMEOUT
-    )
-
-
-@override_options(_GATE_OPTIONS)
-def test_reraises_snuba_error_and_emits_snuba_error_status() -> None:
-    error = SnubaRPCError("snuba failed")
-
-    @track_dynamic_sampling
-    def boom() -> None:
-        raise error
-
-    timer, timer_tags = _capture_timer_tags()
-
-    with (
-        patch("sentry.dynamic_sampling.per_org.telemetry.metrics") as mock_metrics,
-        patch("sentry.dynamic_sampling.per_org.telemetry.emit_status") as emit,
-        pytest.raises(SnubaRPCError),
-    ):
-        mock_metrics.timer.side_effect = timer
-        boom()
-
-    assert timer_tags["status"] == DynamicSamplingStatus.FAILED.value
-    emit.assert_called_once_with("dynamic_sampling.boom.status", DynamicSamplingStatus.SNUBA_ERROR)
+    emit.assert_called_once_with("dynamic_sampling.boom.status", expected_status)
 
 
 @override_options(_GATE_OPTIONS)


### PR DESCRIPTION
- add `_mock_pipeline` helpers to reduce repetition
- cleanup duplicate & useless test cases
- use stored-span tests instead of mocked tests
- delete tests that are now unreachable (e.g. configs without projects)
- parameterize identical tests instead of separate test functions