### PR TITLE
fix(analytics): Track SCM project-creation platform searches

### DIFF
--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.spec.tsx
@@ -3,12 +3,28 @@ import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {RepositoryFixture} from 'sentry-fixture/repository';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
 
 import {ScmPlatformFeaturesCore} from './scmPlatformFeaturesCore';
+
+interface MockDebouncedCallback {
+  callback: () => void;
+  isActive: () => boolean;
+}
+
+const mockDebouncedCallbacks: MockDebouncedCallback[] = [];
+
+jest.mock('lodash/debounce', () => (callback: () => void) => {
+  const debounced = jest.fn();
+  mockDebouncedCallbacks.push({
+    callback,
+    isActive: () => debounced.mock.calls.length > 0,
+  });
+  return debounced;
+});
 
 // Mock the virtualizer so the manual-picker Select renders in JSDOM (no layout
 // engine).
@@ -71,6 +87,10 @@ function defaultProps(overrides: Partial<Record<string, unknown>> = {}) {
 
 describe('ScmPlatformFeaturesCore', () => {
   const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    mockDebouncedCallbacks.length = 0;
+  });
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -180,6 +200,45 @@ describe('ScmPlatformFeaturesCore', () => {
       'growth.select_platform',
       expect.anything()
     );
+  });
+
+  it('tracks one debounced manual platform search with its result count', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    render(
+      <ScmPlatformFeaturesCore
+        {...defaultProps({
+          analyticsFlow: 'project-creation',
+          selectedPlatform: undefined,
+        })}
+      />,
+      {organization}
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), 'java ');
+
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'growth.platformpicker_search',
+      expect.anything()
+    );
+
+    const activeDebouncedCallbacks = mockDebouncedCallbacks.filter(({isActive}) =>
+      isActive()
+    );
+    expect(activeDebouncedCallbacks).toHaveLength(1);
+
+    act(() => {
+      activeDebouncedCallbacks[0]!.callback();
+    });
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledTimes(1);
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith('growth.platformpicker_search', {
+      organization,
+      search: 'java ',
+      num_results: 1,
+      source: 'project-creation',
+      variant: 'scm',
+    });
   });
 
   it('clears the selected platform from the manual picker', async () => {

--- a/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
+++ b/static/app/components/onboarding/scm/scmPlatformFeaturesCore.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {motion} from 'framer-motion';
+import debounce from 'lodash/debounce';
 import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
@@ -9,8 +10,10 @@ import {Select} from '@sentry/scraps/select';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {closeModal, openConsoleModal} from 'sentry/actionCreators/modal';
+import {createFilter} from 'sentry/components/forms/controls/reactSelectWrapper';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconBroadcast} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
@@ -36,6 +39,13 @@ import {
 import {ScmSearchControl} from './scmSearchControl';
 import {ScmVirtualizedMenuList} from './scmVirtualizedMenuList';
 import {useScmResolvedPlatform} from './useScmResolvedPlatform';
+
+type PlatformOption = (typeof platformOptions)[number];
+
+const matchesPlatformOption = createFilter({
+  stringify: (option: {data: PlatformOption; label: string; value: string}) =>
+    option.data.textValue ?? `${option.label} ${option.value}`,
+});
 
 const CHANGE_PLATFORM_CLICKED_EVENT = {
   onboarding: 'onboarding.scm_platform_change_platform_clicked',
@@ -81,6 +91,7 @@ export function ScmPlatformFeaturesCore({
   const organization = useOrganization();
 
   const [showManualPicker, setShowManualPicker] = useState(false);
+  const [manualPickerFilter, setManualPickerFilter] = useState('');
   // Guards the auto-detect analytics event below so it fires once per repo.
   const autoDetectionTrackedRef = useRef(false);
 
@@ -340,6 +351,64 @@ export function ScmPlatformFeaturesCore({
     ];
   }, [currentPlatformKey]);
 
+  const manualPickerFilteredOptions = useMemo(
+    () =>
+      manualPickerOptions.filter(option =>
+        matchesPlatformOption(
+          {label: option.label, value: option.value, data: option},
+          manualPickerFilter
+        )
+      ),
+    [manualPickerFilter, manualPickerOptions]
+  );
+
+  const latestSearchValuesRef = useRef({
+    filter: manualPickerFilter,
+    options: manualPickerFilteredOptions,
+    organization,
+    analyticsFlow,
+  });
+
+  useEffect(() => {
+    latestSearchValuesRef.current = {
+      filter: manualPickerFilter,
+      options: manualPickerFilteredOptions,
+      organization,
+      analyticsFlow,
+    };
+  });
+
+  const debounceManualPickerSearch = useRef(
+    debounce(() => {
+      const {
+        filter,
+        options,
+        organization: currentOrganization,
+        analyticsFlow: flow,
+      } = latestSearchValuesRef.current;
+
+      if (!filter || flow !== 'project-creation') {
+        return;
+      }
+
+      trackAnalytics('growth.platformpicker_search', {
+        organization: currentOrganization,
+        search: filter.toLowerCase(),
+        num_results: options.length,
+        source: 'project-creation',
+        variant: 'scm',
+      });
+    }, DEFAULT_DEBOUNCE_DURATION)
+  ).current;
+
+  function handleManualPickerSearch(query: string, {action}: {action: string}) {
+    if (action !== 'input-change') {
+      return;
+    }
+    setManualPickerFilter(query);
+    debounceManualPickerSearch();
+  }
+
   // When the active platform is a manual (non-detected) pick, show the manual
   // picker so the selection stays visible (see showDetectedPlatforms below).
   const hasDetectedPlatforms = resolvedPlatforms.length > 0 || isDetecting;
@@ -449,6 +518,7 @@ export function ScmPlatformFeaturesCore({
           options={manualPickerOptions}
           value={currentPlatformKey ?? null}
           onChange={handleManualPickerChange}
+          onInputChange={handleManualPickerSearch}
           searchable
           components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}
           styles={{container: base => ({...base, width: '100%'})}}
@@ -459,6 +529,7 @@ export function ScmPlatformFeaturesCore({
           options={manualPickerOptions}
           value={currentPlatformKey ?? null}
           onChange={handleManualPickerChange}
+          onInputChange={handleManualPickerSearch}
           clearable
           searchable
           components={{Control: ScmSearchControl, MenuList: ScmVirtualizedMenuList}}


### PR DESCRIPTION
## TLDR

SCM-first project creation now records manual platform searches on the existing `growth.platformpicker_search` counter, making search behavior comparable with the legacy picker without changing onboarding analytics.

## Details

The SCM manual picker previously exposed the same search interaction as the legacy `PlatformPicker` but emitted no search event. `ScmPlatformFeaturesCore` now follows the existing debounced search pattern and reports the lowercase query, result count, `source: 'project-creation'`, and `variant: 'scm'`.

The shared onboarding arm remains silent, so SCM onboarding traffic does not enter the project-creation growth bucket. Focused coverage verifies the flow and variant carrier fields.

Refs VDY-133
