### PR TITLE
feat(issues): Update v2 activity timeline markers

### DIFF
--- a/static/app/views/issueDetails/actions/statusBanner.spec.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.spec.tsx
@@ -12,7 +12,7 @@ const project = ProjectFixture();
 const actor = UserFixture({name: 'David Cramer'});
 
 describe('StatusBanner', () => {
-  it('renders the activity resolved presentation behind the flag', () => {
+  it('renders the resolved progress indicator behind the progress flag', () => {
     render(
       <StatusBanner
         group={GroupFixture({
@@ -22,7 +22,9 @@ describe('StatusBanner', () => {
         project={project}
       />,
       {
-        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+        organization: OrganizationFixture({
+          features: ['issue-activity-feed-v2', 'issue-activity-progress'],
+        }),
       }
     );
 
@@ -42,7 +44,9 @@ describe('StatusBanner', () => {
         project={project}
       />,
       {
-        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+        organization: OrganizationFixture({
+          features: ['issue-activity-feed-v2', 'issue-activity-progress'],
+        }),
       }
     );
 
@@ -51,6 +55,26 @@ describe('StatusBanner', () => {
       screen.getByText('David Cramer archived until 50 more events occur')
     ).toBeInTheDocument();
     expect(screen.getByRole('img', {name: 'Archived'})).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
+  });
+
+  it('hides other activity progress indicators without the progress flag', () => {
+    render(
+      <StatusBanner
+        group={GroupFixture({
+          status: GroupStatus.IGNORED,
+          substatus: GroupSubstatus.ARCHIVED_FOREVER,
+          statusDetails: {},
+        })}
+        project={project}
+      />,
+      {
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
+      }
+    );
+
+    expect(screen.getByText('Archived')).toBeInTheDocument();
+    expect(screen.queryByRole('img', {name: 'Archived'})).not.toBeInTheDocument();
     expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/actions/statusBanner.stories.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.stories.tsx
@@ -126,6 +126,7 @@ function Banner({
     <StatusBannerFrame
       markerLabel={isArchived ? 'Archived' : undefined}
       markerState={isArchived ? ProgressState.ASSIGNED : ProgressState.FIX_APPLIED}
+      showProgressIndicator
       title={isArchived ? 'Archived' : 'Resolved'}
     >
       {children}

--- a/static/app/views/issueDetails/actions/statusBanner.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.tsx
@@ -33,9 +33,15 @@ export function StatusBanner({group, project, resolvedCopy}: StatusBannerProps) 
   }
 
   const useActivityBanner = organization.features.includes('issue-activity-feed-v2');
+  const showProgressIndicator = organization.features.includes('issue-activity-progress');
 
   return useActivityBanner ? (
-    <ActivityStatusBanner group={group} project={project} resolvedCopy={resolvedCopy} />
+    <ActivityStatusBanner
+      group={group}
+      project={project}
+      resolvedCopy={resolvedCopy}
+      showProgressIndicator={showProgressIndicator}
+    />
   ) : (
     <DefaultStatusBanner group={group} project={project} resolvedCopy={resolvedCopy} />
   );
@@ -45,8 +51,10 @@ function ActivityStatusBanner({
   group,
   project,
   resolvedCopy,
+  showProgressIndicator,
 }: StatusBannerProps & {
   group: StatusGroup;
+  showProgressIndicator: boolean;
 }) {
   const isResolved = group.status === GroupStatus.RESOLVED;
 
@@ -54,6 +62,7 @@ function ActivityStatusBanner({
     <StatusBannerFrame
       markerLabel={isResolved ? undefined : t('Archived')}
       markerState={isResolved ? ProgressState.FIX_APPLIED : ProgressState.ASSIGNED}
+      showProgressIndicator={showProgressIndicator}
       title={isResolved ? resolvedCopy || t('Resolved') : t('Archived')}
     >
       {isResolved ? (
@@ -72,6 +81,7 @@ function ActivityStatusBanner({
 interface StatusBannerFrameProps {
   children: React.ReactNode;
   markerState: ProgressState;
+  showProgressIndicator: boolean;
   title: React.ReactNode;
   markerLabel?: string;
 }
@@ -80,11 +90,14 @@ export function StatusBannerFrame({
   children,
   markerLabel,
   markerState,
+  showProgressIndicator,
   title,
 }: StatusBannerFrameProps) {
   return (
     <Flex align="center" gap="sm">
-      <ActivityProgressMarker label={markerLabel} state={markerState} />
+      {showProgressIndicator ? (
+        <ActivityProgressMarker label={markerLabel} state={markerState} />
+      ) : null}
       <Stack gap="0">
         <Text as="div" bold density="compressed" size="lg">
           {title}

--- a/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
@@ -1,6 +1,9 @@
+import type {ReactNode} from 'react';
+import {useId, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Checkbox} from '@sentry/scraps/checkbox';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
@@ -8,6 +11,8 @@ import type {Group, GroupActivity} from 'sentry/types/group';
 import {GroupActivityType, IssueCategory, PriorityLevel} from 'sentry/types/group';
 import type {Commit, PullRequest, Repository} from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
+import {OrganizationContext} from 'sentry/utils/organizationContext';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {ActivityLine} from 'sentry/views/issueDetails/activitySection/activityLineItem';
 import {
@@ -303,15 +308,51 @@ const seerActivities = [
 ];
 
 export default Storybook.story('Issue Activity', story => {
-  story('Resolution', () => <ResolutionExamples />);
-  story('Archived', () => <ActivityExamples items={archivedActivities} />);
-  story('Assignment', () => <ActivityExamples items={assignmentActivities} />);
-  story('Priority and escalation', () => <ActivityExamples items={priorityActivities} />);
-  story('Source control', () => <ActivityExamples items={sourceControlActivities} />);
-  story('Issue changes', () => <ActivityExamples items={issueActivities} />);
-  story('Comments', () => <CommentExample />);
-  story('Seer', () => <ActivityExamples items={seerActivities} />);
+  const activityStory = (name: string, render: () => ReactNode) =>
+    story(name, () => <ActivityStory>{render()}</ActivityStory>);
+
+  activityStory('Resolution', () => <ResolutionExamples />);
+  activityStory('Archived', () => <ActivityExamples items={archivedActivities} />);
+  activityStory('Assignment', () => <ActivityExamples items={assignmentActivities} />);
+  activityStory('Priority and escalation', () => (
+    <ActivityExamples items={priorityActivities} />
+  ));
+  activityStory('Source control', () => (
+    <ActivityExamples items={sourceControlActivities} />
+  ));
+  activityStory('Issue changes', () => <ActivityExamples items={issueActivities} />);
+  activityStory('Comments', () => <CommentExample />);
+  activityStory('Seer', () => <ActivityExamples items={seerActivities} />);
 });
+
+function ActivityStory({children}: {children: ReactNode}) {
+  const checkboxId = useId();
+  const organization = useOrganization();
+  const [showProgress, setShowProgress] = useState(false);
+  const features = organization.features.filter(
+    feature => feature !== 'issue-activity-progress'
+  );
+
+  if (showProgress) {
+    features.push('issue-activity-progress');
+  }
+
+  return (
+    <OrganizationContext.Provider value={{...organization, features}}>
+      <Stack gap="lg">
+        <Flex as="label" align="center" gap="sm" htmlFor={checkboxId}>
+          <Checkbox
+            id={checkboxId}
+            checked={showProgress}
+            onChange={() => setShowProgress(value => !value)}
+          />
+          <Text>Show progress indicators</Text>
+        </Flex>
+        {children}
+      </Stack>
+    </OrganizationContext.Provider>
+  );
+}
 
 function ResolutionExamples() {
   return (

--- a/static/app/views/issueDetails/activitySection/activityLineItem/actor.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/actor.tsx
@@ -9,14 +9,10 @@ import type {GroupActivity} from 'sentry/types/group';
 import {SEER_ACTIVITY_TYPES} from 'sentry/types/group';
 
 export function ActivityLineActor({item}: {item: GroupActivity}) {
-  return (
-    <ActorSlot>
-      <ActivityLineActorAvatar item={item} />
-    </ActorSlot>
-  );
+  return <ActorSlot>{renderActivityLineActor(item)}</ActorSlot>;
 }
 
-function ActivityLineActorAvatar({item}: {item: GroupActivity}) {
+export function renderActivityLineActor(item: GroupActivity): React.ReactElement | null {
   if (item.sentry_app) {
     return (
       <Tooltip title={item.sentry_app.name}>
@@ -50,8 +46,6 @@ function ActivityLineActorAvatar({item}: {item: GroupActivity}) {
 }
 
 const ActorSlot = styled('div')`
-  grid-column: 2;
-  grid-row: 1;
   display: grid;
   place-items: center;
   min-width: 22px;

--- a/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/index.tsx
@@ -4,7 +4,6 @@ import {TimeSince} from 'sentry/components/timeSince';
 import type {Group, GroupActivity} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-import {ActivityLineActor} from './actor';
 import {ActivityLineBody} from './body';
 import {getCompactGroupActivityItem} from './compactActivityItem';
 import {ActivityLineHeadline, ActivityLineRow} from './layout';
@@ -18,6 +17,7 @@ interface ActivityLineProps {
 
 export function ActivityLine({item, group, timestampUnitStyle}: ActivityLineProps) {
   const organization = useOrganization();
+  const showProgress = organization.features.includes('issue-activity-progress');
   const {issueCategory, project} = group;
   const compactItem = useMemo(
     () =>
@@ -33,8 +33,7 @@ export function ActivityLine({item, group, timestampUnitStyle}: ActivityLineProp
 
   return (
     <ActivityLineRow>
-      <ActivityLineMarker item={item} />
-      <ActivityLineActor item={item} />
+      <ActivityLineMarker item={item} showProgress={showProgress} />
       <ActivityLineHeadline
         title={compactItem.title}
         details={compactItem.details}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/layout.tsx
@@ -18,7 +18,7 @@ export function ActivityLineHeadline({
   timestamp,
 }: ActivityLineHeadlineProps) {
   return (
-    <Flex column={3} row={1} minWidth={0} minHeight="22px" align="baseline">
+    <Flex column={2} row={1} minWidth={0} minHeight="22px" align="baseline">
       <ActivityLineSentence>
         <ActivityLineTitleText
           as="span"
@@ -53,7 +53,7 @@ export function ActivityLineHeadline({
 export const ActivityLineRow = styled('div')`
   position: relative;
   display: grid;
-  grid-template-columns: 22px 22px minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   grid-template-rows: auto auto;
   align-items: start;
   column-gap: ${p => p.theme.space.xs};
@@ -92,7 +92,7 @@ const ActivityLineMeta = styled('span')`
 `;
 
 export const ActivityLineContent = styled('div')`
-  grid-column: 3;
+  grid-column: 2;
   grid-row: 2;
   min-width: 0;
 `;

--- a/static/app/views/issueDetails/activitySection/activityLineItem/note.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/note.tsx
@@ -8,10 +8,10 @@ import {NoteBody} from 'sentry/components/activity/note/body';
 import {TimeSince} from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import {GroupActivityType, type Group, type GroupActivity} from 'sentry/types/group';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {ActivityNoteInput} from 'sentry/views/issueDetails/activitySection/activityNoteInput';
 import {CommentActionsDropdown} from 'sentry/views/issueDetails/activitySection/commentActionsDropdown';
 
-import {ActivityLineActor} from './actor';
 import {ActivityLineContent, ActivityLineRow, type ActivityLineVariant} from './layout';
 import {ActivityLineMarker} from './progressMarker';
 
@@ -47,14 +47,15 @@ export function ActivityLineNote({
   timestampUnitStyle,
 }: ActivityLineNoteProps) {
   const [editing, setEditing] = useState(false);
+  const organization = useOrganization();
+  const showProgress = organization.features.includes('issue-activity-progress');
   const timestamp = (
     <TimeSince date={activity.dateCreated} unitStyle={timestampUnitStyle} />
   );
 
   return (
     <ActivityLineRow>
-      <ActivityLineMarker item={activity} />
-      <ActivityLineActor item={activity} />
+      <ActivityLineMarker item={activity} showProgress={showProgress} />
       <ActivityLineNoteHeadline
         title={t('%s commented', getNoteAuthorName(activity))}
         timestamp={timestamp}
@@ -109,7 +110,7 @@ function ActivityLineNoteHeadline({
 }) {
   return (
     <ActivityLineNoteHeadlineLayout
-      column={3}
+      column={2}
       row={1}
       columns="minmax(0, max-content) auto"
       minWidth={0}

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/index.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/index.tsx
@@ -1,24 +1,66 @@
 import styled from '@emotion/styled';
 
+import {t} from 'sentry/locale';
 import type {GroupActivity} from 'sentry/types/group';
+import {
+  ActivityLineActor,
+  renderActivityLineActor,
+} from 'sentry/views/issueDetails/activitySection/activityLineItem/actor';
 
 import {ActivityProgressMarker} from './progressMarker';
 import {getActivityMarkerState} from './variant';
 
-export function ActivityLineMarker({item}: {item: GroupActivity}) {
+export function ActivityLineMarker({
+  item,
+  showProgress,
+}: {
+  item: GroupActivity;
+  showProgress: boolean;
+}) {
   return (
-    <MarkerCell>
-      <ActivityProgressMarker state={getActivityMarkerState(item)} />
-    </MarkerCell>
+    <LeadingCells>
+      <MarkerCell>
+        {showProgress ? (
+          <ActivityProgressMarker state={getActivityMarkerState(item)} />
+        ) : (
+          (renderActivityLineActor(item) ?? <ActivityLineDot />)
+        )}
+      </MarkerCell>
+      {showProgress ? <ActivityLineActor item={item} /> : null}
+    </LeadingCells>
   );
 }
 
-const MarkerCell = styled('div')`
+function ActivityLineDot() {
+  return <NeutralLineDot aria-label={t('Activity update')} role="img" />;
+}
+
+const LeadingCells = styled('div')`
   grid-column: 1;
   grid-row: 1;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 22px;
+  gap: ${p => p.theme.space.xs};
+
+  @container activity-list (min-width: 90px) {
+    gap: ${p => p.theme.space.sm};
+  }
+`;
+
+const MarkerCell = styled('div')`
   display: grid;
   place-items: center;
   min-width: 22px;
   min-height: 22px;
   margin-top: -2px;
+`;
+
+const NeutralLineDot = styled('span')`
+  width: 8px;
+  height: 8px;
+  border-radius: 100%;
+  background: ${p => p.theme.tokens.graphics.neutral.moderate};
+  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+  box-shadow: 0 0 0 4px ${p => p.theme.tokens.background.primary};
 `;

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/progressMarker.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/progressMarker.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip';
 
+import {ProgressState} from 'sentry/types/group';
 import {getProgressIcon} from 'sentry/views/issueList/utils/progress';
 
 import {formatActivityMarkerState, type ActivityMarkerState} from './variant';
@@ -28,6 +29,10 @@ export function ActivityProgressMarker({
         {getProgressIcon(state)}
       </ProgressIconFrame>
     );
+
+  if (state === 'activity' || state === ProgressState.FIX_APPLIED) {
+    return marker;
+  }
 
   return (
     <Tooltip title={label} {...tooltipProps} skipWrapper>

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1135,6 +1135,36 @@ describe('ActivitySection', () => {
     expect(screen.getByRole('img', {name: 'Activity update'})).toBeInTheDocument();
   });
 
+  it('shows progress markers behind activity progress', () => {
+    const activityGroup = GroupFixture({
+      id: '1339',
+      activity: [
+        {
+          type: GroupActivityType.SET_RESOLVED,
+          id: 'resolved-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {},
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} variant="standalone" size="md" />
+      </GroupDataContextProvider>,
+      {
+        organization: OrganizationFixture({
+          features: ['issue-activity-feed-v2', 'issue-activity-progress'],
+        }),
+      }
+    );
+
+    expect(screen.getByRole('img', {name: 'Fix Applied'})).toBeInTheDocument();
+    expect(screen.getByTestId('user-activity-actor')).toBeInTheDocument();
+  });
+
   it.each([
     {
       name: 'deleted attachments',


### PR DESCRIPTION
progress indicator now behind additional flag `issue-activity-progress` so we can roll out the new activities before progress is ready.

<img width="332" height="293" alt="image" src="https://github.com/user-attachments/assets/33b6d929-59c7-4566-be82-cc6a8a983240" />
