### PR TITLE
feat(flags): Register SCM project creation flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -181,6 +181,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding-scm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM onboarding A/B test measuring conversion impact
     manager.add("organizations:onboarding-scm-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable SCM-first project creation flow
+    manager.add("organizations:onboarding-scm-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM onboarding project details A/B test
     manager.add("organizations:onboarding-scm-project-details-experiment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Experiment: SCM-first project creation wizard A/B test (project creation flow, not new-org onboarding)


### PR DESCRIPTION
## TLDR

Registers the regular SCM project-creation feature alongside the existing experiment, allowing frontend deployments to switch gates without encountering an unregistered flag.

## Details

This PR only adds the backend registration required before the frontend cutover; it deliberately leaves the experiment registration intact. `organizations:onboarding-scm-project-creation` uses the existing organization-scoped Flagpole strategy and remains API-exposed so `organization.features` can gate the project-creation view.

The matching Flagpole configuration is tracked in [sentry-options-automator#8823](https://github.com/getsentry/sentry-options-automator/pull/8823). The frontend adoption is stacked in [#120351](https://github.com/getsentry/sentry/pull/120351), while eventual removal of the experiment remains deferred.

Refs [VDY-136](https://linear.app/getsentry/issue/VDY-136/convert-onboarding-scm-project-creation-experiment-to-a-regular)
