### PR TITLE
fix(scm): cap repo-sync pagination to avoid deadline timeout

### DIFF
--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -67,6 +67,16 @@ SCM_SYNC_PROVIDERS = [
 
 SYNC_BATCH_SIZE = 100
 
+# Cap the number of provider pages we fetch during a single periodic sync.
+# sync_repos_for_org has a 120s processing deadline; each page of ~100 repos
+# costs ~2s to fetch serially, so 50 pages (~5,000 repos) leaves headroom for
+# the rest of the task. Installations larger than this hit the cap and are
+# handled via the ApiPaginationTruncated path below (partial create/restore,
+# no disable), instead of running past the deadline and being SIGALRM-killed.
+# Providers whose client already caps below this (e.g. GitLab, bounded to 10
+# pages) simply never reach it.
+SYNC_PAGE_NUMBER_LIMIT = 50
+
 # Final safety guard before auto-disabling a repo: if it has any commit, PR,
 # or code review event row in the last DISABLE_ACTIVITY_CUTOFF_DAYS days, we
 # skip the disable even if the provider isn't returning the repo right now.
@@ -174,7 +184,9 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
 
         fetch_truncated = False
         try:
-            provider_repos = installation.get_repositories(raise_on_page_limit=True)
+            provider_repos = installation.get_repositories(
+                page_number_limit=SYNC_PAGE_NUMBER_LIMIT, raise_on_page_limit=True
+            )
         except ApiPaginationTruncated as e:
             # Provider fetch hit a pagination cap with more data still
             # available. We keep the partial result for create/restore — those

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -14,6 +14,7 @@ from sentry.integrations.gitlab.integration import GitlabIntegration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.perforce.integration import PerforceIntegrationProvider
 from sentry.integrations.source_code_management.sync_repos import (
+    SYNC_PAGE_NUMBER_LIMIT,
     sync_repos_for_org,
 )
 from sentry.locks import locks
@@ -352,6 +353,25 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
             assert Repository.objects.filter(
                 organization_id=self.organization.id, external_id="1"
             ).exists()
+
+    @patch("sentry.integrations.github.client.GitHubBaseClient.get_repos")
+    def test_fetch_caps_pages_to_deadline_budget(
+        self, mock_get_repos: MagicMock, _: MagicMock
+    ) -> None:
+        # The periodic sync must bound provider pagination so it can't run past
+        # the task's processing deadline on installations with thousands of
+        # repos. Assert the page cap is forwarded to the client.
+        mock_get_repos.return_value = [
+            {"id": 1, "full_name": "getsentry/sentry", "name": "sentry"},
+        ]
+
+        with self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        assert mock_get_repos.call_count == 1
+        _, kwargs = mock_get_repos.call_args
+        assert kwargs["page_number_limit"] == SYNC_PAGE_NUMBER_LIMIT
+        assert kwargs["raise_on_page_limit"] is True
 
 
 @control_silo_test


### PR DESCRIPTION
## Summary

Dispatched by a triage routine for [Sentry issue SENTRY-5NB2](https://sentry.sentry.io/issues/SENTRY-5NB2) (triage session: https://claude.ai/code/session_018ikyCiwB8yoZyPkgqTgwvH).

`sentry.integrations.source_code_management.sync_repos.sync_repos_for_org` was raising `ProcessingDeadlineExceeded: execution deadline of 120 seconds exceeded` (~1,130 occurrences). This caps the number of provider pages the sync fetches so the task completes within its deadline.

## Root cause

`sync_repos_for_org` called `installation.get_repositories(raise_on_page_limit=True)` with **no `page_number_limit`**. When `page_number_limit` is `None`, the GitHub client falls back to its own default cap of **200 pages** (`GitHubClientMixin.page_number_limit = 200`, i.e. up to ~20,000 repos).

For installations with very large repo counts, the serial pagination in `_get_with_pagination` keeps following GitHub's `next` links one round-trip at a time. The triggering install had 63 pages × 100 repos = 6,300+ repos; at ~2s/page that pushes total fetch time well past the task's `processing_deadline_duration=120`, so the worker is SIGALRM-killed mid-fetch and the task never finishes.

Call path:
```
sync_repos.py → installation.get_repositories(raise_on_page_limit=True)   # no page_number_limit
  → github/integration.py → client.get_repos(page_number_limit=None, raise_on_page_limit=True)
  → github/client.py → self._get_with_pagination(...)
  → serial next-link walk up to 200 pages → killed by the 120s deadline
```

## What this fixes

- Adds `SYNC_PAGE_NUMBER_LIMIT = 50` and passes it to `get_repositories(page_number_limit=SYNC_PAGE_NUMBER_LIMIT, raise_on_page_limit=True)`.
- 50 pages ≈ 5,000 repos at ~2s/page ≈ ~100s of fetch, leaving ~20s of headroom for the rest of the task within the 120s deadline.
- The truncation handling **already exists** and is unchanged: when the cap is hit with more pages available, the client raises `ApiPaginationTruncated`, and `_sync_repos_for_org` catches it, uses the partial result for the additive create/restore paths, and **skips the disable path** (`fetch_truncated=True`) so repos beyond the cap are never wrongly disabled. This PR simply makes that path reachable via an explicit limit rather than relying on the 200-page default.

## GitLab (SENTRY-5NAZ)

GitLab's client does not override `page_number_limit`, so it is already hard-bounded to the shared base default of **10 pages** (`ApiClient.page_number_limit = 10`, ~1,000 repos, ~20s) — it cannot exceed the deadline via pagination and never reaches the new 50-page cap. Its `get_repositories(page_number_limit=...)` accepts the kwarg but ignores it, so the provider-agnostic call-site change is safe and a no-op for GitLab. No GitLab code change is needed for the timeout. (Note: GitLab silently truncates at 10 pages without raising `ApiPaginationTruncated`, a separate latent correctness concern for the disable path that is out of scope here.)

## Alternatives ruled out

- **Increase the task deadline** — would only move the ceiling; unbounded pagination can still exceed any fixed deadline for a large enough install, and a longer deadline ties up control-silo workers. Explicitly out of scope.
- **Catch `ProcessingDeadlineExceeded`** — treats the symptom, not the cause, and leaves the sync doing partial/unpredictable work. We fix the root cause (missing page limit) instead. No blanket exception handling added.

## Tests

- Added `test_fetch_caps_pages_to_deadline_budget` asserting the sync forwards `page_number_limit=SYNC_PAGE_NUMBER_LIMIT` and `raise_on_page_limit=True` to the client.
- Existing `test_truncated_fetch_skips_disable` (and the GHE variant) already cover graceful handling of `ApiPaginationTruncated`.

> Note: the sandbox this was authored in has no provisioned Sentry venv (needs `devenv sync`, Python 3.13, Postgres), so the pytest suite could not be executed here. `ruff check`/`ruff format` pass and both files compile. CI should run the full suite.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ikyCiwB8yoZyPkgqTgwvH

---
_Generated by [Claude Code](https://claude.ai/code/session_018ikyCiwB8yoZyPkgqTgwvH)_