### PR TITLE
feat(attributes): Add public alias for `sentry.trace_lifecycle` attribute

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -216,6 +216,11 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             private=True,
         ),
         ResolvedAttribute(
+            public_alias="trace_lifecycle",
+            internal_name="sentry.trace_lifecycle",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="ai.total_tokens.used",
             internal_name="ai_total_tokens_used",
             search_type="integer",


### PR DESCRIPTION
Adding this to avoid inconsistencies between the trace waterfall, where `trace_lifecycle` is already shown without the prefix and Explore, where users still have to query with the `sentry.` prefix. 