### PR TITLE
fix(eslint): ignore linting agents directory

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -253,6 +253,7 @@ export default typescript.config([
   // https://eslint.org/docs/latest/use/configure/configuration-files#globally-ignoring-files-with-ignores
   globalIgnores([
     '.devenv/**/*',
+    '.agents/**/*',
     '.github/**/*',
     '.sentry-refactor-tasks/**/*',
     '.mypy_cache/**/*',


### PR DESCRIPTION
to avoid parsing errors like:

```
0:0  error  Parsing error: sentry/.agents/skills/pr-writer/evals/axis.config.json was not found by the project service        
  because the extension for the file (`.json`) is non-standard.
```