### PR TITLE
feat(api): Type Feedback issue metadata

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -113,6 +113,39 @@ class GroupProjectResponse(TypedDict):
     platform: str | None
 
 
+class FeedbackSdkMetadataResponse(TypedDict):
+    """SDK identity stored in Feedback issue metadata when available."""
+
+    name: str
+    name_normalized: str
+
+
+class FeedbackGroupMetadataOptional(TypedDict, total=False):
+    """Feedback metadata omitted from historical issues or absent by design."""
+
+    associated_event_id: str
+    initial_priority: int
+    sdk: FeedbackSdkMetadataResponse
+    source: str | None
+    summary: str | None
+
+
+class FeedbackGroupMetadataResponse(FeedbackGroupMetadataOptional):
+    """Metadata returned for modern User Feedback issue groups."""
+
+    contact_email: str | None
+    message: str
+    name: str | None
+    title: str
+    value: str
+
+
+# Issue endpoints return heterogeneous group categories. Keeping the generic
+# branch preserves metadata from other issue types while exposing Feedback's
+# stable fields to generated OpenAPI clients.
+GroupMetadataResponse = dict[str, Any] | FeedbackGroupMetadataResponse
+
+
 class BaseGroupResponseOptional(TypedDict, total=False):
     isUnhandled: bool
     count: str
@@ -145,7 +178,7 @@ class BaseGroupSerializerResponse(BaseGroupResponseOptional):
     type: EventTypeStr
     issueType: str
     issueCategory: str
-    metadata: dict[str, Any]
+    metadata: GroupMetadataResponse
     numComments: int
     assignedTo: ActorSerializerResponse | None
     isBookmarked: bool
@@ -1222,7 +1255,7 @@ class SimpleGroupSerializerResponse(TypedDict):
     type: EventTypeStr
     issueType: str
     issueCategory: str
-    metadata: dict[str, Any]
+    metadata: GroupMetadataResponse
     numComments: int
     firstSeen: datetime | None
     lastSeen: datetime | None

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -16,6 +16,7 @@ from sentry.api.serializers.models.group import (
     BaseGroupSerializerResponse,
     GroupAnnotation,
     GroupLevelStr,
+    GroupMetadataResponse,
     GroupProjectResponse,
     GroupSerializer,
     GroupSerializerSnuba,
@@ -270,7 +271,7 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     type: NotRequired[EventTypeStr]
     issueType: NotRequired[str]
     issueCategory: NotRequired[str]
-    metadata: NotRequired[dict[str, Any]]
+    metadata: NotRequired[GroupMetadataResponse]
     numComments: NotRequired[int]
     assignedTo: NotRequired[ActorSerializerResponse | None]
     isBookmarked: NotRequired[bool]

--- a/tests/sentry/apidocs/test_extensions.py
+++ b/tests/sentry/apidocs/test_extensions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
+from unittest.mock import patch
 
 import pytest
 from drf_spectacular.openapi import AutoSchema
@@ -9,6 +10,8 @@ from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer
+from sentry.api.serializers.models.group import GroupDetailsResponse
+from sentry.api.serializers.models.group_stream import StreamGroupSerializerSnubaResponse
 from sentry.apidocs.extensions import (
     RestrictedJsonFieldExtension,
     SentryInlineResponseSerializerExtension,
@@ -121,6 +124,68 @@ def test_sentry_inline_response_serializer_extension() -> None:
             "required": ["b", "c", "d", "e", "f", "g", "h", "i"],
         },
     }
+
+
+@patch.dict("os.environ", {"OPENAPIGENERATE": "1"})
+def test_issue_responses_document_feedback_metadata() -> None:
+    detail_serializer = inline_sentry_response_serializer("IssueDetail", GroupDetailsResponse)
+    detail_schema = SentryInlineResponseSerializerExtension(detail_serializer).map_serializer(
+        AutoSchema(), "response"
+    )
+    list_serializer = inline_sentry_response_serializer(
+        "IssueList", list[StreamGroupSerializerSnubaResponse]
+    )
+    list_schema = SentryInlineResponseSerializerExtension(list_serializer).map_serializer(
+        AutoSchema(), "response"
+    )
+    metadata_schemas = [
+        detail_schema["properties"]["metadata"],
+        list_schema["items"]["properties"]["metadata"],
+    ]
+
+    for metadata_schema in metadata_schemas:
+        assert metadata_schema["anyOf"][0] == {
+            "type": "object",
+            "additionalProperties": {},
+        }
+        feedback_schema = metadata_schema["anyOf"][1]
+
+        assert set(feedback_schema["properties"]) == {
+            "associated_event_id",
+            "contact_email",
+            "initial_priority",
+            "message",
+            "name",
+            "sdk",
+            "source",
+            "summary",
+            "title",
+            "value",
+        }
+        assert set(feedback_schema["required"]) == {
+            "contact_email",
+            "message",
+            "name",
+            "title",
+            "value",
+        }
+        assert feedback_schema["properties"]["initial_priority"] == {"type": "integer"}
+        assert feedback_schema["properties"]["contact_email"] == {
+            "type": "string",
+            "nullable": True,
+        }
+        assert feedback_schema["properties"]["name"] == {
+            "type": "string",
+            "nullable": True,
+        }
+        assert feedback_schema["properties"]["sdk"]["properties"] == {
+            "name": {"type": "string"},
+            "name_normalized": {"type": "string"},
+        }
+        assert feedback_schema["properties"]["sdk"]["required"] == [
+            "name",
+            "name_normalized",
+        ]
 
 
 def test_sentry_fails_when_serializer_not_typed() -> None:


### PR DESCRIPTION
The public issue list and detail schemas currently expose metadata as a generic object, forcing generated clients such as @sentry/api to redefine the stable fields returned for modern User Feedback.

Add a typed Feedback metadata branch while keeping the generic object fallback needed by heterogeneous issue endpoints. The fallback stays first so generated Zod parsers preserve unknown and future metadata keys. There is no runtime API behavior change.

This will let https://github.com/getsentry/cli/pull/1266 derive its Feedback metadata from a future @sentry/api release instead of maintaining the field list locally.

## Test plan

- `.venv/bin/pytest -q tests/sentry/apidocs/test_extensions.py`
- `PATH="$PWD/.venv/bin:$PATH" make build-api-docs`
- changed-file pre-commit hooks and mypy
- generated TypeScript and Zod output inspected for list and detail responses