### PR TITLE
fix(explore): expose user log attributes that collide with reserved aliases

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -74,8 +74,10 @@ from sentry.search.eap.types import (
     SupportedTraceItemType,
 )
 from sentry.search.eap.utils import (
+    can_expose_attribute,
     can_expose_attribute_to_api,
     get_secondary_aliases,
+    is_internal_sentry_convention_attribute,
     is_sentry_convention_replacement_attribute,
     translate_internal_to_public_alias,
 )
@@ -529,6 +531,34 @@ def can_expose_trace_item_attribute_to_api(
     )
 
 
+def _can_expose_data_attribute_to_api(
+    name: str,
+    attribute_key: TraceItemAttributeKey,
+    item_type: SupportedTraceItemType,
+    include_internal: bool = False,
+) -> bool:
+    """Whether an attribute found in a customer's data may be exposed.
+
+    A user-sent attribute whose name collides with a reserved public alias is
+    surfaced under an explicit ``tags[...]`` key that references only the user's
+    column. Its exposure is gated on the attribute's own name, so a private
+    reserved *column* it merely shadows doesn't suppress it (e.g. a customer's
+    ``organization.id``, which shadows the private ``sentry.organization_id``).
+    Internal sentry *conventions* are still hidden unless ``include_internal``.
+    """
+    if attribute_key["attributeSource"]["source_type"] == AttributeSourceType.USER.value:
+        if not can_expose_attribute(name, item_type, include_internal=include_internal):
+            return False
+        if include_internal:
+            return True
+        return not is_internal_sentry_convention_attribute(name, item_type)
+    return can_expose_attribute_to_api(
+        name, item_type, include_internal=include_internal
+    ) and can_expose_trace_item_attribute_to_api(
+        attribute_key, item_type, include_internal=include_internal
+    )
+
+
 @extend_schema(tags=["Discover"])
 @cell_silo_endpoint
 class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEndpointBase):
@@ -812,30 +842,30 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
     ) -> list[TraceItemAttributeKey]:
         attribute_keys = {}
         for attribute in rpc_response.attributes:
-            if attribute.name and can_expose_attribute_to_api(
+            if not attribute.name:
+                continue
+            attr_key = as_attribute_key(
                 attribute.name,
+                attribute_type,
                 trace_item_type,
-                include_internal=include_internal,
-            ):
-                attr_key = as_attribute_key(
+                include_context=include_context,
+            )
+            if (
+                _can_expose_data_attribute_to_api(
                     attribute.name,
-                    attribute_type,
+                    attr_key,
                     trace_item_type,
-                    include_context=include_context,
+                    include_internal=include_internal,
                 )
-                if (
-                    not is_sentry_convention_replacement_attribute(
-                        attr_key["name"], trace_item_type
-                    )
-                    # Remove anything where the public alias doesn't match the substring
-                    # This can happen when the public alias is different, but that's handled by
-                    # aliased_attributes
-                    and (substring_match in attr_key["name"] if substring_match else True)
-                    and can_expose_trace_item_attribute_to_api(
-                        attr_key, trace_item_type, include_internal=include_internal
-                    )
-                ):
-                    attribute_keys[attr_key["key"]] = attr_key
+                and not is_sentry_convention_replacement_attribute(
+                    attr_key["name"], trace_item_type
+                )
+                # Remove anything where the public alias doesn't match the substring
+                # This can happen when the public alias is different, but that's handled by
+                # aliased_attributes
+                and (substring_match in attr_key["name"] if substring_match else True)
+            ):
+                attribute_keys[attr_key["key"]] = attr_key
         # We need to exclude any aliased attributes here since because of pagination they might have already been seen
         # earlier
         for aliased_attr in exclude_attributes:

--- a/src/sentry/search/eap/utils.py
+++ b/src/sentry/search/eap/utils.py
@@ -179,12 +179,14 @@ def translate_internal_to_public_alias(
 
     resolved_column = PUBLIC_ALIAS_TO_INTERNAL_MAPPING.get(item_type, {}).get(internal_alias)
     if resolved_column is not None:
-        # if there is a known public alias with this exact name, it means we need to wrap
-        # it in the explicitly typed tags syntax in order for it to reference the correct column
+        # A data attribute whose name collides with a known public alias is a
+        # user-sent attribute; it's wrapped in the explicitly typed tags syntax so
+        # it references the user's column rather than the reserved alias. It is
+        # user-sourced, not Sentry-defined (e.g. a customer's own `organization.id`).
         return (
             f"tags[{internal_alias},{search_type}]",
             internal_alias,
-            {"source_type": AttributeSourceType.SENTRY},
+            {"source_type": AttributeSourceType.USER},
         )
 
     definitions = TRACE_ITEM_TYPE_DEFINITIONS.get(item_type)

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -425,6 +425,27 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             "tags[timestamp,string]",
         }
 
+    def test_attribute_collision_with_private_reserved_alias(self) -> None:
+        # `organization.id` collides with the private reserved `sentry.organization_id`.
+        # A user-sent attribute of that name must still be exposed, disambiguated
+        # under an explicit `tags[...]` key and attributed to the user.
+        logs = [
+            self.create_ourlog(
+                organization=self.organization,
+                project=self.project,
+                attributes={"organization.id": "user-org-value"},
+            ),
+        ]
+
+        self.store_eap_items(logs)
+
+        response = self.do_request(query={"attributeType": "string"})
+
+        assert response.status_code == 200, response.content
+        org_id = {item["key"]: item for item in response.data if item["name"] == "organization.id"}
+        assert "tags[organization.id,string]" in org_id
+        assert org_id["tags[organization.id,string]"]["attributeSource"] == {"source_type": "user"}
+
     def test_boolean_attributes(self) -> None:
         logs = [
             self.create_ourlog(
@@ -1036,13 +1057,13 @@ class OrganizationTraceItemAttributesEndpointSpansTest(
                 "key": "tags[span.duration,string]",
                 "name": "span.duration",
                 "attributeType": "string",
-                "attributeSource": {"source_type": "sentry"},
+                "attributeSource": {"source_type": "user"},
             },
             {
                 "key": "tags[span.op,string]",
                 "name": "span.op",
                 "attributeType": "string",
-                "attributeSource": {"source_type": "sentry"},
+                "attributeSource": {"source_type": "user"},
             },
         ]
         assert sorted(


### PR DESCRIPTION
Fixes the backend half of LOGS-447: a user-sent log attribute whose name collides with a reserved public alias -e.g. a customer sending their own `organization.id` via OTLP- never appeared in the attributes endpoint, so it couldn't be added as a column in Edit Table.

See #120374 for frontend changes.

### What was wrong

The attributes endpoint gated exposure on the raw attribute name via `can_expose_attribute_to_api`, which expands an attribute to the reserved aliases/columns it shadows. `organization.id` expands to `sentry.organization_id`, which is `private`, so the customer's own attribute was suppressed entirely. Colliding attributes were also labeled `source_type: sentry` even though the data was user-sent.

### Let's Do Something About It

- `_can_expose_data_attribute_to_api`: for user-sent attributes, gate on the attribute's **own** name rather than the reserved column it shadows. That way a private reserved *column* no longer suppresses a customer attribute of the same name, while `sentry.`-namespaced private names and internal conventions (e.g. `dsc.*`) stay hidden.
- `translate_internal_to_public_alias`: attribute a public-alias collision to `source_type: user` (it's the customer's data, surfaced under its explicit `tags[...]` key), not `sentry`.

The customer's attribute now surfaces as `tags[organization.id,string]` with `source_type: user`.

Starts on LOGS-447. 