### PR TITLE
ref(derived): Move framework-only tests into their own file

### DIFF
--- a/tests/sentry/issues/derived/test_framework.py
+++ b/tests/sentry/issues/derived/test_framework.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from sentry.issues.derived.features import IssueStatus
+from sentry.issues.derived.framework import (
+    AggregatorResult,
+    DateTimeCodec,
+    EnumCodec,
+    Feature,
+    OptionalCodec,
+    Pipeline,
+    State,
+    StateUpdate,
+    StateView,
+    aggregator,
+)
+from sentry.issues.progress_state import IssueProgressState
+
+
+def test_mutation_checking_catches_in_place_mutation() -> None:
+    ITEMS = Feature[list[str]]("items", default_factory=list)
+
+    @aggregator((ITEMS,))
+    def bad_mutator(state: StateView, entry: object) -> AggregatorResult:
+        state[ITEMS].append("oops")
+        return None
+
+    p = Pipeline([bad_mutator], check_mutations=True)
+    state = p.initial_state()
+
+    class FakeEntry:
+        type = 0
+
+    with pytest.raises(RuntimeError, match="mutated feature 'items' in place"):
+        p.step(state, FakeEntry())
+
+
+def test_state_updated_tracks_merged_features() -> None:
+    A = Feature[int]("a", default=0)
+    B = Feature[int]("b", default=0)
+    state = State({A: 0, B: 0})
+
+    assert state.updated == frozenset()
+
+    state.merge(StateUpdate({A: 1}))
+    assert state.updated == frozenset({A})
+    assert state[A] == 1
+    assert state[B] == 0
+
+
+class TestDateTimeCodec:
+    def test_json_round_trip(self) -> None:
+        codec = DateTimeCodec()
+        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
+        assert codec.from_json(codec.to_json(dt)) == dt
+
+    def test_to_json_produces_iso_string(self) -> None:
+        codec = DateTimeCodec()
+        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
+        dumped = codec.to_json(dt)
+        assert isinstance(dumped, str)
+        assert dumped == dt.isoformat()
+
+    def test_column_round_trip_is_identity(self) -> None:
+        codec = DateTimeCodec()
+        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
+        assert codec.from_column(codec.to_column(dt)) == dt
+        assert codec.to_column(dt) is dt
+
+    def test_optional_none(self) -> None:
+        codec = OptionalCodec(DateTimeCodec())
+        assert codec.to_json(None) is None
+        assert codec.from_json(None) is None
+
+    def test_optional_json_round_trip(self) -> None:
+        codec = OptionalCodec(DateTimeCodec())
+        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
+        assert codec.from_json(codec.to_json(dt)) == dt
+
+
+class TestEnumCodecCoverage:
+    @pytest.mark.parametrize("raw", ["open", "closed"])
+    def test_issue_status_json_round_trip(self, raw: str) -> None:
+        codec = EnumCodec(IssueStatus)
+        loaded = codec.from_json(raw)
+        assert codec.to_json(loaded) == raw
+
+    @pytest.mark.parametrize("raw", ["open", "closed"])
+    def test_issue_status_column_round_trip(self, raw: str) -> None:
+        codec = EnumCodec(IssueStatus)
+        loaded = codec.from_column(raw)
+        assert isinstance(loaded, IssueStatus)
+        assert codec.to_column(loaded) == raw
+
+    @pytest.mark.parametrize(
+        "raw", ["identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"]
+    )
+    def test_issue_progress_state_json_round_trip(self, raw: str) -> None:
+        codec = EnumCodec(IssueProgressState)
+        loaded = codec.from_json(raw)
+        assert codec.to_json(loaded) == raw
+
+    @pytest.mark.parametrize(
+        "raw", ["identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"]
+    )
+    def test_issue_progress_state_column_produces_enum(self, raw: str) -> None:
+        codec = EnumCodec(IssueProgressState)
+        loaded = codec.from_column(raw)
+        assert isinstance(loaded, IssueProgressState)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, "identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"],
+    )
+    def test_optional_progress_json_round_trip(self, raw: str | None) -> None:
+        codec = OptionalCodec(EnumCodec(IssueProgressState))
+        loaded = codec.from_json(raw)
+        assert codec.to_json(loaded) == raw
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, "identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"],
+    )
+    def test_optional_progress_column_round_trip(self, raw: str | None) -> None:
+        codec = OptionalCodec(EnumCodec(IssueProgressState))
+        loaded = codec.from_column(raw)
+        if raw is not None:
+            assert isinstance(loaded, IssueProgressState)
+        assert codec.to_column(loaded) == raw

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -36,12 +36,8 @@ from sentry.issues.derived.features import (
 )
 from sentry.issues.derived.framework import (
     AggregatorResult,
-    DateTimeCodec,
-    EnumCodec,
     Feature,
-    OptionalCodec,
     Pipeline,
-    State,
     StateUpdate,
     StateView,
     aggregator,
@@ -667,37 +663,6 @@ class PromoteToLiveTest(TestCase):
 # --- Pure Python tests (no DB) ---
 
 
-def test_mutation_checking_catches_in_place_mutation() -> None:
-    ITEMS = Feature[list[str]]("items", default_factory=list)
-
-    @aggregator((ITEMS,))
-    def bad_mutator(state: StateView, entry: object) -> AggregatorResult:
-        state[ITEMS].append("oops")
-        return None
-
-    p = Pipeline([bad_mutator], check_mutations=True)
-    state = p.initial_state()
-
-    class FakeEntry:
-        type = 0
-
-    with pytest.raises(RuntimeError, match="mutated feature 'items' in place"):
-        p.step(state, FakeEntry())
-
-
-def test_state_updated_tracks_merged_features() -> None:
-    A = Feature[int]("a", default=0)
-    B = Feature[int]("b", default=0)
-    state = State({A: 0, B: 0})
-
-    assert state.updated == frozenset()
-
-    state.merge(StateUpdate({A: 1}))
-    assert state.updated == frozenset({A})
-    assert state[A] == 1
-    assert state[B] == 0
-
-
 def test_build_update_json_blob_includes_all_json_features() -> None:
     A = Feature[int]("a", default=0)
     B = Feature[int]("b", default=0)
@@ -731,90 +696,6 @@ def test_all_feature_defaults_round_trip_through_json() -> None:
     serialized = json.loads(json.dumps(blob))
     for f in PIPELINE.features:
         assert f.from_json(serialized[f.name]) == state[f], f"round-trip failed for {f.name}"
-
-
-# --- Codec tests ---
-
-
-class TestDateTimeCodec:
-    def test_json_round_trip(self) -> None:
-        codec = DateTimeCodec()
-        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
-        assert codec.from_json(codec.to_json(dt)) == dt
-
-    def test_to_json_produces_iso_string(self) -> None:
-        codec = DateTimeCodec()
-        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
-        dumped = codec.to_json(dt)
-        assert isinstance(dumped, str)
-        assert dumped == dt.isoformat()
-
-    def test_column_round_trip_is_identity(self) -> None:
-        codec = DateTimeCodec()
-        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
-        assert codec.from_column(codec.to_column(dt)) == dt
-        assert codec.to_column(dt) is dt
-
-    def test_optional_none(self) -> None:
-        codec = OptionalCodec(DateTimeCodec())
-        assert codec.to_json(None) is None
-        assert codec.from_json(None) is None
-
-    def test_optional_json_round_trip(self) -> None:
-        codec = OptionalCodec(DateTimeCodec())
-        dt = datetime(2025, 3, 15, 12, 30, 45, tzinfo=timezone.utc)
-        assert codec.from_json(codec.to_json(dt)) == dt
-
-
-class TestEnumCodecCoverage:
-    @pytest.mark.parametrize("raw", ["open", "closed"])
-    def test_issue_status_json_round_trip(self, raw: str) -> None:
-        codec = EnumCodec(IssueStatus)
-        loaded = codec.from_json(raw)
-        assert codec.to_json(loaded) == raw
-
-    @pytest.mark.parametrize("raw", ["open", "closed"])
-    def test_issue_status_column_round_trip(self, raw: str) -> None:
-        codec = EnumCodec(IssueStatus)
-        loaded = codec.from_column(raw)
-        assert isinstance(loaded, IssueStatus)
-        assert codec.to_column(loaded) == raw
-
-    @pytest.mark.parametrize(
-        "raw", ["identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"]
-    )
-    def test_issue_progress_state_json_round_trip(self, raw: str) -> None:
-        codec = EnumCodec(IssueProgressState)
-        loaded = codec.from_json(raw)
-        assert codec.to_json(loaded) == raw
-
-    @pytest.mark.parametrize(
-        "raw", ["identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"]
-    )
-    def test_issue_progress_state_column_produces_enum(self, raw: str) -> None:
-        codec = EnumCodec(IssueProgressState)
-        loaded = codec.from_column(raw)
-        assert isinstance(loaded, IssueProgressState)
-
-    @pytest.mark.parametrize(
-        "raw",
-        [None, "identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"],
-    )
-    def test_optional_progress_json_round_trip(self, raw: str | None) -> None:
-        codec = OptionalCodec(EnumCodec(IssueProgressState))
-        loaded = codec.from_json(raw)
-        assert codec.to_json(loaded) == raw
-
-    @pytest.mark.parametrize(
-        "raw",
-        [None, "identified", "assigned", "diagnosed", "fix_proposed", "fix_applied"],
-    )
-    def test_optional_progress_column_round_trip(self, raw: str | None) -> None:
-        codec = OptionalCodec(EnumCodec(IssueProgressState))
-        loaded = codec.from_column(raw)
-        if raw is not None:
-            assert isinstance(loaded, IssueProgressState)
-        assert codec.to_column(loaded) == raw
 
 
 # --- Store tests (need DB) ---


### PR DESCRIPTION
The processing test file is already too big, but this helps a little.
As a bonus, it means the guaranteed very fast framework tests can be easily run quickly.