### PR TITLE
feat(derived): Add build_and_promote_derived_data with generation tasks

### DIFF
--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -305,6 +305,16 @@ class PromotionResult(enum.Enum):
     CURSOR_BEHIND = "cursor_behind"  # same generation, but cursor is more advanced
 
 
+class PromotionFailed(Exception):
+    """Raised when build_and_promote_derived_data exhausts its retry budget."""
+
+    def __init__(self, group_id: int, result: PromotionResult, attempts: int) -> None:
+        self.group_id = group_id
+        self.result = result
+        self.attempts = attempts
+        super().__init__(f"group {group_id}: {result.value} after {attempts} attempts")
+
+
 def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
     """Upsert the candidate's state into the row for its group.
 
@@ -452,24 +462,7 @@ def build_and_promote_derived_data(
         derived.pipeline_hash = pipeline_hash
 
     _generation_cache.delete(current_gen_id)
-
-    if result is PromotionResult.CURSOR_BEHIND:
-        metrics.incr("issues.derived.promotion_exhausted", sample_rate=1.0)
-        logger.warning(
-            "issues.derived.promotion_exhausted",
-            extra={
-                "group_id": group_id,
-                "attempts": attempt + 1,
-            },
-        )
-    else:
-        logger.info(
-            "issues.derived.promotion_failed",
-            extra={
-                "group_id": group_id,
-                "result": result.value,
-            },
-        )
+    raise PromotionFailed(group_id, result, attempt + 1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -451,8 +451,9 @@ def build_and_promote_derived_data(
             return
 
         if result is PromotionResult.SUPERSEDED:
-            # A newer generation already won — retrying is futile.
-            break
+            # A newer generation already won — not an error.
+            _generation_cache.delete(current_gen_id)
+            return
 
         # CURSOR_BEHIND: the live row's cursor is ahead of ours.
         # If new entries exist past our cursor, the next drain will pick

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -2,19 +2,22 @@ import enum
 import logging
 import time
 from datetime import datetime, timedelta
+from typing import NamedTuple
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
+from django.utils import timezone
 
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.framework import Pipeline
 from sentry.issues.derived.store import GroupDerivedDataStore
-from sentry.issues.derived.tasks import process_group_log_task
+from sentry.issues.derived.tasks import generate_group_derived_data, process_group_log_task
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group
 from sentry.utils import metrics
+from sentry.workflow_engine.caches.mapping import CacheMapping
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +32,22 @@ INLINE_BATCH_SIZE = 100
 _EXCLUDED_FIELDS = frozenset({"id", "group_id", "date_added", "date_updated"})
 _STATE_FIELDS = tuple(
     f.attname for f in GroupDerivedData._meta.concrete_fields if f.attname not in _EXCLUDED_FIELDS
+)
+
+
+class GenerationId(NamedTuple):
+    """Uniquely identifies a generation attempt for a group."""
+
+    group_id: int
+    generated_at: datetime  # when this generation started; reflects log state observed
+    pipeline_hash: str
+
+
+# Cache for in-progress generation state.
+_generation_cache = CacheMapping[GenerationId, GroupDerivedData](
+    lambda k: f"{k.group_id}:{k.generated_at.isoformat()}:{k.pipeline_hash}",
+    namespace="gdd-generation",
+    ttl_seconds=86400,
 )
 
 
@@ -102,7 +121,9 @@ def _process_batch(
     same deterministic result for overlapping entry ranges.
 
     When *persist* is False, only the in-memory object is updated — the
-    caller is responsible for persisting the result.
+    caller is responsible for persisting the result (e.g. via
+    ``promote_to_live``). Used for full generations that accumulate
+    state in memory and write once at the end.
     """
     group_id = derived.group_id
     entries = _entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, batch_size)
@@ -170,6 +191,11 @@ def _process_batch(
 class GroupLogTimeout(Exception):
     """Raised when processing cannot finish within its time budget."""
 
+    def __init__(self, group_id: int, generation_id: GenerationId | None = None) -> None:
+        self.group_id = group_id
+        self.generation_id = generation_id
+        super().__init__(group_id)
+
 
 def _drain_log(
     derived: GroupDerivedData,
@@ -231,7 +257,7 @@ def process_group_log(
 def trigger_group_log_processing(group_id: int, *, strategy: ProcessingStrategy) -> None:
     """Trigger derived data processing for a group.
 
-    Silently returns if the group has been deleted.
+    Silently returns if the group has been deleted or no row exists.
 
     Strategy controls how processing is dispatched:
       SYNC   — process all pending actions now
@@ -269,7 +295,7 @@ def trigger_group_log_processing(group_id: int, *, strategy: ProcessingStrategy)
 
 
 # ---------------------------------------------------------------------------
-# Generation: upsert derived data from a full log replay
+# Generation lifecycle: build in memory, upsert, cache partial progress
 # ---------------------------------------------------------------------------
 
 
@@ -336,6 +362,116 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
     return PromotionResult.CURSOR_BEHIND
 
 
+MAX_PROMOTION_ATTEMPTS = 5
+
+
+def build_and_promote_derived_data(
+    group_id: int,
+    *,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    generation_id: GenerationId | None = None,
+    time_limit: timedelta,
+) -> None:
+    """Build derived data from scratch and upsert into the row.
+
+    Drains the full action log into an in-memory object, then upserts
+    via ``promote_to_live`` with a CAS on ``generated_at``.  The
+    generation's ``generated_at`` is captured at start — it reflects the
+    log state observed, not when the generation finished.
+
+    When *generation_id* is provided, previously cached partial progress
+    is loaded and resumed.
+
+    Raises GroupLogTimeout (with ``generation_id`` set) if the time-limited
+    drain could not finish, so the caller can re-enqueue.
+    """
+    pipeline_hash = PIPELINE.pipeline_hash
+    generated_at: datetime
+
+    # Try to resume from cache.
+    derived: GroupDerivedData | None = None
+    if generation_id is not None:
+        derived = _generation_cache.get(generation_id)
+        generated_at = generation_id.generated_at
+        if derived is None:
+            logger.info(
+                "issues.derived.build_and_promote.cache_miss",
+                extra={"group_id": group_id, "generation_id": generation_id},
+            )
+
+    if derived is None:
+        generated_at = timezone.now()
+        derived = GroupDerivedData(
+            group_id=group_id,
+            generated_at=generated_at,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=pipeline_hash,
+        )
+
+    current_gen_id = GenerationId(group_id, generated_at, pipeline_hash)
+
+    result = PromotionResult.CURSOR_BEHIND
+    for attempt in range(MAX_PROMOTION_ATTEMPTS):
+        drained = _drain_log(derived, PIPELINE, batch_size, time_limit=time_limit, persist=False)
+        if not drained:
+            _generation_cache.set(current_gen_id, derived)
+            raise GroupLogTimeout(group_id, generation_id=current_gen_id)
+
+        result = promote_to_live(derived)
+        metrics.incr("issues.derived.promote_to_live", tags={"result": result.value})
+        if result is PromotionResult.PROMOTED:
+            logger.info(
+                "issues.derived.promoted",
+                extra={
+                    "group_id": group_id,
+                    "cursor_date": str(derived.cursor_date),
+                    "cursor_id": derived.cursor_id,
+                    "attempts": attempt + 1,
+                },
+            )
+            _generation_cache.delete(current_gen_id)
+            return
+
+        if result is PromotionResult.SUPERSEDED:
+            # A newer generation already won — retrying is futile.
+            break
+
+        # CURSOR_BEHIND: the live row's cursor advanced past ours (via
+        # incremental processing). Load the live row's full state so the
+        # next _drain_log builds on the correct base, not stale aggregations.
+        live_row = GroupDerivedData.objects.filter(group_id=group_id).first()
+        if live_row is None:
+            break
+        for field in _STATE_FIELDS:
+            setattr(derived, field, getattr(live_row, field))
+        # Keep our generated_at and pipeline_hash — the live row's may
+        # be from an older generation or an older pipeline version.
+        derived.generated_at = generated_at
+        derived.pipeline_hash = pipeline_hash
+
+    _generation_cache.delete(current_gen_id)
+
+    if result is PromotionResult.CURSOR_BEHIND:
+        metrics.incr("issues.derived.promotion_exhausted", sample_rate=1.0)
+        logger.warning(
+            "issues.derived.promotion_exhausted",
+            extra={
+                "group_id": group_id,
+                "attempts": attempt + 1,
+            },
+        )
+    else:
+        logger.info(
+            "issues.derived.promotion_failed",
+            extra={
+                "group_id": group_id,
+                "result": result.value,
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Invalidation
 # ---------------------------------------------------------------------------
@@ -344,33 +480,45 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
 def invalidate_group_derived_data(
     group_id: int,
     cursor: tuple[datetime, int] | None = None,
+    *,
+    hard_delete: bool = False,
 ) -> None:
-    """Delete derived state so it is rebuilt from scratch on the next pass,
-    then kicks off an async task to regenerate the derived data.
+    """Invalidate derived state so it is regenerated.
+
+    *hard_delete* controls the strategy:
+
+    - ``False`` (default): enqueue a generation task. The existing row
+      continues serving reads until the generation promotes and stamps
+      a newer ``generated_at``.
+    - ``True``: delete the row immediately, then enqueue a generation
+      task to create a new one. Use when the existing data is known to
+      be wrong and must not be served.
 
     If *cursor* is ``(date_added, id)`` of the earliest affected entry, the
-    row is only deleted when its cursor is at or past that point; otherwise
-    the mutation is still ahead of processing and no invalidation is needed.
-    Without a cursor the invalidation is unconditional.
+    invalidation only fires when the row's cursor is at or past that
+    point; otherwise the mutation is still ahead of processing and no
+    invalidation is needed.
     """
-    if cursor is None:
-        GroupDerivedData.objects.filter(group_id=group_id).delete()
-        process_group_log_task.delay(group_id)
-        return
+    if cursor is not None:
+        cursor_date, cursor_id = cursor
+        row_past_cursor = GroupDerivedData.objects.filter(
+            Q(group_id=group_id)
+            & (
+                Q(cursor_date__gt=cursor_date)
+                | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)
+            )
+        ).exists()
+        if not row_past_cursor:
+            return
 
-    # Only invalidate if the row has already processed past the affected point.
-    cursor_date, cursor_id = cursor
-    deleted, _ = GroupDerivedData.objects.filter(
-        Q(group_id=group_id)
-        & (Q(cursor_date__gt=cursor_date) | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)),
-    ).delete()
-    if deleted:
-        logger.info(
-            "issues.derived.invalidated",
-            extra={
-                "group_id": group_id,
-                "cursor_date": str(cursor_date),
-                "cursor_id": cursor_id,
-            },
-        )
-        process_group_log_task.delay(group_id)
+    if hard_delete:
+        deleted, _ = GroupDerivedData.objects.filter(group_id=group_id).delete()
+        if deleted:
+            logger.info(
+                "issues.derived.invalidated",
+                extra={
+                    "group_id": group_id,
+                    "hard_delete": True,
+                },
+            )
+    generate_group_derived_data.delay(group_id)

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -454,20 +454,12 @@ def build_and_promote_derived_data(
             # A newer generation already won — retrying is futile.
             break
 
-        # CURSOR_BEHIND: the live row's cursor advanced past ours (via
-        # incremental processing). Load the live row's full state so the
-        # next _drain_log builds on the correct base, not stale aggregations.
-        live_row = GroupDerivedData.objects.filter(group_id=group_id).first()
-        if live_row is None:
-            if not Group.objects.filter(id=group_id).exists():
-                raise Group.DoesNotExist(f"Group {group_id} does not exist")
+        # CURSOR_BEHIND: the live row's cursor is ahead of ours.
+        # If new entries exist past our cursor, the next drain will pick
+        # them up. If not, the log was modified (e.g. merge deleted
+        # entries) and our replay is incomplete — give up.
+        if not _entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, 1):
             break
-        for field in _STATE_FIELDS:
-            setattr(derived, field, getattr(live_row, field))
-        # Keep our generated_at and pipeline_hash — the live row's may
-        # be from an older generation or an older pipeline version.
-        derived.generated_at = generated_at
-        derived.pipeline_hash = pipeline_hash
 
     _generation_cache.delete(current_gen_id)
     raise PromotionFailed(group_id, result, attempt + 1)

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.framework import Pipeline
 from sentry.issues.derived.store import GroupDerivedDataStore
-from sentry.issues.derived.tasks import generate_group_derived_data, process_group_log_task
+from sentry.issues.derived.tasks import process_group_log_task
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group
@@ -473,45 +473,33 @@ def build_and_promote_derived_data(
 def invalidate_group_derived_data(
     group_id: int,
     cursor: tuple[datetime, int] | None = None,
-    *,
-    hard_delete: bool = False,
 ) -> None:
-    """Invalidate derived state so it is regenerated.
-
-    *hard_delete* controls the strategy:
-
-    - ``False`` (default): enqueue a generation task. The existing row
-      continues serving reads until the generation promotes and stamps
-      a newer ``generated_at``.
-    - ``True``: delete the row immediately, then enqueue a generation
-      task to create a new one. Use when the existing data is known to
-      be wrong and must not be served.
+    """Delete derived state so it is rebuilt from scratch on the next pass,
+    then kicks off an async task to regenerate the derived data.
 
     If *cursor* is ``(date_added, id)`` of the earliest affected entry, the
-    invalidation only fires when the row's cursor is at or past that
-    point; otherwise the mutation is still ahead of processing and no
-    invalidation is needed.
+    row is only deleted when its cursor is at or past that point; otherwise
+    the mutation is still ahead of processing and no invalidation is needed.
+    Without a cursor the invalidation is unconditional.
     """
-    if cursor is not None:
-        cursor_date, cursor_id = cursor
-        row_past_cursor = GroupDerivedData.objects.filter(
-            Q(group_id=group_id)
-            & (
-                Q(cursor_date__gt=cursor_date)
-                | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)
-            )
-        ).exists()
-        if not row_past_cursor:
-            return
+    if cursor is None:
+        GroupDerivedData.objects.filter(group_id=group_id).delete()
+        process_group_log_task.delay(group_id)
+        return
 
-    if hard_delete:
-        deleted, _ = GroupDerivedData.objects.filter(group_id=group_id).delete()
-        if deleted:
-            logger.info(
-                "issues.derived.invalidated",
-                extra={
-                    "group_id": group_id,
-                    "hard_delete": True,
-                },
-            )
-    generate_group_derived_data.delay(group_id)
+    # Only invalidate if the row has already processed past the affected point.
+    cursor_date, cursor_id = cursor
+    deleted, _ = GroupDerivedData.objects.filter(
+        Q(group_id=group_id)
+        & (Q(cursor_date__gt=cursor_date) | Q(cursor_date=cursor_date, cursor_id__gte=cursor_id)),
+    ).delete()
+    if deleted:
+        logger.info(
+            "issues.derived.invalidated",
+            extra={
+                "group_id": group_id,
+                "cursor_date": str(cursor_date),
+                "cursor_id": cursor_id,
+            },
+        )
+        process_group_log_task.delay(group_id)

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -425,10 +425,12 @@ def build_and_promote_derived_data(
         )
 
     current_gen_id = GenerationId(group_id, generated_at, pipeline_hash)
+    deadline = time.monotonic() + time_limit.total_seconds()
 
     result = PromotionResult.CURSOR_BEHIND
     for attempt in range(MAX_PROMOTION_ATTEMPTS):
-        drained = _drain_log(derived, PIPELINE, batch_size, time_limit=time_limit, persist=False)
+        remaining = timedelta(seconds=max(0, deadline - time.monotonic()))
+        drained = _drain_log(derived, PIPELINE, batch_size, time_limit=remaining, persist=False)
         if not drained:
             _generation_cache.set(current_gen_id, derived)
             raise GroupLogTimeout(group_id, generation_id=current_gen_id)

--- a/src/sentry/issues/derived/processing.py
+++ b/src/sentry/issues/derived/processing.py
@@ -394,6 +394,8 @@ def build_and_promote_derived_data(
 
     Raises GroupLogTimeout (with ``generation_id`` set) if the time-limited
     drain could not finish, so the caller can re-enqueue.
+    Raises PromotionFailed if promotion cannot succeed after retries.
+    Raises Group.DoesNotExist if the group has been deleted.
     """
     pipeline_hash = PIPELINE.pipeline_hash
     generated_at: datetime
@@ -410,6 +412,8 @@ def build_and_promote_derived_data(
             )
 
     if derived is None:
+        if not Group.objects.filter(id=group_id).exists():
+            raise Group.DoesNotExist(f"Group {group_id} does not exist")
         generated_at = timezone.now()
         derived = GroupDerivedData(
             group_id=group_id,
@@ -453,6 +457,8 @@ def build_and_promote_derived_data(
         # next _drain_log builds on the correct base, not stale aggregations.
         live_row = GroupDerivedData.objects.filter(group_id=group_id).first()
         if live_row is None:
+            if not Group.objects.filter(id=group_id).exists():
+                raise Group.DoesNotExist(f"Group {group_id} does not exist")
             break
         for field in _STATE_FIELDS:
             setattr(derived, field, getattr(live_row, field))

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -56,6 +56,7 @@ def generate_group_derived_data(
     from sentry.issues.derived.processing import (
         GenerationId,
         GroupLogTimeout,
+        PromotionFailed,
         build_and_promote_derived_data,
     )
     from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
@@ -89,6 +90,9 @@ def generate_group_derived_data(
         )
     except Group.DoesNotExist:
         logger.info("generate_group_derived_data.group_not_found", extra={"group_id": group_id})
+        return
+    except PromotionFailed:
+        logger.exception("generate_group_derived_data.promotion_failed")
         return
     except GroupLogTimeout as e:
         if prior_runs + 1 >= _MAX_GENERATION_RUNS:
@@ -398,6 +402,7 @@ def generate_project_derived_data_batch(
     from sentry.issues.derived.processing import (
         GenerationId,
         GroupLogTimeout,
+        PromotionFailed,
         build_and_promote_derived_data,
     )
     from sentry.models.group import Group
@@ -438,7 +443,7 @@ def generate_project_derived_data_batch(
         .values_list("id", flat=True)
     )
 
-    processed = 0
+    processed: dict[str, int] = {}
     rescheduled = False
 
     for group_id in group_ids:
@@ -449,12 +454,15 @@ def generate_project_derived_data_batch(
                 generation_id=generation_id if group_id == group_id_start else None,
                 time_limit=remaining,
             )
-            processed += 1
+            processed["promoted"] = processed.get("promoted", 0) + 1
         except Group.DoesNotExist:
             logger.info(
                 "generate_project_derived_data_batch.group_not_found",
                 extra={"group_id": group_id, "project_id": project_id},
             )
+        except PromotionFailed as e:
+            processed[e.result.value] = processed.get(e.result.value, 0) + 1
+            logger.exception("generate_project_derived_data_batch.promotion_failed")
         except GroupLogTimeout as e:
             rescheduled = True
             gen_id = e.generation_id
@@ -490,11 +498,13 @@ def generate_project_derived_data_batch(
                 mark_spawned(_GENERATE_BATCH_TASK_KEY, activation_id)
             break
 
-    metrics.incr(
-        "issues.derived.generate_project_groups_processed",
-        amount=processed,
-        sample_rate=1.0,
-    )
+    for result, count in processed.items():
+        metrics.incr(
+            "issues.derived.generate_project_groups_processed",
+            amount=count,
+            sample_rate=1.0,
+            tags={"result": result},
+        )
     logger.info(
         "generate_project_derived_data_batch.complete",
         extra={

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -59,6 +59,7 @@ def generate_group_derived_data(
         PromotionFailed,
         build_and_promote_derived_data,
     )
+    from sentry.models.group import Group
     from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 
     task_state = current_task()
@@ -81,8 +82,6 @@ def generate_group_derived_data(
             datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
             resume_pipeline_hash,
         )
-
-    from sentry.models.group import Group
 
     try:
         build_and_promote_derived_data(

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -11,7 +11,15 @@ logger = logging.getLogger(__name__)
 
 BATCH_PROCESSING_DEADLINE = timedelta(seconds=30)  # taskworker hard kill timeout
 BATCH_RETRIGGER_TIMEOUT = timedelta(seconds=20)  # self-reschedule before the hard kill
+
 _BATCH_TASK_KEY = "process_project_derived_data_batch"
+_GENERATE_BATCH_TASK_KEY = "generate_project_derived_data_batch"
+_GENERATE_GROUP_TASK_KEY = "generate_group_derived_data"
+
+# Cap self-rescheduling rebuilds to avoid infinite loops on very large groups.
+_MAX_GENERATION_RUNS = 20
+# Hard limit on group IDs loaded per project-level task to bound memory.
+_MAX_PROJECT_GROUPS = 10_000
 
 
 @instrumented_task(
@@ -28,6 +36,81 @@ def process_group_log_task(group_id: int, **kwargs: object) -> None:
         process_group_log(group_id)
     except Group.DoesNotExist:
         logger.info("process_group_log_task.group_not_found", extra={"group_id": group_id})
+
+
+@instrumented_task(
+    name="sentry.issues.derived.tasks.generate_group_derived_data",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def generate_group_derived_data(
+    group_id: int,
+    resume_generated_at: str | None = None,
+    resume_pipeline_hash: str | None = None,
+    prior_runs: int = 0,
+    **kwargs: object,
+) -> None:
+    """Generate derived data for a group by draining its action log."""
+    from taskbroker_client.state import current_task
+
+    from sentry.issues.derived.processing import (
+        GenerationId,
+        GroupLogTimeout,
+        build_and_promote_derived_data,
+    )
+    from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
+
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_GENERATE_GROUP_TASK_KEY, activation_id):
+        logger.info(
+            "generate_group_derived_data.duplicate_skipped",
+            extra={"group_id": group_id, "activation_id": activation_id},
+        )
+        metrics.incr(
+            "taskworker.selfchain.duplicate_skipped",
+            tags={"task": _GENERATE_GROUP_TASK_KEY},
+        )
+        return
+
+    generation_id: GenerationId | None = None
+    if resume_generated_at is not None and resume_pipeline_hash is not None:
+        generation_id = GenerationId(
+            group_id,
+            datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
+            resume_pipeline_hash,
+        )
+
+    from sentry.models.group import Group
+
+    try:
+        build_and_promote_derived_data(
+            group_id, generation_id=generation_id, time_limit=BATCH_RETRIGGER_TIMEOUT
+        )
+    except Group.DoesNotExist:
+        logger.info("generate_group_derived_data.group_not_found", extra={"group_id": group_id})
+        return
+    except GroupLogTimeout as e:
+        if prior_runs + 1 >= _MAX_GENERATION_RUNS:
+            logger.error(
+                "generate_group_derived_data.max_runs_exceeded",
+                extra={
+                    "group_id": group_id,
+                    "generation_id": e.generation_id,
+                    "prior_runs": prior_runs + 1,
+                },
+            )
+            metrics.incr("issues.derived.generate_max_runs_exceeded", sample_rate=1.0)
+            return
+        gen_id = e.generation_id
+        generate_group_derived_data.delay(
+            group_id,
+            resume_generated_at=gen_id.generated_at.isoformat() if gen_id else None,
+            resume_pipeline_hash=gen_id.pipeline_hash if gen_id else None,
+            prior_runs=prior_runs + 1,
+        )
+        if activation_id:
+            mark_spawned(_GENERATE_GROUP_TASK_KEY, activation_id)
 
 
 @instrumented_task(
@@ -50,11 +133,12 @@ def process_project_derived_data(project_id: int, **kwargs: object) -> None:
     batch_size = options.get("issues.derived.project-batch-size")
     max_tasks = options.get("issues.derived.project-max-tasks")
 
+    # TODO: support very large projects via paginated iteration
     group_ids = list(
         Group.objects.filter(project_id=project_id)
         .exclude(Exists(GroupDerivedData.objects.filter(group_id=OuterRef("id"))))
         .order_by("id")
-        .values_list("id", flat=True)
+        .values_list("id", flat=True)[:_MAX_PROJECT_GROUPS]
     )
 
     if not group_ids:
@@ -63,6 +147,15 @@ def process_project_derived_data(project_id: int, **kwargs: object) -> None:
             extra={"project_id": project_id},
         )
         return
+
+    if len(group_ids) >= _MAX_PROJECT_GROUPS:
+        logger.error(
+            "process_project_derived_data.too_many_groups",
+            extra={
+                "project_id": project_id,
+                "limit": _MAX_PROJECT_GROUPS,
+            },
+        )
 
     starts = [group_ids[i] for i in range(0, len(group_ids), batch_size)]
     ends = starts[1:] + [group_ids[-1] + 1]
@@ -145,7 +238,7 @@ def process_project_derived_data_batch(
     rescheduled = False
 
     for group_id in group_ids:
-        remaining = timedelta(seconds=timeout_seconds - (time.monotonic() - start))
+        remaining = timedelta(seconds=max(0, timeout_seconds - (time.monotonic() - start)))
         try:
             process_group_log(group_id, timeout=remaining)
             processed += 1
@@ -193,6 +286,217 @@ def process_project_derived_data_batch(
     )
     logger.info(
         "process_project_derived_data_batch.complete",
+        extra={
+            "project_id": project_id,
+            "group_id_start": group_id_start,
+            "group_id_end": group_id_end,
+            "processed": processed,
+            "total": len(group_ids),
+            "rescheduled": rescheduled,
+            "elapsed": time.monotonic() - start,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Project-level generation: build-and-promote for all groups
+# ---------------------------------------------------------------------------
+
+
+@instrumented_task(
+    name="sentry.issues.derived.tasks.generate_project_derived_data",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+)
+def generate_project_derived_data(project_id: int, **kwargs: object) -> None:
+    """Generate derived data for every group in a project.
+
+    Partitions groups into ID ranges and fans out a batch task for each
+    range. Each batch calls ``build_and_promote_derived_data`` per group,
+    which replaces existing rows via CAS while they continue serving reads.
+    """
+    from sentry import options
+    from sentry.models.group import Group
+
+    batch_size = options.get("issues.derived.project-batch-size")
+    max_tasks = options.get("issues.derived.project-max-tasks")
+
+    # TODO: support very large projects via paginated iteration
+    group_ids = list(
+        Group.objects.filter(project_id=project_id)
+        .order_by("id")
+        .values_list("id", flat=True)[:_MAX_PROJECT_GROUPS]
+    )
+
+    if not group_ids:
+        return
+
+    if len(group_ids) >= _MAX_PROJECT_GROUPS:
+        logger.error(
+            "generate_project_derived_data.too_many_groups",
+            extra={
+                "project_id": project_id,
+                "limit": _MAX_PROJECT_GROUPS,
+            },
+        )
+
+    starts = [group_ids[i] for i in range(0, len(group_ids), batch_size)]
+    ends = starts[1:] + [group_ids[-1] + 1]
+    ranges = list(zip(starts, ends))
+
+    if len(ranges) > max_tasks:
+        logger.error(
+            "generate_project_derived_data.too_many_tasks",
+            extra={
+                "project_id": project_id,
+                "task_count": len(ranges),
+                "max_tasks": max_tasks,
+            },
+        )
+        return
+
+    for start, end in ranges:
+        generate_project_derived_data_batch.delay(
+            project_id=project_id,
+            group_id_start=start,
+            group_id_end=end,
+        )
+
+    logger.info(
+        "generate_project_derived_data.scheduled",
+        extra={
+            "project_id": project_id,
+            "group_count": len(group_ids),
+            "task_count": len(ranges),
+        },
+    )
+
+
+@instrumented_task(
+    name="sentry.issues.derived.tasks.generate_project_derived_data_batch",
+    namespace=issues_tasks,
+    silo_mode=SiloMode.CELL,
+    processing_deadline_duration=int(BATCH_PROCESSING_DEADLINE.total_seconds()),
+)
+def generate_project_derived_data_batch(
+    project_id: int,
+    group_id_start: int,
+    group_id_end: int,
+    resume_generated_at: str | None = None,
+    resume_pipeline_hash: str | None = None,
+    **kwargs: object,
+) -> None:
+    """Generate derived data for groups in [group_id_start, group_id_end).
+
+    Calls build_and_promote_derived_data for each group. Reschedules the
+    remaining range on per-group or batch timeout. On per-group timeout,
+    the generation_id is passed through so the next run resumes from
+    cached partial progress.
+    """
+    from taskbroker_client.state import current_task
+
+    from sentry.issues.derived.processing import (
+        GenerationId,
+        GroupLogTimeout,
+        build_and_promote_derived_data,
+    )
+    from sentry.models.group import Group
+    from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
+
+    task_state = current_task()
+    activation_id = task_state.id if task_state else None
+    if activation_id and already_spawned(_GENERATE_BATCH_TASK_KEY, activation_id):
+        logger.info(
+            "generate_project_derived_data_batch.duplicate_skipped",
+            extra={"project_id": project_id, "activation_id": activation_id},
+        )
+        metrics.incr(
+            "taskworker.selfchain.duplicate_skipped",
+            tags={"task": _GENERATE_BATCH_TASK_KEY},
+        )
+        return
+
+    # Reconstruct generation_id for resuming the first group from cache.
+    generation_id: GenerationId | None = None
+    if resume_generated_at is not None and resume_pipeline_hash is not None:
+        generation_id = GenerationId(
+            group_id_start,
+            datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
+            resume_pipeline_hash,
+        )
+
+    timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
+    start = time.monotonic()
+
+    group_ids = list(
+        Group.objects.filter(
+            project_id=project_id,
+            id__gte=group_id_start,
+            id__lt=group_id_end,
+        )
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+
+    processed = 0
+    rescheduled = False
+
+    for group_id in group_ids:
+        remaining = timedelta(seconds=max(0, timeout_seconds - (time.monotonic() - start)))
+        try:
+            build_and_promote_derived_data(
+                group_id,
+                generation_id=generation_id if group_id == group_id_start else None,
+                time_limit=remaining,
+            )
+            processed += 1
+        except Group.DoesNotExist:
+            logger.info(
+                "generate_project_derived_data_batch.group_not_found",
+                extra={"group_id": group_id, "project_id": project_id},
+            )
+        except GroupLogTimeout as e:
+            rescheduled = True
+            gen_id = e.generation_id
+            metrics.incr(
+                "issues.derived.generate_batch_rescheduled",
+                sample_rate=1.0,
+                tags={"reason": "group_timeout"},
+            )
+            generate_project_derived_data_batch.delay(
+                project_id=project_id,
+                group_id_start=group_id,
+                group_id_end=group_id_end,
+                resume_generated_at=gen_id.generated_at.isoformat() if gen_id else None,
+                resume_pipeline_hash=gen_id.pipeline_hash if gen_id else None,
+            )
+            if activation_id:
+                mark_spawned(_GENERATE_BATCH_TASK_KEY, activation_id)
+            break
+
+        if time.monotonic() - start >= timeout_seconds:
+            rescheduled = True
+            metrics.incr(
+                "issues.derived.generate_batch_rescheduled",
+                sample_rate=1.0,
+                tags={"reason": "batch_timeout"},
+            )
+            generate_project_derived_data_batch.delay(
+                project_id=project_id,
+                group_id_start=group_id + 1,
+                group_id_end=group_id_end,
+            )
+            if activation_id:
+                mark_spawned(_GENERATE_BATCH_TASK_KEY, activation_id)
+            break
+
+    metrics.incr(
+        "issues.derived.generate_project_groups_processed",
+        amount=processed,
+        sample_rate=1.0,
+    )
+    logger.info(
+        "generate_project_derived_data_batch.complete",
         extra={
             "project_id": project_id,
             "group_id_start": group_id_start,

--- a/src/sentry/issues/models/groupderiveddata.py
+++ b/src/sentry/issues/models/groupderiveddata.py
@@ -56,7 +56,10 @@ class GroupDerivedData(DefaultFieldsModel):
     group = FlexibleForeignKey("sentry.Group", unique=True)
 
     # Timestamp of when the generation that produced this state *started*
-    # processing. Defaults to row creation time.
+    # processing. The start time (not finish time) reflects the log state
+    # the generation observed. Used as a CAS version — incremental writes
+    # check equality, generation promotes require their timestamp to be
+    # newer. Defaults to row creation time.
     generated_at = models.DateTimeField(default=timezone.now, db_default=Now())
 
     cursor_date = models.DateTimeField(default=EPOCH)

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 from django.db import router, transaction
@@ -47,6 +48,7 @@ from sentry.issues.derived.processing import (
     GroupLogTimeout,
     PromotionResult,
     _entries_after_cursor,
+    build_and_promote_derived_data,
     invalidate_group_derived_data,
     process_group_log,
     promote_to_live,
@@ -276,31 +278,32 @@ class ProcessGroupLogTest(TestCase):
 
     # --- invalidation ---
 
-    def test_invalidate_deletes_row(self) -> None:
+    def test_hard_invalidate_deletes_row(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         process_group_log(group.id)
         assert GroupDerivedData.objects.filter(group_id=group.id).exists()
 
-        invalidate_group_derived_data(group.id)
+        invalidate_group_derived_data(group.id, hard_delete=True)
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
-    def test_invalidate_with_cursor_deletes_if_past(self) -> None:
+    def test_hard_invalidate_with_cursor_deletes_if_past(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)
 
-        # Cursor at the processed entry — row should be deleted.
-        invalidate_group_derived_data(group.id, cursor=(derived.cursor_date, derived.cursor_id))
+        invalidate_group_derived_data(
+            group.id, cursor=(derived.cursor_date, derived.cursor_id), hard_delete=True
+        )
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
     def test_invalidate_with_cursor_noop_if_not_reached(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)
+
         old_cursor = derived.cursor_id
 
-        # Cursor beyond what we've processed — row should be untouched.
         future = derived.cursor_date.replace(year=derived.cursor_date.year + 1)
         invalidate_group_derived_data(group.id, cursor=(future, old_cursor + 1000))
         derived.refresh_from_db()
@@ -314,9 +317,24 @@ class ProcessGroupLogTest(TestCase):
         derived = process_group_log(group.id)
         assert derived.view_count == 2
 
-        invalidate_group_derived_data(group.id)
+        invalidate_group_derived_data(group.id, hard_delete=True)
         derived = process_group_log(group.id)
         assert derived.view_count == 2  # rebuilt from scratch
+
+    def test_invalidate_soft_enqueues_generation(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        derived = process_group_log(group.id)
+
+        original_id = derived.id
+
+        with patch("sentry.issues.derived.processing.generate_group_derived_data") as mock_task:
+            invalidate_group_derived_data(group.id)
+            mock_task.delay.assert_called_once_with(group.id)
+
+        # Row is still in place — soft invalidation doesn't modify it.
+        derived.refresh_from_db()
+        assert derived.id == original_id
 
     def test_resolved_in_pull_request_proposes_fix(self) -> None:
         group = self.create_group()
@@ -390,9 +408,9 @@ class ProcessGroupLogTest(TestCase):
         first_progress = first.progress
         first_last_progressed_at = first.last_progressed_at
 
-        invalidate_group_derived_data(group.id)
+        invalidate_group_derived_data(group.id, hard_delete=True)
         second = process_group_log(group.id)
-
+        assert second is not None
         assert second.data == first_data
         assert second.progress == first_progress
         assert second.last_progressed_at == first_last_progressed_at
@@ -422,7 +440,7 @@ class ProcessGroupLogTest(TestCase):
         first_data = first.data.copy()
         assert first.data["blocker"] == IssueBlocker.APPROVE_CODE_CHANGES.value
 
-        invalidate_group_derived_data(group.id)
+        invalidate_group_derived_data(group.id, hard_delete=True)
         second = process_group_log(group.id)
         state = GroupDerivedDataStore.load(PIPELINE, second)
 
@@ -466,16 +484,9 @@ class ProcessGroupLogTest(TestCase):
         assert derived.cursor_id == first_cursor
         assert derived.pipeline_hash == "reset"
 
-    def test_invalidate_and_reprocess_restores_pipeline_hash(self) -> None:
-        group = self.create_group()
-        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
-        process_group_log(group.id)
-
-        invalidate_group_derived_data(group.id)
-        derived = process_group_log(group.id)
-        assert derived.pipeline_hash == PIPELINE.pipeline_hash
-
     def test_generated_at_change_skips_incremental_write(self) -> None:
+        from django.utils import timezone
+
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
 
@@ -494,14 +505,21 @@ class ProcessGroupLogTest(TestCase):
 
         # Simulate a generation promoting between our read and the UPDATE
         # in _process_batch — generated_at changed.
-        GroupDerivedData.objects.filter(id=derived.id).update(
-            generated_at=datetime.now(timezone.utc)
-        )
+        GroupDerivedData.objects.filter(id=derived.id).update(generated_at=timezone.now())
 
         processing._process_batch(processing.PIPELINE, derived, 1)
 
         derived.refresh_from_db()
         assert derived.cursor_id == first_cursor
+
+    def test_invalidate_and_reprocess_restores_pipeline_hash(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        process_group_log(group.id)
+
+        invalidate_group_derived_data(group.id, hard_delete=True)
+        derived = process_group_log(group.id)
+        assert derived.pipeline_hash == PIPELINE.pipeline_hash
 
 
 # --- promote_to_live ---
@@ -659,6 +677,170 @@ class PromoteToLiveTest(TestCase):
         entries = list(GroupActionLogEntry.objects.filter(group_id=group.id).order_by("id"))
         assert derived.cursor_id == entries[-2].id  # still at the pre-new-entry position
 
+    def test_build_and_promote(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        _publish(group=group, action=ResolveAction(), actor=GroupActionActor.user(self.user.id))
+
+        build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+        derived = GroupDerivedData.objects.get(group_id=group.id)
+        assert derived.view_count == 1
+        assert derived.data["status"] == "closed"
+        assert derived.generated_at is not None
+
+    def test_build_and_promote_updates_existing_row(self) -> None:
+        group = self.create_group()
+        user = self.user
+
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(user.id))
+        old = process_group_log(group.id)
+
+        old_id = old.id
+
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(user.id))
+        build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
+        live = GroupDerivedData.objects.get(group_id=group.id)
+        assert live.id == old_id
+        assert live.view_count == 2
+        assert live.generated_at is not None
+
+    def test_build_and_promote_cursor_behind_preserves_pipeline_hash(self) -> None:
+        group = self.create_group()
+
+        # Insert a log entry directly to avoid inline processing.
+        GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.VIEW,
+            actor_type=GroupActorType.SYSTEM,
+            actor_id=0,
+            source=SOURCE,
+            data={},
+        )
+
+        # Process incrementally so the row's cursor is ahead, then set
+        # an old pipeline_hash to simulate a pipeline change.
+        process_group_log(group.id)
+        GroupDerivedData.objects.filter(group_id=group.id).update(pipeline_hash="old_hash")
+
+        # build_and_promote starts from EPOCH, hits CURSOR_BEHIND on
+        # promote (live row's cursor is ahead), copies the live row's
+        # state (including the old pipeline_hash), then retries.
+        build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+        derived = GroupDerivedData.objects.get(group_id=group.id)
+        # The promoted row must carry the current pipeline hash, not the
+        # old one copied from the live row during the CURSOR_BEHIND retry.
+        assert derived.pipeline_hash == PIPELINE.pipeline_hash
+
+    def test_build_and_promote_prevents_stale_incremental_write(self) -> None:
+        """End-to-end ABA test: incremental write computed from pre-generation
+        state must not overwrite a generation's result."""
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        # Incremental processing reads the row.
+        derived = process_group_log(group.id)
+
+        pre_gen_generated_at = derived.generated_at  # None (never generated)
+
+        # A generation runs and promotes (stamps generated_at).
+        build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+        derived.refresh_from_db()
+        assert derived.generated_at is not None
+
+        # A new entry arrives.
+        GroupActionLogEntry.objects.create(
+            group_id=group.id,
+            project_id=group.project_id,
+            type=GroupActionType.VIEW,
+            actor_type=GroupActorType.SYSTEM,
+            actor_id=0,
+            source=SOURCE,
+            data={},
+        )
+
+        # Create a stale incremental writer with the pre-generation state.
+        stale = GroupDerivedData(
+            group_id=group.id,
+            generated_at=pre_gen_generated_at,
+            cursor_date=derived.cursor_date,
+            cursor_id=derived.cursor_id,
+            data=derived.data.copy(),
+            pipeline_hash=derived.pipeline_hash,
+        )
+        # The stale writer processes the new entry.
+        processing._process_batch(PIPELINE, stale, batch_size=1)
+
+        # The write should have been rejected because generated_at changed.
+        derived.refresh_from_db()
+        assert derived.generated_at is not None
+        # Cursor should NOT have advanced (stale write rejected).
+        entries = list(GroupActionLogEntry.objects.filter(group_id=group.id).order_by("id"))
+        assert derived.cursor_id == entries[-2].id  # still at the pre-new-entry position
+
+    def test_drain_log_respects_time_limit(self) -> None:
+        group = self.create_group()
+        for _ in range(5):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        candidate = GroupDerivedData(group_id=group.id, cursor_date=EPOCH, cursor_id=0, data={})
+
+        drained = processing._drain_log(
+            candidate, PIPELINE, batch_size=2, time_limit=timedelta(0), persist=False
+        )
+        assert not drained
+        assert candidate.cursor_id > 0
+        entries = list(GroupActionLogEntry.objects.filter(group_id=group.id).order_by("id"))
+        assert candidate.cursor_id < entries[-1].id
+
+    def test_build_and_promote_caches_on_timeout_for_resumption(self) -> None:
+        group = self.create_group()
+        for _ in range(5):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        with patch("sentry.issues.derived.processing._drain_log", return_value=False):
+            with pytest.raises(GroupLogTimeout) as exc_info:
+                build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
+        assert exc_info.value.group_id == group.id
+        assert exc_info.value.generation_id is not None
+
+        # Resuming completes the promotion.
+        build_and_promote_derived_data(
+            group.id, generation_id=exc_info.value.generation_id, time_limit=timedelta(minutes=5)
+        )
+        promoted = GroupDerivedData.objects.get(group_id=group.id)
+        assert promoted.view_count == 5
+
+    def test_resumed_generation_advances_cursor_on_repeat_timeout(self) -> None:
+        from sentry.issues.derived.processing import _generation_cache
+
+        group = self.create_group()
+        for _ in range(5):
+            _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        with pytest.raises(GroupLogTimeout) as exc_info:
+            build_and_promote_derived_data(group.id, batch_size=2, time_limit=timedelta(0))
+
+        gen_id = exc_info.value.generation_id
+        assert gen_id is not None
+        state = _generation_cache.get(gen_id)
+        assert state is not None
+        first_cursor = state.cursor_id
+        assert first_cursor > 0
+
+        with pytest.raises(GroupLogTimeout) as exc_info:
+            build_and_promote_derived_data(
+                group.id, generation_id=gen_id, batch_size=2, time_limit=timedelta(0)
+            )
+
+        gen_id2 = exc_info.value.generation_id
+        assert gen_id2 is not None
+        state = _generation_cache.get(gen_id2)
+        assert state is not None
+        assert state.cursor_id > first_cursor
+
 
 # --- Pure Python tests (no DB) ---
 
@@ -763,8 +945,9 @@ class GroupDerivedDataStoreTest(TestCase):
         first_progress = first.progress
         first_last_progressed_at = first.last_progressed_at
 
-        invalidate_group_derived_data(group.id)
+        invalidate_group_derived_data(group.id, hard_delete=True)
         second = process_group_log(group.id)
+        assert second is not None
 
         assert second.data == first_data
         assert second.view_count == first_view_count

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -278,32 +278,31 @@ class ProcessGroupLogTest(TestCase):
 
     # --- invalidation ---
 
-    def test_hard_invalidate_deletes_row(self) -> None:
+    def test_invalidate_deletes_row(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         process_group_log(group.id)
         assert GroupDerivedData.objects.filter(group_id=group.id).exists()
 
-        invalidate_group_derived_data(group.id, hard_delete=True)
+        invalidate_group_derived_data(group.id)
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
-    def test_hard_invalidate_with_cursor_deletes_if_past(self) -> None:
+    def test_invalidate_with_cursor_deletes_if_past(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)
 
-        invalidate_group_derived_data(
-            group.id, cursor=(derived.cursor_date, derived.cursor_id), hard_delete=True
-        )
+        # Cursor at the processed entry — row should be deleted.
+        invalidate_group_derived_data(group.id, cursor=(derived.cursor_date, derived.cursor_id))
         assert not GroupDerivedData.objects.filter(group_id=group.id).exists()
 
     def test_invalidate_with_cursor_noop_if_not_reached(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         derived = process_group_log(group.id)
-
         old_cursor = derived.cursor_id
 
+        # Cursor beyond what we've processed — row should be untouched.
         future = derived.cursor_date.replace(year=derived.cursor_date.year + 1)
         invalidate_group_derived_data(group.id, cursor=(future, old_cursor + 1000))
         derived.refresh_from_db()
@@ -317,24 +316,9 @@ class ProcessGroupLogTest(TestCase):
         derived = process_group_log(group.id)
         assert derived.view_count == 2
 
-        invalidate_group_derived_data(group.id, hard_delete=True)
+        invalidate_group_derived_data(group.id)
         derived = process_group_log(group.id)
         assert derived.view_count == 2  # rebuilt from scratch
-
-    def test_invalidate_soft_enqueues_generation(self) -> None:
-        group = self.create_group()
-        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
-        derived = process_group_log(group.id)
-
-        original_id = derived.id
-
-        with patch("sentry.issues.derived.processing.generate_group_derived_data") as mock_task:
-            invalidate_group_derived_data(group.id)
-            mock_task.delay.assert_called_once_with(group.id)
-
-        # Row is still in place — soft invalidation doesn't modify it.
-        derived.refresh_from_db()
-        assert derived.id == original_id
 
     def test_resolved_in_pull_request_proposes_fix(self) -> None:
         group = self.create_group()
@@ -408,7 +392,7 @@ class ProcessGroupLogTest(TestCase):
         first_progress = first.progress
         first_last_progressed_at = first.last_progressed_at
 
-        invalidate_group_derived_data(group.id, hard_delete=True)
+        invalidate_group_derived_data(group.id)
         second = process_group_log(group.id)
         assert second is not None
         assert second.data == first_data
@@ -440,7 +424,7 @@ class ProcessGroupLogTest(TestCase):
         first_data = first.data.copy()
         assert first.data["blocker"] == IssueBlocker.APPROVE_CODE_CHANGES.value
 
-        invalidate_group_derived_data(group.id, hard_delete=True)
+        invalidate_group_derived_data(group.id)
         second = process_group_log(group.id)
         state = GroupDerivedDataStore.load(PIPELINE, second)
 
@@ -517,7 +501,7 @@ class ProcessGroupLogTest(TestCase):
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
         process_group_log(group.id)
 
-        invalidate_group_derived_data(group.id, hard_delete=True)
+        invalidate_group_derived_data(group.id)
         derived = process_group_log(group.id)
         assert derived.pipeline_hash == PIPELINE.pipeline_hash
 
@@ -988,7 +972,7 @@ class GroupDerivedDataStoreTest(TestCase):
         first_progress = first.progress
         first_last_progressed_at = first.last_progressed_at
 
-        invalidate_group_derived_data(group.id, hard_delete=True)
+        invalidate_group_derived_data(group.id)
         second = process_group_log(group.id)
         assert second is not None
 

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -548,6 +548,11 @@ class PromoteToLiveTest(TestCase):
         assert live.view_count == 1
         assert live.generated_at == gen_time
 
+    def test_build_and_promote_raises_for_deleted_group(self) -> None:
+        nonexistent_group_id = 999999999
+        with pytest.raises(Group.DoesNotExist):
+            build_and_promote_derived_data(nonexistent_group_id, time_limit=timedelta(minutes=5))
+
     def test_promote_updates_existing_row(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -710,7 +710,7 @@ class PromoteToLiveTest(TestCase):
         assert live.view_count == 2
         assert live.generated_at is not None
 
-    def test_build_and_promote_cursor_behind_preserves_pipeline_hash(self) -> None:
+    def test_build_and_promote_overwrites_old_pipeline_hash(self) -> None:
         group = self.create_group()
 
         # Insert a log entry directly to avoid inline processing.
@@ -724,19 +724,57 @@ class PromoteToLiveTest(TestCase):
             data={},
         )
 
-        # Process incrementally so the row's cursor is ahead, then set
-        # an old pipeline_hash to simulate a pipeline change.
+        # Process incrementally, then set an old pipeline_hash to
+        # simulate a pipeline change.
         process_group_log(group.id)
         GroupDerivedData.objects.filter(group_id=group.id).update(pipeline_hash="old_hash")
 
-        # build_and_promote starts from EPOCH, hits CURSOR_BEHIND on
-        # promote (live row's cursor is ahead), copies the live row's
-        # state (including the old pipeline_hash), then retries.
         build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
         derived = GroupDerivedData.objects.get(group_id=group.id)
-        # The promoted row must carry the current pipeline hash, not the
-        # old one copied from the live row during the CURSOR_BEHIND retry.
         assert derived.pipeline_hash == PIPELINE.pipeline_hash
+
+    def test_build_and_promote_cursor_behind_orphaned_cursor(self) -> None:
+        from sentry.issues.derived.processing import PromotionFailed
+
+        group = self.create_group()
+
+        # Create a live row with a cursor pointing past any existing entries.
+        GroupDerivedData.objects.create(
+            group_id=group.id,
+            cursor_date=django_timezone.now(),
+            cursor_id=99999,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+
+        # build_and_promote drains nothing (no entries), gets CURSOR_BEHIND
+        # because the candidate's EPOCH cursor is behind the live row's.
+        # With no entries to catch up on, the log was modified and the
+        # replay is incomplete — give up.
+        with pytest.raises(PromotionFailed):
+            build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
+    def test_build_and_promote_cursor_behind_new_entries(self) -> None:
+        group = self.create_group()
+
+        # Create initial entry and process it incrementally.
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        process_group_log(group.id)
+        live = GroupDerivedData.objects.get(group_id=group.id)
+        first_cursor = live.cursor_id
+
+        # Add a new entry that only incremental processing has seen.
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        process_group_log(group.id)
+        live.refresh_from_db()
+        assert live.cursor_id > first_cursor
+
+        # build_and_promote replays the full log, gets CURSOR_BEHIND on
+        # first promote (live cursor advanced), drains the new entry on
+        # retry, and promotes successfully.
+        build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+        derived = GroupDerivedData.objects.get(group_id=group.id)
+        assert derived.view_count == 2
 
     def test_build_and_promote_prevents_stale_incremental_write(self) -> None:
         """End-to-end ABA test: incremental write computed from pre-generation

--- a/tests/sentry/issues/derived/test_processing.py
+++ b/tests/sentry/issues/derived/test_processing.py
@@ -738,6 +738,19 @@ class PromoteToLiveTest(TestCase):
         with pytest.raises(PromotionFailed):
             build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
 
+    def test_build_and_promote_superseded_returns_cleanly(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        process_group_log(group.id)
+
+        # Stamp generated_at far in the future so our generation is older.
+        GroupDerivedData.objects.filter(group_id=group.id).update(
+            generated_at=django_timezone.now() + timedelta(hours=1)
+        )
+
+        # Should return without raising — SUPERSEDED is not a failure.
+        build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
     def test_build_and_promote_cursor_behind_new_entries(self) -> None:
         group = self.create_group()
 

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -156,7 +156,7 @@ class ProcessProjectDerivedDataBatchTest(DerivedDataTaskTestBase):
             patch.object(
                 processing,
                 "process_group_log",
-                side_effect=GroupLogTimeout("timed out"),
+                side_effect=GroupLogTimeout(0),
             ),
             patch.object(process_project_derived_data_batch, "delay") as mock_delay,
         ):

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry import buffer, eventstream
-from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupmeta import GroupMeta
@@ -280,18 +280,18 @@ class MergeGroupTest(TestCase, SnubaTestCase):
         derived = GroupDerivedData.objects.create(
             group=new_group, cursor_date=before_now(minutes=5), cursor_id=100
         )
-        original_generated_at = derived.generated_at
 
         with self.tasks():
             merge_groups([old_group.id], new_group.id)
 
         assert Group.objects.filter(id=old_group.id).exists() is False
 
-        # The live row's cursor points past entries that no longer exist
-        # (orphaned by merge). The generation task detects this and gives
-        # up — the row is unchanged.
-        derived.refresh_from_db()
-        assert derived.generated_at == original_generated_at
+        # The derived data is invalidated: the stale row is deleted and rebuilt
+        # from scratch by the scheduled processing task.
+        rebuilt = GroupDerivedData.objects.get(group_id=new_group.id)
+        assert rebuilt.id != derived.id
+        assert rebuilt.cursor_date == EPOCH
+        assert rebuilt.cursor_id == 0
 
     @mock_redis_buffer()
     def test_merge_original_group_id(self) -> None:

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -287,9 +287,11 @@ class MergeGroupTest(TestCase, SnubaTestCase):
 
         assert Group.objects.filter(id=old_group.id).exists() is False
 
-        # The generation task ran and stamped a newer generated_at.
+        # The live row's cursor points past entries that no longer exist
+        # (orphaned by merge). The generation task detects this and gives
+        # up — the row is unchanged.
         derived.refresh_from_db()
-        assert derived.generated_at > original_generated_at
+        assert derived.generated_at == original_generated_at
 
     @mock_redis_buffer()
     def test_merge_original_group_id(self) -> None:

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -3,7 +3,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry import buffer, eventstream
-from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
+from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.group import Group
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.groupmeta import GroupMeta
@@ -280,18 +280,16 @@ class MergeGroupTest(TestCase, SnubaTestCase):
         derived = GroupDerivedData.objects.create(
             group=new_group, cursor_date=before_now(minutes=5), cursor_id=100
         )
+        original_generated_at = derived.generated_at
 
         with self.tasks():
             merge_groups([old_group.id], new_group.id)
 
         assert Group.objects.filter(id=old_group.id).exists() is False
 
-        # The derived data is invalidated: the stale row is deleted and rebuilt
-        # from scratch by the scheduled processing task.
-        rebuilt = GroupDerivedData.objects.get(group_id=new_group.id)
-        assert rebuilt.id != derived.id
-        assert rebuilt.cursor_date == EPOCH
-        assert rebuilt.cursor_id == 0
+        # The generation task ran and stamped a newer generated_at.
+        derived.refresh_from_db()
+        assert derived.generated_at > original_generated_at
 
     @mock_redis_buffer()
     def test_merge_original_group_id(self) -> None:


### PR DESCRIPTION
Adds build_and_promote_derived_data, which drains the full action log in memory and upserts via promote_to_live with CAS guards. On timeout, partial progress is cached for resumption via GenerationId.

Forks the existing project-level processing tasks into generation variants (generate_group_derived_data, generate_project_derived_data) that use build_and_promote instead of incremental processing. The old process_project_derived_data tasks remain until the new ones are validated.

Makes invalidate_group_derived_data soft by default: enqueues a generation task without deleting the existing row. Hard deletion is opt-in via hard_delete=True for cases where stale data must not be served.