### PR TITLE
fix(autofix): Wrong feature flag for autofix plan

### DIFF
--- a/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
@@ -481,9 +481,14 @@ describe('AutofixSection', () => {
     );
   });
 
-  it('skips setup UI for non-seat-based orgs without SCM integration', async () => {
+  it('skips setup UI for legacy seer plan orgs without SCM integration', async () => {
+    const legacyOrg = OrganizationFixture({
+      hideAiFeatures: false,
+      features: ['gen-ai-features', 'seer-added'],
+    });
+
     MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
+      url: `/organizations/${legacyOrg.slug}/seer/onboarding-check/`,
       body: {
         hasSupportedScmIntegration: false,
         isAutofixEnabled: false,
@@ -498,7 +503,7 @@ describe('AutofixSection', () => {
     });
 
     render(<AutofixSection group={mockGroup} project={mockProject} />, {
-      organization,
+      organization: legacyOrg,
     });
 
     expect(await screen.findByText('Have Seer...')).toBeInTheDocument();

--- a/static/app/views/issueDetails/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.tsx
@@ -197,8 +197,8 @@ export function AutofixContent({aiConfig, group, project}: AutofixContentProps) 
     return <Placeholder height="160px" />;
   }
 
-  // non seat based seer plans are allowed to run autofix without the SCM integration
-  if (organization.features.includes('seat-based-seer-enabled')) {
+  // legacy seer plans are allowed to run autofix without the SCM integration
+  if (!organization.features.includes('seer-added')) {
     if (needOrgSetup || needProjSetup) {
       return (
         <Stack border="muted" radius="md" padding="lg" gap="lg">


### PR DESCRIPTION
We only want to skip the checks if the org is on an legacy seer plan. If the org has no seer enabled or has seat based seer enabled, we should do the checks.