### PR TITLE
fix(button): keep the chonky silhouette visible under the focus ring

### DIFF
--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -51,6 +51,8 @@ export function DO_NOT_USE_getButtonStyles(
   const buttonElevation = elevation[p.size];
 
   return {
+    '--button-lift': buttonElevation,
+
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
@@ -105,7 +107,7 @@ export function DO_NOT_USE_getButtonStyles(
       background: buttonTheme.surface,
       borderRadius: 'inherit',
       border: `1px solid ${buttonTheme.background}`,
-      transform: `translateY(-${buttonElevation})`,
+      transform: 'translateY(calc(-1 * var(--button-lift)))',
       transition: `transform ${p.theme.motion.snap.fast}`,
     },
 
@@ -113,10 +115,14 @@ export function DO_NOT_USE_getButtonStyles(
       outline: 'none',
       color: p.disabled || p.busy ? undefined : buttonTheme.color,
 
-      '&::after': {
-        border: `1px solid ${p.theme.tokens.focus.default}`,
-        boxShadow: `0 0 0 1px ${p.theme.tokens.focus.default}`,
-      },
+      '&::after': buttonTheme.focus
+        ? {border: `2px dotted ${buttonTheme.focus}`}
+        : {
+            // Three layers: the chonk color masks the offset ring copy, then
+            // the ring is drawn at the lift offset and again at rest, so it
+            // closes around the surface and chonk as a single outline.
+            boxShadow: `0 var(--button-lift) 0 0 ${buttonTheme.background}, 0 var(--button-lift) 0 2px ${p.theme.tokens.focus.default}, 0 0 0 2px ${p.theme.tokens.focus.default}`,
+          },
     },
 
     '&[aria-busy="true"] > span:last-child': {
@@ -135,28 +141,17 @@ export function DO_NOT_USE_getButtonStyles(
       overflow: 'hidden',
 
       whiteSpace: 'nowrap',
-      transform: `translateY(-${buttonElevation})`,
+      transform: 'translateY(calc(-1 * var(--button-lift)))',
       transition: `transform ${p.theme.motion.snap.fast}`,
     },
 
     '&:hover': {
+      '--button-lift': `calc(${buttonElevation} + ${hoverElevation})`,
       color: p.disabled || p.busy ? undefined : buttonTheme.color,
-
-      '&::after': {
-        transform: `translateY(calc(-${buttonElevation} - ${hoverElevation}))`,
-      },
-      '> span:last-child': {
-        transform: `translateY(calc(-${buttonElevation} - ${hoverElevation}))`,
-      },
     },
 
     '&:active, &[aria-expanded="true"], &[aria-checked="true"]': {
-      '&::after': {
-        transform: 'translateY(0px)',
-      },
-      '> span:last-child': {
-        transform: 'translateY(0px)',
-      },
+      '--button-lift': '0px',
     },
 
     '&[aria-expanded="true"], &[aria-checked="true"]': {
@@ -169,12 +164,7 @@ export function DO_NOT_USE_getButtonStyles(
     },
 
     '&:disabled, &[aria-disabled="true"], &[aria-busy="true"]': {
-      '&::after': {
-        transform: 'translateY(0px)',
-      },
-      '> span:last-child': {
-        transform: 'translateY(0px)',
-      },
+      '--button-lift': '0px',
     },
 
     '&[aria-busy="true"]': {
@@ -259,6 +249,7 @@ function getButtonTheme(variant: ButtonVariant, theme: Theme) {
         surface: theme.tokens.interactive.chonky.embossed.accent.background,
         background: theme.tokens.interactive.chonky.embossed.accent.chonk,
         color: theme.tokens.interactive.chonky.embossed.accent.content,
+        focus: theme.tokens.focus.onVibrant.light,
       };
     case 'secondary':
       return {
@@ -271,12 +262,14 @@ function getButtonTheme(variant: ButtonVariant, theme: Theme) {
         surface: theme.tokens.interactive.chonky.embossed.warning.background,
         background: theme.tokens.interactive.chonky.embossed.warning.chonk,
         color: theme.tokens.interactive.chonky.embossed.warning.content,
+        focus: theme.tokens.focus.onVibrant.dark,
       };
     case 'danger':
       return {
         surface: theme.tokens.interactive.chonky.embossed.danger.background,
         background: theme.tokens.interactive.chonky.embossed.danger.chonk,
         color: theme.tokens.interactive.chonky.embossed.danger.content,
+        focus: theme.tokens.focus.onVibrant.light,
       };
     case 'transparent':
       return {

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -881,4 +881,5 @@ export type StrictCSSObject = {
   [key: `&${string}`]: StrictCSSObject; // Allow nested selectors
   [key: `> ${string}:last-child`]: StrictCSSObject; // Allow some nested selectors
   [key: `> ${string}:first-child`]: StrictCSSObject; // Allow some nested selectors
+  [key: `--${string}`]: string; // Allow CSS custom properties
 }>;


### PR DESCRIPTION
When a `primary` button becomes focused, it gets a blue ring around it. However, since the color is identical to the button itself, it looks a little off. 

Old:
<img width="712" height="140" alt="Screenshot 2026-07-21 at 9 43 33 AM" src="https://github.com/user-attachments/assets/7533e4ea-95b8-4f81-94de-35fa46b47ee8" />
<img width="976" height="140" alt="Screenshot 2026-07-21 at 9 43 40 AM" src="https://github.com/user-attachments/assets/7516b42c-2d31-49d7-bee3-80ede09745c5" />
old focused light mode:
<img width="637" height="102" alt="Screenshot 2026-07-30 at 10 45 49 AM" src="https://github.com/user-attachments/assets/f5086ead-ba3a-4957-921f-3a036e305abc" />

New:
<img width="1068" height="173" alt="Screenshot 2026-07-21 at 9 43 56 AM" src="https://github.com/user-attachments/assets/c084b53e-26b1-4d46-bc75-76089c7d75cf" />
<img width="793" height="151" alt="Screenshot 2026-07-30 at 10 42 54 AM" src="https://github.com/user-attachments/assets/18d0a944-a9cb-46da-b14d-9b3fda473c4c" />
new focused light:
<img width="716" height="118" alt="Screenshot 2026-07-30 at 10 45 40 AM" src="https://github.com/user-attachments/assets/b8ef28d2-8018-4754-81eb-91fd7f1bfb95" />

This was more obvious in this case with the 'Create Internal Integration' button. Since it opened a modal, I would hit escape to get out of the modal, which would make the button suddenly look bigger.
<img width="423" height="61" alt="Screenshot 2026-07-21 at 9 46 51 AM" src="https://github.com/user-attachments/assets/fc9b71f4-d27a-43f6-9835-3cd86a2532e0" />
<img width="434" height="75" alt="Screenshot 2026-07-21 at 9 46 58 AM" src="https://github.com/user-attachments/assets/0405c6de-ec3a-40fe-ad45-b4f2949ea941" />
(light mode ver):
<img width="456" height="86" alt="Screenshot 2026-07-30 at 10 44 44 AM" src="https://github.com/user-attachments/assets/c192da41-137f-4180-93e7-9d5860c7a0de" />
<img width="423" height="79" alt="Screenshot 2026-07-30 at 10 44 50 AM" src="https://github.com/user-attachments/assets/7e2b483f-c9f1-455e-8754-cc6bf125226e" />
vs
<img width="446" height="82" alt="Screenshot 2026-07-30 at 10 43 52 AM" src="https://github.com/user-attachments/assets/f5277bdd-d9ee-484c-9ace-0dbb2250f7d2" />
<img width="447" height="89" alt="Screenshot 2026-07-30 at 10 44 56 AM" src="https://github.com/user-attachments/assets/af803c40-74e4-4397-ba07-08d5a8714d6a" />
