### PR TITLE
fix(analytics): Attribute legacy framework modal actions

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.spec.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.spec.tsx
@@ -10,6 +10,7 @@ import {
 
 import {allPlatforms as platforms} from 'sentry/data/platforms';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import * as analytics from 'sentry/utils/analytics';
 
 import {
   FrameworkSuggestionModal,
@@ -77,6 +78,7 @@ describe('Framework suggestion modal', () => {
   });
 
   it('should only call handleConfigure once on rapid multiple clicks', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const handleSkip = jest.fn();
 
     render(
@@ -100,5 +102,35 @@ describe('Framework suggestion modal', () => {
     await userEvent.click(button);
 
     expect(handleSkip).toHaveBeenCalledTimes(1);
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.select_framework_modal_skip_button_clicked',
+      expect.objectContaining({variant: 'legacy'})
+    );
+  });
+
+  it('adds the legacy variant to framework configuration analytics', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
+    render(
+      <FrameworkSuggestionModal
+        Body={ModalBody}
+        Header={makeClosableHeader(jest.fn())}
+        closeModal={jest.fn()}
+        CloseButton={makeCloseButton(jest.fn())}
+        Footer={ModalFooter}
+        onConfigure={jest.fn()}
+        onSkip={jest.fn()}
+        organization={organization}
+        selectedPlatform={selectedPlatform}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('radio', {name: 'React'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Configure SDK'}));
+
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.select_framework_modal_configure_sdk_button_clicked',
+      expect.objectContaining({variant: 'legacy'})
+    );
   });
 });

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -249,15 +249,20 @@ export function FrameworkSuggestionModal({
         selectedFramework.key,
         'manual'
       );
+    } else if (newOrg) {
+      trackAnalytics('onboarding.select_framework_modal_configure_sdk_button_clicked', {
+        platform: selectedPlatform.key,
+        framework: selectedFramework.key,
+        organization,
+      });
     } else {
       trackAnalytics(
-        newOrg
-          ? 'onboarding.select_framework_modal_configure_sdk_button_clicked'
-          : 'project_creation.select_framework_modal_configure_sdk_button_clicked',
+        'project_creation.select_framework_modal_configure_sdk_button_clicked',
         {
           platform: selectedPlatform.key,
           framework: selectedFramework.key,
           organization,
+          variant: 'legacy',
         }
       );
     }
@@ -281,16 +286,17 @@ export function FrameworkSuggestionModal({
         selectedPlatform.key,
         'manual'
       );
+    } else if (newOrg) {
+      trackAnalytics('onboarding.select_framework_modal_skip_button_clicked', {
+        platform: selectedPlatform.key,
+        organization,
+      });
     } else {
-      trackAnalytics(
-        newOrg
-          ? 'onboarding.select_framework_modal_skip_button_clicked'
-          : 'project_creation.select_framework_modal_skip_button_clicked',
-        {
-          platform: selectedPlatform.key,
-          organization,
-        }
-      );
+      trackAnalytics('project_creation.select_framework_modal_skip_button_clicked', {
+        platform: selectedPlatform.key,
+        organization,
+        variant: 'legacy',
+      });
     }
     onSkip();
   }, [selectedPlatform, organization, onSkip, newOrg, hasScmOnboarding, analyticsFlow]);

--- a/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/projectCreationAnalyticsEvents.tsx
@@ -113,10 +113,12 @@ export type ProjectCreationEventParameters = {
   };
   'project_creation.select_framework_modal_close_button_clicked': {
     platform: string;
+    variant?: ProjectCreationVariant;
   };
   'project_creation.select_framework_modal_configure_sdk_button_clicked': {
     framework: string;
     platform: string;
+    variant?: ProjectCreationVariant;
   };
   'project_creation.select_framework_modal_rendered': {
     platform: string;
@@ -124,6 +126,7 @@ export type ProjectCreationEventParameters = {
   };
   'project_creation.select_framework_modal_skip_button_clicked': {
     platform: string;
+    variant?: ProjectCreationVariant;
   };
   'project_creation.setup_loader_docs_rendered': {
     platform: string;

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -625,6 +625,7 @@ describe('CreateProject', () => {
 
   it('renders framework selection modal if vanilla js is selected', async () => {
     const {organization} = initializeOrg();
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
 
     const frameWorkModalMockRequests = renderFrameworkModalMockRequests({
       organization,
@@ -660,6 +661,10 @@ describe('CreateProject', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
 
     expect(frameWorkModalMockRequests.projectCreationMockRequest).not.toHaveBeenCalled();
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'project_creation.select_framework_modal_close_button_clicked',
+      expect.objectContaining({variant: 'legacy'})
+    );
   });
 
   it('should rollback project when rule creation fails', async () => {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -423,6 +423,7 @@ export function CreateProject() {
               {
                 platform: platform.key,
                 organization,
+                variant: 'legacy',
               }
             );
           },


### PR DESCRIPTION
## TLDR

Legacy project creation now identifies framework-modal close, configure, and skip actions with `variant: 'legacy'`, making those events safe for variant-filtered BI queries.

## Details

The existing framework action events were emitted only by the legacy project-creation flow but did not carry the project-creation variant. The legacy branches in `FrameworkSuggestionModal` and the `CreateProject` close handler now stamp the same explicit discriminator used by the rest of the project-creation analytics contract.

Onboarding branches keep their existing event names and payloads. SCM framework commitments continue using the single canonical `growth.select_platform` event, so this change does not dual-fire action and selection counters for one click.

Focused coverage asserts all three legacy framework action variants.

Refs VDY-133
