### PR TITLE
fix(trace-items): Align metrics context to the attributes `details` shape

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -54,7 +54,9 @@ MAX_METRICS_PER_PAGE = 1000
 
 class TraceMetricContext(TypedDict):
     brief: NotRequired[str]
-    additionalContext: NotRequired[str]
+    # Longer-form notes, normalized to a list to match the attributes context
+    # shape (see TraceItemAttributeContext.details).
+    details: NotRequired[list[str]]
 
 
 class TraceMetricItem(TypedDict):
@@ -240,6 +242,6 @@ class OrganizationTraceItemMetricsEndpoint(OrganizationTraceItemAttributesEndpoi
             context: TraceMetricContext = {}
             if context_row.brief is not None:
                 context["brief"] = context_row.brief
-            if context_row.additional_context is not None:
-                context["additionalContext"] = context_row.additional_context
+            if context_row.additional_context:
+                context["details"] = [context_row.additional_context]
             metric["context"] = context

--- a/src/sentry/api/endpoints/organization_trace_item_metrics.py
+++ b/src/sentry/api/endpoints/organization_trace_item_metrics.py
@@ -82,7 +82,7 @@ class OrganizationTraceItemMetricsSerializer(serializers.Serializer[Never]):
     referrer = serializers.CharField(required=False)
     # Restrict results to metrics that have authored context. Gated behind the
     # data-browsing-attribute-context feature (a no-op without it).
-    context_only = serializers.BooleanField(required=False, default=False)
+    contextOnly = serializers.BooleanField(required=False, default=False, source="context_only")
 
     def validate_sort(self, value: str) -> str:
         field = value[1:] if value.startswith("-") else value

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -73,14 +73,18 @@ def get_metric_metadata(
         stats_period: Time window, e.g. "7d". Defaults to 7d.
         limit: Maximum number of distinct tuples to return. Defaults to
             DEFAULT_LIMIT; the metrics endpoint enforces its own upper bound.
-        include_context: When True, request per-metric context (brief, notes) from
-            the endpoint via expand=context and attach it to each candidate.
+        include_context: When True, request per-metric context from the endpoint
+            via expand=context and attach it to each candidate. Context is
+            `{"brief": str, "details": list[str]}` — the same shape the attributes
+            tool (get_attribute_names) returns — or None when the metric has none.
         context_only: Forwarded to the metrics endpoint as `context_only` to
             restrict results to metrics that have authored context.
 
     Returns:
         {
-            "candidates": [{"name", "type", "unit", "count", "context"}, ...],
+            "candidates": [
+                {"name", "type", "unit", "count", "context"}, ...
+            ],  # context: {"brief": str, "details": list[str]} | None
             "has_more": bool,
             "error": str,  # present only on handler-side failure (e.g.
                            # "organization_not_found", "metrics_query_failed").

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -77,7 +77,7 @@ def get_metric_metadata(
             via expand=context and attach it to each candidate. Context is
             `{"brief": str, "details": list[str]}` — the same shape the attributes
             tool (get_attribute_names) returns — or None when the metric has none.
-        context_only: Forwarded to the metrics endpoint as `context_only` to
+        context_only: Forwarded to the metrics endpoint as `contextOnly` to
             restrict results to metrics that have authored context.
 
     Returns:
@@ -113,7 +113,7 @@ def get_metric_metadata(
         # Highest-count metrics first; over-fetch by 1 to detect has_more.
         "sort": "-count",
         "per_page": limit + 1,
-        "context_only": context_only,
+        "contextOnly": context_only,
         "referrer": Referrer.SEER_EXPLORER_TOOLS,
     }
     # Omit an empty query so the endpoint returns all metrics rather than

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -221,9 +221,9 @@ class MetricMetadataRow(BaseModel):
     type: str
     unit: str
     count: int
-    # Authored context (brief, additionalContext) for the metric, populated only
-    # when the caller passes include_context=True (and the metric has context);
-    # otherwise None.
+    # Authored context (brief, details) for the metric, populated only when the
+    # caller passes include_context=True (and the metric has context); otherwise
+    # None. Mirrors the attributes context shape (see BuiltInField.context).
     context: dict[str, Any] | None = None
 
 

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -103,7 +103,7 @@ class TestGetMetricMetadata(TestCase):
                 "type": "distribution",
                 "unit": "millisecond",
                 "count": 10,
-                "context": {"brief": "Request duration", "additionalContext": "p95 latency"},
+                "context": {"brief": "Request duration", "details": ["p95 latency"]},
             }
         ]
         mock_client.get.return_value = response
@@ -119,7 +119,7 @@ class TestGetMetricMetadata(TestCase):
         assert kwargs["params"]["expand"] == "context"
         assert result.candidates[0].context == {
             "brief": "Request duration",
-            "additionalContext": "p95 latency",
+            "details": ["p95 latency"],
         }
 
     @patch("sentry.seer.assisted_query.metrics_tools.ApiClient")

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -137,7 +137,7 @@ class TestGetMetricMetadata(TestCase):
         )
 
         _args, kwargs = mock_client.get.call_args
-        assert kwargs["params"]["context_only"] is True
+        assert kwargs["params"]["contextOnly"] is True
 
     @patch("sentry.seer.assisted_query.metrics_tools.ApiClient")
     def test_no_substrings_returns_all_metrics(self, mock_client_cls: MagicMock) -> None:

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -200,7 +200,7 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         metric = response.data[0]
         assert metric["context"] == {
             "brief": "Checkout requests",
-            "additionalContext": "Longer notes.",
+            "details": ["Longer notes."],
         }
 
     def test_context_only_matches_metric_type(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_metrics.py
@@ -128,7 +128,7 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         self.store_metric("no.context", "counter")
         self.create_context("has.context", project=None, brief="Described")
 
-        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+        response = self.do_request(query={"project": self.project.id, "contextOnly": "1"})
 
         assert response.status_code == 200, response.data
         assert [row["name"] for row in response.data] == ["has.context"]
@@ -137,7 +137,7 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
     def test_context_only_empty_when_no_context(self) -> None:
         self.store_metric("no.context", "counter")
 
-        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+        response = self.do_request(query={"project": self.project.id, "contextOnly": "1"})
 
         assert response.status_code == 200, response.data
         assert response.data == []
@@ -148,7 +148,7 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         self.store_metric("café.requests", "counter")
         self.create_context("café.requests", project=None, brief="Café")
 
-        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+        response = self.do_request(query={"project": self.project.id, "contextOnly": "1"})
 
         assert response.status_code == 200, response.data
         assert [row["name"] for row in response.data] == ["café.requests"]
@@ -162,7 +162,7 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
             "checkout.requests", metric_type=TraceMetricTypes.COUNTER, project=None, brief="Counter"
         )
 
-        response = self.do_request(query={"project": self.project.id, "context_only": "1"})
+        response = self.do_request(query={"project": self.project.id, "contextOnly": "1"})
 
         assert response.status_code == 200, response.data
         assert [(row["type"], "context" in row) for row in response.data] == [("counter", True)]
@@ -173,7 +173,7 @@ class OrganizationTraceItemMetricsEndpointTest(APITestCase, TraceMetricsTestCase
         self.create_context("has.context", project=None, brief="Described")
 
         response = self.do_request(
-            query={"project": self.project.id, "context_only": "1"},
+            query={"project": self.project.id, "contextOnly": "1"},
             features={
                 "organizations:visibility-explore-view": True,
                 "organizations:tracemetrics-enabled": True,


### PR DESCRIPTION
The metrics listing context (`expand=context` on `/trace-items/metrics/`, surfaced by the `get_metric_metadata` RPC) exposed longer-form notes as `additionalContext: str`, while the attributes listing context (`get_attribute_names`) uses `details: list[str]`.

This aligns metrics to the attributes shape so consumers (Seer, the FE) get **one consistent `context` format**:

```diff
- { "brief": str, "additionalContext": str }
+ { "brief": str, "details": list[str] }
```

## Notes
- The single authored `additional_context` string is normalized to a one-element list, matching how the attributes endpoint normalizes its convention notes.
- The RPC (`get_metric_metadata`) forwards the endpoint's `context` verbatim, so it inherits the new shape automatically.
- **Out of scope:** the context-authoring CRUD serializers (`trace_item_metric_context` / `trace_item_attribute_context`) keep `additionalContext` — those already match each other.

Backend-only. Refs DAIN-1796.