### PR TITLE
fix(inc-2344): route replay bulk delete job to long pool

### DIFF
--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -198,7 +198,7 @@ def _delete_if_exists(filename: str) -> None:
     # namespace="replays") continue to resolve and execute.
     alias_namespace=replays_tasks,
     retry=Retry(times=5),
-    processing_deadline_duration=300,
+    processing_deadline_duration=600,
     silo_mode=SiloMode.CELL,
 )
 def run_bulk_replay_delete_job(

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -27,7 +27,7 @@ from sentry.replays.usecases.ingest.types import ProcessorContext
 from sentry.replays.usecases.reader import fetch_segments_metadata
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import replays_raw_tasks, replays_tasks
+from sentry.taskworker.namespaces import replays_long_tasks, replays_raw_tasks, replays_tasks
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
@@ -192,7 +192,7 @@ def _delete_if_exists(filename: str) -> None:
 
 @instrumented_task(
     name="sentry.replays.tasks.run_bulk_replay_delete_job",
-    namespace=replays_tasks,
+    namespace=replays_long_tasks,
     retry=Retry(times=5),
     processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,

--- a/src/sentry/replays/tasks.py
+++ b/src/sentry/replays/tasks.py
@@ -193,6 +193,10 @@ def _delete_if_exists(filename: str) -> None:
 @instrumented_task(
     name="sentry.replays.tasks.run_bulk_replay_delete_job",
     namespace=replays_long_tasks,
+    # Keep the task registered under the old `replays` namespace as well so
+    # any activations that were enqueued before this deploy (with
+    # namespace="replays") continue to resolve and execute.
+    alias_namespace=replays_tasks,
     retry=Retry(times=5),
     processing_deadline_duration=300,
     silo_mode=SiloMode.CELL,

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -234,6 +234,11 @@ replays_tasks = app.taskregistry.create_namespace(
     app_feature="replays",
 )
 
+replays_long_tasks = app.taskregistry.create_namespace(
+    "replays.long",
+    app_feature="replays",
+)
+
 # Dedicated namespace for the raw ingest-replay-recordings topic, consumed by
 # taskbroker in "raw mode" (one raw topic maps 1:1 to a namespace).
 replays_raw_tasks = app.taskregistry.create_namespace(


### PR DESCRIPTION
replay bulk deletes are taking a while so we're putting them on the long pool. 
Registration in the long pool is in [this pr](https://github.com/getsentry/ops/pull/22183)