### PR TITLE
feat(action log): Log instead of publish temporarily

### DIFF
--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -46,7 +46,7 @@ from sentry.issues.action_log import (
     resolve_action_actor,
     resolve_action_source,
 )
-from sentry.issues.action_log.types import ReconcileStatusAction, ViewAction
+from sentry.issues.action_log.types import ViewAction
 from sentry.issues.constants import (
     ISSUE_VIEW_CACHE_KEY_TTL,
     cache_key_for_issue_view,
@@ -159,15 +159,17 @@ class GroupDetailsEndpoint(GroupEndpoint):
                 "expected_status": expected_status.value,
             },
         )
-        publish_action(
-            ReconcileStatusAction(
-                status=expected_status.value,
-                reason=f"derived status {derived_status.value} does not match expected status {expected_status.value}",
-            ),
-            source=resolve_action_source(request),
-            group_id=group.id,
-            project=group.project,
-            actor=resolve_action_actor(request),
+        # Status reconciliation is disabled for now; log divergences so we can
+        # find and investigate these cases automatically instead of publishing a
+        # ReconcileStatusAction.
+        logger.info(
+            "issues.status_reconciliation.diverged",
+            extra={
+                "group_id": group.id,
+                "project_id": group.project_id,
+                "derived_status": derived_status.value,
+                "expected_status": expected_status.value,
+            },
         )
 
     @staticmethod

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -347,24 +347,44 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
 
     @with_feature("projects:issue-status-reconciliation")
-    def test_diverged_closed_emits_reconcile_action(self) -> None:
+    @mock.patch("sentry.issues.endpoints.group_details.logger")
+    def test_diverged_closed_logs_and_skips_action(self, mock_logger: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.IGNORED, substatus=GroupSubStatus.FOREVER)
         GroupDerivedData.objects.create(group=group, data={"status": "open"})
 
         with capture_action_log() as log:
             self._get(group)
 
-        log.assert_logged(ReconcileStatusAction, group_id=group.id, status="closed")
+        log.assert_not_logged(ReconcileStatusAction)
+        mock_logger.info.assert_called_once_with(
+            "issues.status_reconciliation.diverged",
+            extra={
+                "group_id": group.id,
+                "project_id": group.project_id,
+                "derived_status": "open",
+                "expected_status": "closed",
+            },
+        )
 
     @with_feature("projects:issue-status-reconciliation")
-    def test_diverged_open_emits_reconcile_action(self) -> None:
+    @mock.patch("sentry.issues.endpoints.group_details.logger")
+    def test_diverged_open_logs_and_skips_action(self, mock_logger: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
         GroupDerivedData.objects.create(group=group, data={"status": "closed"})
 
         with capture_action_log() as log:
             self._get(group)
 
-        log.assert_logged(ReconcileStatusAction, group_id=group.id, status="open")
+        log.assert_not_logged(ReconcileStatusAction)
+        mock_logger.info.assert_called_once_with(
+            "issues.status_reconciliation.diverged",
+            extra={
+                "group_id": group.id,
+                "project_id": group.project_id,
+                "derived_status": "closed",
+                "expected_status": "open",
+            },
+        )
 
     @with_feature("projects:issue-status-reconciliation")
     def test_aligned_status_skips(self) -> None:


### PR DESCRIPTION
While we iron out the bugs we can simply log the results instead of actually publishing them. 