### PR TITLE
feat(explore): Add metric descriptions viewer/editor page

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2171,6 +2171,10 @@ function buildRoutes(): RouteObject[] {
       index: true,
       component: make(() => import('sentry/views/explore/metrics/content')),
     },
+    {
+      path: 'descriptions/',
+      component: make(() => import('sentry/views/explore/metrics/metricDescriptions')),
+    },
     traceView,
   ];
 

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2276,6 +2276,10 @@ function buildRoutes(): RouteObject[] {
       children: metricsChildren,
     },
     {
+      path: 'attributes/descriptions/',
+      component: make(() => import('sentry/views/explore/attributeDescriptions')),
+    },
+    {
       path: `${CONVERSATIONS_LANDING_SUB_PATH}/`,
       component: make(() => import('sentry/views/explore/conversations/layout')),
       children: [

--- a/static/app/views/explore/attributeDescriptions/editAttributeDescriptionModal.tsx
+++ b/static/app/views/explore/attributeDescriptions/editAttributeDescriptionModal.tsx
@@ -1,0 +1,182 @@
+import {useState} from 'react';
+import {useMutation} from '@tanstack/react-query';
+
+import {Button} from '@sentry/scraps/button';
+import {InputGroup} from '@sentry/scraps/input';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t, tct} from 'sentry/locale';
+import {defined} from 'sentry/utils/defined';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {
+  TraceItemAttributeListItem,
+  TraceItemDatasetValue,
+} from 'sentry/views/explore/attributeDescriptions/types';
+
+export const BRIEF_MAX_LENGTH = 280;
+
+interface EditAttributeDescriptionModalProps extends ModalRenderProps {
+  attribute: TraceItemAttributeListItem;
+  dataset: TraceItemDatasetValue;
+  onSuccess: () => void;
+}
+
+interface UpdateVariables {
+  additionalContext: string;
+  brief: string;
+  examples: string;
+}
+
+export function EditAttributeDescriptionModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  attribute,
+  dataset,
+  onSuccess,
+}: EditAttributeDescriptionModalProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const [brief, setBrief] = useState(attribute.context?.brief ?? '');
+  const [additionalContext, setAdditionalContext] = useState(
+    attribute.context?.details?.[0] ?? ''
+  );
+  const [examples, setExamples] = useState(
+    (attribute.context?.examples ?? []).join('\n')
+  );
+
+  const {mutate, isPending} = useMutation({
+    mutationFn: (variables: UpdateVariables) => {
+      // Scope the request to the currently selected projects / environments /
+      // time range, so the endpoint's existence check matches what was listed.
+      const query: Record<string, string | string[] | number[] | undefined> = {
+        project: selection.projects.length ? selection.projects.map(String) : ['-1'],
+        environment: selection.environments.length ? selection.environments : undefined,
+      };
+      Object.entries(normalizeDateTimeParams(selection.datetime)).forEach(
+        ([key, value]) => {
+          if (defined(value)) {
+            query[key] = value;
+          }
+        }
+      );
+
+      const exampleList = variables.examples
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+
+      return fetchMutation({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/trace-items/attributes/${encodeURIComponent(
+          attribute.key
+        )}/context/`,
+        options: {query},
+        data: {
+          dataset,
+          attributeType: attribute.attributeType,
+          brief: variables.brief,
+          additionalContext: variables.additionalContext || null,
+          examples: exampleList,
+        },
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('Saved description for %s', attribute.key));
+      onSuccess();
+      closeModal();
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to save description for %s', attribute.key));
+    },
+  });
+
+  const canSubmit = brief.trim().length > 0 && brief.length <= BRIEF_MAX_LENGTH;
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        if (canSubmit && !isPending) {
+          mutate({brief, additionalContext, examples});
+        }
+      }}
+    >
+      <Header closeButton>
+        <Heading as="h4">{t('Edit attribute description')}</Heading>
+      </Header>
+      <Body>
+        <Stack gap="xl">
+          <Text size="sm" variant="muted">
+            {tct('[name] · [type] · [dataset]', {
+              name: <Text bold>{attribute.key}</Text>,
+              type: attribute.attributeType,
+              dataset,
+            })}
+          </Text>
+          <Stack gap="xs">
+            <Text as="label" size="sm" bold>
+              {t('Brief')}
+            </Text>
+            <InputGroup>
+              <InputGroup.Input
+                autoFocus
+                maxLength={BRIEF_MAX_LENGTH}
+                value={brief}
+                placeholder={t('A concise, human-readable summary of this attribute')}
+                onChange={e => setBrief(e.target.value)}
+              />
+            </InputGroup>
+            <Text size="xs" variant="muted">
+              {t('%s/%s characters', brief.length, BRIEF_MAX_LENGTH)}
+            </Text>
+          </Stack>
+          <Stack gap="xs">
+            <Text as="label" size="sm" bold>
+              {t('Additional context (optional)')}
+            </Text>
+            <InputGroup>
+              <InputGroup.TextArea
+                rows={4}
+                value={additionalContext}
+                placeholder={t('Any extra notes, caveats, or usage guidance')}
+                onChange={e => setAdditionalContext(e.target.value)}
+              />
+            </InputGroup>
+          </Stack>
+          <Stack gap="xs">
+            <Text as="label" size="sm" bold>
+              {t('Examples (optional, one per line)')}
+            </Text>
+            <InputGroup>
+              <InputGroup.TextArea
+                rows={3}
+                value={examples}
+                placeholder={t('Example values for this attribute')}
+                onChange={e => setExamples(e.target.value)}
+              />
+            </InputGroup>
+          </Stack>
+        </Stack>
+      </Body>
+      <Footer>
+        <Flex gap="md" justify="end">
+          <Button onClick={closeModal} disabled={isPending}>
+            {t('Cancel')}
+          </Button>
+          <Button type="submit" variant="primary" disabled={!canSubmit || isPending}>
+            {isPending ? t('Saving…') : t('Save')}
+          </Button>
+        </Flex>
+      </Footer>
+    </form>
+  );
+}

--- a/static/app/views/explore/attributeDescriptions/index.tsx
+++ b/static/app/views/explore/attributeDescriptions/index.tsx
@@ -24,10 +24,7 @@ import {IconArrow, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {getFormattedDate} from 'sentry/utils/dates';
-import {defined} from 'sentry/utils/defined';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
@@ -35,36 +32,41 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   BRIEF_MAX_LENGTH,
-  EditMetricDescriptionModal,
-} from 'sentry/views/explore/metrics/metricDescriptions/editMetricDescriptionModal';
-import type {TraceMetricListItem} from 'sentry/views/explore/metrics/metricDescriptions/types';
-import {useMetricDescriptionsQueryOptions} from 'sentry/views/explore/metrics/metricDescriptions/useMetricDescriptions';
+  EditAttributeDescriptionModal,
+} from 'sentry/views/explore/attributeDescriptions/editAttributeDescriptionModal';
 import {
-  isTraceMetricTypeValue,
-  type TraceMetricTypeValue,
-} from 'sentry/views/explore/metrics/types';
+  type AttributeTypeValue,
+  isAttributeTypeValue,
+  isEditableAttribute,
+  type TraceItemAttributeListItem,
+  type TraceItemDatasetValue,
+} from 'sentry/views/explore/attributeDescriptions/types';
+import {useAttributeDescriptionsQueryOptions} from 'sentry/views/explore/attributeDescriptions/useAttributeDescriptions';
 import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
-const METRIC_TYPE_OPTIONS: Array<{label: string; value: TraceMetricTypeValue | ''}> = [
+const DATASET_OPTIONS: Array<{label: string; value: TraceItemDatasetValue}> = [
+  {label: t('Spans'), value: 'spans'},
+  {label: t('Logs'), value: 'logs'},
+  {label: t('Trace Metrics'), value: 'tracemetrics'},
+  {label: t('Preprod'), value: 'preprod'},
+  {label: t('Processing Errors'), value: 'processing_errors'},
+];
+
+const DEFAULT_DATASET: TraceItemDatasetValue = 'spans';
+
+const ATTRIBUTE_TYPE_OPTIONS: Array<{label: string; value: AttributeTypeValue | ''}> = [
   {label: t('All types'), value: ''},
-  {label: t('Counter'), value: 'counter'},
-  {label: t('Gauge'), value: 'gauge'},
-  {label: t('Distribution'), value: 'distribution'},
+  {label: t('String'), value: 'string'},
+  {label: t('Number'), value: 'number'},
+  {label: t('Boolean'), value: 'boolean'},
 ];
 
-const HAS_CONTEXT_OPTIONS: Array<{label: string; value: '' | '1'}> = [
-  {label: t('All metrics'), value: ''},
-  {label: t('Has description'), value: '1'},
-];
+const PAGE_TITLE = t('Attribute Descriptions');
 
-const PAGE_TITLE = t('Metric Descriptions');
-
-export default function MetricDescriptionsContent() {
+export default function AttributeDescriptionsContent() {
   const organization = useOrganization();
-  const maxPickableDays = useMaxPickableDays({
-    dataCategories: [DataCategory.TRACE_METRICS],
-  });
+  const maxPickableDays = useMaxPickableDays({dataCategories: [DataCategory.SPANS]});
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
 
   return (
@@ -74,43 +76,33 @@ export default function MetricDescriptionsContent() {
       renderDisabled={NoAccess}
     >
       <SentryDocumentTitle title={PAGE_TITLE} orgSlug={organization.slug}>
-        <PageFiltersContainer
-          maxPickableDays={datePageFilterProps.maxPickableDays}
-          defaultSelection={
-            datePageFilterProps.defaultPeriod
-              ? {
-                  datetime: {
-                    period: datePageFilterProps.defaultPeriod,
-                    start: null,
-                    end: null,
-                    utc: null,
-                  },
-                }
-              : undefined
-          }
-        >
+        <PageFiltersContainer>
           <TopBar.Slot name="title">{PAGE_TITLE}</TopBar.Slot>
-          <MetricDescriptionsBody datePageFilterProps={datePageFilterProps} />
+          <AttributeDescriptionsBody datePageFilterProps={datePageFilterProps} />
         </PageFiltersContainer>
       </SentryDocumentTitle>
     </Feature>
   );
 }
 
-interface MetricDescriptionsBodyProps {
+interface AttributeDescriptionsBodyProps {
   datePageFilterProps: ReturnType<typeof useDatePageFilterProps>;
 }
 
-function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyProps) {
+function AttributeDescriptionsBody({
+  datePageFilterProps,
+}: AttributeDescriptionsBodyProps) {
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
 
+  const datasetParam = decodeScalar(location.query.dataset, '');
+  const dataset = DATASET_OPTIONS.some(option => option.value === datasetParam)
+    ? (datasetParam as TraceItemDatasetValue)
+    : DEFAULT_DATASET;
   const search = decodeScalar(location.query.query, '');
-  const typeParam = decodeScalar(location.query.type, '');
-  const type = isTraceMetricTypeValue(typeParam) ? typeParam : undefined;
-  const hasContextParam = decodeScalar(location.query.contextOnly, '');
-  const hasContext = hasContextParam === '1';
+  const typeParam = decodeScalar(location.query.attributeType, '');
+  const attributeType = isAttributeTypeValue(typeParam) ? typeParam : undefined;
   const cursor = decodeScalar(location.query.cursor);
 
   const {
@@ -119,11 +111,11 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
     isError,
     refetch: refetchQuery,
   } = useQuery({
-    ...useMetricDescriptionsQueryOptions({search, type, hasContext, cursor}),
+    ...useAttributeDescriptionsQueryOptions({dataset, attributeType, search, cursor}),
     select: selectJsonWithHeaders,
   });
 
-  const metrics = data?.json ?? [];
+  const attributes = data?.json ?? [];
   const pageLinks = data?.headers?.Link ?? null;
 
   // Filter and search changes reset pagination to the first page.
@@ -138,35 +130,52 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
     navigate({pathname: path, query: {...query, cursor: nextCursor}});
   };
 
-  const openEditModal = (metric: TraceMetricListItem) => {
+  const openEditModal = (attribute: TraceItemAttributeListItem) => {
     openModal(deps => (
-      <EditMetricDescriptionModal {...deps} metric={metric} onSuccess={refetchQuery} />
+      <EditAttributeDescriptionModal
+        {...deps}
+        attribute={attribute}
+        dataset={dataset}
+        onSuccess={refetchQuery}
+      />
     ));
   };
 
-  const openViewModal = (metric: TraceMetricListItem) => {
+  const openViewModal = (attribute: TraceItemAttributeListItem) => {
     openModal(({Header, Body}) => (
       <Fragment>
         <Header closeButton>
-          <Heading as="h4">{metric.name}</Heading>
+          <Heading as="h4">{attribute.key}</Heading>
         </Header>
         <Body>
           <Stack gap="xl">
-            {metric.context?.brief ? (
+            {attribute.context?.brief ? (
               <Stack gap="xs">
                 <Text size="sm" bold variant="muted">
                   {t('Brief')}
                 </Text>
-                <Text>{metric.context.brief}</Text>
+                <Text>{attribute.context.brief}</Text>
               </Stack>
             ) : null}
-            {metric.context?.details?.length ? (
+            {attribute.context?.details?.length ? (
               <Stack gap="xs">
                 <Text size="sm" bold variant="muted">
                   {t('Additional context')}
                 </Text>
-                {metric.context.details.map((detail, i) => (
+                {attribute.context.details.map((detail, i) => (
                   <Text key={i}>{detail}</Text>
+                ))}
+              </Stack>
+            ) : null}
+            {attribute.context?.examples?.length ? (
+              <Stack gap="xs">
+                <Text size="sm" bold variant="muted">
+                  {t('Examples')}
+                </Text>
+                {attribute.context.examples.map((example, i) => (
+                  <Text key={i} monospace>
+                    {example}
+                  </Text>
                 ))}
               </Stack>
             ) : null}
@@ -188,11 +197,12 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
         </LinkButton>
         <LinkButton
           size="sm"
-          to={normalizeUrl(
-            `/organizations/${organization.slug}/explore/attributes/descriptions/`
-          )}
+          to={makeMetricsPathname({
+            organizationSlug: organization.slug,
+            path: '/descriptions/',
+          })}
         >
-          {t('Attribute descriptions')}
+          {t('Metric descriptions')}
         </LinkButton>
       </Flex>
 
@@ -201,66 +211,73 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
         <EnvironmentPageFilter />
         <DatePageFilter {...datePageFilterProps} />
         <CompactSelect
-          value={type ?? ''}
-          options={METRIC_TYPE_OPTIONS}
-          onChange={option => updateQuery({type: option.value || undefined})}
+          value={dataset}
+          options={DATASET_OPTIONS}
+          onChange={option => updateQuery({dataset: option.value, cursor: undefined})}
           trigger={triggerProps => (
-            <OverlayTrigger.Button {...triggerProps} prefix={t('Type')} />
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Dataset')} />
           )}
         />
         <CompactSelect
-          value={hasContextParam}
-          options={HAS_CONTEXT_OPTIONS}
-          onChange={option => updateQuery({contextOnly: option.value || undefined})}
+          value={attributeType ?? ''}
+          options={ATTRIBUTE_TYPE_OPTIONS}
+          onChange={option => updateQuery({attributeType: option.value || undefined})}
           trigger={triggerProps => (
-            <OverlayTrigger.Button {...triggerProps} prefix={t('Description')} />
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Type')} />
           )}
         />
         <SearchWrapper>
           <SearchBar
             defaultQuery={search}
-            placeholder={t('Search by metric name')}
+            placeholder={t('Search by attribute name')}
             onSearch={value => updateQuery({query: value || undefined})}
           />
         </SearchWrapper>
       </FilterBar>
 
-      <StyledSimpleTable data-test-id="metric-descriptions-table">
+      <StyledSimpleTable data-test-id="attribute-descriptions-table">
         <SimpleTable.Header>
-          <SimpleTable.HeaderCell>{t('Metric')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Attribute')}</SimpleTable.HeaderCell>
           <SimpleTable.HeaderCell>{t('Type')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Source')}</SimpleTable.HeaderCell>
           <SimpleTable.HeaderCell>{t('Brief')}</SimpleTable.HeaderCell>
           <SimpleTable.HeaderCell>{t('Additional context')}</SimpleTable.HeaderCell>
-          <SimpleTable.HeaderCell>{t('Last seen')}</SimpleTable.HeaderCell>
           <SimpleTable.HeaderCell />
         </SimpleTable.Header>
 
         {isError ? (
-          <SimpleTable.Empty>{t('Unable to load metrics.')}</SimpleTable.Empty>
+          <SimpleTable.Empty>{t('Unable to load attributes.')}</SimpleTable.Empty>
         ) : isPending ? (
           <SimpleTable.Empty>{t('Loading…')}</SimpleTable.Empty>
-        ) : metrics.length === 0 ? (
-          <SimpleTable.Empty>{t('No metrics found.')}</SimpleTable.Empty>
+        ) : attributes.length === 0 ? (
+          <SimpleTable.Empty>{t('No attributes found.')}</SimpleTable.Empty>
         ) : (
-          metrics.map(metric => {
-            const detailsText = metric.context?.details?.join(' ') ?? '';
+          attributes.map(attribute => {
+            const detailsText = attribute.context?.details?.join(' ') ?? '';
             const isDetailsTruncated = detailsText.length > BRIEF_MAX_LENGTH;
+            const editable = isEditableAttribute(attribute);
             return (
-              <SimpleTable.Row key={`${metric.name}:${metric.type}`}>
+              <SimpleTable.Row key={`${attribute.key}:${attribute.attributeType}`}>
                 <SimpleTable.RowCell>
                   <Text bold monospace>
-                    {metric.name}
+                    {attribute.key}
                   </Text>
                 </SimpleTable.RowCell>
                 <SimpleTable.RowCell>
-                  <Text>
-                    {metric.type}
-                    {metric.unit ? ` (${metric.unit})` : ''}
+                  <Text>{attribute.attributeType}</Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  <Text variant="muted">
+                    {attribute.context?.isConvention
+                      ? t('convention')
+                      : attribute.context?.isCustom
+                        ? t('custom')
+                        : attribute.attributeSource.source_type}
                   </Text>
                 </SimpleTable.RowCell>
                 <SimpleTable.RowCell>
-                  {metric.context?.brief ? (
-                    <Text>{metric.context.brief}</Text>
+                  {attribute.context?.brief ? (
+                    <Text>{attribute.context.brief}</Text>
                   ) : (
                     <Text variant="muted">{t('No description')}</Text>
                   )}
@@ -277,7 +294,7 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
                         <Button
                           size="xs"
                           variant="link"
-                          onClick={() => openViewModal(metric)}
+                          onClick={() => openViewModal(attribute)}
                         >
                           {t('View full')}
                         </Button>
@@ -287,24 +304,25 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
                     <Text variant="muted">{'—'}</Text>
                   )}
                 </SimpleTable.RowCell>
-                <SimpleTable.RowCell>
-                  <Text variant="muted">
-                    {defined(metric.lastSeen)
-                      ? // `lastSeen` is max(timestamp_precise) in nanoseconds;
-                        // convert to milliseconds for date formatting.
-                        getFormattedDate(metric.lastSeen / 1_000_000, 'lll')
-                      : '—'}
-                  </Text>
-                </SimpleTable.RowCell>
                 <SimpleTable.RowCell justify="end">
-                  <Button
-                    size="xs"
-                    icon={<IconEdit />}
-                    aria-label={t('Edit description for %s', metric.name)}
-                    onClick={() => openEditModal(metric)}
-                  >
-                    {t('Edit')}
-                  </Button>
+                  {editable ? (
+                    <Button
+                      size="xs"
+                      icon={<IconEdit />}
+                      aria-label={t('Edit description for %s', attribute.key)}
+                      onClick={() => openEditModal(attribute)}
+                    >
+                      {t('Edit')}
+                    </Button>
+                  ) : (
+                    <Button
+                      size="xs"
+                      variant="link"
+                      onClick={() => openViewModal(attribute)}
+                    >
+                      {t('View')}
+                    </Button>
+                  )}
                 </SimpleTable.RowCell>
               </SimpleTable.Row>
             );
@@ -338,6 +356,6 @@ const SearchWrapper = styled('div')`
 
 const StyledSimpleTable = styled(SimpleTable)`
   grid-template-columns:
-    minmax(160px, 1.2fr) max-content minmax(160px, 1.5fr)
-    minmax(160px, 1.5fr) max-content max-content;
+    minmax(160px, 1.2fr) max-content max-content minmax(160px, 1.5fr)
+    minmax(160px, 1.5fr) max-content;
 `;

--- a/static/app/views/explore/attributeDescriptions/types.ts
+++ b/static/app/views/explore/attributeDescriptions/types.ts
@@ -1,0 +1,53 @@
+export type TraceItemDatasetValue =
+  | 'spans'
+  | 'logs'
+  | 'tracemetrics'
+  | 'preprod'
+  | 'processing_errors';
+
+export type AttributeTypeValue = 'string' | 'number' | 'boolean';
+
+export function isAttributeTypeValue(value: string): value is AttributeTypeValue {
+  return value === 'string' || value === 'number' || value === 'boolean';
+}
+
+export interface TraceItemAttributeContext {
+  brief?: string;
+  // Longer-form notes; the authoring endpoint stores a single string, which the
+  // list endpoint normalizes to a one-element list.
+  details?: string[];
+  examples?: string[];
+  // A Sentry-owned convention (not editable).
+  isConvention?: boolean;
+  // Marks a user-authored context row (editable).
+  isCustom?: boolean;
+  isDeprecated?: boolean;
+  replacementAttribute?: string;
+}
+
+/**
+ * A single row from the trace item attributes list endpoint
+ * (`GET /organizations/{org}/trace-items/attributes/`).
+ */
+export interface TraceItemAttributeListItem {
+  attributeSource: {
+    source_type: 'sentry' | 'user';
+    is_transformed_alias?: boolean;
+  };
+  attributeType: AttributeTypeValue;
+  // The public alias used to query the attribute.
+  key: string;
+  // The display name for the attribute.
+  name: string;
+  // Only present when `expand=context` is requested.
+  context?: TraceItemAttributeContext;
+  secondaryAliases?: string[];
+}
+
+/**
+ * Whether an attribute can have user-authored context written to it. The
+ * context endpoint rejects Sentry-owned (reserved) attributes.
+ */
+export function isEditableAttribute(attribute: TraceItemAttributeListItem): boolean {
+  return attribute.attributeSource.source_type === 'user';
+}

--- a/static/app/views/explore/attributeDescriptions/useAttributeDescriptions.tsx
+++ b/static/app/views/explore/attributeDescriptions/useAttributeDescriptions.tsx
@@ -1,0 +1,62 @@
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {defined} from 'sentry/utils/defined';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {
+  AttributeTypeValue,
+  TraceItemAttributeListItem,
+  TraceItemDatasetValue,
+} from 'sentry/views/explore/attributeDescriptions/types';
+
+export const ATTRIBUTE_DESCRIPTIONS_PER_PAGE = 100;
+
+interface UseAttributeDescriptionsProps {
+  dataset: TraceItemDatasetValue;
+  attributeType?: AttributeTypeValue;
+  cursor?: string;
+  search?: string;
+}
+
+/**
+ * Returns `apiOptions` for the paginated trace item attributes list, scoped to
+ * the current page filters and requesting authored context (brief / details /
+ * examples). Pass the result to `useQuery` with `selectJsonWithHeaders` to read
+ * the `Link` pagination header.
+ */
+export function useAttributeDescriptionsQueryOptions({
+  dataset,
+  attributeType,
+  search,
+  cursor,
+}: UseAttributeDescriptionsProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const query: Record<string, string | string[] | number[] | undefined> = {
+    dataset,
+    expand: 'context',
+    per_page: String(ATTRIBUTE_DESCRIPTIONS_PER_PAGE),
+    // The attributes endpoint matches names via a dedicated substring param.
+    substringMatch: search || undefined,
+    attributeType: attributeType || undefined,
+    cursor: cursor || undefined,
+    project: selection.projects.length ? selection.projects.map(String) : undefined,
+    environment: selection.environments.length ? selection.environments : undefined,
+  };
+
+  Object.entries(normalizeDateTimeParams(selection.datetime)).forEach(([key, value]) => {
+    if (defined(value)) {
+      query[key] = value;
+    }
+  });
+
+  return apiOptions.as<TraceItemAttributeListItem[]>()(
+    '/organizations/$organizationIdOrSlug/trace-items/attributes/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      query,
+      staleTime: 0,
+    }
+  );
+}

--- a/static/app/views/explore/metrics/metricDescriptions/editMetricDescriptionModal.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/editMetricDescriptionModal.tsx
@@ -41,7 +41,7 @@ export function EditMetricDescriptionModal({
 
   const [brief, setBrief] = useState(metric.context?.brief ?? '');
   const [additionalContext, setAdditionalContext] = useState(
-    metric.context?.additionalContext ?? ''
+    metric.context?.details?.[0] ?? ''
   );
 
   const {mutate, isPending} = useMutation({

--- a/static/app/views/explore/metrics/metricDescriptions/editMetricDescriptionModal.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/editMetricDescriptionModal.tsx
@@ -16,7 +16,7 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {TraceMetricListItem} from 'sentry/views/explore/metrics/metricDescriptions/types';
 
-const BRIEF_MAX_LENGTH = 280;
+export const BRIEF_MAX_LENGTH = 280;
 
 interface EditMetricDescriptionModalProps extends ModalRenderProps {
   metric: TraceMetricListItem;

--- a/static/app/views/explore/metrics/metricDescriptions/editMetricDescriptionModal.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/editMetricDescriptionModal.tsx
@@ -1,0 +1,155 @@
+import {useState} from 'react';
+import {useMutation} from '@tanstack/react-query';
+
+import {Button} from '@sentry/scraps/button';
+import {InputGroup} from '@sentry/scraps/input';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t, tct} from 'sentry/locale';
+import {defined} from 'sentry/utils/defined';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {TraceMetricListItem} from 'sentry/views/explore/metrics/metricDescriptions/types';
+
+const BRIEF_MAX_LENGTH = 280;
+
+interface EditMetricDescriptionModalProps extends ModalRenderProps {
+  metric: TraceMetricListItem;
+  onSuccess: () => void;
+}
+
+interface UpdateVariables {
+  additionalContext: string;
+  brief: string;
+}
+
+export function EditMetricDescriptionModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  metric,
+  onSuccess,
+}: EditMetricDescriptionModalProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const [brief, setBrief] = useState(metric.context?.brief ?? '');
+  const [additionalContext, setAdditionalContext] = useState(
+    metric.context?.additionalContext ?? ''
+  );
+
+  const {mutate, isPending} = useMutation({
+    mutationFn: (variables: UpdateVariables) => {
+      // Scope the request to the currently selected projects / environments /
+      // time range, so the endpoint's existence check matches what was listed.
+      const query: Record<string, string | string[] | number[] | undefined> = {
+        project: selection.projects.length ? selection.projects.map(String) : ['-1'],
+        environment: selection.environments.length ? selection.environments : undefined,
+      };
+      Object.entries(normalizeDateTimeParams(selection.datetime)).forEach(
+        ([key, value]) => {
+          if (defined(value)) {
+            query[key] = value;
+          }
+        }
+      );
+
+      return fetchMutation({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/trace-items/metrics/${encodeURIComponent(
+          metric.name
+        )}/context/`,
+        options: {query},
+        data: {
+          metricType: metric.type,
+          brief: variables.brief,
+          additionalContext: variables.additionalContext || null,
+        },
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage(t('Saved description for %s', metric.name));
+      onSuccess();
+      closeModal();
+    },
+    onError: () => {
+      addErrorMessage(t('Failed to save description for %s', metric.name));
+    },
+  });
+
+  const canSubmit = brief.trim().length > 0 && brief.length <= BRIEF_MAX_LENGTH;
+
+  return (
+    <form
+      onSubmit={e => {
+        e.preventDefault();
+        if (canSubmit && !isPending) {
+          mutate({brief, additionalContext});
+        }
+      }}
+    >
+      <Header closeButton>
+        <Heading as="h4">{t('Edit metric description')}</Heading>
+      </Header>
+      <Body>
+        <Stack gap="xl">
+          <Stack gap="xs">
+            <Text size="sm" variant="muted">
+              {tct('[name] · [type][unit]', {
+                name: <Text bold>{metric.name}</Text>,
+                type: metric.type,
+                unit: metric.unit ? ` · ${metric.unit}` : '',
+              })}
+            </Text>
+          </Stack>
+          <Stack gap="xs">
+            <Text as="label" size="sm" bold>
+              {t('Brief')}
+            </Text>
+            <InputGroup>
+              <InputGroup.Input
+                autoFocus
+                maxLength={BRIEF_MAX_LENGTH}
+                value={brief}
+                placeholder={t('A concise, human-readable summary of this metric')}
+                onChange={e => setBrief(e.target.value)}
+              />
+            </InputGroup>
+            <Text size="xs" variant="muted">
+              {t('%s/%s characters', brief.length, BRIEF_MAX_LENGTH)}
+            </Text>
+          </Stack>
+          <Stack gap="xs">
+            <Text as="label" size="sm" bold>
+              {t('Additional context (optional)')}
+            </Text>
+            <InputGroup>
+              <InputGroup.TextArea
+                rows={4}
+                value={additionalContext}
+                placeholder={t('Any extra notes, caveats, or usage guidance')}
+                onChange={e => setAdditionalContext(e.target.value)}
+              />
+            </InputGroup>
+          </Stack>
+        </Stack>
+      </Body>
+      <Footer>
+        <Flex gap="md" justify="end">
+          <Button onClick={closeModal} disabled={isPending}>
+            {t('Cancel')}
+          </Button>
+          <Button type="submit" variant="primary" disabled={!canSubmit || isPending}>
+            {isPending ? t('Saving…') : t('Save')}
+          </Button>
+        </Flex>
+      </Footer>
+    </form>
+  );
+}

--- a/static/app/views/explore/metrics/metricDescriptions/index.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/index.tsx
@@ -1,0 +1,261 @@
+import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import type {CursorHandler} from '@sentry/scraps/pagination';
+import {Pagination} from '@sentry/scraps/pagination';
+import {Text} from '@sentry/scraps/text';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import Feature from 'sentry/components/acl/feature';
+import {NoAccess} from 'sentry/components/noAccess';
+import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
+import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
+import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
+import {SearchBar} from 'sentry/components/searchBar';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconArrow, IconEdit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
+import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {getFormattedDate} from 'sentry/utils/dates';
+import {defined} from 'sentry/utils/defined';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {EditMetricDescriptionModal} from 'sentry/views/explore/metrics/metricDescriptions/editMetricDescriptionModal';
+import type {TraceMetricListItem} from 'sentry/views/explore/metrics/metricDescriptions/types';
+import {useMetricDescriptionsQueryOptions} from 'sentry/views/explore/metrics/metricDescriptions/useMetricDescriptions';
+import {
+  isTraceMetricTypeValue,
+  type TraceMetricTypeValue,
+} from 'sentry/views/explore/metrics/types';
+import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
+import {TopBar} from 'sentry/views/navigation/topBar';
+
+const METRIC_TYPE_OPTIONS: Array<{label: string; value: TraceMetricTypeValue | ''}> = [
+  {label: t('All types'), value: ''},
+  {label: t('Counter'), value: 'counter'},
+  {label: t('Gauge'), value: 'gauge'},
+  {label: t('Distribution'), value: 'distribution'},
+];
+
+const PAGE_TITLE = t('Metric Descriptions');
+
+export default function MetricDescriptionsContent() {
+  const organization = useOrganization();
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.TRACE_METRICS],
+  });
+  const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
+
+  return (
+    <Feature
+      features={['data-browsing-attribute-context']}
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <SentryDocumentTitle title={PAGE_TITLE} orgSlug={organization.slug}>
+        <PageFiltersContainer
+          maxPickableDays={datePageFilterProps.maxPickableDays}
+          defaultSelection={
+            datePageFilterProps.defaultPeriod
+              ? {
+                  datetime: {
+                    period: datePageFilterProps.defaultPeriod,
+                    start: null,
+                    end: null,
+                    utc: null,
+                  },
+                }
+              : undefined
+          }
+        >
+          <TopBar.Slot name="title">{PAGE_TITLE}</TopBar.Slot>
+          <MetricDescriptionsBody datePageFilterProps={datePageFilterProps} />
+        </PageFiltersContainer>
+      </SentryDocumentTitle>
+    </Feature>
+  );
+}
+
+interface MetricDescriptionsBodyProps {
+  datePageFilterProps: ReturnType<typeof useDatePageFilterProps>;
+}
+
+function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const search = decodeScalar(location.query.query, '');
+  const typeParam = decodeScalar(location.query.type, '');
+  const type = isTraceMetricTypeValue(typeParam) ? typeParam : undefined;
+  const cursor = decodeScalar(location.query.cursor);
+
+  const {
+    data,
+    isPending,
+    isError,
+    refetch: refetchQuery,
+  } = useQuery({
+    ...useMetricDescriptionsQueryOptions({search, type, cursor}),
+    select: selectJsonWithHeaders,
+  });
+
+  const metrics = data?.json ?? [];
+  const pageLinks = data?.headers?.Link ?? null;
+
+  // Filter and search changes reset pagination to the first page.
+  const updateQuery = (updates: Record<string, string | undefined>) => {
+    navigate({
+      pathname: location.pathname,
+      query: {...location.query, cursor: undefined, ...updates},
+    });
+  };
+
+  const handleCursor: CursorHandler = (nextCursor, path, query) => {
+    navigate({pathname: path, query: {...query, cursor: nextCursor}});
+  };
+
+  const openEditModal = (metric: TraceMetricListItem) => {
+    openModal(deps => (
+      <EditMetricDescriptionModal {...deps} metric={metric} onSuccess={refetchQuery} />
+    ));
+  };
+
+  return (
+    <BodyContainer>
+      <LinkButton
+        icon={<IconArrow direction="left" />}
+        size="sm"
+        to={makeMetricsPathname({organizationSlug: organization.slug, path: '/'})}
+      >
+        {t('Back to metrics')}
+      </LinkButton>
+
+      <FilterBar>
+        <ProjectPageFilter />
+        <EnvironmentPageFilter />
+        <DatePageFilter {...datePageFilterProps} />
+        <CompactSelect
+          value={type ?? ''}
+          options={METRIC_TYPE_OPTIONS}
+          onChange={option => updateQuery({type: option.value || undefined})}
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Type')} />
+          )}
+        />
+        <SearchWrapper>
+          <SearchBar
+            defaultQuery={search}
+            placeholder={t('Search by metric name')}
+            onSearch={value => updateQuery({query: value || undefined})}
+          />
+        </SearchWrapper>
+      </FilterBar>
+
+      <StyledSimpleTable data-test-id="metric-descriptions-table">
+        <SimpleTable.Header>
+          <SimpleTable.HeaderCell>{t('Metric')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Type')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Brief')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Additional context')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell>{t('Last seen')}</SimpleTable.HeaderCell>
+          <SimpleTable.HeaderCell />
+        </SimpleTable.Header>
+
+        {isError ? (
+          <SimpleTable.Empty>{t('Unable to load metrics.')}</SimpleTable.Empty>
+        ) : isPending ? (
+          <SimpleTable.Empty>{t('Loading…')}</SimpleTable.Empty>
+        ) : metrics.length === 0 ? (
+          <SimpleTable.Empty>{t('No metrics found.')}</SimpleTable.Empty>
+        ) : (
+          metrics.map(metric => (
+            <SimpleTable.Row key={`${metric.name}:${metric.type}`}>
+              <SimpleTable.RowCell>
+                <Text bold monospace>
+                  {metric.name}
+                </Text>
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                <Text>
+                  {metric.type}
+                  {metric.unit ? ` (${metric.unit})` : ''}
+                </Text>
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                {metric.context?.brief ? (
+                  <Text>{metric.context.brief}</Text>
+                ) : (
+                  <Text variant="muted">{t('No description')}</Text>
+                )}
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                {metric.context?.additionalContext ? (
+                  <Text>{metric.context.additionalContext}</Text>
+                ) : (
+                  <Text variant="muted">{'—'}</Text>
+                )}
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                <Text variant="muted">
+                  {defined(metric.lastSeen)
+                    ? // `lastSeen` is max(timestamp_precise) in nanoseconds;
+                      // convert to milliseconds for date formatting.
+                      getFormattedDate(metric.lastSeen / 1_000_000, 'lll')
+                    : '—'}
+                </Text>
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell justify="end">
+                <Button
+                  size="xs"
+                  icon={<IconEdit />}
+                  aria-label={t('Edit description for %s', metric.name)}
+                  onClick={() => openEditModal(metric)}
+                >
+                  {t('Edit')}
+                </Button>
+              </SimpleTable.RowCell>
+            </SimpleTable.Row>
+          ))
+        )}
+      </StyledSimpleTable>
+
+      <Pagination pageLinks={pageLinks} onCursor={handleCursor} />
+    </BodyContainer>
+  );
+}
+
+const BodyContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space['2xl']};
+`;
+
+const FilterBar = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${p => p.theme.space.md};
+  align-items: center;
+`;
+
+const SearchWrapper = styled('div')`
+  flex: 1;
+  min-width: 240px;
+`;
+
+const StyledSimpleTable = styled(SimpleTable)`
+  grid-template-columns:
+    minmax(160px, 1.2fr) max-content minmax(160px, 1.5fr)
+    minmax(160px, 1.5fr) max-content max-content;
+`;

--- a/static/app/views/explore/metrics/metricDescriptions/index.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/index.tsx
@@ -1,12 +1,14 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 import {Pagination} from '@sentry/scraps/pagination';
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import Feature from 'sentry/components/acl/feature';
@@ -30,7 +32,10 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {EditMetricDescriptionModal} from 'sentry/views/explore/metrics/metricDescriptions/editMetricDescriptionModal';
+import {
+  BRIEF_MAX_LENGTH,
+  EditMetricDescriptionModal,
+} from 'sentry/views/explore/metrics/metricDescriptions/editMetricDescriptionModal';
 import type {TraceMetricListItem} from 'sentry/views/explore/metrics/metricDescriptions/types';
 import {useMetricDescriptionsQueryOptions} from 'sentry/views/explore/metrics/metricDescriptions/useMetricDescriptions';
 import {
@@ -138,6 +143,38 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
     ));
   };
 
+  const openViewModal = (metric: TraceMetricListItem) => {
+    openModal(({Header, Body}) => (
+      <Fragment>
+        <Header closeButton>
+          <Heading as="h4">{metric.name}</Heading>
+        </Header>
+        <Body>
+          <Stack gap="xl">
+            {metric.context?.brief ? (
+              <Stack gap="xs">
+                <Text size="sm" bold variant="muted">
+                  {t('Brief')}
+                </Text>
+                <Text>{metric.context.brief}</Text>
+              </Stack>
+            ) : null}
+            {metric.context?.details?.length ? (
+              <Stack gap="xs">
+                <Text size="sm" bold variant="muted">
+                  {t('Additional context')}
+                </Text>
+                {metric.context.details.map((detail, i) => (
+                  <Text key={i}>{detail}</Text>
+                ))}
+              </Stack>
+            ) : null}
+          </Stack>
+        </Body>
+      </Fragment>
+    ));
+  };
+
   return (
     <BodyContainer>
       <LinkButton
@@ -194,54 +231,73 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
         ) : metrics.length === 0 ? (
           <SimpleTable.Empty>{t('No metrics found.')}</SimpleTable.Empty>
         ) : (
-          metrics.map(metric => (
-            <SimpleTable.Row key={`${metric.name}:${metric.type}`}>
-              <SimpleTable.RowCell>
-                <Text bold monospace>
-                  {metric.name}
-                </Text>
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <Text>
-                  {metric.type}
-                  {metric.unit ? ` (${metric.unit})` : ''}
-                </Text>
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                {metric.context?.brief ? (
-                  <Text>{metric.context.brief}</Text>
-                ) : (
-                  <Text variant="muted">{t('No description')}</Text>
-                )}
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                {metric.context?.details?.length ? (
-                  <Text>{metric.context.details.join(' ')}</Text>
-                ) : (
-                  <Text variant="muted">{'—'}</Text>
-                )}
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <Text variant="muted">
-                  {defined(metric.lastSeen)
-                    ? // `lastSeen` is max(timestamp_precise) in nanoseconds;
-                      // convert to milliseconds for date formatting.
-                      getFormattedDate(metric.lastSeen / 1_000_000, 'lll')
-                    : '—'}
-                </Text>
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell justify="end">
-                <Button
-                  size="xs"
-                  icon={<IconEdit />}
-                  aria-label={t('Edit description for %s', metric.name)}
-                  onClick={() => openEditModal(metric)}
-                >
-                  {t('Edit')}
-                </Button>
-              </SimpleTable.RowCell>
-            </SimpleTable.Row>
-          ))
+          metrics.map(metric => {
+            const detailsText = metric.context?.details?.join(' ') ?? '';
+            const isDetailsTruncated = detailsText.length > BRIEF_MAX_LENGTH;
+            return (
+              <SimpleTable.Row key={`${metric.name}:${metric.type}`}>
+                <SimpleTable.RowCell>
+                  <Text bold monospace>
+                    {metric.name}
+                  </Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  <Text>
+                    {metric.type}
+                    {metric.unit ? ` (${metric.unit})` : ''}
+                  </Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  {metric.context?.brief ? (
+                    <Text>{metric.context.brief}</Text>
+                  ) : (
+                    <Text variant="muted">{t('No description')}</Text>
+                  )}
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  {detailsText ? (
+                    <Flex gap="sm" align="center">
+                      <Text>
+                        {isDetailsTruncated
+                          ? `${detailsText.slice(0, BRIEF_MAX_LENGTH)}…`
+                          : detailsText}
+                      </Text>
+                      {isDetailsTruncated ? (
+                        <Button
+                          size="xs"
+                          variant="link"
+                          onClick={() => openViewModal(metric)}
+                        >
+                          {t('View full')}
+                        </Button>
+                      ) : null}
+                    </Flex>
+                  ) : (
+                    <Text variant="muted">{'—'}</Text>
+                  )}
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell>
+                  <Text variant="muted">
+                    {defined(metric.lastSeen)
+                      ? // `lastSeen` is max(timestamp_precise) in nanoseconds;
+                        // convert to milliseconds for date formatting.
+                        getFormattedDate(metric.lastSeen / 1_000_000, 'lll')
+                      : '—'}
+                  </Text>
+                </SimpleTable.RowCell>
+                <SimpleTable.RowCell justify="end">
+                  <Button
+                    size="xs"
+                    icon={<IconEdit />}
+                    aria-label={t('Edit description for %s', metric.name)}
+                    onClick={() => openEditModal(metric)}
+                  >
+                    {t('Edit')}
+                  </Button>
+                </SimpleTable.RowCell>
+              </SimpleTable.Row>
+            );
+          })
         )}
       </StyledSimpleTable>
 

--- a/static/app/views/explore/metrics/metricDescriptions/index.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/index.tsx
@@ -47,6 +47,11 @@ const METRIC_TYPE_OPTIONS: Array<{label: string; value: TraceMetricTypeValue | '
   {label: t('Distribution'), value: 'distribution'},
 ];
 
+const HAS_CONTEXT_OPTIONS: Array<{label: string; value: '' | '1'}> = [
+  {label: t('All metrics'), value: ''},
+  {label: t('Has description'), value: '1'},
+];
+
 const PAGE_TITLE = t('Metric Descriptions');
 
 export default function MetricDescriptionsContent() {
@@ -98,6 +103,8 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
   const search = decodeScalar(location.query.query, '');
   const typeParam = decodeScalar(location.query.type, '');
   const type = isTraceMetricTypeValue(typeParam) ? typeParam : undefined;
+  const hasContextParam = decodeScalar(location.query.contextOnly, '');
+  const hasContext = hasContextParam === '1';
   const cursor = decodeScalar(location.query.cursor);
 
   const {
@@ -106,7 +113,7 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
     isError,
     refetch: refetchQuery,
   } = useQuery({
-    ...useMetricDescriptionsQueryOptions({search, type, cursor}),
+    ...useMetricDescriptionsQueryOptions({search, type, hasContext, cursor}),
     select: selectJsonWithHeaders,
   });
 
@@ -151,6 +158,14 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
           onChange={option => updateQuery({type: option.value || undefined})}
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Type')} />
+          )}
+        />
+        <CompactSelect
+          value={hasContextParam}
+          options={HAS_CONTEXT_OPTIONS}
+          onChange={option => updateQuery({contextOnly: option.value || undefined})}
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Description')} />
           )}
         />
         <SearchWrapper>
@@ -200,8 +215,8 @@ function MetricDescriptionsBody({datePageFilterProps}: MetricDescriptionsBodyPro
                 )}
               </SimpleTable.RowCell>
               <SimpleTable.RowCell>
-                {metric.context?.additionalContext ? (
-                  <Text>{metric.context.additionalContext}</Text>
+                {metric.context?.details?.length ? (
+                  <Text>{metric.context.details.join(' ')}</Text>
                 ) : (
                   <Text variant="muted">{'—'}</Text>
                 )}

--- a/static/app/views/explore/metrics/metricDescriptions/types.ts
+++ b/static/app/views/explore/metrics/metricDescriptions/types.ts
@@ -14,7 +14,9 @@ export interface TraceMetricListItem {
   // Only present when `expand=context` is requested and the
   // data-browsing-attribute-context feature is enabled.
   context?: {
-    additionalContext?: string;
     brief?: string;
+    // Longer-form notes; the authoring endpoint stores a single string, which
+    // the list endpoint normalizes to a one-element list.
+    details?: string[];
   };
 }

--- a/static/app/views/explore/metrics/metricDescriptions/types.ts
+++ b/static/app/views/explore/metrics/metricDescriptions/types.ts
@@ -1,0 +1,20 @@
+import type {TraceMetricTypeValue} from 'sentry/views/explore/metrics/types';
+
+/**
+ * A single row from the trace metrics list endpoint
+ * (`GET /organizations/{org}/trace-items/metrics/`).
+ */
+export interface TraceMetricListItem {
+  count: number;
+  /** max(timestamp_precise), in nanoseconds since the epoch. */
+  lastSeen: number | null;
+  name: string;
+  type: TraceMetricTypeValue;
+  unit: string | null;
+  // Only present when `expand=context` is requested and the
+  // data-browsing-attribute-context feature is enabled.
+  context?: {
+    additionalContext?: string;
+    brief?: string;
+  };
+}

--- a/static/app/views/explore/metrics/metricDescriptions/useMetricDescriptions.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/useMetricDescriptions.tsx
@@ -14,6 +14,7 @@ export const METRIC_DESCRIPTIONS_PER_PAGE = 100;
 
 interface UseMetricDescriptionsProps {
   cursor?: string;
+  hasContext?: boolean;
   search?: string;
   type?: TraceMetricTypeValue;
 }
@@ -40,13 +41,14 @@ function buildQueryString({
 
 /**
  * Returns `apiOptions` for the paginated trace metrics list, scoped to the
- * current page filters and requesting authored context (brief / additional
- * context). Pass the result to `useQuery` with `selectJsonWithHeaders` to read
- * the `Link` pagination header.
+ * current page filters and requesting authored context (brief / details).
+ * Pass the result to `useQuery` with `selectJsonWithHeaders` to read the
+ * `Link` pagination header.
  */
 export function useMetricDescriptionsQueryOptions({
   search,
   type,
+  hasContext,
   cursor,
 }: UseMetricDescriptionsProps) {
   const organization = useOrganization();
@@ -59,6 +61,8 @@ export function useMetricDescriptionsQueryOptions({
     // the underlying attribute alias).
     sort: 'name',
     query: buildQueryString({search, type}),
+    // Restricts results to metrics that already have authored context.
+    contextOnly: hasContext ? '1' : undefined,
     cursor: cursor || undefined,
     project: selection.projects.length ? selection.projects.map(String) : undefined,
     environment: selection.environments.length ? selection.environments : undefined,

--- a/static/app/views/explore/metrics/metricDescriptions/useMetricDescriptions.tsx
+++ b/static/app/views/explore/metrics/metricDescriptions/useMetricDescriptions.tsx
@@ -1,0 +1,81 @@
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {defined} from 'sentry/utils/defined';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {TraceMetricListItem} from 'sentry/views/explore/metrics/metricDescriptions/types';
+import {
+  TraceMetricKnownFieldKey,
+  type TraceMetricTypeValue,
+} from 'sentry/views/explore/metrics/types';
+
+export const METRIC_DESCRIPTIONS_PER_PAGE = 100;
+
+interface UseMetricDescriptionsProps {
+  cursor?: string;
+  search?: string;
+  type?: TraceMetricTypeValue;
+}
+
+/**
+ * Builds the search string forwarded to the trace metrics list endpoint. The
+ * name is matched as a "contains" filter and the type (when set) as an exact
+ * match, mirroring how the explore metric picker builds its queries.
+ */
+function buildQueryString({
+  search,
+  type,
+}: Pick<UseMetricDescriptionsProps, 'search' | 'type'>) {
+  const mutableSearch = new MutableSearch('');
+  if (search) {
+    mutableSearch.addContainsFilterValue(TraceMetricKnownFieldKey.METRIC_NAME, search);
+  }
+  if (type) {
+    mutableSearch.addFilterValue(TraceMetricKnownFieldKey.METRIC_TYPE, type);
+  }
+  const formatted = mutableSearch.formatString();
+  return formatted.length > 0 ? formatted : undefined;
+}
+
+/**
+ * Returns `apiOptions` for the paginated trace metrics list, scoped to the
+ * current page filters and requesting authored context (brief / additional
+ * context). Pass the result to `useQuery` with `selectJsonWithHeaders` to read
+ * the `Link` pagination header.
+ */
+export function useMetricDescriptionsQueryOptions({
+  search,
+  type,
+  cursor,
+}: UseMetricDescriptionsProps) {
+  const organization = useOrganization();
+  const {selection} = usePageFilters();
+
+  const query: Record<string, string | string[] | number[] | undefined> = {
+    expand: 'context',
+    per_page: String(METRIC_DESCRIPTIONS_PER_PAGE),
+    // Sort by metric name (endpoint's `sort` uses response field names, not
+    // the underlying attribute alias).
+    sort: 'name',
+    query: buildQueryString({search, type}),
+    cursor: cursor || undefined,
+    project: selection.projects.length ? selection.projects.map(String) : undefined,
+    environment: selection.environments.length ? selection.environments : undefined,
+  };
+
+  Object.entries(normalizeDateTimeParams(selection.datetime)).forEach(([key, value]) => {
+    if (defined(value)) {
+      query[key] = value;
+    }
+  });
+
+  return apiOptions.as<TraceMetricListItem[]>()(
+    '/organizations/$organizationIdOrSlug/trace-items/metrics/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      query,
+      staleTime: 0,
+    }
+  );
+}

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -43,3 +43,10 @@ export const canUseMetricsPiiScrubbingUI = (organization: Organization) => {
 export const canUseMetricsHeatMap = (organization: Organization) => {
   return canUseMetricsUI(organization);
 };
+
+export const canUseMetricDescriptions = (organization: Organization) => {
+  return (
+    canUseMetricsUI(organization) &&
+    organization.features.includes('data-browsing-attribute-context')
+  );
+};

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import {closestCenter, DndContext} from '@dnd-kit/core';
 import {SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 
+import {LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 
@@ -12,8 +13,10 @@ import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/e
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {AiQueryProvider} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
+import {IconList} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
 import {
   ExploreBodyContent,
@@ -28,6 +31,7 @@ import {useEquationReferencedLabels} from 'sentry/views/explore/metrics/hooks/us
 import {useMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
 import {useSortableMetricQueries} from 'sentry/views/explore/metrics/hooks/useSortableMetricQueries';
 import {SortableMetricPanel} from 'sentry/views/explore/metrics/metricPanel/sortableMetricPanel';
+import {canUseMetricDescriptions} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
 import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
 import {
@@ -39,6 +43,7 @@ import {
   FilterBarWithSaveAsContainer,
   StyledPageFilterBar,
 } from 'sentry/views/explore/metrics/styles';
+import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
@@ -65,6 +70,7 @@ function MetricsTabContentInner({datePageFilterProps}: MetricsTabProps) {
 }
 
 function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
+  const organization = useOrganization();
   const metricQueries = useMultiMetricsQueryParams();
   const addMetricQuery = useAddMetricQuery();
   const addEquationQuery = useAddMetricQuery({type: 'equation'});
@@ -87,6 +93,18 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
             />
           </StyledPageFilterBar>
           <Flex gap="sm" align="center">
+            {canUseMetricDescriptions(organization) ? (
+              <LinkButton
+                size="md"
+                icon={<IconList />}
+                to={makeMetricsPathname({
+                  organizationSlug: organization.slug,
+                  path: '/descriptions/',
+                })}
+              >
+                {t('Metric Descriptions')}
+              </LinkButton>
+            ) : null}
             <ToolbarVisualizeAddChart
               add={addMetricQuery}
               disabled={isAddMetricDisabled}

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -15,6 +15,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {AiQueryProvider} from 'sentry/components/searchQueryBuilder/askSeerCombobox/aiQueryContext';
 import {IconList} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {WidgetSyncContextProvider} from 'sentry/views/dashboards/contexts/widgetSyncContext';
@@ -94,16 +95,27 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
           </StyledPageFilterBar>
           <Flex gap="sm" align="center">
             {canUseMetricDescriptions(organization) ? (
-              <LinkButton
-                size="md"
-                icon={<IconList />}
-                to={makeMetricsPathname({
-                  organizationSlug: organization.slug,
-                  path: '/descriptions/',
-                })}
-              >
-                {t('Metric Descriptions')}
-              </LinkButton>
+              <Fragment>
+                <LinkButton
+                  size="md"
+                  icon={<IconList />}
+                  to={makeMetricsPathname({
+                    organizationSlug: organization.slug,
+                    path: '/descriptions/',
+                  })}
+                >
+                  {t('Metric Descriptions')}
+                </LinkButton>
+                <LinkButton
+                  size="md"
+                  icon={<IconList />}
+                  to={normalizeUrl(
+                    `/organizations/${organization.slug}/explore/attributes/descriptions/`
+                  )}
+                >
+                  {t('Attribute Browser')}
+                </LinkButton>
+              </Fragment>
             ) : null}
             <ToolbarVisualizeAddChart
               add={addMetricQuery}


### PR DESCRIPTION
Rough first pass at a page for browsing and editing trace metric descriptions, assisted query agent picks these up to make better queries.

<img width="1415" height="627" alt="image" src="https://github.com/user-attachments/assets/a99a5a83-80db-4a47-abc1-abcbab1ac8ea" />
<img width="1407" height="598" alt="image" src="https://github.com/user-attachments/assets/4bc19a8e-fe31-44dd-b137-88d4adf46918" />
