### PR TITLE
style(search): Match Ask Seer option hover color

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.tsx
@@ -490,6 +490,7 @@ export function AskSeerComboBox<T extends QueryTokensProps>({
               )}
               <AskSeerSearchListBox
                 {...listBoxProps}
+                hasAskSeerUxRework={hasAskSeerUxRework}
                 listBoxRef={listBoxRef}
                 state={state}
               />

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -154,7 +154,12 @@ function AskSeerPollingPopoverContent({
         {hasAskSeerUxRework ? null : (
           <AskSeerSearchHeader title={t('Do any of these look right to you?')} />
         )}
-        <AskSeerSearchListBox {...listBoxProps} listBoxRef={listBoxRef} state={state} />
+        <AskSeerSearchListBox
+          {...listBoxProps}
+          hasAskSeerUxRework={hasAskSeerUxRework}
+          listBoxRef={listBoxRef}
+          state={state}
+        />
       </SeerContent>
     );
   }

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox.tsx
@@ -5,6 +5,7 @@ import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
 interface SeerSearchListBoxProps extends AriaListBoxOptions<unknown> {
+  hasAskSeerUxRework: boolean;
   state: ListState<unknown>;
   listBoxRef?: React.RefObject<HTMLUListElement | null>;
 }
@@ -15,7 +16,11 @@ export function AskSeerSearchListBox(props: SeerSearchListBoxProps) {
   const {listBoxProps} = useListBox(props, state, listBoxRef);
 
   return (
-    <StyledUl {...listBoxProps} ref={listBoxRef}>
+    <StyledUl
+      {...listBoxProps}
+      ref={listBoxRef}
+      $hasAskSeerUxRework={props.hasAskSeerUxRework}
+    >
       {[...state.collection].map(item => {
         return (
           <SeerSearchOption
@@ -47,7 +52,12 @@ function SeerSearchOption({item, state, label}: SeerSearchOptionProps) {
   );
 }
 
-const StyledUl = styled('ul')`
+const StyledUl = styled('ul')<{$hasAskSeerUxRework: boolean}>`
+  --ask-seer-option-interaction-background: ${p =>
+    p.$hasAskSeerUxRework
+      ? p.theme.tokens.interactive.transparent.neutral.background.hover
+      : p.theme.tokens.background.transparent.accent.muted};
+
   width: 100%;
   max-height: 18rem;
   overflow: auto;
@@ -71,23 +81,18 @@ const StyledOption = styled('li')<{isFocused: boolean}>`
   transition: background-color 0.2s ease;
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.xl};
   background-color: ${p =>
-    p.isFocused
-      ? p.theme.tokens.interactive.transparent.neutral.background.hover
-      : 'transparent'};
+    p.isFocused ? 'var(--ask-seer-option-interaction-background)' : 'transparent'};
 
   &:hover {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.hover};
+    background-color: var(--ask-seer-option-interaction-background);
   }
 
   &:focus {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.hover};
+    background-color: var(--ask-seer-option-interaction-background);
   }
 
   &[aria-selected='true'] {
-    background-color: ${p =>
-      p.theme.tokens.interactive.transparent.neutral.background.hover};
+    background-color: var(--ask-seer-option-interaction-background);
   }
 
   &[data-is-none-of-these],

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchListBox.tsx
@@ -71,18 +71,23 @@ const StyledOption = styled('li')<{isFocused: boolean}>`
   transition: background-color 0.2s ease;
   padding: ${p => p.theme.space.xs} ${p => p.theme.space.xl};
   background-color: ${p =>
-    p.isFocused ? p.theme.tokens.background.transparent.accent.muted : 'transparent'};
+    p.isFocused
+      ? p.theme.tokens.interactive.transparent.neutral.background.hover
+      : 'transparent'};
 
   &:hover {
-    background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 
   &:focus {
-    background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 
   &[aria-selected='true'] {
-    background-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+    background-color: ${p =>
+      p.theme.tokens.interactive.transparent.neutral.background.hover};
   }
 
   &[data-is-none-of-these],


### PR DESCRIPTION
Ask Seer search suggestions use the standard neutral interaction background for hover, focus, and selection states when the `gen-ai-ask-seer-ux-rework` feature is enabled. Organizations without the rework retain the existing purple accent treatment, keeping the visual change within the current rollout boundary.

Closes BROWSE-642
