### PR TITLE
fix(notifications): register organization_request notifications for taskworker

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -924,6 +924,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.models.counter",
     "sentry.monitors.tasks.clock_pulse",
     "sentry.monitors.tasks.detect_broken_monitor_envs",
+    "sentry.notifications.notifications.organization_request",
     "sentry.notifications.platform.service",
     "sentry.notifications.utils.tasks",
     "sentry.preprod.size_analysis.tasks",


### PR DESCRIPTION
## Summary

Organization join-request emails never send on self-hosted Sentry, because `sentry.notifications.notifications.organization_request` — the module whose `@register()` decorators populate `JoinRequestNotification`/`InviteRequestNotification` in the `class_manager` registry — is never imported by taskworker processes. `TASKWORKER_IMPORTS` includes `sentry.notifications.utils.tasks` (why the `_send_notification` task is dispatchable at all), but not the module that actually registers these notification classes.

The result: `class_manager.get("JoinRequestNotification")` returns nothing inside the task, raising `NotificationClassNotSetException` — silently, since this gets captured only by the instance's own internal error monitoring, not logged to stdout, and the originating `POST /api/0/organizations/{org}/join-request/` request still returns a clean `204`.

**Traceback**, pulled from the instance's own internal Sentry project (event `44c610cf981547658326245bdbda88d8`, captured by Sentry's own SDK inside its own taskworker):

```
File "<string>", line 1, in <module>
  from multiprocessing.spawn import spawn_main; spawn_main(tracker_fd=9, pipe_handle=19)
File "multiprocessing/spawn.py", line 122, in spawn_main
  exitcode = _main(fd, parent_sentinel)
File "multiprocessing/spawn.py", line 135, in _main
  return self._bootstrap(parent_sentinel)
File "multiprocessing/process.py", line 313, in _bootstrap
  self.run()
File "multiprocessing/process.py", line 108, in run
  self._target(*self._args, **self._kwargs)
File "sentry/taskworker/workerchild.py", line 467, in child_process
  run_worker(
File "sentry/taskworker/workerchild.py", line 300, in run_worker
  sentry_sdk.capture_exception(err)
File "sentry/taskworker/workerchild.py", line 249, in run_worker
  _execute_activation(task_func, inflight.activation)
File "sentry/taskworker/workerchild.py", line 386, in _execute_activation
  task_func(*args, **kwargs)
File "sentry/silo/base.py", line 158, in override
  return original_method(*args, **kwargs)
File "sentry/taskworker/task.py", line 89, in __call__
  return self._func(*args, **kwargs)
File "sentry/notifications/utils/tasks.py", line 110, in _send_notification
  NotificationClass = get(notification_class_name)
File "sentry/notifications/class_manager.py", line 34, in get
  raise NotificationClassNotSetException()
```

Worth noting: this confirms taskworker children are spawned via `multiprocessing.spawn` (visible at the top of the trace), not `fork`. That means each child worker starts as a genuinely fresh Python interpreter and does not inherit any modules already imported by the parent process — reinforcing why `TASKWORKER_IMPORTS` is the correct and necessary mechanism here, rather than something that could be worked around by import ordering elsewhere in the parent.

**Note on scope:** this PR was confirmed against the join-request flow specifically. `InviteRequestNotification` shares the exact same `organization_request` module and would hit the identical registry gap if exercised, since Python can't partially import a module — but that flow wasn't directly tested here, so I'm not claiming it's currently broken, only that it's structurally exposed to the same issue. To be clear, this is **not** about regular admin-initiated invite emails (`OrganizationMember.send_invite_email()`), which build a `MessageBuilder` directly and send synchronously — a completely separate code path, unaffected by this bug, and confirmed still working fine.

## Root cause, isolated via a live self-hosted instance

Reproduced live via `sentry shell`:

```python
from sentry.models.organizationmember import OrganizationMember
from sentry.notifications.notifications.organization_request import JoinRequestNotification
from sentry.users.models.user import User

member = OrganizationMember.objects.get(id=<id>)
requester = User.objects.get(id=<id>)
notif = JoinRequestNotification(member, requester)
notif.get_participants()  # correct recipients: Owner + Manager, EMAIL + SLACK providers
notif.send()              # works perfectly, delivers real email
```

This confirms `JoinRequestNotification`, recipient resolution, `NotificationSettingEnum.APPROVAL` defaults, and the mail-sending path are all correct in isolation. The failure only occurs when the same notification is dispatched via `async_send_notification()` from the real endpoint — i.e., through the taskworker.

Confirmed on the instance's own internal Sentry project: this `NotificationClassNotSetException` group was captured with `first_seen`/`last_seen` timestamps matching two join-request test attempts exactly (1 second after each `POST`), with `times_seen: 2` and zero occurrences outside that window.

## Fix

One-line addition to `TASKWORKER_IMPORTS` in `src/sentry/conf/server.py`, alongside the two existing `sentry.notifications.*` entries.

## Verification

Deployed this exact fix to a live self-hosted instance (via a local settings override appending the same import, ahead of this PR) and confirmed end-to-end:
- `settings.TASKWORKER_IMPORTS` includes the new entry after restart
- Dispatching through the real endpoint's code path (`create_organization_join_request()` + `async_send_notification(JoinRequestNotification, member, requester)`) now produces `mail.queued` → `mail.sent` for both Owner and Manager, with `message_type='join_request'`
- The previously-captured `NotificationClassNotSetException` group did **not** get a new occurrence from this test

## Scope note

This fix addresses `organization_request` (join requests, and structurally `InviteRequestNotification` too, per the note above) specifically, since that's what this investigation covered. It's plausible other `BaseNotification` subclasses dispatched via `async_send_notification()` have the same gap if their containing module isn't already covered by an existing `TASKWORKER_IMPORTS` entry — happy to look into that as a follow-up if useful, but didn't want to scope-creep this fix while it's easy to review.

---

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
