### PR TITLE
Revert "feat(action log): Remove manual date_updated for GALE backfill task

### DIFF
--- a/src/sentry/issues/action_log/backfill.py
+++ b/src/sentry/issues/action_log/backfill.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from django.db import connections, router, transaction
+from django.utils import timezone
 
 from sentry.issues.action_log.types import (
     SYSTEM_ACTOR,
@@ -45,9 +46,9 @@ class BackfillEntry:
 def bulk_insert_action_log_entries(params: list[int | str | datetime], num_rows: int) -> int:
     """Low-level INSERT into GroupActionLogEntry with ON CONFLICT DO NOTHING.
 
-    *params* is a flat list of values for *num_rows* rows, each with 9 columns:
+    *params* is a flat list of values for *num_rows* rows, each with 10 columns:
     (group_id, project_id, type, actor_type, actor_id, source, data,
-     date_added, idempotency_key).
+     date_added, date_updated, idempotency_key).
 
     Returns the number of rows actually inserted (via RETURNING).
     """
@@ -57,14 +58,14 @@ def bulk_insert_action_log_entries(params: list[int | str | datetime], num_rows:
     sql = """
         INSERT INTO sentry_groupactionlogentry
             (group_id, project_id, type, actor_type, actor_id, source, data,
-             date_added, idempotency_key)
+             date_added, date_updated, idempotency_key)
         VALUES %s
         ON CONFLICT (group_id, idempotency_key)
             WHERE idempotency_key IS NOT NULL
         DO NOTHING
         RETURNING id
     """
-    values_template = "(%s, %s, %s, %s, %s, %s, %s, %s, %s)"
+    values_template = "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
     values_clause = ", ".join(values_template for _ in range(num_rows))
     using = router.db_for_write(GroupActionLogEntry)
     with connections[using].cursor() as cursor:
@@ -109,6 +110,7 @@ def backfill_actions(
                 entry.source,
                 json.dumps(entry.action.dict()),
                 entry.date_added,
+                timezone.now(),  # date_updated
                 entry.idempotency_key,
             ]
         )

--- a/src/sentry/tasks/backfill_group_action_log.py
+++ b/src/sentry/tasks/backfill_group_action_log.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+from django.utils import timezone
 from taskbroker_client.state import current_task
 
 from sentry import options
@@ -266,6 +267,7 @@ def _backfill_project(
                 BACKFILL_ACTIVITY_SOURCE,
                 json.dumps(action.dict()),
                 activity.datetime,
+                timezone.now(),  # date_updated
                 activity_action_idempotency_key(activity),
             ]
         )


### PR DESCRIPTION
This reverts commit 5f09076ce2fb65a14457abe976134e14d24a6c15.

Unfortunately, currently the groupactionlogentry routing logic means migrations can't be applied automatically, so this change that moves to relying on the migration-adjusted defaults breaks us.
We'll revert it until we sort out the migration situation.