### PR TITLE
fix(difs): Jitter Objectstore multipart part upload retries

### DIFF
--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -7,6 +7,7 @@ import logging
 import math
 import os
 import os.path
+import random
 import re
 import shutil
 import tempfile
@@ -451,7 +452,8 @@ def _upload_dif_to_objectstore(
             except (RequestError, HTTPError):
                 if attempt == 2:
                     raise
-                time.sleep(2**attempt)
+                delay = 2 ** (attempt + 1)
+                time.sleep(random.uniform(delay, delay * 2))
         raise AssertionError("unreachable")
 
     def read_and_put_part(part_number: int) -> CompletePart | None:


### PR DESCRIPTION
Objectstore multipart debug-file uploads retry failed part PUTs with a longer exponential backoff and full jitter instead of a fixed `2**attempt` sleep.

Because parts are uploaded concurrently, identical retry delays can re-hit Objectstore together after a transient failure. Retries now wait a random duration in `[2**(attempt+1), 2**(attempt+2)]`, which spreads load while keeping the existing 3-attempt budget.
