### PR TITLE
fix(traces): Remove border around project icons in trace header

### DIFF
--- a/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
+++ b/static/app/views/explore/tables/tracesTable/fieldRenderers.tsx
@@ -152,8 +152,7 @@ const ProjectList = styled('div')`
   padding-right: 8px;
 `;
 
-const AvatarStyle = (p: any) => css`
-  border: 2px solid ${p.theme.tokens.border.primary};
+const AvatarStyle = css`
   margin-right: -8px;
   cursor: default;
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/projects.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/projects.tsx
@@ -65,9 +65,11 @@ export function Projects({projects, logs, tree}: Props) {
   );
 }
 
-// We cannot change the cursor of the ProjectBadge component so we need to wrap it in a div
+// We cannot change the cursor or icon separator of the ProjectBadge component so we
+// need to wrap it in a div
 const ProjectsRendererWrapper = styled('div')`
   img {
     cursor: pointer;
+    box-shadow: none;
   }
 `;


### PR DESCRIPTION
**Before**
<img width="230" height="121" alt="image" src="https://github.com/user-attachments/assets/d138f65b-b493-41ad-b596-5d06ed5a9df5" />


**After**
<img width="222" height="115" alt="image" src="https://github.com/user-attachments/assets/06a68d40-d4cf-4d0a-9251-324e6a689497" />
