### PR TITLE
fix(seer): Restore issue summary generation for seat-based orgs 

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1065,6 +1065,12 @@ register(
 # killswitch, which is checked before calling Seer when potentially creating a  new group as part of
 # ingestion.
 register(
+    "seer.post-process-issue-summary-killswitch.enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "seer.similarity-killswitch.enabled",
     default=False,
     type=Bool,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1509,14 +1509,38 @@ def check_if_flags_sent(job: PostProcessJob) -> None:
 
 
 def kick_off_seer_automation(job: PostProcessJob) -> None:
+    from sentry.seer.autofix.issue_summary import (
+        get_issue_summary_cache_key,
+        get_issue_summary_lock_key,
+    )
     from sentry.seer.autofix.trigger import get_default_seer_automation_skip_reason
     from sentry.seer.autofix.utils import is_seer_seat_based_tier_enabled
-    from sentry.tasks.seer.autofix import generate_summary_and_run_automation
+    from sentry.tasks.seer.autofix import (
+        generate_issue_summary_only,
+        generate_summary_and_run_automation,
+    )
 
     event = job["event"]
     group = event.group
 
     if is_seer_seat_based_tier_enabled(group.organization):
+        # Guards to prevent thundering herd on issue summary generation.
+        if options.get("seer.post-process-issue-summary-killswitch.enabled"):
+            return
+        if group.seer_fixability_score is not None:
+            return
+        # Issues created in last 5 minutes only. This can be removed once this is live past 1 week.
+        # We don't want to backfill old issues since that will overwhelm Seer.
+        if (timezone.now() - group.first_seen).total_seconds() > 300:
+            return
+        # Generate issue summary and fixability score if not cached.
+        # Agentic Triage handles automations for seat-based orgs but still needs these.
+        cache_key = get_issue_summary_cache_key(group.id)
+        if cache.get(cache_key) is None:
+            lock_key, lock_name = get_issue_summary_lock_key(group.id)
+            lock = locks.get(lock_key, duration=1, name=lock_name)
+            if not lock.locked():
+                generate_issue_summary_only.delay(group.id)
         return
 
     skip_reason = get_default_seer_automation_skip_reason(group, locks)

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3180,34 +3180,40 @@ class KickOffLightweightRCAClusterTestMixin(BasePostProcessGroupMixin):
 
 @patch("sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True)
 class SeatBasedSeerAutomationTestMixin(BasePostProcessGroupMixin):
-    @patch("sentry.tasks.seer.autofix.generate_summary_and_run_automation.delay")
-    @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
-    @patch("sentry.tasks.seer.autofix.run_automation_only_task.delay")
-    @with_feature({"organizations:gen-ai-features": True})
-    def test_seat_based_org_skips_post_process_automation(
-        self,
-        mock_run_automation,
-        mock_generate_summary_only,
-        mock_generate_summary_and_run_automation,
-        mock_seat_based_tier,
-    ):
-        self.project.update_option("sentry:seer_scanner_automation", True)
-        event = self.create_event(
-            data={"message": "testing"},
-            project_id=self.project.id,
-        )
-
+    def _seat_based_post_process(self, **group_overrides):
+        """Helper: create event, optionally update group fields, run post-process."""
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
+        if group_overrides:
+            event.group.update(**group_overrides)
         self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
-            event=event,
+            is_new=True, is_regression=False, is_new_group_environment=True, event=event
         )
+        return event
 
-        # Nothing is kicked off from post-process for seat-based orgs.
-        mock_generate_summary_and_run_automation.assert_not_called()
+    @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
+    @with_feature({"organizations:gen-ai-features": True})
+    @override_options({"seer.post-process-issue-summary-killswitch.enabled": True})
+    def test_seat_based_org_killswitch_prevents_summary(
+        self, mock_generate_summary_only, mock_seat_based_tier
+    ):
+        self._seat_based_post_process()
         mock_generate_summary_only.assert_not_called()
-        mock_run_automation.assert_not_called()
+
+    @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
+    @with_feature({"organizations:gen-ai-features": True})
+    def test_seat_based_org_skips_old_issues(
+        self, mock_generate_summary_only, mock_seat_based_tier
+    ):
+        self._seat_based_post_process(first_seen=timezone.now() - timedelta(minutes=10))
+        mock_generate_summary_only.assert_not_called()
+
+    @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
+    @with_feature({"organizations:gen-ai-features": True})
+    def test_seat_based_org_skips_when_fixability_exists(
+        self, mock_generate_summary_only, mock_seat_based_tier
+    ):
+        self._seat_based_post_process(seer_fixability_score=0.5)
+        mock_generate_summary_only.assert_not_called()
 
 
 class SeerAutomationHelperFunctionsTestMixin(BasePostProcessGroupMixin):
@@ -3290,6 +3296,18 @@ class PostProcessGroupErrorTest(
     ProcessSimilarityTestMixin,
     CheckIfFlagsSentTestMixin,
 ):
+    @patch("sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True)
+    @patch("sentry.tasks.seer.autofix.generate_issue_summary_only.delay")
+    @with_feature({"organizations:gen-ai-features": True})
+    def test_seat_based_org_generates_summary_for_new_issues(
+        self, mock_generate_summary_only, mock_seat_based_tier
+    ):
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
+        self.call_post_process_group(
+            is_new=True, is_regression=False, is_new_group_environment=True, event=event
+        )
+        mock_generate_summary_only.assert_called_once_with(event.group.id)
+
     def setUp(self) -> None:
         super().setUp()
 


### PR DESCRIPTION
+ Re-enable issue summary and fixability score generation for seat-based orgs during post-process, with three guards to prevent the thundering herd that caused the previous incident caused by this PR : https://github.com/getsentry/sentry/pull/120141

1. Kill switch option (seer.post-process-issue-summary-killswitch.enabled) for instant disable without a deploy. Set to False by default. PR ready to flip if load is still too much: https://github.com/getsentry/sentry-options-automator/pull/8802
2. Skip groups that already have a fixability score.
3. Only process issues created in the last 5 minutes to avoid backfill flood on deploy.

