### PR TITLE
feat(sentry-apps): GA granular webhook subscriptions

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -330,8 +330,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-apps-creation-templates", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable delivery of custom webhook headers configured on a SentryApp
     manager.add("organizations:sentry-apps-custom-webhook-headers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Allow SentryApps to subscribe to individual webhook events instead of whole resources
-    manager.add("organizations:sentry-apps-granular-events", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable select orgs from ingesting mobile replay events.
     # Enable double-read from EAP for session health data validation
     manager.add("organizations:session-health-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -44,7 +44,6 @@ from sentry.sentry_apps.installations import SentryAppInstallationNotifier
 from sentry.sentry_apps.logic import SentryAppUpdater
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
-from sentry.sentry_apps.utils.webhooks import has_granular_events
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.audit import create_audit_entry
@@ -151,24 +150,6 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 {
                     "non_field_errors": [
                         "Your organization does not have access to the 'error' resource subscription."
-                    ]
-                },
-                status=403,
-            )
-
-        if (
-            owner_context
-            and has_granular_events(request.data.get("events"))
-            and not features.has(
-                "organizations:sentry-apps-granular-events",
-                owner_context.organization,
-                actor=request.user,
-            )
-        ):
-            return Response(
-                {
-                    "non_field_errors": [
-                        "Your organization does not have access to per-event webhook subscriptions."
                     ]
                 },
                 status=403,

--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
@@ -26,7 +26,6 @@ from sentry.sentry_apps.api.serializers.sentry_app import (
 )
 from sentry.sentry_apps.logic import SentryAppCreator
 from sentry.sentry_apps.models.sentry_app import SentryApp
-from sentry.sentry_apps.utils.webhooks import has_granular_events
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -105,18 +104,6 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
                 {
                     "non_field_errors": [
                         "Your organization does not have access to the 'error' resource subscription."
-                    ]
-                },
-                status=403,
-            )
-
-        if has_granular_events(request.data.get("events")) and not features.has(
-            "organizations:sentry-apps-granular-events", organization, actor=request.user
-        ):
-            return Response(
-                {
-                    "non_field_errors": [
-                        "Your organization does not have access to per-event webhook subscriptions."
                     ]
                 },
                 status=403,

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -68,7 +68,6 @@ class EventListField(serializers.Field):
         if data is None:
             return
 
-        # Individual events (vs whole resources) are flag-gated at the endpoint.
         valid = set(VALID_EVENT_RESOURCES) | set(VALID_EVENTS)
         if not set(data).issubset(valid):
             raise ValidationError(

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -136,11 +136,6 @@ def resource_of(event: str) -> SentryAppResourceType | None:
     return EVENT_TO_RESOURCE.get(event)
 
 
-def has_granular_events(events: Collection[str] | None) -> bool:
-    """Whether any entry is an individual event rather than a whole resource."""
-    return any(event in EVENT_TO_RESOURCE for event in events or ())
-
-
 def is_subscribed(stored_events: Collection[str], event: str) -> bool:
     """
     Whether a stored subscription covers a fired event.

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -607,9 +607,8 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             status_code=200,
         )
 
-    @with_feature("organizations:sentry-apps-granular-events")
     @override_options({"staff.ga-rollout": True})
-    def test_can_add_granular_events_with_flag(self) -> None:
+    def test_can_add_granular_events(self) -> None:
         app = self.create_sentry_app(name="SampleApp", organization=self.organization)
         self.get_success_response(
             app.slug,

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -700,8 +700,7 @@ class PostSentryAppsTest(SentryAppsTest):
                 ]
             }
 
-    @with_feature("organizations:sentry-apps-granular-events")
-    def test_can_create_with_granular_events_with_flag(self) -> None:
+    def test_can_create_with_granular_events(self) -> None:
         response = self.get_success_response(
             **self.get_data(events=("issue.resolved",)), status_code=201
         )
@@ -709,7 +708,6 @@ class PostSentryAppsTest(SentryAppsTest):
         # Stored verbatim, not expanded to the whole issue resource.
         assert sentry_app.events == ["issue.resolved"]
 
-    @with_feature("organizations:sentry-apps-granular-events")
     def test_granular_event_requires_resource_scope(self) -> None:
         data = self.get_data(events=("issue.resolved",), scopes=("project:read",))
         response = self.get_error_response(**data, status_code=400)

--- a/tests/sentry/sentry_apps/test_webhooks.py
+++ b/tests/sentry/sentry_apps/test_webhooks.py
@@ -5,12 +5,7 @@ import pytest
 
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
-from sentry.sentry_apps.utils.webhooks import (
-    SentryAppResourceType,
-    has_granular_events,
-    is_subscribed,
-    resource_of,
-)
+from sentry.sentry_apps.utils.webhooks import SentryAppResourceType, is_subscribed, resource_of
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -22,14 +17,6 @@ def test_resource_of() -> None:
     # Events outside the subscribable taxonomy (e.g. alerts) resolve to None.
     assert resource_of("metric_alert.critical") is None
     assert resource_of("bogus.thing") is None
-
-
-def test_has_granular_events() -> None:
-    assert has_granular_events(["issue.resolved"])
-    assert has_granular_events(["issue", "issue.resolved"])
-    assert not has_granular_events(["issue", "error"])
-    assert not has_granular_events([])
-    assert not has_granular_events(None)
 
 
 def test_is_subscribed_matches_exact_event() -> None:


### PR DESCRIPTION
Remove the feature flag for granular webhook subscriptions, and make it the default behavior.