### PR TITLE
ref(eslint): no-unnecessary-condition for alert

### DIFF
--- a/static/app/components/core/alert/alert.tsx
+++ b/static/app/components/core/alert/alert.tsx
@@ -235,7 +235,7 @@ export function Alert({
       expand={expand}
       trailingItems={trailingItems}
       onClick={handleClick}
-      className={classNames(variant ? `ref-${variant}` : '', className)}
+      className={classNames(`ref-${variant}`, className)}
       variant={variant}
       {...props}
       showIcon={showIcon}

--- a/static/app/components/core/alert/alertLink.tsx
+++ b/static/app/components/core/alert/alertLink.tsx
@@ -45,7 +45,7 @@ type AlertLinkProps =
 
 export function AlertLink(props: AlertLinkProps): React.ReactNode {
   const alertProps: AlertProps = {
-    variant: props.variant ?? 'info',
+    variant: props.variant,
     system: props.system,
     trailingItems: props.trailingItems ?? <IconChevron direction="right" />,
   };


### PR DESCRIPTION
`variant` is required so no fallback needed