### PR TITLE
feat(trace-items): Filter metrics to those with context via context_only

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -26,6 +26,7 @@ from sentry.search.eap.constants import (
     METRIC_TYPE_ALIAS,
     METRIC_UNIT_ALIAS,
 )
+from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.trace_metrics import TraceMetrics
@@ -77,6 +78,9 @@ class OrganizationTraceItemMetricsSerializer(serializers.Serializer[Never]):
     # Seer tools) remain distinguishable in query analytics. Falls back to the
     # endpoint default when absent or not a recognized referrer.
     referrer = serializers.CharField(required=False)
+    # Restrict results to metrics that have authored context. Gated behind the
+    # data-browsing-attribute-context feature (a no-op without it).
+    context_only = serializers.BooleanField(required=False, default=False)
 
     def validate_sort(self, value: str) -> str:
         field = value[1:] if value.startswith("-") else value
@@ -122,11 +126,33 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
             referrer = Referrer.API_EXPLORE_TRACEMETRICS_METRICS_LIST.value
 
         query_string = serialized.get("query", "")
-        # Authored context is joined from TraceItemAttributeValueContext, gated
+        # Authored context lives in TraceItemAttributeValueContext and is gated
         # behind the feature; conventions don't apply to custom metrics.
-        include_context = "context" in serialized.get("expand", set()) and features.has(
+        has_context_feature = features.has(
             "organizations:data-browsing-attribute-context", organization, actor=request.user
         )
+        # context_only restricts results to metrics that have authored context.
+        context_only = serialized.get("context_only", False) and has_context_feature
+        include_context = has_context_feature and (
+            "context" in serialized.get("expand", set()) or context_only
+        )
+
+        if context_only:
+            context_names = list(
+                TraceItemAttributeValueContext.objects.filter(
+                    organization=organization,
+                    item_type=TraceItemTypes.TRACEMETRICS,
+                    attribute_name=METRIC_NAME_ALIAS,
+                )
+                .values_list("attribute_value", flat=True)
+                .distinct()
+            )
+            if not context_names:
+                return self.paginate(request=request, paginator=ChainPaginator([]))
+            # Restrict the metrics query to names that have context, so count,
+            # sort, and pagination all operate on the filtered set.
+            name_filter = build_escaped_term_filter(METRIC_NAME_ALIAS, context_names)
+            query_string = f"{query_string} {name_filter}".strip()
 
         # Resolve the requested sort to a query orderby, always appending the
         # grouping key so pagination has a stable total order.
@@ -170,6 +196,10 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
             ]
             if include_context:
                 self._attach_context(metrics, organization)
+            if context_only:
+                # The query filters by name only, but context is keyed by
+                # (name, type) — drop rows whose specific type has no context.
+                metrics = [metric for metric in metrics if "context" in metric]
             return metrics
 
         return self.paginate(

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -123,6 +123,66 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         assert response.status_code == 400, response.data
         assert "sort" in response.data
 
+    def test_context_only_filters_to_metrics_with_context(self) -> None:
+        self.store_metric("has.context", "counter")
+        self.store_metric("no.context", "counter")
+        self.create_context("has.context", project=None, brief="Described")
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert [row["name"] for row in response.data] == ["has.context"]
+        assert response.data[0]["context"] == {"brief": "Described"}
+
+    def test_context_only_empty_when_no_context(self) -> None:
+        self.store_metric("no.context", "counter")
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert response.data == []
+
+    def test_context_only_matches_unicode_name(self) -> None:
+        # A unicode metric name must still match the IN filter (regression: json
+        # escaping would emit \uXXXX, which the search grammar doesn't decode).
+        self.store_metric("café.requests", "counter")
+        self.create_context("café.requests", project=None, brief="Café")
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert [row["name"] for row in response.data] == ["café.requests"]
+
+    def test_context_only_drops_type_without_context(self) -> None:
+        # Same name exists as counter and gauge, but only the counter has context.
+        # The name filter returns both; the gauge (no context) must be dropped.
+        self.store_metric("checkout.requests", "counter")
+        self.store_metric("checkout.requests", "gauge")
+        self.create_context(
+            "checkout.requests", metric_type=TraceMetricTypes.COUNTER, project=None, brief="Counter"
+        )
+
+        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+
+        assert response.status_code == 200, response.data
+        assert [(row["type"], "context" in row) for row in response.data] == [("counter", True)]
+
+    def test_context_only_ignored_without_feature(self) -> None:
+        self.store_metric("has.context", "counter")
+        self.store_metric("no.context", "counter")
+        self.create_context("has.context", project=None, brief="Described")
+
+        response = self.do_request(
+            query={"project": self.project.id, "context_only": "1"},
+            features={
+                "organizations:visibility-explore-view": True,
+                "organizations:tracemetrics-enabled": True,
+            },
+        )
+
+        assert response.status_code == 200, response.data
+        assert {row["name"] for row in response.data} == {"has.context", "no.context"}
+
     def test_expand_context(self) -> None:
         self.store_metric("checkout.requests", "counter")
         self.create_context(


### PR DESCRIPTION
Adds a `context_only` param to the trace-items metrics endpoint (`GET /organizations/{org}/trace-items/metrics/`) that restricts results to metrics with **authored context**.

## Changes

- New `context_only` boolean param on `OrganizationTraceItemMetricsEndpoint`. When set (and the `data-browsing-attribute-context` feature is enabled), it:
  - looks up the metric names that have authored context,
  - filters the metrics query to those names via `build_escaped_term_filter` (so count/sort/pagination operate on the filtered set),
  - drops rows whose specific `(name, type)` has no context (context is keyed by name+type; the name filter alone can over-match).
- Returns an empty page when no metrics have context.

## Notes

- This **recreates #120096 against master** — the original merged into the stack branch (`dain-1796-update-get_metric_names...`) by mistake, so the change never landed on master.
- Backend-only. Refs DAIN-1796.