### PR TITLE
chore(seer-alerts): Remove *_started hooks as options

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -46,15 +46,10 @@ WORKFLOW_TRIGGERS_HELP_TEXT = """The conditions on which the alert will trigger.
                     {
                         "type": "seer_activity_trigger",
                         "comparison": [
-                            "rca_started",
                             "rca_completed",
-                            "solution_started",
                             "solution_completed",
-                            "coding_started",
                             "coding_completed",
-                            "pr_created",
-                            "iteration_started",
-                            "iteration_completed"
+                            "pr_created"
                         ],
                         "conditionResult": true
                     }

--- a/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/seer_activity_trigger_handler.py
@@ -13,27 +13,17 @@ class SeerActivityTriggerStage(StrEnum):
     The stages that are configurable options for this SeerActivityTrigger DataCondition.
     """
 
-    RCA_STARTED = "rca_started"
     RCA_COMPLETED = "rca_completed"
-    SOLUTION_STARTED = "solution_started"
     SOLUTION_COMPLETED = "solution_completed"
-    CODING_STARTED = "coding_started"
     CODING_COMPLETED = "coding_completed"
     PR_CREATED = "pr_created"
-    ITERATION_STARTED = "iteration_started"
-    ITERATION_COMPLETED = "iteration_completed"
 
 
 SEER_STAGE_TO_ACTIVITY_TYPE: dict[str, int] = {
-    SeerActivityTriggerStage.RCA_STARTED: ActivityType.SEER_RCA_STARTED.value,
     SeerActivityTriggerStage.RCA_COMPLETED: ActivityType.SEER_RCA_COMPLETED.value,
-    SeerActivityTriggerStage.SOLUTION_STARTED: ActivityType.SEER_SOLUTION_STARTED.value,
     SeerActivityTriggerStage.SOLUTION_COMPLETED: ActivityType.SEER_SOLUTION_COMPLETED.value,
-    SeerActivityTriggerStage.CODING_STARTED: ActivityType.SEER_CODING_STARTED.value,
     SeerActivityTriggerStage.CODING_COMPLETED: ActivityType.SEER_CODING_COMPLETED.value,
     SeerActivityTriggerStage.PR_CREATED: ActivityType.SEER_PR_CREATED.value,
-    SeerActivityTriggerStage.ITERATION_STARTED: ActivityType.SEER_ITERATION_STARTED.value,
-    SeerActivityTriggerStage.ITERATION_COMPLETED: ActivityType.SEER_ITERATION_COMPLETED.value,
 }
 """
 Maps the DataCondition's expected stages to their ActivityType (from the Activity model)
@@ -62,6 +52,8 @@ class SeerActivityTriggerHandler(DataConditionHandler[WorkflowEventData]):
         comparison_activity_types = {
             SEER_STAGE_TO_ACTIVITY_TYPE[stage]
             for stage in comparison
+            # The below check is required, since stale alerts in our DB for stages we've removed
+            # may be evaluated (e.g. `rca_started`, `coding_started`).
             if stage in SEER_STAGE_TO_ACTIVITY_TYPE
         }
         return event.type in comparison_activity_types

--- a/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
+++ b/src/sentry/workflow_engine/handlers/workflow/workflow_activity_handlers.py
@@ -13,16 +13,12 @@ from sentry.workflow_engine.types import DetectorId, WorkflowEventData
 
 logger = logging.getLogger(__name__)
 
+# Seer runs on an issue and reaches the stage...
 SEER_WORKFLOW_ACTIVITIES = [
-    ActivityType.SEER_RCA_STARTED,
     ActivityType.SEER_RCA_COMPLETED,
-    ActivityType.SEER_SOLUTION_STARTED,
     ActivityType.SEER_SOLUTION_COMPLETED,
-    ActivityType.SEER_CODING_STARTED,
     ActivityType.SEER_CODING_COMPLETED,
     ActivityType.SEER_PR_CREATED,
-    ActivityType.SEER_ITERATION_STARTED,
-    ActivityType.SEER_ITERATION_COMPLETED,
 ]
 
 # Activity types handled by the generic activity_handler.

--- a/static/app/views/automations/components/actionFilters/seerActivityTrigger.spec.tsx
+++ b/static/app/views/automations/components/actionFilters/seerActivityTrigger.spec.tsx
@@ -32,14 +32,14 @@ describe('SeerActivityTriggerDetails', () => {
       <SeerActivityTriggerDetails
         condition={DataConditionFixture({
           type: DataConditionType.SEER_ACTIVITY_TRIGGER,
-          comparison: ['rca_started', 'coding_completed'],
+          comparison: ['rca_completed', 'coding_completed'],
         })}
       />
     );
 
     expect(
       screen.getByText(
-        'Seer reaches any of these stages: Root cause analysis started, Coding completed'
+        'Seer reaches any of these stages: Root cause analysis completed, Coding completed'
       )
     ).toBeInTheDocument();
   });
@@ -62,7 +62,7 @@ describe('SeerActivityTriggerNode', () => {
   const dataCondition = DataConditionFixture({
     id: 'seer-1',
     type: DataConditionType.SEER_ACTIVITY_TRIGGER,
-    comparison: ['rca_started', 'coding_completed'],
+    comparison: ['rca_completed', 'coding_completed'],
   });
   const errorContext = {
     errors: {},
@@ -122,7 +122,7 @@ describe('SeerActivityTriggerNode', () => {
       </AutomationBuilderErrorContext.Provider>
     );
 
-    expect(screen.getByText('Root cause analysis started')).toBeInTheDocument();
+    expect(screen.getByText('Root cause analysis completed')).toBeInTheDocument();
     expect(screen.getByText('Coding completed')).toBeInTheDocument();
   });
 });
@@ -153,7 +153,7 @@ describe('validateSeerActivityTriggerCondition', () => {
       validateSeerActivityTriggerCondition({
         condition: DataConditionFixture({
           type: DataConditionType.SEER_ACTIVITY_TRIGGER,
-          comparison: ['rca_started'],
+          comparison: ['rca_completed'],
         }),
       })
     ).toBeUndefined();

--- a/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
+++ b/static/app/views/automations/components/actionFilters/seerActivityTrigger.tsx
@@ -5,39 +5,33 @@ import {Text} from '@sentry/scraps/text';
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
 const SEER_ACTIVITY_STAGE_CHOICES: Array<{label: string; value: string}> = [
-  {value: 'rca_started', label: t('Root cause analysis started')},
   {value: 'rca_completed', label: t('Root cause analysis completed')},
-  {value: 'solution_started', label: t('Planning started')},
   {value: 'solution_completed', label: t('Planning completed')},
-  {value: 'coding_started', label: t('Coding started')},
   {value: 'coding_completed', label: t('Coding completed')},
   {value: 'pr_created', label: t('Pull request created')},
 ];
-
-const SEER_ITERATION_GATED_STAGE_CHOICES: Array<{label: string; value: string}> = [
-  {value: 'iteration_started', label: t('Pull request iteration started')},
-  {value: 'iteration_completed', label: t('Pull request iteration completed')},
-];
+const SEER_ACTIVITY_STAGES = new Set(SEER_ACTIVITY_STAGE_CHOICES.map(c => c.value));
 
 export function SeerActivityTriggerDetails({condition}: {condition: DataCondition}) {
   const stages: string[] = Array.isArray(condition.comparison)
-    ? condition.comparison
+    ? condition.comparison.filter(stage => SEER_ACTIVITY_STAGES.has(stage))
     : [];
-  const allChoices = [
-    ...SEER_ACTIVITY_STAGE_CHOICES,
-    ...SEER_ITERATION_GATED_STAGE_CHOICES,
-  ];
-  const labels = stages.map(s => allChoices.find(c => c.value === s)?.label ?? '');
+
+  const labels = stages.map(
+    s => SEER_ACTIVITY_STAGE_CHOICES.find(c => c.value === s)?.label ?? ''
+  );
+
   const details =
     labels.length === 1
       ? tct("Seer reaches the '[stage]' stage", {stage: labels[0] ?? ''})
-      : tct('Seer reaches any of these stages: [stages]', {stages: labels.join(', ')});
+      : tct('Seer reaches any of these stages: [stages]', {
+          stages: labels.join(', '),
+        });
 
   return <span>{details}</span>;
 }
@@ -45,12 +39,9 @@ export function SeerActivityTriggerDetails({condition}: {condition: DataConditio
 export function SeerActivityTriggerNode() {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
-  const organization = useOrganization();
-  const value: string[] = Array.isArray(condition.comparison) ? condition.comparison : [];
-
-  const stageChoices = organization.features.includes('autofix-pr-iteration')
-    ? [...SEER_ACTIVITY_STAGE_CHOICES, ...SEER_ITERATION_GATED_STAGE_CHOICES]
-    : SEER_ACTIVITY_STAGE_CHOICES;
+  const value: string[] = Array.isArray(condition.comparison)
+    ? condition.comparison.filter(stage => SEER_ACTIVITY_STAGES.has(stage))
+    : [];
 
   return (
     <Stack gap="sm">
@@ -61,7 +52,7 @@ export function SeerActivityTriggerNode() {
         aria-label={t('Seer activity stages')}
         placeholder={t('Select a stage...')}
         value={value}
-        options={stageChoices}
+        options={SEER_ACTIVITY_STAGE_CHOICES}
         onChange={(options: Array<SelectValue<string>>) => {
           onUpdate({comparison: options.map(o => o.value)});
           removeError(condition.id);

--- a/static/app/views/automations/components/actionNodeList.spec.tsx
+++ b/static/app/views/automations/components/actionNodeList.spec.tsx
@@ -209,7 +209,7 @@ describe('ActionNodeList', () => {
               {
                 id: 'condition-1',
                 type: DataConditionType.SEER_ACTIVITY_TRIGGER,
-                comparison: ['rca_started'],
+                comparison: ['pr_created'],
                 conditionResult: true,
               },
             ],

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -175,7 +175,7 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       label: t('Seer runs on an issue and reaches the stage...'),
       dataCondition: SeerActivityTriggerNode,
       details: SeerActivityTriggerDetails,
-      defaultComparison: [],
+      defaultComparison: ['pr_created'],
       validate: validateSeerActivityTriggerCondition,
     },
   ],

--- a/tests/sentry/workflow_engine/handlers/condition/test_seer_activity_trigger_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_seer_activity_trigger_handler.py
@@ -30,13 +30,13 @@ class TestSeerActivityTriggerHandler(ConditionTestCase):
         self.assert_passes(self.dc, event_data)
 
     def test_evaluate_value__non_matching_stage(self) -> None:
-        event_data = self._create_event_data(ActivityType.SEER_RCA_STARTED)
+        event_data = self._create_event_data(ActivityType.SEER_PR_CREATED)
         self.assert_does_not_pass(self.dc, event_data)
 
     def test_evaluate_value__matching_multiple_stages(self) -> None:
         self.dc.update(
             comparison=[
-                SeerActivityTriggerStage.RCA_STARTED,
+                SeerActivityTriggerStage.RCA_COMPLETED,
                 SeerActivityTriggerStage.CODING_COMPLETED,
             ]
         )
@@ -48,15 +48,10 @@ class TestSeerActivityTriggerHandler(ConditionTestCase):
         self.dc.update(comparison=[stage.value for stage in SeerActivityTriggerStage])
 
         for stage, activity_type_value in [
-            (SeerActivityTriggerStage.RCA_STARTED, ActivityType.SEER_RCA_STARTED),
             (SeerActivityTriggerStage.RCA_COMPLETED, ActivityType.SEER_RCA_COMPLETED),
-            (SeerActivityTriggerStage.SOLUTION_STARTED, ActivityType.SEER_SOLUTION_STARTED),
             (SeerActivityTriggerStage.SOLUTION_COMPLETED, ActivityType.SEER_SOLUTION_COMPLETED),
-            (SeerActivityTriggerStage.CODING_STARTED, ActivityType.SEER_CODING_STARTED),
             (SeerActivityTriggerStage.CODING_COMPLETED, ActivityType.SEER_CODING_COMPLETED),
             (SeerActivityTriggerStage.PR_CREATED, ActivityType.SEER_PR_CREATED),
-            (SeerActivityTriggerStage.ITERATION_STARTED, ActivityType.SEER_ITERATION_STARTED),
-            (SeerActivityTriggerStage.ITERATION_COMPLETED, ActivityType.SEER_ITERATION_COMPLETED),
         ]:
             event_data = self._create_event_data(activity_type_value)
             self.assert_passes(self.dc, event_data)
@@ -69,13 +64,22 @@ class TestSeerActivityTriggerHandler(ConditionTestCase):
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         self.assert_does_not_pass(self.dc, event_data)
 
+    def test_evaluate_value__stale_removed_stage_in_db(self) -> None:
+        self.dc.update(comparison=["rca_started", SeerActivityTriggerStage.RCA_COMPLETED])
+
+        event_data = self._create_event_data(ActivityType.SEER_RCA_COMPLETED)
+        self.assert_passes(self.dc, event_data)
+
+        event_data = self._create_event_data(ActivityType.SEER_RCA_STARTED)
+        self.assert_does_not_pass(self.dc, event_data)
+
     def test_json_schema__valid_single_stage(self) -> None:
         self.dc.comparison = [SeerActivityTriggerStage.PR_CREATED]
         self.dc.save()
 
     def test_json_schema__valid_multiple_stages(self) -> None:
         self.dc.comparison = [
-            SeerActivityTriggerStage.RCA_STARTED,
+            SeerActivityTriggerStage.RCA_COMPLETED,
             SeerActivityTriggerStage.CODING_COMPLETED,
             SeerActivityTriggerStage.PR_CREATED,
         ]


### PR DESCRIPTION
Will remove `rca_started`, `solution_started` `coding_started` as options when configuring seer activity alerts. Existing DB rows with these options will be changed safely when overwritten, and noop safely when these events are consumed by the workflow engine, so no risk 🙏 