### PR TITLE
fix(trace): Resolve trace overview data independently

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -58,6 +58,7 @@ import {useTraceState, TraceStateProvider} from './traceState/traceStateProvider
 import {ErrorsOnlyWarnings} from './traceTypeWarnings/errorsOnlyWarnings';
 import {TraceMetaDataHeader} from './traceHeader';
 import {useTraceEventView} from './useTraceEventView';
+import {useTraceOverviewData} from './useTraceOverviewData';
 import {useTraceQueryParams} from './useTraceQueryParams';
 import {useTraceStateAnalytics} from './useTraceStateAnalytics';
 
@@ -128,7 +129,14 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
     ],
   });
   const tree = useTraceTree({traceSlug, trace, replay: null});
-
+  const overview = useTraceOverviewData({
+    logsEnabled,
+    meta: meta.data,
+    metricsEnabled,
+    queryParams,
+    traceSlug,
+    tree,
+  });
   useTraceStateAnalytics({
     trace,
     meta,
@@ -139,18 +147,22 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
 
   const rootEventResults = useTraceRootEvent({
     tree,
-    logs: undefined,
+    logs: overview.logs.representative,
     timestamp: queryParams.timestamp,
     traceId: traceSlug,
   });
 
-  const {tabOptions, currentTab, onTabChange} = useTraceLayoutTabs({
-    isLoading: meta.status === 'pending' || tree.type === 'loading',
+  const tabsConfig = useTraceLayoutTabs({
+    isLoading:
+      meta.status === 'pending' || tree.type === 'loading' || overview.isTabLoading,
     tree,
     meta: meta.data,
     logsEnabled,
     metricsEnabled,
+    overview,
   });
+  const {currentTab} = tabsConfig;
+  const isResolvingEmptyTraceTab = tree.type === 'empty' && tabsConfig.isLoading;
 
   const traceNode = tree.root.children[0];
   const traceErrors = useMemo(() => {
@@ -200,20 +212,17 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
         tree={tree}
         metaResults={meta}
         organization={organization}
+        overview={overview}
         traceSlug={traceSlug}
       />
       <TraceInnerLayout>
         <TraceWaterfallVersionBanner />
         <TraceTabsAndVitals
-          tabsConfig={{
-            tabOptions,
-            currentTab,
-            onTabChange,
-          }}
+          tabsConfig={tabsConfig}
           rootEventResults={rootEventResults}
           tree={tree}
         />
-        {currentTab === TraceLayoutTabKeys.WATERFALL ? (
+        {isResolvingEmptyTraceTab ? null : currentTab === TraceLayoutTabKeys.WATERFALL ? (
           <Fragment>
             <ErrorsOnlyWarnings
               tree={tree}
@@ -222,7 +231,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
             />
             <PartialTraceDataWarning
               timestamp={queryParams.timestamp}
-              logs={undefined}
+              logs={overview.logs.representative}
               tree={tree}
             />
             <TraceViewLogsPageDataProvider
@@ -242,24 +251,20 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
               />
             </TraceViewLogsPageDataProvider>
           </Fragment>
-        ) : null}
-        {currentTab === TraceLayoutTabKeys.PROFILES ? (
+        ) : currentTab === TraceLayoutTabKeys.PROFILES ? (
           <TraceProfiles tree={tree} />
-        ) : null}
-        {currentTab === TraceLayoutTabKeys.LOGS ? (
+        ) : currentTab === TraceLayoutTabKeys.LOGS ? (
           <TraceViewLogsPageDataProvider>
             <TraceViewLogsSection
               errors={traceErrors}
               fallbackTimestampSeconds={traceStartSeconds}
             />
           </TraceViewLogsPageDataProvider>
-        ) : null}
-        {currentTab === TraceLayoutTabKeys.METRICS ? (
+        ) : currentTab === TraceLayoutTabKeys.METRICS ? (
           <TraceViewMetricsProviderWrapper traceSlug={traceSlug}>
             <TraceViewMetricsSection />
           </TraceViewMetricsProviderWrapper>
-        ) : null}
-        {currentTab === TraceLayoutTabKeys.AI_SPANS ? (
+        ) : currentTab === TraceLayoutTabKeys.AI_SPANS ? (
           <TraceAiTab traceSlug={traceSlug} />
         ) : null}
       </TraceInnerLayout>

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -6,6 +6,7 @@ import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary
 
 import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {
   TraceMetaDataHeader,
@@ -43,6 +44,19 @@ const baseProps: Partial<TraceMetadataHeaderProps> = {
   rootEventResults: {
     data: TransactionEventFixture(),
   } as any,
+  overview: {
+    isRepresentativeLoading: false,
+    isTabLoading: false,
+    logs: {
+      availability: 'absent',
+      count: 0,
+      representative: undefined,
+    },
+    metrics: {
+      availability: 'absent',
+      count: 0,
+    },
+  },
   tree: new TraceTree().build(),
   traceSlug: 'trace-slug',
 };
@@ -265,6 +279,53 @@ describe('TraceMetaDataHeader', () => {
   });
 
   describe('meta', () => {
+    it('renders representative information for a log-only trace', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+      const logsOrganization = OrganizationFixture({features: ['ourlogs-enabled']});
+      const representativeLog = {
+        [OurLogKnownFieldKey.MESSAGE]: 'Representative log message',
+        [OurLogKnownFieldKey.PROJECT_ID]: '1',
+        [OurLogKnownFieldKey.SEVERITY]: 'info',
+      } as NonNullable<
+        TraceMetadataHeaderProps['overview']['logs']['representative']
+      >[number];
+      const representativeLogs = [representativeLog];
+      const tree = TraceTree.Empty();
+      const findRepresentativeTraceNode = jest
+        .spyOn(tree, 'findRepresentativeTraceNode')
+        .mockReturnValue({event: representativeLog, dataset: null});
+      const props = {
+        ...baseProps,
+        tree,
+        overview: {
+          isRepresentativeLoading: false,
+          isTabLoading: false,
+          logs: {
+            availability: 'present',
+            count: 4,
+            representative: representativeLogs,
+          },
+          metrics: {
+            availability: 'absent',
+            count: 0,
+          },
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={logsOrganization} />);
+
+      expect(screen.getByText('Representative log message')).toBeInTheDocument();
+      expect(screen.getByText('Logs')).toBeInTheDocument();
+      expect(screen.getByText('4')).toBeInTheDocument();
+      expect(findRepresentativeTraceNode).toHaveBeenCalledWith({
+        logs: representativeLogs,
+      });
+    });
+
     it('should render logs count from trace meta before logs have loaded', () => {
       useLocationMock.mockReturnValue(
         LocationFixture({

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -20,6 +20,7 @@ import {Projects} from 'sentry/views/performance/newTraceDetails/traceHeader/pro
 import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
+import type {TraceOverviewData} from 'sentry/views/performance/newTraceDetails/useTraceOverviewData';
 
 import {getTraceViewBreadcrumbs} from './breadcrumbs';
 import {Meta} from './meta';
@@ -28,6 +29,7 @@ import {Title} from './title';
 export interface TraceMetadataHeaderProps {
   metaResults: TraceMetaQueryResults;
   organization: Organization;
+  overview: TraceOverviewData;
   rootEventResults: TraceRootEventQueryResults;
   traceSlug: string;
   tree: TraceTree;
@@ -50,8 +52,10 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
   const {projects} = useProjects();
   const {hasLogs, hasMetrics} = useTraceContextSections({
     tree: props.tree,
-    logs: undefined,
+    logs: props.overview.logs.representative,
+    logsCount: props.overview.logs.count,
     metrics: undefined,
+    metricsCount: props.overview.metrics.count,
     meta: props.metaResults.data,
     logsEnabled,
     metricsEnabled,
@@ -72,7 +76,9 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
     return <PlaceHolder organization={props.organization} traceSlug={props.traceSlug} />;
   }
 
-  const rep = props.tree.findRepresentativeTraceNode({logs: undefined});
+  const rep = props.tree.findRepresentativeTraceNode({
+    logs: props.overview.logs.representative,
+  });
   const project = projects.find(p => {
     const id =
       rep?.event && OurLogKnownFieldKey.PROJECT_ID in rep.event
@@ -114,6 +120,7 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             <Meta
               tree={props.tree}
               meta={props.metaResults.data}
+              overview={props.overview}
               representativeEvent={rep}
               logsEnabled={logsEnabled}
               metricsEnabled={metricsEnabled}
@@ -127,7 +134,14 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             />
           </Container>
           <Container area="projects" justifySelf={{zero: 'start', xl: 'end'}}>
-            <Projects tree={props.tree} />
+            <Projects
+              projectSlugs={Array.from(
+                new Set([
+                  ...Array.from(props.tree.projects.values()).map(p => p.slug),
+                  ...(project ? [project.slug] : []),
+                ])
+              )}
+            />
           </Container>
         </TraceHeaderComponents.HeaderGrid>
       </TraceHeaderComponents.HeaderContent>

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -16,6 +16,7 @@ import {
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
+import type {TraceOverviewData} from 'sentry/views/performance/newTraceDetails/useTraceOverviewData';
 import {useTraceQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
 
 type MetaDataProps = {
@@ -53,6 +54,7 @@ interface MetaProps {
   logsEnabled: boolean;
   meta: TraceMetaQueryResults['data'];
   metricsEnabled: boolean;
+  overview: TraceOverviewData;
   representativeEvent: TraceTree.RepresentativeTraceEvent | null;
   tree: TraceTree;
 }
@@ -99,9 +101,10 @@ export function Meta(props: MetaProps) {
 
   const hasDifferentSpansCount = loadedSpansCount !== 0 && totalSpansCount !== 0;
   const hasSpans = spansCount > 0 || loadedSpansCount > 0 || totalSpansCount > 0;
-  const logsCount = getTraceMetaLogsCount(props.meta) ?? 0;
+  const logsCount = getTraceMetaLogsCount(props.meta) ?? props.overview.logs.count ?? 0;
   const hasLogs = props.logsEnabled && logsCount > 0;
-  const metricsCount = getTraceMetaMetricsCount(props.meta) ?? 0;
+  const metricsCount =
+    getTraceMetaMetricsCount(props.meta) ?? props.overview.metrics.count ?? 0;
   const hasMetrics = props.metricsEnabled && metricsCount > 0;
 
   const repEvent = props.representativeEvent?.event;

--- a/static/app/views/performance/newTraceDetails/traceHeader/projects.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/projects.tsx
@@ -1,15 +1,14 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {ProjectsRenderer} from 'sentry/views/explore/tables/tracesTable/fieldRenderers';
-import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useTraceStateDispatch} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
 
 type Props = {
-  tree: TraceTree;
+  projectSlugs: string[];
 };
 
-export function Projects({tree}: Props) {
+export function Projects({projectSlugs}: Props) {
   const dispatch = useTraceStateDispatch();
 
   const onProjectClick = useCallback(
@@ -22,12 +21,6 @@ export function Projects({tree}: Props) {
     },
     [dispatch]
   );
-
-  const projectSlugs = useMemo(() => {
-    return Array.from(
-      new Set(Array.from(tree.projects.values()).map(project => project.slug))
-    );
-  }, [tree.projects]);
 
   return (
     <ProjectsRendererWrapper>

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -59,9 +59,9 @@ export function TraceTabsAndVitals({
   rootEventResults,
   tree,
 }: TraceTabsAndVitalsProps) {
-  const {tabOptions, currentTab, onTabChange} = tabsConfig;
+  const {tabOptions, currentTab, isLoading, onTabChange} = tabsConfig;
 
-  if (rootEventResults.isLoading || tree.type === 'loading') {
+  if (isLoading || rootEventResults.isLoading || tree.type === 'loading') {
     return <Placeholder />;
   }
 

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.spec.tsx
@@ -91,6 +91,21 @@ describe('useTraceContextSections', () => {
     expect(result.current.hasTraceEvents).toBe(false);
   });
 
+  it('does not show trace events when metrics are the only available data', () => {
+    const {result} = renderHook(() =>
+      useTraceContextSections({
+        tree: makeTree(),
+        logs: undefined,
+        metrics: undefined,
+        metricsCount: 1,
+        meta: undefined,
+      })
+    );
+
+    expect(result.current.hasMetrics).toBe(true);
+    expect(result.current.hasTraceEvents).toBe(false);
+  });
+
   it('falls back to tree data for AI spans when EAP trace meta has no gen_ai span op count', () => {
     const {result} = renderHook(() =>
       useTraceContextSections({

--- a/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceContextSections.tsx
@@ -23,7 +23,9 @@ function hasCount(count: number | undefined, fallback: boolean): boolean {
 export function useTraceContextSections({
   tree,
   logs,
+  logsCount,
   metrics,
+  metricsCount,
   meta,
   logsEnabled = true,
   metricsEnabled = true,
@@ -31,18 +33,27 @@ export function useTraceContextSections({
   logs: OurLogsResponseItem[] | undefined;
   metrics: {count: number} | undefined;
   tree: TraceTree;
+  logsCount?: number;
   logsEnabled?: boolean;
   meta?: TraceMetaQueryResults['data'];
+  metricsCount?: number;
   metricsEnabled?: boolean;
 }) {
   const hasProfiles = tree.type === 'trace' && tree.profiled_events.size > 0;
 
   const hasLogs =
-    logsEnabled && hasCount(getTraceMetaLogsCount(meta), !!(logs && logs?.length > 0));
+    logsEnabled &&
+    hasCount(
+      getTraceMetaLogsCount(meta),
+      logsCount === undefined ? !!(logs && logs.length > 0) : logsCount > 0
+    );
   const hasMetrics =
     metricsEnabled &&
-    hasCount(getTraceMetaMetricsCount(meta), !!(metrics && metrics.count > 0));
-  const hasOnlyLogs = tree.type === 'empty' && hasLogs;
+    hasCount(
+      getTraceMetaMetricsCount(meta),
+      metricsCount === undefined ? !!(metrics && metrics.count > 0) : metricsCount > 0
+    );
+  const hasOnlyNonTraceData = tree.type === 'empty' && (hasLogs || hasMetrics);
 
   const allowedVitals = Object.keys(VITAL_DETAILS);
   const hasVitals: boolean = Array.from(tree.vitals.values()).some(vitalGroup =>
@@ -60,7 +71,9 @@ export function useTraceContextSections({
     (getTraceMetaUptimeCount(meta) ?? 0);
 
   const hasTraceEvents =
-    meta === undefined ? !hasOnlyLogs : traceEventCount > 0 || !hasOnlyLogs;
+    meta === undefined
+      ? !hasOnlyNonTraceData
+      : traceEventCount > 0 || !hasOnlyNonTraceData;
 
   return useMemo(
     () => ({

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -29,6 +29,23 @@ function makeEapMeta(overrides: Partial<EAPTraceMeta> = {}): EAPTraceMeta {
 
 describe('getInitialTab', () => {
   it.each([
+    [TraceLayoutTabKeys.LOGS, {...sections, hasTraceEvents: false, hasLogs: true}],
+    [TraceLayoutTabKeys.METRICS, {...sections, hasTraceEvents: false, hasMetrics: true}],
+  ])(
+    'selects %s when it is the only available non-trace tab',
+    (expectedTab, availableSections) => {
+      expect(
+        getInitialTab({
+          isLoading: false,
+          sections: availableSections,
+          tabOptions: [],
+          tabSlugFromUrl: undefined,
+        }).slug
+      ).toBe(expectedTab);
+    }
+  );
+
+  it.each([
     [TraceLayoutTabKeys.LOGS, TraceLayoutTabKeys.LOGS],
     [TraceLayoutTabKeys.METRICS, TraceLayoutTabKeys.METRICS],
     [TraceLayoutTabKeys.AI_SPANS, TraceLayoutTabKeys.AI_SPANS],

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -12,6 +12,7 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {useTraceContextSections} from 'sentry/views/performance/newTraceDetails/useTraceContextSections';
+import type {TraceOverviewData} from 'sentry/views/performance/newTraceDetails/useTraceOverviewData';
 
 export enum TraceLayoutTabKeys {
   WATERFALL = 'waterfall',
@@ -28,6 +29,7 @@ interface Tab {
 
 export interface TraceLayoutTabsConfig {
   currentTab: TraceLayoutTabKeys;
+  isLoading: boolean;
   onTabChange: (slug: TraceLayoutTabKeys) => void;
   tabOptions: Tab[];
 }
@@ -57,7 +59,9 @@ const TAB_DEFINITIONS: Record<TraceLayoutTabKeys, Tab> = {
 
 function getTabOptions({
   sections,
+  overview,
 }: {
+  overview: TraceOverviewData;
   sections: ReturnType<typeof useTraceContextSections>;
 }): Tab[] {
   const tabOptions: Tab[] = [];
@@ -70,11 +74,19 @@ function getTabOptions({
     tabOptions.push(TAB_DEFINITIONS[TraceLayoutTabKeys.PROFILES]);
   }
 
-  if (sections.hasLogs) {
+  if (
+    sections.hasLogs ||
+    overview.logs.availability === 'unknown' ||
+    overview.logs.availability === 'loading'
+  ) {
     tabOptions.push(TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS]);
   }
 
-  if (sections.hasMetrics) {
+  if (
+    sections.hasMetrics ||
+    overview.metrics.availability === 'unknown' ||
+    overview.metrics.availability === 'loading'
+  ) {
     tabOptions.push(TAB_DEFINITIONS[TraceLayoutTabKeys.METRICS]);
   }
 
@@ -102,9 +114,8 @@ export function getInitialTab({
   meta?: TraceMetaQueryResults['data'];
   metricsEnabled?: boolean;
 }): Tab {
-  const hasNoLogs = logsEnabled && getTraceMetaLogsCount(meta) === 0 && !sections.hasLogs;
-  const hasNoMetrics =
-    metricsEnabled && getTraceMetaMetricsCount(meta) === 0 && !sections.hasMetrics;
+  const hasNoLogs = logsEnabled && getTraceMetaLogsCount(meta) === 0;
+  const hasNoMetrics = metricsEnabled && getTraceMetaMetricsCount(meta) === 0;
 
   const shouldKeepLogsTabWhileLoading =
     logsEnabled && !hasNoLogs && tabSlugFromUrl === TraceLayoutTabKeys.LOGS;
@@ -135,13 +146,22 @@ export function getInitialTab({
     return TAB_DEFINITIONS[TraceLayoutTabKeys.WATERFALL];
   }
 
-  return TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS];
+  if (sections.hasLogs) {
+    return TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS];
+  }
+
+  if (sections.hasMetrics) {
+    return TAB_DEFINITIONS[TraceLayoutTabKeys.METRICS];
+  }
+
+  return TAB_DEFINITIONS[TraceLayoutTabKeys.WATERFALL];
 }
 
 interface UseTraceLayoutTabsProps {
   isLoading: boolean;
   logsEnabled: boolean;
   metricsEnabled: boolean;
+  overview: TraceOverviewData;
   tree: TraceTree;
   meta?: TraceMetaQueryResults['data'];
 }
@@ -152,25 +172,21 @@ export function useTraceLayoutTabs({
   meta,
   logsEnabled,
   metricsEnabled,
+  overview,
 }: UseTraceLayoutTabsProps): TraceLayoutTabsConfig {
   const navigate = useNavigate();
   const organization = useOrganization();
   const sections = useTraceContextSections({
     tree,
-    logs: undefined,
+    logs: overview.logs.representative,
+    logsCount: overview.logs.count,
     meta,
     metrics: undefined,
+    metricsCount: overview.metrics.count,
     logsEnabled,
     metricsEnabled,
   });
-  const logsCount = getTraceMetaLogsCount(meta);
-  const metricsCount = getTraceMetaMetricsCount(meta);
-  const sectionsWithUnknownData = {
-    ...sections,
-    hasLogs: logsEnabled && (logsCount === undefined || logsCount > 0),
-    hasMetrics: metricsEnabled && (metricsCount === undefined || metricsCount > 0),
-  };
-  const tabOptions = getTabOptions({sections: sectionsWithUnknownData});
+  const tabOptions = getTabOptions({overview, sections});
 
   const queryParams = qs.parse(window.location.search);
 
@@ -179,12 +195,13 @@ export function useTraceLayoutTabs({
     logsEnabled,
     metricsEnabled,
     meta,
-    sections: sectionsWithUnknownData,
+    sections,
     tabOptions,
     tabSlugFromUrl: typeof queryParams.tab === 'string' ? queryParams.tab : undefined,
   });
 
   const [currentTab, setCurrentTab] = useState(initialTab.slug);
+  const isCurrentTabRequested = queryParams.tab === currentTab;
 
   const onTabChange = useCallback(
     (slug: Tab['slug']) => {
@@ -215,8 +232,9 @@ export function useTraceLayoutTabs({
     () => ({
       tabOptions,
       currentTab,
+      isLoading: isLoading && !isCurrentTabRequested,
       onTabChange,
     }),
-    [tabOptions, currentTab, onTabChange]
+    [tabOptions, currentTab, isCurrentTabRequested, isLoading, onTabChange]
   );
 }

--- a/static/app/views/performance/newTraceDetails/useTraceOverviewData.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOverviewData.spec.tsx
@@ -1,0 +1,175 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
+import type {
+  EAPTraceMeta,
+  TraceMeta,
+} from 'sentry/views/performance/newTraceDetails/traceApi/types';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+
+import {useTraceOverviewData} from './useTraceOverviewData';
+
+const TRACE_SLUG = '00000000000000000000000000000000';
+const QUERY_PARAMS = {
+  end: undefined,
+  start: undefined,
+  statsPeriod: '14d',
+  timestamp: undefined,
+};
+
+const LEGACY_META: TraceMeta = {
+  errors: 0,
+  performance_issues: 0,
+  projects: 0,
+  span_count: 0,
+  span_count_map: {},
+  transaction_child_count_map: {},
+  transactions: 0,
+};
+
+function makeEmptyTree(): TraceTree {
+  return {type: 'empty'} as TraceTree;
+}
+
+function makeTraceTree(): TraceTree {
+  return {type: 'trace'} as TraceTree;
+}
+
+function makeEapMeta(overrides: Partial<EAPTraceMeta> = {}): EAPTraceMeta {
+  return {
+    errorsCount: 0,
+    logsCount: 0,
+    metricsCount: 0,
+    performanceIssuesCount: 0,
+    spansCount: 0,
+    spansCountMap: {},
+    transactionChildCountMap: {},
+    uptimeCount: 0,
+    ...overrides,
+  };
+}
+
+describe('useTraceOverviewData', () => {
+  it('uses EAP metadata without supplemental requests', () => {
+    const organization = OrganizationFixture();
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+    const traceLogsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {data: []},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceOverviewData({
+          logsEnabled: true,
+          meta: makeEapMeta({logsCount: 2, metricsCount: 3}),
+          metricsEnabled: true,
+          queryParams: QUERY_PARAMS,
+          traceSlug: TRACE_SLUG,
+          tree: makeTraceTree(),
+        }),
+      {organization}
+    );
+
+    expect(result.current).toEqual({
+      isRepresentativeLoading: false,
+      isTabLoading: false,
+      logs: {
+        availability: 'present',
+        count: 2,
+        representative: undefined,
+      },
+      metrics: {
+        availability: 'present',
+        count: 3,
+      },
+    });
+    expect(eventsRequest).not.toHaveBeenCalled();
+    expect(traceLogsRequest).not.toHaveBeenCalled();
+  });
+
+  it('loads legacy counts and one representative log for a log-only trace', async () => {
+    const organization = OrganizationFixture();
+    const logsCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [MockApiClient.matchQuery({dataset: 'ourlogs'})],
+      body: {data: [{'count(message)': 4}]},
+    });
+    const metricsCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [MockApiClient.matchQuery({dataset: 'tracemetrics'})],
+      body: {data: [{'count(metric.name)': 0}]},
+    });
+    const representativeLog = {
+      [OurLogKnownFieldKey.ID]: 'log-id',
+      [OurLogKnownFieldKey.MESSAGE]: 'Representative log message',
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: 1,
+      [OurLogKnownFieldKey.PROJECT_ID]: '1',
+      [OurLogKnownFieldKey.SEVERITY]: 'info',
+      [OurLogKnownFieldKey.SEVERITY_NUMBER]: 9,
+      [OurLogKnownFieldKey.TIMESTAMP]: new Date().toISOString(),
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1',
+      [OurLogKnownFieldKey.TRACE_ID]: TRACE_SLUG,
+    };
+    const traceLogsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {data: [representativeLog]},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceOverviewData({
+          logsEnabled: true,
+          meta: LEGACY_META,
+          metricsEnabled: true,
+          queryParams: QUERY_PARAMS,
+          traceSlug: TRACE_SLUG,
+          tree: makeEmptyTree(),
+        }),
+      {organization}
+    );
+
+    expect(result.current.isTabLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isRepresentativeLoading).toBe(false);
+      expect(result.current.isTabLoading).toBe(false);
+    });
+
+    expect(result.current.logs).toEqual({
+      availability: 'present',
+      count: 4,
+      representative: [representativeLog],
+    });
+    expect(result.current.metrics).toEqual({
+      availability: 'absent',
+      count: 0,
+    });
+    expect(logsCountRequest.mock.calls[0]?.[1]?.query).toEqual(
+      expect.objectContaining({
+        disableAggregateExtrapolation: '1',
+        project: ['-1'],
+      })
+    );
+    expect(metricsCountRequest.mock.calls[0]?.[1]?.query).toEqual(
+      expect.objectContaining({
+        disableAggregateExtrapolation: '1',
+        project: ['-1'],
+      })
+    );
+    expect(traceLogsRequest).toHaveBeenCalledTimes(1);
+    expect(traceLogsRequest.mock.calls[0]?.[1]?.query).toEqual(
+      expect.objectContaining({
+        orderby: '-timestamp',
+        per_page: 1,
+        project: ['-1'],
+        traceId: [TRACE_SLUG],
+      })
+    );
+  });
+});

--- a/static/app/views/performance/newTraceDetails/useTraceOverviewData.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOverviewData.tsx
@@ -1,0 +1,226 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {AggregationKey} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  OurLogKnownFieldKey,
+  type EventsLogsResult,
+} from 'sentry/views/explore/logs/types';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
+import {
+  getTraceMetaLogsCount,
+  getTraceMetaMetricsCount,
+  type TraceMetaQueryResults,
+} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
+import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import type {TraceViewQueryParams} from 'sentry/views/performance/newTraceDetails/useTraceQueryParams';
+
+type TraceDataAvailability = 'loading' | 'present' | 'absent' | 'unknown';
+
+export interface TraceOverviewData {
+  isRepresentativeLoading: boolean;
+  isTabLoading: boolean;
+  logs: {
+    availability: TraceDataAvailability;
+    count: number | undefined;
+    representative: EventsLogsResult['data'] | undefined;
+  };
+  metrics: {
+    availability: TraceDataAvailability;
+    count: number | undefined;
+  };
+}
+
+const LOGS_COUNT_FIELD = `${AggregationKey.COUNT}(${OurLogKnownFieldKey.MESSAGE})`;
+const METRICS_COUNT_FIELD = `count(${TraceMetricKnownFieldKey.METRIC_NAME})`;
+const STALE_TIME = 5 * 60 * 1000;
+
+interface TraceCountResult {
+  data: Array<Record<string, number>>;
+}
+
+function getDateTimeQuery(queryParams: TraceViewQueryParams) {
+  if (queryParams.timestamp) {
+    const timestampMs = queryParams.timestamp * 1000;
+    const oneDayMs = 24 * 60 * 60 * 1000;
+    return {
+      start: new Date(timestampMs - oneDayMs).toISOString(),
+      end: new Date(timestampMs + oneDayMs).toISOString(),
+    };
+  }
+
+  if (queryParams.start && queryParams.end) {
+    return {start: queryParams.start, end: queryParams.end};
+  }
+
+  return {statsPeriod: queryParams.statsPeriod ?? DEFAULT_STATS_PERIOD};
+}
+
+function getAvailability({
+  enabled,
+  metaCount,
+  shouldFetchSupplementalData,
+  supplementalCount,
+  supplementalStatus,
+}: {
+  enabled: boolean;
+  metaCount: number | undefined;
+  shouldFetchSupplementalData: boolean;
+  supplementalCount: number | undefined;
+  supplementalStatus: 'error' | 'pending' | 'success';
+}): TraceDataAvailability {
+  if (!enabled) {
+    return 'absent';
+  }
+
+  if (metaCount !== undefined) {
+    return metaCount > 0 ? 'present' : 'absent';
+  }
+
+  if (!shouldFetchSupplementalData || supplementalStatus === 'error') {
+    return 'unknown';
+  }
+
+  if (supplementalStatus === 'pending') {
+    return 'loading';
+  }
+
+  return supplementalCount && supplementalCount > 0 ? 'present' : 'absent';
+}
+
+export function useTraceOverviewData({
+  logsEnabled,
+  meta,
+  metricsEnabled,
+  queryParams,
+  traceSlug,
+  tree,
+}: {
+  logsEnabled: boolean;
+  meta: TraceMetaQueryResults['data'];
+  metricsEnabled: boolean;
+  queryParams: TraceViewQueryParams;
+  traceSlug: string;
+  tree: TraceTree;
+}): TraceOverviewData {
+  const organization = useOrganization();
+  const logsMetaCount = getTraceMetaLogsCount(meta);
+  const metricsMetaCount = getTraceMetaMetricsCount(meta);
+  const shouldFetchLogsCount =
+    logsEnabled && meta !== undefined && logsMetaCount === undefined;
+  const shouldFetchMetricsCount =
+    metricsEnabled && meta !== undefined && metricsMetaCount === undefined;
+  const dateTimeQuery = getDateTimeQuery(queryParams);
+  const projectQuery = {project: [String(ALL_ACCESS_PROJECTS)]};
+  const traceSearch = new MutableSearch('');
+  traceSearch.addFilterValue(OurLogKnownFieldKey.TRACE_ID, traceSlug);
+
+  const logsCountResult = useQuery(
+    apiOptions.as<TraceCountResult>()('/organizations/$organizationIdOrSlug/events/', {
+      path: shouldFetchLogsCount ? {organizationIdOrSlug: organization.slug} : skipToken,
+      query: {
+        dataset: DiscoverDatasets.OURLOGS,
+        disableAggregateExtrapolation: '1',
+        field: [LOGS_COUNT_FIELD],
+        query: traceSearch.formatString(),
+        referrer: 'api.trace-details.overview-logs-count',
+        ...projectQuery,
+        ...dateTimeQuery,
+      },
+      staleTime: STALE_TIME,
+    })
+  );
+
+  const metricsSearch = new MutableSearch('');
+  metricsSearch.addFilterValue(TraceMetricKnownFieldKey.TRACE, traceSlug);
+  const metricsCountResult = useQuery(
+    apiOptions.as<TraceCountResult>()('/organizations/$organizationIdOrSlug/events/', {
+      path: shouldFetchMetricsCount
+        ? {organizationIdOrSlug: organization.slug}
+        : skipToken,
+      query: {
+        dataset: DiscoverDatasets.TRACEMETRICS,
+        disableAggregateExtrapolation: '1',
+        field: [METRICS_COUNT_FIELD],
+        query: metricsSearch.formatString(),
+        referrer: 'api.trace-details.overview-metrics-count',
+        ...projectQuery,
+        ...dateTimeQuery,
+      },
+      staleTime: STALE_TIME,
+    })
+  );
+
+  const logsSupplementalCount = logsCountResult.data?.data[0]?.[LOGS_COUNT_FIELD];
+  const metricsSupplementalCount =
+    metricsCountResult.data?.data[0]?.[METRICS_COUNT_FIELD];
+  const logsAvailability = getAvailability({
+    enabled: logsEnabled,
+    metaCount: logsMetaCount,
+    shouldFetchSupplementalData: shouldFetchLogsCount,
+    supplementalCount: logsSupplementalCount,
+    supplementalStatus: logsCountResult.status,
+  });
+  const metricsAvailability = getAvailability({
+    enabled: metricsEnabled,
+    metaCount: metricsMetaCount,
+    shouldFetchSupplementalData: shouldFetchMetricsCount,
+    supplementalCount: metricsSupplementalCount,
+    supplementalStatus: metricsCountResult.status,
+  });
+
+  const shouldFetchRepresentativeLog =
+    tree.type === 'empty' && logsAvailability === 'present';
+  const representativeLogResult = useQuery(
+    apiOptions.as<EventsLogsResult>()(
+      '/organizations/$organizationIdOrSlug/trace-logs/',
+      {
+        path: shouldFetchRepresentativeLog
+          ? {organizationIdOrSlug: organization.slug}
+          : skipToken,
+        query: {
+          traceId: [traceSlug],
+          field: [
+            OurLogKnownFieldKey.ID,
+            OurLogKnownFieldKey.PROJECT_ID,
+            OurLogKnownFieldKey.TRACE_ID,
+            OurLogKnownFieldKey.SEVERITY,
+            OurLogKnownFieldKey.MESSAGE,
+            OurLogKnownFieldKey.TIMESTAMP,
+            OurLogKnownFieldKey.TIMESTAMP_PRECISE,
+          ],
+          orderby: '-timestamp',
+          per_page: 1,
+          referrer: 'api.trace-details.overview-representative-log',
+          ...projectQuery,
+          ...dateTimeQuery,
+        },
+        staleTime: STALE_TIME,
+      }
+    )
+  );
+
+  const representativeLogLoading =
+    shouldFetchRepresentativeLog && representativeLogResult.status === 'pending';
+  const summaryLoading =
+    logsAvailability === 'loading' || metricsAvailability === 'loading';
+
+  return {
+    isRepresentativeLoading: representativeLogLoading,
+    isTabLoading: summaryLoading,
+    logs: {
+      availability: logsAvailability,
+      count: logsMetaCount ?? logsSupplementalCount,
+      representative: representativeLogResult.data?.data,
+    },
+    metrics: {
+      availability: metricsAvailability,
+      count: metricsMetaCount ?? metricsSupplementalCount,
+    },
+  };
+}


### PR DESCRIPTION
Add a trace overview data source that uses trace metadata when available and lightweight count queries for legacy responses. Empty traces fetch a single representative log so the header and tab selection no longer depend on loading the complete Logs table.

This is PR 3 of the EXP-1112 stack and is based on `nd/EXP-1112/lazy-trace-tab-providers`. Review the new overview hook and its legacy/EAP availability behavior first; the following PR localizes the remaining asynchronous loading states.
