### PR TITLE
perf(eslint): Skip irrelevant files in default export rule

### DIFF
--- a/static/eslint/eslintPluginSentry/noDefaultExports.spec.ts
+++ b/static/eslint/eslintPluginSentry/noDefaultExports.spec.ts
@@ -1,6 +1,24 @@
 import {RuleTester} from '@typescript-eslint/rule-tester';
 
-import {noDefaultExports} from './noDefaultExports';
+import {mayContainDynamicImport, noDefaultExports} from './noDefaultExports';
+
+describe.each([
+  ['direct call', "import('component')"],
+  ['whitespace', "import \n ('component')"],
+  ['block comment', "import /* webpackChunkName: 'component' */ ('component')"],
+  ['line comment', "import // component\n ('component')"],
+  ['carriage return line comment', "import // component\r ('component')"],
+  ['unicode line comment', "import // component\u2028 ('component')"],
+  ['multiple comments', "import /* one */ // two\n /* three */ ('component')"],
+])('mayContainDynamicImport - %s', (_description, source) => {
+  it('detects the import call', () => {
+    expect(mayContainDynamicImport(source)).toBe(true);
+  });
+});
+
+it('does not treat a static import as a dynamic import', () => {
+  expect(mayContainDynamicImport("import Component from 'component'")).toBe(false);
+});
 
 const ruleTester = new RuleTester({
   languageOptions: {

--- a/static/eslint/eslintPluginSentry/noDefaultExports.spec.ts
+++ b/static/eslint/eslintPluginSentry/noDefaultExports.spec.ts
@@ -20,6 +20,21 @@ it('does not treat a static import as a dynamic import', () => {
   expect(mayContainDynamicImport("import Component from 'component'")).toBe(false);
 });
 
+it('keeps a comment-separated static import as a candidate', () => {
+  expect(
+    mayContainDynamicImport(
+      "import /* webpackMode: 'eager' */ Component from 'component'"
+    )
+  ).toBe(true);
+});
+
+it.each([
+  ['block-comment overlap', `import /*${'*//*'.repeat(10_000)}`],
+  ['line-comment overlap', `import ${'\r\n//'.repeat(10_000)}`],
+])('handles adversarial %s input', (_description, source) => {
+  expect(mayContainDynamicImport(source)).toBe(true);
+});
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parserOptions: {

--- a/static/eslint/eslintPluginSentry/noDefaultExports.ts
+++ b/static/eslint/eslintPluginSentry/noDefaultExports.ts
@@ -4,6 +4,16 @@ import ts from 'typescript';
 
 import {lazy} from './utils/lazy';
 
+// Match an import call with any valid trivia between the keyword and opening paren.
+// This is only a fast prefilter; the AST traversal below still determines whether
+// the import is one of the lazy-loading patterns this rule supports.
+const dynamicImportPattern =
+  /\bimport(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n\r\u2028\u2029]*(?:\r\n|[\n\r\u2028\u2029]))*\(/;
+
+export function mayContainDynamicImport(source: string): boolean {
+  return dynamicImportPattern.test(source);
+}
+
 function unwrapParenthesized(node: ts.Node): ts.Node {
   return ts.isParenthesizedExpression(node) ? unwrapParenthesized(node.expression) : node;
 }
@@ -55,7 +65,7 @@ function collectResolvedImportFiles(program: ts.Program) {
   }
 
   for (const sourceFile of program.getSourceFiles()) {
-    if (!sourceFile.isDeclarationFile) {
+    if (!sourceFile.isDeclarationFile && mayContainDynamicImport(sourceFile.text)) {
       ts.forEachChild(sourceFile, child => visit(child, sourceFile));
     }
   }

--- a/static/eslint/eslintPluginSentry/noDefaultExports.ts
+++ b/static/eslint/eslintPluginSentry/noDefaultExports.ts
@@ -4,14 +4,11 @@ import ts from 'typescript';
 
 import {lazy} from './utils/lazy';
 
-// Match an import call with any valid trivia between the keyword and opening paren.
-// This is only a fast prefilter; the AST traversal below still determines whether
-// the import is one of the lazy-loading patterns this rule supports.
-const dynamicImportPattern =
-  /\bimport(?:\s|\/\*[\s\S]*?\*\/|\/\/[^\n\r\u2028\u2029]*(?:\r\n|[\n\r\u2028\u2029]))*\(/;
+// Comment-separated static imports are harmless false positives.
+const possibleDynamicImportPattern = /\bimport\s*(?:\(|\/[/*])/u;
 
 export function mayContainDynamicImport(source: string): boolean {
-  return dynamicImportPattern.test(source);
+  return possibleDynamicImportPattern.test(source);
 }
 
 function unwrapParenthesized(node: ts.Node): ts.Node {


### PR DESCRIPTION
`@sentry/no-default-exports` walked every source file in the TypeScript program to find lazy imports, even though most files cannot contain a dynamic import.

Adds a cheap `import()` prefilter before AST traversal. The AST remains the source of truth, and the regex handles whitespace, block comments, line comments, CR, and Unicode line separators.

## Benchmark

Three cold runs of `TIMING=1 /usr/bin/time -p node --run lint:js -- static/app/views/issueDetails/actions/index.tsx`, reporting the median.

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| `@sentry/no-default-exports` | 1,175.7 ms | 66.5 ms | 17.7x faster |
| Command wall time | 12.29 s | 9.30 s | 2.99 s faster |