### PR TITLE
chore(codeowners): Assign ai_monitoring to telemetry-experience

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -602,6 +602,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/relay/config/ai_model_costs.py                                       @getsentry/telemetry-experience
 /src/sentry/tasks/ai_agent_monitoring.py                                         @getsentry/telemetry-experience
 /tests/sentry/tasks/test_ai_agent_monitoring.py                                  @getsentry/telemetry-experience
+/src/sentry/ai_monitoring/                                                       @getsentry/telemetry-experience
+/tests/sentry/ai_monitoring/                                                     @getsentry/telemetry-experience
 /static/app/actionCreators/metrics.tsx                                           @getsentry/telemetry-experience
 /static/app/views/settings/dynamicSampling/                                      @getsentry/telemetry-experience
 /static/app/views/insights/pages/agents/                                         @getsentry/telemetry-experience


### PR DESCRIPTION
`src/sentry/ai_monitoring/` and its tests are owned by `@getsentry/telemetry-experience` so review requests route to the team that owns that area.