### PR TITLE
chore(api) Add metric to apigw to track which routes are getting requests

### DIFF
--- a/src/apigw/proxy.py
+++ b/src/apigw/proxy.py
@@ -75,6 +75,9 @@ metric_cb_overflow = prometheus_client.Counter(
 metric_cb_reject = prometheus_client.Counter(
     "apigw_proxy_circuitbreaker_rejected", "Circuitbreaker rejected", labelnames=["target"]
 )
+metric_legacy_endpoint = prometheus_client.Counter(
+    "apigw_proxy_legacy_endpoint", "Request to legacy endpoint (us only)", labelnames=["route"]
+)
 metric_latency = prometheus_client.Histogram(
     "apigw_proxy_latency",
     "Latency histogram (ms)",

--- a/src/apigw/views/proxy.py
+++ b/src/apigw/views/proxy.py
@@ -9,7 +9,13 @@ from ..dsl import (
     get_cell_for_organization,
     get_cell_from_dsn,
 )
-from ..proxy import ProxyLatencyPipe, ProxyTimeoutPipe, proxy_cell_request, proxy_control_request
+from ..proxy import (
+    ProxyLatencyPipe,
+    ProxyTimeoutPipe,
+    metric_legacy_endpoint,
+    proxy_cell_request,
+    proxy_control_request,
+)
 from ..utils import abort_with_json
 
 proxy = app.module(__name__, "proxy")
@@ -224,6 +230,7 @@ async def proxy_cell_legacy(**kwargs: Any) -> Any:
         cell = get_cell_by_name(app.config.cells.default)
     except CellResolutionError:
         abort_with_json(404, {"error": "apigateway", "detail": "Not found"})
+    metric_legacy_endpoint.labels(route=request.name).inc()
     return await proxy_cell_request(cell, request)
 
 


### PR DESCRIPTION
Add a metric to the apigw implementation that tracks the volume of requests we're receiving that don't have org scope in them.

Refs #118963
