### PR TITLE
perf(weekly-report): Batch issue summaries query to avoid statement timeout

### DIFF
--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -474,6 +474,9 @@ def project_event_counts_for_organization(start, end, ctx, referrer: str) -> lis
     return data
 
 
+_ISSUE_SUMMARY_BATCH_SIZE = 50
+
+
 def organization_project_issue_summaries(
     start: datetime, end: datetime, ctx: OrganizationReportContext
 ) -> list[dict[str, Any]]:
@@ -481,17 +484,22 @@ def organization_project_issue_summaries(
 
     Returns raw rows; callers roll up by substatus or by day as needed.
     """
-    return list(
-        Group.objects.filter(
-            project_id__in=list(ctx.projects_context_map.keys()),
-            last_seen__gte=start,
-            last_seen__lt=end,
-            status=GroupStatus.UNRESOLVED,
+    project_ids = list(ctx.projects_context_map.keys())
+    results: list[dict[str, Any]] = []
+    for i in range(0, len(project_ids), _ISSUE_SUMMARY_BATCH_SIZE):
+        batch = project_ids[i : i + _ISSUE_SUMMARY_BATCH_SIZE]
+        results.extend(
+            Group.objects.filter(
+                project_id__in=batch,
+                last_seen__gte=start,
+                last_seen__lt=end,
+                status=GroupStatus.UNRESOLVED,
+            )
+            .annotate(day=TruncDay("last_seen"))
+            .values("project_id", "substatus", "day")
+            .annotate(total=Count("id"))
         )
-        .annotate(day=TruncDay("last_seen"))
-        .values("project_id", "substatus", "day")
-        .annotate(total=Count("id"))
-    )
+    return results
 
 
 PAST_ISSUES_CANDIDATE_LIMIT = 50

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -474,7 +474,7 @@ def project_event_counts_for_organization(start, end, ctx, referrer: str) -> lis
     return data
 
 
-_ISSUE_SUMMARY_BATCH_SIZE = 50
+ISSUE_SUMMARY_BATCH_SIZE = 50
 
 
 def organization_project_issue_summaries(
@@ -486,8 +486,8 @@ def organization_project_issue_summaries(
     """
     project_ids = list(ctx.projects_context_map.keys())
     results: list[dict[str, Any]] = []
-    for i in range(0, len(project_ids), _ISSUE_SUMMARY_BATCH_SIZE):
-        batch = project_ids[i : i + _ISSUE_SUMMARY_BATCH_SIZE]
+    for i in range(0, len(project_ids), ISSUE_SUMMARY_BATCH_SIZE):
+        batch = project_ids[i : i + ISSUE_SUMMARY_BATCH_SIZE]
         results.extend(
             Group.objects.filter(
                 project_id__in=batch,


### PR DESCRIPTION
NOTE: the OperationalError (see [SENTRY-5RDV](https://sentry.sentry.io/issues/SENTRY-5RDV/)) is intermittent. 

## Summary
- Batches the `organization_project_issue_summaries` query into chunks of 50 project IDs instead of passing all project IDs in a single `IN (...)` clause
- Fixes statement timeouts for orgs with many projects (~284+) where the large `IN` clause causes expensive index scans on `sentry_groupedmessage`

Fixes [SENTRY-5RDV](https://sentry.sentry.io/issues/SENTRY-5RDV/)

## Test plan
- [ ] Verify existing weekly report tests pass (all current failures are pre-existing `ImportError` from `scm.types`)
- [ ] Monitor `sentry.weekly_report.create_context.issue_summaries` p99 duration on Datadog dashboard after deploy
- [ ] Confirm SENTRY-5RDV stops firing for large orgs