### PR TITLE
test(acceptance): Cover SCM project creation flow

### DIFF
--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -1,3 +1,7 @@
+from unittest import mock
+
+from sentry.integrations.github.integration import GitHubOAuthLoginResult
+from sentry.integrations.models.integration import Integration
 from sentry.models.project import Project
 from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
@@ -58,3 +62,217 @@ class CreateProjectTest(AcceptanceTestCase):
         assert_existing_projects_status(
             self.org, active_project_ids=[], deleted_project_ids=[project1.id, project2.id]
         )
+
+
+@no_silo_test
+@thread_leak_allowlist(reason="sentry sdk background worker", issue=97042)
+class ScmCreateProjectTest(AcceptanceTestCase):
+    mock_repos = [
+        {
+            "name": "sentry",
+            "identifier": "getsentry/sentry",
+            "default_branch": "master",
+            "external_id": "12345",
+        },
+    ]
+    mock_platforms = [
+        {
+            "platform": "python-django",
+            "language": "Python",
+            "bytes": 50000,
+            "confidence": "high",
+            "priority": 1,
+        }
+    ]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user("scm-project-creator@example.com")
+        self.org = self.create_organization(name="SCM Project Creation", owner=self.user)
+        self.team = self.create_team(organization=self.org, name="SCM Admins", members=[self.user])
+        self.login_as(self.user)
+        self.path = f"/organizations/{self.org.slug}/projects/new/"
+
+    def create_github_integration(self) -> Integration:
+        integration = self.create_provider_integration(
+            provider="github",
+            name="getsentry",
+            external_id="12345",
+            metadata={"access_token": "ghu_xxxxx"},
+        )
+        integration.add_organization(self.org, self.user)
+        return integration
+
+    def load_project_creation_page(self) -> None:
+        self.browser.get(self.path)
+        self.browser.wait_until(xpath='//h4[text()="Repository"]')
+
+    def select_repository(self) -> None:
+        repository_input = self.browser.element('input[aria-autocomplete="list"]')
+        repository_input.send_keys("sentry")
+        self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+        self.browser.click('[data-test-id="menu-list-item-label"]')
+        self.browser.wait_until(xpath='//*[contains(text(), "Auto-detected from your repository")]')
+        self.browser.wait_until(
+            xpath='//*[@role="radiogroup"]//*[@role="radio" and @aria-checked="true"]'
+            '[contains(., "Django")]'
+        )
+
+    def create_project(self, sdk_name: str, platform: str) -> Project:
+        self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+        self.browser.click(xpath='//button[contains(., "Create project")]')
+        self.browser.wait_until(xpath=f'//h2[text()="Configure {sdk_name} SDK"]')
+
+        project = Project.objects.get(organization=self.org)
+        assert project.platform == platform
+        assert project.name == platform
+        assert project.slug == platform
+        assert_existing_projects_status(
+            self.org, active_project_ids=[project.id], deleted_project_ids=[]
+        )
+        return project
+
+    def test_connect_provider_select_repository_and_create(self) -> None:
+        mock_installation_response = {
+            "id": "12345",
+            "app_id": "1",
+            "account": {
+                "login": "getsentry",
+                "avatar_url": "https://example.com/avatar.png",
+                "html_url": "https://github.com/getsentry",
+                "type": "Organization",
+                "id": 67890,
+            },
+        }
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-project-creation": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=self.mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                return_value=self.mock_platforms,
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.exchange_github_oauth",
+                return_value=GitHubOAuthLoginResult(
+                    authenticated_user="testuser",
+                    installation_info=[],
+                ),
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegrationProvider.get_installation_info",
+                return_value=mock_installation_response,
+            ),
+        ):
+            self.load_project_creation_page()
+            self.browser.driver.execute_script(
+                """
+                window.__testOpenUrl = null;
+                window.open = function(url) {
+                    window.__testOpenUrl = url;
+                    return window;
+                };
+                """
+            )
+
+            self.browser.wait_until(xpath='//button[contains(., "GitHub")]')
+            self.browser.click(xpath='//button[contains(., "GitHub")]')
+            self.browser.wait_until(xpath='//button[contains(., "Authorize GitHub")]')
+            self.browser.click(xpath='//button[contains(., "Authorize GitHub")]')
+
+            oauth_url = self.browser.driver.execute_script("return window.__testOpenUrl")
+            assert oauth_url is not None
+            state = dict(pair.split("=") for pair in oauth_url.split("?")[1].split("&")).get(
+                "state", ""
+            )
+            self.browser.driver.execute_script(
+                "window.postMessage(arguments[0], window.location.origin);",
+                {
+                    "_pipeline_source": "sentry-pipeline",
+                    "code": "fake_oauth_code",
+                    "state": state,
+                },
+            )
+
+            self.browser.wait_until(xpath='//button[contains(., "Install GitHub App")]')
+            self.browser.driver.execute_script("window.__testOpenUrl = null;")
+            self.browser.click(xpath='//button[contains(., "Install GitHub App")]')
+            self.browser.driver.execute_script(
+                "window.postMessage(arguments[0], window.location.origin);",
+                {
+                    "_pipeline_source": "sentry-pipeline",
+                    "installation_id": "12345",
+                },
+            )
+
+            self.browser.wait_until(xpath='//button[contains(., "getsentry")]')
+            self.select_repository()
+            self.create_project("Django", "python-django")
+
+    def test_create_without_repository(self) -> None:
+        with self.feature(
+            {
+                "organizations:onboarding-scm-project-creation": True,
+                "organizations:performance-view": True,
+            }
+        ):
+            self.load_project_creation_page()
+
+            platform_input = self.browser.element('input[aria-autocomplete="list"]')
+            platform_input.send_keys("React")
+            self.browser.wait_until(
+                xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]'
+            )
+            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]')
+
+            self.browser.wait_until(xpath='//*[@role="checkbox"][.//*[text()="Tracing"]]')
+            self.browser.click(xpath='//*[@role="checkbox"][.//*[text()="Tracing"]]')
+            self.browser.wait_until(
+                xpath='//*[@role="checkbox" and @aria-checked="true"][.//*[text()="Tracing"]]'
+            )
+            self.create_project("React", "javascript-react")
+
+    def test_create_with_existing_integration(self) -> None:
+        self.create_github_integration()
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-project-creation": True,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=self.mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                return_value=self.mock_platforms,
+            ),
+        ):
+            self.load_project_creation_page()
+            self.browser.wait_until(xpath='//button[contains(., "getsentry")]')
+            assert not self.browser.element_exists(
+                xpath='//button[contains(., "Authorize GitHub")]'
+            )
+            self.browser.wait_until('input[aria-autocomplete="list"]')
+
+            self.select_repository()
+            self.create_project("Django", "python-django")


### PR DESCRIPTION
## TLDR

Adds browser coverage for all three SCM project-creation journeys while preserving the existing legacy project-creation acceptance suite.

## Details

This PR extends `tests/acceptance/test_create_project.py` rather than introducing a parallel project-creation surface. It is based on the regular feature-flag cutover and enables `organizations:onboarding-scm-project-creation`; the retired experiment gate is intentionally absent.

The new acceptance class covers installing GitHub through the API-driven popup and `postMessage` pipeline, selecting a repository, resolving platform detection, and creating the project. It also covers the optional-repository path with manual platform and product selection, plus the already-connected integration path that reaches the repository selector without reopening installation. Every journey completes at a concrete setup-docs SDK heading and verifies the persisted project platform and name, while the three pre-existing legacy cases continue to run in the same file.

Refs VDY-78
