### PR TITLE
feat(autofix): check-suite feedback view in PR iteration UI

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -151,7 +151,7 @@ interface GithubPrReviewCommentFeedbackSource {
   comment?: {html_url?: string; user?: {login: string}};
 }
 
-export interface CheckSuiteFeedbackSource {
+interface CheckSuiteFeedbackSource {
   app_name: string;
   event: {
     check_suite: {head_sha: string; id: number};
@@ -160,7 +160,7 @@ export interface CheckSuiteFeedbackSource {
   type: 'check-suite';
 }
 
-export type RawFeedbackSource =
+type RawFeedbackSource =
   | UserUiFeedbackSource
   | GithubPrCommentFeedbackSource
   | GithubPrReviewCommentFeedbackSource

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -151,11 +151,20 @@ interface GithubPrReviewCommentFeedbackSource {
   comment?: {html_url?: string; user?: {login: string}};
 }
 
-type RawFeedbackSource =
+export interface CheckSuiteFeedbackSource {
+  app_name: string;
+  event: {
+    check_suite: {head_sha: string; id: number};
+    repository: {html_url: string};
+  };
+  type: 'check-suite';
+}
+
+export type RawFeedbackSource =
   | UserUiFeedbackSource
   | GithubPrCommentFeedbackSource
-  | GithubPrReviewCommentFeedbackSource;
-
+  | GithubPrReviewCommentFeedbackSource
+  | CheckSuiteFeedbackSource;
 export interface RawFeedback {
   text: string;
   source?: RawFeedbackSource;

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -924,6 +924,88 @@ describe('ArtifactCard', () => {
       expect(screen.getByTestId('icon-github')).toBeInTheDocument();
     });
 
+    it('shows a formatted check-suite label instead of the raw feedback text', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [
+            {
+              text: 'raw text',
+              ui_text: 'check suite for app CI failed',
+              source: {
+                type: 'check-suite',
+                app_name: 'CI',
+                event: {
+                  check_suite: {id: 999, head_sha: 'abc123'},
+                  repository: {html_url: 'https://github.com/org/repo'},
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('CI check suite failed')).toBeInTheDocument();
+      expect(screen.queryByText(/raw text/)).not.toBeInTheDocument();
+    });
+
+    it('links check-suite feedback to the failing check suite', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [
+            {
+              text: 'raw text',
+              source: {
+                type: 'check-suite',
+                app_name: 'CI',
+                event: {
+                  check_suite: {id: 999, head_sha: 'abc123'},
+                  repository: {html_url: 'https://github.com/org/repo'},
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      const link = screen.getByRole('link', {name: 'CI check suite failed'});
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/org/repo/commit/abc123/checks?check_suite_id=999'
+      );
+    });
+
     it('shows the code changes for queued feedback without the feature flag', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -70,13 +70,22 @@ interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   githubUsername?: string;
 }
 
+interface CheckSuiteFeedback extends ParsedBaseFeedback {
+  appName: string;
+  checkSuiteUrl: string;
+  sourceType: 'check-suite';
+}
 interface OtherFeedback extends ParsedBaseFeedback {
   source: string;
   sourceType: 'other';
 }
 
 // What `parseFeedback` can produce from the stored JSON alone.
-type ParsedFeedback = UserUiFeedback | GithubPrCommentFeedback | OtherFeedback;
+type ParsedFeedback =
+  | UserUiFeedback
+  | GithubPrCommentFeedback
+  | CheckSuiteFeedback
+  | OtherFeedback;
 
 // A parsed feedback enriched with the iteration context the caller supplies.
 type IterationFeedback = ParsedFeedback & {
@@ -106,6 +115,18 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
         sourceType: source.type,
         githubUsername: source.comment?.user?.login,
         commentUrl,
+      };
+    }
+    case 'check-suite': {
+      const appName = source.app_name;
+      const {head_sha: headSha, id: checkSuiteId} = source.event.check_suite;
+      const repoUrl = source.event.repository.html_url;
+      return {
+        ...base,
+        text: t('%s check suite failed', appName),
+        sourceType: 'check-suite',
+        appName,
+        checkSuiteUrl: `${repoUrl}/commit/${headSha}/checks?check_suite_id=${checkSuiteId}`,
       };
     }
     default:
@@ -453,6 +474,8 @@ function feedbackLinkUrl(item: IterationFeedback): string | undefined {
     case 'github-pr-comment':
     case 'github-pr-review-comment':
       return item.commentUrl;
+    case 'check-suite':
+      return item.checkSuiteUrl;
     default:
       return undefined;
   }
@@ -471,6 +494,18 @@ function FeedbackAttribution({item}: {item: IterationFeedback}) {
           </ExternalLink>
         </Tooltip>
       );
+    case 'check-suite': {
+      const icon = (
+        <Flex align="center">
+          <IconGithub size="md" />
+        </Flex>
+      );
+      return (
+        <Tooltip title={t('%s check suite', item.appName)} skipWrapper>
+          <ExternalLink href={item.checkSuiteUrl}>{icon}</ExternalLink>
+        </Tooltip>
+      );
+    }
     case 'user-ui':
       return item.user ? <UserAvatar size={16} user={item.user} hasTooltip /> : null;
     default:


### PR DESCRIPTION
Teach the PR-iteration Code Changes card to render check-suite queued feedback.
Show a short label ({app} check suite failed) instead of raw feedback text, and link to the GitHub check suite.
Add the CheckSuiteFeedbackSource type and cover the label + link in tests.

https://github.com/user-attachments/assets/3f53a128-547e-4fb6-a0a3-cf3a0a4f597b

