### PR TITLE
fix(seer): Scope autofix state milestones to the latest run

### DIFF
--- a/src/sentry/seer/autofix/issue_search.py
+++ b/src/sentry/seer/autofix/issue_search.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
-from django.db.models import Case, Max, Q, When
+from django.db.models import Case, DateTimeField, Max, OuterRef, Q, Subquery, Value, When
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from sentry.models.activity import Activity
@@ -28,29 +29,44 @@ MILESTONE_ACTIVITY_TYPES = (
     ActivityType.SEER_PR_CREATED,
 )
 
+NO_RUN_THRESHOLD = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+def _latest_run_started() -> Coalesce:
+    return Coalesce(
+        Subquery(
+            SeerAgentRun.objects.filter(group_id=OuterRef("group_id"), source="autofix")
+            .order_by("-id")
+            .values("run__date_added")[:1]
+        ),
+        Value(NO_RUN_THRESHOLD),
+        output_field=DateTimeField(),
+    )
+
 
 def _milestone_state_q(
     projects: Sequence[Project],
     reached: ActivityType,
     not_reached: Sequence[ActivityType],
 ) -> Q:
-    activities = Activity.objects.filter(
-        project__in=projects,
-        type__in=[t.value for t in (reached, *not_reached)],
-        group_id__isnull=False,
-    )
-    if not not_reached:
-        return Q(id__in=activities.values_list("group_id", flat=True))
-
+    types = (reached, *not_reached)
     annotations = {
-        f"reached_{t.value}": Max(Case(When(type=t.value, then=1), default=0))
-        for t in (reached, *not_reached)
+        f"latest_{t.value}": Max(Case(When(type=t.value, then="datetime"))) for t in types
     }
-    having = {f"reached_{reached.value}": 1} | {f"reached_{t.value}": 0 for t in not_reached}
+    condition = Q(**{f"latest_{reached.value}__gte": _latest_run_started()})
+    for t in not_reached:
+        condition &= Q(**{f"latest_{t.value}__lt": _latest_run_started()}) | Q(
+            **{f"latest_{t.value}__isnull": True}
+        )
     return Q(
-        id__in=activities.values("group_id")
+        id__in=Activity.objects.filter(
+            project__in=projects,
+            type__in=[t.value for t in types],
+            group_id__isnull=False,
+        )
+        .values("group_id")
         .annotate(**annotations)
-        .filter(**having)
+        .filter(condition)
         .values_list("group_id", flat=True)
     )
 
@@ -61,7 +77,11 @@ def _any_milestone_q(projects: Sequence[Project]) -> Q:
             project__in=projects,
             type__in=[t.value for t in MILESTONE_ACTIVITY_TYPES],
             group_id__isnull=False,
-        ).values_list("group_id", flat=True)
+        )
+        .values("group_id")
+        .annotate(latest_milestone=Max("datetime"))
+        .filter(latest_milestone__gte=_latest_run_started())
+        .values_list("group_id", flat=True)
     )
 
 

--- a/tests/sentry/seer/autofix/test_issue_search.py
+++ b/tests/sentry/seer/autofix/test_issue_search.py
@@ -54,7 +54,6 @@ class AutofixStateFilterTest(TestCase):
         assert self._matching_group_ids(["review_pr"]) == {self.group2.id}
 
     def test_merged_scoped_to_latest_run(self) -> None:
-        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
         self._create_merged_pr_run(self.group1)
         run = self.create_seer_run(organization=self.organization)
         self.create_seer_agent_run(run, source="autofix", project=self.project, group=self.group1)
@@ -63,9 +62,25 @@ class AutofixStateFilterTest(TestCase):
             repository_id=repo.id, organization_id=self.organization.id, key="102"
         )
         self.create_seer_run_pull_request(run, pr)
+        self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)
 
         assert self._matching_group_ids(["merged"]) == set()
         assert self._matching_group_ids(["review_pr"]) == {self.group1.id}
+
+    def test_stale_milestone_from_older_run_ignored(self) -> None:
+        self.create_group_activity(
+            group=self.group1,
+            type=ActivityType.SEER_PR_CREATED.value,
+            datetime=timezone.now() - timedelta(hours=1),
+        )
+        run = self.create_seer_run(organization=self.organization)
+        self.create_seer_agent_run(run, source="autofix", project=self.project, group=self.group1)
+        self.create_group_activity(
+            group=self.group1, type=ActivityType.SEER_SOLUTION_COMPLETED.value
+        )
+
+        assert self._matching_group_ids(["review_pr"]) == set()
+        assert self._matching_group_ids(["solution_ready"]) == {self.group1.id}
 
     def test_merged_ignores_non_autofix_runs(self) -> None:
         self.create_group_activity(group=self.group1, type=ActivityType.SEER_PR_CREATED.value)


### PR DESCRIPTION
Follow-up to #120293.

The `issue.autofix_state` milestone states (`review_pr`, `code_changes_ready`, `solution_ready`) matched any historical `SEER_*` activity on a group, while `merged` was already scoped to the group's latest autofix run. That asymmetry misclassified re-runs: an issue whose old run opened a (now dead) PR stayed in "Awaiting your review" forever, even after a newer run restarted investigation.

This scopes milestones to the latest run by timestamp: a milestone only counts if its most recent occurrence is at or after the latest autofix run's `SeerRun.date_added`. The ordering invariant (a run's row is committed before Seer is contacted, activities are written later by the update task) was audited across the dispatch/outbox/webhook paths, so a run can never lose its own milestones. Groups with activities but no run rows fall back to counting all milestones.

Known limitation (accepted): if two runs overlap in time, a straggler event from the old run can be attributed to the new run's window — this degrades to today's behavior, never worse, and exact attribution arrives with the planned per-run state column.

Implementation note: the threshold is one correlated subquery per group evaluated in the `HAVING` phase (indexed probe on `SeerAgentRun.group_id`), keeping the single aggregated Activity scan from #120293.
