### PR TITLE
chore(sentry apps): silence inner value error but retry

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -75,6 +75,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     CIRCUIT_BROKEN = "circuit_broken"
     EMAIL_FAILED = "email_failed"
     APP_DISABLED = "app_disabled"
+    INNER_TIMEOUT = "inner_timeout"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -78,6 +78,7 @@ from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError,
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import sentryapp_control_tasks, sentryapp_tasks
+from sentry.taskworker.timeout import InnerTimeoutError
 from sentry.types.rules import RuleFuture
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -93,7 +94,7 @@ from sentry.utils.tracing import trace
 logger = logging.getLogger("sentry.sentry_apps.tasks.sentry_apps")
 
 
-_SENTRY_APP_WEBHOOK_RETRY_ON = (RequestException,)
+_SENTRY_APP_WEBHOOK_RETRY_ON = (RequestException, InnerTimeoutError)
 _SENTRY_APP_WEBHOOK_RETRY_IGNORE = (
     ClientError,
     SentryAppSentryError,
@@ -109,6 +110,7 @@ _SENTRY_APP_WEBHOOK_SILENCED = (
     ApiTimeoutError,
     ConnectionError,
     HTTPError,
+    InnerTimeoutError,
     # Anything not retriable should be silenced by default
     *_SENTRY_APP_WEBHOOK_RETRY_IGNORE,
 )

--- a/src/sentry/taskworker/timeout.py
+++ b/src/sentry/taskworker/timeout.py
@@ -4,6 +4,10 @@ from types import FrameType
 from typing import Callable, Generator
 
 
+class InnerTimeoutError(Exception):
+    pass
+
+
 @contextlib.contextmanager
 def timeout_alarm(
     seconds: float, handler: Callable[[int, FrameType | None], None]
@@ -30,7 +34,7 @@ def timeout_alarm(
         # Undo: restore original outer timer and handler before raising
         signal.setitimer(signal.ITIMER_REAL, previous_remaining)
         signal.signal(signal.SIGALRM, original_handler)
-        raise ValueError(
+        raise InnerTimeoutError(
             f"Inner timeout ({seconds}s) must be less than outer alarm remaining ({previous_remaining}s)"
         )
     try:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -40,7 +40,7 @@ from sentry.sentry_apps.services.app.service import app_service
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.silo.base import SiloMode
-from sentry.taskworker.timeout import timeout_alarm
+from sentry.taskworker.timeout import InnerTimeoutError, timeout_alarm
 from sentry.utils import metrics, redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
 from sentry.utils.http import absolute_uri
@@ -343,7 +343,12 @@ def send_and_save_webhook_request(
                 halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.RESTRICTED_IP}"
             )
             raise
-
+        except InnerTimeoutError:
+            # This means we didn't even start the request since the prev. steps took too long
+            lifecycle.record_halt(
+                halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.INNER_TIMEOUT}"
+            )
+            raise
         track_response_code(response.status_code, slug, event)
 
         project_id = (

--- a/tests/sentry/taskworker/test_timeout.py
+++ b/tests/sentry/taskworker/test_timeout.py
@@ -8,7 +8,7 @@ from types import FrameType
 
 import pytest
 
-from sentry.taskworker.timeout import timeout_alarm
+from sentry.taskworker.timeout import InnerTimeoutError, timeout_alarm
 
 
 class AlarmFired(Exception):
@@ -67,7 +67,7 @@ class TestTimeoutAlarm:
         assert called == [signal.SIGALRM]
 
     def test_raises_if_inner_geq_outer(self) -> None:
-        """Raises ValueError when inner timeout >= outer remaining, fully restores outer timer and handler."""
+        """Raises InnerTimeoutError when inner timeout >= outer remaining, fully restores outer timer and handler."""
         outer_called = []
 
         def outer_handler(signum: int, frame: FrameType | None) -> None:
@@ -76,13 +76,15 @@ class TestTimeoutAlarm:
         signal.signal(signal.SIGALRM, outer_handler)
         signal.setitimer(signal.ITIMER_REAL, 10)
 
-        with pytest.raises(ValueError, match="Inner timeout.*must be less than.*outer alarm"):
+        with pytest.raises(
+            InnerTimeoutError, match="Inner timeout.*must be less than.*outer alarm"
+        ):
             with timeout_alarm(10, self.noop):
                 pass
 
         # Outer timer must still be active
         remaining, _ = signal.getitimer(signal.ITIMER_REAL)
-        assert remaining > 0, "Outer timer should have been restored after ValueError"
+        assert remaining > 0, "Outer timer should have been restored after InnerTimeoutError"
 
         # Outer handler must be restored
         assert signal.getsignal(signal.SIGALRM) is outer_handler


### PR DESCRIPTION
As I mentioned in [ISWF-2935](https://linear.app/getsentry/issue/ISWF-2935/valueerror-inner-timeout-50s-must-be-less-than-outer-alarm-remaining) make a distinct error for inner value timeouts and silence those