### PR TITLE
feat(gdd): Add promote_to_live

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -295,24 +295,14 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
     generated_at = candidate.generated_at
     values = {f: getattr(candidate, f) for f in _STATE_FIELDS}
 
-    updated = (
-        GroupDerivedData.objects.filter(
-            group_id=candidate.group_id,
-        )
-        .filter(
-            Q(generated_at__lt=generated_at)
-            | Q(
-                generated_at=generated_at,
-                cursor_date__lt=candidate.cursor_date,
-            )
-            | Q(
-                generated_at=generated_at,
-                cursor_date=candidate.cursor_date,
-                cursor_id__lte=candidate.cursor_id,
-            )
-        )
-        .update(**values)
+    cursor_ahead = Q(cursor_date__lt=candidate.cursor_date) | Q(
+        cursor_date=candidate.cursor_date, cursor_id__lte=candidate.cursor_id
     )
+    updated = GroupDerivedData.objects.filter(
+        cursor_ahead,
+        group_id=candidate.group_id,
+        generated_at__lte=generated_at,
+    ).update(**values)
 
     if updated:
         return PromotionResult.PROMOTED

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -23,6 +23,14 @@ PIPELINE: Pipeline[GroupActionLogEntry] = Pipeline(AGGREGATORS)
 DEFAULT_BATCH_SIZE = 1000
 INLINE_BATCH_SIZE = 100
 
+# Fields that constitute the derived state, written by promote_to_live.
+# Derived by excluding identity, control, and auto-managed fields from the
+# model — new columns are automatically included unless explicitly excluded.
+_EXCLUDED_FIELDS = frozenset({"id", "group_id", "date_added", "date_updated"})
+_STATE_FIELDS = tuple(
+    f.attname for f in GroupDerivedData._meta.concrete_fields if f.attname not in _EXCLUDED_FIELDS
+)
+
 
 class ProcessingStrategy(enum.Enum):
     SYNC = "sync"  # process all pending actions now
@@ -72,6 +80,8 @@ def _process_batch(
     p: Pipeline[GroupActionLogEntry],
     derived: GroupDerivedData,
     batch_size: int,
+    *,
+    persist: bool = True,
 ) -> bool:
     """
     Process up to `batch_size` entries for a group. Updates derived in place.
@@ -90,6 +100,9 @@ def _process_batch(
     This is an optimistic concurrency scheme — no locks are held, and the
     last-writer-wins semantics are safe because all writers compute the
     same deterministic result for overlapping entry ranges.
+
+    When *persist* is False, only the in-memory object is updated — the
+    caller is responsible for persisting the result.
     """
     group_id = derived.group_id
     entries = _entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, batch_size)
@@ -103,6 +116,12 @@ def _process_batch(
     last_date = last.date_added
     last_id = last.id
     state_update = GroupDerivedDataStore.build_update(p, result)
+
+    if not persist:
+        derived.cursor_date = last_date
+        derived.cursor_id = last_id
+        GroupDerivedDataStore.apply_to_instance(derived, state_update)
+        return len(entries) == batch_size
 
     updated = GroupDerivedData.objects.filter(
         Q(id=derived.id, generated_at=derived.generated_at)
@@ -158,18 +177,26 @@ def _drain_log(
     batch_size: int = DEFAULT_BATCH_SIZE,
     *,
     time_limit: timedelta,
+    persist: bool = True,
 ) -> bool:
     """Process pending log entries into *derived*, batching as needed.
 
     Returns True if all entries were processed, False if the time limit was
     reached and more entries remain. The limit is checked between batches,
     so a single slow batch can exceed it.
+
+    When *persist* is False, batches update only the in-memory object.
     """
     deadline = time.monotonic() + time_limit.total_seconds()
-    while _process_batch(pipeline, derived, batch_size):
+    while _process_batch(pipeline, derived, batch_size, persist=persist):
         if time.monotonic() >= deadline:
             return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# Incremental processing (on event arrival)
+# ---------------------------------------------------------------------------
 
 
 def process_group_log(
@@ -239,6 +266,89 @@ def trigger_group_log_processing(group_id: int, *, strategy: ProcessingStrategy)
         # when the task completes.
         metrics.incr("issues.derived.inline_fallback_to_async")
         process_group_log_task.delay(group_id)
+
+
+# ---------------------------------------------------------------------------
+# Generation: upsert derived data from a full log replay
+# ---------------------------------------------------------------------------
+
+
+class PromotionResult(enum.Enum):
+    PROMOTED = "promoted"
+    SUPERSEDED = "superseded"  # a newer generation already promoted
+    CURSOR_BEHIND = "cursor_behind"  # same generation, but cursor is more advanced
+
+
+def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
+    """Upsert the candidate's state into the row for its group.
+
+    The UPDATE guard requires that ``candidate.generated_at`` is >= the
+    row's (newer generation wins) and the cursor is at or ahead.  On
+    success, all state fields (including ``generated_at``) are stamped.
+
+    Returns SUPERSEDED if the row has a newer ``generated_at``.
+    Returns CURSOR_BEHIND if the cursor guard failed.
+
+    The candidate object itself is not persisted — it may be an unsaved
+    in-memory instance used only to carry the computed state.
+    """
+    generated_at = candidate.generated_at
+    values = {f: getattr(candidate, f) for f in _STATE_FIELDS}
+
+    updated = (
+        GroupDerivedData.objects.filter(
+            group_id=candidate.group_id,
+        )
+        .filter(
+            Q(generated_at__lt=generated_at)
+            | Q(
+                generated_at=generated_at,
+                cursor_date__lt=candidate.cursor_date,
+            )
+            | Q(
+                generated_at=generated_at,
+                cursor_date=candidate.cursor_date,
+                cursor_id__lte=candidate.cursor_id,
+            )
+        )
+        .update(**values)
+    )
+
+    if updated:
+        return PromotionResult.PROMOTED
+
+    # Check why we failed: row missing or newer generation?
+    row = (
+        GroupDerivedData.objects.filter(group_id=candidate.group_id)
+        .values_list("id", "generated_at")
+        .first()
+    )
+
+    if row is None:
+        # Row doesn't exist — try to create it.
+        try:
+            with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
+                GroupDerivedData.objects.create(
+                    group_id=candidate.group_id,
+                    **values,
+                )
+        except IntegrityError:
+            # A concurrent writer created the row first. This could be
+            # SUPERSEDED (if their generated_at is newer) but we'd need
+            # another query to distinguish. CURSOR_BEHIND triggers a
+            # retry which will resolve it on the UPDATE path.
+            return PromotionResult.CURSOR_BEHIND
+        return PromotionResult.PROMOTED
+
+    _row_id, current_generated_at = row
+    if current_generated_at > generated_at:
+        return PromotionResult.SUPERSEDED
+    return PromotionResult.CURSOR_BEHIND
+
+
+# ---------------------------------------------------------------------------
+# Invalidation
+# ---------------------------------------------------------------------------
 
 
 def invalidate_group_derived_data(

--- a/src/sentry/issues/models/groupderiveddata.py
+++ b/src/sentry/issues/models/groupderiveddata.py
@@ -25,7 +25,30 @@ EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 class GroupDerivedData(DefaultFieldsModel):
     """
     Materialized state derived from GroupActionLogEntry entries.
-    One row per group. The cursor tracks the last entry processed.
+    One row per group (enforced by ``unique=True`` on the FK).
+
+    Update safety
+    ~~~~~~~~~~~~~
+    The pipeline is deterministic: replaying the same log produces the same
+    state. However, the log is not strictly append-only — historical entries
+    may be inserted, which is a primary reason generations are triggered.
+
+    * **generated_at** — timestamp of when the generation that produced
+      this row's current state *started* processing. This is a CAS version:
+      incremental writes only succeed if ``generated_at`` hasn't changed
+      since the row was read, and generation promotes only succeed if their
+      ``generated_at`` is newer than the row's.  The start time (rather
+      than finish time) reflects the log state the generation observed.
+
+    * **cursor guard** — incremental writes only succeed if the writer's
+      ``(cursor_date, cursor_id)`` is at or ahead of the row's, preventing
+      cursor regression.
+
+    * **pipeline_hash** — stamped at row creation, incremental writes only
+      succeed if the pipeline version hasn't changed since the row was
+      read. A pipeline upgrade invalidates in-flight incremental work.
+
+    See ``processing.py`` for the full lifecycle.
     """
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from django.db import router, transaction
+from django.utils import timezone as django_timezone
 
 from sentry.hybridcloud.models.outbox import CellOutbox
 from sentry.hybridcloud.outbox.category import OutboxCategory
@@ -48,13 +49,15 @@ from sentry.issues.derived.framework import (
 from sentry.issues.derived.processing import (
     PIPELINE,
     GroupLogTimeout,
+    PromotionResult,
     _entries_after_cursor,
     invalidate_group_derived_data,
     process_group_log,
+    promote_to_live,
 )
 from sentry.issues.derived.store import GroupDerivedDataStore
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
-from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.issues.progress_state import IssueProgressState
 from sentry.models.group import Group
 from sentry.testutils.cases import TestCase
@@ -503,6 +506,118 @@ class ProcessGroupLogTest(TestCase):
 
         derived.refresh_from_db()
         assert derived.cursor_id == first_cursor
+
+
+# --- promote_to_live ---
+
+
+@with_feature("projects:issue-action-log-write-to-db")
+class PromoteToLiveTest(TestCase):
+    def test_promote_inserts_when_no_row(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        GroupDerivedData.objects.filter(group_id=group.id).delete()
+
+        gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id, generated_at=gen_time, cursor_date=EPOCH, cursor_id=0, data={}
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+        assert promote_to_live(candidate) is PromotionResult.PROMOTED
+
+        live = GroupDerivedData.objects.get(group_id=group.id)
+        assert live.view_count == 1
+        assert live.generated_at == gen_time
+
+    def test_promote_updates_existing_row(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        old = process_group_log(group.id)
+        old_id = old.id
+
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id, generated_at=gen_time, cursor_date=EPOCH, cursor_id=0, data={}
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+        assert promote_to_live(candidate) is PromotionResult.PROMOTED
+
+        live = GroupDerivedData.objects.get(group_id=group.id)
+        assert live.id == old_id
+        assert live.view_count == 2
+        assert live.generated_at == gen_time
+
+    def test_promote_superseded_by_newer_generation(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        process_group_log(group.id)
+
+        newer_time = django_timezone.now()
+        GroupDerivedData.objects.filter(group_id=group.id).update(generated_at=newer_time)
+
+        old_time = newer_time - timedelta(seconds=10)
+        candidate = GroupDerivedData(
+            group_id=group.id, generated_at=old_time, cursor_date=EPOCH, cursor_id=0, data={}
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+        assert promote_to_live(candidate) is PromotionResult.SUPERSEDED
+
+    def test_generation_prevents_stale_incremental_write(self) -> None:
+        """End-to-end ABA test: incremental write computed from pre-generation
+        state must not overwrite a generation's result."""
+
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        # Incremental processing reads the row.
+        derived = process_group_log(group.id)
+        pre_gen_generated_at = derived.generated_at
+
+        # Simulate a generation promoting (stamps a newer generated_at).
+        new_gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id,
+            generated_at=new_gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+        assert promote_to_live(candidate) is PromotionResult.PROMOTED
+
+        derived.refresh_from_db()
+        assert derived.generated_at == new_gen_time
+
+        # A new entry arrives.
+        GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.VIEW,
+            actor_type=GroupActorType.SYSTEM,
+            actor_id=0,
+            source=SOURCE,
+            data={},
+        )
+
+        # Create a stale incremental writer with the pre-generation state.
+        stale = GroupDerivedData(
+            group_id=group.id,
+            generated_at=pre_gen_generated_at,
+            cursor_date=derived.cursor_date,
+            cursor_id=derived.cursor_id,
+            data=derived.data.copy(),
+            pipeline_hash=derived.pipeline_hash,
+        )
+        # The stale writer processes the new entry.
+        processing._process_batch(PIPELINE, stale, batch_size=1)
+
+        # The write should have been rejected because generated_at changed.
+        derived.refresh_from_db()
+        entries = list(GroupActionLogEntry.objects.filter(group_id=group.id).order_by("id"))
+        assert derived.cursor_id == entries[-2].id  # still at the pre-new-entry position
 
 
 # --- Pure Python tests (no DB) ---

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -520,7 +520,12 @@ class PromoteToLiveTest(TestCase):
 
         gen_time = django_timezone.now()
         candidate = GroupDerivedData(
-            group_id=group.id, generated_at=gen_time, cursor_date=EPOCH, cursor_id=0, data={}
+            group_id=group.id,
+            generated_at=gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
         )
         processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
         assert promote_to_live(candidate) is PromotionResult.PROMOTED
@@ -540,7 +545,12 @@ class PromoteToLiveTest(TestCase):
 
         gen_time = django_timezone.now()
         candidate = GroupDerivedData(
-            group_id=group.id, generated_at=gen_time, cursor_date=EPOCH, cursor_id=0, data={}
+            group_id=group.id,
+            generated_at=gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
         )
         processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
         assert promote_to_live(candidate) is PromotionResult.PROMOTED
@@ -560,7 +570,12 @@ class PromoteToLiveTest(TestCase):
 
         old_time = newer_time - timedelta(seconds=10)
         candidate = GroupDerivedData(
-            group_id=group.id, generated_at=old_time, cursor_date=EPOCH, cursor_id=0, data={}
+            group_id=group.id,
+            generated_at=old_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
         )
         processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
         assert promote_to_live(candidate) is PromotionResult.SUPERSEDED
@@ -584,6 +599,7 @@ class PromoteToLiveTest(TestCase):
             cursor_date=EPOCH,
             cursor_id=0,
             data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
         )
         processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
         assert promote_to_live(candidate) is PromotionResult.PROMOTED
@@ -602,8 +618,11 @@ class PromoteToLiveTest(TestCase):
             data={},
         )
 
-        # Create a stale incremental writer with the pre-generation state.
+        # Create a stale incremental writer with the pre-generation state
+        # but the correct row id, so the UPDATE filter matches on id and
+        # the generated_at guard is what actually rejects the write.
         stale = GroupDerivedData(
+            id=derived.id,
             group_id=group.id,
             generated_at=pre_gen_generated_at,
             cursor_date=derived.cursor_date,

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -560,6 +560,30 @@ class PromoteToLiveTest(TestCase):
         assert live.view_count == 2
         assert live.generated_at == gen_time
 
+    def test_promote_rejected_if_cursor_behind_despite_newer_generation(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        # Incremental processing advances the cursor past the first entry.
+        process_group_log(group.id)
+
+        # A newer generation only processed the first entry (cursor behind).
+        gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id,
+            generated_at=gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+        processing._process_batch(PIPELINE, candidate, batch_size=1, persist=False)
+
+        # Despite having a newer generated_at, the cursor is behind —
+        # promote must not regress the cursor.
+        assert promote_to_live(candidate) is PromotionResult.CURSOR_BEHIND
+
     def test_promote_superseded_by_newer_generation(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -631,7 +631,8 @@ class PromoteToLiveTest(TestCase):
         derived.refresh_from_db()
         assert derived.generated_at == new_gen_time
 
-        # A new entry arrives.
+        # Insert a log entry directly (not via _publish) to avoid inline
+        # processing, which would advance the cursor and mask the test.
         GroupActionLogEntry.objects.create(
             group_id=group.id,
             project_id=group.project_id,
@@ -642,9 +643,9 @@ class PromoteToLiveTest(TestCase):
             data={},
         )
 
-        # Create a stale incremental writer with the pre-generation state
-        # but the correct row id, so the UPDATE filter matches on id and
-        # the generated_at guard is what actually rejects the write.
+        # Simulate an incremental writer that read the row before the
+        # generation promoted. We construct the GDD manually so we can
+        # control the observed generated_at (pre-generation).
         stale = GroupDerivedData(
             id=derived.id,
             group_id=group.id,
@@ -654,7 +655,7 @@ class PromoteToLiveTest(TestCase):
             data=derived.data.copy(),
             pipeline_hash=derived.pipeline_hash,
         )
-        # The stale writer processes the new entry.
+        # _process_batch with persist=True attempts the guarded UPDATE.
         processing._process_batch(PIPELINE, stale, batch_size=1)
 
         # The write should have been rejected because generated_at changed.


### PR DESCRIPTION
Adds 'promote_to_live' function to support safely replacing a live GroupDerivedData row with a newly generated one.
The new method follows the document CAS safety rules, and returns an enum indicating whether promotion was successful, unnecessary, or currently too stale to allow.

This includes adding an option to existing update methods for 'persist=False', allowing the argument to promote_to_live to be an uncommitted GroupDerivedData.