### PR TITLE
fix(spans): Sample process segment task transactions

### DIFF
--- a/src/sentry/spans/consumers/process_segments/factory.py
+++ b/src/sentry/spans/consumers/process_segments/factory.py
@@ -155,11 +155,16 @@ class DetectPerformanceIssuesStrategyFactory(ProcessingStrategyFactory[KafkaPayl
         self.pool.close()
 
 
-def _process_segment_bytes(segment_bytes: bytes, skip_produce: bool = False) -> list[KafkaPayload]:
+def _process_segment_bytes(
+    segment_bytes: bytes, skip_produce: bool = False, start_new_transaction: bool = True
+) -> list[KafkaPayload]:
     segment = orjson.loads(segment_bytes)
     skip_enrichment = segment.get("skip_enrichment", False)
     processed = process_segment(
-        segment["spans"], skip_produce=skip_produce, skip_enrichment=skip_enrichment
+        segment["spans"],
+        skip_produce=skip_produce,
+        skip_enrichment=skip_enrichment,
+        start_new_transaction=start_new_transaction,
     )
     processed = _check_span_duplicates(processed)
     return [_serialize_payload(span) for span in processed]

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -60,8 +60,14 @@ outcome_aggregator = OutcomeAggregator()
 
 @metrics.wraps("spans.consumers.process_segments.process_segment")
 def process_segment(
-    unprocessed_spans: list[SpanEvent], skip_produce: bool = False, skip_enrichment: bool = False
+    unprocessed_spans: list[SpanEvent],
+    skip_produce: bool = False,
+    skip_enrichment: bool = False,
+    start_new_transaction: bool = True,
 ) -> list[CompatibleSpan]:
+    if not start_new_transaction:
+        return _process_segment(unprocessed_spans, skip_produce, skip_enrichment)
+
     sample_rate = (
         settings.SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE
         * settings.SENTRY_PROCESS_EVENT_APM_SAMPLING

--- a/src/sentry/spans/consumers/process_segments/tasks.py
+++ b/src/sentry/spans/consumers/process_segments/tasks.py
@@ -45,5 +45,5 @@ _snuba_items_topic = ArroyoTopic(get_topic_definition(Topic.SNUBA_ITEMS)["real_t
     silo_mode=SiloMode.CELL,
 )
 def process_segment_task(segment_bytes: bytes) -> None:
-    for payload in _process_segment_bytes(segment_bytes):
+    for payload in _process_segment_bytes(segment_bytes, start_new_transaction=False):
         _snuba_items_task_producer.produce(_snuba_items_topic, payload)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -65,6 +65,12 @@ SAMPLED_TASKS = {
     "sentry.tasks.store.process_event_from_reprocessing": settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
     "sentry.tasks.store.save_event": 0.1 * settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
     "sentry.tasks.store.save_event_transaction": 0.1 * settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
+    # Mirror the rate the process-segments consumer used for its
+    # per-message transaction, now that the work runs as a task.
+    "sentry.spans.process_segments.process_segment": (
+        settings.SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE
+        * settings.SENTRY_PROCESS_EVENT_APM_SAMPLING
+    ),
     "sentry.tasks.process_suspect_commits": settings.SENTRY_SUSPECT_COMMITS_APM_SAMPLING,
     "sentry.tasks.process_commit_context": settings.SENTRY_SUSPECT_COMMITS_APM_SAMPLING,
     "sentry.tasks.post_process.post_process_group": settings.SENTRY_POST_PROCESS_GROUP_APM_SAMPLING,

--- a/tests/sentry/spans/consumers/process_segments/test_factory.py
+++ b/tests/sentry/spans/consumers/process_segments/test_factory.py
@@ -172,6 +172,17 @@ def test_process_segment_task_matches_consumer_output(
     assert headers["project_id"] == b"1"
 
 
+@mock.patch("sentry.spans.consumers.process_segments.tasks._process_segment_bytes", return_value=[])
+def test_process_segment_task_does_not_start_new_transaction(
+    mock_process_segment_bytes: mock.MagicMock,
+) -> None:
+    segment_bytes = b"segment"
+
+    process_segment_task(segment_bytes)
+
+    mock_process_segment_bytes.assert_called_once_with(segment_bytes, start_new_transaction=False)
+
+
 class TestCheckSpanDuplicates:
     @override_options({"spans.process-segments.dedupe-ttl": 0})
     def test_disabled_when_ttl_is_zero(self):


### PR DESCRIPTION
Previously, Kafka processing used the manually created spans.consumers.process_segments.process_segment transaction. Taskworker also created an outer task transaction, but it wasn’t sampled at the intended rate.

This change:
- Samples the outer Taskworker transaction at the existing process-segment rate `SENTRY_PROCESS_SEGMENTS_TRANSACTIONS_SAMPLE_RATE * SENTRY_PROCESS_EVENT_APM_SAMPLING`
- Keeps the consumer-specific transaction for the Kafka consumer path.
- Prevents that consumer transaction from being created inside Taskworker, so segments processing spans go under one complete trace, including queue and task execution context.