### PR TITLE
feat(pr-metrics): Add ci_failed_at_open and no_ci_events diagnosis labels

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -118,10 +118,11 @@ class PrCloseMetricsEvent(analytics.Event):
     verdict: str | None = None
     # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
     # "why", a vocabulary shared across judges, not specific to any one. Mostly
-    # judge-sourced, but Sentry's own deterministic CLOSED_UNMERGED path can also
-    # set "ci_failing_at_close" (see pr_metrics.emit.ci_failing_at_close) — so a
-    # non-null value doesn't by itself mean the row was judged. Repeated
-    # free-string column; null when nothing applies. BigQuery-only.
+    # judge-sourced, but Sentry can also set deterministic labels on its own (see
+    # pr_metrics.emit.calculate_deterministic_diagnosis_labels): "ci_failing_at_close"
+    # (CLOSED_UNMERGED only), and "ci_failed_at_open" / "no_ci_events" (every
+    # verdict) — so a non-null value doesn't by itself mean the row was judged.
+    # Repeated free-string column; null when nothing applies. BigQuery-only.
     diagnosis_labels: list[str] | None = None
 
     # --- Conversation judge (set only on a judged close/merge row) ---

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -107,22 +107,13 @@ class PrCloseMetricsEvent(analytics.Event):
     # ``resolve_autofix_referrers``. Empty when no attribution carries a
     # resolvable Seer run id.
     autofix_referrers: list[str] = field(default_factory=list)
-    # The terminal verdict, one of ``PullRequestVerdict``: the deterministic
-    # outcome (``merged_unchanged`` / ``closed_unmerged``) on the no-judge path, or
-    # the Seer judge's verdict on the judge path. Claimed before emit on both
-    # paths (the claim gates emission), so every emitted row carries a verdict — the
-    # ``| None`` is only the column's unset default, not an expected emitted value.
-    # (The ``JUDGE_IN_PROGRESS`` reaper's indeterminate rows — no reliable local
-    # signal to settle from — release the claim without emitting at all, rather
-    # than emit a null-verdict row; see ``reap_stuck_judge_verdicts``.)
+    # The deterministic outcome (``merged_unchanged`` / ``closed_unmerged``) on
+    # the no-judge path, or the Seer judge's verdict on the judge path.
+    # This differs slightly from PullRequestMetrics.verdicts because some values
+    # there include internal states that are not considered outcomes.
     verdict: str | None = None
-    # Close-reason labels behind the verdict (e.g. out_of_scope_or_unwanted) — the
-    # "why", a vocabulary shared across judges, not specific to any one. Mostly
-    # judge-sourced, but Sentry can also set deterministic labels on its own (see
-    # pr_metrics.emit.calculate_deterministic_diagnosis_labels): "ci_failing_at_close"
-    # (CLOSED_UNMERGED only), and "ci_failed_at_open" / "no_ci_events" (every
-    # verdict) — so a non-null value doesn't by itself mean the row was judged.
-    # Repeated free-string column; null when nothing applies. BigQuery-only.
+    # Relevant datapoint for this PR, mostly related to the conversation and mostly
+    # derived by the judge. Examples include "superseded", "ci_failing_at_close", etc.
     diagnosis_labels: list[str] | None = None
 
     # --- Conversation judge (set only on a judged close/merge row) ---

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -209,24 +209,18 @@ def select_fallback_verdict(pull_request: PullRequest) -> PullRequestVerdict:
     return PullRequestVerdict.CLOSED_UNMERGED
 
 
-# Diagnosis label Sentry can derive on its own (unlike the judge's free-string
-# vocabulary): the deterministic closed-unmerged path's "why", read straight off
-# the PR's own check-suite activity rather than a judge's opinion.
+# Whether the CI was failing at close for the "MERGED_UNCHANGED" verdict.
+# This is a deterministic check because we know there were no other commits
 CI_FAILING_AT_CLOSE = "ci_failing_at_close"
 
 # Diagnosis label for the stale-detection path. See detect_stale_pull_requests_task.
 NO_REVIEWER_ENGAGEMENT = "no_reviewer_engagement"
 
-# Whether any CI provider's check suite was already failing at the PR's opening
-# head, computed for every emitted verdict (not just CLOSED_UNMERGED) — unlike
-# CI_FAILING_AT_CLOSE, this doesn't require "no commits after open" to be
-# meaningful, since it only ever looks at the opening head's own checks.
+# Whether any CI provider's check suite was already failing at the PR's opening commit
 CI_FAILED_AT_OPEN = "ci_failed_at_open"
 
 # No CI check activity of any kind (check_suite or check_run) was ever recorded
-# for this PR — a distinct signal from "CI failed": there's nothing to diagnose
-# because CI never reported in, e.g. no CI configured on the repo, or the org
-# doesn't have check-event webhooks wired up.
+# for this PR
 NO_CI_EVENTS = "no_ci_events"
 
 # Conclusions that unambiguously mean the check errored out, as opposed to

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -229,6 +229,20 @@ NO_CI_EVENTS = "no_ci_events"
 _FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure"})
 
 
+class _Unfetched:
+    """Sentinel distinguishing "caller didn't pass a doc" from "doc is None".
+
+    ``None`` is itself a meaningful ``doc`` value (the PR is on the legacy
+    store), so a plain ``doc: ... | None = None`` default can't tell "go load
+    it yourself" apart from "I checked, there's no document" — which would make
+    a caller that already confirmed the legacy-store case pay for a redundant
+    ``load_activity_document`` call anyway.
+    """
+
+
+_UNFETCHED = _Unfetched()
+
+
 def _any_group_failing(groups: Iterable[activity_doc.CheckGroup]) -> bool:
     """Whether any check-suite group's latest conclusion is a failure.
 
@@ -254,7 +268,9 @@ def _any_app_failing(rows: Iterable[tuple[str, str]]) -> bool:
     )
 
 
-def ci_failing_at_close(pull_request: PullRequest) -> bool:
+def ci_failing_at_close(
+    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None | _Unfetched = _UNFETCHED
+) -> bool:
     """Whether any CI provider's check suite was failing when the PR closed.
 
     Reads ``CHECK_SUITE_COMPLETED`` activity — the aggregate "was CI green or
@@ -265,8 +281,14 @@ def ci_failing_at_close(pull_request: PullRequest) -> bool:
     outcome: that path is reached only when there were no commits after open, so
     every recorded check row necessarily belongs to the PR's one and only head
     commit — there's no other commit's CI status to accidentally mix in.
+
+    ``doc`` lets a caller that already loaded the activity document (e.g.
+    ``calculate_deterministic_diagnosis_labels``, which calls this alongside
+    ``ci_failed_at_open``/``no_ci_events`` for the same PR) pass it in instead of
+    triggering another identical query. Left unset, this loads it itself.
     """
-    doc = load_activity_document(pull_request)
+    if isinstance(doc, _Unfetched):
+        doc = load_activity_document(pull_request)
     if doc is not None:
         # Same narrow failing vocabulary and suite-only read as the legacy path
         # (a check_run-only app has no suite conclusion and doesn't count).
@@ -298,7 +320,9 @@ def _opened_head_sha_from_doc(doc: activity_doc.ActivityDoc) -> str | None:
     return None
 
 
-def ci_failed_at_open(pull_request: PullRequest) -> bool:
+def ci_failed_at_open(
+    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None | _Unfetched = _UNFETCHED
+) -> bool:
     """Whether any CI provider's check suite was already failing at the PR's
     *opening* head — unlike ``ci_failing_at_close``, meaningful for every
     verdict (merged or closed, iterated or not), since it only ever looks at
@@ -315,8 +339,11 @@ def ci_failed_at_open(pull_request: PullRequest) -> bool:
     PR's first ``SYNCHRONIZED`` row (or all of them, if the PR never had a
     later push) — everything recorded before the first push can only belong to
     the one head the PR opened with.
+
+    ``doc``: see ``ci_failing_at_close``.
     """
-    doc = load_activity_document(pull_request)
+    if isinstance(doc, _Unfetched):
+        doc = load_activity_document(pull_request)
     if doc is not None:
         open_head_sha = _opened_head_sha_from_doc(doc)
         if open_head_sha is None:
@@ -347,7 +374,9 @@ def ci_failed_at_open(pull_request: PullRequest) -> bool:
     return _any_app_failing(rows)
 
 
-def no_ci_events(pull_request: PullRequest) -> bool:
+def no_ci_events(
+    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None | _Unfetched = _UNFETCHED
+) -> bool:
     """Whether the PR has no recorded CI check activity at all, of any kind.
 
     A distinct signal from a CI failure: there's nothing to diagnose because CI
@@ -357,8 +386,11 @@ def no_ci_events(pull_request: PullRequest) -> bool:
     recorded check to say anything. Scoped to the whole PR (any head), not just
     the opening head, so a PR whose CI only ever reported against a later push
     still counts as having CI activity.
+
+    ``doc``: see ``ci_failing_at_close``.
     """
-    doc = load_activity_document(pull_request)
+    if isinstance(doc, _Unfetched):
+        doc = load_activity_document(pull_request)
     if doc is not None:
         return not doc.get("checks")
     return not PullRequestActivity.objects.filter(
@@ -424,12 +456,16 @@ def calculate_deterministic_diagnosis_labels(
     - ``NO_CI_EVENTS``: every verdict, independent of the other two — a PR can
       lack CI activity entirely no matter how it was settled.
     """
+    # Loaded once and threaded through to each check: all three read the same
+    # PR's activity, so without this every call below would re-issue an
+    # identical load_activity_document query.
+    doc = load_activity_document(pull_request)
     labels = []
-    if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request):
+    if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request, doc=doc):
         labels.append(CI_FAILING_AT_CLOSE)
-    if ci_failed_at_open(pull_request):
+    if ci_failed_at_open(pull_request, doc=doc):
         labels.append(CI_FAILED_AT_OPEN)
-    if no_ci_events(pull_request):
+    if no_ci_events(pull_request, doc=doc):
         labels.append(NO_CI_EVENTS)
     return labels or None
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -229,20 +229,6 @@ NO_CI_EVENTS = "no_ci_events"
 _FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure"})
 
 
-class _Unfetched:
-    """Sentinel distinguishing "caller didn't pass a doc" from "doc is None".
-
-    ``None`` is itself a meaningful ``doc`` value (the PR is on the legacy
-    store), so a plain ``doc: ... | None = None`` default can't tell "go load
-    it yourself" apart from "I checked, there's no document" — which would make
-    a caller that already confirmed the legacy-store case pay for a redundant
-    ``load_activity_document`` call anyway.
-    """
-
-
-_UNFETCHED = _Unfetched()
-
-
 def _any_group_failing(groups: Iterable[activity_doc.CheckGroup]) -> bool:
     """Whether any check-suite group's latest conclusion is a failure.
 
@@ -268,8 +254,8 @@ def _any_app_failing(rows: Iterable[tuple[str, str]]) -> bool:
     )
 
 
-def ci_failing_at_close(
-    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None | _Unfetched = _UNFETCHED
+def _ci_failing_at_close(
+    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None
 ) -> bool:
     """Whether any CI provider's check suite was failing when the PR closed.
 
@@ -282,13 +268,12 @@ def ci_failing_at_close(
     every recorded check row necessarily belongs to the PR's one and only head
     commit — there's no other commit's CI status to accidentally mix in.
 
-    ``doc`` lets a caller that already loaded the activity document (e.g.
-    ``calculate_deterministic_diagnosis_labels``, which calls this alongside
-    ``ci_failed_at_open``/``no_ci_events`` for the same PR) pass it in instead of
-    triggering another identical query. Left unset, this loads it itself.
+    Private to this module: its only caller,
+    ``calculate_deterministic_diagnosis_labels``, loads the activity document
+    once and threads it through to this and its siblings
+    (``_ci_failed_at_open``/``_no_ci_events``) rather than each triggering an
+    identical query, so ``doc`` is mandatory here rather than optional.
     """
-    if isinstance(doc, _Unfetched):
-        doc = load_activity_document(pull_request)
     if doc is not None:
         # Same narrow failing vocabulary and suite-only read as the legacy path
         # (a check_run-only app has no suite conclusion and doesn't count).
@@ -320,11 +305,9 @@ def _opened_head_sha_from_doc(doc: activity_doc.ActivityDoc) -> str | None:
     return None
 
 
-def ci_failed_at_open(
-    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None | _Unfetched = _UNFETCHED
-) -> bool:
+def _ci_failed_at_open(pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None) -> bool:
     """Whether any CI provider's check suite was already failing at the PR's
-    *opening* head — unlike ``ci_failing_at_close``, meaningful for every
+    *opening* head — unlike ``_ci_failing_at_close``, meaningful for every
     verdict (merged or closed, iterated or not), since it only ever looks at
     checks scoped to the one head the PR opened with.
 
@@ -340,10 +323,8 @@ def ci_failed_at_open(
     later push) — everything recorded before the first push can only belong to
     the one head the PR opened with.
 
-    ``doc``: see ``ci_failing_at_close``.
+    ``doc``: see ``_ci_failing_at_close``.
     """
-    if isinstance(doc, _Unfetched):
-        doc = load_activity_document(pull_request)
     if doc is not None:
         open_head_sha = _opened_head_sha_from_doc(doc)
         if open_head_sha is None:
@@ -374,23 +355,19 @@ def ci_failed_at_open(
     return _any_app_failing(rows)
 
 
-def no_ci_events(
-    pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None | _Unfetched = _UNFETCHED
-) -> bool:
+def _no_ci_events(pull_request: PullRequest, *, doc: activity_doc.ActivityDoc | None) -> bool:
     """Whether the PR has no recorded CI check activity at all, of any kind.
 
     A distinct signal from a CI failure: there's nothing to diagnose because CI
     never reported in for this PR (no CI configured on the repo, or the
     integration doesn't forward check-run/check-suite webhooks) — as opposed to
-    ``ci_failed_at_open``/``ci_failing_at_close``, which need at least one
+    ``_ci_failed_at_open``/``_ci_failing_at_close``, which need at least one
     recorded check to say anything. Scoped to the whole PR (any head), not just
     the opening head, so a PR whose CI only ever reported against a later push
     still counts as having CI activity.
 
-    ``doc``: see ``ci_failing_at_close``.
+    ``doc``: see ``_ci_failing_at_close``.
     """
-    if isinstance(doc, _Unfetched):
-        doc = load_activity_document(pull_request)
     if doc is not None:
         return not doc.get("checks")
     return not PullRequestActivity.objects.filter(
@@ -461,11 +438,13 @@ def calculate_deterministic_diagnosis_labels(
     # identical load_activity_document query.
     doc = load_activity_document(pull_request)
     labels = []
-    if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request, doc=doc):
+    if verdict == PullRequestVerdict.CLOSED_UNMERGED and _ci_failing_at_close(
+        pull_request, doc=doc
+    ):
         labels.append(CI_FAILING_AT_CLOSE)
-    if ci_failed_at_open(pull_request, doc=doc):
+    if _ci_failed_at_open(pull_request, doc=doc):
         labels.append(CI_FAILED_AT_OPEN)
-    if no_ci_events(pull_request, doc=doc):
+    if _no_ci_events(pull_request, doc=doc):
         labels.append(NO_CI_EVENTS)
     return labels or None
 
@@ -644,7 +623,7 @@ def build_pr_metrics_row(
     judge's result (semantic outputs become columns, its ``metadata`` is
     JSON-encoded). ``diagnosis_labels`` is the cross-judge close-reason "why" —
     mostly judge-sourced, but ``select_verdict``'s deterministic
-    ``CLOSED_UNMERGED`` path can also populate it (see ``ci_failing_at_close``),
+    ``CLOSED_UNMERGED`` path can also populate it (see ``_ci_failing_at_close``),
     so its presence doesn't by itself mean the row was judged.
     """
     if close_action != CLOSE_ACTION_ABANDONED:
@@ -885,7 +864,7 @@ def emit_pr_metrics_row(
     judge can call it directly via RPC callback. ``conversation_analysis`` is set
     only on that judge path; ``diagnosis_labels`` is mostly judge-sourced but the
     deterministic ``CLOSED_UNMERGED`` path can also pass one in (see
-    ``ci_failing_at_close``).
+    ``_ci_failing_at_close``).
 
     ``close_action`` is derived from the PR's lifecycle fields:
     - ``merged_at`` set → ``merged``

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -8,7 +8,7 @@ production). A PR is "tracked" once it has at least one valid
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from enum import Enum
 from typing import Any, NamedTuple, cast
 
@@ -217,20 +217,55 @@ CI_FAILING_AT_CLOSE = "ci_failing_at_close"
 # Diagnosis label for the stale-detection path. See detect_stale_pull_requests_task.
 NO_REVIEWER_ENGAGEMENT = "no_reviewer_engagement"
 
+# Whether any CI provider's check suite was already failing at the PR's opening
+# head, computed for every emitted verdict (not just CLOSED_UNMERGED) — unlike
+# CI_FAILING_AT_CLOSE, this doesn't require "no commits after open" to be
+# meaningful, since it only ever looks at the opening head's own checks.
+CI_FAILED_AT_OPEN = "ci_failed_at_open"
+
+# No CI check activity of any kind (check_suite or check_run) was ever recorded
+# for this PR — a distinct signal from "CI failed": there's nothing to diagnose
+# because CI never reported in, e.g. no CI configured on the repo, or the org
+# doesn't have check-event webhooks wired up.
+NO_CI_EVENTS = "no_ci_events"
+
 # Conclusions that unambiguously mean the check errored out, as opposed to
 # cancelled/skipped/stale (never ran to completion, not a failure verdict),
 # neutral (a soft pass), or action_required (blocked on approval, not broken).
 _FAILING_CHECK_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure"})
 
 
+def _any_group_failing(groups: Iterable[activity_doc.CheckGroup]) -> bool:
+    """Whether any check-suite group's latest conclusion is a failure.
+
+    Shared by every doc-store reader over the checks rollup: each group already
+    keeps the latest suite conclusion (a rerun with no new push overwrites the
+    earlier one), so this is just the narrow-vocabulary failing check.
+    """
+    return any(group.get("suite_conclusion") in _FAILING_CHECK_CONCLUSIONS for group in groups)
+
+
+def _any_app_failing(rows: Iterable[tuple[str, str]]) -> bool:
+    """Whether any app's latest conclusion, from ``(app_slug, conclusion)`` rows
+    in arrival order, is a failure.
+
+    Shared by every legacy-store reader over ``CHECK_SUITE_COMPLETED`` rows:
+    ``dict()`` keeps the last entry per key, i.e. each app's latest conclusion,
+    so a rerun with no new push (superseding an earlier failure) is handled the
+    same way as the doc-store rollup.
+    """
+    latest_conclusion_by_app: dict[str, str] = dict(rows)
+    return any(
+        conclusion in _FAILING_CHECK_CONCLUSIONS for conclusion in latest_conclusion_by_app.values()
+    )
+
+
 def ci_failing_at_close(pull_request: PullRequest) -> bool:
     """Whether any CI provider's check suite was failing when the PR closed.
 
-    Reads ``CHECK_SUITE_COMPLETED`` activity rows — the aggregate "was CI green
-    or red" signal per provider app (``app_slug``), per ``CheckSuiteCompletedPayload``
-    — keeping only the latest completion per app: a check suite can be rerun with
-    no new push (no ``SYNCHRONIZED`` row), so an earlier failure superseded by a
-    passing rerun shouldn't count.
+    Reads ``CHECK_SUITE_COMPLETED`` activity — the aggregate "was CI green or
+    red" signal per provider app (``app_slug``) — keeping only the latest
+    completion per app.
 
     Only meaningful for ``select_verdict``'s deterministic ``CLOSED_UNMERGED``
     outcome: that path is reached only when there were no commits after open, so
@@ -239,15 +274,9 @@ def ci_failing_at_close(pull_request: PullRequest) -> bool:
     """
     doc = load_activity_document(pull_request)
     if doc is not None:
-        # The rollup already keeps the latest suite conclusion per (head_sha,
-        # app_slug); on the CLOSED_UNMERGED path there's a single head, so this is
-        # each app's latest suite. Same narrow failing vocabulary and suite-only
-        # read as the legacy path (a check_run-only app has no suite conclusion and
-        # doesn't count, matching the legacy CHECK_SUITE-row read).
-        return any(
-            group.get("suite_conclusion") in _FAILING_CHECK_CONCLUSIONS
-            for group in doc.get("checks", {}).values()
-        )
+        # Same narrow failing vocabulary and suite-only read as the legacy path
+        # (a check_run-only app has no suite conclusion and doesn't count).
+        return _any_group_failing(doc.get("checks", {}).values())
 
     rows = (
         PullRequestActivity.objects.filter(
@@ -256,11 +285,95 @@ def ci_failing_at_close(pull_request: PullRequest) -> bool:
         .order_by("date_added", "id")
         .values_list("payload__app_slug", "payload__conclusion")
     )
-    # dict() keeps the last entry per key, i.e. each app's latest conclusion.
-    latest_conclusion_by_app: dict[str, str] = dict(rows)
-    return any(
-        conclusion in _FAILING_CHECK_CONCLUSIONS for conclusion in latest_conclusion_by_app.values()
+    return _any_app_failing(rows)
+
+
+def _opened_head_sha_from_doc(doc: activity_doc.ActivityDoc) -> str | None:
+    """The head SHA the PR opened with, read off its ``OPENED`` lifecycle entry.
+
+    ``OpenedPayload.head_sha`` round-trips into the entry's stored payload
+    unchanged (it isn't a check/comment family event, so ``apply_activity``
+    appends it as-is). Returns ``None`` when there's no ``OPENED`` entry to read
+    it from — e.g. activity tracking was enabled after the PR had already
+    opened — since there's then no reliable "opening head" to key checks off.
+    """
+    for entry in doc.get("events", []):
+        if entry.get("event_type") == PullRequestActivityType.OPENED:
+            head_sha = (entry.get("payload") or {}).get("head_sha")
+            return head_sha or None
+    return None
+
+
+def ci_failed_at_open(pull_request: PullRequest) -> bool:
+    """Whether any CI provider's check suite was already failing at the PR's
+    *opening* head — unlike ``ci_failing_at_close``, meaningful for every
+    verdict (merged or closed, iterated or not), since it only ever looks at
+    checks scoped to the one head the PR opened with.
+
+    Doc store: keyed precisely off the opening head SHA (see
+    ``_opened_head_sha_from_doc``), via the checks rollup's ``(head_sha,
+    app_slug)`` grouping — a later push's checks, recorded under a different
+    head, are correctly excluded.
+
+    Legacy store: the row payload carries no ``head_sha`` at all (see
+    ``CheckSuiteCompletedPayload``), so the opening head's checks are
+    approximated as every ``CHECK_SUITE_COMPLETED`` row that arrived before the
+    PR's first ``SYNCHRONIZED`` row (or all of them, if the PR never had a
+    later push) — everything recorded before the first push can only belong to
+    the one head the PR opened with.
+    """
+    doc = load_activity_document(pull_request)
+    if doc is not None:
+        open_head_sha = _opened_head_sha_from_doc(doc)
+        if open_head_sha is None:
+            return False
+        return _any_group_failing(
+            group
+            for group in doc.get("checks", {}).values()
+            if group.get("head_sha") == open_head_sha
+        )
+
+    first_sync_id = (
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request, event_type=PullRequestActivityType.SYNCHRONIZED
+        )
+        .order_by("id")
+        .values_list("id", flat=True)
+        .first()
     )
+    check_rows = PullRequestActivity.objects.filter(
+        pull_request=pull_request, event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED
+    )
+    if first_sync_id is not None:
+        check_rows = check_rows.filter(id__lt=first_sync_id)
+
+    rows = check_rows.order_by("date_added", "id").values_list(
+        "payload__app_slug", "payload__conclusion"
+    )
+    return _any_app_failing(rows)
+
+
+def no_ci_events(pull_request: PullRequest) -> bool:
+    """Whether the PR has no recorded CI check activity at all, of any kind.
+
+    A distinct signal from a CI failure: there's nothing to diagnose because CI
+    never reported in for this PR (no CI configured on the repo, or the
+    integration doesn't forward check-run/check-suite webhooks) — as opposed to
+    ``ci_failed_at_open``/``ci_failing_at_close``, which need at least one
+    recorded check to say anything. Scoped to the whole PR (any head), not just
+    the opening head, so a PR whose CI only ever reported against a later push
+    still counts as having CI activity.
+    """
+    doc = load_activity_document(pull_request)
+    if doc is not None:
+        return not doc.get("checks")
+    return not PullRequestActivity.objects.filter(
+        pull_request=pull_request,
+        event_type__in=(
+            PullRequestActivityType.CHECK_SUITE_COMPLETED,
+            PullRequestActivityType.CHECK_RUN_COMPLETED,
+        ),
+    ).exists()
 
 
 def review_activity(pull_request: PullRequest) -> ReviewActivity:
@@ -307,12 +420,23 @@ def calculate_deterministic_diagnosis_labels(
     Shared by every caller that settles a verdict without a judge (the cooldown
     task's deterministic path, and the judge-reap reconciliation), so a label
     added here reaches all of them rather than being re-derived ad hoc per
-    caller. Currently just ``CI_FAILING_AT_CLOSE``, but the shape (verdict in,
-    labels out) is meant to grow more deterministic labels over time.
+    caller. The shape (verdict in, labels out) is meant to grow more
+    deterministic labels over time:
+
+    - ``CI_FAILING_AT_CLOSE``: only the deterministic ``CLOSED_UNMERGED`` path
+      (no commits after open, so the close head is the open head).
+    - ``CI_FAILED_AT_OPEN``: every verdict, since it only ever reads checks
+      scoped to the PR's opening head regardless of what happened after.
+    - ``NO_CI_EVENTS``: every verdict, independent of the other two — a PR can
+      lack CI activity entirely no matter how it was settled.
     """
     labels = []
     if verdict == PullRequestVerdict.CLOSED_UNMERGED and ci_failing_at_close(pull_request):
         labels.append(CI_FAILING_AT_CLOSE)
+    if ci_failed_at_open(pull_request):
+        labels.append(CI_FAILED_AT_OPEN)
+    if no_ci_events(pull_request):
+        labels.append(NO_CI_EVENTS)
     return labels or None
 
 

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -20,14 +20,14 @@ from sentry.pr_metrics.contracts import PrConversationAnalysis
 from sentry.pr_metrics.emit import (
     VerdictDeferral,
     _activity_derived_metrics,
+    _ci_failed_at_open,
+    _ci_failing_at_close,
+    _no_ci_events,
     active_attributions,
     build_pr_metrics_row,
     calculate_deterministic_diagnosis_labels,
-    ci_failed_at_open,
-    ci_failing_at_close,
     emit_pr_metrics_row,
     is_pr_tracked,
-    no_ci_events,
     resolve_autofix_referrers,
     review_activity,
     select_fallback_verdict,
@@ -273,23 +273,23 @@ class PrMetricsEmissionTest(TestCase):
         mock_metrics.incr.assert_called_once_with("pr_metrics.select_verdict.activity_disabled")
 
     def test_ci_failing_at_close_no_check_activity_is_false(self) -> None:
-        assert ci_failing_at_close(self.pull_request) is False
+        assert _ci_failing_at_close(self.pull_request, doc=None) is False
 
     def test_ci_failing_at_close_all_success_is_false(self) -> None:
         self._add_check_suite(conclusion="success", webhook_id="check-1")
-        assert ci_failing_at_close(self.pull_request) is False
+        assert _ci_failing_at_close(self.pull_request, doc=None) is False
 
     def test_ci_failing_at_close_failure_is_true(self) -> None:
         self._add_check_suite(conclusion="failure", webhook_id="check-1")
-        assert ci_failing_at_close(self.pull_request) is True
+        assert _ci_failing_at_close(self.pull_request, doc=None) is True
 
     def test_ci_failing_at_close_timed_out_is_true(self) -> None:
         self._add_check_suite(conclusion="timed_out", webhook_id="check-1")
-        assert ci_failing_at_close(self.pull_request) is True
+        assert _ci_failing_at_close(self.pull_request, doc=None) is True
 
     def test_ci_failing_at_close_startup_failure_is_true(self) -> None:
         self._add_check_suite(conclusion="startup_failure", webhook_id="check-1")
-        assert ci_failing_at_close(self.pull_request) is True
+        assert _ci_failing_at_close(self.pull_request, doc=None) is True
 
     def test_ci_failing_at_close_non_failure_conclusions_are_false(self) -> None:
         # neutral/cancelled/skipped/stale/action_required never ran to a failure
@@ -297,24 +297,24 @@ class PrMetricsEmissionTest(TestCase):
         for conclusion in ("neutral", "cancelled", "skipped", "stale", "action_required"):
             PullRequestActivity.objects.filter(pull_request=self.pull_request).delete()
             self._add_check_suite(conclusion=conclusion, webhook_id="check-1")
-            assert ci_failing_at_close(self.pull_request) is False, conclusion
+            assert _ci_failing_at_close(self.pull_request, doc=None) is False, conclusion
 
     def test_ci_failing_at_close_one_app_failing_among_others_is_true(self) -> None:
         self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-1")
         self._add_check_suite(app_slug="codecov", conclusion="failure", webhook_id="check-2")
-        assert ci_failing_at_close(self.pull_request) is True
+        assert _ci_failing_at_close(self.pull_request, doc=None) is True
 
     def test_ci_failing_at_close_rerun_success_after_failure_is_false(self) -> None:
         # A rerun with no new push (no SYNCHRONIZED row) still writes another
         # CHECK_SUITE_COMPLETED row for the same app; the latest one wins.
         self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-1")
         self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-2")
-        assert ci_failing_at_close(self.pull_request) is False
+        assert _ci_failing_at_close(self.pull_request, doc=None) is False
 
     def test_ci_failing_at_close_rerun_failure_after_success_is_true(self) -> None:
         self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-1")
         self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-2")
-        assert ci_failing_at_close(self.pull_request) is True
+        assert _ci_failing_at_close(self.pull_request, doc=None) is True
 
     def test_reviews_requested_count_no_activity_is_zero(self) -> None:
         assert review_activity(self.pull_request).requested_count == 0
@@ -362,62 +362,62 @@ class PrMetricsEmissionTest(TestCase):
     # --- ci_failed_at_open --------------------------------------------------
 
     def test_ci_failed_at_open_no_check_activity_is_false(self) -> None:
-        assert ci_failed_at_open(self.pull_request) is False
+        assert _ci_failed_at_open(self.pull_request, doc=None) is False
 
     def test_ci_failed_at_open_all_success_is_false(self) -> None:
         self._add_check_suite(conclusion="success", webhook_id="check-1")
-        assert ci_failed_at_open(self.pull_request) is False
+        assert _ci_failed_at_open(self.pull_request, doc=None) is False
 
     def test_ci_failed_at_open_failure_before_any_push_is_true(self) -> None:
         # No SYNCHRONIZED row at all, so every recorded check belongs to the
         # opening head — legacy-store approximation.
         self._add_check_suite(conclusion="failure", webhook_id="check-1")
-        assert ci_failed_at_open(self.pull_request) is True
+        assert _ci_failed_at_open(self.pull_request, doc=None) is True
 
     def test_ci_failed_at_open_failure_after_a_push_is_false(self) -> None:
         # The failing check arrived after the first push, so it can't belong to
         # the opening head under the legacy-store "before first sync" rule.
         self._add_synchronize()
         self._add_check_suite(conclusion="failure", webhook_id="check-1")
-        assert ci_failed_at_open(self.pull_request) is False
+        assert _ci_failed_at_open(self.pull_request, doc=None) is False
 
     def test_ci_failed_at_open_failure_before_a_later_push_is_true(self) -> None:
         # The failing check landed before the push — it's the opening head's,
         # even though the PR went on to iterate afterward.
         self._add_check_suite(conclusion="failure", webhook_id="check-1")
         self._add_synchronize()
-        assert ci_failed_at_open(self.pull_request) is True
+        assert _ci_failed_at_open(self.pull_request, doc=None) is True
 
     def test_ci_failed_at_open_check_run_alone_does_not_count(self) -> None:
-        # Suite-only read, same narrow signal as ci_failing_at_close: a
+        # Suite-only read, same narrow signal as _ci_failing_at_close: a
         # check_run-only app with no suite event doesn't count.
         self._add_check_run(conclusion="failure", webhook_id="run-1")
-        assert ci_failed_at_open(self.pull_request) is False
+        assert _ci_failed_at_open(self.pull_request, doc=None) is False
 
     def test_ci_failed_at_open_rerun_success_after_failure_is_false(self) -> None:
         self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-1")
         self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-2")
-        assert ci_failed_at_open(self.pull_request) is False
+        assert _ci_failed_at_open(self.pull_request, doc=None) is False
 
     # --- no_ci_events --------------------------------------------------------
 
     def test_no_ci_events_true_when_no_checks_recorded(self) -> None:
-        assert no_ci_events(self.pull_request) is True
+        assert _no_ci_events(self.pull_request, doc=None) is True
 
     def test_no_ci_events_false_with_check_suite(self) -> None:
         self._add_check_suite(conclusion="success", webhook_id="check-1")
-        assert no_ci_events(self.pull_request) is False
+        assert _no_ci_events(self.pull_request, doc=None) is False
 
     def test_no_ci_events_false_with_check_run(self) -> None:
         self._add_check_run(conclusion="success", webhook_id="run-1")
-        assert no_ci_events(self.pull_request) is False
+        assert _no_ci_events(self.pull_request, doc=None) is False
 
     def test_no_ci_events_false_even_when_checks_only_follow_a_later_push(self) -> None:
         # Scoped to the whole PR, unlike ci_failed_at_open: CI activity recorded
         # only against a later push still counts as "CI reported in".
         self._add_synchronize()
         self._add_check_suite(conclusion="success", webhook_id="check-1")
-        assert no_ci_events(self.pull_request) is False
+        assert _no_ci_events(self.pull_request, doc=None) is False
 
     # --- calculate_deterministic_diagnosis_labels ----------------------------
 

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -22,9 +22,12 @@ from sentry.pr_metrics.emit import (
     _activity_derived_metrics,
     active_attributions,
     build_pr_metrics_row,
+    calculate_deterministic_diagnosis_labels,
+    ci_failed_at_open,
     ci_failing_at_close,
     emit_pr_metrics_row,
     is_pr_tracked,
+    no_ci_events,
     resolve_autofix_referrers,
     review_activity,
     select_fallback_verdict,
@@ -172,6 +175,16 @@ class PrMetricsEmissionTest(TestCase):
             webhook_id=webhook_id,
             event_type=PullRequestActivityType.REVIEW_SUBMITTED,
             payload={"review_state": review_state},
+        )
+
+    def _add_check_run(
+        self, *, app_slug: str = "github-actions", conclusion: str = "success", webhook_id: str
+    ) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.CHECK_RUN_COMPLETED,
+            payload={"conclusion": conclusion, "app_slug": app_slug, "check_name": "test"},
         )
 
     def test_select_verdict_merged_without_later_commits_is_unchanged(self) -> None:
@@ -345,6 +358,98 @@ class PrMetricsEmissionTest(TestCase):
             "changes_requested": 0,
             "commented": 0,
         }
+
+    # --- ci_failed_at_open --------------------------------------------------
+
+    def test_ci_failed_at_open_no_check_activity_is_false(self) -> None:
+        assert ci_failed_at_open(self.pull_request) is False
+
+    def test_ci_failed_at_open_all_success_is_false(self) -> None:
+        self._add_check_suite(conclusion="success", webhook_id="check-1")
+        assert ci_failed_at_open(self.pull_request) is False
+
+    def test_ci_failed_at_open_failure_before_any_push_is_true(self) -> None:
+        # No SYNCHRONIZED row at all, so every recorded check belongs to the
+        # opening head — legacy-store approximation.
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        assert ci_failed_at_open(self.pull_request) is True
+
+    def test_ci_failed_at_open_failure_after_a_push_is_false(self) -> None:
+        # The failing check arrived after the first push, so it can't belong to
+        # the opening head under the legacy-store "before first sync" rule.
+        self._add_synchronize()
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        assert ci_failed_at_open(self.pull_request) is False
+
+    def test_ci_failed_at_open_failure_before_a_later_push_is_true(self) -> None:
+        # The failing check landed before the push — it's the opening head's,
+        # even though the PR went on to iterate afterward.
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        self._add_synchronize()
+        assert ci_failed_at_open(self.pull_request) is True
+
+    def test_ci_failed_at_open_check_run_alone_does_not_count(self) -> None:
+        # Suite-only read, same narrow signal as ci_failing_at_close: a
+        # check_run-only app with no suite event doesn't count.
+        self._add_check_run(conclusion="failure", webhook_id="run-1")
+        assert ci_failed_at_open(self.pull_request) is False
+
+    def test_ci_failed_at_open_rerun_success_after_failure_is_false(self) -> None:
+        self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-1")
+        self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-2")
+        assert ci_failed_at_open(self.pull_request) is False
+
+    # --- no_ci_events --------------------------------------------------------
+
+    def test_no_ci_events_true_when_no_checks_recorded(self) -> None:
+        assert no_ci_events(self.pull_request) is True
+
+    def test_no_ci_events_false_with_check_suite(self) -> None:
+        self._add_check_suite(conclusion="success", webhook_id="check-1")
+        assert no_ci_events(self.pull_request) is False
+
+    def test_no_ci_events_false_with_check_run(self) -> None:
+        self._add_check_run(conclusion="success", webhook_id="run-1")
+        assert no_ci_events(self.pull_request) is False
+
+    def test_no_ci_events_false_even_when_checks_only_follow_a_later_push(self) -> None:
+        # Scoped to the whole PR, unlike ci_failed_at_open: CI activity recorded
+        # only against a later push still counts as "CI reported in".
+        self._add_synchronize()
+        self._add_check_suite(conclusion="success", webhook_id="check-1")
+        assert no_ci_events(self.pull_request) is False
+
+    # --- calculate_deterministic_diagnosis_labels ----------------------------
+
+    def test_calculate_deterministic_diagnosis_labels_no_ci_events(self) -> None:
+        assert calculate_deterministic_diagnosis_labels(
+            self.pull_request, PullRequestVerdict.CLOSED_UNMERGED
+        ) == ["no_ci_events"]
+
+    def test_calculate_deterministic_diagnosis_labels_closed_unmerged_with_ci_failure(self) -> None:
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        assert calculate_deterministic_diagnosis_labels(
+            self.pull_request, PullRequestVerdict.CLOSED_UNMERGED
+        ) == ["ci_failing_at_close", "ci_failed_at_open"]
+
+    def test_calculate_deterministic_diagnosis_labels_merged_with_ci_failure_at_open_only(
+        self,
+    ) -> None:
+        # ci_failing_at_close is scoped to CLOSED_UNMERGED, but ci_failed_at_open
+        # applies to a merge too.
+        self._add_check_suite(conclusion="failure", webhook_id="check-1")
+        assert calculate_deterministic_diagnosis_labels(
+            self.pull_request, PullRequestVerdict.MERGED_UNCHANGED
+        ) == ["ci_failed_at_open"]
+
+    def test_calculate_deterministic_diagnosis_labels_all_green_is_none(self) -> None:
+        self._add_check_suite(conclusion="success", webhook_id="check-1")
+        assert (
+            calculate_deterministic_diagnosis_labels(
+                self.pull_request, PullRequestVerdict.CLOSED_UNMERGED
+            )
+            is None
+        )
 
     def test_select_fallback_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         assert select_fallback_verdict(self.pull_request) == PullRequestVerdict.MERGED_UNCHANGED

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -359,7 +359,7 @@ class PrMetricsEmissionTest(TestCase):
             "commented": 0,
         }
 
-    # --- ci_failed_at_open --------------------------------------------------
+    # --- _ci_failed_at_open --------------------------------------------------
 
     def test_ci_failed_at_open_no_check_activity_is_false(self) -> None:
         assert _ci_failed_at_open(self.pull_request, doc=None) is False
@@ -399,7 +399,7 @@ class PrMetricsEmissionTest(TestCase):
         self._add_check_suite(app_slug="github-actions", conclusion="success", webhook_id="check-2")
         assert _ci_failed_at_open(self.pull_request, doc=None) is False
 
-    # --- no_ci_events --------------------------------------------------------
+    # --- _no_ci_events --------------------------------------------------------
 
     def test_no_ci_events_true_when_no_checks_recorded(self) -> None:
         assert _no_ci_events(self.pull_request, doc=None) is True
@@ -413,7 +413,7 @@ class PrMetricsEmissionTest(TestCase):
         assert _no_ci_events(self.pull_request, doc=None) is False
 
     def test_no_ci_events_false_even_when_checks_only_follow_a_later_push(self) -> None:
-        # Scoped to the whole PR, unlike ci_failed_at_open: CI activity recorded
+        # Scoped to the whole PR, unlike _ci_failed_at_open: CI activity recorded
         # only against a later push still counts as "CI reported in".
         self._add_synchronize()
         self._add_check_suite(conclusion="success", webhook_id="check-1")
@@ -435,7 +435,7 @@ class PrMetricsEmissionTest(TestCase):
     def test_calculate_deterministic_diagnosis_labels_merged_with_ci_failure_at_open_only(
         self,
     ) -> None:
-        # ci_failing_at_close is scoped to CLOSED_UNMERGED, but ci_failed_at_open
+        # _ci_failing_at_close is scoped to CLOSED_UNMERGED, but _ci_failed_at_open
         # applies to a merge too.
         self._add_check_suite(conclusion="failure", webhook_id="check-1")
         assert calculate_deterministic_diagnosis_labels(

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -279,21 +279,13 @@ class PrMetricsEmissionTest(TestCase):
         self._add_check_suite(conclusion="success", webhook_id="check-1")
         assert _ci_failing_at_close(self.pull_request, doc=None) is False
 
-    def test_ci_failing_at_close_failure_is_true(self) -> None:
-        self._add_check_suite(conclusion="failure", webhook_id="check-1")
-        assert _ci_failing_at_close(self.pull_request, doc=None) is True
-
-    def test_ci_failing_at_close_timed_out_is_true(self) -> None:
-        self._add_check_suite(conclusion="timed_out", webhook_id="check-1")
-        assert _ci_failing_at_close(self.pull_request, doc=None) is True
-
-    def test_ci_failing_at_close_startup_failure_is_true(self) -> None:
-        self._add_check_suite(conclusion="startup_failure", webhook_id="check-1")
-        assert _ci_failing_at_close(self.pull_request, doc=None) is True
-
-    def test_ci_failing_at_close_non_failure_conclusions_are_false(self) -> None:
-        # neutral/cancelled/skipped/stale/action_required never ran to a failure
-        # verdict, so none of them should trip the label.
+    def test_ci_failing_at_close_conclusion_vocabulary(self) -> None:
+        # _FAILING_CHECK_CONCLUSIONS is the enumerated failing set; every other
+        # GitHub check conclusion is not a failure for this label.
+        for conclusion in ("failure", "timed_out", "startup_failure"):
+            PullRequestActivity.objects.filter(pull_request=self.pull_request).delete()
+            self._add_check_suite(conclusion=conclusion, webhook_id="check-1")
+            assert _ci_failing_at_close(self.pull_request, doc=None) is True, conclusion
         for conclusion in ("neutral", "cancelled", "skipped", "stale", "action_required"):
             PullRequestActivity.objects.filter(pull_request=self.pull_request).delete()
             self._add_check_suite(conclusion=conclusion, webhook_id="check-1")

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -26,7 +26,9 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.emit import (
     VerdictDeferral,
     _activity_derived_metrics,
+    ci_failed_at_open,
     ci_failing_at_close,
+    no_ci_events,
     review_activity,
     select_fallback_verdict,
     select_verdict,
@@ -234,6 +236,47 @@ class ActivityDocumentReadersTest(TestCase):
             "changes_requested": 0,
             "commented": 1,
         }
+
+    # --- ci_failed_at_open --------------------------------------------------
+
+    def test_ci_failed_at_open_from_doc(self) -> None:
+        self._write_doc(
+            _doc(
+                events=[_entry("opened", "o1", head_sha="sha1")],
+                checks={"sha1|github-actions": _group(head_sha="sha1", suite_conclusion="failure")},
+            )
+        )
+        assert ci_failed_at_open(self.pr) is True
+
+    def test_ci_failed_at_open_from_doc_excludes_later_head(self) -> None:
+        # The failing check belongs to a later push's head, not the opening one.
+        self._write_doc(
+            _doc(
+                events=[_entry("opened", "o1", head_sha="sha1")],
+                checks={"sha2|github-actions": _group(head_sha="sha2", suite_conclusion="failure")},
+            )
+        )
+        assert ci_failed_at_open(self.pr) is False
+
+    def test_ci_failed_at_open_from_doc_no_opened_entry_is_false(self) -> None:
+        # No OPENED entry recorded (e.g. tracking enabled after the PR opened) —
+        # there's no reliable opening head to scope the check to.
+        self._write_doc(
+            _doc(
+                checks={"sha1|github-actions": _group(head_sha="sha1", suite_conclusion="failure")}
+            )
+        )
+        assert ci_failed_at_open(self.pr) is False
+
+    # --- no_ci_events --------------------------------------------------------
+
+    def test_no_ci_events_true_from_empty_doc(self) -> None:
+        self._write_doc(_doc())
+        assert no_ci_events(self.pr) is True
+
+    def test_no_ci_events_false_from_doc_with_checks(self) -> None:
+        self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="success")}))
+        assert no_ci_events(self.pr) is False
 
     # --- resolved_group_ids -----------------------------------------------
 

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -1,7 +1,7 @@
 """Reader-routing tests for the reduced activity document (CORE-283 PR 4).
 
 Each reader (select_verdict, select_fallback_verdict, the activity-derived counters,
-ci_failing_at_close, resolved_group_ids, the judge timeline forward) routes per PR by
+_ci_failing_at_close, resolved_group_ids, the judge timeline forward) routes per PR by
 store presence: a ``PullRequestActivityLog`` row → read the document; no row → read
 the legacy rows.
 These craft a document and assert the reader returns the document-derived value
@@ -26,9 +26,9 @@ from sentry.models.pullrequest import (
 from sentry.pr_metrics.emit import (
     VerdictDeferral,
     _activity_derived_metrics,
-    ci_failed_at_open,
-    ci_failing_at_close,
-    no_ci_events,
+    _ci_failed_at_open,
+    _ci_failing_at_close,
+    _no_ci_events,
     review_activity,
     select_fallback_verdict,
     select_verdict,
@@ -168,15 +168,15 @@ class ActivityDocumentReadersTest(TestCase):
         assert metrics["reviews_human_count"] == 1
         assert metrics["participants_count"] == 1  # human only; ci[bot] excluded
 
-    # --- ci_failing_at_close ----------------------------------------------
+    # --- _ci_failing_at_close ----------------------------------------------
 
     def test_ci_failing_at_close_from_doc(self) -> None:
         self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="failure")}))
-        assert ci_failing_at_close(self.pr) is True
+        assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is True
 
     def test_ci_not_failing_at_close_from_doc(self) -> None:
         self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="success")}))
-        assert ci_failing_at_close(self.pr) is False
+        assert _ci_failing_at_close(self.pr, doc=load_activity_document(self.pr)) is False
 
     # --- review_activity (requested_count, results) -------------------------
 
@@ -237,7 +237,7 @@ class ActivityDocumentReadersTest(TestCase):
             "commented": 1,
         }
 
-    # --- ci_failed_at_open --------------------------------------------------
+    # --- _ci_failed_at_open --------------------------------------------------
 
     def test_ci_failed_at_open_from_doc(self) -> None:
         self._write_doc(
@@ -246,7 +246,7 @@ class ActivityDocumentReadersTest(TestCase):
                 checks={"sha1|github-actions": _group(head_sha="sha1", suite_conclusion="failure")},
             )
         )
-        assert ci_failed_at_open(self.pr) is True
+        assert _ci_failed_at_open(self.pr, doc=load_activity_document(self.pr)) is True
 
     def test_ci_failed_at_open_from_doc_excludes_later_head(self) -> None:
         # The failing check belongs to a later push's head, not the opening one.
@@ -256,7 +256,7 @@ class ActivityDocumentReadersTest(TestCase):
                 checks={"sha2|github-actions": _group(head_sha="sha2", suite_conclusion="failure")},
             )
         )
-        assert ci_failed_at_open(self.pr) is False
+        assert _ci_failed_at_open(self.pr, doc=load_activity_document(self.pr)) is False
 
     def test_ci_failed_at_open_from_doc_no_opened_entry_is_false(self) -> None:
         # No OPENED entry recorded (e.g. tracking enabled after the PR opened) —
@@ -266,17 +266,17 @@ class ActivityDocumentReadersTest(TestCase):
                 checks={"sha1|github-actions": _group(head_sha="sha1", suite_conclusion="failure")}
             )
         )
-        assert ci_failed_at_open(self.pr) is False
+        assert _ci_failed_at_open(self.pr, doc=load_activity_document(self.pr)) is False
 
-    # --- no_ci_events --------------------------------------------------------
+    # --- _no_ci_events --------------------------------------------------------
 
     def test_no_ci_events_true_from_empty_doc(self) -> None:
         self._write_doc(_doc())
-        assert no_ci_events(self.pr) is True
+        assert _no_ci_events(self.pr, doc=load_activity_document(self.pr)) is True
 
     def test_no_ci_events_false_from_doc_with_checks(self) -> None:
         self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="success")}))
-        assert no_ci_events(self.pr) is False
+        assert _no_ci_events(self.pr, doc=load_activity_document(self.pr)) is False
 
     # --- resolved_group_ids -----------------------------------------------
 

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -451,7 +451,8 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         row = mock_record.call_args_list[-1].args[0]
         assert row.close_action == "closed"
         assert row.verdict == "closed_unmerged"
-        assert row.diagnosis_labels is None
+        # No check activity was ever recorded for this PR.
+        assert row.diagnosis_labels == ["no_ci_events"]
 
     def _add_check_suite(self, *, conclusion: str, webhook_id: str) -> None:
         PullRequestActivity.objects.create(
@@ -469,7 +470,9 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         self._call(merged=False)
         row = mock_record.call_args_list[-1].args[0]
         assert row.verdict == "closed_unmerged"
-        assert row.diagnosis_labels == ["ci_failing_at_close"]
+        # No commits after open, so the failing check is both "at close" and "at
+        # open" — the same one and only head.
+        assert row.diagnosis_labels == ["ci_failing_at_close", "ci_failed_at_open"]
 
     @patch("sentry.analytics.record")
     def test_closed_unmerged_with_passing_ci_has_no_diagnosis_label(
@@ -482,14 +485,18 @@ class HandleWebhookForPrMetricsEmissionTest(TestCase):
         assert row.diagnosis_labels is None
 
     @patch("sentry.analytics.record")
-    def test_merged_with_failing_ci_has_no_diagnosis_label(self, mock_record: MagicMock) -> None:
-        # The deterministic CI-failure label is scoped to CLOSED_UNMERGED; a clean
-        # merge never carries it even if a check suite failed along the way.
+    def test_merged_with_failing_ci_at_open_only_sets_ci_failed_at_open(
+        self, mock_record: MagicMock
+    ) -> None:
+        # The deterministic close-time CI-failure label is scoped to
+        # CLOSED_UNMERGED; a clean merge never carries it even if a check suite
+        # failed along the way. But ci_failed_at_open isn't verdict-scoped: the
+        # failing check recorded before any push is still the opening head's.
         self._add_check_suite(conclusion="failure", webhook_id="check-1")
         self._call(merged=True)
         row = mock_record.call_args_list[-1].args[0]
         assert row.verdict == "merged_unchanged"
-        assert row.diagnosis_labels is None
+        assert row.diagnosis_labels == ["ci_failed_at_open"]
 
     def _add_synchronize(self) -> None:
         # A push to the PR branch after it opened — makes a merge non-deterministic.


### PR DESCRIPTION
Adds two deterministic diagnosis labels to `scm.pr.closed` emission, alongside the existing `ci_failing_at_close`:

- `ci_failed_at_open`: true when a CI check suite was already failing at the PR's opening head. This is computed for every verdict, since it only ever looks at checks tied to the opening head. Doc-store reads key off the `OPENED` entry's `head_sha`; legacy-store approximates it as every check row that arrived before the PR's first `SYNCHRONIZED` row (the legacy row payload carries no `head_sha` to filter on directly).
- `no_ci_events`: true when no CI check activity (check_suite or check_run) was ever recorded for the PR, of any kind or head.

This lets us query PRs where CI failed at open directly, instead of inferring it from `ci_failing_at_close` on closed PRs that never iterated.

Both readers share two helpers extracted from what would otherwise be duplicated logic between `ci_failing_at_close` and `ci_failed_at_open`: `_any_group_failing` (doc-store rollup scan) and `_any_app_failing` (legacy-store latest-per-app dedup scan).

Refs [CW-1598](https://linear.app/getsentry/issue/CW-1598/include-deterministic-ci_failed_at_open-label-for-scmprclosed-events)