### PR TITLE
feat(seer): Add global option to enable night shift for legacy Seer orgs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1228,6 +1228,12 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "seer.night_shift.enable_for_legacy_orgs",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "seer.night_shift.issues_per_org",
     default=10,
     flags=FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -25,7 +25,11 @@ from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
 )
-from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
+from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
+    bulk_read_preferences_from_sentry_db,
+    is_seer_seat_based_tier_enabled,
+)
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
@@ -65,11 +69,6 @@ NIGHT_SHIFT_SPREAD_DURATION = timedelta(hours=1)
 BATCH_FEATURE_NAMES = [
     "organizations:seer-night-shift",
     "organizations:gen-ai-features",
-]
-PER_ORG_FEATURE_NAMES = [
-    # INTERNAL handlers aren't routed through batch_has_for_organizations,
-    # so this gets checked per-org on the survivors of the batch loop.
-    "organizations:seat-based-seer-enabled",
 ]
 
 
@@ -421,10 +420,10 @@ def _get_eligible_orgs_from_batch(
         if not eligible:
             return []
 
-    for feature_name in PER_ORG_FEATURE_NAMES:
-        eligible = [org for org in eligible if features.has(feature_name, org)]
-        if not eligible:
-            return []
+    # Skip the per-org tier lookup entirely once legacy orgs are enabled, rather
+    # than OR'ing it into the filter per org.
+    if not options.get("seer.night_shift.enable_for_legacy_orgs"):
+        eligible = [org for org in eligible if is_seer_seat_based_tier_enabled(org)]
 
     return eligible
 

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -420,12 +420,10 @@ def _get_eligible_orgs_from_batch(
         if not eligible:
             return []
 
-    # Skip the per-org tier lookup entirely once legacy orgs are enabled, rather
-    # than OR'ing it into the filter per org.
-    if not options.get("seer.night_shift.enable_for_legacy_orgs"):
-        eligible = [org for org in eligible if is_seer_seat_based_tier_enabled(org)]
+    if options.get("seer.night_shift.enable_for_legacy_orgs"):
+        return eligible
 
-    return eligible
+    return [org for org in eligible if is_seer_seat_based_tier_enabled(org)]
 
 
 def _record_run_error(run: SeerNightShiftRun, message: str) -> None:

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -25,11 +25,7 @@ from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
 )
-from sentry.seer.autofix.utils import (
-    AutofixStoppingPoint,
-    bulk_read_preferences_from_sentry_db,
-    is_seer_seat_based_tier_enabled,
-)
+from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
@@ -69,6 +65,11 @@ NIGHT_SHIFT_SPREAD_DURATION = timedelta(hours=1)
 BATCH_FEATURE_NAMES = [
     "organizations:seer-night-shift",
     "organizations:gen-ai-features",
+]
+PER_ORG_FEATURE_NAMES = [
+    # INTERNAL handlers aren't routed through batch_has_for_organizations,
+    # so this gets checked per-org on the survivors of the batch loop.
+    "organizations:seat-based-seer-enabled",
 ]
 
 
@@ -423,7 +424,12 @@ def _get_eligible_orgs_from_batch(
     if options.get("seer.night_shift.enable_for_legacy_orgs"):
         return eligible
 
-    return [org for org in eligible if is_seer_seat_based_tier_enabled(org)]
+    for feature_name in PER_ORG_FEATURE_NAMES:
+        eligible = [org for org in eligible if features.has(feature_name, org)]
+        if not eligible:
+            return []
+
+    return eligible
 
 
 def _record_run_error(run: SeerNightShiftRun, message: str) -> None:

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -212,7 +212,12 @@ class TestScheduleNightShift(TestCase):
         org = self.create_org_with_seer()
 
         with (
-            self.options({"seer.night_shift.enable": True}),
+            self.options(
+                {
+                    "seer.night_shift.enable": True,
+                    "seer.night_shift.enable_for_legacy_orgs": False,
+                }
+            ),
             self.feature(
                 {
                     "organizations:seer-night-shift": [org.slug],
@@ -224,6 +229,29 @@ class TestScheduleNightShift(TestCase):
         ):
             schedule_night_shift()
             mock_worker.apply_async.assert_not_called()
+
+    def test_dispatches_legacy_orgs_when_enabled(self) -> None:
+        org = self.create_org_with_seer()
+
+        with (
+            self.options(
+                {
+                    "seer.night_shift.enable": True,
+                    "seer.night_shift.enable_for_legacy_orgs": True,
+                }
+            ),
+            self.feature(
+                {
+                    "organizations:seer-night-shift": [org.slug],
+                    "organizations:gen-ai-features": [org.slug],
+                    # seat-based-seer-enabled intentionally omitted
+                }
+            ),
+            patch("sentry.tasks.seer.night_shift.cron.run_night_shift_for_org") as mock_worker,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_called_once()
+            assert mock_worker.apply_async.call_args.kwargs["args"] == [org.id]
 
     def test_skips_orgs_with_hidden_ai(self) -> None:
         org = self.create_org_with_seer()


### PR DESCRIPTION
Night shift scheduling has been gated to seat-based-tier orgs via `organizations:seat-based-seer-enabled`. This adds `seer.night_shift.enable_for_legacy_orgs`, a single global option, so legacy (non-seat-based) orgs can be opened up to night shift without per-org enrollment: when off, behavior is unchanged; when on, the seat-based check is skipped and all otherwise-eligible orgs are scheduled.