### PR TITLE
fix(performance): Use spans dataset to load replays

### DIFF
--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -553,7 +553,7 @@ export const ReplaySlowestTransactionColumn: ReplayTableColumn = {
       return null;
     }
     const hasTxEvent = 'txEvent' in replay;
-    const txDuration = hasTxEvent ? replay.txEvent?.['transaction.duration'] : undefined;
+    const txDuration = hasTxEvent ? replay.txEvent?.['span.duration'] : undefined;
     if (!hasTxEvent) {
       return null;
     }

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1280,7 +1280,10 @@ export const spanOperationRelativeBreakdownRenderer = (
     (prev, curr) => (isDurationValue(data, curr) ? prev + data[curr] : prev),
     0
   );
-  const cumulativeSpanOpBreakdown = Math.max(sumOfSpanTime, data['transaction.duration']);
+  const cumulativeSpanOpBreakdown = Math.max(
+    sumOfSpanTime,
+    data['transaction.duration'] ?? data['span.duration'] ?? 0
+  );
 
   if (
     SPAN_OP_BREAKDOWN_FIELDS.every(field => !isDurationValue(data, field)) ||

--- a/static/app/views/explore/replays/types.tsx
+++ b/static/app/views/explore/replays/types.tsx
@@ -184,22 +184,6 @@ export type ReplayRecordNestedFieldName =
   | `device.${keyof ReplayRecord['device']}`
   | `os.${keyof ReplayRecord['os']}`
   | `user.${keyof ReplayRecord['user']}`;
-
-export type ReplayListLocationQuery = {
-  cursor?: string;
-  end?: string;
-  environment?: string[];
-  field?: string[];
-  limit?: string;
-  offset?: string;
-  project?: string[];
-  query?: string;
-  sort?: string;
-  start?: string;
-  statsPeriod?: string;
-  utc?: 'true' | 'false';
-};
-
 export type ReplayListQueryReferrer =
   | 'replayList'
   | 'issueReplays'

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -8,10 +8,7 @@ import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {
-  SPAN_OP_BREAKDOWN_FIELDS,
-  SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
-} from 'sentry/utils/discover/fields';
+import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/discover/fields';
 import TransactionSummaryLayout from 'sentry/views/performance/transactionSummary/layout';
 import {Tab as TransactionSummaryTab} from 'sentry/views/performance/transactionSummary/tabs';
 import TransactionReplays from 'sentry/views/performance/transactionSummary/transactionReplays';
@@ -108,7 +105,7 @@ describe('TransactionReplays', () => {
     resetMockDate();
   });
 
-  it('should query the events endpoint for replayIds of a transaction', async () => {
+  it('should query the events endpoint with spans dataset for replayIds of a transaction', async () => {
     renderComponent();
 
     await waitFor(() => {
@@ -116,21 +113,17 @@ describe('TransactionReplays', () => {
         '/organizations/org-slug/events/',
         expect.objectContaining({
           query: expect.objectContaining({
-            cursor: undefined,
-            statsPeriod: '14d',
-            project: ['1'],
-            environment: [],
+            dataset: 'spans',
+            statsPeriod: '90d',
             field: expect.arrayContaining([
               'replayId',
-              'count()',
-              'transaction.duration',
+              'span.duration',
               'trace',
               'timestamp',
               ...SPAN_OP_BREAKDOWN_FIELDS,
-              SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
             ]),
             per_page: 50,
-            query: 'event.type:transaction transaction:"Settings Page" !replayId:""',
+            query: '!replayId:"" is_transaction:true transaction:"Settings Page"',
           }),
         })
       );
@@ -160,7 +153,7 @@ describe('TransactionReplays', () => {
         mockEventsUrl,
         expect.objectContaining({
           query: expect.objectContaining({
-            query: 'event.type:transaction transaction:"Settings Page" !replayId:""',
+            query: '!replayId:"" is_transaction:true transaction:"Settings Page"',
           }),
         })
       );
@@ -168,6 +161,37 @@ describe('TransactionReplays', () => {
   });
 
   it('should show a list of replays and have the correct values', async () => {
+    MockApiClient.addMockResponse({
+      url: mockEventsUrl,
+      statusCode: 200,
+      body: {
+        data: [
+          {
+            replayId: '346789a703f6454384f1de473b8b9fcc',
+            'span.duration': 1000,
+            trace: 'abc123',
+            timestamp: '2022-09-15T06:54:00+00:00',
+            'spans.browser': 100,
+            'spans.db': 200,
+            'spans.http': 300,
+            'spans.resource': 200,
+            'spans.ui': 100,
+          },
+          {
+            replayId: 'b05dae9b6be54d21a4d5ad9f8f02b780',
+            'span.duration': 500,
+            trace: 'def456',
+            timestamp: '2022-09-21T21:40:38+00:00',
+            'spans.browser': 50,
+            'spans.db': 100,
+            'spans.http': 150,
+            'spans.resource': 100,
+            'spans.ui': 50,
+          },
+        ],
+      },
+    });
+
     const mockApi = MockApiClient.addMockResponse({
       url: mockReplaysUrl,
       statusCode: 200,
@@ -211,12 +235,10 @@ describe('TransactionReplays', () => {
 
     renderComponent({location: {query: {query: 'test'}}});
 
-    await waitFor(() => {
-      expect(mockApi).toHaveBeenCalledTimes(1);
-    });
-
-    // Expect the table to have 2 rows
-    expect(screen.getAllByText('testDisplayName')).toHaveLength(2);
+    // Wait for the replays to render
+    const displayNames = await screen.findAllByText('testDisplayName');
+    expect(displayNames).toHaveLength(2);
+    expect(mockApi).toHaveBeenCalledTimes(1);
 
     const expectedQuery =
       'playlistEnd=2022-09-28T23%3A29%3A13&playlistStart=2022-09-14T23%3A29%3A13&query=test&referrer=transactionReplays';
@@ -286,8 +308,6 @@ describe('TransactionReplays', () => {
       },
     });
 
-    // hack: Wait for any pending updates to complete
-    // without await the test fails with "An update to _GenericDiscoverQuery inside a test was not wrapped in act(...)"
     await waitFor(() => {
       expect(screen.queryByTestId('replay-table')).not.toBeInTheDocument();
     });

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -1,6 +1,6 @@
-import {Fragment, useEffect, useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
-import type {Location} from 'history';
+import {useQuery} from '@tanstack/react-query';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -18,19 +18,19 @@ import {
   ReplaySessionColumn,
   ReplaySlowestTransactionColumn,
 } from 'sentry/components/replays/table/replayTableColumns';
+import {useReplayTableSort} from 'sentry/components/replays/table/useReplayTableSort';
 import {usePlaylistQuery} from 'sentry/components/replays/usePlaylistQuery';
-import type {Organization} from 'sentry/types/organization';
+import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {EventView} from 'sentry/utils/discover/eventView';
-import {useReplayList} from 'sentry/utils/replays/hooks/useReplayList';
+import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
+import {replayListApiOptions} from 'sentry/utils/replays/replayListApiOptions';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMedia} from 'sentry/utils/useMedia';
 import {useAllMobileProj} from 'sentry/views/explore/replays/detail/useAllMobileProj';
 import {useTransactionSummaryContext} from 'sentry/views/performance/transactionSummary/transactionSummaryContext';
 
-import type {EventSpanData} from './useReplaysFromTransaction';
 import {useReplaysFromTransaction} from './useReplaysFromTransaction';
 import {useReplaysWithTxData} from './useReplaysWithTxData';
-import {generateTransactionReplaysEventView} from './utils';
 
 export function TransactionReplays() {
   return (
@@ -43,89 +43,84 @@ export function TransactionReplays() {
 function TransactionReplaysContent() {
   const {organization, transactionName, setError} = useTransactionSummaryContext();
 
-  const location = useLocation();
-  const replayIdsEventView = useMemo(
-    () => generateTransactionReplaysEventView({location, transactionName}),
-    [location, transactionName]
-  );
+  const {
+    replayIds,
+    events,
+    isFetching: isFetchingIds,
+    fetchError,
+  } = useReplaysFromTransaction({transactionName});
+
+  useEffect(() => {
+    setError(fetchError?.message ?? undefined);
+  }, [setError, fetchError]);
+
+  const {sortQuery} = useReplayTableSort();
 
   // Hard-code 90d to match the count query. There's no date selector for the replay tab.
-  const {data, fetchError, isFetching} = useReplaysFromTransaction({
-    replayIdsEventView,
-    location: {
-      ...location,
+  const replayListOptions = replayListApiOptions({
+    options: {
       query: {
-        ...location.query,
+        query: replayIds.length ? `id:[${replayIds.join(',')}]` : undefined,
         statsPeriod: '90d',
+        sort: sortQuery,
       },
     },
     organization,
-  });
-
-  useEffect(() => {
-    setError(fetchError?.message ?? fetchError);
-  }, [setError, fetchError]);
-
-  if (!data) {
-    return isFetching ? (
-      <Layout.Main width="full">
-        <LoadingIndicator />
-      </Layout.Main>
-    ) : (
-      <Fragment>{null}</Fragment>
-    );
-  }
-
-  const {events, replayRecordsEventView} = data;
-  return (
-    <ReplaysContent
-      eventView={replayRecordsEventView}
-      events={events}
-      organization={organization}
-    />
-  );
-}
-
-function ReplaysContent({
-  eventView,
-  events,
-  organization,
-}: {
-  eventView: EventView;
-  events: EventSpanData[];
-  organization: Organization;
-}) {
-  const location = useLocation();
-
-  if (!eventView.query) {
-    eventView.query = String(location.query.query ?? '');
-  }
-  const playlistQuery = usePlaylistQuery('transactionReplays', eventView);
-
-  const newLocation = useMemo(() => ({query: {}}) as Location, []);
-  const theme = useTheme();
-  const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.sm})`);
-
-  const {replays, isFetching, fetchError} = useReplayList({
-    enabled: eventView.query !== '',
-    // for the replay tab in transactions, if payload.query is undefined,
-    // this means the transaction has no related replays.
-    // but because we cannot query for an empty list of IDs (e.g. `id:[]` breaks our search endpoint),
-    // and leaving query empty results in ALL replays being returned for a specified project
-    // (which doesn't make sense as we want to show no replays),
-    // we essentially want to hardcode no replays being returned.
-    eventView,
-    location: newLocation,
-    organization,
     queryReferrer: 'transactionReplays',
   });
+
+  // for the replay tab in transactions, if payload.query is undefined,
+  // this means the transaction has no related replays.
+  // but because we cannot query for an empty list of IDs (e.g. `id:[]` breaks our search endpoint),
+  // and leaving query empty results in ALL replays being returned for a specified project
+  // (which doesn't make sense as we want to show no replays),
+  // we essentially want to hardcode no replays being returned.
+  const {
+    data: response,
+    isFetching: isFetchingReplays,
+    error: replayError,
+  } = useQuery({
+    ...replayListOptions,
+    enabled: replayIds.length > 0,
+    select: selectJsonWithHeaders,
+  });
+
+  const replays = useMemo(
+    () => response?.json?.data?.map(mapResponseToReplayRecord) ?? [],
+    [response]
+  );
 
   const replaysWithTx = useReplaysWithTxData({
     replays,
     events,
   });
 
+  const location = useLocation();
+  const playlistEventView = useMemo(
+    () =>
+      EventView.fromSavedQuery({
+        id: '',
+        name: '',
+        version: 2,
+        fields: [],
+        projects: [],
+        query: String(location.query.query ?? ''),
+      }),
+    [location.query.query]
+  );
+  const playlistQuery = usePlaylistQuery('transactionReplays', playlistEventView);
+
+  const theme = useTheme();
+  const hasRoomForColumns = useMedia(`(min-width: ${theme.breakpoints.sm})`);
   const {allMobileProj} = useAllMobileProj({});
+
+  if (isFetchingIds && !replayIds.length) {
+    return (
+      <Layout.Main width="full">
+        <LoadingIndicator />
+      </Layout.Main>
+    );
+  }
 
   return (
     <Layout.Main width="full">
@@ -140,8 +135,8 @@ function ReplaysContent({
           ReplayCountErrorsColumn,
           ReplayActivityColumn,
         ]}
-        error={fetchError}
-        isPending={isFetching}
+        error={replayError}
+        isPending={isFetchingIds || isFetchingReplays}
         replays={replaysWithTx ?? []}
         showDropdownFilters={false}
       />

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -1,114 +1,63 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
-import * as Sentry from '@sentry/react';
-import type {Location} from 'history';
+import {useMemo} from 'react';
 
-import {DEFAULT_REPLAY_LIST_SORT} from 'sentry/components/replays/table/useReplayTableSort';
-import type {Organization} from 'sentry/types/organization';
-import {EventView} from 'sentry/utils/discover/eventView';
-import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
-import {decodeScalar} from 'sentry/utils/queryString';
-import {useApi} from 'sentry/utils/useApi';
-import type {ReplayListLocationQuery} from 'sentry/views/explore/replays/types';
-import {REPLAY_LIST_FIELDS} from 'sentry/views/explore/replays/types';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {SPAN_OP_BREAKDOWN_FIELDS} from 'sentry/utils/discover/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
+import type {SpanProperty} from 'sentry/views/insights/types';
 
-type Options = {
-  location: Location;
-  organization: Organization;
-  replayIdsEventView: EventView;
-};
+const FIELDS = [
+  'replayId',
+  'span.duration',
+  'trace',
+  'timestamp',
+  ...SPAN_OP_BREAKDOWN_FIELDS,
+] as SpanProperty[];
 
-export type EventSpanData = {
-  'count()': number;
-  replayId: string;
-  'span_ops_breakdown.relative': string;
-  'spans.browser': null | number;
-  'spans.db': null | number;
-  'spans.http': null | number;
-  'spans.resource': null | number;
-  'spans.ui': null | number;
-  timestamp: string;
-  trace: string;
-  'transaction.duration': number;
-};
+export function useReplaysFromTransaction({transactionName}: {transactionName: string}) {
+  const {selection} = usePageFilters();
 
-type Return = {
-  data: null | {
-    events: EventSpanData[];
-    replayRecordsEventView: EventView;
-  };
-  fetchError: any;
-  isFetching: boolean;
-  pageLinks: null | string;
-};
+  const search = useMemo(() => {
+    const s = new MutableSearch('!replayId:"" is_transaction:true');
+    s.setFilterValues('transaction', [transactionName]);
+    return s;
+  }, [transactionName]);
 
-export function useReplaysFromTransaction({
-  location,
-  organization,
-  replayIdsEventView,
-}: Options): Return {
-  const api = useApi();
+  // Hard-code 90d to match the count query. There's no date selector for the replay tab.
+  const pageFilters = useMemo(
+    () => ({
+      ...selection,
+      datetime: {...selection.datetime, period: '90d', start: null, end: null},
+    }),
+    [selection]
+  );
 
-  const [response, setResponse] = useState<{
-    events: EventSpanData[];
-    pageLinks: null | string;
-    replayIds: undefined | string[];
-  }>({events: [], pageLinks: null, replayIds: undefined});
+  const {data, isPending, error, pageLinks} = useSpans(
+    {
+      search,
+      fields: FIELDS,
+      limit: 50,
+      pageFilters,
+    },
+    'transactionReplays'
+  );
 
-  const [fetchError, setFetchError] = useState<any>();
-
-  const {cursor} = location.query;
-  const fetchReplayIds = useCallback(async () => {
-    try {
-      const [{data}, _textStatus, resp] = await doDiscoverQuery<{data: EventSpanData[]}>(
-        api,
-        `/organizations/${organization.slug}/events/`,
-        replayIdsEventView.getEventsAPIPayload({
-          query: {cursor},
-          // Will be fixed by https://github.com/typescript-eslint/typescript-eslint/pull/12206
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
-        } as Location<ReplayListLocationQuery>)
-      );
-
-      setResponse({
-        pageLinks: resp?.getResponseHeader('Link') ?? '',
-        replayIds: data.map(record => String(record.replayId)),
-        events: data || [],
-      });
-    } catch (err) {
-      Sentry.captureException(err);
-      setFetchError(err);
-    }
-  }, [api, cursor, organization.slug, replayIdsEventView]);
-
-  const replayRecordsEventView = useMemo(() => {
-    if (!response.replayIds) {
-      return null;
-    }
-
-    return EventView.fromSavedQuery({
-      id: '',
-      name: '',
-      version: 2,
-      fields: REPLAY_LIST_FIELDS,
-      projects: [],
-      query: response.replayIds.length ? `id:[${String(response.replayIds)}]` : undefined,
-      orderby: decodeScalar(location.query.sort, DEFAULT_REPLAY_LIST_SORT),
-    });
-  }, [location.query.sort, response.replayIds]);
-
-  useEffect(() => {
-    fetchReplayIds();
-  }, [fetchReplayIds]);
+  const replayIds = useMemo(
+    () => [
+      ...new Set(
+        (data ?? [])
+          .map(row => String(row.replayId))
+          .filter(id => id && id !== 'undefined')
+      ),
+    ],
+    [data]
+  );
 
   return {
-    data: replayRecordsEventView
-      ? {
-          events: response.events,
-          replayRecordsEventView,
-        }
-      : null,
-    fetchError,
-    isFetching: !fetchError && !response.replayIds,
-    pageLinks: response.pageLinks,
+    replayIds,
+    events: data ?? [],
+    isFetching: isPending,
+    fetchError: error,
+    pageLinks: pageLinks ?? null,
   };
 }

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysWithTxData.tsx
@@ -1,10 +1,10 @@
 import type {ReplayListRecord} from 'sentry/views/explore/replays/types';
-import type {EventSpanData} from 'sentry/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction';
 
-type Opts = {
-  events: EventSpanData[];
-  replays: undefined | ReplayListRecord[];
-};
+interface SpanEvent {
+  [key: string]: unknown;
+  replayId: string;
+  'span.duration': number;
+}
 
 export type ReplayListRecordWithTx = ReplayListRecord & {
   txEvent: Record<string, any>;
@@ -12,25 +12,29 @@ export type ReplayListRecordWithTx = ReplayListRecord & {
 
 type Return = undefined | ReplayListRecordWithTx[];
 
-export function useReplaysWithTxData({events, replays}: Opts): Return {
+export function useReplaysWithTxData({
+  events,
+  replays,
+}: {
+  events: SpanEvent[];
+  replays: undefined | ReplayListRecord[];
+}): Return {
   const replaysWithTx = replays?.map<ReplayListRecordWithTx>(replay => {
-    const slowestEvent = events.reduce((slowest, event) => {
+    const slowestEvent = events.reduce<SpanEvent | undefined>((slowest, event) => {
       if (event.replayId !== replay.id) {
         return slowest;
       }
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      if (!slowest['transaction.duration']) {
+      if (!slowest?.['span.duration']) {
         return event;
       }
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      return event['transaction.duration'] > slowest['transaction.duration']
-        ? event
-        : slowest;
-    }, {});
+      return event['span.duration'] > slowest['span.duration'] ? event : slowest;
+    }, undefined);
+
+    const txEvent: Record<string, any> = slowestEvent ?? {};
 
     return {
       ...replay,
-      txEvent: slowestEvent ?? {},
+      txEvent,
     };
   });
 

--- a/static/app/views/performance/transactionSummary/transactionReplays/utils.ts
+++ b/static/app/views/performance/transactionSummary/transactionReplays/utils.ts
@@ -1,11 +1,6 @@
-import type {Location, Query} from 'history';
+import type {Query} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
-import {EventView} from 'sentry/utils/discover/eventView';
-import {
-  SPAN_OP_BREAKDOWN_FIELDS,
-  SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
-} from 'sentry/utils/discover/fields';
 import type {DomainView} from 'sentry/views/insights/pages/useFilters';
 import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -36,31 +31,4 @@ export function replaysRouteWithQuery({
       query: query.query,
     },
   };
-}
-
-export function generateTransactionReplaysEventView({
-  location,
-  transactionName,
-}: {
-  location: Location;
-  transactionName: string;
-}) {
-  const fields = [
-    'replayId',
-    'count()',
-    'transaction.duration',
-    'trace',
-    'timestamp',
-    ...SPAN_OP_BREAKDOWN_FIELDS,
-    SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
-  ];
-
-  return EventView.fromSavedQuery({
-    id: '',
-    name: 'Replay events within a transaction',
-    version: 2,
-    fields,
-    query: `event.type:transaction transaction:"${transactionName}" !replayId:""`,
-    projects: [Number(location.query.project)],
-  });
 }


### PR DESCRIPTION
Another use of the `transactions` dataset snuck through undiscovered, this time on the transaction summary's Replays tab. Use `spans` instead of the deprecated `transactions` dataset to get the list of replay IDs for the given transaction name.