### PR TITLE
fix(trace): Make span details replay preview independent of transactions

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -53,6 +53,7 @@ import {MCPOutputSection} from 'sentry/views/performance/newTraceDetails/traceDr
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {BreadCrumbs} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs';
 import {ReplayPreview} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview';
+import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
@@ -466,7 +467,7 @@ function EAPSpanNodeDetailsContent({
   );
 
   const links = traceItemData.links;
-  const isTransaction = node.value.is_transaction && !!eventTransaction;
+  const isTransaction = node.value.is_transaction;
 
   const threadIdAttribute = attributesMap['thread.id'];
   const threadId = typeof threadIdAttribute === 'string' ? threadIdAttribute : undefined;
@@ -551,7 +552,7 @@ function EAPSpanNodeDetailsContent({
             node={node}
             organization={organization}
             onTabScrollToNode={onTabScrollToNode}
-            showJSONLink={node.value.is_transaction}
+            showJSONLink={isTransaction && !!eventTransaction}
             profileId={node.profileId}
             profilerId={node.profilerId}
             threadId={threadId}
@@ -594,7 +595,9 @@ function EAPSpanNodeDetailsContent({
           project={project}
         />
 
-        {isTransaction ? <Contexts event={eventTransaction} project={project} /> : null}
+        {isTransaction && eventTransaction ? (
+          <Contexts event={eventTransaction} project={project} />
+        ) : null}
 
         <LogDetails />
 
@@ -621,10 +624,17 @@ function EAPSpanNodeDetailsContent({
         ) : null}
 
         {isTransaction ? (
-          <ReplayPreview event={eventTransaction} organization={organization} />
+          <ReplayPreview
+            replayId={
+              findSpanAttributeValue(attributes, 'replay.id') ||
+              findSpanAttributeValue(attributes, 'replayId')
+            }
+            eventTimestampMs={Math.floor(node.value.start_timestamp * 1000)}
+            organization={organization}
+          />
         ) : null}
 
-        {isTransaction && project ? (
+        {isTransaction && eventTransaction && project ? (
           <EventAttachments
             event={eventTransaction}
             project={project}
@@ -632,9 +642,11 @@ function EAPSpanNodeDetailsContent({
           />
         ) : null}
 
-        {isTransaction ? <BreadCrumbs event={eventTransaction} /> : null}
+        {isTransaction && eventTransaction ? (
+          <BreadCrumbs event={eventTransaction} />
+        ) : null}
 
-        {isTransaction && project ? (
+        {isTransaction && eventTransaction && project ? (
           <EventViewHierarchy
             event={eventTransaction}
             project={project}
@@ -642,7 +654,7 @@ function EAPSpanNodeDetailsContent({
           />
         ) : null}
 
-        {isTransaction && eventTransaction.projectSlug ? (
+        {isTransaction && eventTransaction?.projectSlug ? (
           <EventRRWebIntegration
             event={eventTransaction}
             orgId={organization.slug}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/index.tsx
@@ -14,6 +14,8 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t, tct} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
+import {getAnalyticsDataForEvent} from 'sentry/utils/events';
+import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -42,7 +44,7 @@ import {Entries} from './sections/entries';
 import {GeneralInfo} from './sections/generalInfo';
 import {TransactionHighlights} from './sections/highlights';
 import {hasMeasurements, Measurements} from './sections/measurements';
-import {ReplayPreview} from './sections/replayPreview';
+import {getEventTimestampMs, ReplayPreview} from './sections/replayPreview';
 import {Request} from './sections/request';
 import {hasSDKContext} from './sections/sdk';
 
@@ -199,7 +201,14 @@ export function TransactionNodeDetails({
           <EventEvidence event={event} project={project} disableCollapsePersistence />
         ) : null}
 
-        {replay ? null : <ReplayPreview event={event} organization={organization} />}
+        {replay ? null : (
+          <ReplayPreview
+            replayId={getReplayIdFromEvent(event)}
+            eventTimestampMs={getEventTimestampMs(event)}
+            organization={organization}
+            analyticsParams={getAnalyticsDataForEvent(event)}
+          />
+        )}
 
         <BreadCrumbs event={event} />
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
@@ -1,11 +1,9 @@
-import {EventFixture} from 'sentry-fixture/event';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ConfigStore} from 'sentry/stores/configStore';
-import type {EventTransaction} from 'sentry/types/event';
 
 import {ReplayPreview} from './replayPreview';
 
@@ -26,17 +24,14 @@ describe('ReplayPreview', () => {
   });
 
   it('should render replay preview when user has access', () => {
-    const event = EventFixture({
-      contexts: {
-        replay: {
-          replay_id: 'test-replay-id',
-        },
-      },
-    }) as EventTransaction;
-
-    render(<ReplayPreview event={event} organization={organization} />, {
-      organization,
-    });
+    render(
+      <ReplayPreview
+        replayId="test-replay-id"
+        eventTimestampMs={1000}
+        organization={organization}
+      />,
+      {organization}
+    );
 
     expect(screen.getByText('Session Replay')).toBeInTheDocument();
   });
@@ -45,37 +40,29 @@ describe('ReplayPreview', () => {
     const orgWithGranularPermissions = OrganizationFixture({
       features: ['session-replay'],
       hasGranularReplayPermissions: true,
-      replayAccessMembers: [999], // User ID 1 is not in this list
+      replayAccessMembers: [999],
     });
 
-    const event = EventFixture({
-      contexts: {
-        replay: {
-          replay_id: 'test-replay-id',
-        },
-      },
-    }) as EventTransaction;
-
     const {container} = render(
-      <ReplayPreview event={event} organization={orgWithGranularPermissions} />,
-      {
-        organization: orgWithGranularPermissions,
-      }
+      <ReplayPreview
+        replayId="test-replay-id"
+        eventTimestampMs={1000}
+        organization={orgWithGranularPermissions}
+      />,
+      {organization: orgWithGranularPermissions}
     );
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('should return null when event has no replay id', () => {
-    const event = EventFixture({
-      contexts: {},
-    }) as EventTransaction;
-
+  it('should return null when there is no replay id', () => {
     const {container} = render(
-      <ReplayPreview event={event} organization={organization} />,
-      {
-        organization,
-      }
+      <ReplayPreview
+        replayId={undefined}
+        eventTimestampMs={1000}
+        organization={organization}
+      />,
+      {organization}
     );
 
     expect(container).toBeEmptyDOMElement();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.tsx
@@ -7,8 +7,6 @@ import {ReplayAccess} from 'sentry/components/replays/replayAccess';
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import type {Organization} from 'sentry/types/organization';
-import {getAnalyticsDataForEvent} from 'sentry/utils/events';
-import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
 
 const REPLAY_CLIP_OFFSETS = {
@@ -16,22 +14,27 @@ const REPLAY_CLIP_OFFSETS = {
   durationBeforeMs: 5_000,
 };
 
+export function getEventTimestampMs(event: EventTransaction): number {
+  const startTimestampMS =
+    'startTimestamp' in event ? event.startTimestamp * 1000 : undefined;
+  const timeOfEvent = event.dateCreated ?? startTimestampMS ?? event.dateReceived;
+  return timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
+}
+
 function ReplaySection({
-  event,
+  replayId,
+  eventTimestampMs,
   organization,
+  analyticsParams,
   showTitle = false,
 }: {
-  event: EventTransaction;
+  eventTimestampMs: number;
   organization: Organization;
+  replayId: string;
+  analyticsParams?: Record<string, unknown>;
   showTitle?: boolean;
 }) {
-  const replayId = getReplayIdFromEvent(event);
-  const startTimestampMS =
-    event && 'startTimestamp' in event ? event.startTimestamp * 1000 : undefined;
-  const timeOfEvent = event.dateCreated ?? startTimestampMS ?? event.dateReceived;
-  const eventTimestampMs = timeOfEvent ? Math.floor(new Date(timeOfEvent).getTime()) : 0;
-
-  return replayId ? (
+  return (
     <Stack>
       {showTitle ? <ReplaySectionTitle>{t('Session Replay')}</ReplaySectionTitle> : null}
       <ReplayClipPreview
@@ -43,25 +46,26 @@ function ReplaySection({
         fullReplayButtonProps={{
           analyticsEventKey: 'trace-view.drawer-open-replay-details-clicked',
           analyticsEventName: 'Trace View: Open Replay Details Clicked',
-          analyticsParams: {
-            ...getAnalyticsDataForEvent(event),
-            organization,
-          },
+          ...(analyticsParams
+            ? {analyticsParams: {...analyticsParams, organization}}
+            : {}),
         }}
       />
     </Stack>
-  ) : null;
+  );
 }
 
 export function ReplayPreview({
-  event,
+  replayId,
+  eventTimestampMs,
   organization,
+  analyticsParams,
 }: {
-  event: EventTransaction;
+  eventTimestampMs: number;
   organization: Organization;
+  replayId: string | undefined;
+  analyticsParams?: Record<string, unknown>;
 }) {
-  const replayId = getReplayIdFromEvent(event);
-
   if (!replayId) {
     return null;
   }
@@ -73,7 +77,12 @@ export function ReplayPreview({
         sectionKey="trace_session_replay"
         disableCollapsePersistence
       >
-        <ReplaySection event={event} organization={organization} />
+        <ReplaySection
+          replayId={replayId}
+          eventTimestampMs={eventTimestampMs}
+          organization={organization}
+          analyticsParams={analyticsParams}
+        />
       </FoldSection>
     </ReplayAccess>
   );


### PR DESCRIPTION
The replay preview in the trace waterfall's span drawer currently depends on the presence of a transaction event to function, even in the EAP span version. Under span streaming there are no more transaction events. Update the `ReplayPreview` component to take `replayId`, `eventTimestampMs`, and `analyticsParams` directly instead, allowing the EAP spans and transaction event versions of the span drawer to extract them from the appropriate source and pass them in.

--

🤖: Claude + Opus helped with the refactor (lots of human guidance + review).