### PR TITLE
fix(trace): Load projects for telemetry-only traces

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.spec.tsx
@@ -1,9 +1,11 @@
 import {TransactionEventFixture} from 'sentry-fixture/event';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -14,6 +16,7 @@ import {
   type TraceMetadataHeaderProps,
 } from 'sentry/views/performance/newTraceDetails/traceHeader';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
+import {Projects} from 'sentry/views/performance/newTraceDetails/traceHeader/projects';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import {RootNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/rootNode';
 import {TraceNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/traceNode';
@@ -25,6 +28,7 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeTestUtils';
 
 jest.mock('sentry/views/performance/newTraceDetails/traceState/traceStateProvider');
+jest.mock('sentry/views/performance/newTraceDetails/traceHeader/projects');
 jest.mock('sentry/utils/useLocation');
 
 const baseProps: Partial<TraceMetadataHeaderProps> = {
@@ -46,8 +50,10 @@ const baseProps: Partial<TraceMetadataHeaderProps> = {
     data: TransactionEventFixture(),
   } as any,
   overview: {
+    isProjectsLoading: false,
     isRepresentativeLoading: false,
     isTabLoading: false,
+    projectIds: [],
     logs: {
       availability: 'absent',
       count: 0,
@@ -64,10 +70,12 @@ const baseProps: Partial<TraceMetadataHeaderProps> = {
 let organization: Organization;
 
 const useLocationMock = jest.mocked(useLocation);
+const projectsMock = jest.mocked(Projects);
 
 describe('TraceMetaDataHeader', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    projectsMock.mockReturnValue(<div />);
 
     MockApiClient.addMockResponse({
       method: 'GET',
@@ -292,8 +300,10 @@ describe('TraceMetaDataHeader', () => {
       const props = {
         ...baseProps,
         overview: {
+          isProjectsLoading: true,
           isRepresentativeLoading: false,
           isTabLoading: true,
+          projectIds: undefined,
           logs: {
             availability: 'loading',
             count: undefined,
@@ -332,8 +342,10 @@ describe('TraceMetaDataHeader', () => {
         tree: TraceTree.Empty(),
         rootEventResults,
         overview: {
+          isProjectsLoading: true,
           isRepresentativeLoading: true,
           isTabLoading: true,
+          projectIds: undefined,
           logs: {
             availability: 'loading',
             count: undefined,
@@ -382,6 +394,11 @@ describe('TraceMetaDataHeader', () => {
         })
       );
       const logsOrganization = OrganizationFixture({features: ['ourlogs-enabled']});
+      const projects = [
+        ProjectFixture({id: '1', slug: 'project-one'}),
+        ProjectFixture({id: '2', slug: 'project-two'}),
+      ];
+      ProjectsStore.loadInitialData(projects);
       const representativeLog = {
         [OurLogKnownFieldKey.MESSAGE]: 'Representative log message',
         [OurLogKnownFieldKey.PROJECT_ID]: '1',
@@ -398,8 +415,10 @@ describe('TraceMetaDataHeader', () => {
         ...baseProps,
         tree,
         overview: {
+          isProjectsLoading: false,
           isRepresentativeLoading: false,
           isTabLoading: false,
+          projectIds: ['1', '2'],
           logs: {
             availability: 'present',
             count: 4,
@@ -419,6 +438,9 @@ describe('TraceMetaDataHeader', () => {
       expect(screen.getByText('4')).toBeInTheDocument();
       expect(findRepresentativeTraceNode).toHaveBeenCalledWith({
         logs: representativeLogs,
+      });
+      expect(projectsMock.mock.calls[0]?.[0]).toEqual({
+        projectSlugs: ['project-one', 'project-two'],
       });
     });
 

--- a/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/index.tsx
@@ -4,6 +4,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {defined} from 'sentry/utils/defined';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useProjects} from 'sentry/utils/useProjects';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
@@ -76,6 +77,8 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
   if (isLoading || isError || noEvents) {
     return <PlaceHolder organization={props.organization} traceSlug={props.traceSlug} />;
   }
+
+  const isProjectsLoading = props.overview.isProjectsLoading;
   const rep = props.tree.findRepresentativeTraceNode({
     logs: props.overview.logs.representative,
   });
@@ -86,6 +89,9 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
         : rep?.event?.projectId;
     return p.id === String(id);
   });
+  const overviewProjectSlugs = (props.overview.projectIds ?? [])
+    .map(projectId => projects.find(p => p.id === projectId)?.slug)
+    .filter(defined);
 
   return (
     <TraceHeaderComponents.HeaderLayout>
@@ -138,13 +144,14 @@ export function TraceMetaDataHeader(props: TraceMetadataHeaderProps) {
             />
           </Container>
           <Container area="projects" justifySelf={{zero: 'start', xl: 'end'}}>
-            {isRepresentativeLoading ? (
+            {isProjectsLoading ? (
               <TraceHeaderComponents.StyledPlaceholder _width={50} _height={28} />
             ) : (
               <Projects
                 projectSlugs={Array.from(
                   new Set([
                     ...Array.from(props.tree.projects.values()).map(p => p.slug),
+                    ...overviewProjectSlugs,
                     ...(project ? [project.slug] : []),
                   ])
                 )}

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.spec.tsx
@@ -148,8 +148,10 @@ describe('useTraceLayoutTabs', () => {
             logsEnabled: true,
             metricsEnabled: true,
             overview: {
+              isProjectsLoading: false,
               isRepresentativeLoading: false,
               isTabLoading: true,
+              projectIds: [],
               logs: {
                 availability: 'loading',
                 count: undefined,
@@ -196,8 +198,10 @@ describe('useTraceLayoutTabs', () => {
             logsEnabled: true,
             metricsEnabled: true,
             overview: {
+              isProjectsLoading: false,
               isRepresentativeLoading: false,
               isTabLoading: false,
+              projectIds: [],
               logs: {
                 availability: 'unknown',
                 count: undefined,
@@ -233,8 +237,10 @@ describe('useTraceLayoutTabs', () => {
           logsEnabled: true,
           metricsEnabled: true,
           overview: {
+            isProjectsLoading: false,
             isRepresentativeLoading: false,
             isTabLoading: false,
+            projectIds: [],
             logs: {
               availability: 'unknown',
               count: undefined,
@@ -262,8 +268,10 @@ describe('useTraceLayoutTabs', () => {
       const organization = OrganizationFixture();
       let isLoading = true;
       let overview: TraceOverviewData = {
+        isProjectsLoading: false,
         isRepresentativeLoading: false,
         isTabLoading: true,
+        projectIds: [],
         logs: {
           availability: 'loading',
           count: undefined,
@@ -295,8 +303,10 @@ describe('useTraceLayoutTabs', () => {
       renderedTabs.length = 0;
       isLoading = false;
       overview = {
+        isProjectsLoading: false,
         isRepresentativeLoading: false,
         isTabLoading: false,
+        projectIds: [],
         logs: {
           availability: resolvedTab === TraceLayoutTabKeys.LOGS ? 'present' : 'absent',
           count: resolvedTab === TraceLayoutTabKeys.LOGS ? 1 : 0,

--- a/static/app/views/performance/newTraceDetails/useTraceOverviewData.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOverviewData.spec.tsx
@@ -77,8 +77,10 @@ describe('useTraceOverviewData', () => {
     );
 
     expect(result.current).toEqual({
+      isProjectsLoading: false,
       isRepresentativeLoading: false,
       isTabLoading: false,
+      projectIds: [],
       logs: {
         availability: 'present',
         count: 2,
@@ -93,12 +95,209 @@ describe('useTraceOverviewData', () => {
     expect(traceLogsRequest).not.toHaveBeenCalled();
   });
 
+  it('loads project ids and one representative log for an EAP log-only trace', async () => {
+    const organization = OrganizationFixture();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'ourlogs',
+          field: ['project.id', 'count(message)'],
+        }),
+      ],
+      body: {
+        data: [
+          {'project.id': 1, 'count(message)': 1},
+          {'project.id': 2, 'count(message)': 1},
+        ],
+      },
+    });
+    const representativeLog = {
+      [OurLogKnownFieldKey.ID]: 'log-id',
+      [OurLogKnownFieldKey.MESSAGE]: 'Representative log message',
+      [OurLogKnownFieldKey.ORGANIZATION_ID]: 1,
+      [OurLogKnownFieldKey.PROJECT_ID]: '1',
+      [OurLogKnownFieldKey.SEVERITY]: 'info',
+      [OurLogKnownFieldKey.SEVERITY_NUMBER]: 9,
+      [OurLogKnownFieldKey.TIMESTAMP]: new Date().toISOString(),
+      [OurLogKnownFieldKey.TIMESTAMP_PRECISE]: '1',
+      [OurLogKnownFieldKey.TRACE_ID]: TRACE_SLUG,
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {data: [representativeLog]},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceOverviewData({
+          logsEnabled: true,
+          meta: makeEapMeta({logsCount: 2}),
+          metricsEnabled: true,
+          queryParams: QUERY_PARAMS,
+          traceSlug: TRACE_SLUG,
+          tree: makeEmptyTree(),
+        }),
+      {organization}
+    );
+
+    expect(result.current.isProjectsLoading).toBe(true);
+    expect(result.current.projectIds).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.isProjectsLoading).toBe(false);
+    });
+
+    expect(result.current.projectIds).toEqual(['1', '2']);
+    expect(result.current.logs).toEqual({
+      availability: 'present',
+      count: 2,
+      representative: [representativeLog],
+    });
+  });
+
+  it('loads project ids for an EAP metric-only trace', async () => {
+    const organization = OrganizationFixture();
+    const metricProjectsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          field: ['project.id', 'count(metric.name)'],
+        }),
+      ],
+      body: {
+        data: [
+          {'project.id': 2, 'count(metric.name)': 1},
+          {'project.id': 3, 'count(metric.name)': 1},
+        ],
+      },
+    });
+    const traceLogsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {data: []},
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceOverviewData({
+          logsEnabled: true,
+          meta: makeEapMeta({metricsCount: 2}),
+          metricsEnabled: true,
+          queryParams: QUERY_PARAMS,
+          traceSlug: TRACE_SLUG,
+          tree: makeEmptyTree(),
+        }),
+      {organization}
+    );
+
+    expect(result.current.isProjectsLoading).toBe(true);
+    expect(result.current.projectIds).toBeUndefined();
+
+    await waitFor(() => {
+      expect(result.current.isProjectsLoading).toBe(false);
+    });
+
+    expect(result.current.projectIds).toEqual(['2', '3']);
+    expect(result.current.metrics).toEqual({
+      availability: 'present',
+      count: 2,
+    });
+    expect(metricProjectsRequest.mock.calls[0]?.[1]?.query).toEqual(
+      expect.objectContaining({
+        field: ['project.id', 'count(metric.name)'],
+        per_page: 100,
+        project: ['-1'],
+      })
+    );
+    expect(traceLogsRequest).not.toHaveBeenCalled();
+  });
+
+  it('combines log and metric project ids for an EAP trace', async () => {
+    const organization = OrganizationFixture();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'ourlogs',
+          field: ['project.id', 'count(message)'],
+        }),
+      ],
+      body: {
+        data: [
+          {'project.id': 1, 'count(message)': 1},
+          {'project.id': 2, 'count(message)': 1},
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'tracemetrics',
+          field: ['project.id', 'count(metric.name)'],
+        }),
+      ],
+      body: {
+        data: [
+          {'project.id': 2, 'count(metric.name)': 1},
+          {'project.id': 3, 'count(metric.name)': 1},
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-logs/`,
+      body: {
+        data: [
+          {
+            [OurLogKnownFieldKey.ID]: 'log-id',
+            [OurLogKnownFieldKey.PROJECT_ID]: '1',
+          },
+        ],
+      },
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useTraceOverviewData({
+          logsEnabled: true,
+          meta: makeEapMeta({logsCount: 2, metricsCount: 2}),
+          metricsEnabled: true,
+          queryParams: QUERY_PARAMS,
+          traceSlug: TRACE_SLUG,
+          tree: makeEmptyTree(),
+        }),
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(result.current.isProjectsLoading).toBe(false);
+    });
+
+    expect(result.current.projectIds).toEqual(['1', '2', '3']);
+  });
+
   it('loads legacy counts and one representative log for a log-only trace', async () => {
     const organization = OrganizationFixture();
     const logsCountRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
-      match: [MockApiClient.matchQuery({dataset: 'ourlogs'})],
+      match: [MockApiClient.matchQuery({dataset: 'ourlogs', field: ['count(message)']})],
       body: {data: [{'count(message)': 4}]},
+    });
+    const logProjectsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      match: [
+        MockApiClient.matchQuery({
+          dataset: 'ourlogs',
+          field: ['project.id', 'count(message)'],
+        }),
+      ],
+      body: {
+        data: [
+          {'project.id': 1, 'count(message)': 2},
+          {'project.id': 2, 'count(message)': 2},
+        ],
+      },
     });
     const metricsCountRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
@@ -135,13 +334,17 @@ describe('useTraceOverviewData', () => {
     );
 
     expect(result.current.isTabLoading).toBe(true);
+    expect(result.current.isProjectsLoading).toBe(true);
     expect(result.current.isRepresentativeLoading).toBe(true);
+    expect(result.current.projectIds).toBeUndefined();
 
     await waitFor(() => {
+      expect(result.current.isProjectsLoading).toBe(false);
       expect(result.current.isRepresentativeLoading).toBe(false);
       expect(result.current.isTabLoading).toBe(false);
     });
 
+    expect(result.current.projectIds).toEqual(['1', '2']);
     expect(result.current.logs).toEqual({
       availability: 'present',
       count: 4,
@@ -170,6 +373,14 @@ describe('useTraceOverviewData', () => {
         per_page: 1,
         project: ['-1'],
         traceId: [TRACE_SLUG],
+      })
+    );
+    expect(logProjectsRequest).toHaveBeenCalledTimes(1);
+    expect(logProjectsRequest.mock.calls[0]?.[1]?.query).toEqual(
+      expect.objectContaining({
+        field: ['project.id', 'count(message)'],
+        per_page: 100,
+        project: ['-1'],
       })
     );
   });

--- a/static/app/views/performance/newTraceDetails/useTraceOverviewData.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceOverviewData.tsx
@@ -23,6 +23,7 @@ import type {TraceViewQueryParams} from 'sentry/views/performance/newTraceDetail
 type TraceDataAvailability = 'loading' | 'present' | 'absent' | 'unknown';
 
 export interface TraceOverviewData {
+  isProjectsLoading: boolean;
   isRepresentativeLoading: boolean;
   isTabLoading: boolean;
   logs: {
@@ -34,6 +35,7 @@ export interface TraceOverviewData {
     availability: TraceDataAvailability;
     count: number | undefined;
   };
+  projectIds: string[] | undefined;
 }
 
 const LOGS_COUNT_FIELD = `${AggregationKey.COUNT}(${OurLogKnownFieldKey.MESSAGE})`;
@@ -42,6 +44,19 @@ const STALE_TIME = 5 * 60 * 1000;
 
 interface TraceCountResult {
   data: Array<Record<string, number>>;
+}
+
+interface TraceProjectResult {
+  data: Array<{[TraceMetricKnownFieldKey.PROJECT_ID]?: number | string}>;
+}
+
+function getProjectIds(result: TraceProjectResult | undefined): string[] {
+  return (
+    result?.data.flatMap(row => {
+      const projectId = row[TraceMetricKnownFieldKey.PROJECT_ID];
+      return projectId === undefined ? [] : [String(projectId)];
+    }) ?? []
+  );
 }
 
 function getDateTimeQuery(queryParams: TraceViewQueryParams) {
@@ -174,6 +189,48 @@ export function useTraceOverviewData({
     supplementalStatus: metricsCountResult.status,
   });
 
+  const logsCount = logsMetaCount ?? logsSupplementalCount;
+  const metricsCount = metricsMetaCount ?? metricsSupplementalCount;
+  const shouldFetchLogProjects =
+    tree.type === 'empty' && logsAvailability === 'present' && (logsCount ?? 0) > 1;
+  const logProjectsResult = useQuery(
+    apiOptions.as<TraceProjectResult>()('/organizations/$organizationIdOrSlug/events/', {
+      path: shouldFetchLogProjects
+        ? {organizationIdOrSlug: organization.slug}
+        : skipToken,
+      query: {
+        dataset: DiscoverDatasets.OURLOGS,
+        field: [OurLogKnownFieldKey.PROJECT_ID, LOGS_COUNT_FIELD],
+        query: traceSearch.formatString(),
+        per_page: 100,
+        referrer: 'api.trace-details.overview-log-projects',
+        ...projectQuery,
+        ...dateTimeQuery,
+      },
+      staleTime: STALE_TIME,
+    })
+  );
+
+  const shouldFetchMetricProjects =
+    tree.type === 'empty' && metricsAvailability === 'present';
+  const metricProjectsResult = useQuery(
+    apiOptions.as<TraceProjectResult>()('/organizations/$organizationIdOrSlug/events/', {
+      path: shouldFetchMetricProjects
+        ? {organizationIdOrSlug: organization.slug}
+        : skipToken,
+      query: {
+        dataset: DiscoverDatasets.TRACEMETRICS,
+        field: [TraceMetricKnownFieldKey.PROJECT_ID, METRICS_COUNT_FIELD],
+        query: metricsSearch.formatString(),
+        per_page: 100,
+        referrer: 'api.trace-details.overview-metric-projects',
+        ...projectQuery,
+        ...dateTimeQuery,
+      },
+      staleTime: STALE_TIME,
+    })
+  );
+
   const shouldFetchRepresentativeLog =
     tree.type === 'empty' && logsAvailability === 'present';
   const representativeLogResult = useQuery(
@@ -209,20 +266,47 @@ export function useTraceOverviewData({
     tree.type === 'empty' &&
     (logsAvailability === 'loading' ||
       (shouldFetchRepresentativeLog && representativeLogResult.status === 'pending'));
+  const logProjectsLoading =
+    shouldFetchLogProjects && logProjectsResult.status === 'pending';
+  const metricProjectsLoading =
+    shouldFetchMetricProjects && metricProjectsResult.status === 'pending';
+  const projectAvailabilityLoading =
+    tree.type === 'empty' &&
+    (logsAvailability === 'loading' || metricsAvailability === 'loading');
   const summaryLoading =
     logsAvailability === 'loading' || metricsAvailability === 'loading';
+  const isProjectsLoading =
+    projectAvailabilityLoading ||
+    representativeLogLoading ||
+    logProjectsLoading ||
+    metricProjectsLoading;
+  const representativeLog = representativeLogResult.data?.data[0];
+  const representativeProjectId = representativeLog?.[OurLogKnownFieldKey.PROJECT_ID];
+  const projectIds = isProjectsLoading
+    ? undefined
+    : Array.from(
+        new Set([
+          ...getProjectIds(logProjectsResult.data),
+          ...getProjectIds(metricProjectsResult.data),
+          ...(representativeProjectId === undefined
+            ? []
+            : [String(representativeProjectId)]),
+        ])
+      );
 
   return {
+    isProjectsLoading,
     isRepresentativeLoading: representativeLogLoading,
     isTabLoading: summaryLoading,
+    projectIds,
     logs: {
       availability: logsAvailability,
-      count: logsMetaCount ?? logsSupplementalCount,
+      count: logsCount,
       representative: representativeLogResult.data?.data,
     },
     metrics: {
       availability: metricsAvailability,
-      count: metricsMetaCount ?? metricsSupplementalCount,
+      count: metricsCount,
     },
   };
 }


### PR DESCRIPTION
Preserve project context for telemetry-only traces without loading full tab datasets. Empty traces use lightweight project aggregations for Logs and Application Metrics, combine overlapping project IDs, and keep the header placeholder stable until the relevant summaries resolve.

This is PR 5 of the EXP-1112 GitHub Stack and is based on `nd/EXP-1112/stabilize-trace-overview-loading`. It completes compatibility for multi-project log traces and adds equivalent project context for metric-only and mixed telemetry traces.
