### PR TITLE
fix(spans): Do not propagate traces for process segments task

### DIFF
--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -368,7 +368,8 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
                             )
                             if produce_to_process_segment_task:
                                 task_produce_future = process_segment_task.apply_async_with_future(
-                                    args=[kafka_payload.value]
+                                    args=[kafka_payload.value],
+                                    headers={"sentry-propagate-traces": False},
                                 )
                                 if task_produce_future is not None:
                                     producer_futures.append(

--- a/tests/sentry/spans/consumers/process/test_flusher.py
+++ b/tests/sentry/spans/consumers/process/test_flusher.py
@@ -204,8 +204,10 @@ def test_flusher_produces_flushed_segments_to_process_segment_task() -> None:
     producer_manager.produce.assert_not_called()
     mock_apply_async_with_future.assert_called_once()
     task_args = mock_apply_async_with_future.call_args.kwargs["args"]
+    task_headers = mock_apply_async_with_future.call_args.kwargs["headers"]
     assert len(task_args) == 1
     assert orjson.loads(task_args[0])["spans"][0]["span_id"] == span_id
+    assert task_headers == {"sentry-propagate-traces": False}
     task_future.result.assert_called_once_with()
     assert buffer.client.zscore(queue_key, segment_key) is None
 


### PR DESCRIPTION
Start a new trace for each process segment task.

The spans buffer enqueues many independent task activations, which otherwise join the same trace and can produce traces with hundreds of thousands of spans.