### PR TITLE
fix(alerts): Fix bug in `percent_increase` where evaluation was incorrect

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -32,6 +32,7 @@ from sentry.types.condition_activity import (
 from sentry.utils.iterators import chunked
 from sentry.utils.snuba import options_override
 
+INFINITE_PERCENT_INCREASE = 10_000_000
 STANDARD_INTERVALS: dict[str, tuple[str, timedelta]] = {
     "1m": ("one minute", timedelta(minutes=1)),
     "5m": ("5 minutes", timedelta(minutes=5)),
@@ -1027,8 +1028,9 @@ def bucket_count(start: datetime, end: datetime, buckets: dict[datetime, int]) -
 
 
 def percent_increase(result: int | float, comparison_result: int | float) -> int:
-    return (
-        int(max(0, ((result - comparison_result) / comparison_result * 100)))
-        if comparison_result > 0
-        else 0
-    )
+    # No baseline to compare against: infinite increase if there's any activity, else no change.
+    if comparison_result <= 0:
+        return INFINITE_PERCENT_INCREASE if result > 0 else 0
+
+    change = (result - comparison_result) / comparison_result * 100
+    return int(max(0, change))

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -32,7 +32,6 @@ from sentry.types.condition_activity import (
 from sentry.utils.iterators import chunked
 from sentry.utils.snuba import options_override
 
-INFINITE_PERCENT_INCREASE = 10_000_000
 STANDARD_INTERVALS: dict[str, tuple[str, timedelta]] = {
     "1m": ("one minute", timedelta(minutes=1)),
     "5m": ("5 minutes", timedelta(minutes=5)),
@@ -1028,9 +1027,10 @@ def bucket_count(start: datetime, end: datetime, buckets: dict[datetime, int]) -
 
 
 def percent_increase(result: int | float, comparison_result: int | float) -> int:
-    # No baseline to compare against: infinite increase if there's any activity, else no change.
+    # No baseline to compare against: treat the current count as the full increase over an
+    # effectively empty prior period, i.e. 0 -> N reads as N*100%.
     if comparison_result <= 0:
-        return INFINITE_PERCENT_INCREASE if result > 0 else 0
+        return int(max(0, result) * 100)
 
     change = (result - comparison_result) / comparison_result * 100
     return int(max(0, change))

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -217,6 +217,20 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
         results = [10, 10]
         self.assert_slow_condition_does_not_pass(dc, results)
 
+    def test_with_result_zero(self) -> None:
+        dc = self.create_data_condition(
+            type=self.condition,
+            comparison={
+                "interval": self.payload["interval"],
+                "value": self.payload["value"],
+                "comparison_interval": self.payload["comparisonInterval"],
+            },
+            condition_result=True,
+        )
+
+        results = [10, -1]
+        self.assert_slow_condition_passes(dc, results)
+
     def _test_dual_write(self, value: str | int | float) -> None:
         dcg = self.create_data_condition_group()
         dc = self.translate_to_data_condition(self.payload, dcg)

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_handlers.py
@@ -228,7 +228,7 @@ class TestEventFrequencyPercentCondition(ConditionTestCase):
             condition_result=True,
         )
 
-        results = [10, -1]
+        results = [10, 0]
         self.assert_slow_condition_passes(dc, results)
 
     def _test_dual_write(self, value: str | int | float) -> None:

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -741,8 +741,9 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
         self.assertDoesNotPass(rule, event, is_new=False)
 
     def test_comparison_empty_comparison_period(self) -> None:
-        # Test data is 1 event in the current period and 0 events in the comparison period. This
-        # should always result in 0 and never fire.
+        # Test data is 1 event in the current period and 0 events in the comparison period. With no
+        # baseline to compare against, the current count reads as an N*100% increase (here 100%), so
+        # it fires above a 0% threshold but not above a 100% threshold.
         event = self.add_event(
             data={
                 "fingerprint": ["something_random"],
@@ -758,7 +759,7 @@ class StandardIntervalTestBase(SnubaTestCase, RuleTestCase, PerformanceIssueTest
             "comparisonInterval": "1d",
         }
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
-        self.assertDoesNotPass(rule, event, is_new=False)
+        self.assertPasses(rule, event, is_new=False)
 
         data = {
             "interval": "1h",
@@ -915,8 +916,9 @@ class EventUniqueUserFrequencyConditionWithConditionsTestCase(StandardIntervalTe
         self.assertDoesNotPass(rule, event, is_new=False)
 
     def test_comparison_empty_comparison_period(self) -> None:
-        # Test data is 1 event in the current period and 0 events in the comparison period. This
-        # should always result in 0 and never fire.
+        # Test data is 1 event in the current period and 0 events in the comparison period. With no
+        # baseline to compare against, the current count reads as an N*100% increase (here 100%), so
+        # it fires above a 0% threshold but not above a 100% threshold.
         event = self.add_event(
             data={
                 "fingerprint": ["something_random"],
@@ -926,34 +928,42 @@ class EventUniqueUserFrequencyConditionWithConditionsTestCase(StandardIntervalTe
             timestamp=before_now(minutes=1),
         )
         data = {
-            "filter_match": "all",
-            "conditions": [
-                {
-                    "interval": "1h",
-                    "value": 0,
-                    "comparisonType": "percent",
-                    "comparisonInterval": "1d",
-                }
-            ],
+            "interval": "1h",
+            "value": 0,
+            "comparisonType": "percent",
+            "comparisonInterval": "1d",
+            "id": "EventFrequencyConditionWithConditions",
         }
         rule = self.get_rule(
-            data=data, rule=Rule(environment_id=None, project_id=self.project.id, data=data)
+            data=data,
+            rule=Rule(
+                environment_id=None,
+                project_id=self.project.id,
+                data={
+                    "conditions": [data],
+                    "filter_match": "all",
+                },
+            ),
         )
-        self.assertDoesNotPass(rule, event, is_new=False)
+        self.assertPasses(rule, event, is_new=False)
 
         data = {
-            "filter_match": "all",
-            "conditions": [
-                {
-                    "interval": "1h",
-                    "value": 100,
-                    "comparisonType": "percent",
-                    "comparisonInterval": "1d",
-                }
-            ],
+            "interval": "1h",
+            "value": 100,
+            "comparisonType": "percent",
+            "comparisonInterval": "1d",
+            "id": "EventFrequencyConditionWithConditions",
         }
         rule = self.get_rule(
-            data=data, rule=Rule(environment_id=None, project_id=self.project.id, data=data)
+            data=data,
+            rule=Rule(
+                environment_id=None,
+                project_id=self.project.id,
+                data={
+                    "conditions": [data],
+                    "filter_match": "all",
+                },
+            ),
         )
         self.assertDoesNotPass(rule, event, is_new=False)
 


### PR DESCRIPTION
# Description
The incorrect logic is the else branch of percent_increase (event_frequency.py:1029):
```py
def percent_increase(result, comparison_result) -> int:
    return (
        int(max(0, ((result - comparison_result) / comparison_result * 100)))
        if comparison_result > 0
        else 0          # ← the bug
    )
```
The else 0 exists to avoid a division-by-zero when the historical/comparison window has no events. But it conflates two different situations into one sentinel:

- `comparison_result == 0 and result == 0` → genuinely no change → `0` is correct.
- `comparison_result == 0 and result > 0` → a positive count against a zero baseline, which is conceptually an infinite percent increase → but it also returns `0`.

Why that silently kills the alert: the caller in passes() (event_frequency.py:186-195) does:
```py
current_value = self.get_rate(...)      # == percent_increase(result, comparison_result) for PERCENT
return current_value > value            # value = the user's threshold (e.g. 100 for ">100%")
```

So a spike of 50 events against a 0 baseline yields current_value = 0, and 0 > 100 is False — the alert never fires. This is worst exactly where percent-change rules are meant to be useful: rare/low-frequency issues, which are statistically likely to have an empty comparison window.