### PR TITLE
fix(options): stop truncating option values in WebhookPresenter

### DIFF
--- a/src/sentry/runner/commands/presenters/webhookpresenter.py
+++ b/src/sentry/runner/commands/presenters/webhookpresenter.py
@@ -14,11 +14,13 @@ from sentry.utils import json
 class WebhookPresenter(OptionsPresenter):
     """
     Sends changes of runtime options made via sentry configoptions
-    to a webhook url in a truncated json format. The webhook url can
-    be configured to your liking.
-    """
+    to a webhook url in json format. The webhook url can be configured
+    to your liking.
 
-    MAX_OPTION_VALUE_LENGTH = 100
+    Values are sent in full, untruncated - the receiving webhook is
+    responsible for any truncation needed to fit its own display
+    constraints (e.g. Slack's block/section length limits).
+    """
 
     def __init__(self, source: str, timestamp: float | None = None) -> None:
         self.source = source
@@ -64,20 +66,19 @@ class WebhookPresenter(OptionsPresenter):
             "region": region,
             "source": self.source,
             "drifted_options": [
-                {"option_name": key, "option_value": self.truncate_value(value)}
+                {"option_name": key, "option_value": str(value)}
                 for key, value in self.drifted_options
             ],
             "updated_options": [
                 {
                     "option_name": key,
-                    "db_value": self.truncate_value(db_value),
-                    "value": self.truncate_value(value),
+                    "db_value": str(db_value),
+                    "value": str(value),
                 }
                 for key, db_value, value in self.updated_options
             ],
             "set_options": [
-                {"option_name": key, "option_value": self.truncate_value(value)}
-                for key, value in self.set_options
+                {"option_name": key, "option_value": str(value)} for key, value in self.set_options
             ],
             "unset_options": self.unset_options,
             "not_writable_options": [
@@ -96,13 +97,6 @@ class WebhookPresenter(OptionsPresenter):
             json_data["latency_seconds"] = latency_seconds
 
         self._send_to_webhook(json_data)
-
-    def truncate_value(self, value: str) -> str:
-        value_str = str(value)
-        if len(value_str) > self.MAX_OPTION_VALUE_LENGTH:
-            return value_str[: self.MAX_OPTION_VALUE_LENGTH] + "..."
-        else:
-            return value_str
 
     def set(self, key: str, value: Any) -> None:
         self.set_options.append((key, value))

--- a/tests/sentry/runner/commands/presenters/test_webhookpresenter.py
+++ b/tests/sentry/runner/commands/presenters/test_webhookpresenter.py
@@ -233,3 +233,38 @@ def test_slack_presenter_methods_with_different_types() -> None:
         responses.calls[0].request.headers["x-sentry-options-signature"]
         == "8b7827d99b4373d1a969e38d2813be1ee8de3f4a75c46223af548c04a053f98a"
     )
+
+
+@pytest.mark.django_db
+@responses.activate
+@override_settings(
+    OPTIONS_AUTOMATOR_SLACK_WEBHOOK_URL="https://test/",
+    OPTIONS_AUTOMATOR_HMAC_SECRET="test-secret-key",
+    SENTRY_LOCAL_CELL="test_region",
+)
+def test_slack_presenter_does_not_truncate_long_values() -> None:
+    # Long option values (e.g. serialized dicts/lists) must be sent to the
+    # webhook in full - the receiving webhook, not this presenter, is
+    # responsible for any truncation needed to fit its own display limits.
+    responses.add(responses.POST, "https://test/", status=200)
+    long_value = "x" * 500
+
+    presenter = WebhookPresenter("options-automator")
+    assert presenter.is_webhook_enabled()
+
+    presenter.set("long_option", long_value)
+    presenter.update("updated_option", long_value, long_value)
+    presenter.drift("drifted_option", long_value)
+
+    presenter.flush()
+
+    sent_json_data = json.loads(responses.calls[0].request.body)
+    assert sent_json_data["set_options"] == [
+        {"option_name": "long_option", "option_value": long_value}
+    ]
+    assert sent_json_data["updated_options"] == [
+        {"option_name": "updated_option", "db_value": long_value, "value": long_value}
+    ]
+    assert sent_json_data["drifted_options"] == [
+        {"option_name": "drifted_option", "option_value": long_value}
+    ]


### PR DESCRIPTION
was trying to make this nicer in https://github.com/getsentry/eng-pipes/pull/1011 but turns out we're the ones truncating 
