### PR TITLE
feat(autofix): Render GitHub PR review body feedback in code-changes card

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -151,6 +151,14 @@ interface GithubPrReviewCommentFeedbackSource {
   comment?: {html_url?: string; user?: {login: string}};
 }
 
+interface GithubPrReviewBodyFeedbackSource {
+  type: 'github-pr-review-body';
+  author_is_bot?: boolean;
+  body?: string;
+  html_url?: string;
+  review_id?: number;
+}
+
 interface CheckSuiteFeedbackSource {
   app_name: string;
   event: {
@@ -164,6 +172,7 @@ type RawFeedbackSource =
   | UserUiFeedbackSource
   | GithubPrCommentFeedbackSource
   | GithubPrReviewCommentFeedbackSource
+  | GithubPrReviewBodyFeedbackSource
   | CheckSuiteFeedbackSource;
 export interface RawFeedback {
   text: string;

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -924,6 +924,47 @@ describe('ArtifactCard', () => {
       expect(screen.getByTestId('icon-github')).toBeInTheDocument();
     });
 
+    it('renders GitHub PR review body feedback with a GitHub icon and link', () => {
+      const reviewUrl = 'https://github.com/org/repo/pull/42#pullrequestreview-999';
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [
+            {
+              text: 'Overall this looks good, please add a test.',
+              source: {
+                type: 'github-pr-review-body',
+                review_id: 999,
+                body: 'Overall this looks good, please add a test.',
+                html_url: reviewUrl,
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      const feedbackLink = screen.getByRole('link', {
+        name: 'Overall this looks good, please add a test.',
+      });
+      expect(feedbackLink).toHaveAttribute('href', reviewUrl);
+      expect(screen.getByTestId('icon-github')).toBeInTheDocument();
+    });
+
     it('shows a formatted check-suite label instead of the raw feedback text', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -66,7 +66,7 @@ interface UserUiFeedback extends ParsedBaseFeedback {
 
 interface GithubPrCommentFeedback extends ParsedBaseFeedback {
   commentUrl: string;
-  sourceType: 'github-pr-comment' | 'github-pr-review-comment';
+  sourceType: 'github-pr-comment' | 'github-pr-review-comment' | 'github-pr-review-body';
   githubUsername?: string;
 }
 
@@ -114,6 +114,19 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
         ...base,
         sourceType: source.type,
         githubUsername: source.comment?.user?.login,
+        commentUrl,
+      };
+    }
+    case 'github-pr-review-body': {
+      // Unlike a review comment, the review body carries its link directly on
+      // `html_url` and has no comment author login to attribute.
+      const commentUrl = source.html_url;
+      if (!commentUrl) {
+        return null;
+      }
+      return {
+        ...base,
+        sourceType: source.type,
         commentUrl,
       };
     }
@@ -473,6 +486,7 @@ function feedbackLinkUrl(item: IterationFeedback): string | undefined {
   switch (item.sourceType) {
     case 'github-pr-comment':
     case 'github-pr-review-comment':
+    case 'github-pr-review-body':
       return item.commentUrl;
     case 'check-suite':
       return item.checkSuiteUrl;
@@ -485,8 +499,13 @@ function FeedbackAttribution({item}: {item: IterationFeedback}) {
   switch (item.sourceType) {
     case 'github-pr-comment':
     case 'github-pr-review-comment':
+    case 'github-pr-review-body': {
+      const fallbackTitle =
+        item.sourceType === 'github-pr-review-body'
+          ? t('GitHub PR review')
+          : t('GitHub PR comment');
       return (
-        <Tooltip title={item.githubUsername ?? t('GitHub PR comment')} skipWrapper>
+        <Tooltip title={item.githubUsername ?? fallbackTitle} skipWrapper>
           <ExternalLink href={item.commentUrl}>
             <Flex align="center">
               <IconGithub size="md" data-test-id="icon-github" />
@@ -494,6 +513,7 @@ function FeedbackAttribution({item}: {item: IterationFeedback}) {
           </ExternalLink>
         </Tooltip>
       );
+    }
     case 'check-suite': {
       const icon = (
         <Flex align="center">


### PR DESCRIPTION
let's render the GH PR review body feedback in code changes, forgot to update after implementing the automatic review iterations 😓 

PR review on GH:
<img width="920" height="226" alt="image" src="https://github.com/user-attachments/assets/ef9d84a4-2f31-411a-9381-5b90d1a7c071" />


before:
<img width="801" height="307" alt="image" src="https://github.com/user-attachments/assets/d6b8ed9a-3d68-45a3-8982-6bf74fc3cb2c" />


after:
<img width="801" height="381" alt="image" src="https://github.com/user-attachments/assets/47acecf6-8094-474d-888a-171013de9bc3" />


after correctly links to the PR review body