### PR TITLE
fix(dashboards): Ignore forced project=-1 default when checking for unsaved filters

### DIFF
--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -42,6 +42,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -1190,9 +1191,15 @@ class DashboardDetail extends Component<Props, State> {
       isCommittingChanges,
     } = this.state;
 
+    // Mirrors the member/non-member split in `PageFiltersContainer`: when a
+    // non-superuser is a member of no projects but the org has accessible ones,
+    // the page filters force `project=-1` into the URL as a default.
+    const userHasNoMemberProjects = isActiveSuperuser()
+      ? projects.length === 0
+      : !projects.some(project => project.isMember);
     const hasUnsavedFilters =
       dashboardState !== DashboardState.CREATE &&
-      hasUnsavedFilterChanges(dashboard, location);
+      hasUnsavedFilterChanges(dashboard, location, userHasNoMemberProjects);
 
     const eventView = generatePerformanceEventView(location, projects, {});
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -62,8 +62,8 @@ import {useDashboardChartInterval} from 'sentry/views/dashboards/hooks/useDashbo
 import {getDashboardRevisionsQueryKey} from 'sentry/views/dashboards/hooks/useDashboardRevisions';
 import {
   cloneDashboard,
-  getCurrentPageFilters,
   getMergedDashboardFilters,
+  getSaveablePageFilters,
   hasUnsavedFilterChanges,
   resetPageFilters,
 } from 'sentry/views/dashboards/utils';
@@ -405,6 +405,16 @@ class DashboardDetail extends Component<Props, State> {
     const {dashboard} = this.props;
     const {modifiedDashboard} = this.state;
     return modifiedDashboard ? modifiedDashboard.title : dashboard.title;
+  }
+
+  // Mirrors the member/non-member split in `PageFiltersContainer`: when a
+  // non-superuser is a member of no projects but the org has accessible ones,
+  // the page filters force `project=-1` into the URL as a default.
+  get userHasNoMemberProjects() {
+    const {projects} = this.props;
+    return isActiveSuperuser()
+      ? projects.length === 0
+      : !projects.some(project => project.isMember);
   }
 
   handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -877,7 +887,11 @@ class DashboardDetail extends Component<Props, State> {
         if (modifiedDashboard) {
           const newModifiedDashboard = {
             ...cloneDashboard(modifiedDashboard),
-            ...getCurrentPageFilters(location),
+            ...getSaveablePageFilters(
+              location,
+              modifiedDashboard,
+              this.userHasNoMemberProjects
+            ),
             filters: getMergedDashboardFilters(modifiedDashboard.filters, location),
           };
           createDashboard(api, organization.slug, newModifiedDashboard).then(
@@ -1191,15 +1205,9 @@ class DashboardDetail extends Component<Props, State> {
       isCommittingChanges,
     } = this.state;
 
-    // Mirrors the member/non-member split in `PageFiltersContainer`: when a
-    // non-superuser is a member of no projects but the org has accessible ones,
-    // the page filters force `project=-1` into the URL as a default.
-    const userHasNoMemberProjects = isActiveSuperuser()
-      ? projects.length === 0
-      : !projects.some(project => project.isMember);
     const hasUnsavedFilters =
       dashboardState !== DashboardState.CREATE &&
-      hasUnsavedFilterChanges(dashboard, location, userHasNoMemberProjects);
+      hasUnsavedFilterChanges(dashboard, location, this.userHasNoMemberProjects);
 
     const eventView = generatePerformanceEventView(location, projects, {});
 
@@ -1301,7 +1309,11 @@ class DashboardDetail extends Component<Props, State> {
                               onSave={async () => {
                                 const newModifiedDashboard = {
                                   ...cloneDashboard(modifiedDashboard ?? dashboard),
-                                  ...getCurrentPageFilters(location),
+                                  ...getSaveablePageFilters(
+                                    location,
+                                    modifiedDashboard ?? dashboard,
+                                    this.userHasNoMemberProjects
+                                  ),
                                   filters: getMergedDashboardFilters(
                                     (modifiedDashboard ?? dashboard).filters,
                                     location

--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -9,6 +9,7 @@ import {
   getCurrentPageFilters,
   getFieldsFromEquations,
   getNumEquations,
+  getSaveablePageFilters,
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
   hasUnsavedFilterChanges,
@@ -373,6 +374,59 @@ describe('Dashboards util', () => {
       };
 
       expect(hasUnsavedFilterChanges(initialDashboard, location, true)).toBe(true);
+    });
+  });
+
+  describe('getSaveablePageFilters', () => {
+    it('drops the forced project=-1 default against an empty saved filter', () => {
+      const savedDashboard = {projects: []} as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {project: '-1', environment: 'production'},
+      };
+
+      // For a user with no member projects, the forced `-1` must not be
+      // persisted (it would silently convert "My Projects" to "All Projects").
+      // Other filter changes are still saved.
+      expect(getSaveablePageFilters(location, savedDashboard, true)).toEqual(
+        expect.objectContaining({projects: [], environment: ['production']})
+      );
+    });
+
+    it('keeps project=-1 for a user with member projects', () => {
+      const savedDashboard = {projects: []} as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {project: '-1'},
+      };
+
+      expect(getSaveablePageFilters(location, savedDashboard, false)).toEqual(
+        expect.objectContaining({projects: [-1]})
+      );
+    });
+
+    it('keeps a deliberate All Projects switch on a dashboard with a saved selection', () => {
+      const savedDashboard = {projects: [5]} as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {project: '-1'},
+      };
+
+      expect(getSaveablePageFilters(location, savedDashboard, true)).toEqual(
+        expect.objectContaining({projects: [-1]})
+      );
+    });
+
+    it('keeps a real project selection for a user with no member projects', () => {
+      const savedDashboard = {projects: []} as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {project: '5'},
+      };
+
+      expect(getSaveablePageFilters(location, savedDashboard, true)).toEqual(
+        expect.objectContaining({projects: [5]})
+      );
     });
   });
 });

--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -342,6 +342,23 @@ describe('Dashboards util', () => {
       expect(hasUnsavedFilterChanges(initialDashboard, location, true)).toBe(true);
     });
 
+    it('reports switching a saved project selection to All Projects as a change', () => {
+      const initialDashboard = {
+        projects: [5],
+      } as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {
+          project: '-1',
+        },
+      };
+
+      // A dashboard with a real saved project filter switched to All Projects is
+      // a genuine change, even for a user with no member projects. The forced
+      // `-1` default only collides with an empty ("My Projects") saved filter.
+      expect(hasUnsavedFilterChanges(initialDashboard, location, true)).toBe(true);
+    });
+
     it('still reports other filter changes for a user with no member projects', () => {
       const initialDashboard = {
         projects: [],

--- a/static/app/views/dashboards/utils.spec.tsx
+++ b/static/app/views/dashboards/utils.spec.tsx
@@ -307,6 +307,56 @@ describe('Dashboards util', () => {
         })
       ).toBe(false);
     });
+
+    it('ignores the forced project=-1 default for a user with no member projects', () => {
+      const initialDashboard = {
+        projects: [],
+      } as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {
+          project: '-1',
+        },
+      };
+
+      // With no member projects, the page filters force `project=-1` into the
+      // URL, which should not be treated as an unsaved change against a "My
+      // Projects" (empty) dashboard.
+      expect(hasUnsavedFilterChanges(initialDashboard, location, true)).toBe(false);
+      // A member of some project selecting "All Projects" is a real change.
+      expect(hasUnsavedFilterChanges(initialDashboard, location, false)).toBe(true);
+    });
+
+    it('reports a real project selection for a user with no member projects', () => {
+      const initialDashboard = {
+        projects: [],
+      } as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {
+          // An explicit project selection produces real ids, not the sentinel.
+          project: '5',
+        },
+      };
+
+      expect(hasUnsavedFilterChanges(initialDashboard, location, true)).toBe(true);
+    });
+
+    it('still reports other filter changes for a user with no member projects', () => {
+      const initialDashboard = {
+        projects: [],
+        environment: [],
+      } as unknown as DashboardDetails;
+      const location = {
+        ...LocationFixture(),
+        query: {
+          project: '-1',
+          environment: 'production',
+        },
+      };
+
+      expect(hasUnsavedFilterChanges(initialDashboard, location, true)).toBe(true);
+    });
   });
 });
 

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -14,6 +14,7 @@ import {
   SIX_HOURS,
   TWENTY_FOUR_HOURS,
 } from 'sentry/components/charts/utils';
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeString} from 'sentry/components/pageFilters/parse';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -367,7 +368,8 @@ export function hasSavedPageFilters(
 
 export function hasUnsavedFilterChanges(
   initialDashboard: DashboardDetails,
-  location: Location
+  location: Location,
+  userHasNoMemberProjects = false
 ) {
   // Use Sets to compare the filter fields that are arrays
   type Filters = {
@@ -397,6 +399,21 @@ export function hasUnsavedFilterChanges(
     projects: new Set(currentFilters.projects),
     environment: new Set(currentFilters.environment),
   };
+
+  // When the user isn't a member of any project (e.g. they're not on any team)
+  // but the org has projects they can access, the page filters force
+  // `project=-1` (ALL_ACCESS_PROJECTS) into the URL as a default (see
+  // `initializeUrlState`). That forced default is equivalent to a dashboard's
+  // "My Projects" (empty) saved filter, so don't treat it as an unsaved change.
+  // The user can still save an explicit project selection, since that produces
+  // real project ids in the URL rather than the forced sentinel.
+  if (
+    userHasNoMemberProjects &&
+    currentFilters.projects?.size === 1 &&
+    currentFilters.projects.has(ALL_ACCESS_PROJECTS)
+  ) {
+    currentFilters.projects = new Set(savedFilters.projects);
+  }
 
   if (defined(location.query?.release)) {
     // Release is only included in the comparison if it exists in the query

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -499,6 +499,33 @@ export function getCurrentPageFilters(
 }
 
 /**
+ * Like `getCurrentPageFilters`, but safe to persist to a dashboard. When the
+ * user isn't a member of any project, the page filters force `project=-1`
+ * (ALL_ACCESS_PROJECTS) into the URL as a default (see `initializeUrlState` and
+ * `hasUnsavedFilterChanges`). Persisting that forced default would silently
+ * convert a dashboard's empty "My Projects" filter into "All Projects" for
+ * everyone, so drop it back to the empty saved filter. Scoped to an empty saved
+ * filter on purpose: a real saved selection deliberately switched to All
+ * Projects should still be persisted.
+ */
+export function getSaveablePageFilters(
+  location: Location,
+  savedDashboard: DashboardDetails,
+  userHasNoMemberProjects: boolean
+) {
+  const pageFilters = getCurrentPageFilters(location);
+  if (
+    userHasNoMemberProjects &&
+    (savedDashboard.projects?.length ?? 0) === 0 &&
+    pageFilters.projects?.length === 1 &&
+    pageFilters.projects[0] === ALL_ACCESS_PROJECTS
+  ) {
+    pageFilters.projects = [];
+  }
+  return pageFilters;
+}
+
+/**
  * Merges saved dashboard filters with any overrides from the URL.
  * URL filters take precedence per-key, but saved filters fill in
  * keys that aren't present in the URL (e.g. globalFilter when only

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -514,12 +514,18 @@ export function getSaveablePageFilters(
   userHasNoMemberProjects: boolean
 ) {
   const pageFilters = getCurrentPageFilters(location);
-  if (
-    userHasNoMemberProjects &&
-    (savedDashboard.projects?.length ?? 0) === 0 &&
-    pageFilters.projects?.length === 1 &&
-    pageFilters.projects[0] === ALL_ACCESS_PROJECTS
-  ) {
+
+  const isAllProjectsSelected =
+    pageFilters.projects?.length === 1 && pageFilters.projects[0] === ALL_ACCESS_PROJECTS;
+  // A user with no member projects gets `project=-1` forced into the URL as a
+  // default, so their All Projects value is (treated as) the forced default.
+  const isForcedAllProjectsDefault = userHasNoMemberProjects && isAllProjectsSelected;
+  const doesNotHaveSavedDashboardProjects = (savedDashboard.projects?.length ?? 0) === 0;
+
+  // Only drop the forced default back to empty when the dashboard itself has no
+  // saved projects ("My Projects"); a real saved selection switched to All
+  // Projects is a deliberate change and should be persisted as-is.
+  if (isForcedAllProjectsDefault && doesNotHaveSavedDashboardProjects) {
     pageFilters.projects = [];
   }
   return pageFilters;

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -406,10 +406,13 @@ export function hasUnsavedFilterChanges(
   const isAllProjectsSelected =
     currentFilters.projects?.size === 1 &&
     currentFilters.projects.has(ALL_ACCESS_PROJECTS);
-  const isForcedAllProjectsDefault = userHasNoMemberProjects && isAllProjectsSelected;
   const doesNotHaveSavedDashboardProjects = savedFilters.projects?.size === 0;
 
-  if (isForcedAllProjectsDefault && doesNotHaveSavedDashboardProjects) {
+  if (
+    userHasNoMemberProjects &&
+    isAllProjectsSelected &&
+    doesNotHaveSavedDashboardProjects
+  ) {
     currentFilters.projects = new Set();
   }
 
@@ -506,10 +509,13 @@ export function getSaveablePageFilters(
 
   const isAllProjectsSelected =
     pageFilters.projects?.length === 1 && pageFilters.projects[0] === ALL_ACCESS_PROJECTS;
-  const isForcedAllProjectsDefault = userHasNoMemberProjects && isAllProjectsSelected;
   const doesNotHaveSavedDashboardProjects = (savedDashboard.projects?.length ?? 0) === 0;
 
-  if (isForcedAllProjectsDefault && doesNotHaveSavedDashboardProjects) {
+  if (
+    userHasNoMemberProjects &&
+    isAllProjectsSelected &&
+    doesNotHaveSavedDashboardProjects
+  ) {
     pageFilters.projects = [];
   }
   return pageFilters;

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -403,16 +403,20 @@ export function hasUnsavedFilterChanges(
   // When the user isn't a member of any project (e.g. they're not on any team)
   // but the org has projects they can access, the page filters force
   // `project=-1` (ALL_ACCESS_PROJECTS) into the URL as a default (see
-  // `initializeUrlState`). That forced default is equivalent to a dashboard's
-  // "My Projects" (empty) saved filter, so don't treat it as an unsaved change.
-  // The user can still save an explicit project selection, since that produces
-  // real project ids in the URL rather than the forced sentinel.
+  // `initializeUrlState`). That default is only injected when there's no
+  // explicit selection, so it only collides with a dashboard whose saved
+  // project filter is empty ("My Projects"). In that case, treat the forced
+  // `-1` as equivalent to the empty saved filter so it isn't seen as an
+  // unsaved change. This is scoped to an empty saved filter on purpose: a
+  // dashboard with a real saved selection switched to All Projects is a
+  // genuine change and should still enable saving.
   if (
     userHasNoMemberProjects &&
+    savedFilters.projects?.size === 0 &&
     currentFilters.projects?.size === 1 &&
     currentFilters.projects.has(ALL_ACCESS_PROJECTS)
   ) {
-    currentFilters.projects = new Set(savedFilters.projects);
+    currentFilters.projects = new Set();
   }
 
   if (defined(location.query?.release)) {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -400,22 +400,16 @@ export function hasUnsavedFilterChanges(
     environment: new Set(currentFilters.environment),
   };
 
-  // When the user isn't a member of any project (e.g. they're not on any team)
-  // but the org has projects they can access, the page filters force
-  // `project=-1` (ALL_ACCESS_PROJECTS) into the URL as a default (see
-  // `initializeUrlState`). That default is only injected when there's no
-  // explicit selection, so it only collides with a dashboard whose saved
-  // project filter is empty ("My Projects"). In that case, treat the forced
-  // `-1` as equivalent to the empty saved filter so it isn't seen as an
-  // unsaved change. This is scoped to an empty saved filter on purpose: a
-  // dashboard with a real saved selection switched to All Projects is a
-  // genuine change and should still enable saving.
-  if (
-    userHasNoMemberProjects &&
-    savedFilters.projects?.size === 0 &&
+  // No-member users get `project=-1` forced into the URL as a default (see
+  // `initializeUrlState`); don't count that against a "My Projects" dashboard
+  // as an unsaved change.
+  const isAllProjectsSelected =
     currentFilters.projects?.size === 1 &&
-    currentFilters.projects.has(ALL_ACCESS_PROJECTS)
-  ) {
+    currentFilters.projects.has(ALL_ACCESS_PROJECTS);
+  const isForcedAllProjectsDefault = userHasNoMemberProjects && isAllProjectsSelected;
+  const doesNotHaveSavedDashboardProjects = savedFilters.projects?.size === 0;
+
+  if (isForcedAllProjectsDefault && doesNotHaveSavedDashboardProjects) {
     currentFilters.projects = new Set();
   }
 
@@ -499,14 +493,9 @@ export function getCurrentPageFilters(
 }
 
 /**
- * Like `getCurrentPageFilters`, but safe to persist to a dashboard. When the
- * user isn't a member of any project, the page filters force `project=-1`
- * (ALL_ACCESS_PROJECTS) into the URL as a default (see `initializeUrlState` and
- * `hasUnsavedFilterChanges`). Persisting that forced default would silently
- * convert a dashboard's empty "My Projects" filter into "All Projects" for
- * everyone, so drop it back to the empty saved filter. Scoped to an empty saved
- * filter on purpose: a real saved selection deliberately switched to All
- * Projects should still be persisted.
+ * Like `getCurrentPageFilters`, but drops the forced `project=-1` default (see
+ * `hasUnsavedFilterChanges`) so saving doesn't silently convert a "My Projects"
+ * dashboard into "All Projects" for everyone.
  */
 export function getSaveablePageFilters(
   location: Location,
@@ -517,14 +506,9 @@ export function getSaveablePageFilters(
 
   const isAllProjectsSelected =
     pageFilters.projects?.length === 1 && pageFilters.projects[0] === ALL_ACCESS_PROJECTS;
-  // A user with no member projects gets `project=-1` forced into the URL as a
-  // default, so their All Projects value is (treated as) the forced default.
   const isForcedAllProjectsDefault = userHasNoMemberProjects && isAllProjectsSelected;
   const doesNotHaveSavedDashboardProjects = (savedDashboard.projects?.length ?? 0) === 0;
 
-  // Only drop the forced default back to empty when the dashboard itself has no
-  // saved projects ("My Projects"); a real saved selection switched to All
-  // Projects is a deliberate change and should be persisted as-is.
   if (isForcedAllProjectsDefault && doesNotHaveSavedDashboardProjects) {
     pageFilters.projects = [];
   }


### PR DESCRIPTION
When a non-superuser is a member of **no projects** but the org has projects they can access, the page filters force `project=-1` (All Projects) into the URL as a default. Specifically, `initializeUrlState` injects `-1` when all of these hold:

- the user is a member of no projects (`memberProjects.length === 0`)
- the org has accessible projects they aren't a member of (`nonMemberProjects.length > 0`)
- no project is already selected in the URL or remembered from last time
- the user is not a superuser

On a freshly-opened pre-built dashboard (which has no saved project filter), that forced `-1` was compared against the empty saved state and read as an unsaved change — incorrectly enabling the **Save for Everyone** button before the user did anything.

Before (user with no team)
<img width="873" height="136" alt="image" src="https://github.com/user-attachments/assets/9aeda03b-a5cf-4538-8021-ce84188f7b82" />

After
<img width="700" height="185" alt="image" src="https://github.com/user-attachments/assets/db1b4308-1f4e-41fc-a6cf-8a5cf771604d" />

## Changes

- **Unsaved-filter check**: treat the forced `project=-1` default as equivalent to a dashboard's empty "My Projects" filter for these users, so it no longer counts as a change. Scoped to an **empty** saved project filter on purpose — the forced default is only injected when there's no explicit selection, so it only collides with an empty saved filter. A dashboard with a real saved selection deliberately switched to All Projects (or any explicit selection) is still a genuine change and continues to enable the button.
- **Save paths**: the save handlers wrote the raw URL filters, so changing another filter and saving would persist `projects: [-1]` and silently convert a shared dashboard from "My Projects" to "All Projects". A new `getSaveablePageFilters` helper drops the forced `-1` back to the empty saved filter (same scoping) before persisting, used by both save paths.

## Known limitation

The forced default and a deliberate All Projects selection produce an identical `project=-1` in the URL, so a no-member user still can't save an *empty* dashboard as "All Projects" on its own — that case is indistinguishable from the forced default. Fully resolving it would require propagating a "this was forced" signal from `initializeUrlState`, which is out of scope here.

Fixes DAIN-1433
