### PR TITLE
feat(seer): Add /bash-mode-on and /bash-mode-off slash commands

### DIFF
--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -8,6 +8,7 @@ type MenuMode = 'slash-commands-keyboard' | 'pr-widget' | 'hidden';
 interface SlashCommandHandlers {
   onFeedback: (() => void) | undefined;
   onNew: () => void;
+  onBashMode?: (value: boolean) => void;
   onCodeMode?: (value: 'off' | 'on' | 'only') => void;
   onConversations?: () => void;
   onLangfuse?: () => void;
@@ -284,6 +285,7 @@ export function useExplorerMenu({
 }
 
 function useSlashCommands({
+  onBashMode,
   onMaxSize,
   onMedSize,
   onNew,
@@ -354,6 +356,22 @@ function useSlashCommands({
             },
           ]
         : []),
+      ...(isSentryEmployee && onBashMode
+        ? [
+            {
+              title: '/bash-mode-off',
+              key: '/bash-mode-off',
+              description: 'Disable bash mode tools',
+              handler: () => onBashMode(false),
+            },
+            {
+              title: '/bash-mode-on',
+              key: '/bash-mode-on',
+              description: 'Enable bash mode tools',
+              handler: () => onBashMode(true),
+            },
+          ]
+        : []),
       ...(isSentryEmployee && onLangfuse
         ? [
             {
@@ -380,6 +398,7 @@ function useSlashCommands({
       onMaxSize,
       onMedSize,
       onFeedback,
+      onBashMode,
       onCodeMode,
       onLangfuse,
       onConversations,

--- a/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.spec.tsx
@@ -24,6 +24,7 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
   errorStatusCode: undefined,
   isTimedOut: false,
   runId: null,
+  overrideBashModeEnabled: false,
   overrideCtxEngEnable: true,
   overrideCodeModeEnable: 'off',
   hasSentInterrupt: false,
@@ -33,6 +34,7 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
   interruptRun: jest.fn(),
   respondToUserInput: jest.fn(),
   createPR: jest.fn(),
+  setOverrideBashModeEnabled: jest.fn(),
   setOverrideCtxEngEnable: jest.fn(),
   setOverrideCodeModeEnable: jest.fn(),
 };

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -191,6 +191,7 @@ export function SeerExplorerContent({
     hasSentInterrupt,
     overrideCtxEngEnable,
     setOverrideCtxEngEnable,
+    setOverrideBashModeEnabled,
     setOverrideCodeModeEnable,
   } = useSeerExplorer();
 
@@ -386,6 +387,9 @@ export function SeerExplorerContent({
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,
+      onBashMode: organization?.features.includes('seer-explorer-allow-bash-mode')
+        ? setOverrideBashModeEnabled
+        : undefined,
       onCodeMode: organization?.features.includes('seer-explorer-code-mode-tools')
         ? setOverrideCodeModeEnable
         : undefined,

--- a/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
+++ b/static/app/views/seerExplorer/components/sidebar/seerExplorerSidebarLayout.spec.tsx
@@ -30,6 +30,7 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
   errorStatusCode: undefined,
   isTimedOut: false,
   runId: null,
+  overrideBashModeEnabled: false,
   overrideCtxEngEnable: true,
   overrideCodeModeEnable: 'off',
   hasSentInterrupt: false,
@@ -39,6 +40,7 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
   interruptRun: jest.fn(),
   respondToUserInput: jest.fn(),
   createPR: jest.fn(),
+  setOverrideBashModeEnabled: jest.fn(),
   setOverrideCtxEngEnable: jest.fn(),
   setOverrideCodeModeEnable: jest.fn(),
 };

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -156,6 +156,8 @@ export const useSeerExplorer = () => {
         return 'on'; // default
       }
     );
+  const [overrideBashModeEnabled, setOverrideBashModeEnabled] =
+    useLocalStorageState<boolean>('seer-explorer.override.bash-mode', false);
 
   const {runId, chatStates} = useSeerExplorerChatState();
   const dispatch = useSeerExplorerChatDispatch();
@@ -175,6 +177,7 @@ export const useSeerExplorer = () => {
     {
       insertIndex: number;
       orgSlug: string;
+      overrideBashModeEnabled: boolean;
       overrideCodeModeEnable: 'off' | 'on' | 'only';
       overrideCtxEngEnable: boolean;
       pageName: string;
@@ -212,6 +215,7 @@ export const useSeerExplorer = () => {
           on_page_context: params.screenshot,
           page_name: params.pageName,
           override_ce_enable: params.overrideCtxEngEnable,
+          override_bash_mode_enabled: params.overrideBashModeEnabled,
           override_code_mode_enable: params.overrideCodeModeEnable,
         },
       });
@@ -520,6 +524,7 @@ export const useSeerExplorer = () => {
         orgSlug,
         pageName,
         screenshot,
+        overrideBashModeEnabled,
         overrideCtxEngEnable,
         overrideCodeModeEnable,
       });
@@ -532,6 +537,7 @@ export const useSeerExplorer = () => {
       getLLMContext,
       getPageReferrer,
       organization,
+      overrideBashModeEnabled,
       overrideCtxEngEnable,
       overrideCodeModeEnable,
       sendMessageMutate,
@@ -686,6 +692,8 @@ export const useSeerExplorer = () => {
     hasSentInterrupt,
     respondToUserInput,
     createPR,
+    overrideBashModeEnabled,
+    setOverrideBashModeEnabled,
     overrideCtxEngEnable,
     setOverrideCtxEngEnable,
     overrideCodeModeEnable,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -156,8 +156,10 @@ export const useSeerExplorer = () => {
         return 'on'; // default
       }
     );
-  const [overrideBashModeEnabled, setOverrideBashModeEnabled] =
-    useLocalStorageState<boolean>('seer-explorer.override.bash-mode', false);
+  const [overrideBashModeEnabled, setOverrideBashModeEnabled] = useLocalStorageState(
+    'seer-explorer.override.bash-mode',
+    false
+  );
 
   const {runId, chatStates} = useSeerExplorerChatState();
   const dispatch = useSeerExplorerChatDispatch();


### PR DESCRIPTION
Add `/bash-mode-on` and `/bash-mode-off` slash commands to the Seer Explorer, following the same pattern as the existing `/code-mode-*` commands. The commands are gated behind the `seer-explorer-allow-bash-mode` feature flag and restricted to Sentry employees.

Bash mode state is persisted in localStorage and sent as `override_bash_mode_enabled` in the chat POST body. Unlike code mode (tri-state: off/on/only), bash mode is a simple boolean toggle.

Depends on #120075 for backend support (feature flag, serializer field, client wiring).
