### PR TITLE
fix(stats): Hide `no_parent_span` client outcome

### DIFF
--- a/static/app/views/organizationStats/mapSeriesToChart.spec.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.spec.ts
@@ -262,8 +262,9 @@ describe('mapSeriesToChart func', () => {
     });
 
     expect(mappedSeries.cardStats.clientDiscard).toBe('1.5K');
-    expect(mappedSeries.chartStats.clientDiscard.map(({value}) => value[1])).toEqual([
-      750, 750,
+    expect(mappedSeries.chartStats.clientDiscard).toEqual([
+      {value: [expect.any(String), 750]},
+      {value: [expect.any(String), 750]},
     ]);
     expect(mappedSeries.chartSubLabels).toEqual([
       {

--- a/static/app/views/organizationStats/mapSeriesToChart.spec.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.spec.ts
@@ -220,7 +220,7 @@ describe('mapSeriesToChart func', () => {
     expect(mappedSeries.cardStats.rateLimited).toBe('11');
   });
 
-  it('should correctly format client discard data', () => {
+  it('excludes no_parent_span from client discard data', () => {
     const mappedSeries = mapSeriesToChart({
       orgStats: {
         start: '2021-01-01T00:00:00Z',
@@ -240,6 +240,19 @@ describe('mapSeriesToChart func', () => {
               'sum(quantity)': [750, 750],
             },
           },
+          {
+            by: {
+              outcome: 'client_discard',
+              reason: 'no_parent_span',
+              category: 'span',
+            },
+            totals: {
+              'sum(quantity)': 1000,
+            },
+            series: {
+              'sum(quantity)': [400, 600],
+            },
+          },
         ],
       },
       chartDateInterval: '1h',
@@ -248,7 +261,19 @@ describe('mapSeriesToChart func', () => {
       endpointQuery: {},
     });
 
-    // should format client discard data correctly
     expect(mappedSeries.cardStats.clientDiscard).toBe('1.5K');
+    expect(mappedSeries.chartStats.clientDiscard.map(({value}) => value[1])).toEqual([
+      750, 750,
+    ]);
+    expect(mappedSeries.chartSubLabels).toEqual([
+      {
+        parentLabel: 'Client Discard',
+        label: 'Queue Overflow',
+        data: [
+          {name: '2021-01-01T00:00:00Z', value: 750},
+          {name: '2021-01-02T00:00:00Z', value: 750},
+        ],
+      },
+    ]);
   });
 });

--- a/static/app/views/organizationStats/mapSeriesToChart.ts
+++ b/static/app/views/organizationStats/mapSeriesToChart.ts
@@ -96,6 +96,10 @@ export function mapSeriesToChart({
     orgStats.groups.forEach(group => {
       const {outcome, category} = group.by;
 
+      if (outcome === Outcome.CLIENT_DISCARD && group.by.reason === 'no_parent_span') {
+        return;
+      }
+
       // For spans, we additionally query for `span_indexed` data
       // to get the `accepted_stored` count
       if (category === 'span_indexed') {


### PR DESCRIPTION
The `no_parent_span` client discard reason was added fairly recently. It is sent by SDKs, when a span is not created because it may only be started when a parent span is already active. Since this happens a lot, the amount of client discards is quite high in comparison to other discard reasons. Apparently, this causes a lot of confusion for customers who assume that they're doing something wrong, when in fact this is expected SDK behaviour.

This PR hides the `no_parent_span` client outcomes from the user-facing Stats & Usage page but leaves it in `_admin` so that we can still look into it. 

before:
<img width="434" height="779" alt="image" src="https://github.com/user-attachments/assets/74fc5376-be9d-40c2-9496-52b933dc0f17" />

after:
<img width="419" height="727" alt="image" src="https://github.com/user-attachments/assets/f6610bdf-ccef-4239-baa6-5c340691f04f" />
