### PR TITLE
ref(detectors): Use logging helper in HTTP overhead detector

### DIFF
--- a/src/sentry/issue_detection/detectors/http_overhead_detector.py
+++ b/src/sentry/issue_detection/detectors/http_overhead_detector.py
@@ -13,6 +13,7 @@ from sentry.issue_detection.detectors.utils import (
     get_span_evidence_value,
     get_url_from_span,
     is_filtered_url,
+    log_invalid_span_data,
 )
 from sentry.issues.grouptype import PerformanceHTTPOverheadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
@@ -76,20 +77,27 @@ class HTTPOverheadDetector(PerformanceDetector):
 
         if isinstance(request_start, str):
             try:
+                # Calling `float` on NaN won't actually raise an error, so we have to fake it, since
+                # even if it's technically a valid float, it's not valid for our purposes
+                if request_start == "NaN":
+                    # We log a custom error below, so all we need is something to get us into the
+                    # `except` block
+                    raise ValueError()
+
                 request_start = float(request_start)
-            except (ValueError, OverflowError):
+            except (ValueError, OverflowError) as err:
+                # Smooth over the difference between real errors and the faked NaN case above by
+                # setting a custom error message for both
+                err.args = (
+                    f"could not convert string to `request_start` value: '{request_start}'",
+                )
                 # Track instances of this happening so we know if it's a widespread problem
-                logger.warning(
-                    "issue_detectors.invalid_data",
-                    extra={
-                        "detector": "http_overhead",
-                        "span_id": span.get("span_id"),
-                        "trace_id": span.get("trace_id"),
-                        "project_id": span.get("project_id"),
-                        "org_id": span.get("organization_id"),
-                        "key": "request_start",
-                        "value": request_start,
-                    },
+                log_invalid_span_data(
+                    span,
+                    detector="http_overhead",
+                    key="http.request.request_start",
+                    value=request_start,
+                    error=err,
                 )
                 return
 

--- a/tests/sentry/issue_detection/test_http_overhead_detector.py
+++ b/tests/sentry/issue_detection/test_http_overhead_detector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -285,6 +286,62 @@ class HTTPOverheadDetectorTest(TestCase):
         event["spans"] = [span]
 
         assert self.find_problems(event) == []
+
+    def test_handles_valid_string_request_start_values(self) -> None:
+        event = _valid_http_overhead_event("/api/endpoint/123")
+        event["spans"][0]["data"]["http.request.request_start"] = "0.1"
+
+        assert self.find_problems(event) == [
+            PerformanceProblem(
+                fingerprint="1-1016-/",
+                op="http",
+                desc="/api/endpoint/123",
+                type=PerformanceHTTPOverheadGroupType,
+                parent_span_ids=[],
+                cause_span_ids=[],
+                offender_span_ids=["bbbbbbbbbbbbbbbb"] * 5,
+                evidence_data={
+                    "op": "http",
+                    "parent_span_ids": [],
+                    "cause_span_ids": [],
+                    "offender_span_ids": ["bbbbbbbbbbbbbbbb"] * 5,
+                },
+                evidence_display=[],
+            )
+        ]
+
+    @patch("sentry.issue_detection.detectors.utils.logger.warning")
+    def test_handles_invalid_request_start_values(self, mock_logger_warning: MagicMock) -> None:
+        url = "https://example.com/api/endpoint/123"
+        event = _valid_http_overhead_event("/api/endpoint/123")
+        span = create_span(
+            "http.client",
+            desc=url,
+            duration=1000,
+            data={"url": url, "network.protocol.version": "1.1"},
+        )
+        span["start_timestamp"] = 1121
+        span["project_id"] = self.project.id
+        span["organization_id"] = self.project.organization.id
+        event["spans"] = [span]
+
+        for invalid_value in ["dogs are great", "NaN", "[Filtered]"]:
+            event["spans"][0]["data"]["http.request.request_start"] = invalid_value
+
+            assert self.find_problems(event) == []
+            mock_logger_warning.assert_called_with(
+                "issue_detectors.invalid_data",
+                extra={
+                    "detector": "http_overhead",
+                    "span_id": span["span_id"],
+                    "trace_id": span["trace_id"],
+                    "project_id": span["project_id"],
+                    "org_id": span["organization_id"],
+                    "key": "http.request.request_start",
+                    "value": invalid_value,
+                    "error": f"ValueError(\"could not convert string to `request_start` value: '{invalid_value}'\")",
+                },
+            )
 
     def test_filtered_url(self) -> None:
         injection_event = get_event("http-overhead/http-overhead-filtered-url")


### PR DESCRIPTION
This is a follow-up to https://github.com/getsentry/sentry/pull/119994, which fixed our HTTP overhead detector's handling of invalid `request_start` values, to use the new `log_invalid_span_data` helper. It also adds handling for `NaN` strings and adds a test, which that PR should have done.