### PR TITLE
fix(auth): add debug logging

### DIFF
--- a/src/sentry/web/frontend/signup_email_verification.py
+++ b/src/sentry/web/frontend/signup_email_verification.py
@@ -15,6 +15,7 @@ from sentry.analytics.events.signup_email_verification import (
     SignupEmailVerificationClickedEvent,
 )
 from sentry.auth.email_verification import SignupLinkExpired, hash_email, verify_signup_link
+from sentry.utils.hashlib import sha256_text
 from sentry.web.frontend.base import BaseView
 
 PENDING_VERIFICATION_SESSION_KEY = "pending_signup_verification_email"
@@ -49,6 +50,14 @@ class BaseSignupVerificationView(BaseView):
                 outcome=outcome,
             )
         )
+
+    @staticmethod
+    def _session_fingerprint(request: HttpRequest) -> str:
+        # Non-secret hash of the session id, safe to log.
+        # Same browser session == same fingerprint.
+        # Empty string means the request carried no session.
+        session_key = request.session.session_key or ""
+        return sha256_text(session_key).hexdigest()[:16] if session_key else ""
 
     def _render_error(self, title: str, message: str) -> HttpResponseBase:
         context = {
@@ -94,6 +103,30 @@ class BaseSignupVerificationView(BaseView):
         email = payload["email"].lower()
         email_in_session = request.session.get(PENDING_VERIFICATION_SESSION_KEY)
         if not email_in_session or email_in_session.lower() != email:
+            # TEMP diagnostic: separates a logged-in browser re-hitting the link from a prefetch
+            # vs. an anonymous client like an email scanner.
+            logger.info(
+                "signup_verification.session_mismatch",
+                extra={
+                    "email_hash": hash_email(email),
+                    "is_authenticated": request.user.is_authenticated,
+                    "user_id": request.user.id if request.user.is_authenticated else None,
+                    "had_pending_email": bool(email_in_session),
+                    "session_fingerprint": self._session_fingerprint(request),
+                    "method": request.method,
+                    "user_agent": request.META.get("HTTP_USER_AGENT", ""),
+                    "ip_address": request.META.get("REMOTE_ADDR", ""),
+                    "forwarded_for": request.META.get("HTTP_X_FORWARDED_FOR", ""),
+                    "sec_purpose": request.headers.get("Sec-Purpose", ""),
+                    "purpose": request.headers.get("Purpose", ""),
+                    "x_purpose": request.headers.get("X-Purpose", ""),
+                    "x_moz": request.headers.get("X-Moz", ""),
+                    "sec_fetch_mode": request.headers.get("Sec-Fetch-Mode", ""),
+                    "sec_fetch_dest": request.headers.get("Sec-Fetch-Dest", ""),
+                    "sec_fetch_site": request.headers.get("Sec-Fetch-Site", ""),
+                    "sec_fetch_user": request.headers.get("Sec-Fetch-User", ""),
+                },
+            )
             self._record_clicked(request, "session_mismatch", email=email)
             return self._render_error(
                 title="Verification error",
@@ -104,7 +137,10 @@ class BaseSignupVerificationView(BaseView):
 
         logger.info(
             "signup_verification.verified",
-            extra={"email_hash": hash_email(email)},
+            extra={
+                "email_hash": hash_email(email),
+                "session_fingerprint": self._session_fingerprint(request),
+            },
         )
         self._record_clicked(request, "success", email=email)
 


### PR DESCRIPTION
My events are misfiring - every `success` has a `session_mismatch` about 10s after. Trying to figure out why and whether this is from email link scanners/prefetchers. Added a log with fields to help me investigate.

This code path is behind a feature flag and is only reachable by me, no user can trigger this accidentally so only my own data will be collected.