### PR TITLE
fix(data-browsing): Use canvas renderer for time series graphs

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -5,6 +5,9 @@ import 'echarts/lib/component/brush';
 import 'echarts/lib/component/visualMap';
 import 'echarts/theme/v5.js';
 import 'zrender/lib/svg/svg';
+// Canvas backend. Explicit so `renderer: 'canvas'` never silently relies on
+// another module importing the full `echarts` bundle.
+import 'zrender/lib/canvas/canvas';
 
 import {useId, useMemo} from 'react';
 import type {Theme} from '@emotion/react';

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -63,13 +63,6 @@ import {TimeSeriesWidgetYAxis} from './timeSeriesWidgetYAxis';
 
 const {warn} = Sentry.logger;
 
-const USER_AGENT = typeof navigator === 'undefined' ? '' : navigator.userAgent;
-const CHART_RENDERER =
-  USER_AGENT.includes('Firefox') ||
-  (USER_AGENT.includes('Safari') && !USER_AGENT.includes('Chrome'))
-    ? 'canvas'
-    : 'svg';
-
 export interface TimeSeriesWidgetVisualizationProps extends Partial<LoadableChartWidgetProps> {
   /**
    * An array of `Plottable` objects. This can be any object that implements the `Plottable` interface.
@@ -671,7 +664,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         <BaseChart
           ref={mergeRefs(props.ref, props.chartRef, chartRef, handleChartRef)}
           autoHeightResize
-          renderer={CHART_RENDERER}
+          renderer="canvas"
           series={allSeries}
           grid={{
             // NOTE: Adding a few pixels of left padding prevents ECharts from

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -63,6 +63,13 @@ import {TimeSeriesWidgetYAxis} from './timeSeriesWidgetYAxis';
 
 const {warn} = Sentry.logger;
 
+const USER_AGENT = typeof navigator === 'undefined' ? '' : navigator.userAgent;
+const CHART_RENDERER =
+  USER_AGENT.includes('Firefox') ||
+  (USER_AGENT.includes('Safari') && !USER_AGENT.includes('Chrome'))
+    ? 'canvas'
+    : 'svg';
+
 export interface TimeSeriesWidgetVisualizationProps extends Partial<LoadableChartWidgetProps> {
   /**
    * An array of `Plottable` objects. This can be any object that implements the `Plottable` interface.
@@ -664,6 +671,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
         <BaseChart
           ref={mergeRefs(props.ref, props.chartRef, chartRef, handleChartRef)}
           autoHeightResize
+          renderer={CHART_RENDERER}
           series={allSeries}
           grid={{
             // NOTE: Adding a few pixels of left padding prevents ECharts from


### PR DESCRIPTION
Using the SVG renderer for ECharts causes many woes. This includes but is not limited to:

1. Safari chart series flicker and disappear in Safari when hovered (DAIN-1778)
2. Various problems with re-drawing drag areas when zooming on charts

DAIN-1778 specifically is [a bug in WebKit](https://bugs.webkit.org/show_bug.cgi?id=319917), which makes it _very_ hard to overcome.

This PR changes to the `canvas` renderer for `TimeSeriesWidgetVisualization` (the chart primitive we use in Explore and Dashboards), which immediately solves the Safari issue. This does not result in any major visible differences (thank you, ECharts)!

I think the end goal will be to move _all_ charts to `canvas` (or at least more of them) but I thought it's smart to take a smaller first step.

- this does not seem to cause any visible difference in the UI
- this seems to generally improve performance of chart drawing, or at least not make it worse

Closes DAIN-1778

I think SVG is a perfectly sensible choice, but `canvas` just seems to work better. In fact, it's the _default_ renderer for ECharts. Other charting libraries are split on SVG vs. canvas support.

IMO for us, the downsides of SVG are clear (visible bugs) but the downsides of canvas are not very relevant. We don't worry that much about mobile usage (it's low, and the charts aren't that heavy there) and the visual fidelity _seems_ fine, since we don't do a lot of deep zooming.

Dissenting opinions welcome, if you have specific experience that suggests that blanket-using `canvas` is not safe.