### PR TITLE
ref(project-creation): Replace SCM experiment gate

### DIFF
--- a/static/app/views/projectInstall/newProject.spec.tsx
+++ b/static/app/views/projectInstall/newProject.spec.tsx
@@ -1,32 +1,33 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import NewProject from 'sentry/views/projectInstall/newProject';
 
-describe('NewProjectPlatform', () => {
-  const organization = OrganizationFixture();
-  const integrations = [
-    OrganizationIntegrationsFixture({
-      name: "Moo Deng's Workspace",
-      status: 'active',
-    }),
-  ];
+jest.mock('sentry/views/projectInstall/createProject', () => ({
+  CreateProject: () => <div>Legacy project creation</div>,
+}));
 
-  beforeEach(() => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/`,
-      body: integrations,
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+jest.mock('sentry/views/projectInstall/scmCreateProject', () => ({
+  ScmCreateProject: () => <div>SCM project creation</div>,
+}));
+
+describe('NewProject', () => {
+  it('renders the legacy flow when SCM project creation is disabled', () => {
+    render(<NewProject />, {organization: OrganizationFixture({features: []})});
+
+    expect(screen.getByText('Legacy project creation')).toBeInTheDocument();
+    expect(screen.queryByText('SCM project creation')).not.toBeInTheDocument();
+  });
+
+  it('renders the SCM flow when SCM project creation is enabled', () => {
+    render(<NewProject />, {
+      organization: OrganizationFixture({
+        features: ['onboarding-scm-project-creation'],
+      }),
     });
-  });
 
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
-  it('should render', () => {
-    render(<NewProject />);
+    expect(screen.getByText('SCM project creation')).toBeInTheDocument();
+    expect(screen.queryByText('Legacy project creation')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/projectInstall/newProject.tsx
+++ b/static/app/views/projectInstall/newProject.tsx
@@ -3,16 +3,16 @@ import styled from '@emotion/styled';
 import {Stack} from '@sentry/scraps/layout';
 
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {useExperiment} from 'sentry/utils/useExperiment';
+import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {CreateProject} from './createProject';
 import {ScmCreateProject} from './scmCreateProject';
 
 function NewProject() {
-  const {inExperiment: hasScmProjectCreation} = useExperiment({
-    feature: 'onboarding-scm-project-creation-experiment',
-    reportExposure: true,
-  });
+  const organization = useOrganization();
+  const hasScmProjectCreation = organization.features.includes(
+    'onboarding-scm-project-creation'
+  );
 
   if (hasScmProjectCreation) {
     return <ScmCreateProject />;

--- a/static/app/views/projectInstall/scmCreateProjectSession.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProjectSession.spec.tsx
@@ -47,7 +47,7 @@ describe('useScmCreateProjectProductSync', () => {
     const {result} = renderHookWithProviders(
       () => useScmCreateProjectProductSync(project),
       {
-        organization: {features: ['onboarding-scm-project-creation-experiment']},
+        organization: {features: ['onboarding-scm-project-creation']},
       }
     );
 
@@ -63,7 +63,7 @@ describe('useScmCreateProjectProductSync', () => {
     const {result} = renderHookWithProviders(
       () => useScmCreateProjectProductSync(project),
       {
-        organization: {features: ['onboarding-scm-project-creation-experiment']},
+        organization: {features: ['onboarding-scm-project-creation']},
       }
     );
 
@@ -90,20 +90,20 @@ describe('useScmCreateProjectProductSync', () => {
     const {result} = renderHookWithProviders(
       () => useScmCreateProjectProductSync(project),
       {
-        organization: {features: ['onboarding-scm-project-creation-experiment']},
+        organization: {features: ['onboarding-scm-project-creation']},
       }
     );
 
     expect(result.current).toBeUndefined();
   });
 
-  it('returns undefined when the SCM experiment flag is off', () => {
+  it('returns undefined when the SCM project creation flag is off', () => {
     seedSession();
 
     const {result} = renderHookWithProviders(
       () => useScmCreateProjectProductSync(project),
       {
-        // No experiment feature in org features list.
+        // No SCM project creation feature in org features list.
         organization: {features: []},
       }
     );
@@ -116,7 +116,7 @@ describe('useScmCreateProjectProductSync', () => {
     const {result} = renderHookWithProviders(
       () => useScmCreateProjectProductSync(project),
       {
-        organization: {features: ['onboarding-scm-project-creation-experiment']},
+        organization: {features: ['onboarding-scm-project-creation']},
       }
     );
 

--- a/static/app/views/projectInstall/scmCreateProjectSession.tsx
+++ b/static/app/views/projectInstall/scmCreateProjectSession.tsx
@@ -5,7 +5,7 @@ import type {ProjectDetailsFormState} from 'sentry/components/onboarding/onboard
 import type {Integration, Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Project} from 'sentry/types/project';
-import {useExperiment} from 'sentry/utils/useExperiment';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 export const WIZARD_STORAGE_KEY = 'project-creation-wizard';
@@ -28,10 +28,10 @@ export interface WizardState {
 export function useScmCreateProjectProductSync(
   project: Project
 ): ((products: ProductSolution[]) => void) | undefined {
-  const {inExperiment} = useExperiment({
-    feature: 'onboarding-scm-project-creation-experiment',
-    reportExposure: false,
-  });
+  const organization = useOrganization();
+  const hasScmProjectCreation = organization.features.includes(
+    'onboarding-scm-project-creation'
+  );
 
   const [session, setSession] = useSessionStorage<WizardState | null>(
     WIZARD_STORAGE_KEY,
@@ -41,7 +41,8 @@ export function useScmCreateProjectProductSync(
   // Guard: only sync when this getting-started page belongs to the project the
   // SCM wizard just created. Without this check a non-SCM getting-started page
   // could clobber a stale session that happens to be in storage.
-  const isWizardSession = inExperiment && session?.createdProjectId === project.id;
+  const isWizardSession =
+    hasScmProjectCreation && session?.createdProjectId === project.id;
 
   const syncProducts = useCallback(
     (products: ProductSolution[]) => {


### PR DESCRIPTION
## TLDR

The SCM project-creation flow now uses the regular `onboarding-scm-project-creation` feature, preserving the existing rollout while stopping experiment exposure reporting.

## Details

This PR is stacked on [#120349](https://github.com/getsentry/sentry/pull/120349), which registers the new organization feature. The matching rollout configuration is in [sentry-options-automator#8823](https://github.com/getsentry/sentry-options-automator/pull/8823). The old experiment registration and configuration remain in place for a later deploy-safe cleanup.

`NewProject` now selects `ScmCreateProject` directly from `organization.features`, and `useScmCreateProjectProductSync` uses the same feature when deciding whether a matching wizard session can synchronize product selections. Removing both `useExperiment` calls keeps feature enrollment semantics unchanged because that hook gates on the same organization feature list; the intentional difference is that visiting `/projects/new/` no longer reports experiment exposure.

The route-level tests now exercise both the legacy and SCM branches, while the session-sync tests use the regular feature and continue to cover matching projects, mismatches, absent sessions, and disabled rollout.

Refs [VDY-136](https://linear.app/getsentry/issue/VDY-136/convert-onboarding-scm-project-creation-experiment-to-a-regular)
