### PR TITLE
fix(gdd): Incorporate generated_at into incremental update checks

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -68,10 +68,6 @@ def _entries_after_cursor(
     )
 
 
-def _cursor_lte(cursor_date: datetime, cursor_id: int) -> Q:
-    return Q(cursor_date__lt=cursor_date) | Q(cursor_date=cursor_date, cursor_id__lte=cursor_id)
-
-
 def _process_batch(
     p: Pipeline[GroupActionLogEntry],
     derived: GroupDerivedData,
@@ -86,7 +82,7 @@ def _process_batch(
 
     1. The action log is append-only and the pipeline is deterministic, so
        any caller processing the same entries produces the same result.
-    2. The UPDATE uses a cursor guard (_cursor_lte) that only succeeds if no
+    2. The UPDATE uses a cursor guard that only succeeds if no
        other caller has already advanced the cursor past our batch. If it
        fails (updated == 0), a concurrent caller already wrote a superset
        of our work, so we refresh and check if more remains.
@@ -109,8 +105,8 @@ def _process_batch(
     state_update = GroupDerivedDataStore.build_update(p, result)
 
     updated = GroupDerivedData.objects.filter(
-        Q(group_id=group_id)
-        & _cursor_lte(last_date, last_id)
+        Q(id=derived.id, generated_at=derived.generated_at)
+        & (Q(cursor_date__lt=last_date) | Q(cursor_date=last_date, cursor_id__lte=last_id))
         & Q(pipeline_hash=derived.pipeline_hash)
     ).update(cursor_date=last_date, cursor_id=last_id, **state_update)
 

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -476,6 +476,34 @@ class ProcessGroupLogTest(TestCase):
         derived = process_group_log(group.id)
         assert derived.pipeline_hash == PIPELINE.pipeline_hash
 
+    def test_generated_at_change_skips_incremental_write(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        derived = process_group_log(group.id)
+        first_cursor = derived.cursor_id
+
+        GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.VIEW,
+            actor_type=GroupActorType.SYSTEM,
+            actor_id=0,
+            source=SOURCE,
+            data={},
+        )
+
+        # Simulate a generation promoting between our read and the UPDATE
+        # in _process_batch — generated_at changed.
+        GroupDerivedData.objects.filter(id=derived.id).update(
+            generated_at=datetime.now(timezone.utc)
+        )
+
+        processing._process_batch(processing.PIPELINE, derived, 1)
+
+        derived.refresh_from_db()
+        assert derived.cursor_id == first_cursor
+
 
 # --- Pure Python tests (no DB) ---
 


### PR DESCRIPTION
An update based on one generation shouldn't be applied to another.