### PR TITLE
feat(seer): Request review from triggering user on green Seer PRs

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -305,6 +305,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-autofix-introspection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the PR iteration feedback flow in the explorer autofix drawer
     manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Request review from the triggering user once a Seer PR's checks are green
+    manager.add("organizations:autofix-pr-iteration-review-request", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Expose one-shot question answers on the Seer runs list (?expand=questions)
     manager.add("organizations:seer-run-questions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable showing seer in a persistent sidebar

--- a/src/sentry/seer/autofix/pr_iteration/check_suites.py
+++ b/src/sentry/seer/autofix/pr_iteration/check_suites.py
@@ -1,0 +1,318 @@
+"""Shared helpers for reacting to GitHub ``check_suite`` webhooks on Seer PRs.
+
+Both the PR-iteration feedback path (CI failed -> iterate) and the
+review-request path (CI green -> ask a human to review) consume the same
+events and need the same repository/run resolution, head matching, and
+check-run sweeping. This module keeps that logic independent of the feedback
+machinery in ``feedback_sources/check_suite.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import sentry_sdk
+from pydantic import BaseModel, Field
+from scm import actions as scm_actions
+from scm.helpers import iter_all_pages
+from scm.manager import SourceCodeManager
+from scm.types import ListCheckRunsForRefProtocol
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.repository import Repository
+from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
+from sentry.seer.models import SeerApiError
+
+logger = logging.getLogger(__name__)
+
+SEER_GITHUB_PROVIDER = "integrations:github"
+
+# Suite/run conclusions we treat as a failure. Values match scm BuildConclusion
+# after GitHub normalization (startup_failure -> failure).
+FAILURE_CONCLUSIONS = ("failure", "timed_out", "action_required")
+
+
+class GithubCheckSuiteApp(BaseModel):
+    name: str
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuitePullRequest(BaseModel):
+    id: int
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuite(BaseModel):
+    id: int
+    head_sha: str
+    check_runs_url: str
+    app: GithubCheckSuiteApp
+    conclusion: str | None = None
+    # GitHub bumps this on Actions re-runs while keeping the same suite id.
+    # Optional so legacy serialized feedback (pre-updated_at) still parses.
+    updated_at: str | None = None
+    pull_requests: list[GithubCheckSuitePullRequest] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuiteRepository(BaseModel):
+    html_url: str
+    id: int | None = None
+    full_name: str | None = None
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuiteInstallation(BaseModel):
+    id: int
+
+    class Config:
+        extra = "allow"
+
+
+class GithubCheckSuiteEvent(BaseModel):
+    check_suite: GithubCheckSuite
+    repository: GithubCheckSuiteRepository
+    installation: GithubCheckSuiteInstallation | None = None
+
+    class Config:
+        extra = "allow"
+
+
+def get_check_suite_url(event: GithubCheckSuiteEvent) -> str:
+    return (
+        f"{event.repository.html_url}/commit/{event.check_suite.head_sha}/checks"
+        f"?check_suite_id={event.check_suite.id}"
+    )
+
+
+def resolve_check_suite_repositories(event: GithubCheckSuiteEvent) -> list[Repository]:
+    """All Sentry repos matching this GitHub check-suite installation + external id.
+
+    A single GitHub App installation can be linked to multiple Sentry orgs, each
+    with its own ``Repository`` row. Callers that need an org-scoped Seer run
+    should try each candidate rather than assuming ``.first()`` is correct.
+    """
+    installation_id = event.installation.id if event.installation else None
+    repository_id = event.repository.id
+    if installation_id is None or repository_id is None:
+        logger.info(
+            "autofix.pr_iteration.check_suite.repository.missing_ids",
+            extra={"installation_id": installation_id, "repository_id": repository_id},
+        )
+        return []
+
+    contexts = integration_service.organization_contexts(
+        provider=IntegrationProviderSlug.GITHUB.value,
+        external_id=str(installation_id),
+    )
+    if contexts.integration is None or not contexts.organization_integrations:
+        logger.info(
+            "autofix.pr_iteration.check_suite.repository.missing_integration",
+            extra={
+                "installation_id": installation_id,
+                "repository_id": repository_id,
+                "has_integration": contexts.integration is not None,
+                "organization_integration_count": len(contexts.organization_integrations),
+            },
+        )
+        return []
+
+    organization_ids = [oi.organization_id for oi in contexts.organization_integrations]
+    repos = list(
+        Repository.objects.filter(
+            organization_id__in=organization_ids,
+            provider=SEER_GITHUB_PROVIDER,
+            external_id=str(repository_id),
+        ).exclude(status=ObjectStatus.HIDDEN)
+    )
+    logger.info(
+        "autofix.pr_iteration.check_suite.repository.resolved",
+        extra={
+            "installation_id": installation_id,
+            "repository_id": repository_id,
+            "organization_ids": organization_ids,
+            "repo_ids": [repo.id for repo in repos],
+            "repo_organization_ids": [repo.organization_id for repo in repos],
+        },
+    )
+    return repos
+
+
+@dataclass(frozen=True)
+class CheckSuiteAutofixRun:
+    """The Autofix run tied to a check-suite PR, plus the Sentry repo used to find it."""
+
+    repository: Repository
+    run_state: SeerRunState
+    pr_id: int
+    group_id: int
+
+
+def resolve_check_suite_autofix_run(
+    event: GithubCheckSuiteEvent, repositories: Sequence[Repository] | None = None
+) -> CheckSuiteAutofixRun | None:
+    """Find the Autofix run for this check suite's PR(s).
+
+    Assumes one Autofix run <-> PR in Sentry. Tries each PR x candidate org until
+    Seer returns a run with ``repo_pr_states`` and a ``group_id``; if several
+    match, logs a warning and returns the first. Callers that already resolved
+    (or filtered) the candidate repos can pass ``repositories`` to restrict the
+    search.
+    """
+    repos = (
+        list(repositories) if repositories is not None else resolve_check_suite_repositories(event)
+    )
+    if not repos:
+        return None
+
+    pull_requests = event.check_suite.pull_requests
+    if not pull_requests:
+        return None
+
+    matches: list[CheckSuiteAutofixRun] = []
+    for pr_id in (pr.id for pr in pull_requests):
+        for candidate in repos:
+            try:
+                state = get_agent_state_from_pr_id(
+                    candidate.organization_id, SEER_GITHUB_PROVIDER, pr_id
+                )
+            except SeerApiError as e:
+                sentry_sdk.capture_exception(e)
+                continue
+
+            if state is None or not state.repo_pr_states:
+                continue
+
+            group_id = state.metadata.get("group_id") if state.metadata else None
+            if not group_id:
+                logger.warning(
+                    "autofix.pr_iteration.check_suite.missing_group_id",
+                    extra={
+                        "organization_id": candidate.organization_id,
+                        "pr_id": pr_id,
+                        "run_id": state.run_id,
+                    },
+                )
+                continue
+
+            matches.append(
+                CheckSuiteAutofixRun(
+                    repository=candidate,
+                    run_state=state,
+                    pr_id=pr_id,
+                    group_id=group_id,
+                )
+            )
+
+    if not matches:
+        return None
+
+    if len(matches) > 1:
+        logger.warning(
+            "autofix.pr_iteration.check_suite.multiple_autofix_runs",
+            extra={
+                "match_count": len(matches),
+                "pr_ids": [m.pr_id for m in matches],
+                "run_ids": [m.run_state.run_id for m in matches],
+                "organization_ids": [m.repository.organization_id for m in matches],
+            },
+        )
+
+    return matches[0]
+
+
+class CheckSuiteHeadMatch(NamedTuple):
+    head_sha: str | None
+    repo_name: str | None
+    matched: bool
+
+
+def check_suite_head_match(
+    event: GithubCheckSuiteEvent, run_state: SeerRunState
+) -> CheckSuiteHeadMatch:
+    """Whether the check suite ran on the PR's *current* head commit.
+
+    A ``check_suite`` webhook fires for any commit on the PR (including
+    commits a human pushed or commits Seer made earlier in the run). We only
+    act on results for the commit that is currently the PR head for this
+    run: if Seer has since pushed a newer commit, the CI result is out of
+    date and reacting to it would act on stale code.
+    """
+    head_sha = event.check_suite.head_sha
+    repo_name = event.repository.full_name
+    pr_state = run_state.repo_pr_states.get(repo_name) if repo_name else None
+    matched = bool(head_sha and pr_state and pr_state.commit_sha == head_sha)
+    return CheckSuiteHeadMatch(head_sha=head_sha, repo_name=repo_name, matched=matched)
+
+
+@dataclass(frozen=True)
+class CheckRunsSweep:
+    """Aggregate state of every check run on a commit, across all check suites."""
+
+    total: int
+    incomplete: int
+    failed: int
+
+    @property
+    def is_green(self) -> bool:
+        return self.incomplete == 0 and self.failed == 0
+
+
+def sweep_check_runs(
+    scm: SourceCodeManager, head_sha: str, *, log_extra: Mapping[str, object]
+) -> CheckRunsSweep | None:
+    """Count incomplete and failed check runs for ``head_sha`` across all suites.
+
+    Returns ``None`` when the provider doesn't support listing check runs or the
+    listing fails; callers decide their own fallback.
+    """
+    if not isinstance(scm, ListCheckRunsForRefProtocol):
+        logger.warning(
+            "autofix.pr_iteration.check_runs_sweep.unsupported_provider", extra=dict(log_extra)
+        )
+        return None
+
+    total = incomplete = failed = 0
+    try:
+        for page in iter_all_pages(
+            lambda pagination: scm_actions.list_check_runs_for_ref(
+                scm, head_sha, pagination=pagination
+            )
+        ):
+            total += len(page["data"])
+            incomplete += sum(1 for run in page["data"] if run["status"] != "completed")
+            failed += sum(1 for run in page["data"] if run.get("conclusion") in FAILURE_CONCLUSIONS)
+    except Exception:
+        logger.warning(
+            "autofix.pr_iteration.check_runs_sweep.list_check_runs_failed",
+            extra={**log_extra, "head_sha": head_sha},
+            exc_info=True,
+        )
+        return None
+
+    sweep = CheckRunsSweep(total=total, incomplete=incomplete, failed=failed)
+    logger.info(
+        "autofix.pr_iteration.check_runs_sweep.swept",
+        extra={
+            **log_extra,
+            "head_sha": head_sha,
+            "check_run_count": sweep.total,
+            "incomplete_count": sweep.incomplete,
+            "failed_count": sweep.failed,
+        },
+    )
+    return sweep

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/check_suite.py
@@ -1,28 +1,24 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Literal
 
-import sentry_sdk
-from pydantic import BaseModel, Field, PrivateAttr, root_validator
-from scm import actions as scm_actions
-from scm.helpers import iter_all_pages
-from scm.types import ListCheckRunsForRefProtocol
+from pydantic import Field, PrivateAttr, root_validator
 
-from sentry.constants import ObjectStatus
-from sentry.integrations.services.integration import integration_service
-from sentry.integrations.types import IntegrationProviderSlug
-from sentry.models.repository import Repository
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.agent.client_utils import get_agent_state_from_pr_id
+from sentry.seer.autofix.pr_iteration.check_suites import (
+    CheckSuiteAutofixRun,
+    CheckSuiteHeadMatch,
+    GithubCheckSuiteEvent,
+    check_suite_head_match,
+    get_check_suite_url,
+    resolve_check_suite_autofix_run,
+    sweep_check_runs,
+)
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask, FeedbackSourceBase
-from sentry.seer.models import SeerApiError
 
 logger = logging.getLogger(__name__)
-
-_SEER_GITHUB_PROVIDER = "integrations:github"
 
 
 class MissingCheckSuiteAutofixRun(Exception):
@@ -31,199 +27,6 @@ class MissingCheckSuiteAutofixRun(Exception):
     Raised from ``CheckSuiteFeedbackSource.autofix_run`` (not a ``ValueError``)
     so callers can catch it without colliding with pydantic ``ValidationError``.
     """
-
-
-class GithubCheckSuiteApp(BaseModel):
-    name: str
-
-    class Config:
-        extra = "allow"
-
-
-class GithubCheckSuitePullRequest(BaseModel):
-    id: int
-
-    class Config:
-        extra = "allow"
-
-
-class GithubCheckSuite(BaseModel):
-    id: int
-    head_sha: str
-    check_runs_url: str
-    app: GithubCheckSuiteApp
-    conclusion: str | None = None
-    # GitHub bumps this on Actions re-runs while keeping the same suite id.
-    # Optional so legacy serialized feedback (pre-updated_at) still parses.
-    updated_at: str | None = None
-    pull_requests: list[GithubCheckSuitePullRequest] = Field(default_factory=list)
-
-    class Config:
-        extra = "allow"
-
-
-class GithubCheckSuiteRepository(BaseModel):
-    html_url: str
-    id: int | None = None
-    full_name: str | None = None
-
-    class Config:
-        extra = "allow"
-
-
-class GithubCheckSuiteInstallation(BaseModel):
-    id: int
-
-    class Config:
-        extra = "allow"
-
-
-class GithubCheckSuiteEvent(BaseModel):
-    check_suite: GithubCheckSuite
-    repository: GithubCheckSuiteRepository
-    installation: GithubCheckSuiteInstallation | None = None
-
-    class Config:
-        extra = "allow"
-
-
-def get_check_suite_url(event: GithubCheckSuiteEvent) -> str:
-    return (
-        f"{event.repository.html_url}/commit/{event.check_suite.head_sha}/checks"
-        f"?check_suite_id={event.check_suite.id}"
-    )
-
-
-def resolve_check_suite_repositories(event: GithubCheckSuiteEvent) -> list[Repository]:
-    """All Sentry repos matching this GitHub check-suite installation + external id.
-
-    A single GitHub App installation can be linked to multiple Sentry orgs, each
-    with its own ``Repository`` row. Callers that need an org-scoped Seer run
-    should try each candidate rather than assuming ``.first()`` is correct.
-    """
-    installation_id = event.installation.id if event.installation else None
-    repository_id = event.repository.id
-    if installation_id is None or repository_id is None:
-        logger.info(
-            "autofix.pr_iteration.check_suite.repository.missing_ids",
-            extra={"installation_id": installation_id, "repository_id": repository_id},
-        )
-        return []
-
-    contexts = integration_service.organization_contexts(
-        provider=IntegrationProviderSlug.GITHUB.value,
-        external_id=str(installation_id),
-    )
-    if contexts.integration is None or not contexts.organization_integrations:
-        logger.info(
-            "autofix.pr_iteration.check_suite.repository.missing_integration",
-            extra={
-                "installation_id": installation_id,
-                "repository_id": repository_id,
-                "has_integration": contexts.integration is not None,
-                "organization_integration_count": len(contexts.organization_integrations),
-            },
-        )
-        return []
-
-    organization_ids = [oi.organization_id for oi in contexts.organization_integrations]
-    repos = list(
-        Repository.objects.filter(
-            organization_id__in=organization_ids,
-            provider=_SEER_GITHUB_PROVIDER,
-            external_id=str(repository_id),
-        ).exclude(status=ObjectStatus.HIDDEN)
-    )
-    logger.info(
-        "autofix.pr_iteration.check_suite.repository.resolved",
-        extra={
-            "installation_id": installation_id,
-            "repository_id": repository_id,
-            "organization_ids": organization_ids,
-            "repo_ids": [repo.id for repo in repos],
-            "repo_organization_ids": [repo.organization_id for repo in repos],
-        },
-    )
-    return repos
-
-
-@dataclass(frozen=True)
-class CheckSuiteAutofixRun:
-    """The Autofix run tied to a check-suite PR, plus the Sentry repo used to find it."""
-
-    repository: Repository
-    run_state: SeerRunState
-    pr_id: int
-    group_id: int
-
-
-def resolve_check_suite_autofix_run(event: GithubCheckSuiteEvent) -> CheckSuiteAutofixRun | None:
-    """Find the Autofix run for this check suite's PR(s).
-
-    Assumes one Autofix run ↔ PR in Sentry. Tries each PR × candidate org until
-    Seer returns a run with ``repo_pr_states`` and a ``group_id``. If multiple
-    matches are found, logs a warning and returns the first.
-    """
-    repos = resolve_check_suite_repositories(event)
-    if not repos:
-        return None
-
-    pull_requests = event.check_suite.pull_requests
-    if not pull_requests:
-        return None
-
-    matches: list[CheckSuiteAutofixRun] = []
-    for pr_id in (pr.id for pr in pull_requests):
-        for candidate in repos:
-            try:
-                state = get_agent_state_from_pr_id(
-                    candidate.organization_id, _SEER_GITHUB_PROVIDER, pr_id
-                )
-            except SeerApiError as e:
-                sentry_sdk.capture_exception(e)
-                continue
-
-            if state is None:
-                continue
-            if not state.repo_pr_states:
-                continue
-
-            group_id = state.metadata.get("group_id") if state.metadata else None
-            if not group_id:
-                logger.warning(
-                    "autofix.pr_iteration.check_suite.missing_group_id",
-                    extra={
-                        "organization_id": candidate.organization_id,
-                        "pr_id": pr_id,
-                        "run_id": state.run_id,
-                    },
-                )
-                continue
-
-            matches.append(
-                CheckSuiteAutofixRun(
-                    repository=candidate,
-                    run_state=state,
-                    pr_id=pr_id,
-                    group_id=group_id,
-                )
-            )
-
-    if not matches:
-        return None
-
-    if len(matches) > 1:
-        logger.warning(
-            "autofix.pr_iteration.check_suite.multiple_autofix_runs",
-            extra={
-                "match_count": len(matches),
-                "pr_ids": [m.pr_id for m in matches],
-                "run_ids": [m.run_state.run_id for m in matches],
-                "organization_ids": [m.repository.organization_id for m in matches],
-            },
-        )
-
-    return matches[0]
 
 
 def _processed_check_suite_attempts(run_state: SeerRunState) -> set[tuple[int, str] | int]:
@@ -322,20 +125,8 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
     def is_automated(self) -> bool:
         return True
 
-    def _matches_current_head(self, run_state: SeerRunState) -> tuple[str | None, str | None, bool]:
-        """Whether the check suite ran on the PR's *current* head commit.
-
-        A ``check_suite`` webhook fires for any commit on the PR (including
-        commits a human pushed or commits Seer made earlier in the run). We only
-        act on failures for the commit that is currently the PR head for this
-        run: if Seer has since pushed a newer commit, the CI failure is out of
-        date and reacting to it would waste an iteration on stale code.
-        """
-        head_sha = self.event.check_suite.head_sha
-        repo_name = self.event.repository.full_name
-        pr_state = run_state.repo_pr_states.get(repo_name) if repo_name else None
-        matched = bool(head_sha and pr_state and pr_state.commit_sha == head_sha)
-        return head_sha, repo_name, matched
+    def _matches_current_head(self, run_state: SeerRunState) -> CheckSuiteHeadMatch:
+        return check_suite_head_match(self.event, run_state)
 
     def should_queue(self, run_state: SeerRunState) -> bool:
         from sentry.seer.autofix.pr_iteration.feedback import automated_iteration_cap_reached
@@ -416,59 +207,19 @@ class CheckSuiteFeedbackSource(FeedbackSourceBase):
             )
             return ConsumeTask.Now
 
-        if not isinstance(scm, ListCheckRunsForRefProtocol):
-            logger.warning(
-                "autofix.pr_iteration.should_trigger.unsupported_provider",
-                extra={"organization_id": organization_id, "repo_id": repo_id},
-            )
-            return ConsumeTask.Now
-
-        try:
-            for page in iter_all_pages(
-                lambda pagination: scm_actions.list_check_runs_for_ref(
-                    scm, head_sha, pagination=pagination
-                )
-            ):
-                incomplete_count = sum(1 for run in page["data"] if run["status"] != "completed")
-                logger.info(
-                    "autofix.pr_iteration.check_suite.should_trigger.check_runs_page",
-                    extra={
-                        "run_id": run_state.run_id,
-                        "organization_id": organization_id,
-                        "repo_id": repo_id,
-                        "head_sha": head_sha,
-                        "check_run_count": len(page["data"]),
-                        "incomplete_count": incomplete_count,
-                    },
-                )
-                if incomplete_count:
-                    return ConsumeTask.Later(timedelta(hours=1))
-
-        except Exception:
-            logger.warning(
-                "autofix.pr_iteration.should_trigger.list_check_runs_failed",
-                extra={
-                    "organization_id": organization_id,
-                    "repo_id": repo_id,
-                    "head_sha": head_sha,
-                },
-                exc_info=True,
-            )
+        sweep = sweep_check_runs(
+            scm,
+            head_sha,
+            log_extra={
+                "run_id": run_state.run_id,
+                "organization_id": organization_id,
+                "repo_id": repo_id,
+            },
+        )
+        if sweep is not None and sweep.incomplete:
+            return ConsumeTask.Later(timedelta(hours=1))
 
         return ConsumeTask.Now
 
 
-__all__ = (
-    "CheckSuiteAutofixRun",
-    "CheckSuiteFeedbackSource",
-    "GithubCheckSuite",
-    "GithubCheckSuiteApp",
-    "GithubCheckSuiteEvent",
-    "GithubCheckSuiteInstallation",
-    "GithubCheckSuitePullRequest",
-    "GithubCheckSuiteRepository",
-    "MissingCheckSuiteAutofixRun",
-    "get_check_suite_url",
-    "resolve_check_suite_autofix_run",
-    "resolve_check_suite_repositories",
-)
+__all__ = ("CheckSuiteFeedbackSource", "MissingCheckSuiteAutofixRun")

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -7,17 +7,19 @@ from pydantic import ValidationError
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.check_suites import FAILURE_CONCLUSIONS
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
     MissingCheckSuiteAutofixRun,
 )
 from sentry.seer.autofix.pr_iteration.queue import try_enqueue_autofix_feedback
+from sentry.seer.autofix.pr_iteration.review_request import (
+    GREEN_CONCLUSIONS,
+    request_review_for_green_check_suite,
+)
 
 logger = logging.getLogger(__name__)
-
-# Values match scm BuildConclusion after GitHub normalization (startup_failure → failure).
-CONCLUSIONS = ["failure", "timed_out", "action_required"]
 
 
 @scm_event_stream.listen_for(event_type="check_suite")
@@ -25,7 +27,12 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     if check_suite_event.action != "completed":
         return None
 
-    if check_suite_event.check_suite["conclusion"] not in CONCLUSIONS:
+    conclusion = check_suite_event.check_suite["conclusion"]
+    if conclusion in GREEN_CONCLUSIONS:
+        request_review_for_green_check_suite(check_suite_event)
+        return None
+
+    if conclusion not in FAILURE_CONCLUSIONS:
         return None
 
     try:

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -2,9 +2,11 @@
 
 A review request from Seer must always mean "CI is green, ready to judge" so
 that its requests stay trustworthy. We therefore only request a review after
-every check run on the PR's current head has completed without failures, and
-we request the user who triggered the run — the person most invested in the
-fix landing.
+every check run on the PR's current head has completed without failures.
+
+We ask the best reviewer candidate (see ``reviewer_candidates``) — today
+the user who triggered the run, the person most invested in the fix
+landing.
 """
 
 from __future__ import annotations
@@ -30,10 +32,13 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     resolve_check_suite_repositories,
     sweep_check_runs,
 )
+from sentry.seer.autofix.pr_iteration.reviewer_candidates import (
+    ReviewerCandidate,
+    collect_reviewer_candidates,
+    record_reviewer_candidates_marker,
+)
 from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
 from sentry.seer.models.run import SeerRun
-from sentry.seer.utils import get_github_username_for_user
-from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
 
@@ -49,6 +54,10 @@ GREEN_CONCLUSIONS = ("success", "neutral", "skipped")
 # head_sha, and reviewers so double-fires never re-ping a human and later
 # re-request logic can compare heads.
 REVIEW_REQUESTS_EXTRA = "review_requests"
+
+# How many candidates to try when a request fails (e.g. the provider rejects
+# a login without repo access) before giving up until the next green event.
+MAX_REQUEST_ATTEMPTS = 3
 
 
 def _skip(reason: str, log_extra: dict[str, Any]) -> None:
@@ -154,10 +163,6 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         # Legacy runs predating SeerRun mirroring have no row to hold the marker.
         _skip("no_seer_run", log_extra)
         return
-    if seer_run.user_id is None:
-        # System runs (e.g. Night Shift) have no triggering user to ask.
-        _skip("no_triggering_user", log_extra)
-        return
     if _review_request_marker(seer_run, head_match.repo_name):
         _skip("already_requested", log_extra)
         return
@@ -167,19 +172,6 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     if pr_number is None:
         _skip("no_pr_number", log_extra)
         return
-
-    user = user_service.get_user(user_id=seer_run.user_id)
-    if user is None:
-        _skip("user_not_found", log_extra)
-        return
-    github_login = get_github_username_for_user(user, organization.id, referrer="pr_review_request")
-    if not github_login:
-        _skip("no_github_login", log_extra)
-        return
-    # A list so future candidate selection (e.g. night-shift routing via code
-    # ownership or blame) can request several users; today it's the triggering
-    # user alone.
-    scm_users = [github_login]
 
     # Importing the SCM factory while the check-suite listener module is
     # initialized pulls in integration handlers before options init.
@@ -224,6 +216,23 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         if isinstance(reviewer, dict) and reviewer.get("login")
     }
 
+    # Computed only now — lazily at decision time — because most green events
+    # return before this point and the sources go stale.
+    pr_author = (raw_pr.get("user") or {}).get("login")
+    candidates = collect_reviewer_candidates(
+        organization=organization,
+        seer_run=seer_run,
+        exclude_logins={pr_author} if pr_author else (),
+        log_extra=log_extra,
+    )
+    metrics.incr(
+        "autofix.pr_iteration.reviewer_candidates.computed",
+        tags={"top_source": candidates[0].source if candidates else "none"},
+    )
+    if not candidates:
+        _skip("no_candidates", log_extra)
+        return
+
     # A suite completes once per app/workflow, so several green events can race
     # for the same head; the lock plus a marker re-check makes sure only one of
     # them pings the human.
@@ -232,6 +241,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         duration=30,
         name="autofix_pr_review_request",
     )
+    requested_candidate: ReviewerCandidate | None = None
     try:
         with lock.acquire():
             seer_run.refresh_from_db()
@@ -239,14 +249,21 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 _skip("already_requested", log_extra)
                 return
 
-            # Drop anyone already on the hook — e.g. a CODEOWNERS auto-request.
-            scm_users = [
-                scm_user for scm_user in scm_users if scm_user.lower() not in requested_logins
-            ]
-            if not scm_users:
-                # Record the existing request as the marker so later green
-                # events short-circuit on the marker pre-check instead of
-                # re-fetching check runs and the PR from the provider.
+            # Persist the ranked list with provenance: fallbacks for later
+            # re-request, and the data to measure which source's reviewers
+            # actually respond.
+            record_reviewer_candidates_marker(
+                seer_run,
+                head_match.repo_name,
+                head_sha=head_match.head_sha,
+                candidates=candidates,
+            )
+
+            if any(c.login.lower() in requested_logins for c in candidates):
+                # Someone we would pick is already on the hook — e.g. a
+                # CODEOWNERS auto-request. Record it so later green events
+                # short-circuit on the marker pre-check, and don't rebuild the
+                # bystander effect by adding a second person.
                 _record_review_request_marker(
                     seer_run,
                     head_match.repo_name,
@@ -257,25 +274,37 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 _skip("already_a_reviewer", log_extra)
                 return
 
-            try:
-                scm_actions.request_review(scm, str(pr_number), scm_users)
-            except Exception:
+            for candidate in candidates[:MAX_REQUEST_ATTEMPTS]:
+                try:
+                    scm_actions.request_review(scm, str(pr_number), [candidate.login])
+                    requested_candidate = candidate
+                    break
+                except Exception:
+                    # E.g. the login has no access to this repo; a
+                    # lower-ranked candidate may still be requestable.
+                    _failed(
+                        "request_review_failed",
+                        {**log_extra, "pr_number": pr_number, "source": candidate.source},
+                    )
+            if requested_candidate is None:
                 # Leave the marker unset so the next green event can retry.
-                _failed("request_review_failed", {**log_extra, "pr_number": pr_number})
                 return
 
             _record_review_request_marker(
                 seer_run,
                 head_match.repo_name,
                 head_sha=head_match.head_sha,
-                reviewers=scm_users,
+                reviewers=[requested_candidate.login],
             )
     except UnableToAcquireLock:
         _skip("locked", log_extra)
         return
 
-    metrics.incr("autofix.pr_iteration.review_request.requested")
+    metrics.incr(
+        "autofix.pr_iteration.review_request.requested",
+        tags={"source": requested_candidate.source},
+    )
     logger.info(
         "autofix.pr_iteration.review_request.requested",
-        extra={**log_extra, "pr_number": pr_number},
+        extra={**log_extra, "pr_number": pr_number, "reviewers": [requested_candidate.login]},
     )

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -131,33 +131,33 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     if not flagged_repos:
         return
 
-    resolved = resolve_check_suite_autofix_run(event, flagged_repos)
+    autofix_run = resolve_check_suite_autofix_run(event, flagged_repos)
     # Sizes the funnel: of green events in flagged orgs, how many are Seer PRs.
     metrics.incr(
         "autofix.pr_iteration.review_request.run_resolved",
-        tags={"found": str(resolved is not None).lower()},
+        tags={"found": str(autofix_run is not None).lower()},
     )
-    if resolved is None:
+    if autofix_run is None:
         # Expected: webhooks fan out to every region, so a missing run usually
         # just means this region doesn't own the Autofix session.
         return
-    organization = organizations[resolved.repository.organization_id]
+    organization = organizations[autofix_run.repository.organization_id]
 
     log_extra: dict[str, Any] = {
-        "organization_id": resolved.repository.organization_id,
-        "repo_id": resolved.repository.id,
-        "run_id": resolved.run_state.run_id,
-        "pr_id": resolved.pr_id,
+        "organization_id": autofix_run.repository.organization_id,
+        "repo_id": autofix_run.repository.id,
+        "run_id": autofix_run.run_state.run_id,
+        "pr_id": autofix_run.pr_id,
     }
 
-    head_match = check_suite_head_match(event, resolved.run_state)
+    head_match = check_suite_head_match(event, autofix_run.run_state)
     if not head_match.matched or not head_match.head_sha or not head_match.repo_name:
         # A green result for an older commit says nothing about the current head.
         _skip("stale_head", {**log_extra, "head_sha": head_match.head_sha})
         return
 
     seer_run = SeerRun.objects.filter(
-        seer_run_state_id=resolved.run_state.run_id, organization=organization
+        seer_run_state_id=autofix_run.run_state.run_id, organization=organization
     ).first()
     if seer_run is None:
         # Legacy runs predating SeerRun mirroring have no row to hold the marker.
@@ -167,7 +167,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         _skip("already_requested", log_extra)
         return
 
-    pr_state = resolved.run_state.repo_pr_states.get(head_match.repo_name)
+    pr_state = autofix_run.run_state.repo_pr_states.get(head_match.repo_name)
     pr_number = pr_state.pr_number if pr_state else None
     if pr_number is None:
         _skip("no_pr_number", log_extra)
@@ -178,7 +178,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     from sentry.scm.factory import new as make_scm
 
     try:
-        scm = make_scm(organization.id, resolved.repository.id, referrer="seer")
+        scm = make_scm(organization.id, autofix_run.repository.id, referrer="seer")
     except Exception:
         _failed("scm_init_failed", log_extra)
         return
@@ -234,8 +234,9 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         return
 
     # A suite completes once per app/workflow, so several green events can race
-    # for the same head; the lock plus a marker re-check makes sure only one of
-    # them pings the human.
+    # for the same head. Wait for the lock holder rather than dropping: after
+    # the wait the marker re-check settles it — holder succeeded means we skip,
+    # holder's request failed (marker unset) means this event retries.
     lock = locks.get(
         f"autofix:pr_iteration:review_request:{seer_run.id}",
         duration=30,
@@ -243,7 +244,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     )
     requested_candidate: ReviewerCandidate | None = None
     try:
-        with lock.acquire():
+        with lock.blocking_acquire(initial_delay=0.5, timeout=10):
             seer_run.refresh_from_db()
             if _review_request_marker(seer_run, head_match.repo_name):
                 _skip("already_requested", log_extra)
@@ -296,6 +297,11 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 head_sha=head_match.head_sha,
                 reviewers=[requested_candidate.login],
             )
+    except SeerRun.DoesNotExist:
+        # The run was deleted between our lookup and the marker write (e.g.
+        # cleanup); nothing is left to mark or dedupe against.
+        _skip("run_deleted", log_extra)
+        return
     except UnableToAcquireLock:
         _skip("locked", log_extra)
         return

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -1,0 +1,239 @@
+"""Request a human review on a Seer-authored PR once its CI is green.
+
+A review request from Seer must always mean "CI is green, ready to judge" so
+that its requests stay trustworthy. We therefore only request a review after
+every check run on the PR's current head has completed without failures, and
+we request the user who triggered the run — the person most invested in the
+fix landing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import orjson
+import sentry_sdk
+from django.utils import timezone
+from pydantic import ValidationError
+from scm import actions as scm_actions
+from scm.types import GetPullRequestProtocol, RequestReviewProtocol
+
+from sentry import features
+from sentry.locks import locks
+from sentry.models.organization import Organization
+from sentry.scm.types import CheckSuiteEvent
+from sentry.seer.autofix.pr_iteration.check_suites import (
+    GithubCheckSuiteEvent,
+    check_suite_head_match,
+    resolve_check_suite_autofix_run,
+    resolve_check_suite_repositories,
+    sweep_check_runs,
+)
+from sentry.seer.models.run import SeerRun
+from sentry.seer.utils import get_github_username_for_user
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+from sentry.utils.locking import UnableToAcquireLock
+
+logger = logging.getLogger(__name__)
+
+# Check-suite conclusions that can complete a fully green head. The suite event
+# is only the trigger — the check-runs sweep across all of the head's suites is
+# what actually confirms the PR is green.
+GREEN_CONCLUSIONS = ("success", "neutral", "skipped")
+
+# SeerRun.extras key holding review-request markers, keyed by repo full name
+# (a run can open PRs in several repos). Each marker records requested_at,
+# head_sha, and reviewer so double-fires never re-ping a human and later
+# re-request logic can compare heads.
+REVIEW_REQUESTS_EXTRA = "review_requests"
+
+
+def _skip(reason: str, log_extra: dict[str, Any]) -> None:
+    metrics.incr("autofix.pr_iteration.review_request.skipped", tags={"reason": reason})
+    logger.info(
+        "autofix.pr_iteration.review_request.skipped", extra={**log_extra, "reason": reason}
+    )
+
+
+def _review_request_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] | None:
+    return ((seer_run.extras or {}).get(REVIEW_REQUESTS_EXTRA) or {}).get(repo_name)
+
+
+def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> None:
+    """Entry point from the check-suite listener for green suite conclusions."""
+    try:
+        raw = orjson.loads(check_suite_event.subscription_event["event"])
+        event = GithubCheckSuiteEvent.parse_obj(raw)
+    except (orjson.JSONDecodeError, ValidationError, TypeError, ValueError) as e:
+        # Malformed webhook payload — report and drop; do not fail the listener task.
+        sentry_sdk.capture_exception(e)
+        return
+
+    # Green suites fire for every commit on every PR in every connected repo,
+    # so gate on the flag (DB/cache only) before any Seer run lookup.
+    organizations: dict[int, Organization] = {}
+    flagged_repos = []
+    for repo in resolve_check_suite_repositories(event):
+        organization = organizations.get(repo.organization_id)
+        if organization is None:
+            try:
+                organization = Organization.objects.get_from_cache(id=repo.organization_id)
+            except Organization.DoesNotExist:
+                continue
+            organizations[repo.organization_id] = organization
+        if features.has("organizations:autofix-pr-iteration-review-request", organization):
+            flagged_repos.append(repo)
+    if not flagged_repos:
+        return
+
+    resolved = resolve_check_suite_autofix_run(event, flagged_repos)
+    if resolved is None:
+        # Expected: webhooks fan out to every region, so a missing run usually
+        # just means this region doesn't own the Autofix session.
+        return
+    organization = organizations[resolved.repository.organization_id]
+
+    log_extra: dict[str, Any] = {
+        "organization_id": resolved.repository.organization_id,
+        "repo_id": resolved.repository.id,
+        "run_id": resolved.run_state.run_id,
+        "pr_id": resolved.pr_id,
+    }
+
+    head_match = check_suite_head_match(event, resolved.run_state)
+    if not head_match.matched or not head_match.head_sha or not head_match.repo_name:
+        # A green result for an older commit says nothing about the current head.
+        _skip("stale_head", {**log_extra, "head_sha": head_match.head_sha})
+        return
+
+    seer_run = SeerRun.objects.filter(
+        seer_run_state_id=resolved.run_state.run_id, organization=organization
+    ).first()
+    if seer_run is None:
+        # Legacy runs predating SeerRun mirroring have no row to hold the marker.
+        _skip("no_seer_run", log_extra)
+        return
+    if seer_run.user_id is None:
+        # System runs (e.g. Night Shift) have no triggering user to ask.
+        _skip("no_triggering_user", log_extra)
+        return
+    if _review_request_marker(seer_run, head_match.repo_name):
+        _skip("already_requested", log_extra)
+        return
+
+    pr_state = resolved.run_state.repo_pr_states.get(head_match.repo_name)
+    pr_number = pr_state.pr_number if pr_state else None
+    if pr_number is None:
+        _skip("no_pr_number", log_extra)
+        return
+
+    user = user_service.get_user(user_id=seer_run.user_id)
+    if user is None:
+        _skip("user_not_found", log_extra)
+        return
+    github_login = get_github_username_for_user(user, organization.id)
+    if not github_login:
+        _skip("no_github_login", log_extra)
+        return
+
+    # Importing the SCM factory while the check-suite listener module is
+    # initialized pulls in integration handlers before options init.
+    from sentry.scm.factory import new as make_scm
+
+    try:
+        scm = make_scm(organization.id, resolved.repository.id, referrer="seer")
+    except Exception:
+        logger.warning(
+            "autofix.pr_iteration.review_request.scm_init_failed",
+            extra=log_extra,
+            exc_info=True,
+        )
+        return
+
+    sweep = sweep_check_runs(scm, head_match.head_sha, log_extra=log_extra)
+    if sweep is None:
+        # Couldn't confirm the head is green — never request a review on uncertainty.
+        _skip("sweep_failed", log_extra)
+        return
+    if not sweep.is_green:
+        _skip(
+            "not_green",
+            {**log_extra, "incomplete_count": sweep.incomplete, "failed_count": sweep.failed},
+        )
+        return
+
+    if not isinstance(scm, GetPullRequestProtocol) or not isinstance(scm, RequestReviewProtocol):
+        _skip("unsupported_provider", log_extra)
+        return
+
+    try:
+        pull_request = scm_actions.get_pull_request(scm, str(pr_number))
+    except Exception:
+        logger.warning(
+            "autofix.pr_iteration.review_request.get_pull_request_failed",
+            extra={**log_extra, "pr_number": pr_number},
+            exc_info=True,
+        )
+        return
+
+    if pull_request["data"]["state"] != "open" or pull_request["data"]["merged"]:
+        _skip("pr_not_open", log_extra)
+        return
+
+    # Someone is already on the hook — e.g. a CODEOWNERS auto-request.
+    raw_pr = pull_request["raw"]["data"] or {}
+    requested_logins = {
+        reviewer["login"].lower()
+        for reviewer in (raw_pr.get("requested_reviewers") or [])
+        if isinstance(reviewer, dict) and reviewer.get("login")
+    }
+    if github_login.lower() in requested_logins:
+        _skip("already_a_reviewer", log_extra)
+        return
+
+    # A suite completes once per app/workflow, so several green events can race
+    # for the same head; the lock plus a marker re-check makes sure only one of
+    # them pings the human.
+    lock = locks.get(
+        f"autofix:pr_iteration:review_request:{seer_run.id}",
+        duration=30,
+        name="autofix_pr_review_request",
+    )
+    try:
+        with lock.acquire():
+            seer_run.refresh_from_db()
+            if _review_request_marker(seer_run, head_match.repo_name):
+                _skip("already_requested", log_extra)
+                return
+
+            try:
+                scm_actions.request_review(scm, str(pr_number), [github_login])
+            except Exception:
+                # Leave the marker unset so the next green event can retry.
+                logger.warning(
+                    "autofix.pr_iteration.review_request.request_failed",
+                    extra={**log_extra, "pr_number": pr_number},
+                    exc_info=True,
+                )
+                return
+
+            extras = dict(seer_run.extras or {})
+            markers = dict(extras.get(REVIEW_REQUESTS_EXTRA) or {})
+            markers[head_match.repo_name] = {
+                "requested_at": timezone.now().isoformat(),
+                "head_sha": head_match.head_sha,
+                "reviewer": github_login,
+            }
+            extras[REVIEW_REQUESTS_EXTRA] = markers
+            seer_run.update(extras=extras)
+    except UnableToAcquireLock:
+        _skip("locked", log_extra)
+        return
+
+    metrics.incr("autofix.pr_iteration.review_request.requested")
+    logger.info(
+        "autofix.pr_iteration.review_request.requested",
+        extra={**log_extra, "pr_number": pr_number},
+    )

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -57,11 +57,11 @@ def _skip(reason: str, log_extra: dict[str, Any]) -> None:
     )
 
 
-def _error(reason: str, log_extra: dict[str, Any]) -> None:
+def _failed(reason: str, log_extra: dict[str, Any]) -> None:
     """Record an unexpected failure (vs. a `_skip`, which is an expected condition)."""
-    metrics.incr("autofix.pr_iteration.review_request.error", tags={"reason": reason})
+    metrics.incr("autofix.pr_iteration.review_request.failed", tags={"reason": reason})
     logger.warning(
-        "autofix.pr_iteration.review_request.error",
+        "autofix.pr_iteration.review_request.failed",
         extra={**log_extra, "reason": reason},
         exc_info=True,
     )
@@ -160,7 +160,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     try:
         scm = make_scm(organization.id, resolved.repository.id, referrer="seer")
     except Exception:
-        _error("scm_init_failed", log_extra)
+        _failed("scm_init_failed", log_extra)
         return
 
     sweep = sweep_check_runs(scm, head_match.head_sha, log_extra=log_extra)
@@ -182,7 +182,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     try:
         pull_request = scm_actions.get_pull_request(scm, str(pr_number))
     except Exception:
-        _error("get_pull_request_failed", {**log_extra, "pr_number": pr_number})
+        _failed("get_pull_request_failed", {**log_extra, "pr_number": pr_number})
         return
 
     if pull_request["data"]["state"] != "open" or pull_request["data"]["merged"]:
@@ -219,7 +219,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 scm_actions.request_review(scm, str(pr_number), [github_login])
             except Exception:
                 # Leave the marker unset so the next green event can retry.
-                _error("request_review_failed", {**log_extra, "pr_number": pr_number})
+                _failed("request_review_failed", {**log_extra, "pr_number": pr_number})
                 return
 
             extras = dict(seer_run.extras or {})

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -57,6 +57,16 @@ def _skip(reason: str, log_extra: dict[str, Any]) -> None:
     )
 
 
+def _error(reason: str, log_extra: dict[str, Any]) -> None:
+    """Record an unexpected failure (vs. a `_skip`, which is an expected condition)."""
+    metrics.incr("autofix.pr_iteration.review_request.error", tags={"reason": reason})
+    logger.warning(
+        "autofix.pr_iteration.review_request.error",
+        extra={**log_extra, "reason": reason},
+        exc_info=True,
+    )
+
+
 def _review_request_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] | None:
     return ((seer_run.extras or {}).get(REVIEW_REQUESTS_EXTRA) or {}).get(repo_name)
 
@@ -89,6 +99,11 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         return
 
     resolved = resolve_check_suite_autofix_run(event, flagged_repos)
+    # Sizes the funnel: of green events in flagged orgs, how many are Seer PRs.
+    metrics.incr(
+        "autofix.pr_iteration.review_request.run_resolved",
+        tags={"found": str(resolved is not None).lower()},
+    )
     if resolved is None:
         # Expected: webhooks fan out to every region, so a missing run usually
         # just means this region doesn't own the Autofix session.
@@ -133,7 +148,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     if user is None:
         _skip("user_not_found", log_extra)
         return
-    github_login = get_github_username_for_user(user, organization.id)
+    github_login = get_github_username_for_user(user, organization.id, referrer="pr_review_request")
     if not github_login:
         _skip("no_github_login", log_extra)
         return
@@ -145,11 +160,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     try:
         scm = make_scm(organization.id, resolved.repository.id, referrer="seer")
     except Exception:
-        logger.warning(
-            "autofix.pr_iteration.review_request.scm_init_failed",
-            extra=log_extra,
-            exc_info=True,
-        )
+        _error("scm_init_failed", log_extra)
         return
 
     sweep = sweep_check_runs(scm, head_match.head_sha, log_extra=log_extra)
@@ -171,11 +182,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     try:
         pull_request = scm_actions.get_pull_request(scm, str(pr_number))
     except Exception:
-        logger.warning(
-            "autofix.pr_iteration.review_request.get_pull_request_failed",
-            extra={**log_extra, "pr_number": pr_number},
-            exc_info=True,
-        )
+        _error("get_pull_request_failed", {**log_extra, "pr_number": pr_number})
         return
 
     if pull_request["data"]["state"] != "open" or pull_request["data"]["merged"]:
@@ -212,11 +219,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 scm_actions.request_review(scm, str(pr_number), [github_login])
             except Exception:
                 # Leave the marker unset so the next green event can retry.
-                logger.warning(
-                    "autofix.pr_iteration.review_request.request_failed",
-                    extra={**log_extra, "pr_number": pr_number},
-                    exc_info=True,
-                )
+                _error("request_review_failed", {**log_extra, "pr_number": pr_number})
                 return
 
             extras = dict(seer_run.extras or {})

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -45,7 +45,7 @@ GREEN_CONCLUSIONS = ("success", "neutral", "skipped")
 
 # SeerRun.extras key holding review-request markers, keyed by repo full name
 # (a run can open PRs in several repos). Each marker records requested_at,
-# head_sha, and reviewer so double-fires never re-ping a human and later
+# head_sha, and reviewers so double-fires never re-ping a human and later
 # re-request logic can compare heads.
 REVIEW_REQUESTS_EXTRA = "review_requests"
 
@@ -152,6 +152,10 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
     if not github_login:
         _skip("no_github_login", log_extra)
         return
+    # A list so future candidate selection (e.g. night-shift routing via code
+    # ownership or blame) can request several users; today it's the triggering
+    # user alone.
+    scm_users = [github_login]
 
     # Importing the SCM factory while the check-suite listener module is
     # initialized pulls in integration handlers before options init.
@@ -189,14 +193,15 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         _skip("pr_not_open", log_extra)
         return
 
-    # Someone is already on the hook — e.g. a CODEOWNERS auto-request.
+    # Drop anyone already on the hook — e.g. a CODEOWNERS auto-request.
     raw_pr = pull_request["raw"]["data"] or {}
     requested_logins = {
         reviewer["login"].lower()
         for reviewer in (raw_pr.get("requested_reviewers") or [])
         if isinstance(reviewer, dict) and reviewer.get("login")
     }
-    if github_login.lower() in requested_logins:
+    scm_users = [scm_user for scm_user in scm_users if scm_user.lower() not in requested_logins]
+    if not scm_users:
         _skip("already_a_reviewer", log_extra)
         return
 
@@ -216,7 +221,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 return
 
             try:
-                scm_actions.request_review(scm, str(pr_number), [github_login])
+                scm_actions.request_review(scm, str(pr_number), scm_users)
             except Exception:
                 # Leave the marker unset so the next green event can retry.
                 _failed("request_review_failed", {**log_extra, "pr_number": pr_number})
@@ -227,7 +232,7 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
             markers[head_match.repo_name] = {
                 "requested_at": timezone.now().isoformat(),
                 "head_sha": head_match.head_sha,
-                "reviewer": github_login,
+                "reviewers": scm_users,
             }
             extras[REVIEW_REQUESTS_EXTRA] = markers
             seer_run.update(extras=extras)

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -30,6 +30,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     resolve_check_suite_repositories,
     sweep_check_runs,
 )
+from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
 from sentry.seer.models.run import SeerRun
 from sentry.seer.utils import get_github_username_for_user
 from sentry.users.services.user.service import user_service
@@ -68,7 +69,7 @@ def _failed(reason: str, log_extra: dict[str, Any]) -> None:
 
 
 def _review_request_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] | None:
-    return ((seer_run.extras or {}).get(REVIEW_REQUESTS_EXTRA) or {}).get(repo_name)
+    return get_run_marker(seer_run, REVIEW_REQUESTS_EXTRA, repo_name)
 
 
 def _record_review_request_marker(
@@ -91,11 +92,7 @@ def _record_review_request_marker(
     }
     if preexisting:
         marker["preexisting"] = True
-    extras = dict(seer_run.extras or {})
-    markers = dict(extras.get(REVIEW_REQUESTS_EXTRA) or {})
-    markers[repo_name] = marker
-    extras[REVIEW_REQUESTS_EXTRA] = markers
-    seer_run.update(extras=extras)
+    record_run_marker(seer_run, REVIEW_REQUESTS_EXTRA, repo_name, marker)
 
 
 def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> None:

--- a/src/sentry/seer/autofix/pr_iteration/review_request.py
+++ b/src/sentry/seer/autofix/pr_iteration/review_request.py
@@ -71,6 +71,33 @@ def _review_request_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] 
     return ((seer_run.extras or {}).get(REVIEW_REQUESTS_EXTRA) or {}).get(repo_name)
 
 
+def _record_review_request_marker(
+    seer_run: SeerRun,
+    repo_name: str,
+    *,
+    head_sha: str,
+    reviewers: list[str],
+    preexisting: bool = False,
+) -> None:
+    """Write the per-repo marker; caller must hold the run's review-request lock.
+
+    ``preexisting`` records that the reviewers were already requested by someone
+    else (e.g. a CODEOWNERS auto-request) rather than by us.
+    """
+    marker: dict[str, Any] = {
+        "requested_at": timezone.now().isoformat(),
+        "head_sha": head_sha,
+        "reviewers": reviewers,
+    }
+    if preexisting:
+        marker["preexisting"] = True
+    extras = dict(seer_run.extras or {})
+    markers = dict(extras.get(REVIEW_REQUESTS_EXTRA) or {})
+    markers[repo_name] = marker
+    extras[REVIEW_REQUESTS_EXTRA] = markers
+    seer_run.update(extras=extras)
+
+
 def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> None:
     """Entry point from the check-suite listener for green suite conclusions."""
     try:
@@ -193,17 +220,12 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
         _skip("pr_not_open", log_extra)
         return
 
-    # Drop anyone already on the hook — e.g. a CODEOWNERS auto-request.
     raw_pr = pull_request["raw"]["data"] or {}
     requested_logins = {
         reviewer["login"].lower()
         for reviewer in (raw_pr.get("requested_reviewers") or [])
         if isinstance(reviewer, dict) and reviewer.get("login")
     }
-    scm_users = [scm_user for scm_user in scm_users if scm_user.lower() not in requested_logins]
-    if not scm_users:
-        _skip("already_a_reviewer", log_extra)
-        return
 
     # A suite completes once per app/workflow, so several green events can race
     # for the same head; the lock plus a marker re-check makes sure only one of
@@ -220,6 +242,24 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 _skip("already_requested", log_extra)
                 return
 
+            # Drop anyone already on the hook — e.g. a CODEOWNERS auto-request.
+            scm_users = [
+                scm_user for scm_user in scm_users if scm_user.lower() not in requested_logins
+            ]
+            if not scm_users:
+                # Record the existing request as the marker so later green
+                # events short-circuit on the marker pre-check instead of
+                # re-fetching check runs and the PR from the provider.
+                _record_review_request_marker(
+                    seer_run,
+                    head_match.repo_name,
+                    head_sha=head_match.head_sha,
+                    reviewers=sorted(requested_logins),
+                    preexisting=True,
+                )
+                _skip("already_a_reviewer", log_extra)
+                return
+
             try:
                 scm_actions.request_review(scm, str(pr_number), scm_users)
             except Exception:
@@ -227,15 +267,12 @@ def request_review_for_green_check_suite(check_suite_event: CheckSuiteEvent) -> 
                 _failed("request_review_failed", {**log_extra, "pr_number": pr_number})
                 return
 
-            extras = dict(seer_run.extras or {})
-            markers = dict(extras.get(REVIEW_REQUESTS_EXTRA) or {})
-            markers[head_match.repo_name] = {
-                "requested_at": timezone.now().isoformat(),
-                "head_sha": head_match.head_sha,
-                "reviewers": scm_users,
-            }
-            extras[REVIEW_REQUESTS_EXTRA] = markers
-            seer_run.update(extras=extras)
+            _record_review_request_marker(
+                seer_run,
+                head_match.repo_name,
+                head_sha=head_match.head_sha,
+                reviewers=scm_users,
+            )
     except UnableToAcquireLock:
         _skip("locked", log_extra)
         return

--- a/src/sentry/seer/autofix/pr_iteration/reviewer_candidates.py
+++ b/src/sentry/seer/autofix/pr_iteration/reviewer_candidates.py
@@ -1,0 +1,133 @@
+"""Reviewer candidates for a Seer-authored PR.
+
+Requesting the whole owning team rebuilds the bystander effect, so the
+review-request flow asks one specific person. This module computes who that
+should be — today the run's triggering user, resolved to a GitHub login —
+as a ranked candidate list where each entry carries its source as
+provenance, so we can measure which source's reviewers actually respond.
+
+The list is computed lazily at decision time (identity links go stale, and
+most green events never reach a request) and persisted on ``SeerRun`` so
+later re-request logic can fall back to the next candidate without
+recomputing.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Collection, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from django.utils import timezone
+
+from sentry.models.organization import Organization
+from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
+from sentry.seer.models.run import SeerRun
+from sentry.seer.utils import get_github_username_for_user
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+# Provenance labels stored per candidate and used as metric tag values.
+SOURCE_TRIGGERING_USER = "triggering_user"
+
+# SeerRun.extras key holding the computed candidates, keyed by repo full name
+# (a run can open PRs in several repos). Each marker records the ranked list
+# with provenance so re-request logic can fall back without recomputing.
+REVIEWER_CANDIDATES_EXTRA = "reviewer_candidates"
+
+
+@dataclass(frozen=True)
+class ReviewerCandidate:
+    """A GitHub login we could ask for review, and which source proposed it."""
+
+    login: str
+    source: str
+
+
+def get_reviewer_candidates_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] | None:
+    return get_run_marker(seer_run, REVIEWER_CANDIDATES_EXTRA, repo_name)
+
+
+def record_reviewer_candidates_marker(
+    seer_run: SeerRun,
+    repo_name: str,
+    *,
+    head_sha: str,
+    candidates: list[ReviewerCandidate],
+) -> None:
+    record_run_marker(
+        seer_run,
+        REVIEWER_CANDIDATES_EXTRA,
+        repo_name,
+        {
+            "computed_at": timezone.now().isoformat(),
+            "head_sha": head_sha,
+            "candidates": [{"login": c.login, "source": c.source} for c in candidates],
+        },
+    )
+
+
+def collect_reviewer_candidates(
+    *,
+    organization: Organization,
+    seer_run: SeerRun,
+    exclude_logins: Collection[str] = (),
+    log_extra: Mapping[str, Any],
+) -> list[ReviewerCandidate]:
+    """The ranked reviewer candidates for a Seer PR, best first.
+
+    Bots, ``exclude_logins`` (e.g. the PR author), and duplicates are dropped;
+    a login proposed by several sources keeps its highest-ranked provenance.
+    A source that errors is skipped so one flaky lookup can't empty the list.
+    """
+    excluded = {login.lower() for login in exclude_logins}
+    candidates: list[ReviewerCandidate] = []
+    seen: set[str] = set()
+
+    def resolve_source(source: str, resolve: Callable[[], list[str]]) -> None:
+        try:
+            logins = resolve()
+        except Exception:
+            metrics.incr(
+                "autofix.pr_iteration.reviewer_candidates.source_failed", tags={"source": source}
+            )
+            logger.warning(
+                "autofix.pr_iteration.reviewer_candidates.source_failed",
+                extra={**log_extra, "source": source},
+                exc_info=True,
+            )
+            return
+        # Sizes each source's resolution rate — e.g. how often a triggering
+        # user exists but has no mappable GitHub identity.
+        metrics.incr(
+            "autofix.pr_iteration.reviewer_candidates.source_resolved",
+            tags={"source": source, "found": str(bool(logins)).lower()},
+        )
+        for login in logins:
+            key = login.lower()
+            if key in seen or key in excluded or _is_bot_login(login):
+                continue
+            seen.add(key)
+            candidates.append(ReviewerCandidate(login=login, source=source))
+
+    resolve_source(SOURCE_TRIGGERING_USER, lambda: _triggering_user_logins(seer_run, organization))
+    return candidates
+
+
+def _is_bot_login(login: str) -> bool:
+    # GitHub app identities ("dependabot[bot]").
+    return login.lower().endswith("[bot]")
+
+
+def _triggering_user_logins(seer_run: SeerRun, organization: Organization) -> list[str]:
+    if seer_run.user_id is None:
+        # System runs (e.g. Night Shift) have no triggering user to ask.
+        return []
+    user = user_service.get_user(user_id=seer_run.user_id)
+    if user is None:
+        return []
+    login = get_github_username_for_user(user, organization.id, referrer="pr_reviewer_candidates")
+    return [login] if login else []

--- a/src/sentry/seer/autofix/pr_iteration/run_markers.py
+++ b/src/sentry/seer/autofix/pr_iteration/run_markers.py
@@ -1,0 +1,40 @@
+"""Per-repo feature markers stored in ``SeerRun.extras``.
+
+Several PR-iteration features (review requests, cap-exhausted handoffs)
+persist a durable "we already pinged a human" marker on the run, keyed by
+feature and repo full name. Each feature serializes its own side effects
+with its own advisory lock, but the features run concurrently with each
+other — and a plain read-modify-write of the whole ``extras`` blob would
+let one feature's write erase another's marker. ``record_run_marker``
+therefore re-reads the row under a row lock and merges only its own key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import router, transaction
+
+from sentry.seer.models.run import SeerRun
+
+
+def get_run_marker(seer_run: SeerRun, extra_key: str, repo_name: str) -> dict[str, Any] | None:
+    return ((seer_run.extras or {}).get(extra_key) or {}).get(repo_name)
+
+
+def record_run_marker(
+    seer_run: SeerRun, extra_key: str, repo_name: str, marker: dict[str, Any]
+) -> None:
+    """Atomically set ``extras[extra_key][repo_name] = marker`` on the run.
+
+    The merge happens against a freshly locked row, so a stale ``seer_run``
+    instance can't clobber markers written concurrently under other keys.
+    """
+    with transaction.atomic(router.db_for_write(SeerRun)):
+        locked = SeerRun.objects.select_for_update().get(id=seer_run.id)
+        extras = dict(locked.extras or {})
+        markers = dict(extras.get(extra_key) or {})
+        markers[repo_name] = marker
+        extras[extra_key] = markers
+        locked.update(extras=extras)
+    seer_run.extras = extras

--- a/src/sentry/seer/utils.py
+++ b/src/sentry/seer/utils.py
@@ -13,6 +13,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.repository import Repository
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,9 @@ def filter_repo_by_provider(
     )
 
 
-def get_github_username_for_user(user: User | RpcUser, organization_id: int) -> str | None:
+def get_github_username_for_user(
+    user: User | RpcUser, organization_id: int, *, referrer: str = "unknown"
+) -> str | None:
     """
     Get GitHub username for a user by checking multiple sources.
 
@@ -58,6 +61,9 @@ def get_github_username_for_user(user: User | RpcUser, organization_id: int) -> 
     1. Checking ExternalActor for explicit user->GitHub mappings
     2. Falling back to CommitAuthor records matched by email (like suspect commits)
     3. Extracting the GitHub username from the CommitAuthor external_id
+
+    ``referrer`` names the calling feature; it only tags the resolution metric
+    so per-caller resolution rates stay separable.
     """
     # Method 1: Check ExternalActor for direct user->GitHub mapping
     external_actor: ExternalActor | None = (
@@ -74,6 +80,7 @@ def get_github_username_for_user(user: User | RpcUser, organization_id: int) -> 
     )
 
     if external_actor and external_actor.external_name:
+        _record_username_resolution("external_actor", referrer)
         username = external_actor.external_name
         return username[1:] if username.startswith("@") else username
 
@@ -105,6 +112,15 @@ def get_github_username_for_user(user: User | RpcUser, organization_id: int) -> 
         if commit_author:
             commit_username = commit_author.get_username_from_external_id()
             if commit_username:
+                _record_username_resolution("commit_author", referrer)
                 return commit_username
 
+    _record_username_resolution("none", referrer)
     return None
+
+
+def _record_username_resolution(source: str, referrer: str) -> None:
+    metrics.incr(
+        "seer.github_username_for_user",
+        tags={"source": source, "referrer": referrer},
+    )

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -5,14 +5,14 @@ import orjson
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
-from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
-from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
+from sentry.seer.autofix.pr_iteration.check_suites import (
     CheckSuiteAutofixRun,
-    CheckSuiteFeedbackSource,
     GithubCheckSuiteEvent,
     resolve_check_suite_autofix_run,
 )
+from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
     GithubPullRequestReviewComment,
@@ -25,6 +25,7 @@ from sentry.testutils.cases import TestCase
 
 CHECK_PATH = "sentry.seer.autofix.pr_iteration.listeners.check_suite"
 CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
+CHECK_SUITES_PATH = "sentry.seer.autofix.pr_iteration.check_suites"
 # Lazy-imported inside the listener (must not load at AppConfig.ready).
 TRIGGER_CONSUME_PATH = "sentry.tasks.seer.pr_iteration.trigger_consume_pr_iteration_feedback"
 
@@ -79,24 +80,36 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
             metadata={"group_id": self.group.id},
         )
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     def test_skips_non_completed_action(self, mock_get_state: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(action="requested"))
         mock_get_state.assert_not_called()
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     def test_skips_uninteresting_conclusion(self, mock_get_state: MagicMock) -> None:
-        pr_iteration_from_check_suite_listener(self._event(conclusion="success"))
+        pr_iteration_from_check_suite_listener(self._event(conclusion="cancelled"))
         mock_get_state.assert_not_called()
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories", return_value=[])
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_PATH}.request_review_for_green_check_suite")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    def test_green_conclusion_routes_to_review_request(
+        self, mock_get_state: MagicMock, mock_request_review: MagicMock
+    ) -> None:
+        event = self._event(self._raw(), conclusion="success")
+
+        pr_iteration_from_check_suite_listener(event)
+
+        mock_request_review.assert_called_once_with(event)
+        mock_get_state.assert_not_called()
+
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories", return_value=[])
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     def test_no_repository(self, mock_get_state: MagicMock, _mock_resolve: MagicMock) -> None:
         pr_iteration_from_check_suite_listener(self._event(self._raw()))
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     def test_invalid_payload_captures_and_returns(
         self, mock_get_state: MagicMock, mock_capture: MagicMock
     ) -> None:
@@ -107,7 +120,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.sentry_sdk.capture_exception")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
     def test_invalid_json_captures_and_returns(
         self, mock_get_state: MagicMock, mock_capture: MagicMock
     ) -> None:
@@ -118,8 +131,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state.assert_not_called()
 
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id", return_value=None)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id", return_value=None)
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_skips_pr_without_run(
         self,
         mock_resolve: MagicMock,
@@ -134,8 +147,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_enqueue.assert_not_called()
 
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_skips_run_missing_group_id(
         self,
         mock_resolve: MagicMock,
@@ -154,8 +167,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=False)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_does_not_trigger_when_not_enqueued(
         self,
         mock_resolve: MagicMock,
@@ -173,8 +186,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_enqueues_and_triggers_for_matched_run(
         self,
         mock_resolve: MagicMock,
@@ -203,11 +216,11 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert autofix.run_state is not None
         mock_trigger_consume.assert_called_once()
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.sentry_sdk.capture_exception")
+    @patch(f"{CHECK_SUITES_PATH}.sentry_sdk.capture_exception")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_seer_error_on_one_pr_continues_to_remaining(
         self,
         mock_resolve: MagicMock,
@@ -232,8 +245,8 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_tries_each_org_until_agent_state_found(
         self,
         mock_resolve: MagicMock,
@@ -283,9 +296,9 @@ class ResolveCheckSuiteAutofixRunTest(TestCase):
             metadata={"group_id": 1},
         )
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.logger")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.get_agent_state_from_pr_id")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.resolve_check_suite_repositories")
+    @patch(f"{CHECK_SUITES_PATH}.logger")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
     def test_warns_and_returns_first_when_multiple_matches(
         self,
         mock_resolve: MagicMock,
@@ -436,8 +449,8 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert not self._source().should_queue(self._run_state_on_head(blocks=blocks))
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_not_capped_when_fewer_than_cap_iterations(self, mock_new: MagicMock, _pages) -> None:
         mock_new.return_value = MagicMock()
@@ -445,8 +458,8 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_not_capped_when_one_iteration_has_human_feedback(
         self, mock_new: MagicMock, _pages
@@ -479,8 +492,8 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) is None
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_not_capped_when_human_review_breaks_mixed_streak(
         self, mock_new: MagicMock, _pages
@@ -497,8 +510,8 @@ class CheckSuiteHardCapTest(TestCase):
 
         assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_cap_disabled_when_zero(self, mock_new: MagicMock, _pages) -> None:
         mock_new.return_value = MagicMock()
@@ -507,8 +520,8 @@ class CheckSuiteHardCapTest(TestCase):
         with self.options({"autofix.pr-iteration.max-iterations": 0}):
             assert self._source().should_trigger(_run_state(blocks=blocks)) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", return_value=[{"data": []}])
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", return_value=[{"data": []}])
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_empty_after_parse_iteration_counts_as_automated(
         self, mock_new: MagicMock, _pages

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -2,9 +2,9 @@ from unittest.mock import MagicMock, patch
 
 from sentry.seer.agent.client_models import RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.check_suites import CheckSuiteAutofixRun
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
-    CheckSuiteAutofixRun,
     CheckSuiteFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -234,6 +234,8 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         with self.feature(FLAG):
             request_review_for_green_check_suite(_green_event())
 
+        # The marker pre-check must short-circuit before any SCM work.
+        mock_actions.get_pull_request.assert_not_called()
         mock_actions.request_review.assert_not_called()
 
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
@@ -373,7 +375,12 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
             request_review_for_green_check_suite(_green_event())
 
         mock_actions.request_review.assert_not_called()
-        assert self._marker() is None
+        # The existing request is recorded as a preexisting marker so later
+        # green events short-circuit before any SCM calls.
+        marker = self._marker()
+        assert marker is not None
+        assert marker["reviewers"] == ["octocat"]
+        assert marker["preexisting"] is True
 
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -151,15 +151,19 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         mock_actions.request_review.assert_not_called()
         assert self._marker() is None
 
+    @patch(f"{REVIEW_REQUEST_PATH}.metrics")
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run", return_value=None)
     def test_noop_when_no_run_resolved(
-        self, _mock_resolve: MagicMock, mock_actions: MagicMock
+        self, _mock_resolve: MagicMock, mock_actions: MagicMock, mock_metrics: MagicMock
     ) -> None:
         with self.feature(FLAG):
             request_review_for_green_check_suite(_green_event())
 
         mock_actions.request_review.assert_not_called()
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.review_request.run_resolved", tags={"found": "false"}
+        )
 
     @patch(f"{REVIEW_REQUEST_PATH}.sentry_sdk.capture_exception")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
@@ -390,7 +394,10 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         mock_actions.get_pull_request.return_value = _pull_request_result()
         mock_actions.request_review.side_effect = Exception("boom")
 
-        with self.feature(FLAG):
+        with self.feature(FLAG), patch(f"{REVIEW_REQUEST_PATH}.metrics") as mock_metrics:
             request_review_for_green_check_suite(_green_event())
 
         assert self._marker() is None
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.review_request.error", tags={"reason": "request_review_failed"}
+        )

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -15,6 +15,7 @@ from sentry.seer.autofix.pr_iteration.reviewer_candidates import (
     SOURCE_TRIGGERING_USER,
     ReviewerCandidate,
 )
+from sentry.seer.models.run import SeerRun
 from sentry.testutils.cases import TestCase
 
 REVIEW_REQUEST_PATH = "sentry.seer.autofix.pr_iteration.review_request"
@@ -433,6 +434,32 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         mock_metrics.incr.assert_any_call(
             "autofix.pr_iteration.review_request.failed", tags={"reason": "request_review_failed"}
         )
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_skips_when_run_deleted_before_marker_write(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+
+        with (
+            self.feature(FLAG),
+            patch.object(SeerRun, "refresh_from_db", side_effect=SeerRun.DoesNotExist),
+        ):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
 
 
 # Provenance is opaque to the request flow — the wiring must work for any

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -1,0 +1,396 @@
+from unittest.mock import MagicMock, patch
+
+import orjson
+
+from sentry.scm.types import CheckSuiteEvent
+from sentry.seer.agent.client_models import RepoPRState, SeerRunState
+from sentry.seer.autofix.pr_iteration.check_suites import CheckRunsSweep, CheckSuiteAutofixRun
+from sentry.seer.autofix.pr_iteration.review_request import (
+    REVIEW_REQUESTS_EXTRA,
+    request_review_for_green_check_suite,
+)
+from sentry.testutils.cases import TestCase
+
+REVIEW_REQUEST_PATH = "sentry.seer.autofix.pr_iteration.review_request"
+FLAG = "organizations:autofix-pr-iteration-review-request"
+
+RUN_ID = 67890
+REPO_NAME = "owner/repo"
+HEAD_SHA = "abc"
+PR_NUMBER = 42
+
+GREEN_SWEEP = CheckRunsSweep(total=3, incomplete=0, failed=0)
+
+
+def _green_event(raw: dict | None = None) -> CheckSuiteEvent:
+    if raw is None:
+        raw = {
+            "check_suite": {
+                "id": 1,
+                "head_sha": HEAD_SHA,
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {"html_url": "https://github.com/owner/repo", "full_name": REPO_NAME},
+        }
+    return CheckSuiteEvent(
+        action="completed",
+        check_suite={
+            "id": "1",
+            "status": "completed",
+            "conclusion": "success",
+            "html_url": "",
+            "pull_request_ids": [],
+        },
+        subscription_event={
+            "event": orjson.dumps(raw).decode(),
+            "event_type_hint": "check_suite",
+            "extra": {},
+            "received_at": 0,
+            "sentry_meta": None,
+            "type": "github",
+        },
+    )
+
+
+def _pull_request_result(
+    *, state: str = "open", merged: bool = False, requested_reviewers: list[dict] | None = None
+) -> dict:
+    return {
+        "data": {"state": state, "merged": merged},
+        "raw": {"headers": None, "data": {"requested_reviewers": requested_reviewers or []}},
+        "type": "github",
+        "meta": {},
+    }
+
+
+class RequestReviewForGreenCheckSuiteTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(
+            project=self.project, provider="integrations:github", name=REPO_NAME
+        )
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=RUN_ID, user_id=self.user.id
+        )
+        repos_patcher = patch(
+            f"{REVIEW_REQUEST_PATH}.resolve_check_suite_repositories", return_value=[self.repo]
+        )
+        repos_patcher.start()
+        self.addCleanup(repos_patcher.stop)
+
+    def _resolved(self, *, commit_sha: str = HEAD_SHA) -> CheckSuiteAutofixRun:
+        run_state = SeerRunState(
+            run_id=RUN_ID,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                REPO_NAME: RepoPRState(
+                    repo_name=REPO_NAME, commit_sha=commit_sha, pr_number=PR_NUMBER
+                )
+            },
+        )
+        return CheckSuiteAutofixRun(
+            repository=self.repo, run_state=run_state, pr_id=555, group_id=1
+        )
+
+    def _marker(self) -> dict | None:
+        self.seer_run.refresh_from_db()
+        return (self.seer_run.extras or {}).get(REVIEW_REQUESTS_EXTRA, {}).get(REPO_NAME)
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_requests_review_from_triggering_user(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        scm, pr_number, reviewers = mock_actions.request_review.call_args[0]
+        assert pr_number == str(PR_NUMBER)
+        assert reviewers == ["octocat"]
+        marker = self._marker()
+        assert marker is not None
+        assert marker["reviewer"] == "octocat"
+        assert marker["head_sha"] == HEAD_SHA
+        assert marker["requested_at"]
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_noop_when_flag_disabled(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+
+        request_review_for_green_check_suite(_green_event())
+
+        # The flag gate runs before any Seer lookup so disabled orgs cost nothing.
+        mock_resolve.assert_not_called()
+        mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run", return_value=None)
+    def test_noop_when_no_run_resolved(
+        self, _mock_resolve: MagicMock, mock_actions: MagicMock
+    ) -> None:
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.sentry_sdk.capture_exception")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_invalid_payload_captures_and_returns(
+        self, mock_resolve: MagicMock, mock_capture: MagicMock
+    ) -> None:
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event(raw={"check_suite": {"id": 1}}))
+
+        mock_capture.assert_called_once()
+        mock_resolve.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_stale_head(self, mock_resolve: MagicMock, mock_actions: MagicMock) -> None:
+        mock_resolve.return_value = self._resolved(commit_sha="newer-sha")
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_night_shift_run_without_user(
+        self, mock_resolve: MagicMock, mock_actions: MagicMock
+    ) -> None:
+        self.seer_run.update(user_id=None)
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_when_no_seer_run_row(
+        self, mock_resolve: MagicMock, mock_actions: MagicMock
+    ) -> None:
+        self.seer_run.delete()
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_when_already_requested(
+        self, mock_resolve: MagicMock, mock_actions: MagicMock
+    ) -> None:
+        self.seer_run.update(
+            extras={
+                REVIEW_REQUESTS_EXTRA: {
+                    REPO_NAME: {
+                        "requested_at": "2024-01-01T00:00:00+00:00",
+                        "head_sha": "older-sha",
+                        "reviewer": "octocat",
+                    }
+                }
+            }
+        )
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value=None)
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_when_no_github_login(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=None)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_when_sweep_fails(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(
+        f"{REVIEW_REQUEST_PATH}.sweep_check_runs",
+        return_value=CheckRunsSweep(total=3, incomplete=1, failed=0),
+    )
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_when_checks_incomplete(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(
+        f"{REVIEW_REQUEST_PATH}.sweep_check_runs",
+        return_value=CheckRunsSweep(total=3, incomplete=0, failed=1),
+    )
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    def test_skips_when_checks_failed(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_skips_when_pr_not_open(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            state="closed", merged=True
+        )
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_skips_when_already_in_requested_reviewers(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            requested_reviewers=[{"login": "Octocat"}]
+        )
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_request_failure_leaves_marker_unset(
+        self,
+        mock_resolve: MagicMock,
+        _mock_username: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+        mock_actions.request_review.side_effect = Exception("boom")
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        assert self._marker() is None

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -9,9 +10,15 @@ from sentry.seer.autofix.pr_iteration.review_request import (
     REVIEW_REQUESTS_EXTRA,
     request_review_for_green_check_suite,
 )
+from sentry.seer.autofix.pr_iteration.reviewer_candidates import (
+    REVIEWER_CANDIDATES_EXTRA,
+    SOURCE_TRIGGERING_USER,
+    ReviewerCandidate,
+)
 from sentry.testutils.cases import TestCase
 
 REVIEW_REQUEST_PATH = "sentry.seer.autofix.pr_iteration.review_request"
+CANDIDATES_PATH = "sentry.seer.autofix.pr_iteration.reviewer_candidates"
 FLAG = "organizations:autofix-pr-iteration-review-request"
 
 RUN_ID = 67890
@@ -54,17 +61,26 @@ def _green_event(raw: dict | None = None) -> CheckSuiteEvent:
 
 
 def _pull_request_result(
-    *, state: str = "open", merged: bool = False, requested_reviewers: list[dict] | None = None
+    *,
+    state: str = "open",
+    merged: bool = False,
+    requested_reviewers: list[dict] | None = None,
+    author: str | None = None,
 ) -> dict:
+    raw: dict[str, Any] = {"requested_reviewers": requested_reviewers or []}
+    if author is not None:
+        raw["user"] = {"login": author}
     return {
         "data": {"state": state, "merged": merged},
-        "raw": {"headers": None, "data": {"requested_reviewers": requested_reviewers or []}},
+        "raw": {"headers": None, "data": raw},
         "type": "github",
         "meta": {},
     }
 
 
 class RequestReviewForGreenCheckSuiteTest(TestCase):
+    """End-to-end through the real candidate collection."""
+
     def setUp(self) -> None:
         super().setUp()
         self.repo = self.create_repo(
@@ -95,14 +111,14 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
             repository=self.repo, run_state=run_state, pr_id=555, group_id=1
         )
 
-    def _marker(self) -> dict | None:
+    def _marker(self, extra_key: str = REVIEW_REQUESTS_EXTRA) -> dict | None:
         self.seer_run.refresh_from_db()
-        return (self.seer_run.extras or {}).get(REVIEW_REQUESTS_EXTRA, {}).get(REPO_NAME)
+        return (self.seer_run.extras or {}).get(extra_key, {}).get(REPO_NAME)
 
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
     @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
@@ -128,16 +144,19 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         assert marker["reviewers"] == ["octocat"]
         assert marker["head_sha"] == HEAD_SHA
         assert marker["requested_at"]
+        candidates_marker = self._marker(REVIEWER_CANDIDATES_EXTRA)
+        assert candidates_marker is not None
+        assert candidates_marker["candidates"] == [
+            {"login": "octocat", "source": SOURCE_TRIGGERING_USER}
+        ]
 
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     def test_noop_when_flag_disabled(
         self,
         mock_resolve: MagicMock,
-        _mock_username: MagicMock,
         _mock_sweep: MagicMock,
         _mock_scm: MagicMock,
         mock_actions: MagicMock,
@@ -188,17 +207,28 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         assert self._marker() is None
 
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
-    def test_skips_night_shift_run_without_user(
-        self, mock_resolve: MagicMock, mock_actions: MagicMock
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_skips_night_shift_run_without_candidates(
+        self,
+        mock_resolve: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
     ) -> None:
+        # No triggering user, so no candidate resolves.
         self.seer_run.update(user_id=None)
         mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
 
         with self.feature(FLAG):
             request_review_for_green_check_suite(_green_event())
 
         mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
 
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
@@ -241,9 +271,11 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value=None)
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value=None)
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
-    def test_skips_when_no_github_login(
+    @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+    def test_skips_when_no_candidate_resolves(
         self,
         mock_resolve: MagicMock,
         _mock_username: MagicMock,
@@ -252,6 +284,7 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         mock_actions: MagicMock,
     ) -> None:
         mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
 
         with self.feature(FLAG):
             request_review_for_green_check_suite(_green_event())
@@ -262,12 +295,10 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=None)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     def test_skips_when_sweep_fails(
         self,
         mock_resolve: MagicMock,
-        _mock_username: MagicMock,
         _mock_sweep: MagicMock,
         _mock_scm: MagicMock,
         mock_actions: MagicMock,
@@ -285,12 +316,10 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         f"{REVIEW_REQUEST_PATH}.sweep_check_runs",
         return_value=CheckRunsSweep(total=3, incomplete=1, failed=0),
     )
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     def test_skips_when_checks_incomplete(
         self,
         mock_resolve: MagicMock,
-        _mock_username: MagicMock,
         _mock_sweep: MagicMock,
         _mock_scm: MagicMock,
         mock_actions: MagicMock,
@@ -308,12 +337,10 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         f"{REVIEW_REQUEST_PATH}.sweep_check_runs",
         return_value=CheckRunsSweep(total=3, incomplete=0, failed=1),
     )
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     def test_skips_when_checks_failed(
         self,
         mock_resolve: MagicMock,
-        _mock_username: MagicMock,
         _mock_sweep: MagicMock,
         _mock_scm: MagicMock,
         mock_actions: MagicMock,
@@ -328,14 +355,12 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
     @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
     def test_skips_when_pr_not_open(
         self,
         mock_resolve: MagicMock,
-        _mock_username: MagicMock,
         _mock_sweep: MagicMock,
         _mock_scm: MagicMock,
         mock_actions: MagicMock,
@@ -354,7 +379,7 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
     @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
@@ -385,7 +410,7 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
     @patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
     @patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
-    @patch(f"{REVIEW_REQUEST_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="octocat")
     @patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
     @patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
     @patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
@@ -408,3 +433,173 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         mock_metrics.incr.assert_any_call(
             "autofix.pr_iteration.review_request.failed", tags={"reason": "request_review_failed"}
         )
+
+
+# Provenance is opaque to the request flow — the wiring must work for any
+# ranked list the collector produces.
+CANDIDATES = [
+    ReviewerCandidate(login="reviewer-one", source="source-one"),
+    ReviewerCandidate(login="reviewer-two", source="source-two"),
+]
+
+
+@patch(f"{REVIEW_REQUEST_PATH}.collect_reviewer_candidates", return_value=CANDIDATES)
+@patch(f"{REVIEW_REQUEST_PATH}.scm_actions")
+@patch("sentry.scm.factory.new", return_value=MagicMock())
+@patch(f"{REVIEW_REQUEST_PATH}.sweep_check_runs", return_value=GREEN_SWEEP)
+@patch(f"{REVIEW_REQUEST_PATH}.resolve_check_suite_autofix_run")
+@patch(f"{REVIEW_REQUEST_PATH}.GetPullRequestProtocol", object)
+@patch(f"{REVIEW_REQUEST_PATH}.RequestReviewProtocol", object)
+class RequestReviewFromCandidatesTest(TestCase):
+    """Wiring of the (mocked) candidate list into the request flow: markers,
+    the preexisting-reviewer check, and request-failure fallback."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(
+            project=self.project, provider="integrations:github", name=REPO_NAME
+        )
+        # A system run: candidate selection must work without a triggering user.
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=RUN_ID, user_id=None
+        )
+        repos_patcher = patch(
+            f"{REVIEW_REQUEST_PATH}.resolve_check_suite_repositories", return_value=[self.repo]
+        )
+        repos_patcher.start()
+        self.addCleanup(repos_patcher.stop)
+
+    def _resolved(self) -> CheckSuiteAutofixRun:
+        run_state = SeerRunState(
+            run_id=RUN_ID,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                REPO_NAME: RepoPRState(
+                    repo_name=REPO_NAME, commit_sha=HEAD_SHA, pr_number=PR_NUMBER
+                )
+            },
+        )
+        return CheckSuiteAutofixRun(
+            repository=self.repo, run_state=run_state, pr_id=555, group_id=1
+        )
+
+    def _marker(self, extra_key: str = REVIEW_REQUESTS_EXTRA) -> dict | None:
+        self.seer_run.refresh_from_db()
+        return (self.seer_run.extras or {}).get(extra_key, {}).get(REPO_NAME)
+
+    def test_requests_top_candidate_and_records_provenance(
+        self,
+        mock_resolve: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        mock_collect: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result(author="seer[bot]")
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        _scm, pr_number, reviewers = mock_actions.request_review.call_args[0]
+        assert pr_number == str(PR_NUMBER)
+        assert reviewers == ["reviewer-one"]
+        assert mock_collect.call_args.kwargs["exclude_logins"] == {"seer[bot]"}
+        marker = self._marker()
+        assert marker is not None
+        assert marker["reviewers"] == ["reviewer-one"]
+        candidates_marker = self._marker(REVIEWER_CANDIDATES_EXTRA)
+        assert candidates_marker is not None
+        assert candidates_marker["head_sha"] == HEAD_SHA
+        assert candidates_marker["candidates"] == [
+            {"login": "reviewer-one", "source": "source-one"},
+            {"login": "reviewer-two", "source": "source-two"},
+        ]
+
+    def test_skips_when_no_candidates(
+        self,
+        mock_resolve: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        mock_collect: MagicMock,
+    ) -> None:
+        mock_collect.return_value = []
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+        assert self._marker() is None
+        assert self._marker(REVIEWER_CANDIDATES_EXTRA) is None
+
+    def test_records_preexisting_when_any_candidate_already_requested(
+        self,
+        mock_resolve: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_collect: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        # The lower-ranked candidate is already on the hook (e.g. CODEOWNERS
+        # auto-request) — adding a second person would rebuild the bystander
+        # effect, so no request is made.
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            requested_reviewers=[{"login": "Reviewer-Two"}]
+        )
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        mock_actions.request_review.assert_not_called()
+        marker = self._marker()
+        assert marker is not None
+        assert marker["reviewers"] == ["reviewer-two"]
+        assert marker["preexisting"] is True
+
+    def test_falls_back_to_next_candidate_when_request_fails(
+        self,
+        mock_resolve: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_collect: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+        mock_actions.request_review.side_effect = [Exception("no repo access"), None]
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        _scm, _pr_number, reviewers = mock_actions.request_review.call_args[0]
+        assert reviewers == ["reviewer-two"]
+        marker = self._marker()
+        assert marker is not None
+        assert marker["reviewers"] == ["reviewer-two"]
+
+    def test_no_request_marker_when_all_attempts_fail(
+        self,
+        mock_resolve: MagicMock,
+        _mock_sweep: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_collect: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = self._resolved()
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+        mock_actions.request_review.side_effect = Exception("no repo access")
+
+        with self.feature(FLAG):
+            request_review_for_green_check_suite(_green_event())
+
+        assert mock_actions.request_review.call_count == len(CANDIDATES)
+        # The request marker stays unset so the next green event retries, but
+        # the computed candidates are kept as re-request fallbacks.
+        assert self._marker() is None
+        assert self._marker(REVIEWER_CANDIDATES_EXTRA) is not None

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -125,7 +125,7 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
         assert reviewers == ["octocat"]
         marker = self._marker()
         assert marker is not None
-        assert marker["reviewer"] == "octocat"
+        assert marker["reviewers"] == ["octocat"]
         assert marker["head_sha"] == HEAD_SHA
         assert marker["requested_at"]
 
@@ -224,7 +224,7 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
                     REPO_NAME: {
                         "requested_at": "2024-01-01T00:00:00+00:00",
                         "head_sha": "older-sha",
-                        "reviewer": "octocat",
+                        "reviewers": ["octocat"],
                     }
                 }
             }

--- a/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_review_request.py
@@ -399,5 +399,5 @@ class RequestReviewForGreenCheckSuiteTest(TestCase):
 
         assert self._marker() is None
         mock_metrics.incr.assert_any_call(
-            "autofix.pr_iteration.review_request.error", tags={"reason": "request_review_failed"}
+            "autofix.pr_iteration.review_request.failed", tags={"reason": "request_review_failed"}
         )

--- a/tests/sentry/seer/autofix/pr_iteration/test_reviewer_candidates.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_reviewer_candidates.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.seer.autofix.pr_iteration.reviewer_candidates import (
+    REVIEWER_CANDIDATES_EXTRA,
+    SOURCE_TRIGGERING_USER,
+    ReviewerCandidate,
+    collect_reviewer_candidates,
+    get_reviewer_candidates_marker,
+    record_reviewer_candidates_marker,
+)
+from sentry.testutils.cases import TestCase
+
+CANDIDATES_PATH = "sentry.seer.autofix.pr_iteration.reviewer_candidates"
+
+RUN_ID = 67890
+REPO_NAME = "owner/repo"
+
+
+class CollectReviewerCandidatesTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=RUN_ID, user_id=self.user.id
+        )
+
+    def _collect(self, **kwargs) -> list[ReviewerCandidate]:
+        return collect_reviewer_candidates(
+            organization=self.organization,
+            seer_run=self.seer_run,
+            log_extra={},
+            **kwargs,
+        )
+
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="trigger-dev")
+    def test_triggering_user_is_the_candidate(self, _mock_username: MagicMock) -> None:
+        assert self._collect() == [
+            ReviewerCandidate(login="trigger-dev", source=SOURCE_TRIGGERING_USER)
+        ]
+
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value=None)
+    def test_empty_when_no_source_resolves(self, _mock_username: MagicMock) -> None:
+        assert self._collect() == []
+
+    def test_empty_for_run_without_user(self) -> None:
+        self.seer_run.update(user_id=None)
+        assert self._collect() == []
+
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="renovate[bot]")
+    def test_filters_bot_logins(self, _mock_username: MagicMock) -> None:
+        assert self._collect() == []
+
+    @patch(f"{CANDIDATES_PATH}.get_github_username_for_user", return_value="trigger-dev")
+    def test_excludes_given_logins(self, _mock_username: MagicMock) -> None:
+        assert self._collect(exclude_logins={"Trigger-Dev"}) == []
+
+    @patch(f"{CANDIDATES_PATH}.metrics")
+    @patch(
+        f"{CANDIDATES_PATH}.get_github_username_for_user", side_effect=Exception("identity down")
+    )
+    def test_failing_source_is_counted_not_raised(
+        self, _mock_username: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        assert self._collect() == []
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.reviewer_candidates.source_failed",
+            tags={"source": SOURCE_TRIGGERING_USER},
+        )
+
+
+class ReviewerCandidatesMarkerTest(TestCase):
+    def test_roundtrip(self) -> None:
+        seer_run = self.create_seer_run(organization=self.organization, seer_run_state_id=RUN_ID)
+        # Provenance is opaque at the marker layer — any source label roundtrips.
+        candidates = [
+            ReviewerCandidate(login="reviewer-one", source="source-one"),
+            ReviewerCandidate(login="reviewer-two", source="source-two"),
+        ]
+
+        record_reviewer_candidates_marker(
+            seer_run, REPO_NAME, head_sha="abc", candidates=candidates
+        )
+
+        seer_run.refresh_from_db()
+        marker = get_reviewer_candidates_marker(seer_run, REPO_NAME)
+        assert marker is not None
+        assert marker["head_sha"] == "abc"
+        assert marker["computed_at"]
+        assert marker["candidates"] == [
+            {"login": "reviewer-one", "source": "source-one"},
+            {"login": "reviewer-two", "source": "source-two"},
+        ]
+        assert (seer_run.extras or {}).get(REVIEWER_CANDIDATES_EXTRA, {}).get(REPO_NAME) == marker

--- a/tests/sentry/seer/autofix/pr_iteration/test_run_markers.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_run_markers.py
@@ -1,0 +1,72 @@
+from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
+from sentry.seer.models.run import SeerRun
+from sentry.testutils.cases import TestCase
+
+REPO_NAME = "owner/repo"
+
+
+class RunMarkersTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=1, user_id=self.user.id
+        )
+
+    def test_records_and_reads_marker(self) -> None:
+        record_run_marker(self.seer_run, "review_requests", REPO_NAME, {"reviewers": ["octocat"]})
+
+        self.seer_run.refresh_from_db()
+        assert get_run_marker(self.seer_run, "review_requests", REPO_NAME) == {
+            "reviewers": ["octocat"]
+        }
+        assert get_run_marker(self.seer_run, "review_requests", "other/repo") is None
+        assert get_run_marker(self.seer_run, "cap_exhausted", REPO_NAME) is None
+
+    def test_stale_instance_preserves_other_features_marker(self) -> None:
+        # Two features race on the same run: each loads its own instance, then
+        # writes its own marker key. The second write must not clobber the
+        # first even though its in-memory instance predates it.
+        stale = SeerRun.objects.get(id=self.seer_run.id)
+        record_run_marker(self.seer_run, "review_requests", REPO_NAME, {"reviewers": ["octocat"]})
+
+        record_run_marker(stale, "cap_exhausted", REPO_NAME, {"assignees": ["octocat"]})
+
+        self.seer_run.refresh_from_db()
+        assert get_run_marker(self.seer_run, "review_requests", REPO_NAME) == {
+            "reviewers": ["octocat"]
+        }
+        assert get_run_marker(self.seer_run, "cap_exhausted", REPO_NAME) == {
+            "assignees": ["octocat"]
+        }
+
+    def test_stale_instance_preserves_other_repos_marker(self) -> None:
+        stale = SeerRun.objects.get(id=self.seer_run.id)
+        record_run_marker(self.seer_run, "review_requests", "other/repo", {"reviewers": ["alice"]})
+
+        record_run_marker(stale, "review_requests", REPO_NAME, {"reviewers": ["octocat"]})
+
+        self.seer_run.refresh_from_db()
+        assert get_run_marker(self.seer_run, "review_requests", "other/repo") == {
+            "reviewers": ["alice"]
+        }
+        assert get_run_marker(self.seer_run, "review_requests", REPO_NAME) == {
+            "reviewers": ["octocat"]
+        }
+
+    def test_overwrites_same_feature_and_repo(self) -> None:
+        record_run_marker(self.seer_run, "review_requests", REPO_NAME, {"reviewers": ["octocat"]})
+        record_run_marker(self.seer_run, "review_requests", REPO_NAME, {"reviewers": ["alice"]})
+
+        self.seer_run.refresh_from_db()
+        assert get_run_marker(self.seer_run, "review_requests", REPO_NAME) == {
+            "reviewers": ["alice"]
+        }
+
+    def test_updates_caller_instance_in_memory(self) -> None:
+        record_run_marker(self.seer_run, "review_requests", REPO_NAME, {"reviewers": ["octocat"]})
+
+        # The caller's instance reflects the write without a refresh, so marker
+        # re-checks against it see the fresh state.
+        assert get_run_marker(self.seer_run, "review_requests", REPO_NAME) == {
+            "reviewers": ["octocat"]
+        }

--- a/tests/sentry/seer/autofix/pr_iteration/test_types.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_types.py
@@ -5,6 +5,12 @@ import pytest
 from pydantic import ValidationError
 
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
+from sentry.seer.autofix.pr_iteration.check_suites import (
+    CheckSuiteAutofixRun,
+    GithubCheckSuiteEvent,
+    get_check_suite_url,
+    resolve_check_suite_repositories,
+)
 from sentry.seer.autofix.pr_iteration.feedback import (
     Feedback,
     parse_feedback,
@@ -12,12 +18,8 @@ from sentry.seer.autofix.pr_iteration.feedback import (
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
-    CheckSuiteAutofixRun,
     CheckSuiteFeedbackSource,
-    GithubCheckSuiteEvent,
     MissingCheckSuiteAutofixRun,
-    get_check_suite_url,
-    resolve_check_suite_repositories,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubIssueComment,
@@ -30,6 +32,7 @@ from sentry.testutils.cases import TestCase
 from sentry.utils import json
 
 CHECK_SUITE_SOURCE_PATH = "sentry.seer.autofix.pr_iteration.feedback_sources.check_suite"
+CHECK_SUITES_PATH = "sentry.seer.autofix.pr_iteration.check_suites"
 
 
 def _check_suite_event(*, updated_at: str | None = "2024-01-01T00:00:00Z") -> dict:
@@ -705,15 +708,15 @@ class CheckSuiteShouldTriggerTest(TestCase):
     def test_now_when_scm_init_fails(self, _mock_new: MagicMock) -> None:
         assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", type("Other", (), {}))
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", type("Other", (), {}))
     @patch("sentry.scm.factory.new")
     def test_now_when_unsupported_provider(self, mock_new: MagicMock) -> None:
         mock_new.return_value = MagicMock()
 
         assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages")
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_later_when_a_check_suite_not_completed(
         self,
@@ -725,8 +728,8 @@ class CheckSuiteShouldTriggerTest(TestCase):
 
         assert self._source().should_trigger(_run_state()) == ConsumeTask.Later(timedelta(hours=1))
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages")
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages")
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_now_when_all_completed(
         self,
@@ -738,8 +741,8 @@ class CheckSuiteShouldTriggerTest(TestCase):
 
         assert self._source().should_trigger(_run_state()) == ConsumeTask.Now
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.iter_all_pages", side_effect=Exception("boom"))
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.ListCheckRunsForRefProtocol", object)
+    @patch(f"{CHECK_SUITES_PATH}.iter_all_pages", side_effect=Exception("boom"))
+    @patch(f"{CHECK_SUITES_PATH}.ListCheckRunsForRefProtocol", object)
     @patch("sentry.scm.factory.new")
     def test_now_when_list_check_suites_fails(
         self,
@@ -764,7 +767,7 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
             == []
         )
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
+    @patch(f"{CHECK_SUITES_PATH}.integration_service.organization_contexts")
     def test_empty_when_no_integration(self, mock_contexts: MagicMock) -> None:
         mock_contexts.return_value = MagicMock(integration=None, organization_integrations=[])
 
@@ -780,7 +783,7 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
 
         assert result == []
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
+    @patch(f"{CHECK_SUITES_PATH}.integration_service.organization_contexts")
     def test_returns_matching_repos(self, mock_contexts: MagicMock) -> None:
         repo = self.create_repo(
             project=self.project,
@@ -805,7 +808,7 @@ class ResolveCheckSuiteRepositoriesTest(TestCase):
 
         assert [r.id for r in result] == [repo.id]
 
-    @patch(f"{CHECK_SUITE_SOURCE_PATH}.integration_service.organization_contexts")
+    @patch(f"{CHECK_SUITES_PATH}.integration_service.organization_contexts")
     def test_returns_all_matching_repos_across_orgs(self, mock_contexts: MagicMock) -> None:
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -595,6 +596,62 @@ class TestGetGithubUsernameForUser(TestCase):
 
         username = get_github_username_for_user(user, organization.id)
         assert username == "ghuser"
+
+    @patch("sentry.seer.utils.metrics.incr")
+    def test_get_github_username_for_user_records_resolution_source(
+        self, mock_incr: MagicMock
+    ) -> None:
+        """Tests that each resolution outcome is counted with its source and referrer."""
+        from sentry.integrations.models.external_actor import ExternalActor
+        from sentry.integrations.types import ExternalProviders
+        from sentry.models.commitauthor import CommitAuthor
+
+        organization = self.create_organization()
+
+        mapped_user = self.create_user()
+        ExternalActor.objects.create(
+            user_id=mapped_user.id,
+            organization=organization,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="@mapped",
+            external_id="1",
+            integration_id=1,
+        )
+        committer = self.create_user(email="committer@example.com")
+        self.create_member(user=committer, organization=organization)
+        CommitAuthor.objects.create(
+            organization_id=organization.id,
+            name="Committer",
+            email="committer@example.com",
+            external_id="github:committer",
+        )
+        unmapped_user = self.create_user()
+
+        get_github_username_for_user(mapped_user, organization.id, referrer="pr_review_request")
+        get_github_username_for_user(committer, organization.id, referrer="pr_review_request")
+        get_github_username_for_user(unmapped_user, organization.id)
+
+        # `sentry.seer.utils.metrics` is the shared metrics module, so the mock
+        # also sees unrelated counters (e.g. lock bookkeeping); filter to ours.
+        resolution_calls = [
+            c
+            for c in mock_incr.call_args_list
+            if c.args and c.args[0] == "seer.github_username_for_user"
+        ]
+        assert resolution_calls == [
+            call(
+                "seer.github_username_for_user",
+                tags={"source": "external_actor", "referrer": "pr_review_request"},
+            ),
+            call(
+                "seer.github_username_for_user",
+                tags={"source": "commit_author", "referrer": "pr_review_request"},
+            ),
+            call(
+                "seer.github_username_for_user",
+                tags={"source": "none", "referrer": "unknown"},
+            ),
+        ]
 
     def test_get_github_username_for_user_external_actor_priority(self) -> None:
         """Tests that ExternalActor is checked before CommitAuthor."""

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -7,10 +7,10 @@ from sentry.seer.autofix.autofix_agent import (
     PrIterationNoPullRequestException,
 )
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.check_suites import CheckSuiteAutofixRun
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTask
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
-    CheckSuiteAutofixRun,
     CheckSuiteFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (


### PR DESCRIPTION
## Problem

Seer-authored PRs (autofix / explorer) often get no review — PR creation sets title/body/branch and nothing else, so the only review requests come from CODEOWNERS auto-requests, which are absent in many repos and team-level (diffuse) where they exist.

**Principle:** a review request from Seer always means *"CI is green, ready to judge."* This times an explicit, individual review request to the moment the PR is actually worth reviewing.

## What this does

Adds a success branch to the check-suite listener (which previously dropped all non-failure conclusions). On a green suite conclusion (`success`/`neutral`/`skipped`) for a Seer PR:

1. **Flag gate before any Seer lookup** — candidate orgs are filtered by the new `organizations:autofix-pr-iteration-review-request` flag first. Green suites fire for every commit on every PR in every connected repo, so disabled orgs cost only a DB/cache read.
2. **Head match** — green results for commits that are no longer the PR head are ignored, reusing the same head-match logic as the iteration path.
3. **Green confirmation** — a check-runs sweep across all suites on the head must show every run completed with none in `failure`/`timed_out`/`action_required`. If the sweep can't run, we skip: never request a review on uncertainty.
4. **Reviewer selection** — a new `reviewer_candidates` module returns a ranked candidate list with per-candidate provenance; today the only source is the triggering user (from the `SeerRun` mirror row), resolved to a GitHub login via the existing `get_github_username_for_user` (ExternalActor, then CommitAuthor fallback). Bots and the PR author are filtered. The computed list persists in `SeerRun.extras["reviewer_candidates"]` so later selection sources (suspect-commit author, code owners, recent committers — the follow-up PR in this stack) and re-request logic build on the same shape while we measure which source's reviewers respond. Skipped when no candidate resolves, when a candidate is already in `requested_reviewers` (e.g. CODEOWNERS — recorded as a `preexisting` marker so later green events short-circuit on the DB pre-check), or when the PR is closed/merged.
5. **Request + durable marker** — the top candidate is requested via the scm platform (with a bounded retry over the list when the provider rejects a login, e.g. no repo access), then a marker is recorded in `SeerRun.extras["review_requests"]` keyed by repo full name (`requested_at`, `head_sha`, `reviewers`). A lock + marker re-check handles concurrent green events (one suite per workflow); a fully failed request leaves the marker unset so the next green event retries. Storing the head SHA sets up later re-request-on-new-head logic.

Both markers persist through a shared `run_markers` helper that re-reads the row under `select_for_update` and merges only its own key, so concurrent features writing to the shared `extras` blob (e.g. the cap-exhausted handoff stacked above) can't clobber each other's markers.

## Metrics

The whole decision funnel is counted so rollout can be observed end to end:

- `seer.github_username_for_user` tagged `source: external_actor | commit_author | none` and `referrer` — how often the review user resolves, and which mapping provides it.
- `autofix.pr_iteration.review_request.run_resolved` tagged `found` — of green events in flagged orgs, how many belong to Seer PRs.
- `…reviewer_candidates.source_resolved` tagged `source`/`found` — per-source resolution rate (e.g. how often a triggering user exists but has no mappable GitHub identity); `…reviewer_candidates.source_failed` — a source lookup errored.
- `…reviewer_candidates.computed` tagged `top_source` (or `none`) — candidate availability at decision time.
- `…review_request.skipped` tagged `reason` (stale head, no marker-bearing run, not green, no candidates, already requested, PR closed, …) — expected exits.
- `…review_request.failed` tagged `reason` (`scm_init_failed`, `get_pull_request_failed`, `request_review_failed` — the latter also carries the candidate's `source`) — unexpected failures, alertable.
- `…review_request.requested` tagged `source` — successes, by candidate provenance.

## Refactor: `pr_iteration/check_suites.py`

The review-request path consumes the same webhook events as the iteration feedback path but isn't "feedback", so the check-suite event models, repository/run resolution, head matching, and the check-runs sweep move out of `feedback_sources/check_suite.py` into a new shared module. `CheckSuiteFeedbackSource` keeps only feedback concerns and delegates to it.

> **Why not `git mv` the whole file?** This is a split, not a relocation: `CheckSuiteFeedbackSource` plus the iteration hard-cap/dedupe logic stay behind in `feedback_sources/` (that package is one-module-per-source, and those pieces depend on feedback internals), so the original file survives with the feedback half and there is no whole-file move for git to track. Blame for the moved helpers therefore restarts in `check_suites.py`.

Behavioral deltas from the extraction, all inert for the iteration path:
- the sweep now also counts failed conclusions (needed by the green gate) and scans all pages instead of early-exiting on the first incomplete run;
- the sweep's log messages moved from the `…should_trigger.…` prefix to `…check_runs_sweep.…` — dashboards/alerts keyed on those names need updating.
