### PR TITLE
fix(weekly-report): Catch exception in issue summaries to prevent report failure

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -131,9 +131,13 @@ class OrganizationReportContextFactory:
                     project_ctx.prev_week_accepted_error_count += data["total"]
 
             if issue_missed_project_ids:
-                issue_data = organization_project_issue_summaries(
-                    start=prev_start, end=prev_end, ctx=ctx
-                )
+                try:
+                    issue_data = organization_project_issue_summaries(
+                        start=prev_start, end=prev_end, ctx=ctx
+                    )
+                except Exception:
+                    sentry_sdk.capture_exception()
+                    issue_data = []
                 for item in issue_data:
                     project_id = item["project_id"]
                     if project_id not in issue_missed_project_ids:

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -149,7 +149,11 @@ class OrganizationReportContextFactory:
             op="weekly_reports.organization_project_issue_summaries",
             name="weekly_reports.organization_project_issue_summaries",
         ):
-            data = organization_project_issue_summaries(start=ctx.start, end=ctx.end, ctx=ctx)
+            try:
+                data = organization_project_issue_summaries(start=ctx.start, end=ctx.end, ctx=ctx)
+            except Exception:
+                sentry_sdk.capture_exception()
+                return
             for item in data:
                 project_id = item["project_id"]
                 if project_id not in ctx.projects_context_map:

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -153,6 +153,7 @@ class OrganizationReportContextFactory:
                 data = organization_project_issue_summaries(start=ctx.start, end=ctx.end, ctx=ctx)
             except Exception:
                 sentry_sdk.capture_exception()
+                ctx.issue_summaries_failed = True
                 return
             for item in data:
                 project_id = item["project_id"]

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -60,6 +60,8 @@ class OrganizationReportContext:
         for project in organization.project_set.all():
             self.projects_context_map[project.id] = ProjectContext(project)
 
+        self.issue_summaries_failed = False
+
         # Top spans data for the spans chart
         self.top_spans: list[dict[str, Any]] = []  # [{name, p95, sum}, ...]
         self.top_spans_timeseries: dict[str, dict[int, float]] = {}  # {span_name: {timestamp: p95}}

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -258,10 +258,10 @@ def prepare_organization_report(
             try:
                 project_metrics: dict[int, dict[str, int]] = {}
                 for project_id, project_ctx in ctx.projects_context_map.items():
-                    project_metrics[project_id] = {
-                        "e": project_ctx.accepted_error_count,
-                        "i": project_ctx.total_substatus_count,
-                    }
+                    entry: dict[str, int] = {"e": project_ctx.accepted_error_count}
+                    if not ctx.issue_summaries_failed:
+                        entry["i"] = project_ctx.total_substatus_count
+                    project_metrics[project_id] = entry
                 if project_metrics:
                     cache_project_metrics(organization_id, project_metrics)
             except Exception:


### PR DESCRIPTION
## Summary
- Wraps the `organization_project_issue_summaries` DB query in a try/except so a statement timeout doesn't crash the entire `prepare_organization_report` task
- On failure, the report is still generated (and cache isn't poisoned)— just without issue substatus breakdowns (new/escalating/ongoing/regressed counts)
- Follows the same resilience pattern already used by `_append_organization_top_spans`

Refs SENTRY-5RDV

See also: https://github.com/getsentry/sentry/pull/120297 (batches the query to prevent most timeouts)

## Test plan
- [ ] Verify existing weekly report tests pass (all current failures are pre-existing `ImportError` from `scm.types`)
- [ ] Monitor SENTRY-5RDV — occurrences should still be captured via `sentry_sdk.capture_exception()` but the task will no longer fail