### PR TITLE
ref(preprod): graduate preprod-artifact-webhooks flag (frontend)

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -1,5 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Form} from 'sentry/components/forms/form';
@@ -20,27 +18,6 @@ const basePermissions: Permissions = {
 describe('Resource Subscriptions', () => {
   describe('initial no-access permissions', () => {
     it('renders disabled checkbox with no issue permission', () => {
-      const org = OrganizationFixture({features: ['preprod-artifact-webhooks']});
-      render(
-        <Form>
-          <Subscriptions
-            events={[]}
-            permissions={{...basePermissions, Event: 'no-access'}}
-            onChange={jest.fn()}
-          />
-        </Form>,
-        {organization: org}
-      );
-
-      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
-      expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
-      expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
-      expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
-      // preprod_artifact requires Project permission which is 'write' here, so it's enabled
-      expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
-    });
-
-    it('hides preprod_artifact checkbox without preprod-artifact-webhooks flag', () => {
       render(
         <Form>
           <Subscriptions
@@ -51,14 +28,12 @@ describe('Resource Subscriptions', () => {
         </Form>
       );
 
-      expect(
-        screen.queryByRole('checkbox', {name: 'preprod_artifact'})
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('checkbox', {
-          name: 'preprod_artifact.size_analysis_completed',
-        })
-      ).not.toBeInTheDocument();
+      expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'seer'})).toBeDisabled();
+      // preprod_artifact requires Project permission which is 'write' here, so it's enabled
+      expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
     });
 
     it('updates events state when new permissions props is passed', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -92,17 +92,8 @@ describe('SubscriptionBox', () => {
   });
 
   describe('preprod_artifact resource subscription', () => {
-    it('hidden without preprod-artifact-webhooks flag', () => {
+    it('renders preprod_artifact checkbox enabled', () => {
       renderComponent({resource: 'preprod_artifact'});
-
-      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
-    });
-
-    it('renders preprod_artifact checkbox enabled with preprod-artifact-webhooks flag', () => {
-      renderComponent(
-        {resource: 'preprod_artifact'},
-        {organization: OrganizationFixture({features: ['preprod-artifact-webhooks']})}
-      );
 
       expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
     });

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -42,13 +42,6 @@ export function SubscriptionBox({
 }: Props) {
   const {features} = useOrganization();
 
-  if (
-    resource === 'preprod_artifact' &&
-    !features.includes('preprod-artifact-webhooks')
-  ) {
-    return null;
-  }
-
   let disabled = disabledFromPermissions;
   let message = t(
     "Must have at least 'Read' permissions enabled for %s",


### PR DESCRIPTION
Remove `organizations:preprod-artifact-webhooks`. This flag is at 100% GA (no conditions) in the automator — introduced in getsentry/sentry-options-automator#6980 (2026-03-26) and unchanged since — so the `preprod_artifact` webhook subscription is now always available.

This PR removes the frontend feature check and updates the affected specs. Registration removal, flagpole config removal, and the options-schema entry are handled in companion PRs. Merge this (frontend) first, then the registration removal, to avoid a deploy-window regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01REwPyzXKWiNh8Gu8zpyrw3)_