### PR TITLE
feat(conversations): Default span selection per view, merge drawer URL state

### DIFF
--- a/static/app/views/explore/conversations/components/conversationViewNew.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.spec.tsx
@@ -1,0 +1,134 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+
+import {ConversationViewContentNew} from './conversationViewNew';
+
+const CONVERSATION_ID = 'conv-1';
+
+function spanFixture(overrides: Record<string, unknown>) {
+  return {
+    'gen_ai.conversation.id': CONVERSATION_ID,
+    parent_span: 'parent-1',
+    project: 'test-project',
+    'project.id': 1,
+    'span.status': 'ok',
+    trace: 'trace-1',
+    'gen_ai.operation.type': 'ai_client',
+    ...overrides,
+  };
+}
+
+// Two assistant turns so there is an unambiguous "first" span to default to.
+const CONVERSATION_BODY = [
+  spanFixture({
+    span_id: 'span-a',
+    'span.name': 'first turn',
+    'precise.start_ts': 1000,
+    'precise.finish_ts': 1000.5,
+    'gen_ai.request.messages': JSON.stringify([{role: 'user', content: 'First?'}]),
+    'gen_ai.response.text': 'First answer',
+  }),
+  spanFixture({
+    span_id: 'span-b',
+    'span.name': 'second turn',
+    'precise.start_ts': 2000,
+    'precise.finish_ts': 2000.5,
+    'gen_ai.request.messages': JSON.stringify([{role: 'user', content: 'Second?'}]),
+    'gen_ai.response.text': 'Second answer',
+  }),
+];
+
+function mockConversation() {
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
+    body: CONVERSATION_BODY,
+  });
+  // The detail pane fetches full attributes per span; keep it empty.
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/trace-items/attributes/',
+    body: [],
+  });
+}
+
+function renderView(
+  props: Partial<React.ComponentProps<typeof ConversationViewContentNew>> = {}
+) {
+  return render(
+    <ConversationViewContentNew
+      conversation={{conversationId: CONVERSATION_ID}}
+      activeTab="transcript"
+      {...props}
+    />,
+    {organization: OrganizationFixture()}
+  );
+}
+
+// The detail pane's Close button is the stable signal that a span is open.
+function detailPane() {
+  return screen.queryByRole('button', {name: 'Close'});
+}
+
+describe('ConversationViewContentNew', () => {
+  beforeEach(() => {
+    // jsdom doesn't implement Element.scrollTo, which the detail pane calls.
+    Element.prototype.scrollTo = jest.fn();
+    MockApiClient.clearMockResponses();
+    act(() => {
+      PageFiltersStore.reset();
+      PageFiltersStore.init();
+    });
+    mockConversation();
+  });
+
+  it('opens no span by default on the transcript', async () => {
+    renderView({activeTab: 'transcript'});
+
+    expect(await screen.findByText('First answer')).toBeInTheDocument();
+    expect(detailPane()).not.toBeInTheDocument();
+  });
+
+  it('opens the first span by default on the timeline', async () => {
+    renderView({activeTab: 'timeline'});
+
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+  });
+
+  it('does not write the timeline default into the URL selection', async () => {
+    const onSelectSpan = jest.fn();
+    renderView({activeTab: 'timeline', onSelectSpan});
+
+    // Wait until the default detail pane has opened.
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+    // The default is view-local, so the sticky (URL) selection stays untouched;
+    // this is what keeps it from leaking back into the transcript.
+    expect(onSelectSpan).not.toHaveBeenCalled();
+  });
+
+  it('opens a deep-linked span on the transcript', async () => {
+    renderView({activeTab: 'transcript', selectedSpanId: 'span-a'});
+
+    expect(await screen.findByRole('button', {name: 'Close'})).toBeInTheDocument();
+  });
+
+  it('writes a sticky selection when the user picks a span', async () => {
+    const onSelectSpan = jest.fn();
+    renderView({activeTab: 'transcript', onSelectSpan});
+
+    await userEvent.click(await screen.findByText('First answer'));
+
+    expect(onSelectSpan).toHaveBeenCalledWith('span-a');
+  });
+
+  it('closes the timeline default and does not reopen it', async () => {
+    const onDeselectSpan = jest.fn();
+    renderView({activeTab: 'timeline', onDeselectSpan});
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Close'}));
+
+    expect(onDeselectSpan).toHaveBeenCalled();
+    await waitFor(() => expect(detailPane()).not.toBeInTheDocument());
+  });
+});

--- a/static/app/views/explore/conversations/components/conversationViewNew.tsx
+++ b/static/app/views/explore/conversations/components/conversationViewNew.tsx
@@ -1,6 +1,6 @@
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
-import {parseAsBoolean, parseAsStringLiteral, useQueryStates} from 'nuqs';
+import {parseAsStringLiteral, useQueryStates} from 'nuqs';
 
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {t} from 'sentry/locale';
@@ -16,6 +16,7 @@ import {
 } from 'sentry/views/explore/conversations/hooks/useConversation';
 import {useConversationSelection} from 'sentry/views/explore/conversations/hooks/useConversationSelection';
 import {AiSpanTimeline} from 'sentry/views/insights/pages/agents/components/aiSpanTimeline';
+import {getDefaultSelectedNode} from 'sentry/views/insights/pages/agents/utils/getDefaultSelectedNode';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
@@ -52,7 +53,6 @@ export function ConversationViewContentNew({
 
   const [detailState, setDetailState] = useQueryStates(
     {
-      detailOpen: parseAsBoolean.withDefault(true),
       detailTab: parseAsStringLiteral(CONVERSATION_SPAN_DETAIL_TABS).withDefault('input'),
     },
     {history: 'replace'}
@@ -64,17 +64,49 @@ export function ConversationViewContentNew({
     onSelectSpan,
     focusedTool,
     isLoading,
-    // Neither view auto-selects a span on load. The span detail only opens on
-    // user action or when a span is deep-linked in the URL.
+    // The hook never auto-selects a default: `selectedNode` reflects only the
+    // sticky selection from the URL (a user click or a deep link), which is why
+    // it survives switching tabs. The timeline's default span is layered on
+    // below as view-local state so it never leaks back into the transcript.
     autoSelectDefaultNode: false,
   });
+
+  // The timeline opens on its first span by default; the transcript opens on
+  // nothing. This default is view-local (never written to the URL) so returning
+  // to the transcript only keeps a span open when one was selected manually.
+  const defaultTimelineNode = useMemo(() => getDefaultSelectedNode(nodes), [nodes]);
+  const [timelineDefaultDismissed, setTimelineDefaultDismissed] = useState(false);
+
+  // Re-show the timeline default each time the user enters the timeline tab.
+  useEffect(() => {
+    setTimelineDefaultDismissed(false);
+  }, [activeTab]);
+
+  const displayedNode = useMemo(() => {
+    if (selectedNode) {
+      return selectedNode;
+    }
+    if (isTimeline && !timelineDefaultDismissed) {
+      return defaultTimelineNode;
+    }
+    return;
+  }, [selectedNode, isTimeline, timelineDefaultDismissed, defaultTimelineNode]);
+
   const handleSelectAndOpenDetail = useCallback(
     (node: AITraceSpanNode) => {
-      setDetailState({detailOpen: true});
+      setTimelineDefaultDismissed(false);
       handleSelectNode(node);
     },
-    [handleSelectNode, setDetailState]
+    [handleSelectNode]
   );
+
+  const handleCloseDetail = useCallback(() => {
+    // Dismiss the timeline default and clear any sticky selection so the pane
+    // closes on both tabs and does not spring back to the default.
+    setTimelineDefaultDismissed(true);
+    setDetailState({detailTab: null});
+    onDeselectSpan?.();
+  }, [onDeselectSpan, setDetailState]);
 
   useEffect(() => {
     if (!isLoading && !error && nodes.length === 0) {
@@ -103,7 +135,7 @@ export function ConversationViewContentNew({
             <MessagesPanelNew
               isLoading={isLoading}
               nodes={nodes}
-              selectedNodeId={selectedNode?.id ?? null}
+              selectedNodeId={displayedNode?.id ?? null}
               onSelectNode={handleSelectAndOpenDetail}
               onViewTimeline={onViewTimeline}
             />
@@ -111,28 +143,25 @@ export function ConversationViewContentNew({
             <AiSpanTimeline
               isLoading={isLoading}
               nodes={nodes}
-              selectedNodeKey={selectedNode?.id ?? ''}
+              selectedNodeKey={displayedNode?.id ?? ''}
               onSelectNode={handleSelectAndOpenDetail}
               compressGaps
             />
           )
         }
         right={
-          // Only show the detail pane (and its loading skeleton) when a span is
-          // deep-linked in the URL, or once the user has selected one.
-          detailState.detailOpen &&
-          (isLoading ? Boolean(selectedSpanId) : Boolean(selectedNode)) ? (
+          // Show the detail pane once a span is resolved: a deep link or manual
+          // selection (either tab), or the timeline's default span. While
+          // loading, only the deep-linked skeleton is known.
+          (isLoading ? Boolean(selectedSpanId) : Boolean(displayedNode)) ? (
             <ConversationSpanDetail
               isLoading={isLoading}
               scrollResetKey={activeTab}
-              node={selectedNode ?? undefined}
-              traceId={selectedNode ? (nodeTraceMap?.get(selectedNode.id) ?? '') : ''}
+              node={displayedNode ?? undefined}
+              traceId={displayedNode ? (nodeTraceMap?.get(displayedNode.id) ?? '') : ''}
               activeTab={detailState.detailTab}
               onTabChange={detailTab => setDetailState({detailTab})}
-              onClose={() => {
-                setDetailState({detailOpen: false, detailTab: null});
-                onDeselectSpan?.();
-              }}
+              onClose={handleCloseDetail}
             />
           ) : null
         }

--- a/static/app/views/explore/conversations/conversationDetailNew.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.spec.tsx
@@ -1,0 +1,103 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {TopBar} from 'sentry/views/navigation/topBar';
+
+import {ConversationDetailPageNew} from './conversationDetailNew';
+
+const CONVERSATION_ID = 'conv-1';
+
+function spanFixture(overrides: Record<string, unknown>) {
+  return {
+    'gen_ai.conversation.id': CONVERSATION_ID,
+    parent_span: 'parent-1',
+    project: 'test-project',
+    'project.id': 1,
+    'span.status': 'ok',
+    trace: 'trace-1',
+    'gen_ai.operation.type': 'ai_client',
+    ...overrides,
+  };
+}
+
+const CONVERSATION_BODY = [
+  spanFixture({
+    span_id: 'span-a',
+    'span.name': 'first turn',
+    'precise.start_ts': 1000,
+    'precise.finish_ts': 1000.5,
+    'gen_ai.request.messages': JSON.stringify([{role: 'user', content: 'First?'}]),
+    'gen_ai.response.text': 'First answer',
+  }),
+  spanFixture({
+    span_id: 'span-b',
+    'span.name': 'second turn',
+    'precise.start_ts': 2000,
+    'precise.finish_ts': 2000.5,
+    'gen_ai.request.messages': JSON.stringify([{role: 'user', content: 'Second?'}]),
+    'gen_ai.response.text': 'Second answer',
+  }),
+];
+
+function mockApis() {
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/ai-conversations/${CONVERSATION_ID}/`,
+    body: CONVERSATION_BODY,
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/trace-items/attributes/',
+    body: [],
+  });
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/projects/',
+    body: [],
+  });
+}
+
+function renderPage() {
+  return render(
+    <TopBar.Slot.Provider>
+      <ConversationDetailPageNew />
+    </TopBar.Slot.Provider>,
+    {
+      organization: OrganizationFixture(),
+      initialRouterConfig: {
+        route: '/organizations/:orgId/explore/conversations/:conversationId/',
+        location: {
+          pathname: `/organizations/org-slug/explore/conversations/${CONVERSATION_ID}/`,
+        },
+      },
+    }
+  );
+}
+
+function detailPane() {
+  return screen.queryByRole('button', {name: 'Close'});
+}
+
+describe('ConversationDetailPageNew span default selection', () => {
+  beforeEach(() => {
+    Element.prototype.scrollTo = jest.fn();
+    MockApiClient.clearMockResponses();
+    act(() => {
+      PageFiltersStore.reset();
+      PageFiltersStore.init();
+    });
+    mockApis();
+  });
+
+  it('opens the first span when switching from transcript to timeline', async () => {
+    renderPage();
+
+    // Transcript is the default tab: nothing is open.
+    expect(await screen.findByText('First answer')).toBeInTheDocument();
+    expect(detailPane()).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('tab', {name: 'Timeline'}));
+
+    // Timeline should open on its first span.
+    await waitFor(() => expect(detailPane()).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
Changes how the redesigned conversations view decides whether a span's detail drawer is open, so each tab behaves the way it should and a manually chosen span follows the user between tabs.

The transcript is for reading the conversation, so it opens with nothing selected. The timeline is a span-first view, so it opens focused on the first span. Crucially, the timeline's default focus is not treated as a "real" selection: it never becomes part of the shareable/persisted selection, so switching back to the transcript doesn't drag an un-chosen span along. Only a span the user actually clicked (or one deep-linked via the URL) is sticky and shows on both tabs.

This also folds the separate "is the drawer open" URL state into the selected-span state. They were two params describing one thing, which made it possible for them to get out of sync.

## Behavior

| Scenario | Detail drawer |
|---|---|
| Land on **Transcript** | Closed — nothing selected |
| Land on / switch to **Timeline** | Open on the first span |
| Click a span in the Timeline, then switch to Transcript | Stays open on that span |
| Only see the Timeline's default (no click), then switch to Transcript | Closed |
| Open a deep link (`?spanId=…`) on either tab | Open on that span |
| Close the drawer (either tab) | Closed, and the Timeline default does not spring back |
| Re-enter the Timeline later | Default first span shows again |

Closes TET-2653
Closes TET-2688