### PR TITLE
feat(integrations): support prefill templates when creating internal integrations

### DIFF
--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -18,6 +18,7 @@ import {
 } from 'sentry/utils/analytics/integrations/platformAnalyticsEvents';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {getSentryAppTemplates} from 'sentry/views/settings/organizationDeveloperSettings/creationTemplates';
 import {ExampleIntegrationButton} from 'sentry/views/settings/organizationIntegrations/exampleIntegrationButton';
 
 const analyticsView = 'new_integration_modal';
@@ -28,6 +29,7 @@ function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRend
   const hasCreationTemplates = organization.features.includes(
     'sentry-apps-creation-templates'
   );
+  const templates = getSentryAppTemplates(organization);
   const [option, selectOption] = useState('internal');
   const baseUrl = `/settings/${organization.slug}/developer-settings/`;
   const choices = [
@@ -186,6 +188,43 @@ function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRend
                 />
               </Stack>
             </Stack>
+            {templates.length > 0 && (
+              <Stack gap="sm">
+                <Stack gap="2xs">
+                  <Text bold>{t('Templates')}</Text>
+                  <Text variant="muted" size="sm">
+                    {t('Get started with a pre-configured internal integration.')}
+                  </Text>
+                </Stack>
+                <Stack border="primary" radius="md">
+                  {templates.map((template, index) => (
+                    <Fragment key={template.slug}>
+                      {index > 0 && <Stack.Separator />}
+                      <ChoiceRow
+                        title={template.heading}
+                        description={template.description}
+                        action={
+                          <LinkButton
+                            variant="secondary"
+                            size="sm"
+                            to={`${baseUrl}new-internal/?template=${template.slug}&referrer=new_integration_modal`}
+                            onClick={() => {
+                              trackIntegrationAnalytics(PlatformEvents.CHOSE_INTERNAL, {
+                                organization,
+                                view: analyticsView,
+                              });
+                              closeModal();
+                            }}
+                          >
+                            {t('Use template')}
+                          </LinkButton>
+                        }
+                      />
+                    </Fragment>
+                  ))}
+                </Stack>
+              </Stack>
+            )}
           </Stack>
         ) : (
           <StyledRadioGroup

--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -77,6 +77,11 @@ type ProjectOwnershipModalParams = {
   net_change?: number;
 };
 
+type SentryAppTemplateAppliedParams = {
+  template: string;
+  referrer?: string;
+};
+
 // Event key to payload mappings
 export type IntegrationEventParameters = {
   'integrations.cloudformation_link_clicked': SingleIntegrationEventParams;
@@ -97,6 +102,7 @@ export type IntegrationEventParameters = {
   'integrations.plugin_add_to_project_clicked': SingleIntegrationEventParams;
   'integrations.request_install': SingleIntegrationEventParams;
   'integrations.resolve_now_clicked': SingleIntegrationEventParams;
+  'integrations.sentry_app_template_applied': SentryAppTemplateAppliedParams;
   'integrations.serverless_function_action': IntegrationServerlessFunctionActionParams;
   'integrations.serverless_functions_viewed': IntegrationServerlessFunctionsViewedParams;
   'integrations.switch_manual_sdk_setup': SingleIntegrationEventParams;
@@ -134,6 +140,7 @@ export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
   'integrations.serverless_functions_viewed': 'Integrations: Serverless Functions Viewed',
   'integrations.installation_input_value_changed':
     'Integrations: Installation Input Value Changed',
+  'integrations.sentry_app_template_applied': 'Integrations: Sentry App Template Applied',
   'integrations.serverless_function_action': 'Integrations: Serverless Function Action',
   'integrations.cloudformation_link_clicked': 'Integrations: CloudFormation Link Clicked',
   'integrations.switch_manual_sdk_setup': 'Integrations: Switch Manual SDK Setup',

--- a/static/app/views/settings/organizationDeveloperSettings/creationTemplates.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/creationTemplates.tsx
@@ -1,0 +1,23 @@
+import type {Organization} from 'sentry/types/organization';
+
+/**
+ * A curated creation flow on the internal integration page, selected with
+ * the `?template=<slug>` query param.
+ *
+ * Each template is its own creation form; this registry carries the display
+ * metadata for the new-integration modal cards and the template header.
+ */
+export interface SentryAppTemplate {
+  description: string;
+  heading: string;
+  slug: string;
+}
+
+const SENTRY_APP_TEMPLATES: SentryAppTemplate[] = [];
+
+export function getSentryAppTemplates(organization: Organization): SentryAppTemplate[] {
+  if (!organization.features.includes('sentry-apps-creation-templates')) {
+    return [];
+  }
+  return SENTRY_APP_TEMPLATES;
+}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState, type MouseEvent} from 'react';
+import {Fragment, useEffect, useState, type MouseEvent} from 'react';
 import styled from '@emotion/styled';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
@@ -6,9 +6,10 @@ import {z} from 'zod';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
@@ -46,9 +47,11 @@ import type {
 } from 'sentry/types/integrations';
 import type {InternalAppApiToken, NewInternalAppApiToken} from 'sentry/types/user';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -64,6 +67,10 @@ import {
   granularWebhookEvents,
   WEBHOOK_GRANULAR_EVENT_CHOICES,
 } from 'sentry/views/settings/organizationDeveloperSettings/constants';
+import {
+  getSentryAppTemplates,
+  type SentryAppTemplate,
+} from 'sentry/views/settings/organizationDeveloperSettings/creationTemplates';
 import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 import {
   AllowedOriginsField,
@@ -396,6 +403,9 @@ function useSaveSentryApp({
   return {handleSaveError, saveSentryAppMutation, scopeErrors};
 }
 
+// Each template renders its own creation form, keyed by registry slug.
+const TEMPLATE_FORMS: Record<string, React.ComponentType> = {};
+
 export default function SentryApplicationDetails() {
   const location = useLocation();
   const {appSlug} = useParams<{appSlug: string}>();
@@ -404,6 +414,25 @@ export default function SentryApplicationDetails() {
 
   const isInternalRoute = location.pathname.endsWith('new-internal/');
   const isPublicRoute = location.pathname.endsWith('new-public/');
+
+  const templateSlug = isInternalRoute
+    ? decodeScalar(location.query.template)
+    : undefined;
+  const template = getSentryAppTemplates(organization).find(
+    entry => entry.slug === templateSlug
+  );
+  const TemplateForm = template && TEMPLATE_FORMS[template.slug];
+  const referrer = decodeScalar(location.query.referrer);
+
+  useEffect(() => {
+    if (template && TemplateForm) {
+      trackAnalytics('integrations.sentry_app_template_applied', {
+        organization,
+        referrer,
+        template: template.slug,
+      });
+    }
+  }, [template, TemplateForm, organization, referrer]);
 
   const sentryAppQueryOptions = sentryAppApiOptions({appSlug: appSlug ?? null});
 
@@ -443,6 +472,11 @@ export default function SentryApplicationDetails() {
         <LoadingIndicator />
       ) : isError ? (
         <LoadingError onRetry={refetch} />
+      ) : template && TemplateForm ? (
+        <Fragment>
+          <TemplateHeader template={template} />
+          <TemplateForm key={template.slug} />
+        </Fragment>
       ) : isInternalRoute ? (
         <InternalSentryAppCreationForm />
       ) : isPublicRoute ? (
@@ -453,6 +487,30 @@ export default function SentryApplicationDetails() {
         <LoadingError onRetry={refetch} />
       )}
     </div>
+  );
+}
+
+function TemplateHeader({template}: {template: SentryAppTemplate}) {
+  const location = useLocation();
+  const organization = useOrganization();
+
+  return (
+    <Alert.Container>
+      <Alert variant="info">
+        <Stack gap="xs" align="start">
+          <Text bold>{template.heading}</Text>
+          <Text>{template.description}</Text>
+          <Link
+            to={{
+              pathname: `/settings/${organization.slug}/developer-settings/new-internal/`,
+              query: {...location.query, template: undefined},
+            }}
+          >
+            {t('Start from a blank integration instead')}
+          </Link>
+        </Stack>
+      </Alert>
+    </Alert.Container>
   );
 }
 


### PR DESCRIPTION
Add a framework for custom integration templates. Some notable features:
- hiding certain fields when creating a new custom integration
    - prefilling hidden fields with text
- adding 'new' fields that map to existing fields
- adding a templates abstraction so that we can specify the above in sets

No functional changes yet. Mostly this is to set up this section in the 'create integration modal' (the claude routines part isn't in this PR)
<img width="567" height="123" alt="Screenshot 2026-07-23 at 2 48 50 PM" src="https://github.com/user-attachments/assets/3d33a7d2-613b-4950-9201-0f3c5b0f5a51" />
