### PR TITLE
ref(seer-infra-telemetry): Create updated schema for monitoring provider connections

### DIFF
--- a/src/sentry/integrations/datadog/integration.py
+++ b/src/sentry/integrations/datadog/integration.py
@@ -37,7 +37,7 @@ from sentry.seer.agent.monitoring_providers import (
     OrgMonitoringProvider,
     org_monitoring_provider_registry,
 )
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import HeaderAuthConnectionData
 from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
@@ -220,9 +220,7 @@ class DatadogOrgMonitoringProvider(OrgMonitoringProvider):
 
     provider_key = IntegrationProviderSlug.DATADOG.value
 
-    def build_connection(
-        self, organization: Organization
-    ) -> list[MonitoringProviderConnectionData] | None:
+    def build_connection(self, organization: Organization) -> list[HeaderAuthConnectionData] | None:
         ctx = integration_service.organization_context(
             organization_id=organization.id, provider=self.provider_key
         )
@@ -256,7 +254,7 @@ class DatadogOrgMonitoringProvider(OrgMonitoringProvider):
             return None
 
         return [
-            MonitoringProviderConnectionData(
+            HeaderAuthConnectionData(
                 provider_key=self.provider_key,
                 url=f"{base_url}{MCP_ENDPOINT_PATH}",
                 encrypted_auth_headers={

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -37,7 +37,7 @@ from sentry.seer.agent.monitoring_providers import (
     OrgMonitoringProvider,
     org_monitoring_provider_registry,
 )
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import GcpSaImpersonationConnectionData
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
 
 logger = logging.getLogger(__name__)
@@ -207,7 +207,7 @@ class GcpOrgMonitoringProvider(OrgMonitoringProvider):
 
     def build_connection(
         self, organization: Organization
-    ) -> list[MonitoringProviderConnectionData] | None:
+    ) -> list[GcpSaImpersonationConnectionData] | None:
         ctx = integration_service.organization_context(
             organization_id=organization.id, provider=self.provider_key
         )
@@ -223,6 +223,9 @@ class GcpOrgMonitoringProvider(OrgMonitoringProvider):
 
         config = org_integration.config
         projects: list[str] = config.get("projects", [])
+        sentry_sa_email: str | None = config.get("sentry_sa_email")
+        customer_sa_email: str | None = config.get("customer_sa_email")
+
         if not projects:
             logger.error(
                 "seer.monitoring_providers.gcp_integration_no_projects",
@@ -233,12 +236,22 @@ class GcpOrgMonitoringProvider(OrgMonitoringProvider):
             )
             return None
 
+        if not sentry_sa_email or not customer_sa_email:
+            logger.error(
+                "seer.monitoring_providers.gcp_integration_missing_sa_emails",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": integration.id,
+                },
+            )
+            return None
+
         return [
-            MonitoringProviderConnectionData(
+            GcpSaImpersonationConnectionData(
                 provider_key=self.provider_key,
                 url=url,
-                auth_method="gcp_adc",
-                refreshable=False,
+                sentry_sa_email=sentry_sa_email,
+                customer_sa_email=customer_sa_email,
                 gcp_project_ids=projects,
             )
             for url in GCP_MCP_URLS

--- a/src/sentry/seer/agent/monitoring_providers.py
+++ b/src/sentry/seer/agent/monitoring_providers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import logging
+from collections.abc import Sequence
 
 from sentry import features
 from sentry.hybridcloud.rpc.service import RpcException
@@ -9,10 +10,12 @@ from sentry.identity import default_manager as identity_manager
 from sentry.identity.mcp import McpIdentityProvider
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.identity.services.identity import identity_service
-from sentry.integrations.gcp.utils import GCP_MCP_URLS
 from sentry.integrations.types import MONITORING_PROVIDERS
 from sentry.models.organization import Organization
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import (
+    HeaderAuthConnectionData,
+    MonitoringProviderConnectionData,
+)
 from sentry.seer.utils import encrypt_access_token_for_seer
 from sentry.utils.registry import Registry
 
@@ -27,7 +30,7 @@ class OrgMonitoringProvider(abc.ABC):
     @abc.abstractmethod
     def build_connection(
         self, organization: Organization
-    ) -> list[MonitoringProviderConnectionData] | None:
+    ) -> Sequence[MonitoringProviderConnectionData] | None:
         """
         Build Seer connection(s) for this org's integration, or None if unconfigured.
 
@@ -125,7 +128,7 @@ def _get_personal_monitoring_connections(
             auth_method = "oauth" if is_oauth_provider else "pat"
             for url in urls:
                 connections.append(
-                    MonitoringProviderConnectionData(
+                    HeaderAuthConnectionData(
                         provider_key=provider_type,
                         url=url,
                         encrypted_auth_headers={"Authorization": encrypted_auth_header},
@@ -136,24 +139,6 @@ def _get_personal_monitoring_connections(
                 )
 
     return connections
-
-
-# TEMPORARY: hardcoded GCP MCP connections for the Sentry org for internal dogfooding.
-# Remove when the full GcpIntegrationProvider + setup UI is built.
-_SENTRY_ORG_GCP_PROJECT_IDS = ["internal-sentry"]
-
-
-def _get_gcp_connections_for_sentry_org() -> list[MonitoringProviderConnectionData]:
-    return [
-        MonitoringProviderConnectionData(
-            provider_key="gcp",
-            url=url,
-            auth_method="gcp_adc",
-            refreshable=False,
-            gcp_project_ids=_SENTRY_ORG_GCP_PROJECT_IDS,
-        )
-        for url in GCP_MCP_URLS
-    ]
 
 
 def get_monitoring_provider_connections(
@@ -177,11 +162,4 @@ def get_monitoring_provider_connections(
         if provider_family(connection.provider_key) not in connected_families
     ]
 
-    all_connections = personal_connections + org_connections
-
-    # TEMPORARY: hardcoded GCP MCP connections for the Sentry org (id=1) for internal dogfooding.
-    # Remove when the full GcpIntegrationProvider + setup UI is built.
-    if organization.id == 1:
-        all_connections.extend(_get_gcp_connections_for_sentry_org())
-
-    return all_connections
+    return personal_connections + org_connections

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -857,7 +857,7 @@ class ExecuteTimeseriesQueryErrorResponse(BaseModel):
 
 
 class HeaderAuthConnectionData(BaseModel):
-    """Connection authenticated via encrypted HTTP headers (API key, PAT, OAuth)."""
+    """Connection authenticated via encrypted HTTP headers."""
 
     type: Literal["header_auth"] = "header_auth"
     provider_key: str

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -5,7 +5,7 @@ These should be kept in sync with the models in Seer.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -856,17 +856,46 @@ class ExecuteTimeseriesQueryErrorResponse(BaseModel):
         return id(self)
 
 
-class MonitoringProviderConnectionData(BaseModel):
+class HeaderAuthConnectionData(BaseModel):
+    """Connection authenticated via encrypted HTTP headers (API key, PAT, OAuth)."""
+
+    type: Literal["header_auth"] = "header_auth"
     provider_key: str
     url: str
     encrypted_auth_headers: dict[str, str] | None = None
     identity_id: int | None = None
     auth_method: str
     refreshable: bool = True
+
+    def __getitem__(self, key: str) -> Any:
+        return self.dict()[key]
+
+
+class GcpSaImpersonationConnectionData(BaseModel):
+    """
+    Connection authenticated via GCP two-hop SA impersonation chain.
+
+    Seer uses ``sentry_sa_email`` and ``customer_sa_email`` to construct
+    ``GcpMcpCredentials`` for the ADC -> per-customer SA -> customer SA chain.
+    """
+
+    type: Literal["gcp_sa_impersonation"] = "gcp_sa_impersonation"
+    provider_key: str
+    url: str
+    sentry_sa_email: str
+    customer_sa_email: str
+    auth_method: Literal["gcp_sa_impersonation"] = "gcp_sa_impersonation"
+    refreshable: bool = False
     gcp_project_ids: list[str] | None = None
 
     def __getitem__(self, key: str) -> Any:
         return self.dict()[key]
+
+
+MonitoringProviderConnectionData = Annotated[
+    Union[HeaderAuthConnectionData, GcpSaImpersonationConnectionData],
+    Field(discriminator="type"),
+]
 
 
 class MonitoringProviderConnectionsResponse(BaseModel):

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -22,7 +22,7 @@ from sentry.seer.agent.client_models import (
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
-from sentry.seer.sentry_data_models import MonitoringProviderConnectionData
+from sentry.seer.sentry_data_models import HeaderAuthConnectionData
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_options, with_feature
 from sentry.testutils.requests import make_request
@@ -445,7 +445,7 @@ class TestSeerAgentClient(TestCase):
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response(run_id=1)
         mock_conns.return_value = [
-            MonitoringProviderConnectionData(
+            HeaderAuthConnectionData(
                 provider_key="datadog",
                 url="https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
                 encrypted_auth_headers={"DD-API-KEY": "x", "DD-APPLICATION-KEY": "y"},

--- a/tests/sentry/seer/agent/test_monitoring_providers.py
+++ b/tests/sentry/seer/agent/test_monitoring_providers.py
@@ -472,11 +472,14 @@ class TestGetMonitoringProviderConnections(TestCase):
             "https://cloudtrace.googleapis.com/mcp",
         }
         for conn in result:
-            assert conn["auth_method"] == "gcp_adc"
+            assert conn["type"] == "gcp_sa_impersonation"
+            assert conn["auth_method"] == "gcp_sa_impersonation"
             assert conn["refreshable"] is False
             assert conn["gcp_project_ids"] == ["my-project-prod", "my-project-staging"]
-            assert conn["identity_id"] is None
-            assert conn["encrypted_auth_headers"] is None
+            assert (
+                conn["sentry_sa_email"] == "sentry-org-1@sentry-connectors.iam.gserviceaccount.com"
+            )
+            assert conn["customer_sa_email"] == "gcp-sentry@my-project.iam.gserviceaccount.com"
 
     def test_org_gcp_connection_ignores_non_active_integration(self) -> None:
         self._create_org_gcp_integration(status=ObjectStatus.DISABLED)
@@ -505,11 +508,27 @@ class TestGetMonitoringProviderConnections(TestCase):
         result = get_monitoring_provider_connections(self.organization, self.user.id)
         assert result == []
 
+    def test_org_gcp_connection_skips_missing_sa_emails(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="gcp",
+            external_id=str(self.organization.id),
+            name="Google Cloud Platform",
+            metadata={},
+            oi_params={
+                "config": {
+                    "projects": ["my-project-prod"],
+                }
+            },
+        )
+        result = get_monitoring_provider_connections(self.organization, self.user.id)
+        assert result == []
+
     def test_org_gcp_connection_for_no_user_run(self) -> None:
         self._create_org_gcp_integration()
         result = get_monitoring_provider_connections(self.organization, None)
         assert len(result) == 3
-        assert all(c["auth_method"] == "gcp_adc" for c in result)
+        assert all(c["auth_method"] == "gcp_sa_impersonation" for c in result)
 
     def test_org_gcp_and_datadog_together(self) -> None:
         self._create_org_gcp_integration()

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -33,6 +33,7 @@ from sentry.seer.endpoints.seer_rpc import (
 from sentry.seer.sentry_data_models import (
     GitHubEnterpriseConfigErrorResponse,
     GitHubEnterpriseConfigSuccessResponse,
+    HeaderAuthConnectionData,
     SendSeerWebhookSuccessResponse,
 )
 from sentry.sentry_apps.event_types import SentryAppEventType
@@ -888,6 +889,7 @@ class TestGetMonitoringProviderConnections(APITestCase):
 
         assert len(result.connections) == 1
         connection = result.connections[0]
+        assert isinstance(connection, HeaderAuthConnectionData)
         assert connection.provider_key == "datadog"
         assert connection.url == "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
         assert connection.identity_id == identity.id


### PR DESCRIPTION
Resolves [CW-1692](https://linear.app/getsentry/issue/CW-1692/schema-update-sentry-side-wiring-for-gcp-sa-based-connections).

Sentry-side PR for [CW-1683](https://linear.app/getsentry/issue/CW-1683/clean-up-temporary-gcp-org-level-integration-dogfooding-code).

Introduces a `type` discriminator on `MonitoringProviderConnectionData` via a Pydantic discriminated union, splitting it into `HeaderAuthConnectionData` (which works for most use cases across API keys/PAT/OAuth) and `GcpSaImpersonationConnectionData` (which is specific to Google authentication via service account impersonation).

The Datadog `build_connection` implementation is updated to use `HeaderAuthConnectionData`. The GCP `build_connection` implementation is updated to populate the service account emails on the connection data we send to Seer (needed to perform authentication via impersonation on the Seer side of things).

This PR also removes some temporary code previously added in https://github.com/getsentry/sentry/pull/120106.

https://app.notion.com/p/sentry/GCP-MCP-Org-Level-Integration-39f8b10e4b5d8030ba01cd62373641df