### PR TITLE
feat(issues): Support Autofix trigger activities

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -613,6 +613,7 @@ export enum GroupActivityType {
   PULL_REQUEST_REOPENED = 'pull_request_reopened',
   PULL_REQUEST_MERGED = 'pull_request_merged',
   PULL_REQUEST_UNLINKED = 'pull_request_unlinked',
+  TRIGGER_AUTOFIX = 'trigger_autofix',
 }
 
 export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
@@ -625,6 +626,7 @@ export const SEER_ACTIVITY_TYPES = new Set<GroupActivityType>([
   GroupActivityType.SEER_PR_CREATED,
   GroupActivityType.SEER_ITERATION_STARTED,
   GroupActivityType.SEER_ITERATION_COMPLETED,
+  GroupActivityType.TRIGGER_AUTOFIX,
 ]);
 
 interface GroupActivityBase {
@@ -820,6 +822,11 @@ interface GroupActivityPullRequestUnlinked extends GroupActivityBase {
     pullRequest?: PullRequest | null;
   };
   type: GroupActivityType.PULL_REQUEST_UNLINKED;
+}
+
+interface GroupActivityTriggerAutofix extends GroupActivityBase {
+  data: Record<string, unknown>;
+  type: GroupActivityType.TRIGGER_AUTOFIX;
 }
 
 export interface GroupActivitySetIgnored extends GroupActivityBase {
@@ -1066,7 +1073,8 @@ export type GroupActivity =
   | GroupActivityPullRequestClosed
   | GroupActivityPullRequestReopened
   | GroupActivityPullRequestMerged
-  | GroupActivityPullRequestUnlinked;
+  | GroupActivityPullRequestUnlinked
+  | GroupActivityTriggerAutofix;
 
 export type Activity = GroupActivity;
 

--- a/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem.stories.tsx
@@ -292,6 +292,7 @@ const seerPullRequest = {
 };
 
 const seerActivities = [
+  seerActivity(GroupActivityType.TRIGGER_AUTOFIX),
   seerActivity(GroupActivityType.SEER_RCA_STARTED),
   seerActivity(GroupActivityType.SEER_RCA_COMPLETED),
   seerActivity(GroupActivityType.SEER_SOLUTION_STARTED),

--- a/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/compactActivityItem.tsx
@@ -505,6 +505,10 @@ export function getCompactGroupActivityItem({
           : null,
       };
     }
+    case GroupActivityType.TRIGGER_AUTOFIX:
+      return {
+        title: t('Autofix triggered'),
+      };
   }
 
   Sentry.captureMessage(`Unknown group activity type: ${activityContext.type}`, {

--- a/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/variant.ts
+++ b/static/app/views/issueDetails/activitySection/activityLineItem/progressMarker/variant.ts
@@ -28,6 +28,7 @@ export function getActivityMarkerState(item: GroupActivity): ActivityMarkerState
     case GroupActivityType.SEER_CODING_COMPLETED:
     case GroupActivityType.SEER_ITERATION_STARTED:
     case GroupActivityType.SEER_ITERATION_COMPLETED:
+    case GroupActivityType.TRIGGER_AUTOFIX:
     case GroupActivityType.CREATE_ISSUE:
     case GroupActivityType.SET_PUBLIC:
     case GroupActivityType.SET_PRIVATE:

--- a/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityIcons.tsx
@@ -204,6 +204,11 @@ export const groupActivityTypeIconMapping: Record<
     defaultProps: {},
     propsFunction: () => ({variant: 'success'}),
   },
+  [GroupActivityType.TRIGGER_AUTOFIX]: {
+    Component: IconSeer,
+    defaultProps: {},
+    propsFunction: () => ({}),
+  },
 };
 
 const StyledUserAvatar = styled(UserAvatar)`

--- a/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/activitySection/groupActivityItem.tsx
@@ -879,6 +879,11 @@ export function getGroupActivityItem(
           message: t('Seer finished iterating on the pull request'),
         };
       }
+      case GroupActivityType.TRIGGER_AUTOFIX:
+        return {
+          title: t('Autofix'),
+          message: t('Autofix was triggered'),
+        };
       default:
         Sentry.captureMessage(`Unknown group activity type: ${activityContext.type}`, {
           contexts: {activity: activityContext},

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -945,6 +945,7 @@ describe('ActivitySection', () => {
     activity: GroupActivity;
     expectedCopy: Array<RegExp | string>;
     name: string;
+    expectedMarker?: string;
   }>([
     {
       name: 'automatic ongoing',
@@ -1090,32 +1091,40 @@ describe('ActivitySection', () => {
         data: {},
       } satisfies GroupActivity,
       expectedCopy: ['Autofix triggered'],
+      expectedMarker: 'Activity update',
     },
-  ])('renders $name v2 activity copy', async ({activity, expectedCopy}) => {
-    const activityGroup = GroupFixture({
-      id: '1339',
-      activity: [activity],
-      project,
-    });
+  ])(
+    'renders $name v2 activity copy',
+    async ({activity, expectedCopy, expectedMarker}) => {
+      const activityGroup = GroupFixture({
+        id: '1339',
+        activity: [activity],
+        project,
+      });
 
-    render(
-      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
-        <ActivitySection group={activityGroup} variant="standalone" size="md" />
-      </GroupDataContextProvider>,
-      {
-        organization: OrganizationFixture({
-          features: [
-            'display-seer-actions-as-issue-activities',
-            'issue-activity-feed-v2',
-          ],
-        }),
+      render(
+        <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+          <ActivitySection group={activityGroup} variant="standalone" size="md" />
+        </GroupDataContextProvider>,
+        {
+          organization: OrganizationFixture({
+            features: [
+              'display-seer-actions-as-issue-activities',
+              'issue-activity-feed-v2',
+              ...(expectedMarker ? ['issue-activity-progress'] : []),
+            ],
+          }),
+        }
+      );
+
+      for (const copy of expectedCopy) {
+        expect(await screen.findByText(copy)).toBeInTheDocument();
       }
-    );
-
-    for (const copy of expectedCopy) {
-      expect(await screen.findByText(copy)).toBeInTheDocument();
+      if (expectedMarker) {
+        expect(screen.getByRole('img', {name: expectedMarker})).toBeInTheDocument();
+      }
     }
-  });
+  );
 
   it('renders reprocessed events as a linked activity update', () => {
     const activityGroup = GroupFixture({

--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1081,6 +1081,16 @@ describe('ActivitySection', () => {
       } satisfies GroupActivity,
       expectedCopy: [/Pull request.*updated/, '#42', 'on GitHub'],
     },
+    {
+      name: 'Autofix trigger',
+      activity: {
+        type: GroupActivityType.TRIGGER_AUTOFIX,
+        id: 'autofix-trigger-1',
+        dateCreated: '2020-01-01T00:00:00',
+        data: {},
+      } satisfies GroupActivity,
+      expectedCopy: ['Autofix triggered'],
+    },
   ])('renders $name v2 activity copy', async ({activity, expectedCopy}) => {
     const activityGroup = GroupFixture({
       id: '1339',
@@ -1584,6 +1594,13 @@ describe('ActivitySection', () => {
           data: {run_id: 123},
           user: null,
         },
+        {
+          type: GroupActivityType.TRIGGER_AUTOFIX,
+          id: 'autofix-trigger-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {},
+          user: null,
+        },
       ],
       project,
     });
@@ -1600,6 +1617,8 @@ describe('ActivitySection', () => {
     );
     expect(await screen.findByText('Root Cause Analysis')).toBeInTheDocument();
     expect(screen.getByText('Seer completed root cause analysis')).toBeInTheDocument();
+    expect(screen.getByText('Autofix')).toBeInTheDocument();
+    expect(screen.getByText('Autofix was triggered')).toBeInTheDocument();
   });
 
   it('hides Seer activity when feature flag is disabled', () => {
@@ -1611,6 +1630,13 @@ describe('ActivitySection', () => {
           id: 'seer-rca-2',
           dateCreated: '2020-01-01T00:00:00',
           data: {run_id: 123},
+          user: null,
+        },
+        {
+          type: GroupActivityType.TRIGGER_AUTOFIX,
+          id: 'autofix-trigger-2',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {},
           user: null,
         },
       ],
@@ -1626,6 +1652,8 @@ describe('ActivitySection', () => {
     expect(
       screen.queryByText('Seer completed root cause analysis')
     ).not.toBeInTheDocument();
+    expect(screen.queryByText('Autofix')).not.toBeInTheDocument();
+    expect(screen.queryByText('Autofix was triggered')).not.toBeInTheDocument();
   });
 
   it('does not render Seer PR created activity in timeline', () => {


### PR DESCRIPTION
Adds Autofix trigger activities to both issue activity feeds and keeps them behind the existing Seer activity flag.

This prepares the frontend for the action log serializer returning `trigger_autofix`.