### PR TITLE
fix(trace): Stabilize asynchronous overview loading

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -54,7 +54,7 @@ import {
   getInitialTracePreferences,
   TRACE_WATERFALL_TIME_COMPRESSION_FEATURE,
 } from './traceState/tracePreferences';
-import {useTraceState, TraceStateProvider} from './traceState/traceStateProvider';
+import {TraceStateProvider} from './traceState/traceStateProvider';
 import {ErrorsOnlyWarnings} from './traceTypeWarnings/errorsOnlyWarnings';
 import {TraceMetaDataHeader} from './traceHeader';
 import {useTraceEventView} from './useTraceEventView';
@@ -110,7 +110,6 @@ export default function TraceView() {
 
 function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   const organization = useOrganization();
-  const traceState = useTraceState();
   const logsEnabled = isLogsEnabled(organization);
   const metricsEnabled = canUseMetricsUI(organization);
   const queryParams = useTraceQueryParams();
@@ -234,22 +233,18 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
               logs={overview.logs.representative}
               tree={tree}
             />
-            <TraceViewLogsPageDataProvider
-              disabled={traceState.tabs.current_tab === null}
-            >
-              <TraceWaterfall
-                tree={tree}
-                trace={trace}
-                meta={meta}
-                replay={null}
-                source="performance"
-                rootEventResults={rootEventResults}
-                traceSlug={traceSlug}
-                traceEventView={traceEventView}
-                organization={organization}
-                hideIfNoData={false}
-              />
-            </TraceViewLogsPageDataProvider>
+            <TraceWaterfall
+              tree={tree}
+              trace={trace}
+              meta={meta}
+              replay={null}
+              source="performance"
+              rootEventResults={rootEventResults}
+              traceSlug={traceSlug}
+              traceEventView={traceEventView}
+              organization={organization}
+              hideIfNoData={false}
+            />
           </Fragment>
         ) : currentTab === TraceLayoutTabKeys.PROFILES ? (
           <TraceProfiles tree={tree} />

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -2049,6 +2049,24 @@ describe('trace view', () => {
   });
 
   describe('tabbing', () => {
+    it('does not fetch trace-wide logs when opening a waterfall drawer', async () => {
+      const organization = OrganizationFixture({features: ['ourlogs-enabled']});
+      const traceLogsRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/trace-logs/`,
+        body: {data: []},
+      });
+      const {virtualizedContainer} = await completeTestSetup({organization});
+      const rows = getVirtualizedRows(virtualizedContainer);
+
+      expect(traceLogsRequest).not.toHaveBeenCalled();
+      await userEvent.click(rows[5]!);
+
+      await waitFor(() => {
+        expect(screen.queryAllByTestId(DRAWER_TABS_TEST_ID)).toHaveLength(1);
+      });
+      expect(traceLogsRequest).not.toHaveBeenCalled();
+    });
+
     it('clicking on a node spawns a new tab when none is selected', async () => {
       const {virtualizedContainer} = await simpleTestSetup();
       const rows = getVirtualizedRows(virtualizedContainer);

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -8,6 +8,7 @@ import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {TopBar} from 'sentry/views/navigation/topBar';
+import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {
   TraceMetaDataHeader,
   type TraceMetadataHeaderProps,
@@ -279,6 +280,101 @@ describe('TraceMetaDataHeader', () => {
   });
 
   describe('meta', () => {
+    it('renders the core header while optional overview data is loading', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+      const overviewOrganization = OrganizationFixture({
+        features: ['ourlogs-enabled', 'tracemetrics-enabled'],
+      });
+      const props = {
+        ...baseProps,
+        overview: {
+          isRepresentativeLoading: false,
+          isTabLoading: true,
+          logs: {
+            availability: 'loading',
+            count: undefined,
+            representative: undefined,
+          },
+          metrics: {
+            availability: 'loading',
+            count: undefined,
+          },
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={overviewOrganization} />);
+
+      expect(screen.getByText('Issues')).toBeInTheDocument();
+      expect(screen.getByText('Logs')).toBeInTheDocument();
+      expect(screen.getByText('Metrics')).toBeInTheDocument();
+    });
+
+    it('keeps the core header for an empty tree while overview availability loads', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+      const overviewOrganization = OrganizationFixture({
+        features: ['ourlogs-enabled', 'tracemetrics-enabled'],
+      });
+      const rootEventResults = {
+        data: undefined,
+        isLoading: false,
+        status: 'pending',
+      } as TraceRootEventQueryResults;
+      const props = {
+        ...baseProps,
+        tree: TraceTree.Empty(),
+        rootEventResults,
+        overview: {
+          isRepresentativeLoading: true,
+          isTabLoading: true,
+          logs: {
+            availability: 'loading',
+            count: undefined,
+            representative: undefined,
+          },
+          metrics: {
+            availability: 'loading',
+            count: undefined,
+          },
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={overviewOrganization} />);
+
+      expect(screen.getByText('Issues')).toBeInTheDocument();
+      expect(screen.getByText('Logs')).toBeInTheDocument();
+      expect(screen.getByText('Metrics')).toBeInTheDocument();
+    });
+
+    it('renders the core header when root event details fail', () => {
+      useLocationMock.mockReturnValue(
+        LocationFixture({
+          pathname: '/organizations/org-slug/traces/trace/trace-slug',
+        })
+      );
+      const props = {
+        ...baseProps,
+        rootEventResults: {
+          data: undefined,
+          error: new Error('Trace item not found'),
+          isLoading: false,
+          status: 'error',
+        },
+      } as TraceMetadataHeaderProps;
+
+      render(<TraceMetaDataHeader {...props} organization={organization} />);
+
+      expect(screen.getByText('Issues')).toBeInTheDocument();
+      expect(screen.getByText('Spans')).toBeInTheDocument();
+    });
+
     it('renders representative information for a log-only trace', () => {
       useLocationMock.mockReturnValue(
         LocationFixture({

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -62,20 +62,20 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
   });
 
   const isLoading =
-    props.metaResults.status === 'pending' ||
-    props.rootEventResults.isLoading ||
-    props.tree.type === 'loading';
+    props.metaResults.status === 'pending' || props.tree.type === 'loading';
 
-  const isError =
-    props.metaResults.status === 'error' ||
-    props.rootEventResults.status === 'error' ||
-    props.tree.type === 'error';
+  const isError = props.metaResults.status === 'error' || props.tree.type === 'error';
 
-  const noEvents = props.tree.type === 'empty' && !hasLogs && !hasMetrics;
+  const isRepresentativeLoading = props.overview.isRepresentativeLoading;
+  const noEvents =
+    props.tree.type === 'empty' &&
+    !hasLogs &&
+    !hasMetrics &&
+    !props.overview.isTabLoading &&
+    !isRepresentativeLoading;
   if (isLoading || isError || noEvents) {
     return <PlaceHolder organization={props.organization} traceSlug={props.traceSlug} />;
   }
-
   const rep = props.tree.findRepresentativeTraceNode({
     logs: props.overview.logs.representative,
   });
@@ -114,7 +114,11 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
 
         <TraceHeaderComponents.HeaderGrid>
           <Container area="title" minWidth={0}>
-            <Title representativeEvent={rep} rootEventResults={props.rootEventResults} />
+            <Title
+              isLoading={isRepresentativeLoading}
+              representativeEvent={rep}
+              rootEventResults={props.rootEventResults}
+            />
           </Container>
           <Container area="meta" justifySelf={{zero: 'start', xl: 'end'}}>
             <Meta
@@ -134,14 +138,18 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             />
           </Container>
           <Container area="projects" justifySelf={{zero: 'start', xl: 'end'}}>
-            <Projects
-              projectSlugs={Array.from(
-                new Set([
-                  ...Array.from(props.tree.projects.values()).map(p => p.slug),
-                  ...(project ? [project.slug] : []),
-                ])
-              )}
-            />
+            {isRepresentativeLoading ? (
+              <TraceHeaderComponents.StyledPlaceholder _width={50} _height={28} />
+            ) : (
+              <Projects
+                projectSlugs={Array.from(
+                  new Set([
+                    ...Array.from(props.tree.projects.values()).map(p => p.slug),
+                    ...(project ? [project.slug] : []),
+                  ])
+                )}
+              />
+            )}
           </Container>
         </TraceHeaderComponents.HeaderGrid>
       </TraceHeaderComponents.HeaderContent>

--- a/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/meta.tsx
@@ -14,6 +14,7 @@ import {
   type TraceMetaQueryResults,
 } from 'sentry/views/performance/newTraceDetails/traceApi/useTraceMeta';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
+import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
 import type {TraceOverviewData} from 'sentry/views/performance/newTraceDetails/useTraceOverviewData';
@@ -103,9 +104,12 @@ export function Meta(props: MetaProps) {
   const hasSpans = spansCount > 0 || loadedSpansCount > 0 || totalSpansCount > 0;
   const logsCount = getTraceMetaLogsCount(props.meta) ?? props.overview.logs.count ?? 0;
   const hasLogs = props.logsEnabled && logsCount > 0;
+  const logsLoading = props.logsEnabled && props.overview.logs.availability === 'loading';
   const metricsCount =
     getTraceMetaMetricsCount(props.meta) ?? props.overview.metrics.count ?? 0;
   const hasMetrics = props.metricsEnabled && metricsCount > 0;
+  const metricsLoading =
+    props.metricsEnabled && props.overview.metrics.availability === 'loading';
 
   const repEvent = props.representativeEvent?.event;
 
@@ -150,14 +154,22 @@ export function Meta(props: MetaProps) {
             : '\u2014'}
         </MetaSection>
       ) : null}
-      {hasLogs ? (
+      {hasLogs || logsLoading ? (
         <MetaSection rightAlignBody headingText={t('Logs')}>
-          {logsCount}
+          {hasLogs ? (
+            logsCount
+          ) : (
+            <TraceHeaderComponents.StyledPlaceholder _width={32} _height={20} />
+          )}
         </MetaSection>
       ) : null}
-      {hasMetrics ? (
+      {hasMetrics || metricsLoading ? (
         <MetaSection rightAlignBody headingText={t('Metrics')}>
-          {metricsCount}
+          {hasMetrics ? (
+            metricsCount
+          ) : (
+            <TraceHeaderComponents.StyledPlaceholder _width={32} _height={20} />
+          )}
         </MetaSection>
       ) : null}
     </MetaWrapper>

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -16,9 +16,11 @@ import {Divider} from 'sentry/views/issueDetails/divider';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
 interface TitleProps {
+  isLoading: boolean;
   representativeEvent: TraceTree.RepresentativeTraceEvent | null;
   rootEventResults: TraceRootEventQueryResults;
 }
@@ -85,7 +87,16 @@ const ReplayButton = styled(LinkButton)`
   text-decoration-style: dotted;
 `;
 
-export function Title({representativeEvent, rootEventResults}: TitleProps) {
+export function Title({isLoading, representativeEvent, rootEventResults}: TitleProps) {
+  if (isLoading) {
+    return (
+      <Stack align="start" gap="xs" width="75%">
+        <TraceHeaderComponents.StyledPlaceholder _width={100} _height={24} />
+        <TraceHeaderComponents.StyledPlaceholder _width={300} _height={20} />
+      </Stack>
+    );
+  }
+
   const traceTitle = getTitle(representativeEvent);
 
   if (traceTitle) {

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.spec.tsx
@@ -1,0 +1,40 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
+import {TraceTabsAndVitals} from 'sentry/views/performance/newTraceDetails/traceTabsAndVitals';
+import {
+  TraceLayoutTabKeys,
+  type TraceLayoutTabsConfig,
+} from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
+
+describe('TraceTabsAndVitals', () => {
+  it('renders tabs while optional root event details are loading', () => {
+    const tabsConfig: TraceLayoutTabsConfig = {
+      currentTab: TraceLayoutTabKeys.WATERFALL,
+      isLoading: false,
+      onTabChange: jest.fn(),
+      tabOptions: [
+        {
+          label: 'Waterfall',
+          slug: TraceLayoutTabKeys.WATERFALL,
+        },
+      ],
+    };
+    const rootEventResults = {
+      data: undefined,
+      isLoading: true,
+      status: 'pending',
+    } as TraceRootEventQueryResults;
+
+    render(
+      <TraceTabsAndVitals
+        tabsConfig={tabsConfig}
+        rootEventResults={rootEventResults}
+        tree={new TraceTree().build()}
+      />
+    );
+
+    expect(screen.getByRole('tab', {name: 'Waterfall'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -61,7 +61,7 @@ export function TraceTabsAndVitals({
 }: TraceTabsAndVitalsProps) {
   const {tabOptions, currentTab, isLoading, onTabChange} = tabsConfig;
 
-  if (isLoading || rootEventResults.isLoading || tree.type === 'loading') {
+  if (isLoading || tree.type === 'loading') {
     return <Placeholder />;
   }
 

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -1,8 +1,16 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {setWindowLocation} from 'sentry-test/utils';
+
 import type {EAPTraceMeta} from 'sentry/views/performance/newTraceDetails/traceApi/types';
+import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {
   getInitialTab,
   TraceLayoutTabKeys,
+  useTraceLayoutTabs,
 } from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
+import type {TraceOverviewData} from 'sentry/views/performance/newTraceDetails/useTraceOverviewData';
 
 const sections = {
   hasAiSpans: false,
@@ -120,4 +128,189 @@ describe('getInitialTab', () => {
       }).slug
     ).toBe(TraceLayoutTabKeys.WATERFALL);
   });
+});
+
+describe('useTraceLayoutTabs', () => {
+  it.each([
+    [TraceLayoutTabKeys.LOGS, 'Logs'],
+    [TraceLayoutTabKeys.METRICS, 'Application Metrics'],
+  ])(
+    'includes the deep-linked %s tab while its availability is loading',
+    (tabSlug, tabLabel) => {
+      setWindowLocation(
+        `http://localhost/organizations/org-slug/traces/trace-id/?tab=${tabSlug}`
+      );
+      const organization = OrganizationFixture();
+      const {result} = renderHookWithProviders(
+        () =>
+          useTraceLayoutTabs({
+            isLoading: true,
+            logsEnabled: true,
+            metricsEnabled: true,
+            overview: {
+              isRepresentativeLoading: false,
+              isTabLoading: true,
+              logs: {
+                availability: 'loading',
+                count: undefined,
+                representative: undefined,
+              },
+              metrics: {
+                availability: 'loading',
+                count: undefined,
+              },
+            },
+            tree: new TraceTree().build(),
+          }),
+        {organization}
+      );
+
+      expect(result.current.currentTab).toBe(tabSlug);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.tabOptions).toContainEqual({
+        label: tabLabel,
+        slug: tabSlug,
+      });
+      expect(result.current.tabOptions.map(tab => tab.slug)).not.toContain(
+        tabSlug === TraceLayoutTabKeys.LOGS
+          ? TraceLayoutTabKeys.METRICS
+          : TraceLayoutTabKeys.LOGS
+      );
+    }
+  );
+
+  it.each([
+    [TraceLayoutTabKeys.LOGS, 'Logs'],
+    [TraceLayoutTabKeys.METRICS, 'Application Metrics'],
+  ])(
+    'includes only the deep-linked %s tab when availability is unknown',
+    (tabSlug, tabLabel) => {
+      setWindowLocation(
+        `http://localhost/organizations/org-slug/traces/trace-id/?tab=${tabSlug}`
+      );
+      const organization = OrganizationFixture();
+      const {result} = renderHookWithProviders(
+        () =>
+          useTraceLayoutTabs({
+            isLoading: false,
+            logsEnabled: true,
+            metricsEnabled: true,
+            overview: {
+              isRepresentativeLoading: false,
+              isTabLoading: false,
+              logs: {
+                availability: 'unknown',
+                count: undefined,
+                representative: undefined,
+              },
+              metrics: {
+                availability: 'unknown',
+                count: undefined,
+              },
+            },
+            tree: new TraceTree().build(),
+          }),
+        {organization}
+      );
+
+      expect(result.current.currentTab).toBe(tabSlug);
+      expect(result.current.tabOptions).toContainEqual({label: tabLabel, slug: tabSlug});
+      expect(result.current.tabOptions.map(tab => tab.slug)).not.toContain(
+        tabSlug === TraceLayoutTabKeys.LOGS
+          ? TraceLayoutTabKeys.METRICS
+          : TraceLayoutTabKeys.LOGS
+      );
+    }
+  );
+
+  it('does not include optional tabs with unknown availability by default', () => {
+    setWindowLocation('http://localhost/organizations/org-slug/traces/trace-id/');
+    const organization = OrganizationFixture();
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceLayoutTabs({
+          isLoading: false,
+          logsEnabled: true,
+          metricsEnabled: true,
+          overview: {
+            isRepresentativeLoading: false,
+            isTabLoading: false,
+            logs: {
+              availability: 'unknown',
+              count: undefined,
+              representative: undefined,
+            },
+            metrics: {
+              availability: 'unknown',
+              count: undefined,
+            },
+          },
+          tree: new TraceTree().build(),
+        }),
+      {organization}
+    );
+
+    expect(result.current.tabOptions.map(tab => tab.slug)).toEqual([
+      TraceLayoutTabKeys.WATERFALL,
+    ]);
+  });
+
+  it.each([TraceLayoutTabKeys.LOGS, TraceLayoutTabKeys.METRICS])(
+    'switches directly from loading to the resolved %s tab',
+    resolvedTab => {
+      setWindowLocation('http://localhost/organizations/org-slug/traces/trace-id/');
+      const organization = OrganizationFixture();
+      let isLoading = true;
+      let overview: TraceOverviewData = {
+        isRepresentativeLoading: false,
+        isTabLoading: true,
+        logs: {
+          availability: 'loading',
+          count: undefined,
+          representative: undefined,
+        },
+        metrics: {
+          availability: 'loading',
+          count: undefined,
+        },
+      };
+      const renderedTabs: TraceLayoutTabKeys[] = [];
+      const {result, rerender} = renderHookWithProviders(
+        () => {
+          const tabsConfig = useTraceLayoutTabs({
+            isLoading,
+            logsEnabled: true,
+            metricsEnabled: true,
+            overview,
+            tree: TraceTree.Empty(),
+          });
+          renderedTabs.push(tabsConfig.currentTab);
+          return tabsConfig;
+        },
+        {organization}
+      );
+
+      expect(result.current.currentTab).toBe(TraceLayoutTabKeys.WATERFALL);
+
+      renderedTabs.length = 0;
+      isLoading = false;
+      overview = {
+        isRepresentativeLoading: false,
+        isTabLoading: false,
+        logs: {
+          availability: resolvedTab === TraceLayoutTabKeys.LOGS ? 'present' : 'absent',
+          count: resolvedTab === TraceLayoutTabKeys.LOGS ? 1 : 0,
+          representative: undefined,
+        },
+        metrics: {
+          availability: resolvedTab === TraceLayoutTabKeys.METRICS ? 'present' : 'absent',
+          count: resolvedTab === TraceLayoutTabKeys.METRICS ? 1 : 0,
+        },
+      };
+      rerender();
+
+      expect(renderedTabs).not.toContain(TraceLayoutTabKeys.WATERFALL);
+      expect(result.current.currentTab).toBe(resolvedTab);
+    }
+  );
 });

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -60,9 +60,11 @@ const TAB_DEFINITIONS: Record<TraceLayoutTabKeys, Tab> = {
 function getTabOptions({
   sections,
   overview,
+  tabSlugFromUrl,
 }: {
   overview: TraceOverviewData;
   sections: ReturnType<typeof useTraceContextSections>;
+  tabSlugFromUrl: string | undefined;
 }): Tab[] {
   const tabOptions: Tab[] = [];
 
@@ -76,16 +78,18 @@ function getTabOptions({
 
   if (
     sections.hasLogs ||
-    overview.logs.availability === 'unknown' ||
-    overview.logs.availability === 'loading'
+    ((overview.logs.availability === 'loading' ||
+      overview.logs.availability === 'unknown') &&
+      tabSlugFromUrl === TraceLayoutTabKeys.LOGS)
   ) {
     tabOptions.push(TAB_DEFINITIONS[TraceLayoutTabKeys.LOGS]);
   }
 
   if (
     sections.hasMetrics ||
-    overview.metrics.availability === 'unknown' ||
-    overview.metrics.availability === 'loading'
+    ((overview.metrics.availability === 'loading' ||
+      overview.metrics.availability === 'unknown') &&
+      tabSlugFromUrl === TraceLayoutTabKeys.METRICS)
   ) {
     tabOptions.push(TAB_DEFINITIONS[TraceLayoutTabKeys.METRICS]);
   }
@@ -176,6 +180,9 @@ export function useTraceLayoutTabs({
 }: UseTraceLayoutTabsProps): TraceLayoutTabsConfig {
   const navigate = useNavigate();
   const organization = useOrganization();
+  const queryParams = qs.parse(window.location.search);
+  const tabSlugFromUrl =
+    typeof queryParams.tab === 'string' ? queryParams.tab : undefined;
   const sections = useTraceContextSections({
     tree,
     logs: overview.logs.representative,
@@ -186,9 +193,7 @@ export function useTraceLayoutTabs({
     logsEnabled,
     metricsEnabled,
   });
-  const tabOptions = getTabOptions({overview, sections});
-
-  const queryParams = qs.parse(window.location.search);
+  const tabOptions = getTabOptions({overview, sections, tabSlugFromUrl});
 
   const initialTab = getInitialTab({
     isLoading,
@@ -197,10 +202,12 @@ export function useTraceLayoutTabs({
     meta,
     sections,
     tabOptions,
-    tabSlugFromUrl: typeof queryParams.tab === 'string' ? queryParams.tab : undefined,
+    tabSlugFromUrl,
   });
 
-  const [currentTab, setCurrentTab] = useState(initialTab.slug);
+  const [selectedTab, setSelectedTab] = useState(initialTab.slug);
+  const isSelectedTabAvailable = tabOptions.some(tab => tab.slug === selectedTab);
+  const currentTab = isLoading || isSelectedTabAvailable ? selectedTab : initialTab.slug;
   const isCurrentTabRequested = queryParams.tab === currentTab;
 
   const onTabChange = useCallback(
@@ -218,15 +225,16 @@ export function useTraceLayoutTabs({
         },
         {replace: true}
       );
-      setCurrentTab(slug);
+      setSelectedTab(slug);
     },
     [navigate, queryParams, organization]
   );
 
-  // Update the tab when the tabOptions change
+  // Keep the stored selection in sync with URL and availability changes. The
+  // render above falls back synchronously so stale content never mounts first.
   useEffect(() => {
-    setCurrentTab(initialTab.slug);
-  }, [tabOptions, initialTab]);
+    setSelectedTab(initialTab.slug);
+  }, [initialTab.slug]);
 
   return useMemo(
     () => ({

--- a/static/app/views/performance/newTraceDetails/useTraceOverviewData.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOverviewData.spec.tsx
@@ -135,6 +135,7 @@ describe('useTraceOverviewData', () => {
     );
 
     expect(result.current.isTabLoading).toBe(true);
+    expect(result.current.isRepresentativeLoading).toBe(true);
 
     await waitFor(() => {
       expect(result.current.isRepresentativeLoading).toBe(false);

--- a/static/app/views/performance/newTraceDetails/useTraceOverviewData.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOverviewData.tsx
@@ -206,7 +206,9 @@ export function useTraceOverviewData({
   );
 
   const representativeLogLoading =
-    shouldFetchRepresentativeLog && representativeLogResult.status === 'pending';
+    tree.type === 'empty' &&
+    (logsAvailability === 'loading' ||
+      (shouldFetchRepresentativeLog && representativeLogResult.status === 'pending'));
   const summaryLoading =
     logsAvailability === 'loading' || metricsAvailability === 'loading';
 


### PR DESCRIPTION
Keep the trace header and tab navigation stable while optional overview data resolves. Direct links to Logs and Application Metrics remain selected during loading, unavailable selections fall back synchronously, and representative details use localized placeholders instead of replacing the full trace chrome.

This is PR 4 of the EXP-1112 stack and is based on `nd/EXP-1112/resolve-trace-overview`. The final PR adds multi-project context for telemetry-only traces.
