### PR TITLE
fix(explore): show user log attributes that collide with reserved names in Edit Table

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -459,6 +459,14 @@ export type Tag = {
   name: string;
   alias?: string;
 
+  /**
+   * For trace-item attributes, whether the attribute was defined by Sentry
+   * ('sentry') or sent by the user ('user'). Used to keep user attributes whose
+   * name collides with a reserved field (e.g. a custom `organization.id`) out of
+   * the reserved-field hidden lists.
+   */
+  attributeSource?: string;
+
   isInput?: boolean;
 
   kind?: FieldKind;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -461,11 +461,9 @@ export type Tag = {
 
   /**
    * For trace-item attributes, whether the attribute was defined by Sentry
-   * ('sentry') or sent by the user ('user'). Used to keep user attributes whose
-   * name collides with a reserved field (e.g. a custom `organization.id`) out of
-   * the reserved-field hidden lists.
+   * ('sentry') or sent by the user ('user').
    */
-  attributeSource?: string;
+  attributeSource?: 'sentry' | 'user';
 
   isInput?: boolean;
 

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
@@ -14,7 +14,7 @@ function mockTraceItemAttributeKeysByType({
     key: string;
     kind: FieldKind;
     name: string;
-    attributeSource?: {source_type: string};
+    attributeSource?: {source_type: 'sentry' | 'user'};
   }>;
   itemType?: TraceItemDataset;
 }) {

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
@@ -14,6 +14,7 @@ function mockTraceItemAttributeKeysByType({
     key: string;
     kind: FieldKind;
     name: string;
+    attributeSource?: {source_type: string};
   }>;
   itemType?: TraceItemDataset;
 }) {
@@ -222,6 +223,31 @@ describe('useGetTraceItemAttributeTagKeys', () => {
 
     expect(tags).toHaveLength(1);
     expect(tags).toMatchObject([{key: 'log.field', name: 'log.field'}]);
+  });
+
+  it('keeps user-sent attributes whose name collides with a hidden key', async () => {
+    mockTraceItemAttributeKeysByType({
+      body: [
+        {
+          attributeType: 'string',
+          key: 'organization.id',
+          name: 'organization.id',
+          kind: FieldKind.TAG,
+          attributeSource: {source_type: 'user'},
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeTagKeys, {
+      initialProps: {
+        itemType: TraceItemDataset.LOGS,
+        hiddenKeys: ['organization.id'],
+      },
+    });
+
+    const tags = await result.current('search-query');
+
+    expect(tags).toMatchObject([{key: 'organization.id', name: 'organization.id'}]);
   });
 
   it('appends extraTags that are not in fetched results', async () => {

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -5,6 +5,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Tag, TagCollection} from 'sentry/types/group';
 import {useGetTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useGetTraceItemAttributeKeys';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
+import {isHiddenAttribute} from 'sentry/views/explore/utils';
 
 export function useGetTraceItemAttributeTagKeys({
   itemType,
@@ -38,7 +39,7 @@ export function useGetTraceItemAttributeTagKeys({
         ...Object.values(keys.booleanAttributes),
       ];
       const filteredFetched = hiddenKeySet
-        ? fetched.filter(t => !hiddenKeySet.has(t.key) && !hiddenKeySet.has(t.name))
+        ? fetched.filter(t => !isHiddenAttribute(t, hiddenKeySet))
         : fetched;
       const fetchedKeySet = new Set(filteredFetched.map(t => t.key));
       return [

--- a/static/app/views/explore/hooks/useTraceItemAttributes.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributes.tsx
@@ -211,34 +211,35 @@ function processTraceItemAttributes(
   type?: TraceItemAttributeType,
   hiddenKeys?: string[]
 ) {
+  const hiddenKeySet = hiddenKeys ? new Set(hiddenKeys) : undefined;
   if (type === 'boolean') {
     return {
-      attributes: hiddenKeys
-        ? removeHiddenKeys(typedAttributesResult.boolean, hiddenKeys)
+      attributes: hiddenKeySet
+        ? removeHiddenKeys(typedAttributesResult.boolean, hiddenKeySet)
         : typedAttributesResult.boolean,
-      secondaryAliases: hiddenKeys
-        ? removeHiddenKeys(typedAttributesResult.booleanSecondaryAliases, hiddenKeys)
+      secondaryAliases: hiddenKeySet
+        ? removeHiddenKeys(typedAttributesResult.booleanSecondaryAliases, hiddenKeySet)
         : typedAttributesResult.booleanSecondaryAliases,
       isLoading: typedAttributesResult.booleanAttributesLoading,
     };
   }
   if (type === 'number') {
     return {
-      attributes: hiddenKeys
-        ? removeHiddenKeys(typedAttributesResult.number, hiddenKeys)
+      attributes: hiddenKeySet
+        ? removeHiddenKeys(typedAttributesResult.number, hiddenKeySet)
         : typedAttributesResult.number,
-      secondaryAliases: hiddenKeys
-        ? removeHiddenKeys(typedAttributesResult.numberSecondaryAliases, hiddenKeys)
+      secondaryAliases: hiddenKeySet
+        ? removeHiddenKeys(typedAttributesResult.numberSecondaryAliases, hiddenKeySet)
         : typedAttributesResult.numberSecondaryAliases,
       isLoading: typedAttributesResult.numberAttributesLoading,
     };
   }
   return {
-    attributes: hiddenKeys
-      ? removeHiddenKeys(typedAttributesResult.string, hiddenKeys)
+    attributes: hiddenKeySet
+      ? removeHiddenKeys(typedAttributesResult.string, hiddenKeySet)
       : typedAttributesResult.string,
-    secondaryAliases: hiddenKeys
-      ? removeHiddenKeys(typedAttributesResult.stringSecondaryAliases, hiddenKeys)
+    secondaryAliases: hiddenKeySet
+      ? removeHiddenKeys(typedAttributesResult.stringSecondaryAliases, hiddenKeySet)
       : typedAttributesResult.stringSecondaryAliases,
     isLoading: typedAttributesResult.stringAttributesLoading,
   };

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -534,4 +534,35 @@ describe('ColumnEditorModal', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
     expect(onColumnsChange).toHaveBeenCalledWith(['id', 'organization.id']);
   });
+
+  it('does not offer a hidden field as an option when it is a selected column', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'sentry.organization_id']}
+            onColumnsChange={jest.fn()}
+            stringTags={stringTags}
+            numberTags={{}}
+            booleanTags={{}}
+            hiddenKeys={['sentry.organization_id']}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
+
+    const addedColumn = screen.getAllByTestId('editor-column')[2]!;
+    await userEvent.click(within(addedColumn).getByRole('button', {name: 'Column —'}));
+
+    const hiddenOptions = (await screen.findAllByRole('option')).filter(option =>
+      option.textContent?.includes('sentry.organization_id')
+    );
+    expect(hiddenOptions).toHaveLength(0);
+  });
 });

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -479,4 +479,59 @@ describe('ColumnEditorModal', () => {
     expect(column).toHaveTextContent('sentry.duration');
     expect(column).toHaveTextContent('number');
   });
+
+  it('keeps user-sent attributes that collide with a hidden field selectable', async () => {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    const stringTagsWithCollision: TagCollection = {
+      ...stringTags,
+      'organization.id': {
+        key: 'organization.id',
+        name: 'organization.id',
+        kind: FieldKind.TAG,
+        attributeSource: 'user',
+      },
+      'sentry.organization.id': {
+        key: 'sentry.organization.id',
+        name: 'organization.id',
+        kind: FieldKind.TAG,
+        attributeSource: 'sentry',
+      },
+    };
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id']}
+            onColumnsChange={onColumnsChange}
+            stringTags={stringTagsWithCollision}
+            numberTags={{}}
+            booleanTags={{}}
+            hiddenKeys={['organization.id']}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add a Column'}));
+
+    const addedColumn = screen.getAllByTestId('editor-column')[1]!;
+    await userEvent.click(within(addedColumn).getByRole('button', {name: 'Column —'}));
+
+    // Only the user-sent attribute survives the hidden list; the Sentry-sourced
+    // field of the same display name is dropped.
+    const orgIdOptions = (await screen.findAllByRole('option')).filter(option =>
+      option.textContent?.includes('organization.id')
+    );
+    expect(orgIdOptions).toHaveLength(1);
+
+    await userEvent.click(orgIdOptions[0]!);
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith(['id', 'organization.id']);
+  });
 });

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -28,6 +28,7 @@ import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+import {removeHiddenKeys} from 'sentry/views/explore/utils';
 import {
   sortKnownAttributes,
   sortSearchedAttributes,
@@ -399,26 +400,16 @@ function buildColumnOptions({
   traceItemType,
   validatedFieldTypes,
 }: BuildColumnOptionsParams) {
+  const hidden = hiddenKeys ?? [];
   return buildAttributeOptions({
-    numberTags,
-    stringTags,
-    booleanTags,
+    numberTags: removeHiddenKeys(numberTags, hidden),
+    stringTags: removeHiddenKeys(stringTags, hidden),
+    booleanTags: removeHiddenKeys(booleanTags, hidden),
     traceItemType,
     extraColumns: columns,
     extraColumnKind: column =>
       fieldKindFromFieldType(validatedFieldTypes?.[column]) ?? classifyTagKey(column),
-  })
-    .filter(option => {
-      const hidden = hiddenKeys ?? [];
-      if (hidden.includes(option.value)) {
-        return false;
-      }
-      if (typeof option.label === 'string' && hidden.includes(option.label)) {
-        return false;
-      }
-      return true;
-    })
-    .toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));
+  }).toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));
 }
 
 function fieldKindFromFieldType(fieldType?: FieldValueType) {

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -17,7 +17,12 @@ import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils/defined';
-import {classifyTagKey, FieldKind, FieldValueType} from 'sentry/utils/fields';
+import {
+  classifyTagKey,
+  FieldKind,
+  FieldValueType,
+  prettifyTagKey,
+} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {
@@ -400,13 +405,15 @@ function buildColumnOptions({
   traceItemType,
   validatedFieldTypes,
 }: BuildColumnOptionsParams) {
-  const hidden = hiddenKeys ?? [];
+  const hidden = new Set(hiddenKeys);
   return buildAttributeOptions({
     numberTags: removeHiddenKeys(numberTags, hidden),
     stringTags: removeHiddenKeys(stringTags, hidden),
     booleanTags: removeHiddenKeys(booleanTags, hidden),
     traceItemType,
-    extraColumns: columns,
+    extraColumns: columns.filter(
+      column => !hidden.has(column) && !hidden.has(prettifyTagKey(column))
+    ),
     extraColumnKind: column =>
       fieldKindFromFieldType(validatedFieldTypes?.[column]) ?? classifyTagKey(column),
   }).toSorted((a, b) => sortKnownAttributes(a, b, traceItemType));

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -460,6 +460,32 @@ describe('removeHiddenKeys', () => {
 
     expect(removeHiddenKeys(tags, ['project_id'])).toEqual(tags);
   });
+
+  it('keeps user-sent attributes whose name collides with a hidden key', () => {
+    const tags: TagCollection = {
+      'organization.id': {
+        key: 'organization.id',
+        name: 'organization.id',
+        kind: FieldKind.TAG,
+        attributeSource: 'user',
+      },
+    };
+
+    expect(removeHiddenKeys(tags, ['organization.id'])).toEqual(tags);
+  });
+
+  it('still hides Sentry-sourced attributes that match a hidden key', () => {
+    const tags: TagCollection = {
+      'organization.id': {
+        key: 'organization.id',
+        name: 'organization.id',
+        kind: FieldKind.TAG,
+        attributeSource: 'sentry',
+      },
+    };
+
+    expect(removeHiddenKeys(tags, ['organization.id'])).toEqual({});
+  });
 });
 
 function seriesWithSampleRates(sampleRates: Array<number | null>): TimeSeries[] {

--- a/static/app/views/explore/utils.spec.tsx
+++ b/static/app/views/explore/utils.spec.tsx
@@ -414,7 +414,7 @@ describe('removeHiddenKeys', () => {
       project_id: {key: 'project_id', name: 'project_id', kind: FieldKind.TAG},
     };
 
-    expect(removeHiddenKeys(tags, ['project_id'])).toEqual({
+    expect(removeHiddenKeys(tags, new Set(['project_id']))).toEqual({
       'log.field': {key: 'log.field', name: 'log.field', kind: FieldKind.TAG},
     });
   });
@@ -435,7 +435,7 @@ describe('removeHiddenKeys', () => {
       },
     };
 
-    expect(removeHiddenKeys(tags, ['project_id'])).toEqual({
+    expect(removeHiddenKeys(tags, new Set(['project_id']))).toEqual({
       'log.duration': {
         key: 'log.duration',
         name: 'log.duration',
@@ -458,7 +458,7 @@ describe('removeHiddenKeys', () => {
       },
     };
 
-    expect(removeHiddenKeys(tags, ['project_id'])).toEqual(tags);
+    expect(removeHiddenKeys(tags, new Set(['project_id']))).toEqual(tags);
   });
 
   it('keeps user-sent attributes whose name collides with a hidden key', () => {
@@ -471,7 +471,7 @@ describe('removeHiddenKeys', () => {
       },
     };
 
-    expect(removeHiddenKeys(tags, ['organization.id'])).toEqual(tags);
+    expect(removeHiddenKeys(tags, new Set(['organization.id']))).toEqual(tags);
   });
 
   it('still hides Sentry-sourced attributes that match a hidden key', () => {
@@ -484,7 +484,7 @@ describe('removeHiddenKeys', () => {
       },
     };
 
-    expect(removeHiddenKeys(tags, ['organization.id'])).toEqual({});
+    expect(removeHiddenKeys(tags, new Set(['organization.id']))).toEqual({});
   });
 });
 

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -10,7 +10,7 @@ import {normalizeDateTimeString} from 'sentry/components/pageFilters/parse';
 import type {CaseInsensitive} from 'sentry/components/searchQueryBuilder/hooks';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import type {Confidence, Organization} from 'sentry/types/organization';
 import type {DetailedProject, Project} from 'sentry/types/project';
 import {escapeDoubleQuotes} from 'sentry/utils';
@@ -641,6 +641,19 @@ export function prettifyAggregation(aggregation: string): string | null {
   return null;
 }
 
+// The hidden lists target Sentry-defined fields. A user-sent attribute is kept
+// even when its name collides with a reserved field (e.g. a custom
+// `organization.id`), so it stays selectable in search and the column editor.
+export const isHiddenAttribute = (tag: Tag, hiddenKeys: Set<string>): boolean => {
+  if (tag.attributeSource === 'user') {
+    return false;
+  }
+  // Hide by both the raw key and the display name. Explicitly-typed keys such as
+  // `tags[project_id,number]` carry a display name (`project_id`) that is what
+  // appears in the hidden lists.
+  return hiddenKeys.has(tag.key) || (!!tag.name && hiddenKeys.has(tag.name));
+};
+
 export const removeHiddenKeys = (
   tagCollection: TagCollection,
   hiddenKeys: string[]
@@ -652,10 +665,7 @@ export const removeHiddenKeys = (
     if (!key || !tag) {
       continue;
     }
-    // Hide by both the raw key and the display name, matching the column
-    // editor. Explicitly-typed keys such as `tags[project_id,number]` carry a
-    // display name (`project_id`) that is what appears in the hidden lists.
-    if (hiddenKeySet.has(key) || (tag.name && hiddenKeySet.has(tag.name))) {
+    if (isHiddenAttribute(tag, hiddenKeySet)) {
       continue;
     }
     result[key] = tag;

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -656,16 +656,15 @@ export const isHiddenAttribute = (tag: Tag, hiddenKeys: Set<string>): boolean =>
 
 export const removeHiddenKeys = (
   tagCollection: TagCollection,
-  hiddenKeys: string[]
+  hiddenKeys: Set<string>
 ): TagCollection => {
-  const hiddenKeySet = new Set(hiddenKeys);
   const result: TagCollection = {};
   for (const key in tagCollection) {
     const tag = tagCollection[key];
     if (!key || !tag) {
       continue;
     }
-    if (isHiddenAttribute(tag, hiddenKeySet)) {
+    if (isHiddenAttribute(tag, hiddenKeys)) {
       continue;
     }
     result[key] = tag;

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
@@ -279,6 +279,7 @@ describe('getTraceItemTagCollection', () => {
         name: key,
         kind: FieldKind.MEASUREMENT,
         secondaryAliases: [],
+        attributeSource: 'custom',
       },
     });
   });
@@ -292,6 +293,21 @@ describe('getTraceItemTagCollection', () => {
         name: key,
         kind: FieldKind.MEASUREMENT,
         secondaryAliases: [],
+        attributeSource: 'custom',
+      },
+    });
+  });
+
+  it('preserves explicitly-typed string tags', () => {
+    const key = 'tags[organization.id,string]';
+
+    expect(getTraceItemTagCollection([makeAttribute(key, 'string')], 'string')).toEqual({
+      [key]: {
+        key,
+        name: key,
+        kind: FieldKind.TAG,
+        secondaryAliases: [],
+        attributeSource: 'custom',
       },
     });
   });

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
@@ -12,7 +12,7 @@ import {
 
 type Attribute = {
   attributeSource: {
-    source_type: string;
+    source_type: 'sentry' | 'user';
   };
   attributeType: 'boolean' | 'number' | 'string';
   key: string;

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.spec.tsx
@@ -30,7 +30,7 @@ function makeAttribute(
   attributeType: Attribute['attributeType'] = 'string'
 ): Attribute {
   return {
-    attributeSource: {source_type: 'custom'},
+    attributeSource: {source_type: 'user'},
     attributeType,
     key,
     name: key,
@@ -271,7 +271,7 @@ describe('traceItemAttributeKeysOptions', () => {
 
 describe('getTraceItemTagCollection', () => {
   it('preserves plain tags with @ in the tag name', () => {
-    const key = 'custom.metric@primary';
+    const key = 'user.metric@primary';
 
     expect(getTraceItemTagCollection([makeAttribute(key, 'number')], 'number')).toEqual({
       [key]: {
@@ -279,13 +279,13 @@ describe('getTraceItemTagCollection', () => {
         name: key,
         kind: FieldKind.MEASUREMENT,
         secondaryAliases: [],
-        attributeSource: 'custom',
+        attributeSource: 'user',
       },
     });
   });
 
   it('preserves wrapped number tags with @ in the tag name', () => {
-    const key = 'tags[custom.metric@primary,number]';
+    const key = 'tags[user.metric@primary,number]';
 
     expect(getTraceItemTagCollection([makeAttribute(key, 'number')], 'number')).toEqual({
       [key]: {
@@ -293,7 +293,7 @@ describe('getTraceItemTagCollection', () => {
         name: key,
         kind: FieldKind.MEASUREMENT,
         secondaryAliases: [],
-        attributeSource: 'custom',
+        attributeSource: 'user',
       },
     });
   });
@@ -307,7 +307,7 @@ describe('getTraceItemTagCollection', () => {
         name: key,
         kind: FieldKind.TAG,
         secondaryAliases: [],
-        attributeSource: 'custom',
+        attributeSource: 'user',
       },
     });
   });

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
@@ -2,7 +2,7 @@ import {queryOptions, type QueryFunctionContext} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import type {TagCollection} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
@@ -167,7 +167,7 @@ export function getTraceItemTagCollection(
     // SnQL forbids `-` but is allowed in RPC. So add it back later
     if (
       !/^[\w.:@-]+$/.test(attribute.key) &&
-      !/^tags\[[\w.:@-]+,(number|boolean)\]$/.test(attribute.key)
+      !/^tags\[[\w.:@-]+,(number|boolean|string)\]$/.test(attribute.key)
     ) {
       continue;
     }
@@ -184,6 +184,7 @@ export function getTraceItemTagCollection(
         name: attribute.name,
         kind: FieldKind.TAG,
         secondaryAliases: attribute?.secondaryAliases ?? [],
+        attributeSource: attribute.attributeSource?.source_type,
       };
     } else if (attributeType === 'number') {
       numberAttributes[attribute.key] = {
@@ -191,6 +192,7 @@ export function getTraceItemTagCollection(
         name: attribute.name,
         kind: FieldKind.MEASUREMENT,
         secondaryAliases: attribute?.secondaryAliases ?? [],
+        attributeSource: attribute.attributeSource?.source_type,
       };
     } else if (attributeType === 'boolean') {
       booleanAttributes[attribute.key] = {
@@ -198,6 +200,7 @@ export function getTraceItemTagCollection(
         name: attribute.name,
         kind: FieldKind.BOOLEAN,
         secondaryAliases: attribute?.secondaryAliases ?? [],
+        attributeSource: attribute.attributeSource?.source_type,
       };
     }
   }
@@ -221,7 +224,7 @@ export function getTraceItemTagCollection(
   };
 }
 
-function isKnownAttribute(attribute: Tag) {
+function isKnownAttribute(attribute: {key: string}) {
   // For now, skip all the sentry. prefixed attributes as they
   // should be covered by the static attributes that will be
   // merged with these results.

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
@@ -15,7 +15,7 @@ import {findFreshEmptyPrefixSearchCacheMatch} from 'sentry/views/explore/utils/f
 
 type AttributeType = {
   attributeSource: {
-    source_type: string;
+    source_type: 'sentry' | 'user';
   };
   attributeType: TraceItemAttributeType;
   key: string;


### PR DESCRIPTION
Fixes the frontend half of LOGS-447: a user-sent log attribute whose name collides with a reserved field -e.g. a customer's own `organization.id` sent via OTLP- couldn't be added as a column in Edit Table. This adds an `attributeSource` so that key validation can know to allow things even if they happen to match a known name.

See #120373 for frontend changes.

Closes LOGS-447.