### PR TITLE
feat(pr-metrics): Add reviews_requested_count to scm.pr.closed

### DIFF
--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -75,6 +75,16 @@ class PrCloseMetricsEvent(analytics.Event):
     # so a requested-but-unreviewed PR doesn't look identical to one nobody was
     # ever asked to review.
     reviews_requested_count: int = 0
+    # Every REVIEW_SUBMITTED tallied by its GitHub review state — JSON-encoded
+    # {"approved": int, "changes_requested": int, "commented": int}, all three
+    # keys always present (0 default) on an emitted row. A reviewer who submits
+    # twice counts twice, same as reviews_count, which the three values sum to.
+    # Activity-derived and unpersisted, like reviews_requested_count above (see
+    # emit.review_activity). GitHub-only: this pipeline doesn't track GitLab
+    # reviews, so every count is 0 for a GitLab-hosted PR — same as every other
+    # activity-derived counter when activity isn't tracked. "{}" is only the
+    # dataclass default, never an emitted value.
+    review_results: str = "{}"
     # Pushes (opened + synchronize events) split by the pusher's account class. A
     # push, not a commit: GitHub's synchronize payload carries no commit count, so
     # this counts push events, with a bot-app push attributed to the bot.

--- a/src/sentry/analytics/events/pr_metrics_events.py
+++ b/src/sentry/analytics/events/pr_metrics_events.py
@@ -69,6 +69,12 @@ class PrCloseMetricsEvent(analytics.Event):
     # Reviews split by the reviewer's account class; the two sum to reviews_count.
     reviews_bot_count: int = 0
     reviews_human_count: int = 0
+    # Net outstanding review requests at the terminal event (REVIEW_REQUESTED
+    # minus REVIEW_REQUEST_REMOVED, floored at 0). Distinct from reviews_count:
+    # this answers "was a review ever asked for", not "was one ever submitted",
+    # so a requested-but-unreviewed PR doesn't look identical to one nobody was
+    # ever asked to review.
+    reviews_requested_count: int = 0
     # Pushes (opened + synchronize events) split by the pusher's account class. A
     # push, not a commit: GitHub's synchronize payload carries no commit count, so
     # this counts push events, with a bot-app push attributed to the bot.

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -505,7 +505,7 @@ def reviews_requested_count_from_doc(doc: ActivityDoc) -> int:
     Not part of ``derived_metrics_from_doc``'s persisted-counters dict — unlike
     ``reviews_count`` and friends, nothing downstream re-reads this off
     ``PullRequestMetrics`` after emission, so it's read straight from the doc at
-    emit time (see ``emit.reviews_requested_count``) rather than written through
+    emit time (see ``emit.review_activity``) rather than written through
     to the model.
 
     Both counts come from ``counts`` (not the ``events`` list) so the total
@@ -519,6 +519,37 @@ def reviews_requested_count_from_doc(doc: ActivityDoc) -> int:
     requested = counts.get(PullRequestActivityType.REVIEW_REQUESTED, 0)
     removed = counts.get(PullRequestActivityType.REVIEW_REQUEST_REMOVED, 0)
     return max(requested - removed, 0)
+
+
+# GitHub's review-submission vocabulary — mirrors emit.REVIEW_STATES. Duplicated
+# rather than imported to avoid a circular import (emit.py imports this module).
+_REVIEW_STATES = ("approved", "changes_requested", "commented")
+
+
+def review_activity_from_doc(doc: ActivityDoc) -> dict[str, Any]:
+    """Review-submission facts, projected from the document: the same shape as
+    ``emit.review_activity``, returned as a plain dict for that function to
+    wrap into its ``ReviewActivity`` NamedTuple.
+
+    ``requested_count`` reuses ``reviews_requested_count_from_doc`` (from
+    ``counts``, cap-surviving). ``results`` tallies each ``REVIEW_SUBMITTED``
+    entry's ``review_state`` from the stored entries — like the bot/human
+    splits in ``derived_metrics_from_doc``, this is *not* cap-surviving (no
+    per-state totals are kept in ``counts``), so a PR past the events cap
+    undercounts here the same way it already does for
+    ``reviews_bot_count``/``reviews_human_count``.
+    """
+    results: Counter[str] = Counter()
+    for event in doc.get("events", []):
+        if event["event_type"] != PullRequestActivityType.REVIEW_SUBMITTED:
+            continue
+        review_state = (event.get("payload") or {}).get("review_state")
+        if review_state in _REVIEW_STATES:
+            results[review_state] += 1
+    return {
+        "requested_count": reviews_requested_count_from_doc(doc),
+        "results": {state: results[state] for state in _REVIEW_STATES},
+    }
 
 
 def derived_metrics_from_doc(doc: ActivityDoc) -> dict[str, Any]:

--- a/src/sentry/pr_metrics/activity_doc.py
+++ b/src/sentry/pr_metrics/activity_doc.py
@@ -498,6 +498,29 @@ def _bot_human_counts(
     return counts
 
 
+def reviews_requested_count_from_doc(doc: ActivityDoc) -> int:
+    """Net outstanding review requests: ``REVIEW_REQUESTED`` minus
+    ``REVIEW_REQUEST_REMOVED``, floored at 0.
+
+    Not part of ``derived_metrics_from_doc``'s persisted-counters dict — unlike
+    ``reviews_count`` and friends, nothing downstream re-reads this off
+    ``PullRequestMetrics`` after emission, so it's read straight from the doc at
+    emit time (see ``emit.reviews_requested_count``) rather than written through
+    to the model.
+
+    Both counts come from ``counts`` (not the ``events`` list) so the total
+    survives the events cap the same way ``reviews_count`` does. Floored
+    because a removal can't be matched to which earlier request it revoked —
+    e.g. a second reviewer's request outliving the first's removal — so the
+    net can't go negative; 0 just means "no request outstanding", not "one too
+    many removals".
+    """
+    counts = doc.get("counts", {})
+    requested = counts.get(PullRequestActivityType.REVIEW_REQUESTED, 0)
+    removed = counts.get(PullRequestActivityType.REVIEW_REQUEST_REMOVED, 0)
+    return max(requested - removed, 0)
+
+
 def derived_metrics_from_doc(doc: ActivityDoc) -> dict[str, Any]:
     """The activity-derived counters, projected from the document.
 

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from enum import Enum
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from django.db.models import Count, Q
 
@@ -46,6 +46,36 @@ from sentry.seer.models.run import SeerRun
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
+
+# GitHub's review-submission vocabulary (a "submitted" pull_request_review
+# action's review.state) — see ReviewSubmittedPayload.review_state. Always
+# emitted with all three keys present (0 for a state never seen), rather than
+# sparse, so a consumer doesn't need to coalesce missing keys itself. GitLab
+# reviews aren't tracked by this pipeline at all (see webhooks.py), so these
+# are GitHub-only today.
+REVIEW_STATES = ("approved", "changes_requested", "commented")
+
+
+class ReviewActivity(NamedTuple):
+    """Review-submission facts read live off activity at emit time (see
+    ``review_activity``), never persisted onto ``PullRequestMetrics``.
+
+    ``requested_count``: net outstanding review requests (``REVIEW_REQUESTED``
+    minus ``REVIEW_REQUEST_REMOVED``, floored at 0). Distinct from
+    ``reviews_count``: that only says whether a review was ever *submitted*, so
+    a PR with reviewers requested but never actioned looks identical to one
+    nobody was ever asked to review. Floored at 0 because a removal can't be
+    matched to which earlier request it revoked — e.g. a second reviewer's
+    request outliving the first's removal — so the net can't go negative.
+
+    ``results``: every ``REVIEW_SUBMITTED`` tallied by its ``review_state``
+    (``REVIEW_STATES``), each key always present (0 default). A reviewer who
+    submits twice counts twice, same as ``reviews_count``; the three values sum
+    to ``reviews_count``.
+    """
+
+    requested_count: int
+    results: dict[str, int]
 
 
 class VerdictDeferral(Enum):
@@ -229,33 +259,40 @@ def ci_failing_at_close(pull_request: PullRequest) -> bool:
     )
 
 
-def reviews_requested_count(pull_request: PullRequest) -> int:
-    """Net outstanding review requests at the PR's terminal event:
-    ``REVIEW_REQUESTED`` minus ``REVIEW_REQUEST_REMOVED``, floored at 0.
+def review_activity(pull_request: PullRequest) -> ReviewActivity:
+    """Review-submission facts read live off activity at emit time — never
+    persisted onto ``PullRequestMetrics`` like ``reviews_count`` and its
+    siblings, since every current caller of ``build_pr_metrics_row`` runs
+    before that PR's activity is swept (``cleanup_pr_activity_task`` is only
+    ever enqueued from inside a successful ``emit_pr_metrics_row``, and each PR
+    is only emitted once), so there's no "later re-derivation" that would need
+    a persisted copy. See ``ReviewActivity`` for what each field means.
 
-    Distinct from ``PullRequestMetrics.reviews_count``: that only says whether a
-    review was ever *submitted*, so a PR with reviewers requested but never
-    actioned looks identical to one nobody was ever asked to review. Floored at
-    0 because a removal can't be matched to which earlier request it revoked —
-    e.g. a second reviewer's request outliving the first's removal — so the net
-    can't go negative.
-
-    Read directly off the activity store at emit time rather than written
-    through to ``PullRequestMetrics`` like ``reviews_count`` and its siblings:
-    every current caller of ``build_pr_metrics_row`` runs before that PR's
-    activity is swept (``cleanup_pr_activity_task`` is only ever enqueued from
-    inside a successful ``emit_pr_metrics_row``, and each PR is only emitted
-    once), so there's no "later re-derivation" that would need a persisted copy.
+    A single conditional aggregate does all the bucketing in Postgres — no rows
+    cross into Python — rather than pulling every row over to count client-side.
     """
     doc = load_activity_document(pull_request)
     if doc is not None:
-        return activity_doc.reviews_requested_count_from_doc(doc)
+        return ReviewActivity(**activity_doc.review_activity_from_doc(doc))
 
     counts = PullRequestActivity.objects.filter(pull_request=pull_request).aggregate(
         requested=Count("id", filter=Q(event_type=PullRequestActivityType.REVIEW_REQUESTED)),
         removed=Count("id", filter=Q(event_type=PullRequestActivityType.REVIEW_REQUEST_REMOVED)),
+        **{
+            state: Count(
+                "id",
+                filter=Q(
+                    event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+                    payload__review_state=state,
+                ),
+            )
+            for state in REVIEW_STATES
+        },
     )
-    return max(counts["requested"] - counts["removed"], 0)
+    return ReviewActivity(
+        requested_count=max(counts["requested"] - counts["removed"], 0),
+        results={state: counts[state] for state in REVIEW_STATES},
+    )
 
 
 def calculate_deterministic_diagnosis_labels(
@@ -462,6 +499,9 @@ def build_pr_metrics_row(
     metrics = (
         PullRequestMetrics.objects.filter(pull_request=pull_request).first() or PullRequestMetrics()
     )
+    # Read once so requested_count and results (both unpersisted) come from the
+    # same activity snapshot rather than two separate reads.
+    review = review_activity(pull_request)
 
     return PrCloseMetricsEvent(
         organization_id=pull_request.organization_id,
@@ -490,7 +530,8 @@ def build_pr_metrics_row(
         reviews_count=metrics.reviews_count,
         reviews_bot_count=metrics.reviews_bot_count,
         reviews_human_count=metrics.reviews_human_count,
-        reviews_requested_count=reviews_requested_count(pull_request),
+        reviews_requested_count=review.requested_count,
+        review_results=json.dumps(review.results),
         pushes_bot_count=metrics.pushes_bot_count,
         pushes_human_count=metrics.pushes_human_count,
         opened_by_bot=metrics.opened_by_bot,

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -227,6 +227,46 @@ def ci_failing_at_close(pull_request: PullRequest) -> bool:
     )
 
 
+def reviews_requested_count(pull_request: PullRequest) -> int:
+    """Net outstanding review requests at the PR's terminal event:
+    ``REVIEW_REQUESTED`` minus ``REVIEW_REQUEST_REMOVED``, floored at 0.
+
+    Distinct from ``PullRequestMetrics.reviews_count``: that only says whether a
+    review was ever *submitted*, so a PR with reviewers requested but never
+    actioned looks identical to one nobody was ever asked to review. Floored at
+    0 because a removal can't be matched to which earlier request it revoked —
+    e.g. a second reviewer's request outliving the first's removal — so the net
+    can't go negative.
+
+    Read directly off the activity store at emit time rather than written
+    through to ``PullRequestMetrics`` like ``reviews_count`` and its siblings:
+    every current caller of ``build_pr_metrics_row`` runs before that PR's
+    activity is swept (``cleanup_pr_activity_task`` is only ever enqueued from
+    inside a successful ``emit_pr_metrics_row``, and each PR is only emitted
+    once), so there's no "later re-derivation" that would need a persisted copy.
+    """
+    doc = load_activity_document(pull_request)
+    if doc is not None:
+        return activity_doc.reviews_requested_count_from_doc(doc)
+
+    rows = list(
+        PullRequestActivity.objects.filter(
+            pull_request=pull_request,
+            event_type__in=(
+                PullRequestActivityType.REVIEW_REQUESTED,
+                PullRequestActivityType.REVIEW_REQUEST_REMOVED,
+            ),
+        ).values_list("event_type", flat=True)
+    )
+    requested = sum(
+        1 for event_type in rows if event_type == PullRequestActivityType.REVIEW_REQUESTED
+    )
+    removed = sum(
+        1 for event_type in rows if event_type == PullRequestActivityType.REVIEW_REQUEST_REMOVED
+    )
+    return max(requested - removed, 0)
+
+
 def calculate_deterministic_diagnosis_labels(
     pull_request: PullRequest, verdict: PullRequestVerdict | None
 ) -> list[str] | None:
@@ -459,6 +499,7 @@ def build_pr_metrics_row(
         reviews_count=metrics.reviews_count,
         reviews_bot_count=metrics.reviews_bot_count,
         reviews_human_count=metrics.reviews_human_count,
+        reviews_requested_count=reviews_requested_count(pull_request),
         pushes_bot_count=metrics.pushes_bot_count,
         pushes_human_count=metrics.pushes_human_count,
         opened_by_bot=metrics.opened_by_bot,

--- a/src/sentry/pr_metrics/emit.py
+++ b/src/sentry/pr_metrics/emit.py
@@ -12,6 +12,8 @@ from collections.abc import Sequence
 from enum import Enum
 from typing import Any, cast
 
+from django.db.models import Count, Q
+
 from sentry import analytics
 from sentry.analytics.events.pr_metrics_events import PrCloseMetricsEvent
 from sentry.models.commit import Commit
@@ -249,22 +251,11 @@ def reviews_requested_count(pull_request: PullRequest) -> int:
     if doc is not None:
         return activity_doc.reviews_requested_count_from_doc(doc)
 
-    rows = list(
-        PullRequestActivity.objects.filter(
-            pull_request=pull_request,
-            event_type__in=(
-                PullRequestActivityType.REVIEW_REQUESTED,
-                PullRequestActivityType.REVIEW_REQUEST_REMOVED,
-            ),
-        ).values_list("event_type", flat=True)
+    counts = PullRequestActivity.objects.filter(pull_request=pull_request).aggregate(
+        requested=Count("id", filter=Q(event_type=PullRequestActivityType.REVIEW_REQUESTED)),
+        removed=Count("id", filter=Q(event_type=PullRequestActivityType.REVIEW_REQUEST_REMOVED)),
     )
-    requested = sum(
-        1 for event_type in rows if event_type == PullRequestActivityType.REVIEW_REQUESTED
-    )
-    removed = sum(
-        1 for event_type in rows if event_type == PullRequestActivityType.REVIEW_REQUEST_REMOVED
-    )
-    return max(requested - removed, 0)
+    return max(counts["requested"] - counts["removed"], 0)
 
 
 def calculate_deterministic_diagnosis_labels(

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -28,6 +28,7 @@ from sentry.pr_metrics.activity_doc import (
     human_participant_count,
     is_failing_conclusion,
     new_document,
+    reviews_requested_count_from_doc,
     timeline_events_from_doc,
 )
 
@@ -878,6 +879,24 @@ def test_derived_metrics_empty_doc() -> None:
         "closed_by_bot": None,
         "opened_and_closed_by_same_actor": None,
     }
+
+
+def test_reviews_requested_count_from_doc_nets_removals() -> None:
+    doc = new_document()
+    doc["counts"] = {"review_requested": 3, "review_request_removed": 1}
+    assert reviews_requested_count_from_doc(doc) == 2
+
+
+def test_reviews_requested_count_from_doc_floors_at_zero() -> None:
+    # More removals than requests can't be matched 1:1 (e.g. a second
+    # reviewer's outstanding request), so the net never goes negative.
+    doc = new_document()
+    doc["counts"] = {"review_requested": 1, "review_request_removed": 3}
+    assert reviews_requested_count_from_doc(doc) == 0
+
+
+def test_reviews_requested_count_from_doc_empty() -> None:
+    assert reviews_requested_count_from_doc(new_document()) == 0
 
 
 def test_commit_shas_from_doc_normal_chain() -> None:

--- a/tests/sentry/pr_metrics/test_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_activity_doc.py
@@ -28,6 +28,7 @@ from sentry.pr_metrics.activity_doc import (
     human_participant_count,
     is_failing_conclusion,
     new_document,
+    review_activity_from_doc,
     reviews_requested_count_from_doc,
     timeline_events_from_doc,
 )
@@ -897,6 +898,56 @@ def test_reviews_requested_count_from_doc_floors_at_zero() -> None:
 
 def test_reviews_requested_count_from_doc_empty() -> None:
     assert reviews_requested_count_from_doc(new_document()) == 0
+
+
+def test_review_activity_from_doc_tallies_results() -> None:
+    doc = new_document()
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+        webhook_id="r1",
+        review_state="approved",
+    )
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+        webhook_id="r2",
+        review_state="approved",
+    )
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+        webhook_id="r3",
+        review_state="commented",
+    )
+    assert review_activity_from_doc(doc) == {
+        "requested_count": 0,
+        "results": {"approved": 2, "changes_requested": 0, "commented": 1},
+    }
+
+
+def test_review_activity_from_doc_ignores_unrecognized_state() -> None:
+    doc = new_document()
+    # A review_dismissed row (or any future/unmapped state) contributes
+    # nothing rather than erroring or padding an unexpected key.
+    _entry(
+        doc,
+        event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+        webhook_id="r1",
+        review_state="dismissed",
+    )
+    assert review_activity_from_doc(doc)["results"] == {
+        "approved": 0,
+        "changes_requested": 0,
+        "commented": 0,
+    }
+
+
+def test_review_activity_from_doc_empty() -> None:
+    assert review_activity_from_doc(new_document()) == {
+        "requested_count": 0,
+        "results": {"approved": 0, "changes_requested": 0, "commented": 0},
+    }
 
 
 def test_commit_shas_from_doc_normal_chain() -> None:

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -26,7 +26,7 @@ from sentry.pr_metrics.emit import (
     emit_pr_metrics_row,
     is_pr_tracked,
     resolve_autofix_referrers,
-    reviews_requested_count,
+    review_activity,
     select_fallback_verdict,
     select_verdict,
 )
@@ -166,6 +166,14 @@ class PrMetricsEmissionTest(TestCase):
             payload={},
         )
 
+    def _add_review(self, *, webhook_id: str, review_state: str) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+            payload={"review_state": review_state},
+        )
+
     def test_select_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         # Merged with no SYNCHRONIZED activity: merge head == opened head.
         assert (
@@ -296,19 +304,47 @@ class PrMetricsEmissionTest(TestCase):
         assert ci_failing_at_close(self.pull_request) is True
 
     def test_reviews_requested_count_no_activity_is_zero(self) -> None:
-        assert reviews_requested_count(self.pull_request) == 0
+        assert review_activity(self.pull_request).requested_count == 0
 
     def test_reviews_requested_count_nets_removals(self) -> None:
         self._add_review_request(webhook_id="rr1")
         self._add_review_request(webhook_id="rr2")
         self._add_review_request(webhook_id="rr3", removed=True)
-        assert reviews_requested_count(self.pull_request) == 1  # 2 requested - 1 removed
+        assert review_activity(self.pull_request).requested_count == 1  # 2 requested - 1 removed
 
     def test_reviews_requested_count_floors_at_zero(self) -> None:
         # More removals than requests can't be matched 1:1 (e.g. a second
         # reviewer's outstanding request), so the net never goes negative.
         self._add_review_request(webhook_id="rr1", removed=True)
-        assert reviews_requested_count(self.pull_request) == 0
+        assert review_activity(self.pull_request).requested_count == 0
+
+    def test_review_results_no_activity_is_all_zero(self) -> None:
+        assert review_activity(self.pull_request).results == {
+            "approved": 0,
+            "changes_requested": 0,
+            "commented": 0,
+        }
+
+    def test_review_results_tallies_each_state(self) -> None:
+        self._add_review(webhook_id="r1", review_state="approved")
+        self._add_review(webhook_id="r2", review_state="approved")
+        self._add_review(webhook_id="r3", review_state="changes_requested")
+        self._add_review(webhook_id="r4", review_state="commented")
+        assert review_activity(self.pull_request).results == {
+            "approved": 2,
+            "changes_requested": 1,
+            "commented": 1,
+        }
+
+    def test_review_results_ignores_unrecognized_state(self) -> None:
+        # A review_dismissed row (or any future/unmapped state) contributes
+        # nothing rather than erroring or padding an unexpected key.
+        self._add_review(webhook_id="r1", review_state="dismissed")
+        assert review_activity(self.pull_request).results == {
+            "approved": 0,
+            "changes_requested": 0,
+            "commented": 0,
+        }
 
     def test_select_fallback_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         assert select_fallback_verdict(self.pull_request) == PullRequestVerdict.MERGED_UNCHANGED
@@ -370,6 +406,24 @@ class PrMetricsEmissionTest(TestCase):
             group_ids=[],
         )
         assert row.reviews_requested_count == 1
+
+    def test_build_row_carries_review_results(self) -> None:
+        # Like reviews_requested_count, review_results is read live from
+        # activity at build time (never persisted), JSON-encoded on the row.
+        self._add_review(webhook_id="r1", review_state="approved")
+        self._add_review(webhook_id="r2", review_state="changes_requested")
+        self._add_review(webhook_id="r3", review_state="changes_requested")
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert json.loads(row.review_results) == {
+            "approved": 1,
+            "changes_requested": 2,
+            "commented": 0,
+        }
 
     def test_build_row_carries_repository_provider(self) -> None:
         # setUp's repo is created with the prefixed "integrations:github" form —
@@ -838,6 +892,7 @@ class PrMetricsEmissionTest(TestCase):
                 review_comments_count=6,
                 is_assigned=True,
                 attributions=json.dumps([SENTRY_APP_ATTRIBUTION]),
+                review_results=json.dumps({"approved": 0, "changes_requested": 0, "commented": 0}),
             ),
         )
 
@@ -1054,6 +1109,13 @@ class PrMetricsEmissionTest(TestCase):
         assert emitted.reviews_human_count == 1
         assert emitted.reviews_requested_count == 1
         assert emitted.opened_and_closed_by_same_actor is True
+        # review_results is also read live, not persisted; the review above
+        # carries no review_state, so no state key is incremented.
+        assert json.loads(emitted.review_results) == {
+            "approved": 0,
+            "changes_requested": 0,
+            "commented": 0,
+        }
 
     # --- _commit_shas_from_activity ---
 

--- a/tests/sentry/pr_metrics/test_emit.py
+++ b/tests/sentry/pr_metrics/test_emit.py
@@ -26,6 +26,7 @@ from sentry.pr_metrics.emit import (
     emit_pr_metrics_row,
     is_pr_tracked,
     resolve_autofix_referrers,
+    reviews_requested_count,
     select_fallback_verdict,
     select_verdict,
 )
@@ -151,6 +152,18 @@ class PrMetricsEmissionTest(TestCase):
             webhook_id=webhook_id,
             event_type=PullRequestActivityType.CHECK_SUITE_COMPLETED,
             payload={"conclusion": conclusion, "app_slug": app_slug, "check_runs_count": 1},
+        )
+
+    def _add_review_request(self, *, webhook_id: str, removed: bool = False) -> None:
+        PullRequestActivity.objects.create(
+            pull_request=self.pull_request,
+            webhook_id=webhook_id,
+            event_type=(
+                PullRequestActivityType.REVIEW_REQUEST_REMOVED
+                if removed
+                else PullRequestActivityType.REVIEW_REQUESTED
+            ),
+            payload={},
         )
 
     def test_select_verdict_merged_without_later_commits_is_unchanged(self) -> None:
@@ -282,6 +295,21 @@ class PrMetricsEmissionTest(TestCase):
         self._add_check_suite(app_slug="github-actions", conclusion="failure", webhook_id="check-2")
         assert ci_failing_at_close(self.pull_request) is True
 
+    def test_reviews_requested_count_no_activity_is_zero(self) -> None:
+        assert reviews_requested_count(self.pull_request) == 0
+
+    def test_reviews_requested_count_nets_removals(self) -> None:
+        self._add_review_request(webhook_id="rr1")
+        self._add_review_request(webhook_id="rr2")
+        self._add_review_request(webhook_id="rr3", removed=True)
+        assert reviews_requested_count(self.pull_request) == 1  # 2 requested - 1 removed
+
+    def test_reviews_requested_count_floors_at_zero(self) -> None:
+        # More removals than requests can't be matched 1:1 (e.g. a second
+        # reviewer's outstanding request), so the net never goes negative.
+        self._add_review_request(webhook_id="rr1", removed=True)
+        assert reviews_requested_count(self.pull_request) == 0
+
     def test_select_fallback_verdict_merged_without_later_commits_is_unchanged(self) -> None:
         assert select_fallback_verdict(self.pull_request) == PullRequestVerdict.MERGED_UNCHANGED
 
@@ -328,6 +356,20 @@ class PrMetricsEmissionTest(TestCase):
         assert row.comments_count == 5
         assert row.review_comments_count == 6
         assert row.is_assigned is True
+
+    def test_build_row_carries_reviews_requested_count(self) -> None:
+        # Unlike the other counters (persisted onto PullRequestMetrics),
+        # reviews_requested_count is read live from activity at build time.
+        self._add_review_request(webhook_id="rr1")
+        self._add_review_request(webhook_id="rr2")
+        self._add_review_request(webhook_id="rr3", removed=True)
+        row = build_pr_metrics_row(
+            pull_request=self.pull_request,
+            close_action="merged",
+            attributions=[],
+            group_ids=[],
+        )
+        assert row.reviews_requested_count == 1
 
     def test_build_row_carries_repository_provider(self) -> None:
         # setUp's repo is created with the prefixed "integrations:github" form —
@@ -982,11 +1024,16 @@ class PrMetricsEmissionTest(TestCase):
         )
         self._activity(
             webhook_id="c2",
+            event_type=PullRequestActivityType.REVIEW_REQUESTED,
+            sender_login="octocat",
+        )
+        self._activity(
+            webhook_id="c3",
             event_type=PullRequestActivityType.REVIEW_SUBMITTED,
             sender_login="reviewer",
         )
         self._activity(
-            webhook_id="c3", event_type=PullRequestActivityType.MERGED, sender_login="octocat"
+            webhook_id="c4", event_type=PullRequestActivityType.MERGED, sender_login="octocat"
         )
         emit_pr_metrics_row(pull_request=self.pull_request)
 
@@ -999,11 +1046,13 @@ class PrMetricsEmissionTest(TestCase):
         assert row.opened_by_bot is False
         assert row.closed_by_bot is False
         assert row.opened_and_closed_by_same_actor is True
-        # ...and carried on the emitted analytics row.
+        # ...and carried on the emitted analytics row. reviews_requested_count is
+        # read live from activity rather than persisted, so it only shows up here.
         emitted = mock_record.call_args[0][0]
         assert emitted.participants_count == 2
         assert emitted.reviews_count == 1
         assert emitted.reviews_human_count == 1
+        assert emitted.reviews_requested_count == 1
         assert emitted.opened_and_closed_by_same_actor is True
 
     # --- _commit_shas_from_activity ---

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -27,6 +27,7 @@ from sentry.pr_metrics.emit import (
     VerdictDeferral,
     _activity_derived_metrics,
     ci_failing_at_close,
+    reviews_requested_count,
     select_fallback_verdict,
     select_verdict,
 )
@@ -174,6 +175,35 @@ class ActivityDocumentReadersTest(TestCase):
     def test_ci_not_failing_at_close_from_doc(self) -> None:
         self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="success")}))
         assert ci_failing_at_close(self.pr) is False
+
+    # --- reviews_requested_count -------------------------------------------
+
+    def test_reviews_requested_count_from_doc(self) -> None:
+        self._write_doc(_doc(counts={"review_requested": 3, "review_request_removed": 1}))
+        assert reviews_requested_count(self.pr) == 2
+
+    def test_reviews_requested_count_from_legacy_rows(self) -> None:
+        # No PullRequestActivityLog row → routes to the legacy PullRequestActivity
+        # rows instead of the doc.
+        PullRequestActivity.objects.create(
+            pull_request=self.pr,
+            webhook_id="rr1",
+            event_type=PullRequestActivityType.REVIEW_REQUESTED,
+            payload={},
+        )
+        PullRequestActivity.objects.create(
+            pull_request=self.pr,
+            webhook_id="rr2",
+            event_type=PullRequestActivityType.REVIEW_REQUESTED,
+            payload={},
+        )
+        PullRequestActivity.objects.create(
+            pull_request=self.pr,
+            webhook_id="rr3",
+            event_type=PullRequestActivityType.REVIEW_REQUEST_REMOVED,
+            payload={},
+        )
+        assert reviews_requested_count(self.pr) == 1
 
     # --- resolved_group_ids -----------------------------------------------
 

--- a/tests/sentry/pr_metrics/test_readers_activity_doc.py
+++ b/tests/sentry/pr_metrics/test_readers_activity_doc.py
@@ -27,7 +27,7 @@ from sentry.pr_metrics.emit import (
     VerdictDeferral,
     _activity_derived_metrics,
     ci_failing_at_close,
-    reviews_requested_count,
+    review_activity,
     select_fallback_verdict,
     select_verdict,
 )
@@ -176,11 +176,11 @@ class ActivityDocumentReadersTest(TestCase):
         self._write_doc(_doc(checks={"sha1|github-actions": _group(suite_conclusion="success")}))
         assert ci_failing_at_close(self.pr) is False
 
-    # --- reviews_requested_count -------------------------------------------
+    # --- review_activity (requested_count, results) -------------------------
 
     def test_reviews_requested_count_from_doc(self) -> None:
         self._write_doc(_doc(counts={"review_requested": 3, "review_request_removed": 1}))
-        assert reviews_requested_count(self.pr) == 2
+        assert review_activity(self.pr).requested_count == 2
 
     def test_reviews_requested_count_from_legacy_rows(self) -> None:
         # No PullRequestActivityLog row → routes to the legacy PullRequestActivity
@@ -203,7 +203,37 @@ class ActivityDocumentReadersTest(TestCase):
             event_type=PullRequestActivityType.REVIEW_REQUEST_REMOVED,
             payload={},
         )
-        assert reviews_requested_count(self.pr) == 1
+        assert review_activity(self.pr).requested_count == 1
+
+    def test_review_results_from_doc(self) -> None:
+        self._write_doc(
+            _doc(
+                events=[
+                    _entry("review_submitted", "r1", review_state="approved"),
+                    _entry("review_submitted", "r2", review_state="changes_requested"),
+                ]
+            )
+        )
+        assert review_activity(self.pr).results == {
+            "approved": 1,
+            "changes_requested": 1,
+            "commented": 0,
+        }
+
+    def test_review_results_from_legacy_rows(self) -> None:
+        # No PullRequestActivityLog row → routes to the legacy PullRequestActivity
+        # rows instead of the doc.
+        PullRequestActivity.objects.create(
+            pull_request=self.pr,
+            webhook_id="r1",
+            event_type=PullRequestActivityType.REVIEW_SUBMITTED,
+            payload={"review_state": "commented"},
+        )
+        assert review_activity(self.pr).results == {
+            "approved": 0,
+            "changes_requested": 0,
+            "commented": 1,
+        }
 
     # --- resolved_group_ids -----------------------------------------------
 


### PR DESCRIPTION
Adds reviews_requested_count to the scm.pr.closed analytics event: net outstanding review requests at the PR's terminal event (REVIEW_REQUESTED minus REVIEW_REQUEST_REMOVED, floored at 0).

reviews_count only tells us whether a review was submitted, so a PR with reviewers requested but never actioned looks identical to one nobody was ever asked to review. This field distinguishes those two cases.
