### PR TITLE
fix(action_log): Give action log-based Activity APIs their own feature

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -478,6 +478,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:error-upsampling", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable calculating a severity score for events which create a new group
     manager.add("projects:first-event-severity-calculation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable using issue action log entries as the activity source in group details
+    manager.add("projects:issue-action-log-activity", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable writing issue action log entries to the database
     manager.add("projects:issue-action-log-write-to-db", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("projects:issue-status-reconciliation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -379,7 +379,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
             )
 
             if features.has(
-                "projects:issue-action-log-write-to-db", group.project, actor=request.user
+                "projects:issue-action-log-activity", group.project, actor=request.user
             ):
                 action_log = GroupActionLogEntry.objects.get_actions_for_group(group, 99)
                 if action_log:

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -100,7 +100,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["firstRelease"] is None
         assert response.data["lastRelease"] is None
 
-    @with_feature("projects:issue-action-log-write-to-db")
+    @with_feature(["projects:issue-action-log-write-to-db", "projects:issue-action-log-activity"])
     def test_group_action_log_entry(self) -> None:
         group = self.create_group()
 


### PR DESCRIPTION
The action log write flag shouldn't gate other product functionality so we can turn on writes prior to using the data.