### PR TITLE
ref(preprod): remove preprod-artifact-webhooks flag registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -217,8 +217,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:pr-metrics-emit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Forward a terminal PR event that needs a judge to Seer (PR Merge Live Metrics judge path)
     manager.add("organizations:pr-metrics-judge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable preprod_artifact webhook subscription UI in Sentry App settings
-    manager.add("organizations:preprod-artifact-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod PR comments for build distribution
     manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -226,8 +226,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:pr-metrics-emit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Forward a terminal PR event that needs a judge to Seer (PR Merge Live Metrics judge path)
     manager.add("organizations:pr-metrics-judge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable preprod_artifact webhook subscription UI in Sentry App settings
-    manager.add("organizations:preprod-artifact-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod PR comments for size analysis


### PR DESCRIPTION
Deregister `organizations:preprod-artifact-webhooks`, which is at 100% GA (no conditions) in the automator — introduced in getsentry/sentry-options-automator#6980 (2026-03-26) and unchanged since.

Code references were removed in #120257. Split from that PR because backend (`src/`) and frontend (`static/`) are not atomically deployed. Merge order: #120257 (frontend) → automator flagpole removal → this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01REwPyzXKWiNh8Gu8zpyrw3)_