### PR TITLE
fix(ourlogs): measure expanded row heights more often in the virtual table

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -293,9 +293,13 @@ export function LogsInfiniteTable({
   const estimateSize = useCallback(
     (index: number) => {
       const logItemId = data?.[index]?.[OurLogKnownFieldKey.ID];
-      const estimatedHeight =
-        expandedLogRowsHeights[logItemId ?? ''] ?? LOGS_GRID_BODY_ROW_HEIGHT;
-      return estimatedHeight;
+      const expandedDetailsHeight = expandedLogRowsHeights[logItemId ?? ''];
+      // A virtual item is the collapsed row plus, when expanded, its details
+      // panel rendered as a sibling row. The stored height only covers the
+      // details panel, so add the base row height back for the full item.
+      return expandedDetailsHeight === undefined
+        ? LOGS_GRID_BODY_ROW_HEIGHT
+        : LOGS_GRID_BODY_ROW_HEIGHT + expandedDetailsHeight;
     },
     [expandedLogRowsHeights, data]
   );
@@ -323,9 +327,14 @@ export function LogsInfiniteTable({
     getItemKey,
   });
 
+  // @tanstack/react-virtual does not rebuild its measurements cache when
+  // estimateSize returns new values, so re-measure whenever an expanded row's
+  // height changes. Without this the total size and item offsets keep treating
+  // expanded rows as collapsed, which desyncs the scroll range and leaves large
+  // blank gaps.
   useLayoutEffect(() => {
     virtualizer.measure();
-  }, [virtualizer]);
+  }, [virtualizer, expandedLogRowsHeights]);
 
   const virtualItems = virtualizer.getVirtualItems();
 
@@ -475,7 +484,9 @@ export function LogsInfiniteTable({
     });
   }, []);
   const handleExpandHeight = useCallback((logItemId: string, estimatedHeight: number) => {
-    setExpandedLogRowsHeights(prev => ({...prev, [logItemId]: estimatedHeight}));
+    setExpandedLogRowsHeights(prev =>
+      prev[logItemId] === estimatedHeight ? prev : {...prev, [logItemId]: estimatedHeight}
+    );
   }, []);
   const handleCollapse = useCallback((logItemId: string) => {
     setExpandedLogRows(prev => {

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -663,10 +663,13 @@ function LogRowDetails({
   // and the scroll range desyncs.
   const measureRef = useCallback(
     (node: HTMLTableRowElement | null) => {
-      if (!node) {
+      if (!node || !onExpandHeight) {
         return;
       }
-      const report = () => onExpandHeight?.(expansionKey, node.clientHeight);
+      // offsetHeight (not clientHeight) so the panel's top/bottom borders are
+      // included — the virtualizer's item size must match the space the row
+      // actually occupies.
+      const report = () => onExpandHeight(expansionKey, node.offsetHeight);
       report();
       const observer = new ResizeObserver(report);
       observer.observe(node);

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -1,5 +1,5 @@
 import type {ComponentProps, SyntheticEvent} from 'react';
-import {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, memo, useCallback, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import type {UseQueryResult} from '@tanstack/react-query';
 import classNames from 'classnames';
@@ -255,7 +255,6 @@ export const LogRowContent = memo(function LogRowContent({
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const isFrozen = useLogsFrozenIsFrozen();
-  const measureRef = useRef<HTMLTableRowElement>(null);
 
   const rowId = String(dataRow[OurLogKnownFieldKey.ID]);
   const expansionKey = expansionKeyProp ?? rowId;
@@ -318,12 +317,6 @@ export const LogRowContent = memo(function LogRowContent({
       organization,
     });
   }
-
-  useLayoutEffect(() => {
-    if (measureRef.current && isExpanded) {
-      onExpandHeight?.(expansionKey, measureRef.current.clientHeight);
-    }
-  }, [expansionKey, isExpanded, onExpandHeight]);
 
   const addSearchFilter = useAddSearchFilter();
   const {copy} = useCopyToClipboard();
@@ -640,7 +633,8 @@ export const LogRowContent = memo(function LogRowContent({
           highlightTerms={highlightTerms}
           embedded={embedded}
           meta={meta}
-          ref={measureRef}
+          expansionKey={expansionKey}
+          onExpandHeight={onExpandHeight}
         />
       )}
     </Fragment>
@@ -652,14 +646,34 @@ function LogRowDetails({
   embedded,
   highlightTerms,
   meta,
-  ref,
+  expansionKey,
+  onExpandHeight,
 }: {
   dataRow: OurLogsResponseItem;
   embedded: boolean;
+  expansionKey: string;
   highlightTerms: string[];
   meta: EventsMetaType | undefined;
-  ref: React.RefObject<HTMLTableRowElement | null>;
+  onExpandHeight?: (logItemId: string, estimatedHeight: number) => void;
 }) {
+  // Report the details panel's height to the virtualizer whenever it changes.
+  // The panel loads asynchronously and can resize after mount, so a
+  // ResizeObserver (rather than a one-shot measurement) is required to keep the
+  // stored height accurate; otherwise the virtualizer keeps a stale estimate
+  // and the scroll range desyncs.
+  const measureRef = useCallback(
+    (node: HTMLTableRowElement | null) => {
+      if (!node) {
+        return;
+      }
+      const report = () => onExpandHeight?.(expansionKey, node.clientHeight);
+      report();
+      const observer = new ResizeObserver(report);
+      observer.observe(node);
+      return () => observer.disconnect();
+    },
+    [expansionKey, onExpandHeight]
+  );
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
@@ -714,7 +728,7 @@ function LogRowDetails({
 
   if (missingLogId || isError) {
     return (
-      <DetailsWrapper ref={ref}>
+      <DetailsWrapper ref={measureRef}>
         <EmptyStreamWrapper>
           <IconWarning variant="muted" size="lg" />
         </EmptyStreamWrapper>
@@ -728,7 +742,7 @@ function LogRowDetails({
   );
 
   return (
-    <DetailsWrapper ref={isPending ? undefined : ref}>
+    <DetailsWrapper ref={measureRef}>
       <LogDetailTableBodyCell colSpan={colSpan}>
         {isPending && <LoadingIndicator />}
         {!isPending && data && (

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -656,19 +656,11 @@ function LogRowDetails({
   meta: EventsMetaType | undefined;
   onExpandHeight?: (logItemId: string, estimatedHeight: number) => void;
 }) {
-  // Report the details panel's height to the virtualizer whenever it changes.
-  // The panel loads asynchronously and can resize after mount, so a
-  // ResizeObserver (rather than a one-shot measurement) is required to keep the
-  // stored height accurate; otherwise the virtualizer keeps a stale estimate
-  // and the scroll range desyncs.
   const measureRef = useCallback(
     (node: HTMLTableRowElement | null) => {
       if (!node || !onExpandHeight) {
         return;
       }
-      // offsetHeight (not clientHeight) so the panel's top/bottom borders are
-      // included — the virtualizer's item size must match the space the row
-      // actually occupies.
       const report = () => onExpandHeight(expansionKey, node.offsetHeight);
       report();
       const observer = new ResizeObserver(report);


### PR DESCRIPTION
Expanding several rows in the Logs Explorer and then scrolling caused rows to flicker and disappear behind a large blank space. This was actually two bugs working together:

* The virtualizer never picked up new heights for rows, since `estimateSize` wasn't in the `getMeasurementsOptions` memo (i.e. it just ran on mount, not again)
* Similarly, heights were measured in a `useLayoutEffect` that didn't capture re-running after data finished loading

This runs the `measureRef` in a ResizeObserver so that it'll just run a whole bunch of times. What was happening before, and more, and probably a few more size changes than we need. You know, just in case.

Closes LOGS-918. Closes LOGS-929.
