### PR TITLE
fix(analytics): Preserve setup-docs project attribution

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
 import {
+  docsFlowProjectIdParams,
   docsFlowVariantParams,
   DSN_COPIED_EVENT,
   resolveDocsFlowEvent,
@@ -27,6 +28,7 @@ function CopyDsnField({params}: {params: DocsParams<any>}) {
           trackAnalytics(resolveDocsFlowEvent(DSN_COPIED_EVENT, params.docsFlow), {
             organization: params.organization,
             platform: params.platformKey,
+            ...docsFlowProjectIdParams(params.docsFlow, params.project.id),
             ...docsFlowVariantParams(params.docsFlow),
           })
         }

--- a/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.spec.tsx
@@ -1,5 +1,6 @@
 import {
   docsFlowGamingOrigin,
+  docsFlowProjectIdParams,
   docsFlowMarkdownParams,
   docsFlowVariantParams,
   DSN_COPIED_EVENT,
@@ -80,6 +81,20 @@ describe('docsFlowAnalytics', () => {
 
     it('omits variant when project-creation origin is unmarked', () => {
       expect(docsFlowVariantParams(undefined)).toEqual({});
+    });
+  });
+
+  describe('docsFlowProjectIdParams', () => {
+    it('adds project context only to project-creation events', () => {
+      expect(docsFlowProjectIdParams('project-creation', '42')).toEqual({
+        project_id: '42',
+      });
+      expect(docsFlowProjectIdParams('project-creation-scm', '42')).toEqual({
+        project_id: '42',
+      });
+      expect(docsFlowProjectIdParams(undefined, '42')).toEqual({project_id: '42'});
+      expect(docsFlowProjectIdParams('onboarding', '42')).toEqual({});
+      expect(docsFlowProjectIdParams('onboarding-scm', '42')).toEqual({});
     });
   });
 

--- a/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/docsFlowAnalytics.ts
@@ -42,6 +42,20 @@ export function docsFlowVariantParams(flow: DocsFlow | undefined): {
   }
 }
 
+/**
+ * Project context for shared setup-docs events. Unmarked surfaces keep the
+ * historical project-creation fallback, while onboarding events retain their
+ * existing payload shape.
+ */
+export function docsFlowProjectIdParams(
+  flow: DocsFlow | undefined,
+  projectId: string
+): {project_id?: string} {
+  return flow === 'onboarding' || flow === 'onboarding-scm'
+    ? {}
+    : {project_id: projectId};
+}
+
 export const DSN_COPIED_EVENT = {
   onboarding: 'onboarding.dsn-copied',
   'onboarding-scm': 'onboarding.scm_dsn_copied',

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -9,6 +9,7 @@ import {ListItem} from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
   docsFlowMarkdownParams,
+  docsFlowProjectIdParams,
   docsFlowVariantParams,
   DSN_COPIED_EVENT,
   NEXT_STEP_CLICKED_EVENT,
@@ -141,6 +142,7 @@ export function OnboardingLayout({
             trackAnalytics(resolveDocsFlowEvent(DSN_COPIED_EVENT, docsFlow), {
               organization,
               platform: platformKey,
+              ...docsFlowProjectIdParams(docsFlow, project.id),
               ...docsFlowVariantParams(docsFlow),
             });
           },

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -52,6 +52,7 @@ export type ProjectCreationEventParameters = {
   // event name (see docsFlowAnalytics.ts / docsFlowVariantParams).
   'project_creation.dsn_copied': {
     platform: string;
+    project_id: string;
     variant?: ProjectCreationVariant;
   };
   'project_creation.js_loader_npm_docs_shown': {

--- a/static/app/views/projectInstall/platform.spec.tsx
+++ b/static/app/views/projectInstall/platform.spec.tsx
@@ -313,7 +313,7 @@ describe('ProjectInstallPlatform', () => {
         'project_creation.data_removal_modal_confirm_button_clicked',
         expect.objectContaining({
           organization,
-          platform: project.slug,
+          platform: 'other',
           project_id: project.id,
           variant,
         })
@@ -324,7 +324,7 @@ describe('ProjectInstallPlatform', () => {
           expect.objectContaining({
             organization,
             date_created: project.dateCreated,
-            platform: project.slug,
+            platform: 'other',
             project_id: project.id,
             variant,
           })
@@ -357,7 +357,7 @@ describe('ProjectInstallPlatform', () => {
       'project_creation.data_removal_modal_confirm_button_clicked',
       expect.objectContaining({
         organization,
-        platform: project.slug,
+        platform: 'other',
         project_id: project.id,
       })
     );
@@ -371,7 +371,7 @@ describe('ProjectInstallPlatform', () => {
         expect.objectContaining({
           organization,
           date_created: project.dateCreated,
-          platform: project.slug,
+          platform: 'other',
           project_id: project.id,
         })
       );

--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -63,7 +63,7 @@ export function PlatformDocHeader({
     if (!isProjectActive) {
       trackAnalytics('project_creation.data_removal_modal_confirm_button_clicked', {
         organization,
-        platform: recentCreatedProject.slug,
+        platform: platform.id,
         project_id: recentCreatedProject.id,
         ...variantParams,
       });
@@ -79,7 +79,7 @@ export function PlatformDocHeader({
         trackAnalytics('project_creation.data_removed', {
           organization,
           date_created: recentCreatedProject.dateCreated,
-          platform: recentCreatedProject.slug,
+          platform: platform.id,
           project_id: recentCreatedProject.id,
           ...variantParams,
         });
@@ -106,6 +106,7 @@ export function PlatformDocHeader({
     isProjectActive,
     navigate,
     projectCreationVariant,
+    platform.id,
   ]);
 
   useBlocker(({historyAction}) => {


### PR DESCRIPTION
## TLDR

Project-creation setup-docs events now retain the project and platform identifiers BI needs to join downstream activity to the project that was created.

## Details

The project-creation BI audit found two payload-shape gaps after the getting-started handoff. `project_creation.dsn_copied` carried platform and variant but not `project_id`, while the getting-started removal events populated their `platform` field with the project slug.

A small `docsFlowProjectIdParams` helper now adds `project_id` to DSN-copy events for the project-creation and unmarked project surfaces. The onboarding and SCM-onboarding arms keep their existing payload shape, matching the established rule that their distinct event names remain unchanged.

`PlatformDocHeader` now reports `platform.id` for data-removal confirmation and completion instead of `recentCreatedProject.slug`. The callback dependency and regression expectations move with that value so the event contract consistently identifies the SDK platform rather than the project.

Focused coverage locks the four docs-flow project-ID cases, the unmarked fallback, both onboarding exclusions, and the corrected platform payload for marked and unmarked getting-started views.

Refs VDY-133
