### PR TITLE
fix(issues): Restore sidebar comment actions in activity v2

### DIFF
--- a/static/app/views/issueDetails/activitySection/activityLineItem/note.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/note.tsx
@@ -60,7 +60,6 @@ export function ActivityLineNote({
         timestamp={timestamp}
         variant={inputVariant}
         actions={
-          inputVariant === 'full' &&
           !editing && (
             <CommentActionsDropdown
               onDelete={onDelete}
@@ -111,11 +110,12 @@ function ActivityLineNoteHeadline({
     <ActivityLineNoteHeadlineLayout
       column={3}
       row={1}
-      columns="minmax(0, max-content) auto"
+      columns={variant === 'compact' ? 'minmax(0, 1fr)' : 'minmax(0, max-content) auto'}
       minWidth={0}
       minHeight="22px"
       align="center"
       gap="xs"
+      data-compact={variant === 'compact' ? true : undefined}
     >
       <ActivityLineNoteSentence data-compact={variant === 'compact' ? true : undefined}>
         <ActivityLineNoteTitle
@@ -135,14 +135,23 @@ function ActivityLineNoteHeadline({
           </Text>
         </ActivityLineNoteMeta>
       </ActivityLineNoteSentence>
-      {actions ? <ActivityLineNoteActions>{actions}</ActivityLineNoteActions> : null}
+      {actions ? (
+        <ActivityLineNoteActions data-compact={variant === 'compact' ? true : undefined}>
+          {actions}
+        </ActivityLineNoteActions>
+      ) : null}
     </ActivityLineNoteHeadlineLayout>
   );
 }
 
 const ActivityLineNoteHeadlineLayout = styled(Grid)`
+  position: relative;
   justify-self: start;
   max-width: 100%;
+
+  &[data-compact='true'] {
+    justify-self: stretch;
+  }
 `;
 
 const ActivityLineNoteSentence = styled('span')`
@@ -155,6 +164,7 @@ const ActivityLineNoteSentence = styled('span')`
     overflow: hidden;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+    padding-right: ${p => p.theme.space.xl};
   }
 `;
 
@@ -172,6 +182,12 @@ const ActivityLineNoteMeta = styled('span')`
 const ActivityLineNoteActions = styled('span')`
   display: inline-grid;
   place-items: center;
+
+  &[data-compact='true'] {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
 `;
 
 const ActivityNoteBubble = styled('div')`

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -306,9 +306,7 @@ describe('ActivitySection', () => {
     expect(await screen.findByText('User note')).toBeInTheDocument();
     expect(screen.getByText(`${user.name} commented`)).toBeInTheDocument();
     expect(screen.getByTestId('user-activity-actor')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {name: 'Comment Actions'})
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Comment Actions'})).toBeInTheDocument();
   });
 
   it('renders provider-specific icon for create issue in activity line items', async () => {
@@ -687,7 +685,7 @@ describe('ActivitySection', () => {
 
     render(
       <GroupDataContextProvider group={editGroup} project={editGroup.project}>
-        <ActivitySection group={editGroup} variant="standalone" size="md" />
+        <ActivitySection group={editGroup} />
       </GroupDataContextProvider>,
       {
         organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
@@ -709,14 +707,14 @@ describe('ActivitySection', () => {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Edit'}));
 
     await userEvent.type(screen.getByDisplayValue('Group Test'), ' Updated');
-    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Save comment'}));
 
     await waitFor(() => expect(editMock).toHaveBeenCalledTimes(1));
     expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Comment updated');
 
     // Editor closes only after the update succeeds.
     await waitFor(() =>
-      expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', {name: 'Save comment'})).not.toBeInTheDocument()
     );
   });
 


### PR DESCRIPTION
brings the three-dot comment menu back to activity-v2 sidebar notes and pins it to the top-right so it does not squeeze the headline.

<img width="349" height="218" alt="image" src="https://github.com/user-attachments/assets/4d95de8d-e345-4cd3-a512-3af7e83a30a1" />
