### PR TITLE
feat(weekly-report): Add WoW change to Total Spans

### DIFF
--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -18,6 +18,7 @@ from sentry.tasks.summaries.utils import (
     project_event_counts_for_organization,
     project_key_performance_issues,
     project_past_resolved_issues,
+    spans_count_by_project,
 )
 from sentry.tasks.summaries.weekly_report_cache import read_project_metrics
 from sentry.types.group import GroupSubStatus
@@ -95,6 +96,7 @@ class OrganizationReportContextFactory:
 
             error_missed_project_ids: set[int] = set()
             issue_missed_project_ids: set[int] = set()
+            spans_missed_project_ids: set[int] = set()
 
             for project_id, values in cached.items():
                 project_ctx = ctx.projects_context_map[project_id]
@@ -106,10 +108,15 @@ class OrganizationReportContextFactory:
                     project_ctx.prev_week_total_substatus_count = values["i"]
                 else:
                     issue_missed_project_ids.add(project_id)
+                if "s" in values:
+                    ctx.prev_week_spans_count_by_project[project_id] = values["s"]
+                else:
+                    spans_missed_project_ids.add(project_id)
 
             no_cache_project_ids = set(project_ids) - set(cached.keys())
             error_missed_project_ids |= no_cache_project_ids
             issue_missed_project_ids |= no_cache_project_ids
+            spans_missed_project_ids |= no_cache_project_ids
 
             prev_start = ctx.start - (ctx.end - ctx.start)
             prev_end = ctx.start
@@ -142,6 +149,22 @@ class OrganizationReportContextFactory:
                         ctx.projects_context_map[
                             project_id
                         ].prev_week_total_substatus_count += item["total"]
+
+            if spans_missed_project_ids:
+                tx_projects = [
+                    pctx.project
+                    for pid, pctx in ctx.projects_context_map.items()
+                    if pid in spans_missed_project_ids and pctx.project.flags.has_transactions
+                ]
+                if tx_projects:
+                    fallback = spans_count_by_project(
+                        tx_projects,
+                        ctx.organization,
+                        prev_start,
+                        prev_end,
+                        Referrer.REPORTS_TOP_SPANS.value,
+                    )
+                    ctx.prev_week_spans_count_by_project.update(fallback)
 
     @metrics.wraps("weekly_report.create_context.issue_summaries")
     def _append_organization_project_issue_summaries(self, ctx: OrganizationReportContext) -> None:

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -150,21 +150,26 @@ class OrganizationReportContextFactory:
                             project_id
                         ].prev_week_total_substatus_count += item["total"]
 
-            if spans_missed_project_ids:
-                tx_projects = [
-                    pctx.project
-                    for pid, pctx in ctx.projects_context_map.items()
-                    if pid in spans_missed_project_ids and pctx.project.flags.has_transactions
-                ]
-                if tx_projects:
-                    fallback = spans_count_by_project(
-                        tx_projects,
-                        ctx.organization,
-                        prev_start,
-                        prev_end,
-                        Referrer.REPORTS_TOP_SPANS.value,
-                    )
-                    ctx.prev_week_spans_count_by_project.update(fallback)
+            if spans_missed_project_ids and features.has(
+                "organizations:weekly-report-spans-chart", ctx.organization
+            ):
+                try:
+                    tx_projects = [
+                        pctx.project
+                        for pid, pctx in ctx.projects_context_map.items()
+                        if pid in spans_missed_project_ids and pctx.project.flags.has_transactions
+                    ]
+                    if tx_projects:
+                        fallback = spans_count_by_project(
+                            tx_projects,
+                            ctx.organization,
+                            prev_start,
+                            prev_end,
+                            Referrer.REPORTS_TOP_SPANS.value,
+                        )
+                        ctx.prev_week_spans_count_by_project.update(fallback)
+                except Exception:
+                    sentry_sdk.capture_exception()
 
     @metrics.wraps("weekly_report.create_context.issue_summaries")
     def _append_organization_project_issue_summaries(self, ctx: OrganizationReportContext) -> None:

--- a/src/sentry/tasks/summaries/organization_report_context_factory.py
+++ b/src/sentry/tasks/summaries/organization_report_context_factory.py
@@ -150,8 +150,10 @@ class OrganizationReportContextFactory:
                             project_id
                         ].prev_week_total_substatus_count += item["total"]
 
-            if spans_missed_project_ids and features.has(
-                "organizations:weekly-report-spans-chart", ctx.organization
+            if (
+                spans_missed_project_ids
+                and not ctx.organization.flags.enhanced_privacy
+                and features.has("organizations:weekly-report-spans-chart", ctx.organization)
             ):
                 try:
                     tx_projects = [

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -710,6 +710,39 @@ def _get_transaction_projects(ctx: OrganizationReportContext) -> list[Project]:
     ]
 
 
+def spans_count_by_project(
+    projects: list[Project],
+    organization: Organization,
+    start: datetime,
+    end: datetime,
+    referrer: str,
+) -> dict[int, int]:
+    snuba_params = SnubaParams(
+        start=start,
+        end=end,
+        projects=projects,
+        organization=organization,
+    )
+    config = SearchResolverConfig(auto_fields=True)
+    result = Spans.run_table_query(
+        params=snuba_params,
+        query_string="is_transaction:1",
+        selected_columns=["project.id", "count()"],
+        orderby=None,
+        offset=0,
+        limit=len(projects),
+        referrer=referrer,
+        config=config,
+        sampling_mode=None,
+    )
+    counts: dict[int, int] = {}
+    for row in result.get("data", []):
+        project_id = row.get("project.id")
+        if project_id:
+            counts[int(project_id)] = row.get("count()", 0)
+    return counts
+
+
 def organization_top_spans(
     ctx: OrganizationReportContext,
     referrer: str,
@@ -760,22 +793,9 @@ def organization_top_spans(
         op="weekly_reports.spans_count_by_project",
         name="weekly_reports.spans_count_by_project",
     ):
-        count_by_project_result = Spans.run_table_query(
-            params=snuba_params,
-            query_string="is_transaction:1",
-            selected_columns=["project.id", "count()"],
-            orderby=None,
-            offset=0,
-            limit=len(projects),
-            referrer=referrer,
-            config=config,
-            sampling_mode=None,
+        ctx.spans_count_by_project = spans_count_by_project(
+            projects, ctx.organization, ctx.start, ctx.end, referrer
         )
-
-    for row in count_by_project_result.get("data", []):
-        project_id = row.get("project.id")
-        if project_id:
-            ctx.spans_count_by_project[int(project_id)] = row.get("count()", 0)
 
     for row in result.get("data", []):
         span_name = row.get("span.name", "")

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -65,6 +65,7 @@ class OrganizationReportContext:
         self.top_spans_timeseries: dict[str, dict[int, float]] = {}  # {span_name: {timestamp: p95}}
         self.top_spans_projects: dict[str, int] = {}  # {span_name: project_id}
         self.spans_count_by_project: dict[int, int] = {}  # {project_id: count}
+        self.prev_week_spans_count_by_project: dict[int, int] = {}  # {project_id: count}
 
     def __repr__(self) -> str:
         return self.projects_context_map.__repr__()

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -739,7 +739,7 @@ def spans_count_by_project(
     for row in result.get("data", []):
         project_id = row.get("project.id")
         if project_id:
-            counts[int(project_id)] = row.get("count()", 0)
+            counts[int(project_id)] = row.get("count()") or 0
     return counts
 
 

--- a/src/sentry/tasks/summaries/utils.py
+++ b/src/sentry/tasks/summaries/utils.py
@@ -712,7 +712,7 @@ def _get_transaction_projects(ctx: OrganizationReportContext) -> list[Project]:
 
 
 def spans_count_by_project(
-    projects: list[Project],
+    projects: Sequence[Project],
     organization: Organization,
     start: datetime,
     end: datetime,

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -258,10 +258,13 @@ def prepare_organization_report(
             try:
                 project_metrics: dict[int, dict[str, int]] = {}
                 for project_id, project_ctx in ctx.projects_context_map.items():
-                    project_metrics[project_id] = {
+                    values: dict[str, int] = {
                         "e": project_ctx.accepted_error_count,
                         "i": project_ctx.total_substatus_count,
                     }
+                    if project_id in ctx.spans_count_by_project:
+                        values["s"] = ctx.spans_count_by_project[project_id]
+                    project_metrics[project_id] = values
                 if project_metrics:
                     cache_project_metrics(organization_id, project_metrics)
             except Exception:
@@ -919,7 +922,16 @@ def render_template_context(
                     "url": span_url,
                 }
             )
-        return {"total_spans_count": user_total_spans_count, "top_spans_table": table}
+        prev_week_total_spans_count = sum(
+            count
+            for pid, count in ctx.prev_week_spans_count_by_project.items()
+            if pid in user_project_ids
+        )
+        return {
+            "total_spans_count": user_total_spans_count,
+            "top_spans_table": table,
+            "spans_pct_change": _pct_change(user_total_spans_count, prev_week_total_spans_count),
+        }
 
     show_past_issues = features.has("organizations:weekly-report-past-issues", ctx.organization)
 

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -262,8 +262,8 @@ def prepare_organization_report(
                         "e": project_ctx.accepted_error_count,
                         "i": project_ctx.total_substatus_count,
                     }
-                    if project_id in ctx.spans_count_by_project:
-                        values["s"] = ctx.spans_count_by_project[project_id]
+                    if ctx.spans_count_by_project:
+                        values["s"] = ctx.spans_count_by_project.get(project_id, 0)
                     project_metrics[project_id] = values
                 if project_metrics:
                     cache_project_metrics(organization_id, project_metrics)

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -472,6 +472,9 @@
     <h4 class="total-count-title" style="font-weight: bold; margin-top: 0; margin-bottom: 0;">Total Spans</h4>
     <h1 style="margin: 0; font-weight: bold;">
       {{ total_spans_count|small_count:1 }}
+      {% if show_week_over_week_metric and spans_pct_change %}
+      <span style="font-size: 14px; font-weight: 500; margin-left: 8px; padding: 2px 8px; border-radius: 6px; vertical-align: middle; background-color: {{ spans_pct_change.bg_color }}; color: {{ spans_pct_change.text_color }};">{{ spans_pct_change.arrow }}&nbsp;{{ spans_pct_change.pct }}</span>
+      {% endif %}
     </h1>
     <a href="{% org_url organization '/explore/traces/' %}"
        style="font-size: 12px; margin-bottom: 16px; display: block; font-weight: bold;">View All Spans</a>

--- a/src/sentry/web/frontend/debug/debug_weekly_report.py
+++ b/src/sentry/web/frontend/debug/debug_weekly_report.py
@@ -22,7 +22,11 @@ from sentry.tasks.summaries.utils import (
     OrganizationReportContext,
     ProjectContext,
 )
-from sentry.tasks.summaries.weekly_reports import get_group_display, render_template_context
+from sentry.tasks.summaries.weekly_reports import (
+    _pct_change,
+    get_group_display,
+    render_template_context,
+)
 from sentry.types.group import GroupSubStatus
 from sentry.utils import loremipsum
 from sentry.utils.auth import AuthenticatedHttpRequest
@@ -228,6 +232,10 @@ class DebugWeeklyReportView(MailPreviewView):
         ctx.spans_count_by_project = {
             pid: random.randint(100000, 1500000) for pid in all_project_ids
         }
+        ctx.prev_week_spans_count_by_project = {
+            pid: int(ctx.spans_count_by_project[pid] * random.uniform(0.5, 1.5))
+            for pid in all_project_ids
+        }
         intervals = 28
         for name in span_names:
             ctx.top_spans_timeseries[name] = {
@@ -243,7 +251,10 @@ class DebugWeeklyReportView(MailPreviewView):
                 request.GET.get("show_week_over_week_metric", "1") != "0"
             )
             context["show_past_issues"] = True
-            context["total_spans_count"] = sum(ctx.spans_count_by_project.values())
+            total_spans = sum(ctx.spans_count_by_project.values())
+            prev_total_spans = sum(ctx.prev_week_spans_count_by_project.values())
+            context["total_spans_count"] = total_spans
+            context["spans_pct_change"] = _pct_change(total_spans, prev_total_spans)
             project_by_id = {pid: pctx.project for pid, pctx in ctx.projects_context_map.items()}
             context["top_spans_table"] = [
                 {


### PR DESCRIPTION
## Summary
- Adds Week-over-Week percentage change badge next to the Total Spans count in the weekly report email, matching the existing WoW badges for Total Errors and Total Issues.
- Extracts `spans_count_by_project()` helper for reuse across current-week and previous-week queries.
- Integrates with the existing Redis cache pattern: writes spans count (`"s"` key) alongside errors (`"e"`) and issues (`"i"`) after delivery, reads from cache first next week, falls back to Snuba on cache miss.

To test:
- Start dev environment
- Go to `debug/mail/weekly-reports/`

<img width="168" height="106" alt="Screenshot 2026-07-22 at 9 18 23 AM" src="https://github.com/user-attachments/assets/7405871c-8686-4944-82d5-4a178146081d" />