### PR TITLE
feat(action log): Use GALE in group notes endpoints

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -332,6 +332,8 @@ class CommentAction(GroupAction):
 class CommentEditAction(GroupAction):
     user_visible = True
     comment_id: int
+    text: Optional[str] = None
+    mentions: Optional[list[SentryActorRef]] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -62,7 +62,7 @@ class GroupNotesEndpoint(GroupEndpoint):
         if features.has("projects:issue-action-log-activity", group.project, actor=request.user):
             edit_entries = GroupActionLogEntry.objects.filter(
                 group_id=group.id, type=GroupActionType.COMMENT_EDIT.value
-            ).order_by("-date_added")
+            ).order_by("-date_added", "id")
 
             # A COMMENT_EDIT points at the GALE id of the original COMMENT it
             # supersedes; entries are newest-first, so keep the latest edit's

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -69,9 +69,19 @@ class GroupNotesEndpoint(GroupEndpoint):
                         original_comment_id, edit.data.get("text")
                     )
 
+            # A COMMENT_DELETE points at the GALE id of the COMMENT it removes;
+            # GALE is append-only, so exclude those so deleted notes drop out.
+            deleted_comment_ids = {
+                comment_id
+                for entry in GroupActionLogEntry.objects.filter(
+                    group_id=group.id, type=GroupActionType.COMMENT_DELETE.value
+                )
+                if (comment_id := entry.data.get("comment_id")) is not None
+            }
+
             entries = GroupActionLogEntry.objects.filter(
                 group_id=group.id, type=GroupActionType.COMMENT.value
-            )
+            ).exclude(id__in=deleted_comment_ids)
 
             def serialize_with_edits(comment_entries: list[GroupActionLogEntry]) -> list[object]:
                 # An edit doesn't mutate the original COMMENT entry, so re-derive
@@ -82,7 +92,14 @@ class GroupNotesEndpoint(GroupEndpoint):
                             **entry.data,
                             "text": latest_edit_text_by_comment[entry.id],
                         }
-                return serialize(comment_entries, request.user)
+                serialized = serialize(comment_entries, request.user)
+                # Return the Activity id (in comment_id) as `id`, matching the
+                # flag-off contract so clients can still edit/delete via note_id.
+                for entry, item in zip(comment_entries, serialized):
+                    comment_id = entry.data.get("comment_id")
+                    if comment_id is not None:
+                        item["id"] = str(comment_id)
+                return serialized
 
             return self.paginate(
                 request=request,
@@ -180,7 +197,11 @@ class GroupNotesEndpoint(GroupEndpoint):
                 idempotency_key=activity_action_idempotency_key(activity),
             ).first()
             if entry:
-                return Response(serialize(entry, request.user), status=201)
+                serialized = serialize(entry, request.user)
+                # Return the Activity id as `id`, matching the flag-off contract
+                # so clients can edit/delete via note_id.
+                serialized["id"] = str(activity.id)
+                return Response(serialized, status=201)
             logger.info("group_notes.groupactionlogentry.not_found", extra={"group_id": group.id})
 
         return Response(serialize(activity, request.user), status=201)

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -19,7 +19,13 @@ from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import action_context_scope, resolve_action_source
-from sentry.issues.action_log.types import GroupActionActor, GroupActionType
+from sentry.issues.action_log.types import (
+    CommentAction,
+    CommentDeleteAction,
+    CommentEditAction,
+    GroupActionActor,
+    GroupActionType,
+)
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
@@ -63,20 +69,18 @@ class GroupNotesEndpoint(GroupEndpoint):
             # text per comment.
             latest_edit_text_by_comment: dict[int, str | None] = {}
             for edit in edit_entries:
-                original_comment_id = edit.data.get("comment_id")
-                if original_comment_id is not None:
-                    latest_edit_text_by_comment.setdefault(
-                        original_comment_id, edit.data.get("text")
-                    )
+                action = edit.action
+                if isinstance(action, CommentEditAction):
+                    latest_edit_text_by_comment.setdefault(action.comment_id, action.text)
 
             # A COMMENT_DELETE points at the GALE id of the COMMENT it removes;
             # GALE is append-only, so exclude those so deleted notes drop out.
             deleted_comment_ids = {
-                comment_id
+                action.comment_id
                 for entry in GroupActionLogEntry.objects.filter(
                     group_id=group.id, type=GroupActionType.COMMENT_DELETE.value
                 )
-                if (comment_id := entry.data.get("comment_id")) is not None
+                if isinstance(action := entry.action, CommentDeleteAction)
             }
 
             entries = GroupActionLogEntry.objects.filter(
@@ -96,9 +100,9 @@ class GroupNotesEndpoint(GroupEndpoint):
                 # Return the Activity id (in comment_id) as `id`, matching the
                 # flag-off contract so clients can still edit/delete via note_id.
                 for entry, item in zip(comment_entries, serialized):
-                    comment_id = entry.data.get("comment_id")
-                    if comment_id is not None:
-                        item["id"] = str(comment_id)
+                    action = entry.action
+                    if isinstance(action, CommentAction):
+                        item["id"] = str(action.comment_id)
                 return serialized
 
             return self.paginate(

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -93,7 +93,7 @@ class GroupNotesEndpoint(GroupEndpoint):
                 for entry in comment_entries:
                     if entry.id in latest_edit_text_by_comment:
                         entry.data = {
-                            **entry.data,
+                            **(entry.data or {}),
                             "text": latest_edit_text_by_comment[entry.id],
                         }
                 serialized = serialize(comment_entries, request.user)

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -54,15 +54,42 @@ class GroupNotesEndpoint(GroupEndpoint):
     )
     def get(self, request: Request, group: Group) -> Response:
         if features.has("projects:issue-action-log-activity", group.project, actor=request.user):
+            edit_entries = GroupActionLogEntry.objects.filter(
+                group_id=group.id, type=GroupActionType.COMMENT_EDIT.value
+            ).order_by("-date_added")
+
+            # A COMMENT_EDIT points at the GALE id of the original COMMENT it
+            # supersedes; entries are newest-first, so keep the latest edit's
+            # text per comment.
+            latest_edit_text_by_comment: dict[int, str | None] = {}
+            for edit in edit_entries:
+                original_comment_id = edit.data.get("comment_id")
+                if original_comment_id is not None:
+                    latest_edit_text_by_comment.setdefault(
+                        original_comment_id, edit.data.get("text")
+                    )
+
             entries = GroupActionLogEntry.objects.filter(
                 group_id=group.id, type=GroupActionType.COMMENT.value
             )
+
+            def serialize_with_edits(comment_entries: list[GroupActionLogEntry]) -> list[object]:
+                # An edit doesn't mutate the original COMMENT entry, so re-derive
+                # the current text from the latest COMMENT_EDIT before serializing.
+                for entry in comment_entries:
+                    if entry.id in latest_edit_text_by_comment:
+                        entry.data = {
+                            **entry.data,
+                            "text": latest_edit_text_by_comment[entry.id],
+                        }
+                return serialize(comment_entries, request.user)
+
             return self.paginate(
                 request=request,
                 queryset=entries,
                 paginator_cls=DateTimePaginator,
                 order_by="-date_added",
-                on_results=lambda x: serialize(x, request.user),
+                on_results=serialize_with_edits,
             )
 
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -62,7 +62,7 @@ class GroupNotesEndpoint(GroupEndpoint):
         if features.has("projects:issue-action-log-activity", group.project, actor=request.user):
             edit_entries = GroupActionLogEntry.objects.filter(
                 group_id=group.id, type=GroupActionType.COMMENT_EDIT.value
-            ).order_by("-date_added", "id")
+            ).order_by("-date_added", "-id")
 
             # A COMMENT_EDIT points at the GALE id of the original COMMENT it
             # supersedes; entries are newest-first, so keep the latest edit's

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -53,7 +53,7 @@ class GroupNotesEndpoint(GroupEndpoint):
         url_names=["sentry-api-0-group-notes"],
     )
     def get(self, request: Request, group: Group) -> Response:
-        if features.has("projects:issue-action-log-write-to-db", group.project, actor=request.user):
+        if features.has("projects:issue-action-log-activity", group.project, actor=request.user):
             entries = GroupActionLogEntry.objects.filter(
                 group_id=group.id, type=GroupActionType.COMMENT.value
             )
@@ -147,7 +147,7 @@ class GroupNotesEndpoint(GroupEndpoint):
             sender="post",
         )
 
-        if features.has("projects:issue-action-log-write-to-db", group.project, actor=request.user):
+        if features.has("projects:issue-action-log-activity", group.project, actor=request.user):
             entry = GroupActionLogEntry.objects.filter(
                 group_id=group.id,
                 idempotency_key=activity_action_idempotency_key(activity),

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 
 from django.utils import timezone
@@ -7,6 +8,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
@@ -17,14 +19,18 @@ from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import action_context_scope, resolve_action_source
-from sentry.issues.action_log.types import GroupActionActor
+from sentry.issues.action_log.types import GroupActionActor, GroupActionType
 from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import comment_created
 from sentry.types.activity import ActivityType
+from sentry.utils.action_log.activity_translator import activity_action_idempotency_key
+
+logger = logging.getLogger(__name__)
 
 
 @cell_silo_endpoint
@@ -47,6 +53,18 @@ class GroupNotesEndpoint(GroupEndpoint):
         url_names=["sentry-api-0-group-notes"],
     )
     def get(self, request: Request, group: Group) -> Response:
+        if features.has("projects:issue-action-log-write-to-db", group.project, actor=request.user):
+            entries = GroupActionLogEntry.objects.filter(
+                group_id=group.id, type=GroupActionType.COMMENT.value
+            )
+            return self.paginate(
+                request=request,
+                queryset=entries,
+                paginator_cls=DateTimePaginator,
+                order_by="-date_added",
+                on_results=lambda x: serialize(x, request.user),
+            )
+
         notes = Activity.objects.filter(group=group, type=ActivityType.NOTE.value)
 
         return self.paginate(
@@ -128,4 +146,14 @@ class GroupNotesEndpoint(GroupEndpoint):
             data=webhook_data,
             sender="post",
         )
+
+        if features.has("projects:issue-action-log-write-to-db", group.project, actor=request.user):
+            entry = GroupActionLogEntry.objects.filter(
+                group_id=group.id,
+                idempotency_key=activity_action_idempotency_key(activity),
+            ).first()
+            if entry:
+                return Response(serialize(entry, request.user), status=201)
+            logger.info("group_notes.groupactionlogentry.not_found", extra={"group_id": group.id})
+
         return Response(serialize(activity, request.user), status=201)

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -169,7 +169,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             )
 
             if features.has(
-                "projects:issue-action-log-write-to-db", group.project, actor=request.user
+                "projects:issue-action-log-activity", group.project, actor=request.user
             ):
                 entry = GroupActionLogEntry.objects.filter(
                     group_id=group.id,

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -1,9 +1,12 @@
+import logging
+
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -22,12 +25,16 @@ from sentry.issues.action_log import (
 )
 from sentry.issues.action_log.types import CommentDeleteAction, CommentEditAction
 from sentry.issues.endpoints.bases.group import GroupEndpoint
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import comment_deleted, comment_updated
 from sentry.types.activity import ActivityType
+from sentry.utils.action_log.activity_translator import activity_action_idempotency_key
+
+logger = logging.getLogger(__name__)
 
 
 @cell_silo_endpoint
@@ -160,6 +167,24 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
                 data=webhook_data,
                 sender="put",
             )
+
+            if features.has(
+                "projects:issue-action-log-write-to-db", group.project, actor=request.user
+            ):
+                entry = GroupActionLogEntry.objects.filter(
+                    group_id=group.id,
+                    idempotency_key=activity_action_idempotency_key(note),
+                ).first()
+                if entry:
+                    # Editing a note doesn't update its COMMENT entry (an edit only
+                    # appends a separate COMMENT_EDIT entry), so re-derive the fresh
+                    # text from the activity we just saved.
+                    entry.data = {**entry.data, "text": note.data.get("text")}
+                    return Response(serialize(entry, request.user), status=200)
+                logger.info(
+                    "group_notes.groupactionlogentry.not_found", extra={"group_id": group.id}
+                )
+
             return Response(serialize(note, request.user), status=200)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -71,10 +71,19 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             raise ResourceDoesNotExist
         note = user_note[0]
 
+        # The Activity lookups above are what signal whether the note exists.
+        # When the write flag is on every note is mirrored to a GALE, so a missing
+        # entry means it's already gone -> 404 rather than deleting nothing and
+        # returning 204. With the write flag off the GALE is never written, so we
+        # fall through and rely on the Activity alone.
         original_comment_log_action = GroupActionLogEntry.objects.filter(
             group_id=group.id,
             idempotency_key=activity_action_idempotency_key(note),
         ).first()
+        if original_comment_log_action is None and features.has(
+            "projects:issue-action-log-write-to-db", group.project, actor=request.user
+        ):
+            raise ResourceDoesNotExist
 
         webhook_data = {
             "comment_id": note.id,
@@ -146,14 +155,23 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             # Remove mentions as they shouldn't go into the database
             mentions = [mention.dict() for mention in payload.pop("mentions", [])]
 
-            # Would be nice to have a last_modified timestamp we could bump here
-            note.data.update(dict(payload))
-            note.save()
-
+            # The Activity fetched above is what signals whether the note exists.
+            # When the write flag is on every note is mirrored to a GALE, so a
+            # missing entry means it's already gone -> 404 rather than editing the
+            # Activity and returning 200. With the write flag off the GALE is never
+            # written, so we fall through and rely on the Activity alone.
             original_comment_log_action = GroupActionLogEntry.objects.filter(
                 group_id=group.id,
                 idempotency_key=activity_action_idempotency_key(note),
             ).first()
+            if original_comment_log_action is None and features.has(
+                "projects:issue-action-log-write-to-db", group.project, actor=request.user
+            ):
+                raise ResourceDoesNotExist
+
+            # Would be nice to have a last_modified timestamp we could bump here
+            note.data.update(dict(payload))
+            note.save()
 
             if original_comment_log_action is not None:
                 publish_action(
@@ -195,11 +213,12 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             ):
                 if original_comment_log_action is not None:
                     # editing a note doesn't update its COMMENT entry (instead it
-                    # appends a separate COMMENT_EDIT entry), so re-derive the fresh
-                    # text from the activity we just saved
+                    # appends a separate COMMENT_EDIT entry), so patch in the fresh
+                    # text we just published to GALE; the Activity is used only for
+                    # the id below.
                     original_comment_log_action.data = {
                         **original_comment_log_action.data,
-                        "text": note.data.get("text"),
+                        "text": payload.get("text"),
                     }
                     serialized = serialize(original_comment_log_action, request.user)
                     # Return the Activity id as `id`, matching the flag-off

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -159,7 +159,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
                 publish_action(
                     CommentEditAction(
                         comment_id=original_comment_log_action.id,
-                        text=payload.data.get("text"),
+                        text=payload.get("text"),
                         mentions=mentions,
                     ),
                     source=resolve_action_source(request),

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -159,7 +159,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
                 publish_action(
                     CommentEditAction(
                         comment_id=original_comment_log_action.id,
-                        text=note.data.get("text"),
+                        text=payload.data.get("text"),
                         mentions=mentions,
                     ),
                     source=resolve_action_source(request),

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -71,6 +71,11 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             raise ResourceDoesNotExist
         note = user_note[0]
 
+        original_comment_log_action = GroupActionLogEntry.objects.filter(
+            group_id=group.id,
+            idempotency_key=activity_action_idempotency_key(note),
+        ).first()
+
         webhook_data = {
             "comment_id": note.id,
             "timestamp": note.datetime,
@@ -80,13 +85,16 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
 
         note.delete()
 
-        publish_action(
-            CommentDeleteAction(comment_id=note_id_int),
-            source=resolve_action_source(request),
-            group_id=group.id,
-            project=group.project,
-            actor=GroupActionActor.user(request.user.id),
-        )
+        if original_comment_log_action is not None:
+            publish_action(
+                CommentDeleteAction(comment_id=original_comment_log_action.id),
+                source=resolve_action_source(request),
+                group_id=group.id,
+                project=group.project,
+                actor=GroupActionActor.user(request.user.id),
+            )
+        else:
+            logger.info("group_notes.groupactionlogentry.not_found", extra={"group_id": group.id})
 
         comment_deleted.send_robust(
             project=group.project,

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -201,9 +201,11 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
                         **original_comment_log_action.data,
                         "text": note.data.get("text"),
                     }
-                    return Response(
-                        serialize(original_comment_log_action, request.user), status=200
-                    )
+                    serialized = serialize(original_comment_log_action, request.user)
+                    # Return the Activity id as `id`, matching the flag-off
+                    # contract so clients can edit/delete via note_id.
+                    serialized["id"] = str(note.id)
+                    return Response(serialized, status=200)
 
             return Response(serialize(note, request.user), status=200)
 

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -136,19 +136,33 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             payload = serializer.validated_data
             # TODO: adding mentions to a note doesn't send notifications. Should it?
             # Remove mentions as they shouldn't go into the database
-            payload.pop("mentions", [])
+            mentions = [mention.dict() for mention in payload.pop("mentions", [])]
 
             # Would be nice to have a last_modified timestamp we could bump here
             note.data.update(dict(payload))
             note.save()
 
-            publish_action(
-                CommentEditAction(comment_id=note.id),
-                source=resolve_action_source(request),
+            original_comment_log_action = GroupActionLogEntry.objects.filter(
                 group_id=group.id,
-                project=group.project,
-                actor=GroupActionActor.user(request.user.id),
-            )
+                idempotency_key=activity_action_idempotency_key(note),
+            ).first()
+
+            if original_comment_log_action is not None:
+                publish_action(
+                    CommentEditAction(
+                        comment_id=original_comment_log_action.id,
+                        text=note.data.get("text"),
+                        mentions=mentions,
+                    ),
+                    source=resolve_action_source(request),
+                    group_id=group.id,
+                    project=group.project,
+                    actor=GroupActionActor.user(request.user.id),
+                )
+            else:
+                logger.info(
+                    "group_notes.groupactionlogentry.not_found", extra={"group_id": group.id}
+                )
 
             if note.data.get("external_id"):
                 self.update_external_comment(request, group, note)
@@ -171,19 +185,17 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
             if features.has(
                 "projects:issue-action-log-activity", group.project, actor=request.user
             ):
-                entry = GroupActionLogEntry.objects.filter(
-                    group_id=group.id,
-                    idempotency_key=activity_action_idempotency_key(note),
-                ).first()
-                if entry:
-                    # Editing a note doesn't update its COMMENT entry (an edit only
+                if original_comment_log_action is not None:
+                    # editing a note doesn't update its COMMENT entry (instead it
                     # appends a separate COMMENT_EDIT entry), so re-derive the fresh
-                    # text from the activity we just saved.
-                    entry.data = {**entry.data, "text": note.data.get("text")}
-                    return Response(serialize(entry, request.user), status=200)
-                logger.info(
-                    "group_notes.groupactionlogentry.not_found", extra={"group_id": group.id}
-                )
+                    # text from the activity we just saved
+                    original_comment_log_action.data = {
+                        **original_comment_log_action.data,
+                        "text": note.data.get("text"),
+                    }
+                    return Response(
+                        serialize(original_comment_log_action, request.user), status=200
+                    )
 
             return Response(serialize(note, request.user), status=200)
 

--- a/tests/sentry/issues/endpoints/test_group_notes.py
+++ b/tests/sentry/issues/endpoints/test_group_notes.py
@@ -129,6 +129,57 @@ class GroupNoteTest(APITestCase):
         assert response.data[0]["data"]["text"] == "hello world"
         assert response.data[0]["data"]["comment_id"] == 123
 
+    @with_feature("projects:issue-action-log-activity")
+    def test_reads_from_gale_with_edits(self) -> None:
+        group = self.group
+
+        unedited = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": 1, "text": "unedited comment"},
+        )
+        edited = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": 2, "text": "stale text"},
+        )
+        # two edits of the same comment; only the latest text should win
+        self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_EDIT,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": edited.id, "text": "first edit"},
+        )
+        self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_EDIT,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": edited.id, "text": "latest edit"},
+        )
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+
+        # edits collapse into the original comment, so there is one row per comment
+        assert len(response.data) == 2
+        rows_by_id = {row["id"]: row for row in response.data}
+        assert set(rows_by_id) == {str(unedited.id), str(edited.id)}
+
+        # the edited comment keeps type "note" and shows the latest edit text
+        assert rows_by_id[str(edited.id)]["type"] == "note"
+        assert rows_by_id[str(edited.id)]["data"]["text"] == "latest edit"
+        # the unedited comment is unaffected
+        assert rows_by_id[str(unedited.id)]["data"]["text"] == "unedited comment"
+
 
 class GroupNoteCreateTest(APITestCase):
     def test_simple(self) -> None:
@@ -152,7 +203,7 @@ class GroupNoteCreateTest(APITestCase):
         response = self.client.post(url, format="json", data={"text": "hello world"})
         assert response.status_code == 400, response.content
 
-    @with_feature("projects:issue-action-log-activity")
+    @with_feature(["projects:issue-action-log-write-to-db", "projects:issue-action-log-activity"])
     def test_returns_gale(self) -> None:
         group = self.group
 

--- a/tests/sentry/issues/endpoints/test_group_notes.py
+++ b/tests/sentry/issues/endpoints/test_group_notes.py
@@ -1,6 +1,8 @@
 import datetime
 
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
@@ -9,6 +11,7 @@ from sentry.notifications.types import GroupSubscriptionReason
 from sentry.silo.base import SiloMode
 from sentry.tasks.merge import merge_groups
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
@@ -102,6 +105,30 @@ class GroupNoteTest(APITestCase):
         assert response.data[3]["id"] == str(note3.id)
         assert response.data[3]["data"]["text"] == note3.data["text"]
 
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_reads_from_gale(self) -> None:
+        group = self.group
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": 123, "text": "hello world"},
+        )
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(entry.id)
+        assert response.data[0]["type"] == "note"
+        assert response.data[0]["user"]["id"] == str(self.user.id)
+        assert response.data[0]["data"]["text"] == "hello world"
+        assert response.data[0]["data"]["comment_id"] == 123
+
 
 class GroupNoteCreateTest(APITestCase):
     def test_simple(self) -> None:
@@ -124,6 +151,29 @@ class GroupNoteCreateTest(APITestCase):
 
         response = self.client.post(url, format="json", data={"text": "hello world"})
         assert response.status_code == 400, response.content
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_returns_gale(self) -> None:
+        group = self.group
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.post(url, format="json", data={"text": "hello world"})
+        assert response.status_code == 201, response.content
+
+        activity = Activity.objects.get(
+            group=group, type=ActivityType.NOTE.value, user_id=self.user.id
+        )
+        entry = GroupActionLogEntry.objects.get(
+            group_id=group.id, type=GroupActionType.COMMENT.value
+        )
+
+        assert response.data["id"] == str(entry.id)
+        assert response.data["type"] == "note"
+        assert response.data["user"]["id"] == str(self.user.id)
+        assert response.data["data"]["text"] == "hello world"
+        assert response.data["data"]["comment_id"] == activity.id
 
     def test_with_mentions(self) -> None:
         user_not_on_team = self.create_user(email="hello@meow.com")

--- a/tests/sentry/issues/endpoints/test_group_notes.py
+++ b/tests/sentry/issues/endpoints/test_group_notes.py
@@ -105,7 +105,7 @@ class GroupNoteTest(APITestCase):
         assert response.data[3]["id"] == str(note3.id)
         assert response.data[3]["data"]["text"] == note3.data["text"]
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-action-log-activity")
     def test_reads_from_gale(self) -> None:
         group = self.group
 
@@ -152,7 +152,7 @@ class GroupNoteCreateTest(APITestCase):
         response = self.client.post(url, format="json", data={"text": "hello world"})
         assert response.status_code == 400, response.content
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-action-log-activity")
     def test_returns_gale(self) -> None:
         group = self.group
 

--- a/tests/sentry/issues/endpoints/test_group_notes.py
+++ b/tests/sentry/issues/endpoints/test_group_notes.py
@@ -109,7 +109,7 @@ class GroupNoteTest(APITestCase):
     def test_reads_from_gale(self) -> None:
         group = self.group
 
-        entry = self.create_group_action_log_entry(
+        self.create_group_action_log_entry(
             group=group,
             type=GroupActionType.COMMENT,
             actor_type=GroupActorType.USER,
@@ -123,7 +123,8 @@ class GroupNoteTest(APITestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(entry.id)
+        # `id` is the Activity id (comment_id), matching the flag-off contract
+        assert response.data[0]["id"] == "123"
         assert response.data[0]["type"] == "note"
         assert response.data[0]["user"]["id"] == str(self.user.id)
         assert response.data[0]["data"]["text"] == "hello world"
@@ -171,14 +172,17 @@ class GroupNoteTest(APITestCase):
 
         # edits collapse into the original comment, so there is one row per comment
         assert len(response.data) == 2
+        # `id` is the Activity id (comment_id), matching the flag-off contract
+        unedited_id = str(unedited.data["comment_id"])
+        edited_id = str(edited.data["comment_id"])
         rows_by_id = {row["id"]: row for row in response.data}
-        assert set(rows_by_id) == {str(unedited.id), str(edited.id)}
+        assert set(rows_by_id) == {unedited_id, edited_id}
 
         # the edited comment keeps type "note" and shows the latest edit text
-        assert rows_by_id[str(edited.id)]["type"] == "note"
-        assert rows_by_id[str(edited.id)]["data"]["text"] == "latest edit"
+        assert rows_by_id[edited_id]["type"] == "note"
+        assert rows_by_id[edited_id]["data"]["text"] == "latest edit"
         # the unedited comment is unaffected
-        assert rows_by_id[str(unedited.id)]["data"]["text"] == "unedited comment"
+        assert rows_by_id[unedited_id]["data"]["text"] == "unedited comment"
 
 
 class GroupNoteCreateTest(APITestCase):
@@ -216,11 +220,10 @@ class GroupNoteCreateTest(APITestCase):
         activity = Activity.objects.get(
             group=group, type=ActivityType.NOTE.value, user_id=self.user.id
         )
-        entry = GroupActionLogEntry.objects.get(
-            group_id=group.id, type=GroupActionType.COMMENT.value
-        )
+        GroupActionLogEntry.objects.get(group_id=group.id, type=GroupActionType.COMMENT.value)
 
-        assert response.data["id"] == str(entry.id)
+        # `id` is the Activity id (comment_id), matching the flag-off contract
+        assert response.data["id"] == str(activity.id)
         assert response.data["type"] == "note"
         assert response.data["user"]["id"] == str(self.user.id)
         assert response.data["data"]["text"] == "hello world"

--- a/tests/sentry/issues/endpoints/test_group_notes_details.py
+++ b/tests/sentry/issues/endpoints/test_group_notes_details.py
@@ -251,6 +251,33 @@ class GroupNotesDetailsTest(APITestCase):
         original_entry.refresh_from_db()
         assert original_entry.data["text"] == "original"
 
+    @with_feature(["projects:issue-action-log-write-to-db", "projects:issue-action-log-activity"])
+    def test_delete_writes_comment_delete_entry(self) -> None:
+        self.login_as(user=self.user)
+        group = self.group
+
+        post_url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.post(post_url, format="json", data={"text": "original"})
+        assert response.status_code == 201, response.content
+        activity_id = response.data["data"]["comment_id"]
+
+        original_entry = GroupActionLogEntry.objects.get(
+            group_id=group.id,
+            type=GroupActionType.COMMENT.value,
+            data__comment_id=activity_id,
+        )
+
+        delete_url = f"/api/0/issues/{group.id}/comments/{activity_id}/"
+        response = self.client.delete(delete_url, format="json")
+        assert response.status_code == 204, response.status_code
+
+        delete_entry = GroupActionLogEntry.objects.get(
+            group_id=group.id, type=GroupActionType.COMMENT_DELETE.value
+        )
+        # the tombstone references the original COMMENT entry by its GALE id, the
+        # same way COMMENT_EDIT entries do, so it can be joined to the COMMENT row
+        assert delete_entry.data["comment_id"] == original_entry.id
+
     @with_feature("projects:issue-action-log-activity")
     def test_put_falls_back_to_activity_without_gale_entry(self) -> None:
         # read flag on but write flag off: no COMMENT entry was ever written, so

--- a/tests/sentry/issues/endpoints/test_group_notes_details.py
+++ b/tests/sentry/issues/endpoints/test_group_notes_details.py
@@ -208,12 +208,13 @@ class GroupNotesDetailsTest(APITestCase):
         response = self.client.put(put_url, format="json", data={"text": "updated text"})
         assert response.status_code == 200, response.content
 
-        entry = GroupActionLogEntry.objects.get(
+        GroupActionLogEntry.objects.get(
             group_id=group.id,
             type=GroupActionType.COMMENT.value,
             data__comment_id=activity_id,
         )
-        assert response.data["id"] == str(entry.id)
+        # `id` is the Activity id (comment_id), matching the flag-off contract
+        assert response.data["id"] == str(activity_id)
         assert response.data["type"] == "note"
         assert response.data["user"]["id"] == str(self.user.id)
         # the fresh text is re-derived from the edited activity, not the stale GALE entry

--- a/tests/sentry/issues/endpoints/test_group_notes_details.py
+++ b/tests/sentry/issues/endpoints/test_group_notes_details.py
@@ -193,7 +193,7 @@ class GroupNotesDetailsTest(APITestCase):
             "text": f"hi **@{self.user.username}**",
         }
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature("projects:issue-action-log-activity")
     def test_put_returns_gale(self) -> None:
         self.login_as(user=self.user)
         group = self.group

--- a/tests/sentry/issues/endpoints/test_group_notes_details.py
+++ b/tests/sentry/issues/endpoints/test_group_notes_details.py
@@ -193,7 +193,7 @@ class GroupNotesDetailsTest(APITestCase):
             "text": f"hi **@{self.user.username}**",
         }
 
-    @with_feature("projects:issue-action-log-activity")
+    @with_feature(["projects:issue-action-log-write-to-db", "projects:issue-action-log-activity"])
     def test_put_returns_gale(self) -> None:
         self.login_as(user=self.user)
         group = self.group
@@ -219,6 +219,54 @@ class GroupNotesDetailsTest(APITestCase):
         # the fresh text is re-derived from the edited activity, not the stale GALE entry
         assert response.data["data"]["text"] == "updated text"
         assert response.data["data"]["comment_id"] == activity_id
+
+    @with_feature(["projects:issue-action-log-write-to-db", "projects:issue-action-log-activity"])
+    def test_put_writes_comment_edit_entry(self) -> None:
+        self.login_as(user=self.user)
+        group = self.group
+
+        post_url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.post(post_url, format="json", data={"text": "original"})
+        assert response.status_code == 201, response.content
+        activity_id = response.data["data"]["comment_id"]
+
+        original_entry = GroupActionLogEntry.objects.get(
+            group_id=group.id,
+            type=GroupActionType.COMMENT.value,
+            data__comment_id=activity_id,
+        )
+
+        put_url = f"/api/0/issues/{group.id}/comments/{activity_id}/"
+        response = self.client.put(put_url, format="json", data={"text": "updated text"})
+        assert response.status_code == 200, response.content
+
+        edit_entry = GroupActionLogEntry.objects.get(
+            group_id=group.id, type=GroupActionType.COMMENT_EDIT.value
+        )
+        # the edit references the original COMMENT entry by its GALE id and carries the new text
+        assert edit_entry.data["comment_id"] == original_entry.id
+        assert edit_entry.data["text"] == "updated text"
+
+        # the original COMMENT entry is left untouched
+        original_entry.refresh_from_db()
+        assert original_entry.data["text"] == "original"
+
+    @with_feature("projects:issue-action-log-activity")
+    def test_put_falls_back_to_activity_without_gale_entry(self) -> None:
+        # read flag on but write flag off: no COMMENT entry was ever written, so
+        # the edit can't reference one and the endpoint returns the activity.
+        del self.activity.data["external_id"]
+        self.activity.save()
+        self.login_as(user=self.user)
+
+        response = self.client.put(self.url, format="json", data={"text": "updated"})
+        assert response.status_code == 200, response.content
+
+        assert response.data["id"] == str(self.activity.id)
+        assert response.data["data"]["text"] == "updated"
+        assert not GroupActionLogEntry.objects.filter(
+            group_id=self.group.id, type=GroupActionType.COMMENT_EDIT.value
+        ).exists()
 
     @patch("sentry.integrations.mixins.issues.IssueBasicIntegration.update_comment")
     def test_put_no_external_id(self, mock_update_comment: MagicMock) -> None:

--- a/tests/sentry/issues/endpoints/test_group_notes_details.py
+++ b/tests/sentry/issues/endpoints/test_group_notes_details.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 import responses
 
 from sentry.integrations.models.external_issue import ExternalIssue
+from sentry.issues.action_log.types import GroupActionType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
@@ -11,6 +13,7 @@ from sentry.models.groupsubscription import GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
 
@@ -189,6 +192,33 @@ class GroupNotesDetailsTest(APITestCase):
             "external_id": "123",
             "text": f"hi **@{self.user.username}**",
         }
+
+    @with_feature("projects:issue-action-log-write-to-db")
+    def test_put_returns_gale(self) -> None:
+        self.login_as(user=self.user)
+        group = self.group
+
+        # create a comment that dual writes to GALE
+        post_url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.post(post_url, format="json", data={"text": "original"})
+        assert response.status_code == 201, response.content
+        activity_id = response.data["data"]["comment_id"]
+
+        put_url = f"/api/0/issues/{group.id}/comments/{activity_id}/"
+        response = self.client.put(put_url, format="json", data={"text": "updated text"})
+        assert response.status_code == 200, response.content
+
+        entry = GroupActionLogEntry.objects.get(
+            group_id=group.id,
+            type=GroupActionType.COMMENT.value,
+            data__comment_id=activity_id,
+        )
+        assert response.data["id"] == str(entry.id)
+        assert response.data["type"] == "note"
+        assert response.data["user"]["id"] == str(self.user.id)
+        # the fresh text is re-derived from the edited activity, not the stale GALE entry
+        assert response.data["data"]["text"] == "updated text"
+        assert response.data["data"]["comment_id"] == activity_id
 
     @patch("sentry.integrations.mixins.issues.IssueBasicIntegration.update_comment")
     def test_put_no_external_id(self, mock_update_comment: MagicMock) -> None:


### PR DESCRIPTION
Serialize `GroupActionLogEntry` in place of `Activity` in `GroupNotesDetailsEndpoint` and `GroupNotesEndpoint`. We're still dual writing but just returning the GALE rows instead.

For edited comments (PUT method in `GroupNotesDetailsEndpoint`) we'll write the comment text to the edited log entry and update comment fetching to prioritize an edited comment over an original one. I also updated the note id that we store for the edited comment to be the original comment id so we can look it up by that. 