### PR TITLE
feat(seer): Assign triggering user when a Seer PR exhausts its iteration cap

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -307,6 +307,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-pr-iteration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Request review from the triggering user once a Seer PR's checks are green
     manager.add("organizations:autofix-pr-iteration-review-request", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Assign the triggering user and post a status comment once a Seer PR exhausts its CI-fix iteration cap
+    manager.add("organizations:autofix-pr-iteration-cap-assign", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Expose one-shot question answers on the Seer runs list (?expand=questions)
     manager.add("organizations:seer-run-questions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable showing seer in a persistent sidebar

--- a/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
+++ b/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
@@ -1,0 +1,260 @@
+"""Hand a Seer-authored PR to a human once automated CI-fix iterations run out.
+
+When the last N PR iterations were all driven by failing check suites, the
+iteration hard cap stops further automated attempts and the run would
+otherwise go quiet. Instead, we assign the triggering user and post one
+status comment so a human knows the PR needs their decision. We deliberately
+do *not* request a review here — a review request from Seer must keep
+meaning "CI is green, ready to judge".
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.utils import timezone
+from scm import actions as scm_actions
+from scm.types import CreatePullRequestCommentProtocol, GetPullRequestProtocol, UpdateIssueProtocol
+
+from sentry import features, options
+from sentry.locks import locks
+from sentry.models.organization import Organization
+from sentry.seer.autofix.pr_iteration.check_suites import (
+    CheckSuiteAutofixRun,
+    GithubCheckSuiteEvent,
+    check_suite_head_match,
+)
+from sentry.seer.autofix.pr_iteration.feedback import automated_iteration_cap_reached
+from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
+from sentry.seer.models.run import SeerRun
+from sentry.seer.utils import get_github_username_for_user
+from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
+from sentry.utils.locking import UnableToAcquireLock
+
+logger = logging.getLogger(__name__)
+
+# SeerRun.extras key holding cap-exhausted markers, keyed by repo full name
+# (a run can open PRs in several repos). Each marker records what reached the
+# human so retries and later suite events never re-ping them.
+CAP_EXHAUSTED_EXTRA = "cap_exhausted"
+
+
+def _skip(reason: str, log_extra: dict[str, Any]) -> None:
+    metrics.incr("autofix.pr_iteration.cap_exhausted.skipped", tags={"reason": reason})
+    logger.info("autofix.pr_iteration.cap_exhausted.skipped", extra={**log_extra, "reason": reason})
+
+
+def _failed(reason: str, log_extra: dict[str, Any]) -> None:
+    """Record an unexpected failure (vs. a `_skip`, which is an expected condition)."""
+    metrics.incr("autofix.pr_iteration.cap_exhausted.failed", tags={"reason": reason})
+    logger.warning(
+        "autofix.pr_iteration.cap_exhausted.failed",
+        extra={**log_extra, "reason": reason},
+        exc_info=True,
+    )
+
+
+def _cap_exhausted_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] | None:
+    return get_run_marker(seer_run, CAP_EXHAUSTED_EXTRA, repo_name)
+
+
+def _record_cap_exhausted_marker(
+    seer_run: SeerRun,
+    repo_name: str,
+    *,
+    head_sha: str,
+    assignees: list[str],
+    commented: bool,
+    preexisting: bool = False,
+) -> None:
+    """Write the per-repo marker; caller must hold the run's cap-exhausted lock.
+
+    ``preexisting`` records that the user was already assigned by someone else
+    rather than by us.
+    """
+    marker: dict[str, Any] = {
+        "recorded_at": timezone.now().isoformat(),
+        "head_sha": head_sha,
+        "assignees": assignees,
+        "commented": commented,
+    }
+    if preexisting:
+        marker["preexisting"] = True
+    record_run_marker(seer_run, CAP_EXHAUSTED_EXTRA, repo_name, marker)
+
+
+def _status_comment_body(github_login: str) -> str:
+    cap = options.get("autofix.pr-iteration.max-iterations")
+    return (
+        f"@{github_login} CI is still failing after {cap} automated "
+        "fix attempts, so Seer has stopped iterating on this pull request. It needs a human "
+        "decision — you can:\n\n"
+        "- push a fix to this branch yourself,\n"
+        "- comment `@sentry <guidance>` to send Seer back for another attempt, or\n"
+        "- close this pull request if it is not worth pursuing."
+    )
+
+
+def assign_user_for_exhausted_cap(
+    event: GithubCheckSuiteEvent, resolved: CheckSuiteAutofixRun
+) -> None:
+    """Entry point from the check-suite listener when a failing suite won't iterate."""
+    organization_id = resolved.repository.organization_id
+    try:
+        organization = Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist:
+        return
+    if not features.has("organizations:autofix-pr-iteration-cap-assign", organization):
+        return
+
+    log_extra: dict[str, Any] = {
+        "organization_id": organization_id,
+        "repo_id": resolved.repository.id,
+        "run_id": resolved.run_state.run_id,
+        "pr_id": resolved.pr_id,
+    }
+
+    head_match = check_suite_head_match(event, resolved.run_state)
+    if not head_match.matched or not head_match.head_sha or not head_match.repo_name:
+        # A failure on an older commit says nothing about the current head.
+        _skip("stale_head", {**log_extra, "head_sha": head_match.head_sha})
+        return
+
+    if not automated_iteration_cap_reached(resolved.run_state):
+        # The listener only hands over cap-blocked events; re-check anyway so
+        # this stays safe to call from other paths.
+        logger.info("autofix.pr_iteration.cap_exhausted.cap_not_reached", extra=log_extra)
+        return
+
+    seer_run = SeerRun.objects.filter(
+        seer_run_state_id=resolved.run_state.run_id, organization=organization
+    ).first()
+    if seer_run is None:
+        # Legacy runs predating SeerRun mirroring have no row to hold the marker.
+        _skip("no_seer_run", log_extra)
+        return
+    if seer_run.user_id is None:
+        # System runs (e.g. Night Shift) have no user to hand the PR to; how
+        # often this fires sizes the need for candidate-reviewer selection.
+        _skip("no_triggering_user", log_extra)
+        return
+    if _cap_exhausted_marker(seer_run, head_match.repo_name):
+        _skip("already_handed_off", log_extra)
+        return
+
+    pr_state = resolved.run_state.repo_pr_states.get(head_match.repo_name)
+    pr_number = pr_state.pr_number if pr_state else None
+    if pr_number is None:
+        _skip("no_pr_number", log_extra)
+        return
+
+    user = user_service.get_user(user_id=seer_run.user_id)
+    if user is None:
+        _skip("user_not_found", log_extra)
+        return
+    github_login = get_github_username_for_user(user, organization.id, referrer="pr_cap_exhausted")
+    if not github_login:
+        _skip("no_github_login", log_extra)
+        return
+
+    # Importing the SCM factory while the check-suite listener module is
+    # initialized pulls in integration handlers before options init.
+    from sentry.scm.factory import new as make_scm
+
+    try:
+        scm = make_scm(organization.id, resolved.repository.id, referrer="seer")
+    except Exception:
+        _failed("scm_init_failed", log_extra)
+        return
+
+    if (
+        not isinstance(scm, GetPullRequestProtocol)
+        or not isinstance(scm, UpdateIssueProtocol)
+        or not isinstance(scm, CreatePullRequestCommentProtocol)
+    ):
+        _skip("unsupported_provider", log_extra)
+        return
+
+    try:
+        pull_request = scm_actions.get_pull_request(scm, str(pr_number))
+    except Exception:
+        _failed("get_pull_request_failed", {**log_extra, "pr_number": pr_number})
+        return
+
+    if pull_request["data"]["state"] != "open" or pull_request["data"]["merged"]:
+        _skip("pr_not_open", log_extra)
+        return
+
+    raw_pr = pull_request["raw"]["data"] or {}
+    existing_assignees = [
+        assignee["login"]
+        for assignee in (raw_pr.get("assignees") or [])
+        if isinstance(assignee, dict) and assignee.get("login")
+    ]
+    already_assigned = github_login.lower() in {login.lower() for login in existing_assignees}
+
+    # A suite completes once per app/workflow, so several failing events can
+    # race for the same head; the lock plus a marker re-check makes sure only
+    # one of them pings the human.
+    lock = locks.get(
+        f"autofix:pr_iteration:cap_exhausted:{seer_run.id}",
+        duration=30,
+        name="autofix_pr_cap_exhausted",
+    )
+    try:
+        with lock.acquire():
+            seer_run.refresh_from_db()
+            if _cap_exhausted_marker(seer_run, head_match.repo_name):
+                _skip("already_handed_off", log_extra)
+                return
+
+            assigned = already_assigned
+            if not already_assigned:
+                try:
+                    # The issues PATCH replaces the assignee list wholesale, so
+                    # merge with whoever is already assigned.
+                    scm_actions.update_issue(
+                        scm, str(pr_number), assignees=[*existing_assignees, github_login]
+                    )
+                    assigned = True
+                except Exception:
+                    # Best effort — e.g. the user may not be assignable in this
+                    # repo; the @-mention in the comment still notifies them.
+                    _failed("assign_failed", {**log_extra, "pr_number": pr_number})
+
+            commented = False
+            try:
+                scm_actions.create_pull_request_comment(
+                    scm, str(pr_number), _status_comment_body(github_login)
+                )
+                commented = True
+            except Exception:
+                _failed("comment_failed", {**log_extra, "pr_number": pr_number})
+
+            if not assigned and not commented:
+                # Nothing reached the human; leave the marker unset so the
+                # next failing suite retries.
+                return
+
+            _record_cap_exhausted_marker(
+                seer_run,
+                head_match.repo_name,
+                head_sha=head_match.head_sha,
+                assignees=[github_login] if assigned else [],
+                commented=commented,
+                preexisting=already_assigned,
+            )
+    except UnableToAcquireLock:
+        _skip("locked", log_extra)
+        return
+
+    metrics.incr(
+        "autofix.pr_iteration.cap_exhausted.handed_off",
+        tags={"assigned": str(assigned).lower(), "commented": str(commented).lower()},
+    )
+    logger.info(
+        "autofix.pr_iteration.cap_exhausted.handed_off",
+        extra={**log_extra, "pr_number": pr_number, "assigned": assigned, "commented": commented},
+    )

--- a/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
+++ b/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
@@ -208,17 +208,18 @@ def assign_user_for_exhausted_cap(
     already_assigned = github_login.lower() in {login.lower() for login in existing_assignees}
 
     # A suite completes once per app/workflow, so several failing events can
-    # race for the same head; the lock plus a marker re-check makes sure only
-    # one of them pings the human. Scoped per repo — markers are per-repo and
-    # written atomically, so on a multi-repo run one repo's handoff must not
-    # make another's bail with UnableToAcquireLock.
+    # race for the same head. Wait for the lock holder rather than dropping:
+    # after the wait the marker re-check settles it — holder succeeded means we
+    # skip, holder's handoff failed (marker unset) means this event retries.
+    # Scoped per repo — markers are per-repo and written atomically, so on a
+    # multi-repo run one repo's handoff must not stall another's.
     lock = locks.get(
         f"autofix:pr_iteration:cap_exhausted:{seer_run.id}:{head_match.repo_name}",
         duration=30,
         name="autofix_pr_cap_exhausted",
     )
     try:
-        with lock.acquire():
+        with lock.blocking_acquire(initial_delay=0.5, timeout=10):
             seer_run.refresh_from_db()
             if _already_handed_off(seer_run, head_match.repo_name, head_match.head_sha):
                 _skip("already_handed_off", log_extra)
@@ -262,6 +263,11 @@ def assign_user_for_exhausted_cap(
                 commented=commented,
                 preexisting=already_assigned,
             )
+    except SeerRun.DoesNotExist:
+        # The run was deleted between our lookup and the marker write (e.g.
+        # cleanup); nothing is left to mark or dedupe against.
+        _skip("run_deleted", log_extra)
+        return
     except UnableToAcquireLock:
         _skip("locked", log_extra)
         return

--- a/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
+++ b/src/sentry/seer/autofix/pr_iteration/cap_exhausted.py
@@ -37,7 +37,8 @@ logger = logging.getLogger(__name__)
 
 # SeerRun.extras key holding cap-exhausted markers, keyed by repo full name
 # (a run can open PRs in several repos). Each marker records what reached the
-# human so retries and later suite events never re-ping them.
+# human for one head, so duplicate suite events never re-ping them but a later
+# cap exhaustion on a new head is handled afresh.
 CAP_EXHAUSTED_EXTRA = "cap_exhausted"
 
 
@@ -60,6 +61,17 @@ def _cap_exhausted_marker(seer_run: SeerRun, repo_name: str) -> dict[str, Any] |
     return get_run_marker(seer_run, CAP_EXHAUSTED_EXTRA, repo_name)
 
 
+def _already_handed_off(seer_run: SeerRun, repo_name: str, head_sha: str) -> bool:
+    """A marker only suppresses re-handling for the head it recorded.
+
+    After a handoff the user can send Seer back (``@sentry <guidance>``); if
+    that later streak exhausts the cap again, it does so on a new head, and
+    the run would otherwise go quiet without ever telling them.
+    """
+    marker = _cap_exhausted_marker(seer_run, repo_name)
+    return marker is not None and marker.get("head_sha") == head_sha
+
+
 def _record_cap_exhausted_marker(
     seer_run: SeerRun,
     repo_name: str,
@@ -69,7 +81,7 @@ def _record_cap_exhausted_marker(
     commented: bool,
     preexisting: bool = False,
 ) -> None:
-    """Write the per-repo marker; caller must hold the run's cap-exhausted lock.
+    """Write the per-repo marker; caller must hold the repo's cap-exhausted lock.
 
     ``preexisting`` records that the user was already assigned by someone else
     rather than by us.
@@ -140,7 +152,7 @@ def assign_user_for_exhausted_cap(
         # often this fires sizes the need for candidate-reviewer selection.
         _skip("no_triggering_user", log_extra)
         return
-    if _cap_exhausted_marker(seer_run, head_match.repo_name):
+    if _already_handed_off(seer_run, head_match.repo_name, head_match.head_sha):
         _skip("already_handed_off", log_extra)
         return
 
@@ -197,20 +209,22 @@ def assign_user_for_exhausted_cap(
 
     # A suite completes once per app/workflow, so several failing events can
     # race for the same head; the lock plus a marker re-check makes sure only
-    # one of them pings the human.
+    # one of them pings the human. Scoped per repo — markers are per-repo and
+    # written atomically, so on a multi-repo run one repo's handoff must not
+    # make another's bail with UnableToAcquireLock.
     lock = locks.get(
-        f"autofix:pr_iteration:cap_exhausted:{seer_run.id}",
+        f"autofix:pr_iteration:cap_exhausted:{seer_run.id}:{head_match.repo_name}",
         duration=30,
         name="autofix_pr_cap_exhausted",
     )
     try:
         with lock.acquire():
             seer_run.refresh_from_db()
-            if _cap_exhausted_marker(seer_run, head_match.repo_name):
+            if _already_handed_off(seer_run, head_match.repo_name, head_match.head_sha):
                 _skip("already_handed_off", log_extra)
                 return
 
-            assigned = already_assigned
+            newly_assigned = False
             if not already_assigned:
                 try:
                     # The issues PATCH replaces the assignee list wholesale, so
@@ -218,11 +232,12 @@ def assign_user_for_exhausted_cap(
                     scm_actions.update_issue(
                         scm, str(pr_number), assignees=[*existing_assignees, github_login]
                     )
-                    assigned = True
+                    newly_assigned = True
                 except Exception:
                     # Best effort — e.g. the user may not be assignable in this
                     # repo; the @-mention in the comment still notifies them.
                     _failed("assign_failed", {**log_extra, "pr_number": pr_number})
+            assigned = already_assigned or newly_assigned
 
             commented = False
             try:
@@ -233,9 +248,10 @@ def assign_user_for_exhausted_cap(
             except Exception:
                 _failed("comment_failed", {**log_extra, "pr_number": pr_number})
 
-            if not assigned and not commented:
-                # Nothing reached the human; leave the marker unset so the
-                # next failing suite retries.
+            if not newly_assigned and not commented:
+                # Nothing new reached the human — a preexisting assignment
+                # doesn't tell them Seer stopped — so leave the marker unset
+                # and let the next failing suite retry.
                 return
 
             _record_cap_exhausted_marker(

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.cap_exhausted import assign_user_for_exhausted_cap
 from sentry.seer.autofix.pr_iteration.check_suites import FAILURE_CONCLUSIONS
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
@@ -63,6 +64,10 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
         run_state=agent_state,
     )
     if not enqueued:
+        # Feedback is rejected for a stale head or for the iteration hard cap.
+        # In the cap case the run would otherwise just go quiet, so hand the PR
+        # to a human instead (the handler re-checks which case applies).
+        assign_user_for_exhausted_cap(source.event, resolved)
         return None
 
     # Defer Now/Later/skip to `should_trigger` (incomplete check runs schedule

--- a/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
@@ -173,7 +173,7 @@ class AssignUserForExhaustedCapTest(TestCase):
                 CAP_EXHAUSTED_EXTRA: {
                     REPO_NAME: {
                         "recorded_at": "2024-01-01T00:00:00+00:00",
-                        "head_sha": "older-sha",
+                        "head_sha": HEAD_SHA,
                         "assignees": ["octocat"],
                         "commented": True,
                     }
@@ -188,6 +188,48 @@ class AssignUserForExhaustedCapTest(TestCase):
         mock_actions.get_pull_request.assert_not_called()
         mock_actions.update_issue.assert_not_called()
         mock_actions.create_pull_request_comment.assert_not_called()
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_rehandles_when_cap_exhausted_on_new_head(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        # A previous handoff on an older head; the user then sent Seer back
+        # with guidance and the new streak exhausted the cap again.
+        self.seer_run.update(
+            extras={
+                CAP_EXHAUSTED_EXTRA: {
+                    REPO_NAME: {
+                        "recorded_at": "2024-01-01T00:00:00+00:00",
+                        "head_sha": "older-sha",
+                        "assignees": ["octocat"],
+                        "commented": True,
+                    }
+                }
+            }
+        )
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            assignees=[{"login": "octocat"}]
+        )
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        # The user must learn the run went quiet again: a fresh comment, no
+        # re-assignment (they still are), marker moved to the new head.
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_called_once()
+        marker = self._marker()
+        assert marker is not None
+        assert marker["head_sha"] == HEAD_SHA
 
     @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())
@@ -334,6 +376,32 @@ class AssignUserForExhaustedCapTest(TestCase):
         assert marker is not None
         assert marker["assignees"] == ["octocat"]
         assert marker["commented"] is False
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_comment_failure_with_preexisting_assignment_retries(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            assignees=[{"login": "octocat"}]
+        )
+        mock_actions.create_pull_request_comment.side_effect = Exception("boom")
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        # With the user already assigned, the comment is the only thing we add;
+        # if it fails, nothing new reached them, so the next suite must retry.
+        mock_actions.update_issue.assert_not_called()
+        assert self._marker() is None
 
     @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
     @patch("sentry.scm.factory.new", return_value=MagicMock())

--- a/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
@@ -1,0 +1,359 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.seer.agent.client_models import RepoPRState, SeerRunState
+from sentry.seer.autofix.pr_iteration.cap_exhausted import (
+    CAP_EXHAUSTED_EXTRA,
+    assign_user_for_exhausted_cap,
+)
+from sentry.seer.autofix.pr_iteration.check_suites import (
+    CheckSuiteAutofixRun,
+    GithubCheckSuiteEvent,
+)
+from sentry.testutils.cases import TestCase
+
+CAP_EXHAUSTED_PATH = "sentry.seer.autofix.pr_iteration.cap_exhausted"
+FLAG = "organizations:autofix-pr-iteration-cap-assign"
+
+RUN_ID = 67890
+REPO_NAME = "owner/repo"
+HEAD_SHA = "abc"
+PR_NUMBER = 42
+
+
+def _event(head_sha: str = HEAD_SHA) -> GithubCheckSuiteEvent:
+    return GithubCheckSuiteEvent.parse_obj(
+        {
+            "check_suite": {
+                "id": 1,
+                "head_sha": head_sha,
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+                "conclusion": "failure",
+            },
+            "repository": {"html_url": "https://github.com/owner/repo", "full_name": REPO_NAME},
+        }
+    )
+
+
+def _pull_request_result(
+    *, state: str = "open", merged: bool = False, assignees: list[dict] | None = None
+) -> dict:
+    return {
+        "data": {"state": state, "merged": merged},
+        "raw": {"headers": None, "data": {"assignees": assignees or []}},
+        "type": "github",
+        "meta": {},
+    }
+
+
+@patch(f"{CAP_EXHAUSTED_PATH}.automated_iteration_cap_reached", return_value=True)
+class AssignUserForExhaustedCapTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo = self.create_repo(
+            project=self.project, provider="integrations:github", name=REPO_NAME
+        )
+        self.seer_run = self.create_seer_run(
+            organization=self.organization, seer_run_state_id=RUN_ID, user_id=self.user.id
+        )
+
+    def _resolved(self, *, commit_sha: str = HEAD_SHA) -> CheckSuiteAutofixRun:
+        run_state = SeerRunState(
+            run_id=RUN_ID,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={
+                REPO_NAME: RepoPRState(
+                    repo_name=REPO_NAME, commit_sha=commit_sha, pr_number=PR_NUMBER
+                )
+            },
+        )
+        return CheckSuiteAutofixRun(
+            repository=self.repo, run_state=run_state, pr_id=555, group_id=1
+        )
+
+    def _marker(self) -> dict | None:
+        self.seer_run.refresh_from_db()
+        return (self.seer_run.extras or {}).get(CAP_EXHAUSTED_EXTRA, {}).get(REPO_NAME)
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_assigns_and_comments(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        _, pr_number = mock_actions.update_issue.call_args[0]
+        assert pr_number == str(PR_NUMBER)
+        assert mock_actions.update_issue.call_args[1]["assignees"] == ["octocat"]
+        _, pr_number, body = mock_actions.create_pull_request_comment.call_args[0]
+        assert pr_number == str(PR_NUMBER)
+        assert "@octocat" in body
+        assert "automated fix attempts" in body
+        marker = self._marker()
+        assert marker is not None
+        assert marker["assignees"] == ["octocat"]
+        assert marker["commented"] is True
+        assert marker["head_sha"] == HEAD_SHA
+        assert marker["recorded_at"]
+        assert "preexisting" not in marker
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    def test_noop_when_flag_disabled(self, mock_actions: MagicMock, mock_cap: MagicMock) -> None:
+        assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        # The flag gate runs before everything else so disabled orgs cost nothing.
+        mock_cap.assert_not_called()
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    def test_skips_stale_head(self, mock_actions: MagicMock, _mock_cap: MagicMock) -> None:
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved(commit_sha="newer-sha"))
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    def test_noop_when_cap_not_reached(self, mock_actions: MagicMock, mock_cap: MagicMock) -> None:
+        mock_cap.return_value = False
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    def test_skips_night_shift_run_without_user(
+        self, mock_actions: MagicMock, _mock_cap: MagicMock
+    ) -> None:
+        self.seer_run.update(user_id=None)
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    def test_skips_when_no_seer_run_row(
+        self, mock_actions: MagicMock, _mock_cap: MagicMock
+    ) -> None:
+        self.seer_run.delete()
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    def test_skips_when_already_handed_off(
+        self, mock_actions: MagicMock, _mock_cap: MagicMock
+    ) -> None:
+        self.seer_run.update(
+            extras={
+                CAP_EXHAUSTED_EXTRA: {
+                    REPO_NAME: {
+                        "recorded_at": "2024-01-01T00:00:00+00:00",
+                        "head_sha": "older-sha",
+                        "assignees": ["octocat"],
+                        "commented": True,
+                    }
+                }
+            }
+        )
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        # The marker pre-check must short-circuit before any SCM work.
+        mock_actions.get_pull_request.assert_not_called()
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value=None)
+    def test_skips_when_no_github_login(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_skips_when_pr_not_open(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            state="closed", merged=True
+        )
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()
+        assert self._marker() is None
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_merges_existing_assignees(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            assignees=[{"login": "alice"}]
+        )
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        # The issues PATCH replaces assignees wholesale, so the existing
+        # assignee must be preserved.
+        assert mock_actions.update_issue.call_args[1]["assignees"] == ["alice", "octocat"]
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_comments_without_assigning_when_already_assigned(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result(
+            assignees=[{"login": "Octocat"}]
+        )
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_called_once()
+        marker = self._marker()
+        assert marker is not None
+        assert marker["assignees"] == ["octocat"]
+        assert marker["commented"] is True
+        assert marker["preexisting"] is True
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_assign_failure_still_comments(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+        mock_actions.update_issue.side_effect = Exception("boom")
+
+        with self.feature(FLAG), patch(f"{CAP_EXHAUSTED_PATH}.metrics") as mock_metrics:
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.create_pull_request_comment.assert_called_once()
+        marker = self._marker()
+        assert marker is not None
+        assert marker["assignees"] == []
+        assert marker["commented"] is True
+        mock_metrics.incr.assert_any_call(
+            "autofix.pr_iteration.cap_exhausted.failed", tags={"reason": "assign_failed"}
+        )
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_comment_failure_still_records_assignment(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+        mock_actions.create_pull_request_comment.side_effect = Exception("boom")
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_called_once()
+        marker = self._marker()
+        assert marker is not None
+        assert marker["assignees"] == ["octocat"]
+        assert marker["commented"] is False
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_both_failures_leave_marker_unset(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+        mock_actions.update_issue.side_effect = Exception("boom")
+        mock_actions.create_pull_request_comment.side_effect = Exception("boom")
+
+        with self.feature(FLAG):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        # Nothing reached the human, so the next failing suite must retry.
+        assert self._marker() is None

--- a/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
@@ -9,6 +9,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     CheckSuiteAutofixRun,
     GithubCheckSuiteEvent,
 )
+from sentry.seer.models.run import SeerRun
 from sentry.testutils.cases import TestCase
 
 CAP_EXHAUSTED_PATH = "sentry.seer.autofix.pr_iteration.cap_exhausted"
@@ -425,3 +426,27 @@ class AssignUserForExhaustedCapTest(TestCase):
 
         # Nothing reached the human, so the next failing suite must retry.
         assert self._marker() is None
+
+    @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
+    @patch("sentry.scm.factory.new", return_value=MagicMock())
+    @patch(f"{CAP_EXHAUSTED_PATH}.get_github_username_for_user", return_value="octocat")
+    @patch(f"{CAP_EXHAUSTED_PATH}.GetPullRequestProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.UpdateIssueProtocol", object)
+    @patch(f"{CAP_EXHAUSTED_PATH}.CreatePullRequestCommentProtocol", object)
+    def test_skips_when_run_deleted_before_marker_write(
+        self,
+        _mock_username: MagicMock,
+        _mock_scm: MagicMock,
+        mock_actions: MagicMock,
+        _mock_cap: MagicMock,
+    ) -> None:
+        mock_actions.get_pull_request.return_value = _pull_request_result()
+
+        with (
+            self.feature(FLAG),
+            patch.object(SeerRun, "refresh_from_db", side_effect=SeerRun.DoesNotExist),
+        ):
+            assign_user_for_exhausted_cap(_event(), self._resolved())
+
+        mock_actions.update_issue.assert_not_called()
+        mock_actions.create_pull_request_comment.assert_not_called()

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -165,6 +165,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
 
         mock_enqueue.assert_not_called()
 
+    @patch(f"{CHECK_PATH}.assign_user_for_exhausted_cap")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=False)
     @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
@@ -175,6 +176,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state: MagicMock,
         _mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
+        mock_assign: MagicMock,
     ) -> None:
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
         mock_get_state.return_value = self._agent_state()
@@ -183,7 +185,14 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         pr_iteration_from_check_suite_listener(self._event(raw))
 
         mock_trigger_consume.assert_not_called()
+        # Rejected feedback routes to the cap-exhausted handler, which decides
+        # itself whether this is the hard-cap case that needs a human.
+        mock_assign.assert_called_once()
+        event_arg, resolved_arg = mock_assign.call_args[0]
+        assert event_arg.check_suite.head_sha == "abc"
+        assert resolved_arg.run_state.run_id == 67890
 
+    @patch(f"{CHECK_PATH}.assign_user_for_exhausted_cap")
     @patch(TRIGGER_CONSUME_PATH)
     @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
     @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
@@ -194,6 +203,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         mock_get_state: MagicMock,
         mock_enqueue: MagicMock,
         mock_trigger_consume: MagicMock,
+        mock_assign: MagicMock,
     ) -> None:
         mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
         mock_get_state.return_value = self._agent_state()
@@ -215,6 +225,7 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert autofix.repository.id == 2
         assert autofix.run_state is not None
         mock_trigger_consume.assert_called_once()
+        mock_assign.assert_not_called()
 
     @patch(f"{CHECK_SUITES_PATH}.sentry_sdk.capture_exception")
     @patch(TRIGGER_CONSUME_PATH)


### PR DESCRIPTION
> Stacked on #120185 (green-gated review requests)

## Problem

When PR iteration hits its hard cap (the last N iterations were all driven by check-suite failures), iteration silently stops: the failing Seer PR is left open with no owner, no explanation, and no further activity. Per the principle from #120185 — a review request from Seer always means *"CI is green, ready to judge"* — a PR that can't reach green must get an **assignee** ("needs an owner's decision") plus a status comment, never a review request.

## What this does

In the check-suite listener's failure path, feedback rejected by the enqueue gate now routes to a new handler (gated by `organizations:autofix-pr-iteration-cap-assign`) instead of returning silently. The handler:

1. **Re-checks head match and the cap** itself — the enqueue gate rejects both stale heads and cap-blocked events, so the handler decides which case applies and stays safe to call from other paths.
2. **Assigns the triggering user** — resolved from the `SeerRun` mirror row via `get_github_username_for_user`. Assignment goes through the issues PATCH (`update_issue`, GitHub treats PRs as issues), which replaces the assignee list wholesale, so existing assignees are merged in; a user who is already assigned is skipped and recorded as `preexisting`. Assignment is best-effort — e.g. a user who isn't assignable in the repo still gets notified by the comment's @-mention.
3. **Posts one status comment** — "CI is still failing after N automated fix attempts, so Seer has stopped iterating…" (N from the shared cap option) with the human's options: push a fix, comment `@sentry <guidance>` to send Seer back for another attempt, or close the PR.
4. **Records a durable marker** — `SeerRun.extras["cap_exhausted"]`, keyed by repo full name, records what actually reached the human (`assignees`, `commented`, `head_sha`). A lock plus marker re-check dedupes racing suite events (suites complete once per CI app). Only a total failure — neither assign nor comment landed — leaves the marker unset so the next failing suite retries. Markers persist through the shared `run_markers` helper introduced in #120185, which merges only its own key under a row lock so the two features can't clobber each other's markers on the shared `extras` blob.
5. **Skips night-shift runs** (no triggering user) for now, counted to size the need for candidate-reviewer selection.

The handler re-checks the cap via the shared `automated_iteration_cap_reached` (`feedback.py`, backed by the `autofix.pr-iteration.max-iterations` option since #119630 generalized the streak across automated sources), so it shares exact cap semantics with `should_queue`/`should_trigger`.

## Metrics

- `autofix.pr_iteration.cap_exhausted.handed_off` tagged `assigned` / `commented` — successes, split by what reached the human.
- `…cap_exhausted.skipped` tagged `reason` (stale head, night shift, already handed off, PR closed, identity unresolvable, …) — expected exits; `no_triggering_user` doubles as the night-shift-PRs-hitting-the-cap counter.
- `…cap_exhausted.failed` tagged `reason` (`scm_init_failed`, `get_pull_request_failed`, `assign_failed`, `comment_failed`) — unexpected failures, alertable.


