### PR TITLE
fix(issues): Serialize Autofix trigger activity type

### DIFF
--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -373,6 +373,7 @@ class MarkReviewedAction(GroupAction):
 
 class TriggerAutofixAction(GroupAction):
     user_visible = True
+    referrer: Optional[str] = None
 
     @classmethod
     def get_type(cls) -> GroupActionType:

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -49,6 +49,7 @@ class ActivityType(Enum):
     PULL_REQUEST_REOPENED = 39
     PULL_REQUEST_MERGED = 40
     PULL_REQUEST_UNLINKED = 41
+    TRIGGER_AUTOFIX = 42
 
 
 # Warning: This must remain in this EXACT order.
@@ -96,6 +97,7 @@ CHOICES = tuple(
         ActivityType.PULL_REQUEST_REOPENED,  # 39
         ActivityType.PULL_REQUEST_MERGED,  # 40
         ActivityType.PULL_REQUEST_UNLINKED,  # 41
+        ActivityType.TRIGGER_AUTOFIX,  # 42
     ]
 )
 

--- a/src/sentry/utils/action_log/activity_translator.py
+++ b/src/sentry/utils/action_log/activity_translator.py
@@ -40,6 +40,7 @@ from sentry.issues.action_log.types import (
     SetResolvedByAgeAction,
     SetResolvedInCommitAction,
     SetResolvedInReleaseAction,
+    TriggerAutofixAction,
     UnassignAction,
     UnmergeDestinationAction,
     UnmergeSourceAction,
@@ -99,6 +100,7 @@ ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE: Mapping[int, type[GroupAction]] = {
     ActivityType.PULL_REQUEST_REOPENED.value: PullRequestReopenedAction,
     ActivityType.PULL_REQUEST_MERGED.value: PullRequestMergedAction,
     ActivityType.PULL_REQUEST_UNLINKED.value: PullRequestUnlinkedAction,
+    ActivityType.TRIGGER_AUTOFIX.value: TriggerAutofixAction,
 }
 
 ACTIVITY_TYPE_TO_ARG_TRANSLATIONS: Mapping[int, Mapping[str, str]] = {

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -9,6 +9,20 @@ from sentry.testutils.silo import assume_test_silo_mode
 
 
 class GroupActionLogEntrySerializerTestCase(TestCase):
+    def test_trigger_autofix_entry_type(self) -> None:
+        user = self.create_user()
+        group = self.create_group()
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.TRIGGER_AUTOFIX,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+        )
+
+        result = serialize(entry, user)
+
+        assert result["type"] == "trigger_autofix"
+
     def test_pull_request_entry(self) -> None:
         self.org = self.create_organization(name="Rowdy Tiger")
         user = self.create_user()

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -17,11 +17,13 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
             type=GroupActionType.TRIGGER_AUTOFIX,
             actor_type=GroupActorType.USER,
             actor_id=user.id,
+            data={"referrer": "slack"},
         )
 
         result = serialize(entry, user)
 
         assert result["type"] == "trigger_autofix"
+        assert result["data"] == {"referrer": "slack"}
 
     def test_pull_request_entry(self) -> None:
         self.org = self.create_organization(name="Rowdy Tiger")


### PR DESCRIPTION
`TRIGGER_AUTOFIX` action log entries currently serialize as uppercase because they have no matching Activity type.

Adds the Activity type and translator mapping so the existing serializer returns `trigger_autofix`. This also sets up the follow-up that writes regular issue activities.