### PR TITLE
fix(issue-progress): Treat escalating issues as open

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -19,6 +19,7 @@ from sentry.issues.action_log.types import (
     SeerRCAStartedAction,
     SeerSolutionCompletedAction,
     SeerSolutionStartedAction,
+    SetEscalatingAction,
     SetRegressedAction,
     SetResolvedByAgeAction,
     SetResolvedInCommitAction,
@@ -65,6 +66,7 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
         SetResolvedInCommitAction,
         ArchiveAction,
         UnresolveAction,
+        SetEscalatingAction,
         SetRegressedAction,
         ReconcileStatusAction,
     ),
@@ -85,7 +87,9 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
             | ArchiveAction()
         ) if current == IssueStatus.OPEN:
             return emit(STATUS.value(IssueStatus.CLOSED))
-        case UnresolveAction() | SetRegressedAction() if current == IssueStatus.CLOSED:
+        case UnresolveAction() | SetRegressedAction() | SetEscalatingAction() if (
+            current == IssueStatus.CLOSED
+        ):
             return emit(STATUS.value(IssueStatus.OPEN))
 
     return None

--- a/src/sentry/issues/derived/features.py
+++ b/src/sentry/issues/derived/features.py
@@ -15,7 +15,9 @@ class IssueStatus(StrEnum):
 VIEW_COUNT = Feature[int]("view_count", default=0)
 
 # Status of the issue based on the log.
-STATUS = Feature[IssueStatus]("status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus))
+STATUS = Feature[IssueStatus](
+    "status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus), version=1
+)
 
 # The current Progress of the issue.
 PROGRESS = Feature[IssueProgressState | None](

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -233,6 +233,19 @@ def test_regression_reopens() -> None:
     )
 
 
+def test_escalating_reopens_archived_issue() -> None:
+    assert (
+        _run_for_feature(
+            STATUS,
+            [
+                FakeEntry(type=GroupActionType.ARCHIVE),
+                FakeEntry(type=GroupActionType.SET_ESCALATING),
+            ],
+        )
+        == IssueStatus.OPEN
+    )
+
+
 def test_regression_resets_progress() -> None:
     assert (
         _run_for_feature(


### PR DESCRIPTION
The `STATUS` feature was not responding to the `set_escalating` action type. The escalating action should open the issue, similar to regressions.