### PR TITLE
fix(seer): Show loading state instead of empty agent dropdown on initial load

### DIFF
--- a/static/app/components/seer/preferredAgentDropdownMenu.tsx
+++ b/static/app/components/seer/preferredAgentDropdownMenu.tsx
@@ -19,15 +19,16 @@ export function PreferredAgentDropdownMenu({
   size?: DropdownMenuProps['size'];
 }) {
   const organization = useOrganization();
-  const {data: agentOptions = []} = useQuery(
+  const {data: agentOptions = [], isPending: isAgentOptionsPending} = useQuery(
     seerAgentIntegrationsSelectQueryOptions({organization})
   );
 
   return (
     <DropdownMenu
-      isDisabled={isDisabled}
+      isDisabled={isDisabled || isAgentOptionsPending}
       size={size}
       triggerLabel={t('Agent')}
+      triggerProps={{busy: isAgentOptionsPending}}
       items={
         agentOptions.map(({value, label}) => ({
           key: value,

--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -32,12 +32,17 @@ describe('SeerProjectTable', () => {
   const organization = OrganizationFixture({access: ['org:write']});
   const project = ProjectFixture({id: '2', slug: 'project-slug'});
 
-  function mockBaseEndpoints() {
+  function mockBaseEndpoints({
+    codingAgentsAsyncDelay,
+  }: {codingAgentsAsyncDelay?: number} = {}) {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/coding-agents/`,
       body: {
         integrations: [{id: '123', provider: 'cursor', name: 'Cursor Cloud Agent'}],
       },
+      ...(codingAgentsAsyncDelay === undefined
+        ? {}
+        : {asyncDelay: codingAgentsAsyncDelay}),
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/projects/`,
@@ -184,5 +189,28 @@ describe('SeerProjectTable', () => {
     // blur-to-save flow to persist) and no warning is shown.
     expect(await screen.findByText('Cursor Cloud Agent')).toBeInTheDocument();
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading indicator instead of an empty select while agent options are still loading', async () => {
+    // Overrides the beforeEach mock with one that never resolves within the
+    // test, keeping the agentSelectOptions query pending indefinitely.
+    mockBaseEndpoints({codingAgentsAsyncDelay: 100_000});
+
+    renderTable();
+
+    // The project row itself has loaded (its own query is unaffected), but the
+    // agent cell must show a loading indicator rather than a select with an
+    // empty/mismatched value.
+    await screen.findByText('project-slug');
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+    expect(screen.queryByText('Seer')).not.toBeInTheDocument();
+  });
+
+  it('shows the real agent value once options finish loading', async () => {
+    mockBaseEndpoints({codingAgentsAsyncDelay: 10});
+
+    renderTable();
+
+    expect(await screen.findByText('Seer')).toBeInTheDocument();
   });
 });

--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -191,7 +191,7 @@ describe('SeerProjectTable', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('shows a loading indicator instead of an empty select while agent options are still loading', async () => {
+  it('disables the agent select while agent options are still loading', async () => {
     // Overrides the beforeEach mock with one that never resolves within the
     // test, keeping the agentSelectOptions query pending indefinitely.
     mockBaseEndpoints({codingAgentsAsyncDelay: 100_000});
@@ -199,18 +199,20 @@ describe('SeerProjectTable', () => {
     renderTable();
 
     // The project row itself has loaded (its own query is unaffected), but the
-    // agent cell must show a loading indicator rather than a select with an
+    // agent select must stay disabled rather than showing a select with an
     // empty/mismatched value.
     await screen.findByText('project-slug');
-    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    expect(screen.queryByText('Seer')).not.toBeInTheDocument();
+    const select = await screen.findByRole('textbox', {name: 'Agent'});
+    await waitFor(() => expect(select).toBeDisabled());
   });
 
-  it('shows the real agent value once options finish loading', async () => {
+  it('enables the agent select once options finish loading', async () => {
     mockBaseEndpoints({codingAgentsAsyncDelay: 10});
 
     renderTable();
 
+    const select = await screen.findByRole('textbox', {name: 'Agent'});
+    await waitFor(() => expect(select).toBeEnabled());
     expect(await screen.findByText('Seer')).toBeInTheDocument();
   });
 });

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -337,18 +337,6 @@ function AgentSelectCell({
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  // The select's value comes from the row data, but its options come from
-  // agentSelectOptions. Rendering before the options load leaves the select
-  // with a value that matches nothing, so it briefly shows blank before the
-  // option pops in. Show a loading indicator instead until options settle.
-  if (optionsPending) {
-    return (
-      <Flex align="center" justify="center">
-        <LoadingIndicator size={20} />
-      </Flex>
-    );
-  }
-
   return (
     <AutoSaveForm
       name="agentOption"
@@ -363,7 +351,8 @@ function AgentSelectCell({
     >
       {field => (
         <field.Select
-          disabled={disabled}
+          aria-label={t('Agent')}
+          disabled={disabled || optionsPending}
           menuPortalTarget={document.body}
           multiple={false}
           onMenuOpen={() => {
@@ -398,7 +387,16 @@ function AgentSelectCell({
             }
             field.handleChange(newValue);
           }}
-          options={agentSelectOptions}
+          // The select's value comes from the row data, but its options come
+          // from agentSelectOptions. Before that query resolves there are no
+          // options to match the value against, so the select would render
+          // blank. Fall back to a single placeholder option (kept in sync
+          // with the current value) so it renders normally while disabled.
+          options={
+            optionsPending
+              ? [{value: field.state.value, label: t('Loading…')}]
+              : agentSelectOptions
+          }
           // @ts-expect-error: Select component does not have a size prop defined
           size="xs"
           value={field.state.value}

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -97,7 +97,7 @@ export function SeerProjectTable() {
   const {data: knownAgents} = useQuery(
     knownAgentIntegrationsQueryOptions({organization})
   );
-  const {data: agentSelectOptions = []} = useQuery(
+  const {data: agentSelectOptions = [], isPending: isAgentOptionsPending} = useQuery(
     seerAgentIntegrationsSelectQueryOptions({organization})
   );
   const stoppingPointOptions = useStoppingPointSelectOptions();
@@ -270,6 +270,7 @@ export function SeerProjectTable() {
                             item.integrationId
                           )}
                           agentSelectOptions={agentSelectOptions}
+                          optionsPending={isAgentOptionsPending}
                           knownAgents={knownAgents}
                           disabled={!canWrite}
                         />
@@ -321,6 +322,7 @@ interface AgentSelectCellProps {
   disabled: boolean;
   initialValue: AutofixAgentSelectOption;
   knownAgents: AgentIntegration[] | undefined;
+  optionsPending: boolean;
   projectSlug: string;
 }
 
@@ -329,10 +331,23 @@ function AgentSelectCell({
   disabled,
   initialValue,
   knownAgents,
+  optionsPending,
   projectSlug,
 }: AgentSelectCellProps) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
+
+  // The select's value comes from the row data, but its options come from
+  // agentSelectOptions. Rendering before the options load leaves the select
+  // with a value that matches nothing, so it briefly shows blank before the
+  // option pops in. Show a loading indicator instead until options settle.
+  if (optionsPending) {
+    return (
+      <Flex align="center" justify="center">
+        <LoadingIndicator size={20} />
+      </Flex>
+    );
+  }
 
   return (
     <AutoSaveForm


### PR DESCRIPTION
## Summary
- The per-row agent `Select` in `SeerProjectTable` renders with a real `value` (e.g. `'seer'`) but an empty `options` list until the separate `agentSelectOptions` query resolves, so the dropdown briefly appears blank before the correct option pops in.
- Gate the cell's render on that query's pending state and show a loading indicator instead, mirroring the existing fix in `AutofixAgent`.
- Apply the same gating to the bulk header `PreferredAgentDropdownMenu` (disabled + busy trigger while pending).

Fixes [CW-1529](https://linear.app/getsentry/issue/CW-1529/agent-dropdown-empty-on-initial-seer-setup).

## Test plan
- [x] Added `seerProjectTable.spec.tsx` tests asserting a loading indicator (not an empty select) shows while options are pending, and the real `Seer` value appears once they resolve
- [x] `pnpm test-ci static/app/components/seer/projectTable/seerProjectTable.spec.tsx` passes (5/5)
- [x] `pnpm run typecheck` clean for touched files