### PR TITLE
feat(issue-progress): add inbox assignment filter

### DIFF
--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -285,7 +285,7 @@ describe('InboxPage', () => {
       mockSection('issue.progress:assigned assigned:my_teams', [assignedGroup]),
     ];
 
-    render(<InboxPage />, {organization, initialRouterConfig});
+    const {router} = render(<InboxPage />, {organization, initialRouterConfig});
 
     const meFilter = screen.getByRole('radio', {name: 'Me'});
     const myTeamsFilter = screen.getByRole('radio', {name: 'My Teams'});
@@ -296,6 +296,7 @@ describe('InboxPage', () => {
     await userEvent.click(myTeamsFilter);
 
     expect(myTeamsFilter).toBeChecked();
+    expect(router.location.query.assignment).toBe('my_teams');
     for (const request of myTeamsRequests) {
       await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
     }

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -208,7 +208,8 @@ describe('InboxPage', () => {
     expect(await screen.findByText('Diagnosed issue')).toBeInTheDocument();
     const assignedIssue = await screen.findByText('Assigned issue');
     expect(assignedIssue).not.toBeVisible();
-    expect(screen.getByRole('heading', {name: 'Issues'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Inbox', level: 1})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Issues', level: 2})).toBeInTheDocument();
 
     for (const [index, query] of [
       'issue.progress:fix_proposed assigned:me',
@@ -238,6 +239,12 @@ describe('InboxPage', () => {
     const fixSection = screen.getByRole('region', {name: 'Fix Proposed'});
     const diagnosedSection = screen.getByRole('region', {name: 'Diagnosed'});
     const assignedSection = screen.getByRole('region', {name: 'Assigned'});
+    expect(
+      within(fixSection).getByRole('heading', {name: 'Fix Proposed', level: 3})
+    ).toBeInTheDocument();
+    expect(
+      within(fixSection).getByRole('heading', {name: 'Fix proposed issue', level: 4})
+    ).toBeInTheDocument();
     expect(within(fixSection).getByText('2')).toBeInTheDocument();
     expect(within(diagnosedSection).getByText('2')).toBeInTheDocument();
     expect(within(assignedSection).getByText('12')).toBeInTheDocument();

--- a/static/app/views/issueList/pages/inbox.spec.tsx
+++ b/static/app/views/issueList/pages/inbox.spec.tsx
@@ -142,9 +142,9 @@ describe('InboxPage', () => {
 
   function mockSuccessfulSections() {
     return [
-      mockSection('issue.progress:fix_proposed', [fixProposedGroup], 200, 2),
-      mockSection('issue.progress:diagnosed', [diagnosedGroup], 200, 2),
-      mockSection('issue.progress:assigned', [assignedGroup], 200, 12),
+      mockSection('issue.progress:fix_proposed assigned:me', [fixProposedGroup], 200, 2),
+      mockSection('issue.progress:diagnosed assigned:me', [diagnosedGroup], 200, 2),
+      mockSection('issue.progress:assigned assigned:me', [assignedGroup], 200, 12),
     ];
   }
 
@@ -208,11 +208,12 @@ describe('InboxPage', () => {
     expect(await screen.findByText('Diagnosed issue')).toBeInTheDocument();
     const assignedIssue = await screen.findByText('Assigned issue');
     expect(assignedIssue).not.toBeVisible();
+    expect(screen.getByRole('heading', {name: 'Issues'})).toBeInTheDocument();
 
     for (const [index, query] of [
-      'issue.progress:fix_proposed',
-      'issue.progress:diagnosed',
-      'issue.progress:assigned',
+      'issue.progress:fix_proposed assigned:me',
+      'issue.progress:diagnosed assigned:me',
+      'issue.progress:assigned assigned:me',
     ].entries()) {
       await waitFor(() =>
         expect(requests[index]).toHaveBeenCalledWith(
@@ -276,6 +277,30 @@ describe('InboxPage', () => {
     expect(assignedIssue).toBeVisible();
   });
 
+  it('filters sections by the selected assignee', async () => {
+    mockSuccessfulSections();
+    const myTeamsRequests = [
+      mockSection('issue.progress:fix_proposed assigned:my_teams', [fixProposedGroup]),
+      mockSection('issue.progress:diagnosed assigned:my_teams', [diagnosedGroup]),
+      mockSection('issue.progress:assigned assigned:my_teams', [assignedGroup]),
+    ];
+
+    render(<InboxPage />, {organization, initialRouterConfig});
+
+    const meFilter = screen.getByRole('radio', {name: 'Me'});
+    const myTeamsFilter = screen.getByRole('radio', {name: 'My Teams'});
+    expect(meFilter).toBeChecked();
+    expect(myTeamsFilter).not.toBeChecked();
+    expect(await screen.findByText('Fix proposed issue')).toBeInTheDocument();
+
+    await userEvent.click(myTeamsFilter);
+
+    expect(myTeamsFilter).toBeChecked();
+    for (const request of myTeamsRequests) {
+      await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    }
+  });
+
   it('loads and appends the next page of a section', async () => {
     const nextFixProposedGroup = GroupFixture({
       id: '104',
@@ -289,7 +314,9 @@ describe('InboxPage', () => {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/',
-      match: [MockApiClient.matchQuery({query: 'issue.progress:fix_proposed'})],
+      match: [
+        MockApiClient.matchQuery({query: 'issue.progress:fix_proposed assigned:me'}),
+      ],
       body: [fixProposedGroup],
       headers: {
         'X-Hits': '2',
@@ -300,7 +327,7 @@ describe('InboxPage', () => {
       url: '/organizations/org-slug/issues/',
       match: [
         MockApiClient.matchQuery({
-          query: 'issue.progress:fix_proposed',
+          query: 'issue.progress:fix_proposed assigned:me',
           cursor: '0:5:0',
         }),
       ],
@@ -308,8 +335,8 @@ describe('InboxPage', () => {
       headers: {'X-Hits': '2'},
       asyncDelay: 100,
     });
-    mockSection('issue.progress:diagnosed', [diagnosedGroup]);
-    mockSection('issue.progress:assigned', [assignedGroup]);
+    mockSection('issue.progress:diagnosed assigned:me', [diagnosedGroup]);
+    mockSection('issue.progress:assigned assigned:me', [assignedGroup]);
 
     render(<InboxPage />, {organization, initialRouterConfig});
 

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -1,7 +1,6 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
 import {useInfiniteQuery} from '@tanstack/react-query';
-import {parseAsString, useQueryState} from 'nuqs';
+import {parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {ActorAvatar, ProjectAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Badge} from '@sentry/scraps/badge';
@@ -45,7 +44,9 @@ import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 const TITLE = t('Inbox');
 const ISSUE_LIMIT = 5;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
-type AssignmentFilter = 'me' | 'my_teams';
+const ASSIGNMENT_QUERY_PARAM = 'assignment';
+const ASSIGNMENT_FILTERS = ['me', 'my_teams'] as const;
+type AssignmentFilter = (typeof ASSIGNMENT_FILTERS)[number];
 
 interface InboxSectionConfig {
   defaultExpanded: boolean;
@@ -103,7 +104,12 @@ export default function InboxPage() {
 
 function InboxContent() {
   const {selection, isReady} = usePageFilters();
-  const [assignmentFilter, setAssignmentFilter] = useState<AssignmentFilter>('me');
+  const [assignmentFilter, setAssignmentFilter] = useQueryState(
+    ASSIGNMENT_QUERY_PARAM,
+    parseAsStringLiteral(ASSIGNMENT_FILTERS)
+      .withDefault('me')
+      .withOptions({history: 'replace'})
+  );
   const [selectedIssueId, setSelectedIssueId] = useQueryState(
     SELECTED_ISSUE_QUERY_PARAM,
     parseAsString.withOptions({history: 'replace'})

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 import {useInfiniteQuery} from '@tanstack/react-query';
 import {parseAsString, useQueryState} from 'nuqs';
@@ -9,6 +10,7 @@ import {Disclosure} from '@sentry/scraps/disclosure';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -43,6 +45,7 @@ import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 const TITLE = t('Inbox');
 const ISSUE_LIMIT = 5;
 const SELECTED_ISSUE_QUERY_PARAM = 'preview';
+type AssignmentFilter = 'me' | 'my_teams';
 
 interface InboxSectionConfig {
   defaultExpanded: boolean;
@@ -100,6 +103,7 @@ export default function InboxPage() {
 
 function InboxContent() {
   const {selection, isReady} = usePageFilters();
+  const [assignmentFilter, setAssignmentFilter] = useState<AssignmentFilter>('me');
   const [selectedIssueId, setSelectedIssueId] = useQueryState(
     SELECTED_ISSUE_QUERY_PARAM,
     parseAsString.withOptions({history: 'replace'})
@@ -133,10 +137,35 @@ function InboxContent() {
           background="primary"
           borderRight="muted"
         >
+          <Flex
+            as="header"
+            align="center"
+            justify="between"
+            padding="md lg"
+            background="secondary"
+            borderBottom="muted"
+            flexShrink={0}
+          >
+            <Heading as="h2" size="md">
+              {t('Issues')}
+            </Heading>
+            <SegmentedControl
+              aria-label={t('Issue assignee')}
+              size="xs"
+              value={assignmentFilter}
+              onChange={setAssignmentFilter}
+            >
+              <SegmentedControl.Item key="me">{t('Me')}</SegmentedControl.Item>
+              <SegmentedControl.Item key="my_teams">
+                {t('My Teams')}
+              </SegmentedControl.Item>
+            </SegmentedControl>
+          </Flex>
           {SECTIONS.map(section => (
             <InboxSection
               key={section.key}
               section={section}
+              assignmentFilter={assignmentFilter}
               selection={selection}
               isReady={isReady}
               selectedIssueId={selectedIssueId}
@@ -174,13 +203,20 @@ function InboxContent() {
 }
 
 interface InboxSectionProps {
+  assignmentFilter: AssignmentFilter;
   isReady: boolean;
   section: InboxSectionConfig;
   selectedIssueId: string | null;
   selection: ReturnType<typeof usePageFilters>['selection'];
 }
 
-function InboxSection({isReady, section, selection, selectedIssueId}: InboxSectionProps) {
+function InboxSection({
+  assignmentFilter,
+  isReady,
+  section,
+  selection,
+  selectedIssueId,
+}: InboxSectionProps) {
   const organization = useOrganization();
   const {start, end, period, utc} = selection.datetime;
   const queryResult = useInfiniteQuery({
@@ -189,7 +225,7 @@ function InboxSection({isReady, section, selection, selectedIssueId}: InboxSecti
       query: {
         project: selection.projects,
         environment: selection.environments,
-        query: section.query,
+        query: `${section.query} assigned:${assignmentFilter}`,
         sort: IssueSortOptions.PROGRESS,
         limit: ISSUE_LIMIT,
         expand: ['owners', 'derivedData'],

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -263,7 +263,7 @@ function InboxSection({
           <Disclosure.Title trailingItems={<Badge variant="muted">{count}</Badge>}>
             <Flex align="center" gap="sm">
               {getProgressIcon(section.progress)}
-              <Heading as="h2" size="md">
+              <Heading as="h3" size="md">
                 {section.label}
               </Heading>
             </Flex>
@@ -362,7 +362,7 @@ function InboxIssueCard({
           )}
         </Flex>
         <Stack minWidth={0} gap="xs">
-          <Heading as="h3" size="md" ellipsis>
+          <Heading as="h4" size="md" ellipsis>
             {title}
           </Heading>
           <EventMessage level={group.level} message={message} type={group.type} />

--- a/static/app/views/issueList/pages/inbox.tsx
+++ b/static/app/views/issueList/pages/inbox.tsx
@@ -138,7 +138,6 @@ function InboxContent() {
           as="section"
           aria-label={t('Issue inbox')}
           minHeight={0}
-          overflowY="auto"
           display={selectedIssueId ? {'screen:xs': 'none', 'screen:md': 'flex'} : 'flex'}
           background="primary"
           borderRight="muted"
@@ -167,16 +166,18 @@ function InboxContent() {
               </SegmentedControl.Item>
             </SegmentedControl>
           </Flex>
-          {SECTIONS.map(section => (
-            <InboxSection
-              key={section.key}
-              section={section}
-              assignmentFilter={assignmentFilter}
-              selection={selection}
-              isReady={isReady}
-              selectedIssueId={selectedIssueId}
-            />
-          ))}
+          <Stack flex={1} minHeight={0} overflowY="auto">
+            {SECTIONS.map(section => (
+              <InboxSection
+                key={section.key}
+                section={section}
+                assignmentFilter={assignmentFilter}
+                selection={selection}
+                isReady={isReady}
+                selectedIssueId={selectedIssueId}
+              />
+            ))}
+          </Stack>
         </Stack>
         <Stack
           as="aside"


### PR DESCRIPTION
The Inbox issue list now has a dedicated Issues header with a Me/My Teams assignment control, matching the [designs](https://www.figma.com/design/KuZeAtuy3hzLRCCUMg3UxB/Agentic-triage-issue-workflow?node-id=55-12706&t=wNzMH1k53MT3xn2d-0).

<img width="533" height="231" alt="CleanShot 2026-07-21 at 12 42 01" src="https://github.com/user-attachments/assets/f08759b1-ddca-4025-8246-daba1a2455d2" />
