### PR TITLE
fix(search): Wrap long Ask Seer query tokens

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -4,6 +4,7 @@ import {mutationOptions} from '@tanstack/react-query';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {getEmotionRules} from 'sentry-test/utils';
 
 import type {FeedbackIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
@@ -282,6 +283,38 @@ describe('AskSeerComboBox', () => {
     expect(filter).toBeInTheDocument();
     expect(screen.getByText('Do any of these look right to you?')).toBeInTheDocument();
     expect(screen.queryByText('Time Range')).not.toBeInTheDocument();
+  });
+
+  it('wraps long query tokens', async () => {
+    const longValue = 'a'.repeat(400);
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-explorer-ai/query/',
+      method: 'POST',
+      body: {status: 'ok', queries: [{query: `message:${longValue}`}]},
+    });
+    const reworkedOrganization = {
+      ...organization,
+      features: [...organization.features, 'gen-ai-ask-seer-ux-rework'],
+    };
+
+    render(
+      <SearchQueryBuilderProvider {...defaultProps}>
+        <AskSeerComboBox
+          initialQuery=""
+          askSeerMutationOptions={askSeerMutationOptions}
+          applySeerSearchQuery={() => {}}
+        />
+      </SearchQueryBuilderProvider>,
+      {organization: reworkedOrganization}
+    );
+
+    const input = await screen.findByRole('combobox', {
+      name: 'Ask Seer with Natural Language',
+    });
+    await userEvent.type(input, 'test{Enter}');
+
+    const value = await screen.findByText(longValue);
+    expect(getEmotionRules(value).join(' ')).toContain('overflow-wrap: anywhere');
   });
 
   it('hides the feedback option when the rework is enabled', async () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -315,6 +315,52 @@ describe('AskSeerComboBox', () => {
 
     const value = await screen.findByText(longValue);
     expect(getEmotionRules(value).join(' ')).toContain('overflow-wrap: anywhere');
+
+    const formattedQuery = screen
+      .getAllByLabelText(`message:${longValue}`)
+      .find(element => element.parentElement?.tagName === 'SPAN')!;
+    expect(getEmotionRules(formattedQuery.parentElement!).join(' ')).toContain(
+      'width: fit-content'
+    );
+  });
+
+  it('sizes parameter chips to their content', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-explorer-ai/query/',
+      method: 'POST',
+      body: {
+        status: 'ok',
+        queries: [
+          {
+            query: 'span.duration:>30s',
+            groupBys: ['span.name', 'browser.name'],
+          },
+        ],
+      },
+    });
+    const reworkedOrganization = {
+      ...organization,
+      features: [...organization.features, 'gen-ai-ask-seer-ux-rework'],
+    };
+
+    render(
+      <SearchQueryBuilderProvider {...defaultProps}>
+        <AskSeerComboBox
+          initialQuery=""
+          askSeerMutationOptions={askSeerMutationOptions}
+          applySeerSearchQuery={() => {}}
+        />
+      </SearchQueryBuilderProvider>,
+      {organization: reworkedOrganization}
+    );
+
+    const input = await screen.findByRole('combobox', {
+      name: 'Ask Seer with Natural Language',
+    });
+    await userEvent.type(input, 'test{Enter}');
+
+    const groupBy = await screen.findByText('span.name');
+    expect(getEmotionRules(groupBy).join(' ')).toContain('width: fit-content');
   });
 
   it('hides the feedback option when the rework is enabled', async () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/oldQueryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/oldQueryTokens.tsx
@@ -238,6 +238,7 @@ const ExploreVisualizes = styled('span')`
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
   min-height: 24px;
+  width: fit-content;
   max-width: 100%;
   overflow-wrap: anywhere;
   white-space: normal;
@@ -249,6 +250,7 @@ const ExploreGroupBys = ExploreVisualizes;
 
 const FormattedQueryWrapper = styled('span')`
   display: block;
+  width: fit-content;
   min-width: 0;
   max-width: 100%;
 `;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/oldQueryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/oldQueryTokens.tsx
@@ -47,7 +47,7 @@ export function OldQueryTokens({
           .filter(({text}) => text.trim() !== '')
           .map(({text}) => (
             <FormattedQueryWrapper key={text}>
-              <ProvidedFormattedQuery query={text} />
+              <ProvidedFormattedQuery query={text} wrapTokens />
             </FormattedQueryWrapper>
           ))}
       </Flex>
@@ -195,7 +195,7 @@ export function OldQueryTokens({
                   ?.filter(({text}) => text.trim() !== '')
                   .map(({text}) => (
                     <FormattedQueryWrapper key={text}>
-                      <ProvidedFormattedQuery query={text} />
+                      <ProvidedFormattedQuery query={text} wrapTokens />
                     </FormattedQueryWrapper>
                   ))}
               </Flex>
@@ -237,10 +237,10 @@ const ExploreVisualizes = styled('span')`
   padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
-  height: 24px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  min-height: 24px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
   display: inline-flex;
   align-items: center;
 `;
@@ -248,5 +248,7 @@ const ExploreVisualizes = styled('span')`
 const ExploreGroupBys = ExploreVisualizes;
 
 const FormattedQueryWrapper = styled('span')`
-  display: inline-block;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
 `;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -223,6 +223,7 @@ const ExploreVisualizes = styled('span')`
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
   min-height: 24px;
+  width: fit-content;
   max-width: 100%;
   overflow-wrap: anywhere;
   white-space: normal;
@@ -234,6 +235,7 @@ const ExploreGroupBys = ExploreVisualizes;
 
 const FormattedQueryWrapper = styled('span')`
   display: block;
+  width: fit-content;
   min-width: 0;
   max-width: 100%;
 `;

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -56,14 +56,14 @@ function NewQueryTokens({
     : null;
   if (displayQuery && parsedQuery?.length) {
     tokens.push(
-      <Stack key="filter">
+      <Stack key="filter" minWidth="0" maxWidth="100%">
         <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
         <Stack gap="xs" overflow="hidden">
           {parsedQuery
             .filter(({text}) => text.trim() !== '')
             .map(({text}) => (
               <FormattedQueryWrapper key={text}>
-                <ProvidedFormattedQuery query={text} />
+                <ProvidedFormattedQuery query={text} wrapTokens />
               </FormattedQueryWrapper>
             ))}
         </Stack>
@@ -173,21 +173,21 @@ function NewQueryTokens({
     tokens.push(
       <Stack overflow="hidden" key={`${crossEvent.type}-${idx}`}>
         <ExploreParamTitle>{t('Cross Event Filter:')}</ExploreParamTitle>
-        <Flex gap="md">
-          <Stack gap="xs">
+        <Flex gap="md" wrap="wrap">
+          <Stack gap="xs" minWidth="0" maxWidth="100%">
             <ExploreParamTitle>{t('Dataset')}</ExploreParamTitle>
             <Container>
               <ExploreGroupBys>{crossEvent.type}</ExploreGroupBys>
             </Container>
           </Stack>
-          <Stack gap="xs">
+          <Stack gap="xs" minWidth="0" maxWidth="100%">
             <ExploreParamTitle>{t('Filter')}</ExploreParamTitle>
             <Stack gap="xs">
               {parsedCrossEvent
                 ?.filter(({text}) => text.trim() !== '')
                 .map(({text}) => (
                   <FormattedQueryWrapper key={text}>
-                    <ProvidedFormattedQuery query={text} />
+                    <ProvidedFormattedQuery query={text} wrapTokens />
                   </FormattedQueryWrapper>
                 ))}
             </Stack>
@@ -222,10 +222,10 @@ const ExploreVisualizes = styled('span')`
   padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
   border: 1px solid ${p => p.theme.tokens.border.secondary};
   border-radius: ${p => p.theme.radius.md};
-  height: 24px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  min-height: 24px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  white-space: normal;
   display: inline-flex;
   align-items: center;
 `;
@@ -233,5 +233,7 @@ const ExploreVisualizes = styled('span')`
 const ExploreGroupBys = ExploreVisualizes;
 
 const FormattedQueryWrapper = styled('span')`
-  display: inline-block;
+  display: block;
+  min-width: 0;
+  max-width: 100%;
 `;

--- a/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
@@ -115,14 +115,14 @@ describe('FormattedQuery', () => {
     expect(screen.getByText('foo*bar')).toBeInTheDocument();
   });
 
-  it('allows filter tokens to wrap when requested', () => {
+  it('wraps filter values without wrapping keys and operators', () => {
     const query = `message:${'a'.repeat(400)}`;
     render(<FormattedQuery {...defaultProps} query={query} wrapTokens />);
 
     const value = screen.getByText('a'.repeat(400));
     const filter = value.parentElement!.parentElement!;
 
-    expect(getEmotionRules(filter).join(' ')).toContain('white-space: normal');
+    expect(getEmotionRules(filter).join(' ')).toContain('white-space: nowrap');
     expect(getEmotionRules(value).join(' ')).toContain('white-space: normal');
     expect(getEmotionRules(value).join(' ')).toContain('overflow-wrap: anywhere');
   });

--- a/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
@@ -1,5 +1,5 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
+import {getEmotionRules, textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {
   FormattedQuery,
@@ -113,5 +113,17 @@ describe('FormattedQuery', () => {
     render(<FormattedQuery {...defaultProps} query="message:foo*bar" />);
 
     expect(screen.getByText('foo*bar')).toBeInTheDocument();
+  });
+
+  it('allows filter tokens to wrap when requested', () => {
+    const query = `message:${'a'.repeat(400)}`;
+    render(<FormattedQuery {...defaultProps} query={query} wrapTokens />);
+
+    const value = screen.getByText('a'.repeat(400));
+    const filter = value.parentElement!.parentElement!;
+
+    expect(getEmotionRules(filter).join(' ')).toContain('white-space: normal');
+    expect(getEmotionRules(value).join(' ')).toContain('white-space: normal');
+    expect(getEmotionRules(value).join(' ')).toContain('overflow-wrap: anywhere');
   });
 });

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useContext, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
@@ -8,10 +8,7 @@ import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilderConfig,
 } from 'sentry/components/searchQueryBuilder/context';
-import {
-  FormattedQueryConfigContext,
-  useFormattedQueryConfig,
-} from 'sentry/components/searchQueryBuilder/formattedQueryContext';
+import {FormattedQueryConfigContext} from 'sentry/components/searchQueryBuilder/formattedQueryContext';
 import {AggregateKeyVisual} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {FilterValueText} from 'sentry/components/searchQueryBuilder/tokens/filter/filter';
 import {getOperatorInfo} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
@@ -63,7 +60,7 @@ function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
 
 function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
-  const {wrapTokens} = useFormattedQueryConfig();
+  const {wrapTokens} = useContext(FormattedQueryConfigContext);
   const label = useMemo(
     () =>
       getOperatorInfo({
@@ -84,7 +81,7 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 }
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
-  const {wrapTokens} = useFormattedQueryConfig();
+  const {wrapTokens} = useContext(FormattedQueryConfigContext);
   const label = token.text.toUpperCase();
   return (
     <FilterWrapper aria-label={label} $wrapTokens={wrapTokens}>
@@ -94,7 +91,7 @@ function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
 }
 
 function QueryToken({token}: TokenProps) {
-  const {wrapTokens} = useFormattedQueryConfig();
+  const {wrapTokens} = useContext(FormattedQueryConfigContext);
 
   switch (token.type) {
     case Token.FILTER:

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,12 +1,17 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex, type FlexProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
   SearchQueryBuilderProvider,
   useSearchQueryBuilderConfig,
 } from 'sentry/components/searchQueryBuilder/context';
+import {
+  FormattedQueryConfigContext,
+  useFormattedQueryConfig,
+} from 'sentry/components/searchQueryBuilder/formattedQueryContext';
 import {AggregateKeyVisual} from 'sentry/components/searchQueryBuilder/tokens/filter/aggregateKey';
 import {FilterValueText} from 'sentry/components/searchQueryBuilder/tokens/filter/filter';
 import {getOperatorInfo} from 'sentry/components/searchQueryBuilder/tokens/filter/filterOperator';
@@ -31,6 +36,7 @@ export type FormattedQueryProps = {
   filterKeyAliases?: TagCollection;
   filterKeys?: TagCollection;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
+  wrapTokens?: boolean;
 };
 
 type TokenProps = {
@@ -57,6 +63,7 @@ function FilterKey({token}: {token: TokenResult<Token.FILTER>}) {
 
 function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
+  const {wrapTokens} = useFormattedQueryConfig();
   const label = useMemo(
     () =>
       getOperatorInfo({
@@ -67,9 +74,9 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
   );
 
   return (
-    <FilterWrapper aria-label={token.text}>
+    <FilterWrapper aria-label={token.text} $wrapTokens={wrapTokens}>
       <FilterKey token={token} /> {label}{' '}
-      <FilterValue>
+      <FilterValue $wrapTokens={wrapTokens}>
         <FilterValueText token={token} />
       </FilterValue>
     </FilterWrapper>
@@ -77,21 +84,28 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 }
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
+  const {wrapTokens} = useFormattedQueryConfig();
   const label = token.text.toUpperCase();
   return (
-    <FilterWrapper aria-label={label}>
+    <FilterWrapper aria-label={label} $wrapTokens={wrapTokens}>
       <Text variant="muted">{label}</Text>
     </FilterWrapper>
   );
 }
 
 function QueryToken({token}: TokenProps) {
+  const {wrapTokens} = useFormattedQueryConfig();
+
   switch (token.type) {
     case Token.FILTER:
       return <Filter token={token} />;
     case Token.FREE_TEXT:
       if (token.value.trim()) {
-        return <span>{token.value.trim()}</span>;
+        return (
+          <Text as="span" wordBreak={wrapTokens ? 'break-word' : undefined}>
+            {token.value.trim()}
+          </Text>
+        );
       }
       return null;
     case Token.L_PAREN:
@@ -121,6 +135,7 @@ export function FormattedQuery({
   fieldDefinitionGetter = defaultFieldDefinitionGetter,
   filterKeys = EMPTY_FILTER_KEYS,
   filterKeyAliases = EMPTY_FILTER_KEYS,
+  wrapTokens = false,
 }: FormattedQueryProps) {
   const parsedQuery = useMemo(() => {
     return parseQueryBuilderValue(query, fieldDefinitionGetter, {
@@ -128,17 +143,20 @@ export function FormattedQuery({
       filterKeyAliases,
     });
   }, [fieldDefinitionGetter, filterKeys, query, filterKeyAliases]);
+  const formattedQueryConfig = useMemo(() => ({wrapTokens}), [wrapTokens]);
 
   if (!parsedQuery) {
     return <QueryWrapper className={className} />;
   }
 
   return (
-    <QueryWrapper aria-label={query} className={className}>
-      {parsedQuery.map((token: any, index: any) => {
-        return <QueryToken key={index} token={token} />;
-      })}
-    </QueryWrapper>
+    <FormattedQueryConfigContext.Provider value={formattedQueryConfig}>
+      <QueryWrapper aria-label={query} className={className}>
+        {parsedQuery.map((token: any, index: any) => {
+          return <QueryToken key={index} token={token} />;
+        })}
+      </QueryWrapper>
+    </FormattedQueryConfigContext.Provider>
   );
 }
 
@@ -158,6 +176,7 @@ export function ProvidedFormattedQuery({
   filterKeys = EMPTY_FILTER_KEYS,
   filterKeyAliases = EMPTY_FILTER_KEYS,
   getFilterTokenWarning,
+  wrapTokens,
 }: FormattedQueryProps) {
   return (
     <SearchQueryBuilderProvider
@@ -174,44 +193,64 @@ export function ProvidedFormattedQuery({
         fieldDefinitionGetter={fieldDefinitionGetter}
         filterKeys={filterKeys}
         filterKeyAliases={filterKeyAliases}
+        wrapTokens={wrapTokens}
       />
     </SearchQueryBuilderProvider>
   );
 }
 
-const QueryWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  row-gap: ${p => p.theme.space.xs};
-  column-gap: ${p => p.theme.space.md};
-`;
+function QueryWrapper(props: FlexProps) {
+  return <Flex {...props} align="center" wrap="wrap" gap="xs md" />;
+}
 
-export const FilterWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  background: ${p => p.theme.tokens.background.primary};
-  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.xs};
-  border: 1px solid ${p => p.theme.tokens.border.secondary};
-  border-radius: ${p => p.theme.radius.md};
-  height: 24px;
-  white-space: nowrap;
-  overflow: hidden;
-`;
+type FilterWrapperProps = FlexProps & {
+  $wrapTokens?: boolean;
+};
 
-const FilterValue = styled('div')`
+export function FilterWrapper({
+  $wrapTokens = false,
+  style,
+  ...props
+}: FilterWrapperProps) {
+  return (
+    <Flex
+      {...props}
+      align="center"
+      gap="xs"
+      background="primary"
+      padding="2xs xs"
+      border="secondary"
+      radius="md"
+      minHeight="24px"
+      height={$wrapTokens ? 'auto' : '24px'}
+      maxWidth="100%"
+      whiteSpace={$wrapTokens ? 'normal' : 'nowrap'}
+      overflow={$wrapTokens ? 'visible' : 'hidden'}
+      style={{...style, overflowWrap: $wrapTokens ? 'anywhere' : undefined}}
+    />
+  );
+}
+
+const FilterValue = styled('div')<{$wrapTokens?: boolean}>`
   max-width: 300px;
+  min-width: 0;
   color: ${p => p.theme.tokens.content.accent};
   display: block;
   width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: ${p => (p.$wrapTokens ? 'normal' : 'nowrap')};
+  overflow: ${p => (p.$wrapTokens ? 'visible' : 'hidden')};
+  text-overflow: ${p => (p.$wrapTokens ? 'clip' : 'ellipsis')};
+  overflow-wrap: ${p => (p.$wrapTokens ? 'anywhere' : undefined)};
 `;
 
-const Paren = styled('div')`
-  display: flex;
-  align-items: center;
-  color: ${p => p.theme.tokens.content.secondary};
-`;
+function Paren({children}: {children: React.ReactNode}) {
+  return (
+    <Text variant="muted">
+      {props => (
+        <Flex {...props} align="center">
+          {children}
+        </Flex>
+      )}
+    </Text>
+  );
+}

--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -207,11 +207,7 @@ type FilterWrapperProps = FlexProps & {
   $wrapTokens?: boolean;
 };
 
-export function FilterWrapper({
-  $wrapTokens = false,
-  style,
-  ...props
-}: FilterWrapperProps) {
+export function FilterWrapper({$wrapTokens = false, ...props}: FilterWrapperProps) {
   return (
     <Flex
       {...props}
@@ -224,9 +220,8 @@ export function FilterWrapper({
       minHeight="24px"
       height={$wrapTokens ? 'auto' : '24px'}
       maxWidth="100%"
-      whiteSpace={$wrapTokens ? 'normal' : 'nowrap'}
+      whiteSpace="nowrap"
       overflow={$wrapTokens ? 'visible' : 'hidden'}
-      style={{...style, overflowWrap: $wrapTokens ? 'anywhere' : undefined}}
     />
   );
 }

--- a/static/app/components/searchQueryBuilder/formattedQueryContext.ts
+++ b/static/app/components/searchQueryBuilder/formattedQueryContext.ts
@@ -4,18 +4,12 @@ type FormattedQueryConfig = {
   wrapTokens: boolean;
 };
 
+// FilterValueText is also used by the interactive query builder, where the
+// absence of a provider means tokens should retain their default no-wrap behavior.
 export const FormattedQueryConfigContext = createContext<FormattedQueryConfig>({
   wrapTokens: false,
 });
 
 export function useFormattedQueryConfig() {
-  const context = useContext(FormattedQueryConfigContext);
-
-  if (!context) {
-    throw new Error(
-      'useFormattedQueryConfig must be used within a FormattedQueryConfigProvider'
-    );
-  }
-
-  return context;
+  return useContext(FormattedQueryConfigContext);
 }

--- a/static/app/components/searchQueryBuilder/formattedQueryContext.ts
+++ b/static/app/components/searchQueryBuilder/formattedQueryContext.ts
@@ -1,4 +1,4 @@
-import {createContext, useContext} from 'react';
+import {createContext} from 'react';
 
 type FormattedQueryConfig = {
   wrapTokens: boolean;
@@ -9,7 +9,3 @@ type FormattedQueryConfig = {
 export const FormattedQueryConfigContext = createContext<FormattedQueryConfig>({
   wrapTokens: false,
 });
-
-export function useFormattedQueryConfig() {
-  return useContext(FormattedQueryConfigContext);
-}

--- a/static/app/components/searchQueryBuilder/formattedQueryContext.ts
+++ b/static/app/components/searchQueryBuilder/formattedQueryContext.ts
@@ -9,5 +9,13 @@ export const FormattedQueryConfigContext = createContext<FormattedQueryConfig>({
 });
 
 export function useFormattedQueryConfig() {
-  return useContext(FormattedQueryConfigContext);
+  const context = useContext(FormattedQueryConfigContext);
+
+  if (!context) {
+    throw new Error(
+      'useFormattedQueryConfig must be used within a FormattedQueryConfigProvider'
+    );
+  }
+
+  return context;
 }

--- a/static/app/components/searchQueryBuilder/formattedQueryContext.ts
+++ b/static/app/components/searchQueryBuilder/formattedQueryContext.ts
@@ -1,0 +1,13 @@
+import {createContext, useContext} from 'react';
+
+type FormattedQueryConfig = {
+  wrapTokens: boolean;
+};
+
+export const FormattedQueryConfigContext = createContext<FormattedQueryConfig>({
+  wrapTokens: false,
+});
+
+export function useFormattedQueryConfig() {
+  return useContext(FormattedQueryConfigContext);
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -14,6 +14,7 @@ import {
   useSearchQueryBuilderLayout,
   useSearchQueryBuilderState,
 } from 'sentry/components/searchQueryBuilder/context';
+import {useFormattedQueryConfig} from 'sentry/components/searchQueryBuilder/formattedQueryContext';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {
   BaseGridCell,
@@ -57,11 +58,12 @@ interface FilterValueProps extends SearchQueryTokenProps {
 export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
   const {size} = useSearchQueryBuilderLayout();
+  const {wrapTokens} = useFormattedQueryConfig();
   const valueType = getFilterValueType(token, getFieldDefinition(getKeyName(token.key)));
 
   if (token.filter === FilterType.HAS) {
     return (
-      <FilterValueSingleTruncatedValue>
+      <FilterValueSingleTruncatedValue $wrap={wrapTokens}>
         {prettifyTagKey(token.value.text)}
       </FilterValueSingleTruncatedValue>
     );
@@ -75,7 +77,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
 
       if (items.length === 1 && items[0]!.value) {
         return (
-          <FilterValueSingleTruncatedValue>
+          <FilterValueSingleTruncatedValue $wrap={wrapTokens}>
             {formatFilterValue({token: items[0]!.value, valueType})}
           </FilterValueSingleTruncatedValue>
         );
@@ -84,10 +86,15 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
       const maxItems = size === 'small' ? 1 : 3;
 
       return (
-        <Flex align="center" wrap="nowrap" gap="xs" maxWidth="400px">
+        <Flex
+          align="center"
+          wrap={wrapTokens ? 'wrap' : 'nowrap'}
+          gap="xs"
+          maxWidth="400px"
+        >
           {items.slice(0, maxItems).map((item, index) => (
             <Fragment key={index}>
-              <FilterMultiValueTruncated>
+              <FilterMultiValueTruncated $wrap={wrapTokens}>
                 {formatFilterValue({token: item.value!, valueType})}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
@@ -108,7 +115,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
     }
     default: {
       return (
-        <FilterValueSingleTruncatedValue>
+        <FilterValueSingleTruncatedValue $wrap={wrapTokens}>
           {formatFilterValue({token: token.value, valueType})}
         </FilterValueSingleTruncatedValue>
       );
@@ -357,20 +364,22 @@ const FilterValueJoiner = styled('span')`
   color: ${p => p.theme.tokens.content.secondary};
 `;
 
-const FilterMultiValueTruncated = styled('div')`
+const FilterMultiValueTruncated = styled('div')<{$wrap?: boolean}>`
   display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 110px;
-  width: min-content;
+  white-space: ${p => (p.$wrap ? 'normal' : 'nowrap')};
+  overflow: ${p => (p.$wrap ? 'visible' : 'hidden')};
+  text-overflow: ${p => (p.$wrap ? 'clip' : 'ellipsis')};
+  overflow-wrap: ${p => (p.$wrap ? 'anywhere' : undefined)};
+  max-width: ${p => (p.$wrap ? '100%' : '110px')};
+  width: ${p => (p.$wrap ? 'auto' : 'min-content')};
 `;
 
-const FilterValueSingleTruncatedValue = styled('div')`
+const FilterValueSingleTruncatedValue = styled('div')<{$wrap?: boolean}>`
   display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: ${p => (p.$wrap ? 'normal' : 'nowrap')};
+  overflow: ${p => (p.$wrap ? 'visible' : 'hidden')};
+  text-overflow: ${p => (p.$wrap ? 'clip' : 'ellipsis')};
+  overflow-wrap: ${p => (p.$wrap ? 'anywhere' : undefined)};
   max-width: 100%;
-  width: min-content;
+  width: ${p => (p.$wrap ? 'auto' : 'min-content')};
 `;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useLayoutEffect, useRef, useState} from 'react';
+import {Fragment, useContext, useLayoutEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
 import {mergeProps} from '@react-aria/utils';
@@ -14,7 +14,7 @@ import {
   useSearchQueryBuilderLayout,
   useSearchQueryBuilderState,
 } from 'sentry/components/searchQueryBuilder/context';
-import {useFormattedQueryConfig} from 'sentry/components/searchQueryBuilder/formattedQueryContext';
+import {FormattedQueryConfigContext} from 'sentry/components/searchQueryBuilder/formattedQueryContext';
 import {useQueryBuilderGridItem} from 'sentry/components/searchQueryBuilder/hooks/useQueryBuilderGridItem';
 import {
   BaseGridCell,
@@ -58,7 +58,7 @@ interface FilterValueProps extends SearchQueryTokenProps {
 export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
   const {getFieldDefinition} = useSearchQueryBuilderConfig();
   const {size} = useSearchQueryBuilderLayout();
-  const {wrapTokens} = useFormattedQueryConfig();
+  const {wrapTokens} = useContext(FormattedQueryConfigContext);
   const valueType = getFilterValueType(token, getFieldDefinition(getKeyName(token.key)));
 
   if (token.filter === FilterType.HAS) {


### PR DESCRIPTION
Ask Seer query suggestions now wrap long filter values, generated chips, and cross-event filters instead of clipping content outside the result row. Both the legacy and reworked token renderers use the new behavior.

Formatted queries gain an opt-in wrapping configuration so existing consumers retain their current single-line truncation. The formatter also uses Scraps primitives for layout-only wrappers while preserving custom overflow styling where needed.

Closes BROWSE-640

**Before:**
<img width="616" height="226" alt="Screenshot 2026-07-21 at 12 02 06" src="https://github.com/user-attachments/assets/a912e0a3-117a-4618-9fdb-084b59e811ba" />

**After:**
<img width="619" height="269" alt="Screenshot 2026-07-21 at 12 01 57" src="https://github.com/user-attachments/assets/f3069387-97a2-447c-9606-093d247eeed8" />