### PR TITLE
feat(seer): Render Code Mode todos in the Explorer chat

### DIFF
--- a/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.spec.tsx
@@ -106,6 +106,35 @@ describe('ToolUseBlock', () => {
     expect(checkboxes[2]).not.toBeChecked();
   });
 
+  it('renders todo list for Code Mode (non-todo_write) tool calls', () => {
+    // Code Mode's execute tool projects its todos onto block.todos; the checklist should
+    // render even though the tool is not todo_write (code-mode-effects-bus).
+    const block = createBlock({
+      message: {
+        role: 'tool_use',
+        content: null,
+        tool_calls: [{id: 'call-1', function: 'sentry_api_execute', args: '{}'}],
+      },
+      tool_results: [
+        {
+          tool_call_id: 'call-1',
+          tool_call_function: 'sentry_api_execute',
+          content: 'ran',
+        },
+      ],
+      todos: [
+        {content: 'Investigate p95', status: 'in_progress'},
+        {content: 'Propose a fix', status: 'pending'},
+      ],
+    });
+
+    const blocks = [block];
+    render(<BlockComponent block={block} blockIndex={0} blocks={blocks} />);
+
+    expect(screen.getByText('Investigate p95')).toBeInTheDocument();
+    expect(screen.getByText('Propose a fix')).toBeInTheDocument();
+  });
+
   it('does not render action bar', () => {
     render(<BlockComponent block={createBlock()} blockIndex={0} runId={123} />);
     expect(

--- a/static/app/views/seerExplorer/components/chat/toolUse.tsx
+++ b/static/app/views/seerExplorer/components/chat/toolUse.tsx
@@ -142,9 +142,12 @@ function ToolCallList({block, blocks, getPageReferrer}: ToolCallListProps) {
             }
           : undefined;
 
-        const isTodoWrite = toolCall.function === 'todo_write';
+        // Render the checklist once per block (on the last tool-call row), regardless of
+        // which tool produced it — classic `todo_write` or Code Mode `sentry_api_execute`,
+        // which projects its todos onto block.todos (code-mode-effects-bus).
+        const isLastToolCall = idx === (block.message.tool_calls?.length ?? 0) - 1;
         const todos =
-          isTodoWrite &&
+          isLastToolCall &&
           block.todos?.length &&
           blocks?.findLast(b => b.todos?.length) === block
             ? block.todos


### PR DESCRIPTION
The Explorer chat rendered the todo checklist only for classic `todo_write` tool calls (`toolUse.tsx` gated on `toolCall.function === 'todo_write'`). Code Mode surfaces todos differently — the seer loop projects them onto `block.todos` under a `sentry_api_execute` call (openspec: code-mode-effects-bus) — so the checklist never rendered for Code Mode sessions.

Relax the gate to render the checklist once per block (on the last tool-call row), regardless of which tool produced it. Now both classic and Code Mode todos display.

Pairs with getsentry/seer#7466 (which produces the todos and does the block.todos projection). Frontend-only; no backend/wire change needed since `block.todos` already crosses the wire.