### PR TITLE
ref(seer-infra-telemetry): Refactor schema used for typing of monitoring provider connections

### DIFF
--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -34,7 +34,7 @@ from sentry.seer.agent.monitoring_providers import (
     OrgMonitoringProvider,
     org_monitoring_provider_registry,
 )
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import GcpSaImpersonationConnectionData
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
 logger = logging.getLogger(__name__)
@@ -217,7 +217,7 @@ class GcpOrgMonitoringProvider(OrgMonitoringProvider):
 
     def build_connection(
         self, organization: Organization
-    ) -> list[MonitoringProviderConnectionData] | None:
+    ) -> list[GcpSaImpersonationConnectionData] | None:
         ctx = integration_service.organization_context(
             organization_id=organization.id, provider=self.provider_key
         )
@@ -233,6 +233,9 @@ class GcpOrgMonitoringProvider(OrgMonitoringProvider):
 
         config = org_integration.config
         projects: list[str] = config.get("projects", [])
+        sentry_sa_email: str | None = config.get("sentry_sa_email")
+        customer_sa_email: str | None = config.get("customer_sa_email")
+
         if not projects:
             logger.error(
                 "seer.monitoring_providers.gcp_integration_no_projects",
@@ -243,12 +246,22 @@ class GcpOrgMonitoringProvider(OrgMonitoringProvider):
             )
             return None
 
+        if not sentry_sa_email or not customer_sa_email:
+            logger.error(
+                "seer.monitoring_providers.gcp_integration_missing_sa_emails",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                },
+            )
+            return None
+
         return [
-            MonitoringProviderConnectionData(
+            GcpSaImpersonationConnectionData(
                 provider_key=self.provider_key,
                 url=url,
-                auth_method="gcp_adc",
-                refreshable=False,
+                sentry_sa_email=sentry_sa_email,
+                customer_sa_email=customer_sa_email,
                 gcp_project_ids=projects,
             )
             for url in GCP_MCP_URLS

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -12,7 +12,10 @@ from sentry.identity.services.identity import identity_service
 from sentry.integrations.gcp.utils import GCP_MCP_URLS
 from sentry.integrations.types import MONITORING_PROVIDERS
 from sentry.models.organization import Organization
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import (
+    HeaderAuthConnectionData,
+    MonitoringProviderConnectionData,
+)
 from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.utils.registry import Registry
 
@@ -125,7 +128,7 @@ def _get_personal_monitoring_connections(
             auth_method = "oauth" if is_oauth_provider else "pat"
             for url in urls:
                 connections.append(
-                    MonitoringProviderConnectionData(
+                    HeaderAuthConnectionData(
                         provider_key=provider_type,
                         url=url,
                         encrypted_auth_headers={"Authorization": encrypted_auth_header},
@@ -143,9 +146,9 @@ def _get_personal_monitoring_connections(
 _SENTRY_ORG_GCP_PROJECT_IDS = ["internal-sentry"]
 
 
-def _get_gcp_connections_for_sentry_org() -> list[MonitoringProviderConnectionData]:
+def _get_gcp_connections_for_sentry_org() -> list[HeaderAuthConnectionData]:
     return [
-        MonitoringProviderConnectionData(
+        HeaderAuthConnectionData(
             provider_key="gcp",
             url=url,
             auth_method="gcp_adc",

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -5,7 +5,7 @@ These should be kept in sync with the models in Seer.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -856,7 +856,10 @@ class ExecuteTimeseriesQueryErrorResponse(BaseModel):
         return id(self)
 
 
-class MonitoringProviderConnectionData(BaseModel):
+class HeaderAuthConnectionData(BaseModel):
+    """Connection authenticated via encrypted HTTP headers (API key, PAT, OAuth)."""
+
+    type: Literal["header_auth"] = "header_auth"
     provider_key: str
     url: str
     encrypted_auth_headers: dict[str, str] | None = None
@@ -867,6 +870,33 @@ class MonitoringProviderConnectionData(BaseModel):
 
     def __getitem__(self, key: str) -> Any:
         return self.dict()[key]
+
+
+class GcpSaImpersonationConnectionData(BaseModel):
+    """
+    Connection authenticated via GCP two-hop SA impersonation chain.
+
+    Seer uses ``sentry_sa_email`` and ``customer_sa_email`` to construct
+    ``GcpMcpCredentials`` for the ADC -> per-customer SA -> customer SA chain.
+    """
+
+    type: Literal["gcp_sa_impersonation"] = "gcp_sa_impersonation"
+    provider_key: str
+    url: str
+    sentry_sa_email: str
+    customer_sa_email: str
+    auth_method: Literal["gcp_sa_impersonation"] = "gcp_sa_impersonation"
+    refreshable: bool = False
+    gcp_project_ids: list[str] | None = None
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+
+MonitoringProviderConnectionData = Annotated[
+    Union[HeaderAuthConnectionData, GcpSaImpersonationConnectionData],
+    Field(discriminator="type"),
+]
 
 
 class MonitoringProviderConnectionsResponse(BaseModel):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -22,7 +22,7 @@ from sentry.seer.agent.client_models import (
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import HeaderAuthConnectionData
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options, with_feature
 from sentry.testutils.requests import make_request
@@ -445,7 +445,7 @@ class TestSeerAgentClient(TestCase):
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response(run_id=1)
         mock_conns.return_value = [
-            MonitoringProviderConnectionData(
+            HeaderAuthConnectionData(
                 provider_key="datadog",
                 url="https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
                 encrypted_auth_headers={"DD-API-KEY": "x", "DD-APPLICATION-KEY": "y"},

--- a/tests/sentry/seer/agent/test_monitoring_providers.py
+++ b/tests/sentry/seer/agent/test_monitoring_providers.py
@@ -472,11 +472,14 @@ class TestGetMonitoringProviderConnections(TestCase):
             "https://cloudtrace.googleapis.com/mcp",
         }
         for conn in result:
-            assert conn["auth_method"] == "gcp_adc"
+            assert conn["type"] == "gcp_sa_impersonation"
+            assert conn["auth_method"] == "gcp_sa_impersonation"
             assert conn["refreshable"] is False
             assert conn["gcp_project_ids"] == ["my-project-prod", "my-project-staging"]
-            assert conn["identity_id"] is None
-            assert conn["encrypted_auth_headers"] is None
+            assert (
+                conn["sentry_sa_email"] == "sentry-org-1@sentry-connectors.iam.gserviceaccount.com"
+            )
+            assert conn["customer_sa_email"] == "gcp-sentry@my-project.iam.gserviceaccount.com"
 
     def test_org_gcp_connection_ignores_non_active_integration(self) -> None:
         self._create_org_gcp_integration(status=ObjectStatus.DISABLED)
@@ -505,11 +508,27 @@ class TestGetMonitoringProviderConnections(TestCase):
         result = get_monitoring_provider_connections(self.organization, self.user.id)
         assert result == []
 
+    def test_org_gcp_connection_skips_missing_sa_emails(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="gcp",
+            external_id=str(self.organization.id),
+            name="Google Cloud Platform",
+            metadata={},
+            oi_params={
+                "config": {
+                    "projects": ["my-project-prod"],
+                }
+            },
+        )
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+        assert result == []
+
     def test_org_gcp_connection_for_no_user_run(self) -> None:
         self._create_org_gcp_integration()
         result = get_monitoring_provider_connections(self.organization, None)
         assert len(result) == 3
-        assert all(c["auth_method"] == "gcp_adc" for c in result)
+        assert all(c["auth_method"] == "gcp_sa_impersonation" for c in result)
 
     def test_org_gcp_and_datadog_together(self) -> None:
         self._create_org_gcp_integration()


### PR DESCRIPTION
Resolves [CW-1692](https://linear.app/getsentry/issue/CW-1692/schema-update-sentry-side-wiring-for-gcp-sa-based-connections).

Introduces a `type` discriminator on `MonitoringProviderConnectionData` via a Pydantic discriminated union, splitting it into `HeaderAuthConnectionData` (which works for most use cases across API keys/PAT/OAuth) and `GcpSaImpersonationConnectionData` (which is specific to Google authentication via service account impersonation).

The Datadog `build_connection` implementation is updated to use `HeaderAuthConnectionData`. The GCP `build_connection` implementation is updated to populate the service account emails on the connection data we send to Seer (needed to perform authentication via impersonation on the Seer side of things).

https://app.notion.com/p/sentry/GCP-MCP-Org-Level-Integration-39f8b10e4b5d8030ba01cd62373641df