### PR TITLE
feat(conversations): Add copy transcript button to redesigned view

### DIFF
--- a/static/app/views/explore/conversations/conversationDetailNew.spec.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.spec.tsx
@@ -100,4 +100,20 @@ describe('ConversationDetailPageNew span default selection', () => {
     // Timeline should open on its first span.
     await waitFor(() => expect(detailPane()).toBeInTheDocument());
   });
+
+  it('shows the copy transcript button only on the transcript tab', async () => {
+    renderPage();
+
+    // The transcript tab exposes the copy control once messages have loaded.
+    expect(
+      await screen.findByRole('button', {name: 'Copy Transcript'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('tab', {name: 'Timeline'}));
+
+    // The timeline tab has no transcript to copy.
+    expect(
+      screen.queryByRole('button', {name: 'Copy Transcript'})
+    ).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -100,7 +100,7 @@ export function ConversationDetailPageNew() {
               <TabList.Item key="timeline">{t('Timeline')}</TabList.Item>
             </TabList>
           </Tabs>
-          {queryState.tab === 'transcript' && messages.length > 0 && (
+          {queryState.tab === 'transcript' && !isLoading && messages.length > 0 && (
             <Button
               size="xs"
               icon={<IconCopy />}

--- a/static/app/views/explore/conversations/conversationDetailNew.tsx
+++ b/static/app/views/explore/conversations/conversationDetailNew.tsx
@@ -1,11 +1,14 @@
 import {useCallback, useEffect, useMemo} from 'react';
 import {parseAsString, parseAsStringLiteral, useQueryStates} from 'nuqs';
 
+import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
+import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -18,6 +21,10 @@ import {
 } from 'sentry/views/explore/conversations/components/conversationViewNew';
 import {ConversationViewContainer} from 'sentry/views/explore/conversations/conversationDetail';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
+import {
+  extractMessagesFromNodes,
+  messagesToMarkdown,
+} from 'sentry/views/explore/conversations/utils/conversationMessages';
 import {TopBar} from 'sentry/views/navigation/topBar';
 
 function useConversationDetailQueryState() {
@@ -39,6 +46,8 @@ export function ConversationDetailPageNew() {
   const conversation = useMemo(() => ({conversationId}), [conversationId]);
 
   const {nodes, nodeTraceMap, isLoading} = useConversation(conversation);
+
+  const messages = useMemo(() => extractMessagesFromNodes(nodes), [nodes]);
 
   const projectSlug = useMemo(
     () => nodes.find(node => node.projectSlug)?.projectSlug,
@@ -84,13 +93,27 @@ export function ConversationDetailPageNew() {
         />
       </Container>
       <Stack flex={1} minHeight="0" overflow="hidden" padding="xl" gap="xl">
-        <Flex flexShrink={0}>
+        <Flex flexShrink={0} align="center" justify="between" gap="md">
           <Tabs value={queryState.tab} onChange={tab => setQueryState({tab})}>
             <TabList variant="floating">
               <TabList.Item key="transcript">{t('Transcript')}</TabList.Item>
               <TabList.Item key="timeline">{t('Timeline')}</TabList.Item>
             </TabList>
           </Tabs>
+          {queryState.tab === 'transcript' && messages.length > 0 && (
+            <Button
+              size="xs"
+              icon={<IconCopy />}
+              onClick={() => {
+                trackAnalytics('conversations.detail.copy-conversation', {
+                  organization,
+                });
+                copyToClipboard(messagesToMarkdown(messages));
+              }}
+            >
+              {t('Copy Transcript')}
+            </Button>
+          )}
         </Flex>
         <ConversationViewContainer>
           <ConversationViewContentNew


### PR DESCRIPTION
Add a Copy Transcript button to the transcript tab of the redesigned conversation view, so users can copy a conversation as Markdown.

The redesigned view shipped without this action, while the legacy conversation view already had it. This closes that parity gap.

Closes TET-2659