### PR TITLE
ref(scraps): Rename UserBubble to UserMessage and add width prop

### DIFF
--- a/static/app/components/core/chat/assistantMessage.mdx
+++ b/static/app/components/core/chat/assistantMessage.mdx
@@ -7,7 +7,7 @@ resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/assistantMessage.tsx
 ---
 
-import {AssistantMessage, MessageRow, UserBubble} from '@sentry/scraps/chat';
+import {AssistantMessage, MessageRow, UserMessage} from '@sentry/scraps/chat';
 import {Stack} from '@sentry/scraps/layout';
 
 import * as Storybook from 'sentry/stories';
@@ -15,7 +15,7 @@ import * as Storybook from 'sentry/stories';
 export const documentation = import('!!type-loader!@sentry/scraps/chat/assistantMessage');
 
 The `AssistantMessage` renders the content region for an agent's response.
-Unlike the sender's own messages — which are bubbled with `UserBubble` — an
+Unlike the sender's own messages — which are bubbled with `UserMessage` — an
 agent response is not bubbled: it renders as full-width, left-aligned content so
 rich output like markdown, tables, and code reads naturally.
 
@@ -27,7 +27,7 @@ content region.
 <Storybook.Demo align="stretch">
   <Stack width="100%">
     <MessageRow from="user">
-      <UserBubble>How many errors happened in the last 24 hours?</UserBubble>
+      <UserMessage>How many errors happened in the last 24 hours?</UserMessage>
     </MessageRow>
     <MessageRow from="assistant">
       <AssistantMessage>

--- a/static/app/components/core/chat/assistantMessage.tsx
+++ b/static/app/components/core/chat/assistantMessage.tsx
@@ -7,7 +7,7 @@ interface AssistantMessageProps extends React.HTMLAttributes<HTMLDivElement> {
 /**
  * The content region for an agent's response in a conversation.
  *
- * Unlike the sender's messages (see `UserBubble`), an agent response is not
+ * Unlike the sender's messages (see `UserMessage`), an agent response is not
  * bubbled — it renders as full-width left-aligned content so rich output
  * (markdown, tables, code) reads naturally. It keeps wide content from forcing
  * the row wider; the turn's gutter is owned by the wrapping `MessageRow`.

--- a/static/app/components/core/chat/index.tsx
+++ b/static/app/components/core/chat/index.tsx
@@ -1,6 +1,6 @@
 export {AssistantMessage} from './assistantMessage';
 export {AssistantActions} from './assistantActions';
-export {UserBubble} from './userBubble';
+export {UserMessage} from './userMessage';
 export {ToolCallIndicator, type ToolCallStatus} from './toolCallIndicator';
 export {Spinner} from './spinner';
 export {MessageRow} from './messageRow';

--- a/static/app/components/core/chat/messageRow.mdx
+++ b/static/app/components/core/chat/messageRow.mdx
@@ -7,7 +7,7 @@ resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/messageRow.tsx
 ---
 
-import {MessageRow, UserBubble} from '@sentry/scraps/chat';
+import {MessageRow, UserMessage} from '@sentry/scraps/chat';
 import {Container} from '@sentry/scraps/layout';
 
 import * as Storybook from 'sentry/stories';
@@ -27,7 +27,7 @@ role-to-side mapping — callers express whose turn it is, not the layout.
 <Storybook.Demo align="stretch">
   <Container width="100%" background="secondary" radius="md">
     <MessageRow from="user">
-      <UserBubble>Which of my issues are getting worse?</UserBubble>
+      <UserMessage>Which of my issues are getting worse?</UserMessage>
     </MessageRow>
     <MessageRow from="assistant">
       Here are the three escalating issues I found.
@@ -37,7 +37,7 @@ role-to-side mapping — callers express whose turn it is, not the layout.
 
 ```jsx
 <MessageRow from="user">
-  <UserBubble>Which of my issues are getting worse?</UserBubble>
+  <UserMessage>Which of my issues are getting worse?</UserMessage>
 </MessageRow>
 <MessageRow from="assistant">Here are the three escalating issues I found.</MessageRow>
 ```

--- a/static/app/components/core/chat/userMessage.mdx
+++ b/static/app/components/core/chat/userMessage.mdx
@@ -1,20 +1,20 @@
 ---
-title: UserBubble
+title: UserMessage
 description: A single message bubble for the sender's own messages in an agent conversation.
 category: chat
 source: '@sentry/scraps/chat'
 resources:
-  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/userBubble.tsx
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/userMessage.tsx
 ---
 
 import {Flex} from '@sentry/scraps/layout';
-import {UserBubble} from '@sentry/scraps/chat';
+import {UserMessage} from '@sentry/scraps/chat';
 
 import * as Storybook from 'sentry/stories';
 
-export const documentation = import('!!type-loader!@sentry/scraps/chat/userBubble');
+export const documentation = import('!!type-loader!@sentry/scraps/chat/userMessage');
 
-The `UserBubble` renders a single message bubble, styled for the
+The `UserMessage` renders a single message bubble, styled for the
 sender's own messages in an agent conversation. It is presentation only —
 alignment within the conversation is the caller's responsibility.
 
@@ -25,13 +25,13 @@ agent's responses.
 
 <Storybook.Demo>
   <Flex justify="end" width="100%">
-    <UserBubble>How many errors happened in the last 24 hours?</UserBubble>
+    <UserMessage>How many errors happened in the last 24 hours?</UserMessage>
   </Flex>
 </Storybook.Demo>
 
 ```jsx
 <Flex justify="end" width="100%">
-  <UserBubble>How many errors happened in the last 24 hours?</UserBubble>
+  <UserMessage>How many errors happened in the last 24 hours?</UserMessage>
 </Flex>
 ```
 
@@ -43,15 +43,15 @@ wider surfaces.
 
 <Storybook.Demo>
   <Flex justify="end" width="100%">
-    <UserBubble maxWidth="60%">
+    <UserMessage maxWidth="60%">
       A longer question that wraps onto multiple lines once it reaches the max width of
       the bubble.
-    </UserBubble>
+    </UserMessage>
   </Flex>
 </Storybook.Demo>
 
 ```jsx
-<UserBubble maxWidth="60%">…</UserBubble>
+<UserMessage maxWidth="60%">…</UserMessage>
 ```
 
 Whitespace and long unbroken tokens are preserved and wrapped, so pasted URLs

--- a/static/app/components/core/chat/userMessage.mdx
+++ b/static/app/components/core/chat/userMessage.mdx
@@ -9,10 +9,9 @@ resources:
 
 import {useState} from 'react';
 
-import {UserMessage} from '@sentry/scraps/chat';
+import {Button} from '@sentry/scraps/button';
+import {MessageRow, UserMessage} from '@sentry/scraps/chat';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {Switch} from '@sentry/scraps/switch';
-import {Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
 
@@ -24,19 +23,19 @@ alignment within the conversation is the caller's responsibility.
 
 ## Usage
 
-Wrap the bubble in a right-aligned row for user messages so it sits opposite the
+Wrap the bubble in a `MessageRow` with `from="user"` so it sits opposite the
 agent's responses.
 
 <Storybook.Demo>
-  <Flex justify="end" width="100%">
+  <MessageRow from="user">
     <UserMessage>How many errors happened in the last 24 hours?</UserMessage>
-  </Flex>
+  </MessageRow>
 </Storybook.Demo>
 
 ```jsx
-<Flex justify="end" width="100%">
+<MessageRow from="user">
   <UserMessage>How many errors happened in the last 24 hours?</UserMessage>
-</Flex>
+</MessageRow>
 ```
 
 ## Width
@@ -46,12 +45,12 @@ never spans the full conversation width. Override `maxWidth` for narrower or
 wider surfaces.
 
 <Storybook.Demo>
-  <Flex justify="end" width="100%">
+  <MessageRow from="user">
     <UserMessage maxWidth="60%">
       A longer question that wraps onto multiple lines once it reaches the max width of
       the bubble.
     </UserMessage>
-  </Flex>
+  </MessageRow>
 </Storybook.Demo>
 
 ```jsx
@@ -69,14 +68,15 @@ export function WidthDemo() {
   const [fill, setFill] = useState(false);
   return (
     <Stack gap="md" width="100%">
-      <Flex gap="sm" align="center">
-        <Switch checked={fill} onChange={() => setFill(v => !v)} />
-        <Text>{fill ? 'width="100%"' : 'width unset (fit-content)'}</Text>
-      </Flex>
-      <Flex justify="end" width="100%">
+      <MessageRow from="user">
         <UserMessage width={fill ? '100%' : undefined}>
           {'Which of my issues are getting worse?\nAnd which ones are new this week?'}
         </UserMessage>
+      </MessageRow>
+      <Flex justify="end" padding="xl">
+        <Button variant="primary" onClick={() => setFill(v => !v)}>
+          {fill ? 'Fit content' : 'Fill width'}
+        </Button>
       </Flex>
     </Stack>
   );
@@ -87,5 +87,7 @@ export function WidthDemo() {
 </Storybook.Demo>
 
 ```jsx
-<UserMessage width="100%">…</UserMessage>
+<UserMessage width="100%">
+  Which of my issues are getting worse? And which ones are new this week?
+</UserMessage>
 ```

--- a/static/app/components/core/chat/userMessage.mdx
+++ b/static/app/components/core/chat/userMessage.mdx
@@ -7,8 +7,12 @@ resources:
   js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/chat/userMessage.tsx
 ---
 
-import {Flex} from '@sentry/scraps/layout';
+import {useState} from 'react';
+
 import {UserMessage} from '@sentry/scraps/chat';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
 
@@ -56,3 +60,32 @@ wider surfaces.
 
 Whitespace and long unbroken tokens are preserved and wrapped, so pasted URLs
 or stack frames won't overflow the bubble.
+
+By default the bubble hugs its content. Pass `width="100%"` to fill up to
+`maxWidth` instead — useful for multiline or rich content that reads better in a
+wider bubble. Toggle the switch to compare:
+
+export function WidthDemo() {
+  const [fill, setFill] = useState(false);
+  return (
+    <Stack gap="md" width="100%">
+      <Flex gap="sm" align="center">
+        <Switch checked={fill} onChange={() => setFill(v => !v)} />
+        <Text>{fill ? 'width="100%"' : 'width unset (fit-content)'}</Text>
+      </Flex>
+      <Flex justify="end" width="100%">
+        <UserMessage width={fill ? '100%' : undefined}>
+          {'Which of my issues are getting worse?\nAnd which ones are new this week?'}
+        </UserMessage>
+      </Flex>
+    </Stack>
+  );
+}
+
+<Storybook.Demo>
+  <WidthDemo />
+</Storybook.Demo>
+
+```jsx
+<UserMessage width="100%">…</UserMessage>
+```

--- a/static/app/components/core/chat/userMessage.tsx
+++ b/static/app/components/core/chat/userMessage.tsx
@@ -9,6 +9,12 @@ interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
    * `80%` so a bubble never spans the full conversation width.
    */
   maxWidth?: React.CSSProperties['maxWidth'];
+  /**
+   * How wide the bubble sizes itself. Left unset by default so it hugs its
+   * content; pass `100%` to fill up to `maxWidth`, useful for multiline or rich
+   * content that reads better in a wider bubble.
+   */
+  width?: React.CSSProperties['width'];
 }
 
 /**
@@ -18,10 +24,11 @@ interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
  * Presentation only — alignment within the conversation is the caller's
  * responsibility (wrap it in a right-aligned row for user messages).
  */
-export function UserMessage({children, maxWidth = '80%', ...props}: UserMessageProps) {
+export function UserMessage({children, maxWidth = '80%', width, ...props}: UserMessageProps) {
   return (
     <Container
       maxWidth={maxWidth}
+      width={width}
       minWidth={0}
       padding="xs md"
       background="secondary"

--- a/static/app/components/core/chat/userMessage.tsx
+++ b/static/app/components/core/chat/userMessage.tsx
@@ -2,7 +2,7 @@ import {css} from '@emotion/react';
 
 import {Container} from '@sentry/scraps/layout';
 
-interface UserBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
+interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   /**
    * Caps how wide the bubble can grow relative to its container. Defaults to
@@ -18,7 +18,7 @@ interface UserBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
  * Presentation only — alignment within the conversation is the caller's
  * responsibility (wrap it in a right-aligned row for user messages).
  */
-export function UserBubble({children, maxWidth = '80%', ...props}: UserBubbleProps) {
+export function UserMessage({children, maxWidth = '80%', ...props}: UserMessageProps) {
   return (
     <Container
       maxWidth={maxWidth}

--- a/static/app/components/core/chat/userMessage.tsx
+++ b/static/app/components/core/chat/userMessage.tsx
@@ -24,7 +24,12 @@ interface UserMessageProps extends React.HTMLAttributes<HTMLDivElement> {
  * Presentation only — alignment within the conversation is the caller's
  * responsibility (wrap it in a right-aligned row for user messages).
  */
-export function UserMessage({children, maxWidth = '80%', width, ...props}: UserMessageProps) {
+export function UserMessage({
+  children,
+  maxWidth = '80%',
+  width,
+  ...props
+}: UserMessageProps) {
   return (
     <Container
       maxWidth={maxWidth}

--- a/static/app/views/seerExplorer/components/chat/user.tsx
+++ b/static/app/views/seerExplorer/components/chat/user.tsx
@@ -1,11 +1,11 @@
-import {MessageRow, UserBubble} from '@sentry/scraps/chat';
+import {MessageRow, UserMessage} from '@sentry/scraps/chat';
 
 import type {UserBlockProps} from './shared';
 
 export function UserBlock({block}: UserBlockProps) {
   return (
     <MessageRow from="user">
-      <UserBubble>{block.message.content ?? ''}</UserBubble>
+      <UserMessage>{block.message.content ?? ''}</UserMessage>
     </MessageRow>
   );
 }


### PR DESCRIPTION
Renames the `UserBubble` chat primitive to `UserMessage` so the sender-side component aligns with its siblings in `@sentry/scraps/chat` (`AssistantMessage`, `MessageRow`), which follow a `Message`-based naming convention. Updates the barrel export and the Seer Explorer consumer.

Also adds an optional `width` prop. The bubble still hugs its content by default; passing `width="100%"` fills it up to `maxWidth`, which reads better for multiline or rich content. Existing callers are unaffected since the default is unset. The story gains a `Switch`-driven example to compare the two.
