### PR TITLE
fix(scraps): fix responsive display flex & grid emit

### DIFF
--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -67,7 +67,7 @@ export const Flex = styled(Container, {
     return !omitFlexProps.has(prop as keyof FlexLayoutProps | 'as');
   },
 })<FlexProps<any> | FlexPropsWithRenderFunction<any>>`
-  ${p => rc('display', p.display ?? 'flex', p.theme, v => v ?? 'flex')};
+  ${p => rc('display', p.display ?? 'flex', p.theme)};
   ${p => rc('order', p.order, p.theme)};
   ${p => rc('gap', p.gap, p.theme, getSpacing)};
 

--- a/static/app/components/core/layout/grid.tsx
+++ b/static/app/components/core/layout/grid.tsx
@@ -100,7 +100,7 @@ export const Grid = styled(Container, {
     return !omitGridProps.has(prop as keyof GridLayoutProps | 'as');
   },
 })<GridProps<any> | GridPropsWithRenderFunction<any>>`
-  ${p => rc('display', p.display ?? 'grid', p.theme, v => v ?? 'grid')}
+  ${p => rc('display', p.display ?? 'grid', p.theme)}
 
   ${p => rc('gap', p.gap, p.theme, getSpacing)};
 

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -253,7 +253,11 @@ export function DebugMeta({data, projectSlug, groupId, event}: DebugMetaProps) {
             </Flex>
             <Flex
               align="center"
-              display={{'screen:2xs': 'none', 'screen:xs': 'none'}}
+              display={{
+                'screen:2xs': 'none',
+                'screen:xs': 'none',
+                'screen:sm': 'flex',
+              }}
               minWidth="0"
               paddingTop="md"
               paddingBottom="md"


### PR DESCRIPTION
Flex's responsive display resolver was adding fallback `display: flex` rules at every media breakpoint, overriding the container-query `display: none` passed by consumers.

This was likely on purpose to allow “sparse” flex props (as seen in `debugMeta`) where we want to hide things with `display:none` for some small breakpoints, but didn’t want to add `display:flex` at all for at least one breakpoint.

This is a footgun because a) `Container` doesn’t work that way so switching from `Container` to `Flex` breaks things unexpectedly and b) this is very hard to debug if you don’t know that this exists internally. I needed to go to xhigh reasoning on codex to find it 😂 .

Grid had the same problem, also fixed in this PR.
