### PR TITLE
feat(issues): Add issue.autofix_state search key for autofix overview

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -967,6 +967,7 @@ SKIP_SNUBA_FIELDS = frozenset(
         "issue.seer_actionability",
         "issue.seer_last_run",
         "issue.progress",
+        "issue.autofix_state",
     )
 )
 

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -283,7 +283,7 @@ def convert_issue_progress_value(
 def convert_autofix_state_value(
     value: Iterable[str],
     projects: Sequence[Project],
-    user: User,
+    user: User | RpcUser | AnonymousUser | None,
     environments: Sequence[Environment] | None,
 ) -> list[str]:
     results: list[str] = []

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -42,6 +42,7 @@ from sentry.search.utils import (
     parse_user_value,
 )
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
+from sentry.seer.autofix.issue_search import AUTOFIX_STATE_VALUES
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, PriorityLevel
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -279,6 +280,20 @@ def convert_issue_progress_value(
     return results
 
 
+def convert_autofix_state_value(
+    value: Iterable[str],
+    projects: Sequence[Project],
+    user: User,
+    environments: Sequence[Environment] | None,
+) -> list[str]:
+    results: list[str] = []
+    for state in value:
+        if state not in AUTOFIX_STATE_VALUES:
+            raise InvalidSearchQuery(f"Invalid issue.autofix_state value of '{state}'")
+        results.append(state)
+    return results
+
+
 def convert_detector_value(
     value: Iterable[str],
     projects: Sequence[Project],
@@ -305,6 +320,7 @@ value_converters: Mapping[str, ValueConverter] = {
     "substatus": convert_substatus_value,
     "issue.seer_actionability": convert_seer_actionability_value,
     "issue.progress": convert_issue_progress_value,
+    "issue.autofix_state": convert_autofix_state_value,
     "detector": convert_detector_value,  # TODO - delete this once the UI has been updated
     "monitor": convert_detector_value,
 }

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -37,6 +37,7 @@ from sentry.search.snuba.executors import (
     TrendsSortWeights,
 )
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
+from sentry.seer.autofix.issue_search import autofix_state_filter
 from sentry.sentry_apps.models.platformexternalissue import PlatformExternalIssue
 from sentry.users.models.user import User
 from sentry.utils import metrics
@@ -724,6 +725,13 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "issue.seer_actionability": QCallbackCondition(seer_actionability_filter),
             "issue.progress": QCallbackCondition(
                 functools.partial(issue_progress_filter, projects=projects)
+            ),
+            "issue.autofix_state": QCallbackCondition(
+                functools.partial(
+                    autofix_state_filter,
+                    projects=projects,
+                    recency_window=SEER_LAST_RUN_RECENCY_WINDOW,
+                )
             ),
             # TODO: the recency window approximates an "active" run while
             # we figure out how to handle deletion of seer runs better. Once runs

--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import timedelta
 
-from django.db.models import Q
+from django.db.models import Case, Max, Q, When
 from django.utils import timezone
 
 from sentry.models.activity import Activity
@@ -22,11 +22,45 @@ AUTOFIX_STATE_VALUES = frozenset(
     }
 )
 
+MILESTONE_ACTIVITY_TYPES = (
+    ActivityType.SEER_SOLUTION_COMPLETED,
+    ActivityType.SEER_CODING_COMPLETED,
+    ActivityType.SEER_PR_CREATED,
+)
 
-def _milestone_q(activity_type: ActivityType, projects: Sequence[Project]) -> Q:
+
+def _milestone_state_q(
+    projects: Sequence[Project],
+    reached: ActivityType,
+    not_reached: Sequence[ActivityType],
+) -> Q:
+    activities = Activity.objects.filter(
+        project__in=projects,
+        type__in=[t.value for t in (reached, *not_reached)],
+        group_id__isnull=False,
+    )
+    if not not_reached:
+        return Q(id__in=activities.values_list("group_id", flat=True))
+
+    annotations = {
+        f"reached_{t.value}": Max(Case(When(type=t.value, then=1), default=0))
+        for t in (reached, *not_reached)
+    }
+    having = {f"reached_{reached.value}": 1} | {f"reached_{t.value}": 0 for t in not_reached}
+    return Q(
+        id__in=activities.values("group_id")
+        .annotate(**annotations)
+        .filter(**having)
+        .values_list("group_id", flat=True)
+    )
+
+
+def _any_milestone_q(projects: Sequence[Project]) -> Q:
     return Q(
         id__in=Activity.objects.filter(
-            project__in=projects, type=activity_type.value, group_id__isnull=False
+            project__in=projects,
+            type__in=[t.value for t in MILESTONE_ACTIVITY_TYPES],
+            group_id__isnull=False,
         ).values_list("group_id", flat=True)
     )
 
@@ -54,20 +88,29 @@ def autofix_state_filter(
     values: list[str], projects: Sequence[Project], recency_window: timedelta
 ) -> Q:
     merged = _merged_pr_q(projects)
-    pr_created = _milestone_q(ActivityType.SEER_PR_CREATED, projects)
-    coding = _milestone_q(ActivityType.SEER_CODING_COMPLETED, projects)
-    solution = _milestone_q(ActivityType.SEER_SOLUTION_COMPLETED, projects)
 
     conditions: dict[str, Q] = {
         "merged": merged,
-        "review_pr": pr_created & ~merged,
-        "code_changes_ready": coding & ~pr_created & ~merged,
-        "solution_ready": solution & ~coding & ~pr_created & ~merged,
+        "review_pr": _milestone_state_q(projects, ActivityType.SEER_PR_CREATED, []) & ~merged,
+        "code_changes_ready": (
+            _milestone_state_q(
+                projects,
+                ActivityType.SEER_CODING_COMPLETED,
+                [ActivityType.SEER_PR_CREATED],
+            )
+            & ~merged
+        ),
+        "solution_ready": (
+            _milestone_state_q(
+                projects,
+                ActivityType.SEER_SOLUTION_COMPLETED,
+                [ActivityType.SEER_CODING_COMPLETED, ActivityType.SEER_PR_CREATED],
+            )
+            & ~merged
+        ),
         "needs_investigation": (
             Q(seer_explorer_autofix_last_triggered__gte=timezone.now() - recency_window)
-            & ~solution
-            & ~coding
-            & ~pr_created
+            & ~_any_milestone_q(projects)
             & ~merged
         ),
     }

--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -87,6 +87,9 @@ def _merged_pr_q(projects: Sequence[Project]) -> Q:
 def autofix_state_filter(
     values: list[str], projects: Sequence[Project], recency_window: timedelta
 ) -> Q:
+    if not values:
+        return Q(id__in=[])
+
     merged = _merged_pr_q(projects)
 
     conditions: dict[str, Q] = {

--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import timedelta
+
+from django.db.models import Q
+from django.utils import timezone
+
+from sentry.models.activity import Activity
+from sentry.models.project import Project
+from sentry.models.pullrequest import PullRequestLifecycleState
+from sentry.seer.models.run import SeerAgentRun
+from sentry.types.activity import ActivityType
+
+AUTOFIX_STATE_VALUES = frozenset(
+    {
+        "merged",
+        "review_pr",
+        "code_changes_ready",
+        "solution_ready",
+        "needs_investigation",
+    }
+)
+
+
+def _milestone_q(activity_type: ActivityType, projects: Sequence[Project]) -> Q:
+    return Q(
+        id__in=Activity.objects.filter(project__in=projects, type=activity_type.value).values_list(
+            "group_id", flat=True
+        )
+    )
+
+
+def _merged_pr_q(projects: Sequence[Project]) -> Q:
+    return Q(
+        id__in=SeerAgentRun.objects.filter(
+            project_id__in=[p.id for p in projects],
+            group_id__isnull=False,
+            run__pull_request_links__pull_request__state=PullRequestLifecycleState.MERGED,
+        ).values_list("group_id", flat=True)
+    )
+
+
+def autofix_state_filter(
+    values: list[str], projects: Sequence[Project], recency_window: timedelta
+) -> Q:
+    merged = _merged_pr_q(projects)
+    pr_created = _milestone_q(ActivityType.SEER_PR_CREATED, projects)
+    coding = _milestone_q(ActivityType.SEER_CODING_COMPLETED, projects)
+    solution = _milestone_q(ActivityType.SEER_SOLUTION_COMPLETED, projects)
+
+    conditions: dict[str, Q] = {
+        "merged": merged,
+        "review_pr": pr_created & ~merged,
+        "code_changes_ready": coding & ~pr_created & ~merged,
+        "solution_ready": solution & ~coding & ~pr_created & ~merged,
+        "needs_investigation": (
+            Q(seer_explorer_autofix_last_triggered__gte=timezone.now() - recency_window)
+            & ~solution
+            & ~coding
+            & ~pr_created
+            & ~merged
+        ),
+    }
+
+    q = Q()
+    for value in values:
+        q |= conditions[value]
+    return q

--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -36,6 +36,7 @@ def _merged_pr_q(projects: Sequence[Project]) -> Q:
         SeerAgentRun.objects.filter(
             project_id__in=[p.id for p in projects],
             group_id__isnull=False,
+            source="autofix",
         )
         .order_by("group_id", "-id")
         .distinct("group_id")

--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -32,10 +32,18 @@ def _milestone_q(activity_type: ActivityType, projects: Sequence[Project]) -> Q:
 
 
 def _merged_pr_q(projects: Sequence[Project]) -> Q:
-    return Q(
-        id__in=SeerAgentRun.objects.filter(
+    latest_runs = (
+        SeerAgentRun.objects.filter(
             project_id__in=[p.id for p in projects],
             group_id__isnull=False,
+        )
+        .order_by("group_id", "-id")
+        .distinct("group_id")
+        .values("id")
+    )
+    return Q(
+        id__in=SeerAgentRun.objects.filter(
+            id__in=latest_runs,
             run__pull_request_links__pull_request__state=PullRequestLifecycleState.MERGED,
         ).values_list("group_id", flat=True)
     )

--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -25,9 +25,9 @@ AUTOFIX_STATE_VALUES = frozenset(
 
 def _milestone_q(activity_type: ActivityType, projects: Sequence[Project]) -> Q:
     return Q(
-        id__in=Activity.objects.filter(project__in=projects, type=activity_type.value).values_list(
-            "group_id", flat=True
-        )
+        id__in=Activity.objects.filter(
+            project__in=projects, type=activity_type.value, group_id__isnull=False
+        ).values_list("group_id", flat=True)
     )
 
 

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -30,6 +30,7 @@ from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOI
 from sentry.models.release import ReleaseStatus
 from sentry.search.utils import get_teams_for_users
 from sentry.seer.autofix.constants import FixabilityScoreThresholds
+from sentry.seer.autofix.issue_search import AUTOFIX_STATE_VALUES
 from sentry.testutils.cases import TestCase
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, GroupSubStatus, PriorityLevel
 
@@ -368,20 +369,14 @@ class ConvertIssueProgressValueTest(TestCase):
             convert_query_values(filters, [self.project], self.user, None)
 
 
-class ConvertAutofixStateValueTest(TestCase):
-    def test_valid(self) -> None:
-        for state in (
-            "merged",
-            "review_pr",
-            "code_changes_ready",
-            "solution_ready",
-            "needs_investigation",
-        ):
-            assert convert_autofix_state_value([state], [self.project], self.user, None) == [state]
+@pytest.mark.parametrize("state", sorted(AUTOFIX_STATE_VALUES))
+def test_convert_autofix_state_value_valid(state: str) -> None:
+    assert convert_autofix_state_value([state], [], None, None) == [state]
 
-    def test_invalid(self) -> None:
-        with pytest.raises(InvalidSearchQuery):
-            convert_autofix_state_value(["bogus"], [self.project], self.user, None)
+
+def test_convert_autofix_state_value_invalid() -> None:
+    with pytest.raises(InvalidSearchQuery):
+        convert_autofix_state_value(["bogus"], [], None, None)
 
 
 class ConvertDetectorValueTest(TestCase):

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -14,6 +14,7 @@ from sentry.issues.grouptype import GroupCategory
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.issues.issue_search import (
     convert_actor_or_none_value,
+    convert_autofix_state_value,
     convert_category_value,
     convert_device_class_value,
     convert_first_release_value,
@@ -365,6 +366,22 @@ class ConvertIssueProgressValueTest(TestCase):
         filters = [SearchFilter(SearchKey("issue.progress"), "=", SearchValue("wrong"))]
         with pytest.raises(InvalidSearchQuery):
             convert_query_values(filters, [self.project], self.user, None)
+
+
+class ConvertAutofixStateValueTest(TestCase):
+    def test_valid(self) -> None:
+        for state in (
+            "merged",
+            "review_pr",
+            "code_changes_ready",
+            "solution_ready",
+            "needs_investigation",
+        ):
+            assert convert_autofix_state_value([state], [self.project], self.user, None) == [state]
+
+    def test_invalid(self) -> None:
+        with pytest.raises(InvalidSearchQuery):
+            convert_autofix_state_value(["bogus"], [self.project], self.user, None)
 
 
 class ConvertDetectorValueTest(TestCase):

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -98,6 +98,11 @@ class AutofixStateFilterTest(TestCase):
 
         assert self._matching_group_ids(["code_changes_ready"]) == {self.group1.id}
 
+    def test_empty_values_matches_nothing(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+
+        assert self._matching_group_ids([]) == set()
+
     def test_multiple_values_union(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
         self.create_group_activity(

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -1,0 +1,89 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.models.pullrequest import PullRequestLifecycleState
+from sentry.seer.autofix.issue_search import AUTOFIX_STATE_VALUES, autofix_state_filter
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+RECENCY_WINDOW = timedelta(days=30)
+
+
+class AutofixStateFilterTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group1 = self.create_group(project=self.project)
+        self.group2 = self.create_group(project=self.project)
+
+    def _matching_group_ids(self, values: list[str]) -> set[int]:
+        q = autofix_state_filter(values, [self.project], recency_window=RECENCY_WINDOW)
+        from sentry.models.group import Group
+
+        return set(Group.objects.filter(q, project=self.project).values_list("id", flat=True))
+
+    def _create_merged_pr_run(self, group):
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", project=self.project, group=group)
+        repo = self.create_repo(self.project, name="getsentry/sentry")
+        pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="101"
+        )
+        pr.update(state=PullRequestLifecycleState.MERGED, merged_at=timezone.now())
+        self.create_seer_run_pull_request(run, pr)
+
+    def test_values_frozenset(self) -> None:
+        assert AUTOFIX_STATE_VALUES == frozenset(
+            {
+                "merged",
+                "review_pr",
+                "code_changes_ready",
+                "solution_ready",
+                "needs_investigation",
+            }
+        )
+
+    def test_milestones_are_exclusive(self) -> None:
+        self.create_group_activity(
+            group=self.group1, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_CODING_COMPLETED.value)
+        self.create_group_activity(
+            group=self.group2, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+
+        assert self._matching_group_ids(["code_changes_ready"]) == {self.group1.id}
+        assert self._matching_group_ids(["solution_ready"]) == {self.group2.id}
+
+    def test_review_pr_excludes_merged(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)
+        self._create_merged_pr_run(self.group1)
+
+        assert self._matching_group_ids(["merged"]) == {self.group1.id}
+        assert self._matching_group_ids(["review_pr"]) == {self.group2.id}
+
+    def test_needs_investigation_recency(self) -> None:
+        self.group1.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=1))
+        self.group2.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=45))
+
+        assert self._matching_group_ids(["needs_investigation"]) == {self.group1.id}
+
+    def test_needs_investigation_excludes_milestones(self) -> None:
+        self.group1.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=1))
+        self.create_group_activity(
+            group=self.group1, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+
+        assert self._matching_group_ids(["needs_investigation"]) == set()
+
+    def test_multiple_values_union(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(
+            group=self.group2, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+
+        assert self._matching_group_ids(["review_pr", "solution_ready"]) == {
+            self.group1.id,
+            self.group2.id,
+        }

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -64,6 +64,20 @@ class AutofixStateFilterTest(TestCase):
         assert self._matching_group_ids(["merged"]) == {self.group1.id}
         assert self._matching_group_ids(["review_pr"]) == {self.group2.id}
 
+    def test_merged_scoped_to_latest_run(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self._create_merged_pr_run(self.group1)
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", project=self.project, group=self.group1)
+        repo = self.create_repo(self.project, name="getsentry/other")
+        pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="102"
+        )
+        self.create_seer_run_pull_request(run, pr)
+
+        assert self._matching_group_ids(["merged"]) == set()
+        assert self._matching_group_ids(["review_pr"]) == {self.group1.id}
+
     def test_needs_investigation_recency(self) -> None:
         self.group1.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=1))
         self.group2.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=45))

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 
 from sentry.models.activity import Activity
 from sentry.models.pullrequest import PullRequestLifecycleState
-from sentry.seer.autofix.issue_search import AUTOFIX_STATE_VALUES, autofix_state_filter
+from sentry.seer.autofix.issue_search import autofix_state_filter
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
 
@@ -32,17 +32,6 @@ class AutofixStateFilterTest(TestCase):
         )
         pr.update(state=PullRequestLifecycleState.MERGED, merged_at=timezone.now())
         self.create_seer_run_pull_request(run, pr)
-
-    def test_values_frozenset(self) -> None:
-        assert AUTOFIX_STATE_VALUES == frozenset(
-            {
-                "merged",
-                "review_pr",
-                "code_changes_ready",
-                "solution_ready",
-                "needs_investigation",
-            }
-        )
 
     def test_milestones_are_exclusive(self) -> None:
         self.create_group_activity(

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -78,6 +78,15 @@ class AutofixStateFilterTest(TestCase):
         assert self._matching_group_ids(["merged"]) == set()
         assert self._matching_group_ids(["review_pr"]) == {self.group1.id}
 
+    def test_merged_ignores_non_autofix_runs(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self._create_merged_pr_run(self.group1)
+        chat_run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(chat_run, source="chat", project=self.project, group=self.group1)
+
+        assert self._matching_group_ids(["merged"]) == {self.group1.id}
+        assert self._matching_group_ids(["review_pr"]) == set()
+
     def test_needs_investigation_recency(self) -> None:
         self.group1.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=1))
         self.group2.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=45))

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry.models.activity import Activity
 from sentry.models.pullrequest import PullRequestLifecycleState
 from sentry.seer.autofix.issue_search import AUTOFIX_STATE_VALUES, autofix_state_filter
 from sentry.testutils.cases import TestCase
@@ -76,6 +77,14 @@ class AutofixStateFilterTest(TestCase):
         )
 
         assert self._matching_group_ids(["needs_investigation"]) == set()
+
+    def test_null_group_activity_does_not_break_negation(self) -> None:
+        Activity.objects.create(
+            project=self.project, group=None, type=ActivityType.SEER_PR_CREATED.value
+        )
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_CODING_COMPLETED.value)
+
+        assert self._matching_group_ids(["code_changes_ready"]) == {self.group1.id}
 
     def test_multiple_values_union(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1152,6 +1152,13 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         with pytest.raises(InvalidSearchQuery):
             self.make_query(search_filter_query="issue.autofix_state:bogus")
 
+    def test_autofix_state_negation(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+
+        results = self.make_query(search_filter_query="!issue.autofix_state:review_pr")
+        assert self.group1 not in set(results)
+        assert self.group2 in set(results)
+
     def test_issue_progress(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
         self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1076,6 +1076,82 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == {linked_group2}
 
+    def _create_merged_autofix_pr(self, group):
+        run = self.create_seer_run(organization=group.project.organization)
+        self.create_seer_agent_run(run, source="autofix", project=group.project, group=group)
+        repo = self.create_repo(group.project, name="getsentry/example")
+        pr = self.create_pull_request(
+            repository_id=repo.id,
+            organization_id=group.project.organization_id,
+            key="9001",
+        )
+        pr.update(state="merged", merged_at=timezone.now())
+        self.create_seer_run_pull_request(run, pr)
+
+    def test_autofix_state_milestones(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(
+            group=self.group2, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+
+        results = self.make_query(search_filter_query="issue.autofix_state:review_pr")
+        assert set(results) == {self.group1}
+
+        results = self.make_query(search_filter_query="issue.autofix_state:solution_ready")
+        assert set(results) == {self.group2}
+
+        results = self.make_query(search_filter_query="issue.autofix_state:code_changes_ready")
+        assert set(results) == set()
+
+    def test_autofix_state_precedence(self) -> None:
+        self.create_group_activity(
+            group=self.group1, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_CODING_COMPLETED.value)
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+
+        assert set(self.make_query(search_filter_query="issue.autofix_state:review_pr")) == {
+            self.group1
+        }
+        assert (
+            set(self.make_query(search_filter_query="issue.autofix_state:code_changes_ready"))
+            == set()
+        )
+        assert (
+            set(self.make_query(search_filter_query="issue.autofix_state:solution_ready")) == set()
+        )
+
+    def test_autofix_state_merged(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self._create_merged_autofix_pr(self.group1)
+
+        assert set(self.make_query(search_filter_query="issue.autofix_state:merged")) == {
+            self.group1
+        }
+        assert set(self.make_query(search_filter_query="issue.autofix_state:review_pr")) == set()
+
+    def test_autofix_state_needs_investigation(self) -> None:
+        self.group1.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=1))
+        self.group2.update(seer_explorer_autofix_last_triggered=timezone.now() - timedelta(days=45))
+
+        results = self.make_query(search_filter_query="issue.autofix_state:needs_investigation")
+        assert set(results) == {self.group1}
+
+    def test_autofix_state_multiple_values(self) -> None:
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
+        self.create_group_activity(
+            group=self.group2, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+
+        results = self.make_query(
+            search_filter_query="issue.autofix_state:[review_pr, solution_ready]"
+        )
+        assert set(results) == {self.group1, self.group2}
+
+    def test_autofix_state_invalid_value(self) -> None:
+        with pytest.raises(InvalidSearchQuery):
+            self.make_query(search_filter_query="issue.autofix_state:bogus")
+
     def test_issue_progress(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_RCA_COMPLETED.value)
         self.create_group_activity(group=self.group2, type=ActivityType.SEER_PR_CREATED.value)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1103,24 +1103,6 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(search_filter_query="issue.autofix_state:code_changes_ready")
         assert set(results) == set()
 
-    def test_autofix_state_precedence(self) -> None:
-        self.create_group_activity(
-            group=self.group1, type=ActivityType.SEER_SOLUTION_COMPLETED.value
-        )
-        self.create_group_activity(group=self.group1, type=ActivityType.SEER_CODING_COMPLETED.value)
-        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
-
-        assert set(self.make_query(search_filter_query="issue.autofix_state:review_pr")) == {
-            self.group1
-        }
-        assert (
-            set(self.make_query(search_filter_query="issue.autofix_state:code_changes_ready"))
-            == set()
-        )
-        assert (
-            set(self.make_query(search_filter_query="issue.autofix_state:solution_ready")) == set()
-        )
-
     def test_autofix_state_merged(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
         self._create_merged_autofix_pr(self.group1)


### PR DESCRIPTION
Adds a Postgres-only issue-search key, `issue.autofix_state`, that classifies issues into five mutually exclusive autofix pipeline states:

- `merged` — the group's latest autofix run has a merged PR (via the `SeerAgentRun → SeerRun → SeerRunPullRequest → PullRequest.state` join, webhook-fresh and flag-free)
- `review_pr` — `SEER_PR_CREATED` activity exists, PR not merged
- `code_changes_ready` — `SEER_CODING_COMPLETED`, no PR yet
- `solution_ready` — `SEER_SOLUTION_COMPLETED`, no code yet
- `needs_investigation` — a Seer run in the last 30 days with none of the above

The autofix overview page currently classifies issues client-side by fetching each issue's full run state from Seer (two Seer round trips per issue per page load), which makes true per-section counts and server-side filtering impossible. With this key, each overview section becomes a plain filtered issue-stream query with real counts from `X-Hits`. Milestone signals come from the `SEER_*` activity rows Sentry already records when Seer pushes step-completion events; precedence is baked into the conditions so every seer-touched issue lands in exactly one state.

The filter logic lives in a Seer-owned module (`sentry/seer/autofix/issue_search.py`); registration mirrors `issue.progress` at the standard three points (value converter, `QCallbackCondition`, `SKIP_SNUBA_FIELDS`). No migration (the join is already indexed), no new flags, no behavior change for any existing query.

**Performance notes (verified against compiled SQL + prod indexes):** milestone subqueries hit Activity's `(project_id, type)` index and plan as hashed anti-joins (NULL-guarded); the Postgres candidate query is capped at 5k. Two known plan-shape assumptions: the merged join relies on the planner anchoring on `SeerAgentRun.project_id` (`PullRequest.state` is unindexed), and `needs_investigation` has no positive anchor — its scan is bounded by the standard issue-search indexes, same cost model as `issue.progress`.

The frontend consumer (per-section fetches on the autofix overview) follows in a separate PR.

