### PR TITLE
fix(seer): Rate-limit autofix triggers from night shift

### DIFF
--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -19,6 +19,7 @@ from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     bulk_read_preferences_from_sentry_db,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
+    is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
@@ -199,8 +200,12 @@ def _process_verdicts(
         }
 
         referrer = referrer_map[SeerAutomationSource.NIGHT_SHIFT]
+
+        # Rate limit only applies to legacy org plans
+        check_rate_limit = not is_seer_seat_based_tier_enabled(organization)
+
         for group in fixable_groups:
-            if is_seer_autotriggered_autofix_rate_limited_and_increment(
+            if check_rate_limit and is_seer_autotriggered_autofix_rate_limited_and_increment(
                 group.project, organization
             ):
                 rate_limited_group_ids.add(group.id)

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -15,7 +15,11 @@ from sentry.seer.agent.types import FeatureRunStatus
 from sentry.seer.autofix.autofix_agent import AutofixStep, trigger_autofix_agent
 from sentry.seer.autofix.constants import SeerAutomationSource
 from sentry.seer.autofix.issue_summary import referrer_map
-from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
+from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
+    bulk_read_preferences_from_sentry_db,
+    is_seer_autotriggered_autofix_rate_limited_and_increment,
+)
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
     SeerNightShiftRunResult,
@@ -175,6 +179,7 @@ def _process_verdicts(
 
     reason_by_group_id = {v.group_id: v.reason for v in verdicts}
     state_id_by_group: dict[int, int] = {}
+    rate_limited_group_ids: set[int] = set()
     if not dry_run and fixable_groups:
         # Cache organization on each group's project to avoid N+1 queries
         for group in groups_by_id.values():
@@ -195,6 +200,12 @@ def _process_verdicts(
 
         referrer = referrer_map[SeerAutomationSource.NIGHT_SHIFT]
         for group in fixable_groups:
+            if is_seer_autotriggered_autofix_rate_limited_and_increment(
+                group.project, organization
+            ):
+                rate_limited_group_ids.add(group.id)
+                continue
+
             reason = reason_by_group_id[group.id]
             user_context = (
                 f"Night-shift triage already investigated this issue and concluded:\n{reason}"
@@ -216,6 +227,14 @@ def _process_verdicts(
                 )
 
         sentry_sdk.metrics.count("night_shift.autofix_triggered", len(state_id_by_group))
+        if rate_limited_group_ids:
+            sentry_sdk.metrics.count(
+                "night_shift.autofix_rate_limited", len(rate_limited_group_ids)
+            )
+            logger.info(
+                "night_shift.autofix_rate_limited",
+                extra={**log_extra, "num_rate_limited": len(rate_limited_group_ids)},
+            )
 
     # TODO: have trigger_autofix_agent return the SeerRun directly to avoid this lookup.
     seer_run_by_state_id = {
@@ -235,7 +254,10 @@ def _process_verdicts(
         if v.action == TriageAction.AUTOFIX and not dry_run:
             state_id = state_id_by_group.get(v.group_id)
             if state_id is None:
-                extras["trigger_error"] = True
+                if v.group_id in rate_limited_group_ids:
+                    extras["rate_limited"] = True
+                else:
+                    extras["trigger_error"] = True
             else:
                 seer_run_id = str(state_id)
                 result_seer_run = seer_run_by_state_id.get(state_id)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -25,7 +25,11 @@ from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
 )
-from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
+from sentry.seer.autofix.utils import (
+    AutofixStoppingPoint,
+    bulk_read_preferences_from_sentry_db,
+    is_seer_autotriggered_autofix_rate_limited,
+)
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
@@ -498,6 +502,8 @@ def _get_eligible_projects(
             reasons.append("automation_tuning_off")
         if source == "cron" and not tweaks.enabled:
             reasons.append("tweaks_disabled")
+        if is_seer_autotriggered_autofix_rate_limited(project):
+            reasons.append("autofix_rate_limited")
         if stopping_point != AutofixStoppingPoint.OPEN_PR:
             # Night shift's only output is a PR, so a project that stops
             # short of open_pr can never produce a usable result.

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -29,6 +29,7 @@ from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     bulk_read_preferences_from_sentry_db,
     is_seer_autotriggered_autofix_rate_limited,
+    is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.models.night_shift import (
@@ -485,6 +486,9 @@ def _get_eligible_projects(
 
     preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
+    # Rate limit only applies to legacy org plans
+    check_rate_limit = not is_seer_seat_based_tier_enabled(organization)
+
     eligible: list[EligibleProject] = []
     for pid, project in project_map.items():
         pref = preferences.get(pid)
@@ -502,7 +506,7 @@ def _get_eligible_projects(
             reasons.append("automation_tuning_off")
         if source == "cron" and not tweaks.enabled:
             reasons.append("tweaks_disabled")
-        if is_seer_autotriggered_autofix_rate_limited(project):
+        if check_rate_limit and is_seer_autotriggered_autofix_rate_limited(project):
             reasons.append("autofix_rate_limited")
         if stopping_point != AutofixStoppingPoint.OPEN_PR:
             # Night shift's only output is a PR, so a project that stops

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -433,6 +433,63 @@ class TestDeliverNightShiftResult(TestCase):
         assert results[failing_group.id].extras["action"] == TriageAction.AUTOFIX.value
         assert results[failing_group.id].extras["trigger_error"] is True
 
+    def test_rate_limited_group_skips_trigger_and_continues_with_others(self) -> None:
+        """A group whose project is at the autotriggered-autofix rate limit
+        should not have autofix triggered, but other groups in the same
+        delivery should still go through."""
+        org = self.create_organization()
+        limited_project = self.create_project(organization=org, slug="limited")
+        ok_project = self.create_project(organization=org, slug="ok")
+        limited_group = self.create_group(project=limited_project)
+        ok_group = self.create_group(project=ok_project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {
+                    "group_id": limited_group.id,
+                    "action": TriageAction.AUTOFIX.value,
+                    "reason": "rate limited",
+                },
+                {
+                    "group_id": ok_group.id,
+                    "action": TriageAction.AUTOFIX.value,
+                    "reason": "will work",
+                },
+            ]
+        }
+
+        def rate_limited_side_effect(project, organization):
+            return project.id == limited_group.project_id
+
+        with (
+            patch(
+                "sentry.seer.night_shift.delivery.is_seer_autotriggered_autofix_rate_limited_and_increment",
+                side_effect=rate_limited_side_effect,
+            ),
+            patch(
+                "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=7
+            ) as mock_trigger,
+        ):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args.kwargs["group"].id == ok_group.id
+
+        results = {r.group_id: r for r in SeerNightShiftRunResult.objects.filter(run=run)}
+        assert set(results) == {limited_group.id, ok_group.id}
+        assert results[ok_group.id].seer_run_id == "7"
+        assert results[limited_group.id].seer_run_id is None
+        assert results[limited_group.id].extras["action"] == TriageAction.AUTOFIX.value
+        assert results[limited_group.id].extras["rate_limited"] is True
+        assert "trigger_error" not in results[limited_group.id].extras
+
     def test_unknown_group_ids_logged(self) -> None:
         """Groups not belonging to the org should be logged and skipped."""
         org = self.create_organization()

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -490,6 +490,46 @@ class TestDeliverNightShiftResult(TestCase):
         assert results[limited_group.id].extras["rate_limited"] is True
         assert "trigger_error" not in results[limited_group.id].extras
 
+    def test_seat_based_orgs_skip_the_rate_limit_check(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {"group_id": group.id, "action": TriageAction.AUTOFIX.value, "reason": "ok"}
+            ]
+        }
+
+        with (
+            patch(
+                "sentry.seer.night_shift.delivery.is_seer_autotriggered_autofix_rate_limited_and_increment",
+                return_value=True,
+            ) as mock_rate_limited,
+            patch(
+                "sentry.seer.night_shift.delivery.is_seer_seat_based_tier_enabled",
+                return_value=True,
+            ),
+            patch(
+                "sentry.seer.night_shift.delivery.trigger_autofix_agent", return_value=1
+            ) as mock_trigger,
+        ):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+        mock_rate_limited.assert_not_called()
+        mock_trigger.assert_called_once()
+
+        result_row = SeerNightShiftRunResult.objects.get(run=run)
+        assert result_row.seer_run_id == "1"
+        assert "rate_limited" not in result_row.extras
+
     def test_unknown_group_ids_logged(self) -> None:
         """Groups not belonging to the org should be logged and skipped."""
         org = self.create_organization()

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import patch
 
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models.night_shift import (
     SeerNightShiftRun,
@@ -459,7 +460,7 @@ class TestDeliverNightShiftResult(TestCase):
             ]
         }
 
-        def rate_limited_side_effect(project, organization):
+        def rate_limited_side_effect(project: Project, organization: Organization) -> bool:
             return project.id == limited_group.project_id
 
         with (

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -5,6 +5,7 @@ from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.issues.search import group_types_from
 from sentry.models.group import Group
 from sentry.models.organization import OrganizationStatus
+from sentry.models.project import Project
 from sentry.processing_errors.grouptype import LowValueSpanConfigurationType
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
@@ -439,7 +440,7 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         under_limit = self._make_eligible(self.create_project(organization=org, slug="under"))
         at_limit = self._make_eligible(self.create_project(organization=org, slug="at-limit"))
 
-        def fake_rate_limited(project):
+        def fake_rate_limited(project: Project) -> bool:
             return project.id == at_limit.id
 
         with (

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -460,6 +460,24 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         )
         assert at_limit_extra["reasons"] == ["autofix_rate_limited"]
 
+    def test_seat_based_orgs_skip_the_rate_limit_check(self) -> None:
+        org = self.create_organization()
+        at_limit = self._make_eligible(self.create_project(organization=org))
+
+        with (
+            patch(
+                "sentry.tasks.seer.night_shift.cron.is_seer_autotriggered_autofix_rate_limited",
+                return_value=True,
+            ),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.is_seer_seat_based_tier_enabled",
+                return_value=True,
+            ),
+        ):
+            result = _get_eligible_projects(org, "manual")
+
+        assert [ep.project for ep in result] == [at_limit]
+
 
 @django_db_all
 class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -432,6 +432,34 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
 
         assert [ep.project for ep in result] == [present]
 
+    def test_filters_projects_at_autofix_rate_limit(self) -> None:
+        """A project already at its autotriggered-autofix rate limit shouldn't
+        be triaged — the eventual autofix trigger would be rate limited anyway."""
+        org = self.create_organization()
+        under_limit = self._make_eligible(self.create_project(organization=org, slug="under"))
+        at_limit = self._make_eligible(self.create_project(organization=org, slug="at-limit"))
+
+        def fake_rate_limited(project):
+            return project.id == at_limit.id
+
+        with (
+            patch(
+                "sentry.tasks.seer.night_shift.cron.is_seer_autotriggered_autofix_rate_limited",
+                side_effect=fake_rate_limited,
+            ),
+            patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
+        ):
+            result = _get_eligible_projects(org, "manual")
+
+        assert [ep.project for ep in result] == [under_limit]
+
+        at_limit_extra = next(
+            call.kwargs["extra"]
+            for call in mock_logger.info.call_args_list
+            if call.kwargs["extra"]["project_id"] == at_limit.id
+        )
+        assert at_limit_extra["reasons"] == ["autofix_rate_limited"]
+
 
 @django_db_all
 class TestRunNightShiftForOrg(NightShiftFixtures, TestCase, SnubaTestCase):


### PR DESCRIPTION
Night shift's autofix trigger path never consulted the per-project autotriggered-autofix rate limit that the regular auto-run path already enforces. This became a real gap once night shift was opened up to legacy (non-seat-based) orgs, which had no other gate on autofix volume.

Adds the check in both places: a read-only check filters out already-limited projects during triage eligibility, and a check-and-increment guards each autofix trigger at delivery time, skipping just that group and recording it as `rate_limited` rather than a trigger error.