### PR TITLE
feat(conversations): Disallow negation filters on conversations page

### DIFF
--- a/static/app/components/performance/spanSearchQueryBuilder.tsx
+++ b/static/app/components/performance/spanSearchQueryBuilder.tsx
@@ -25,6 +25,7 @@ export interface UseSpanSearchQueryBuilderProps {
   datetime?: PageFilters['datetime'];
   defaultToAskSeerOnFreeTextSearch?: SearchQueryBuilderProps['defaultToAskSeerOnFreeTextSearch'];
   disableLoadingTags?: boolean;
+  disallowNegation?: boolean;
   getFilterTokenWarning?: (key: string) => React.ReactNode;
   onBlur?: (query: string, state: CallbackSearchState) => void;
   onCaseInsensitiveClick?: SearchQueryBuilderProps['onCaseInsensitiveClick'];

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -54,6 +54,7 @@ interface SearchQueryBuilderConfigContextData {
   disabled: boolean;
   disallowFreeText: boolean;
   disallowLogicalOperators: boolean;
+  disallowNegation: boolean;
   disallowWildcard: boolean;
   filterKeyAliases: TagCollection | undefined;
   filterKeyRegistryQueryKey: QueryKey;
@@ -166,6 +167,7 @@ export function SearchQueryBuilderProvider({
   disabled = false,
   disallowLogicalOperators,
   disallowFreeText,
+  disallowNegation,
   disallowUnsupportedFilters,
   disallowWildcard,
   defaultToAskSeerOnFreeTextSearch: defaultToAskSeerOnFreeTextSearchProp,
@@ -273,6 +275,7 @@ export function SearchQueryBuilderProvider({
         getFilterTokenWarning,
         disallowFreeText,
         disallowLogicalOperators,
+        disallowNegation,
         disallowUnsupportedFilters,
         disallowWildcard,
         filterKeys: mergedFilterKeys,
@@ -283,6 +286,7 @@ export function SearchQueryBuilderProvider({
     [
       disallowFreeText,
       disallowLogicalOperators,
+      disallowNegation,
       disallowUnsupportedFilters,
       disallowWildcard,
       getFieldDefinitionWithTagMetadata,
@@ -393,6 +397,7 @@ export function SearchQueryBuilderProvider({
       disabled,
       disallowFreeText: Boolean(disallowFreeText),
       disallowLogicalOperators: Boolean(disallowLogicalOperators),
+      disallowNegation: Boolean(disallowNegation),
       disallowWildcard: Boolean(disallowWildcard),
       filterKeyAliases,
       filterKeyRegistryQueryKey: filterKeyRegistryQueryOptions.queryKey,
@@ -416,6 +421,7 @@ export function SearchQueryBuilderProvider({
     disabled,
     disallowFreeText,
     disallowLogicalOperators,
+    disallowNegation,
     disallowWildcard,
     filterKeyAliases,
     filterKeyRegistryQueryOptions.queryKey,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -6014,6 +6014,76 @@ describe('SearchQueryBuilder', () => {
     });
   });
 
+  describe('disallowNegation', () => {
+    it('removes negation operators from string filter options', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowNegation
+          initialQuery="browser.name:firefox"
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit operator for filter: browser.name'})
+      );
+
+      // Positive operators remain available
+      expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'contains'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'starts with'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'ends with'})).toBeInTheDocument();
+
+      // Negation operators are hidden
+      expect(screen.queryByRole('option', {name: 'is not'})).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'does not contain'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'does not start with'})
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'does not end with'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('removes "does not have" from has filter options', async () => {
+      render(
+        <SearchQueryBuilder {...defaultProps} disallowNegation initialQuery="has:key" />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit operator for filter: has'})
+      );
+
+      expect(await screen.findByRole('option', {name: 'has'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'does not have'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('marks a negated filter invalid (e.g. when pasted)', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowNegation
+          initialQuery="!browser.name:firefox"
+        />
+      );
+
+      expect(screen.getByRole('row', {name: '!browser.name:firefox'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{ArrowLeft}');
+      expect(
+        await screen.findByText('Negation is not allowed in this search.')
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('highlightUnsupportedFilters', () => {
     it('should mark unsupported filters as invalid', async () => {
       render(

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -6082,6 +6082,27 @@ describe('SearchQueryBuilder', () => {
         await screen.findByText('Negation is not allowed in this search.')
       ).toBeInTheDocument();
     });
+
+    it('marks operator-based negation invalid (e.g. pasted "!=")', async () => {
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          disallowNegation
+          initialQuery="timesSeen:!=5"
+        />
+      );
+
+      expect(screen.getByRole('row', {name: 'timesSeen:!=5'})).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('{ArrowLeft}');
+      expect(
+        await screen.findByText('Negation is not allowed in this search.')
+      ).toBeInTheDocument();
+    });
   });
 
   describe('highlightUnsupportedFilters', () => {

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -627,6 +627,7 @@ export default Storybook.story('SearchQueryBuilder', story => {
       'disallowFreeText',
       'disallowLogicalOperators',
       'disallowWildcard',
+      'disallowNegation',
       'disallowUnsupportedFilters',
     ];
 
@@ -657,7 +658,7 @@ export default Storybook.story('SearchQueryBuilder', story => {
           ))}
         </MultipleCheckbox>
         <SearchQueryBuilder
-          initialQuery="(unsupported_key:value OR browser.name:Internet*) TypeError"
+          initialQuery="(!browser.name:Firefox OR browser.name:Internet*) unsupported_key:value TypeError"
           filterKeySections={FILTER_KEY_SECTIONS}
           filterKeys={FILTER_KEYS}
           getTagValues={getTagValues}

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -103,6 +103,11 @@ export interface SearchQueryBuilderProps {
    */
   disallowLogicalOperators?: boolean;
   /**
+   * When true, negation operators (e.g. "is not", "does not contain") are
+   * removed from the operator suggestions so only positive filters can be built.
+   */
+  disallowNegation?: boolean;
+  /**
    * When true, unsupported filter keys will be highlighted as invalid.
    */
   disallowUnsupportedFilters?: boolean;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -30,6 +30,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/utils';
 import {
   FilterType,
+  negationOperators,
   TermOperator,
   type ParseResultToken,
   type Token,
@@ -95,14 +96,18 @@ function FilterKeyOperatorLabel({
 export function getOperatorInfo({
   filterToken,
   fieldDefinition,
+  disallowNegation,
 }: {
   fieldDefinition: FieldDefinition | null;
   filterToken: TokenResult<Token.FILTER>;
+  disallowNegation?: boolean;
 }): {
   label: ReactNode;
   operator: TermOperator;
   options: Array<SelectOption<TermOperator>>;
 } {
+  const isNegationOperator = (op: TermOperator) =>
+    (negationOperators as readonly TermOperator[]).includes(op);
   if (isDateToken(filterToken)) {
     const operator = getOperatorFromDateToken(filterToken);
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -148,18 +153,22 @@ export function getOperatorInfo({
           ),
           textValue: 'is',
         },
-        {
-          value: TermOperator.NOT_EQUAL,
-          label: (
-            <FilterKeyOperatorLabel
-              keyLabel={filterToken.key.text}
-              keyValue={filterToken.key.value}
-              opLabel="not"
-              includeKeyLabel
-            />
-          ),
-          textValue: 'is not',
-        },
+        ...(disallowNegation
+          ? []
+          : [
+              {
+                value: TermOperator.NOT_EQUAL,
+                label: (
+                  <FilterKeyOperatorLabel
+                    keyLabel={filterToken.key.text}
+                    keyValue={filterToken.key.value}
+                    opLabel="not"
+                    includeKeyLabel
+                  />
+                ),
+                textValue: 'is not',
+              },
+            ]),
       ],
     };
   }
@@ -186,17 +195,21 @@ export function getOperatorInfo({
           ),
           textValue: 'has',
         },
-        {
-          value: TermOperator.NOT_EQUAL,
-          label: (
-            <FilterKeyOperatorLabel
-              keyLabel="does not have"
-              keyValue={filterToken.key.value}
-              includeKeyLabel
-            />
-          ),
-          textValue: 'does not have',
-        },
+        ...(disallowNegation
+          ? []
+          : [
+              {
+                value: TermOperator.NOT_EQUAL,
+                label: (
+                  <FilterKeyOperatorLabel
+                    keyLabel="does not have"
+                    keyValue={filterToken.key.value}
+                    includeKeyLabel
+                  />
+                ),
+                textValue: 'does not have',
+              },
+            ]),
       ],
     };
   }
@@ -208,6 +221,7 @@ export function getOperatorInfo({
     label: <OpLabel>{label}</OpLabel>,
     options: getValidOpsForFilter({filterToken, fieldDefinition})
       .filter(op => op !== TermOperator.EQUAL)
+      .filter(op => !disallowNegation || !isNegationOperator(op))
       .map((op): SelectOption<TermOperator> => {
         const optionOpLabel = OP_LABELS[op] ?? op;
 
@@ -223,7 +237,7 @@ export function getOperatorInfo({
 export function FilterOperator({state, item, token, onOpenChange}: FilterOperatorProps) {
   const organization = useOrganization();
   const {dispatch, query, focusOverride} = useSearchQueryBuilderState();
-  const {searchSource, recentSearches, disabled, getFieldDefinition} =
+  const {searchSource, recentSearches, disabled, disallowNegation, getFieldDefinition} =
     useSearchQueryBuilderConfig();
   const filterButtonProps = useFilterButtonProps({state, item});
   const {focusWithinProps} = useFocusWithin({});
@@ -233,8 +247,9 @@ export function FilterOperator({state, item, token, onOpenChange}: FilterOperato
       getOperatorInfo({
         filterToken: token,
         fieldDefinition: getFieldDefinition(token.key.text),
+        disallowNegation,
       }),
-    [token, getFieldDefinition]
+    [token, getFieldDefinition, disallowNegation]
   );
 
   const onlyOperator = token.filter === FilterType.IS || token.filter === FilterType.HAS;

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -106,8 +106,7 @@ export function getOperatorInfo({
   operator: TermOperator;
   options: Array<SelectOption<TermOperator>>;
 } {
-  const isNegationOperator = (op: TermOperator) =>
-    (negationOperators as readonly TermOperator[]).includes(op);
+  const isNegationOperator = (op: TermOperator) => negationOperators.includes(op);
   if (isDateToken(filterToken)) {
     const operator = getOperatorFromDateToken(filterToken);
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -93,6 +93,10 @@ function FilterKeyOperatorLabel({
   );
 }
 
+function isNegationOperator(op: TermOperator) {
+  return negationOperators.includes(op);
+}
+
 export function getOperatorInfo({
   filterToken,
   fieldDefinition,
@@ -106,7 +110,6 @@ export function getOperatorInfo({
   operator: TermOperator;
   options: Array<SelectOption<TermOperator>>;
 } {
-  const isNegationOperator = (op: TermOperator) => negationOperators.includes(op);
   if (isDateToken(filterToken)) {
     const operator = getOperatorFromDateToken(filterToken);
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -164,6 +164,7 @@ export function parseQueryBuilderValue(
     filterKeys: TagCollection;
     disallowFreeText?: boolean;
     disallowLogicalOperators?: boolean;
+    disallowNegation?: boolean;
     disallowUnsupportedFilters?: boolean;
     disallowWildcard?: boolean;
     filterKeyAliases?: TagCollection;
@@ -180,6 +181,7 @@ export function parseQueryBuilderValue(
         getFilterTokenWarning: options?.getFilterTokenWarning,
         validateKeys: options?.disallowUnsupportedFilters,
         disallowWildcard: options?.disallowWildcard,
+        disallowNegation: options?.disallowNegation,
         disallowedLogicalOperators: options?.disallowLogicalOperators
           ? new Set([BooleanOperator.AND, BooleanOperator.OR])
           : undefined,

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -153,6 +153,13 @@ export const wildcardOperators = [
 
 export type WildcardOperator = (typeof wildcardOperators)[number];
 
+export const negationOperators = [
+  TermOperator.NOT_EQUAL,
+  TermOperator.DOES_NOT_CONTAIN,
+  TermOperator.DOES_NOT_START_WITH,
+  TermOperator.DOES_NOT_END_WITH,
+] as const;
+
 /**
  * Map of certain filter types to other filter types with applicable operators
  * e.g. SpecificDate can use the operators from Date to become a Date filter.

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -153,12 +153,12 @@ export const wildcardOperators = [
 
 export type WildcardOperator = (typeof wildcardOperators)[number];
 
-export const negationOperators = [
+export const negationOperators: readonly TermOperator[] = [
   TermOperator.NOT_EQUAL,
   TermOperator.DOES_NOT_CONTAIN,
   TermOperator.DOES_NOT_START_WITH,
   TermOperator.DOES_NOT_END_WITH,
-] as const;
+];
 
 /**
  * Map of certain filter types to other filter types with applicable operators
@@ -482,7 +482,7 @@ export class TokenConverter {
       value,
       negated,
       operator: operatorToUse,
-      invalid: this.checkInvalidFilter(filter, key, value, negated),
+      invalid: this.checkInvalidFilter(filter, key, value, negated, operatorToUse),
       warning: this.checkFilterWarning(key),
     } as FilterResult;
 
@@ -921,7 +921,8 @@ export class TokenConverter {
     filter: T,
     key: FilterMap[T]['key'],
     value: FilterMap[T]['value'],
-    negated: FilterMap[T]['negated']
+    negated: FilterMap[T]['negated'],
+    operator: FilterMap[T]['operator']
   ) => {
     // Text filter is the "fall through" filter that will match when other
     // filter predicates fail.
@@ -936,7 +937,10 @@ export class TokenConverter {
       };
     }
 
-    if (this.config.disallowNegation && negated) {
+    if (
+      this.config.disallowNegation &&
+      (negated || negationOperators.includes(operator))
+    ) {
       return {
         type: InvalidReason.NEGATION_NOT_ALLOWED,
         reason: this.config.invalidMessages[InvalidReason.NEGATION_NOT_ALLOWED],

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -39,6 +39,7 @@ export type TraceItemSearchQueryBuilderProps = {
   disallowFreeText?: boolean;
   disallowHas?: boolean;
   disallowLogicalOperators?: boolean;
+  disallowNegation?: boolean;
   hiddenAttributeKeys?: string[];
   invalidFilterKeys?: string[];
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
@@ -111,6 +112,7 @@ export function useTraceItemSearchQueryBuilderProps({
   disallowHas,
   disallowFreeText,
   disallowLogicalOperators,
+  disallowNegation,
   disableRecentSearches,
   disabled,
   defaultToAskSeerOnFreeTextSearch,
@@ -210,6 +212,7 @@ export function useTraceItemSearchQueryBuilderProps({
       disallowUnsupportedFilters: !getTagKeys,
       disallowFreeText,
       disallowLogicalOperators,
+      disallowNegation,
       defaultToAskSeerOnFreeTextSearch,
       recentSearches: disableRecentSearches
         ? undefined
@@ -238,6 +241,7 @@ export function useTraceItemSearchQueryBuilderProps({
       defaultToAskSeerOnFreeTextSearch,
       disallowFreeText,
       disallowLogicalOperators,
+      disallowNegation,
       filterKeySections,
       filterTags,
       getFilterTokenWarning,
@@ -292,6 +296,7 @@ export function TraceItemSearchQueryBuilder({
   disallowHas,
   disallowFreeText,
   disallowLogicalOperators,
+  disallowNegation,
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
@@ -325,6 +330,7 @@ export function TraceItemSearchQueryBuilder({
     disallowHas,
     disallowFreeText,
     disallowLogicalOperators,
+    disallowNegation,
     disableRecentSearches,
     disabled,
     defaultToAskSeerOnFreeTextSearch,

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -83,6 +83,9 @@ function ConversationsOverviewPage() {
         unsetCursor();
       },
       searchSource: 'conversations',
+      // The conversations API cannot express negation given how it fetches
+      // conversations, so hide negation operators from the search suggestions.
+      disallowNegation: true,
       replaceRawSearchKeys: ['gen_ai.conversation.id', 'gen_ai.input.messages'],
       matchKeySuggestions: [
         {key: 'gen_ai.conversation.id', valuePattern: /^[0-9a-fA-F]{8,32}$/},

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -78,7 +78,12 @@ function ConversationsOverviewPage() {
   const searchQueryBuilderProps: UseSpanSearchQueryBuilderProps = useMemo(
     () => ({
       initialQuery: searchQuery ?? '',
-      onSearch: (newQuery: string) => {
+      onSearch: (newQuery, {queryIsValid}) => {
+        // The conversations API can't express negation (and other invalid
+        // syntax), so don't apply a query the builder has flagged as invalid.
+        if (!queryIsValid) {
+          return;
+        }
         setSearchQuery(newQuery);
         unsetCursor();
       },


### PR DESCRIPTION
Negation filters aren't offered on the conversations page anymore — neither as operator suggestions nor via a pasted query, in both prefix (`!key:value`) and operator (`key:!=value`) forms.

The conversations API can't express negation given how it fetches conversations, so the search bar shouldn't let users build negated filters.

Adds a `disallowNegation` option to the search query builder, following the existing `disallow*` options and wiring it into the parser's existing negation handling. Enabled on the conversations page.

Closes TET-2699