### PR TITLE
feat(sentry-apps): graduate granular webhook subscription UI

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -32,7 +32,6 @@ describe('Resource Subscriptions', () => {
         {organization: org}
       );
 
-      expect(screen.getAllByRole('checkbox')).toHaveLength(5);
       expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
       expect(screen.getByRole('checkbox', {name: 'comment'})).toBeDisabled();
@@ -52,9 +51,13 @@ describe('Resource Subscriptions', () => {
         </Form>
       );
 
-      expect(screen.getAllByRole('checkbox')).toHaveLength(4);
       expect(
         screen.queryByRole('checkbox', {name: 'preprod_artifact'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('checkbox', {
+          name: 'preprod_artifact.size_analysis_completed',
+        })
       ).not.toBeInTheDocument();
     });
 
@@ -72,10 +75,6 @@ describe('Resource Subscriptions', () => {
   });
 
   describe('granular event subscriptions', () => {
-    const organization = OrganizationFixture({
-      features: ['sentry-apps-granular-events'],
-    });
-
     function renderSubscriptions(
       events: WebhookSubscription[],
       permissions: Permissions = basePermissions
@@ -84,8 +83,7 @@ describe('Resource Subscriptions', () => {
       render(
         <Form>
           <Subscriptions events={events} permissions={permissions} onChange={onChange} />
-        </Form>,
-        {organization}
+        </Form>
       );
       return onChange;
     }

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -7,7 +7,6 @@ import {Text} from '@sentry/scraps/text';
 
 import {tct} from 'sentry/locale';
 import type {Permissions} from 'sentry/types/integrations';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import type {
   WebhookGranularEvent,
   WebhookSubscription,
@@ -28,9 +27,6 @@ type Props = {
 };
 
 export function Subscriptions({events, onChange, permissions}: Props) {
-  const organization = useOrganization();
-  const granular = organization.features.includes('sentry-apps-granular-events');
-
   // Every event needs its backing permission.
   useEffect(() => {
     const permitted = new Set<string>(
@@ -52,7 +48,7 @@ export function Subscriptions({events, onChange, permissions}: Props) {
       onChange(others);
       return;
     }
-    onChange([...others, ...(granular ? RESOURCE_EVENTS[resource] : [resource])]);
+    onChange([...others, ...RESOURCE_EVENTS[resource]]);
   };
 
   const handleEventChange = (event: WebhookGranularEvent, checked: boolean) => {
@@ -73,9 +69,7 @@ export function Subscriptions({events, onChange, permissions}: Props) {
 
     let checked: boolean | 'indeterminate' = false;
     if (!disabledFromPermissions) {
-      if (!granular) {
-        checked = events.includes(choice);
-      } else if (selectedEvents.length === RESOURCE_EVENTS[choice].length) {
+      if (selectedEvents.length === RESOURCE_EVENTS[choice].length) {
         checked = true;
       } else if (selectedEvents.length > 0) {
         checked = 'indeterminate';
@@ -96,10 +90,6 @@ export function Subscriptions({events, onChange, permissions}: Props) {
     );
   });
 
-  if (!granular) {
-    return <SubscriptionGrid>{boxes}</SubscriptionGrid>;
-  }
-
   return (
     <SubscriptionList>
       <Container padding="lg md" maxWidth="80ch">
@@ -118,14 +108,6 @@ export function Subscriptions({events, onChange, permissions}: Props) {
     </SubscriptionList>
   );
 }
-
-const SubscriptionGrid = styled('div')`
-  display: grid;
-  grid-template: auto / 1fr 1fr 1fr;
-  @media (max-width: ${props => props.theme.breakpoints.lg}) {
-    grid-template: 1fr 1fr 1fr / auto;
-  }
-`;
 
 const SubscriptionList = styled('div')`
   display: flex;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.tsx
@@ -119,7 +119,13 @@ describe('Sentry Application Details', () => {
           'event:admin',
           'org:ci',
         ]),
-        events: ['issue'],
+        events: [
+          'issue.created',
+          'issue.resolved',
+          'issue.assigned',
+          'issue.ignored',
+          'issue.unresolved',
+        ],
         isInternal: false,
         verifyInstall: true,
         isAlertable: true,
@@ -551,6 +557,13 @@ describe('Sentry Application Details', () => {
     beforeEach(() => {
       sentryApp = SentryAppFixture();
       sentryApp.events = ['issue'];
+      sentryApp.webhookEvents = [
+        'issue.created',
+        'issue.resolved',
+        'issue.assigned',
+        'issue.ignored',
+        'issue.unresolved',
+      ];
       sentryApp.scopes = ['project:read', 'event:read'];
 
       editAppRequest = MockApiClient.addMockResponse({
@@ -651,9 +664,6 @@ describe('Sentry Application Details', () => {
   });
 
   describe('Editing granular event subscriptions', () => {
-    const organization = OrganizationFixture({
-      features: ['sentry-apps-granular-events'],
-    });
     const initialRouterConfig: RouterConfig = {
       location: {
         pathname: '/sentry-apps/sample-app/',
@@ -661,7 +671,7 @@ describe('Sentry Application Details', () => {
       route: '/sentry-apps/:appSlug/',
     };
     function renderComponent() {
-      return render(<SentryApplicationDetails />, {initialRouterConfig, organization});
+      return render(<SentryApplicationDetails />, {initialRouterConfig});
     }
 
     beforeEach(() => {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -44,7 +44,6 @@ import type {
   PermissionResource,
   SentryApp,
   SentryAppAvatar,
-  WebhookEvent,
 } from 'sentry/types/integrations';
 import type {InternalAppApiToken, NewInternalAppApiToken} from 'sentry/types/user';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
@@ -364,22 +363,9 @@ function SentryApplicationForm({
       }),
   });
 
-  // Events may come from the API as "issue.created" when we just want "issue" here.
-  const normalize = (events: WebhookEvent[]) => {
-    if (events.length === 0) {
-      return events;
-    }
-
-    return events.map(event => event.split('.').shift() as WebhookEvent);
-  };
-
-  const granular = organization.features.includes('sentry-apps-granular-events');
-
   // Older API responses only send the consolidated resource list
   const initialEvents: WebhookSubscription[] = app
-    ? granular
-      ? granularWebhookEvents(app.webhookEvents ?? app.events)
-      : normalize(app.events)
+    ? granularWebhookEvents(app.webhookEvents ?? app.events)
     : [];
 
   const hasTokenAccess = () => {

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -32,23 +32,36 @@ describe('SubscriptionBox', () => {
     );
   }
 
-  it('renders resource checkbox', () => {
-    renderComponent();
+  it('renders a checkbox per event alongside the resource checkbox', () => {
+    renderComponent({selectedEvents: ['issue.created']});
+
+    expect(screen.getAllByRole('checkbox')).toHaveLength(6);
+    expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
+    expect(screen.getByRole('checkbox', {name: 'issue.resolved'})).not.toBeChecked();
   });
 
-  it('calls onChange prop when checking checkbox', async () => {
+  it('calls onChange prop when checking the resource checkbox', async () => {
     renderComponent();
 
-    await userEvent.click(screen.getByRole('checkbox'));
+    await userEvent.click(screen.getByRole('checkbox', {name: 'issue'}));
     expect(onChange).toHaveBeenCalledWith('issue', true);
   });
 
-  it('disables the checkbox from permissions', async () => {
+  it('calls onEventChange when toggling an event', async () => {
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('checkbox', {name: 'issue.resolved'}));
+    expect(onEventChange).toHaveBeenCalledWith('issue.resolved', true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('disables the checkboxes from permissions', async () => {
     renderComponent({disabledFromPermissions: true});
 
-    expect(screen.getByRole('checkbox')).toBeDisabled();
+    expect(screen.getByRole('checkbox', {name: 'issue'})).toBeDisabled();
+    expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeDisabled();
 
-    await userEvent.hover(screen.getByRole('checkbox'));
+    await userEvent.hover(screen.getByRole('checkbox', {name: 'issue'}));
     expect(
       await screen.findByText("Must have at least 'Read' permissions enabled for Event")
     ).toBeInTheDocument();
@@ -58,9 +71,9 @@ describe('SubscriptionBox', () => {
     it('checkbox disabled without integrations-event-hooks flag', async () => {
       renderComponent({resource: 'error'});
 
-      expect(screen.getByRole('checkbox')).toBeDisabled();
+      expect(screen.getByRole('checkbox', {name: 'error'})).toBeDisabled();
 
-      await userEvent.hover(screen.getByRole('checkbox'));
+      await userEvent.hover(screen.getByRole('checkbox', {name: 'error'}));
       expect(
         await screen.findByText(
           'Your organization does not have access to the error subscription resource.'
@@ -74,35 +87,7 @@ describe('SubscriptionBox', () => {
         {organization: OrganizationFixture({features: ['integrations-event-hooks']})}
       );
 
-      expect(screen.getByRole('checkbox')).toBeEnabled();
-    });
-  });
-
-  describe('granular event subscriptions', () => {
-    const organization = OrganizationFixture({
-      features: ['sentry-apps-granular-events'],
-    });
-
-    it('renders a checkbox per event', () => {
-      renderComponent({selectedEvents: ['issue.created']}, {organization});
-
-      expect(screen.getAllByRole('checkbox')).toHaveLength(6);
-      expect(screen.getByRole('checkbox', {name: 'issue.created'})).toBeChecked();
-      expect(screen.getByRole('checkbox', {name: 'issue.resolved'})).not.toBeChecked();
-    });
-
-    it('calls onEventChange when toggling an event', async () => {
-      renderComponent({}, {organization});
-
-      await userEvent.click(screen.getByRole('checkbox', {name: 'issue.resolved'}));
-      expect(onEventChange).toHaveBeenCalledWith('issue.resolved', true);
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('does not render event checkboxes without the flag', () => {
-      renderComponent({selectedEvents: ['issue.created']});
-
-      expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+      expect(screen.getByRole('checkbox', {name: 'error'})).toBeEnabled();
     });
   });
 
@@ -119,7 +104,7 @@ describe('SubscriptionBox', () => {
         {organization: OrganizationFixture({features: ['preprod-artifact-webhooks']})}
       );
 
-      expect(screen.getByRole('checkbox')).toBeEnabled();
+      expect(screen.getByRole('checkbox', {name: 'preprod_artifact'})).toBeEnabled();
     });
   });
 });

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -62,113 +62,58 @@ export function SubscriptionBox({
     );
   }
 
-  const granular = features.includes('sentry-apps-granular-events');
-  const description = RESOURCE_EVENTS[resource].map(webhookEventLabel).join(', ');
-
-  if (granular) {
-    return (
-      <SubscriptionRow
-        align="start"
-        gap="2xl"
-        padding="lg md"
-        direction={{'screen:xs': 'column', 'screen:md': 'row'}}
-        data-disabled={disabled || undefined}
-      >
-        <Tooltip disabled={!disabled} title={message}>
-          <Flex
-            as="label"
-            align="center"
-            gap="md"
-            flex="none"
-            width={{'screen:xs': '100%', 'screen:md': '180px'}}
-          >
-            <Checkbox
-              aria-label={resource}
-              disabled={disabled}
-              checked={checked}
-              onChange={evt => onChange(resource, evt.target.checked)}
-            />
-            <Text size="md" bold>
-              {webhookResourceLabel(resource)}
-              {isNew && <FeatureBadge type="new" />}
-            </Text>
-          </Flex>
-        </Tooltip>
-        <Grid flex="1" columns="repeat(auto-fill, 220px)" gap="md lg">
-          {RESOURCE_EVENTS[resource].map(event => (
-            <Tooltip key={event} disabled={!disabled} title={message}>
-              <Flex as="label" align="center" gap="sm">
-                <Checkbox
-                  aria-label={event}
-                  disabled={disabled}
-                  checked={selectedEvents.includes(event)}
-                  onChange={evt => onEventChange(event, evt.target.checked)}
-                />
-                <Text size="md" variant="muted">
-                  {webhookEventLabel(event)}
-                </Text>
-              </Flex>
-            </Tooltip>
-          ))}
-        </Grid>
-      </SubscriptionRow>
-    );
-  }
-
   return (
-    <Tooltip disabled={!disabled} title={message} key={resource}>
-      <SubscriptionGridItem disabled={disabled}>
-        <Stack alignSelf="center">
-          <SubscriptionTitle>
+    <SubscriptionRow
+      align="start"
+      gap="2xl"
+      padding="lg md"
+      direction={{'screen:xs': 'column', 'screen:md': 'row'}}
+      data-disabled={disabled || undefined}
+    >
+      <Tooltip disabled={!disabled} title={message}>
+        <Flex
+          as="label"
+          align="center"
+          gap="md"
+          flex="none"
+          width={{'screen:xs': '100%', 'screen:md': '180px'}}
+        >
+          <Checkbox
+            aria-label={resource}
+            disabled={disabled}
+            checked={checked}
+            onChange={evt => onChange(resource, evt.target.checked)}
+          />
+          <Text size="md" bold>
             {webhookResourceLabel(resource)}
             {isNew && <FeatureBadge type="new" />}
-          </SubscriptionTitle>
-          <SubscriptionDescription>{description}</SubscriptionDescription>
-        </Stack>
-        <Checkbox
-          key={`${resource}${checked}`}
-          aria-label={resource}
-          disabled={disabled}
-          id={resource}
-          value={resource}
-          checked={checked}
-          onChange={evt => onChange(resource, evt.target.checked)}
-        />
-      </SubscriptionGridItem>
-    </Tooltip>
+          </Text>
+        </Flex>
+      </Tooltip>
+      <Grid flex="1" columns="repeat(auto-fill, 220px)" gap="md lg">
+        {RESOURCE_EVENTS[resource].map(event => (
+          <Tooltip key={event} disabled={!disabled} title={message}>
+            <Flex as="label" align="center" gap="sm">
+              <Checkbox
+                aria-label={event}
+                disabled={disabled}
+                checked={selectedEvents.includes(event)}
+                onChange={evt => onEventChange(event, evt.target.checked)}
+              />
+              <Text size="md" variant="muted">
+                {webhookEventLabel(event)}
+              </Text>
+            </Flex>
+          </Tooltip>
+        ))}
+      </Grid>
+    </SubscriptionRow>
   );
 }
-
-const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  background: ${p => p.theme.tokens.background.secondary};
-  opacity: ${p => (p.disabled ? 0.6 : 1)};
-  border-radius: ${p => p.theme.radius.md};
-  cursor: ${p => (p.disabled ? 'not-allowed' : 'auto')};
-  margin: ${p => p.theme.space.lg};
-  padding: ${p => p.theme.space.lg};
-  box-sizing: border-box;
-`;
 
 const SubscriptionRow = styled(Flex)`
   &[data-disabled] {
     opacity: 0.6;
     cursor: not-allowed;
   }
-`;
-
-const SubscriptionDescription = styled('div')`
-  font-size: ${p => p.theme.font.size.md};
-  line-height: 1;
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-
-const SubscriptionTitle = styled('div')`
-  font-size: ${p => p.theme.font.size.lg};
-  line-height: 1;
-  color: ${p => p.theme.tokens.content.primary};
-  white-space: nowrap;
-  margin-bottom: ${p => p.theme.space.sm};
 `;


### PR DESCRIPTION
Remove the feature flag for granular webhook subscriptions, and make it the default behavior.
<img width="1228" height="446" alt="Screenshot 2026-07-21 at 2 47 14 PM" src="https://github.com/user-attachments/assets/a840b486-df0d-4a20-b7b7-b1c881ac9f4c" />

