### PR TITLE
fix(api): Scope trace item context PUT endpoints to event:write, not org:write

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attribute_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attribute_context.py
@@ -86,9 +86,6 @@ class OrganizationTraceItemAttributeContextEndpoint(OrganizationTraceItemAttribu
         "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
-    # Authoring attribute context is writing telemetry metadata, not
-    # organization settings, so scope it to `event:write` rather than
-    # `org:write`.
     permission_classes = (OrganizationEventPermission,)
 
     def put(self, request: Request, organization: Organization, key: str) -> Response:

--- a/src/sentry/api/endpoints/organization_trace_item_attribute_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attribute_context.py
@@ -13,6 +13,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEventPermission
 from sentry.api.endpoints.organization_trace_item_attributes import (
     POSSIBLE_ATTRIBUTE_TYPES,
     SUPPORTED_DATASETS,
@@ -85,6 +86,10 @@ class OrganizationTraceItemAttributeContextEndpoint(OrganizationTraceItemAttribu
         "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
+    # Authoring attribute context is writing telemetry metadata, not
+    # organization settings, so scope it to `event:write` rather than
+    # `org:write`.
+    permission_classes = (OrganizationEventPermission,)
 
     def put(self, request: Request, organization: Organization, key: str) -> Response:
         """Create or update the authored context for a custom trace item attribute."""

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -9,6 +9,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
+from sentry.api.bases.organization import OrganizationEventPermission
 from sentry.api.endpoints.organization_trace_item_attributes import (
     OrganizationTraceItemAttributesEndpointBase,
     adjust_start_end_window,
@@ -79,6 +80,9 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
+    # Authoring metric context is writing telemetry metadata, not organization
+    # settings, so scope it to `event:write` rather than `org:write`.
+    permission_classes = (OrganizationEventPermission,)
 
     def put(self, request: Request, organization: Organization, metric: str) -> Response:
         """Create or update the authored context for a trace metric."""

--- a/src/sentry/api/endpoints/organization_trace_item_metric_context.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metric_context.py
@@ -80,8 +80,6 @@ class OrganizationTraceItemMetricContextEndpoint(OrganizationTraceItemAttributes
         "PUT": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
-    # Authoring metric context is writing telemetry metadata, not organization
-    # settings, so scope it to `event:write` rather than `org:write`.
     permission_classes = (OrganizationEventPermission,)
 
     def put(self, request: Request, organization: Organization, metric: str) -> Response:

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attribute_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attribute_context.py
@@ -300,3 +300,25 @@ class OrganizationTraceItemAttributeContextEndpointTest(
 
         assert response.status_code == 400, response.data
         assert "dataset" in response.data
+
+    def test_member_role_can_write_context(self) -> None:
+        # Authoring attribute context is scoped to `event:write`, which the
+        # base member role has, rather than `org:write` (Manager/Owner only).
+        self.store_attribute(my_custom_attr="value")
+
+        member = self.create_user(is_superuser=False)
+        self.create_member(
+            user=member, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(member)
+
+        response = self.do_request(
+            "my_custom_attr",
+            {
+                "dataset": "spans",
+                "attributeType": "string",
+                "brief": "My custom attribute",
+            },
+        )
+
+        assert response.status_code == 201, response.data

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py
@@ -295,3 +295,24 @@ class OrganizationTraceItemMetricContextEndpointTest(
 
         assert response.status_code == 400, response.data
         assert "brief" in response.data
+
+    def test_member_role_can_write_context(self) -> None:
+        # Authoring metric context is scoped to `event:write`, which the base
+        # member role has, rather than `org:write` (Manager/Owner only).
+        self.store_metric("checkout.requests")
+
+        member = self.create_user(is_superuser=False)
+        self.create_member(
+            user=member, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(member)
+
+        response = self.do_request(
+            "checkout.requests",
+            {
+                "metricType": "counter",
+                "brief": "Checkout requests",
+            },
+        )
+
+        assert response.status_code == 201, response.data


### PR DESCRIPTION
## Summary
- `OrganizationTraceItemMetricContextEndpoint.put` and `OrganizationTraceItemAttributeContextEndpoint.put` previously fell back to the default `OrganizationPermission`, requiring `org:write` (Manager/Owner only) to save a metric or attribute description.
- Authoring this context is writing telemetry metadata, not organization settings — it should follow the same access model as other event data (`OrganizationEventPermission`), which the base Member role already has via `event:write`.
- Both endpoints now set `permission_classes = (OrganizationEventPermission,)`.

## Test plan
- [x] Added `test_member_role_can_write_context` to each endpoint's test suite, asserting a plain `member`-role user (no `org:write`) can now PUT context successfully.
- [ ] CI run of `tests/snuba/api/endpoints/test_organization_trace_item_metric_context.py` and `tests/snuba/api/endpoints/test_organization_trace_item_attribute_context.py`