### PR TITLE
fix(dashboards): Add widget action tooltips

### DIFF
--- a/static/app/views/dashboards/widgetCard/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.spec.tsx
@@ -152,11 +152,15 @@ describe('WidgetFrame', () => {
         />
       );
 
-      await userEvent.click(screen.getByRole('button', {name: 'Widget actions'}));
+      const $trigger = screen.getByRole('button', {name: 'Widget actions'});
+      await userEvent.hover($trigger);
+      expect(await screen.findByText('Widget actions')).toBeInTheDocument();
+
+      await userEvent.click($trigger);
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'One'}));
       expect(onAction1).toHaveBeenCalledTimes(1);
 
-      await userEvent.click(screen.getByRole('button', {name: 'Widget actions'}));
+      await userEvent.click($trigger);
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'Two'}));
       expect(onAction2).toHaveBeenCalledTimes(1);
     });
@@ -242,6 +246,10 @@ describe('WidgetFrame', () => {
 
       const $button = screen.getByRole('button', {name: 'Open Full-Screen View'});
       expect($button).toBeInTheDocument();
+
+      await userEvent.hover($button);
+      expect(await screen.findByText('Open Full-Screen View')).toBeInTheDocument();
+
       await userEvent.click($button);
 
       expect(onFullScreenViewClick).toHaveBeenCalledTimes(1);

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -56,6 +56,9 @@ export function WidgetFrame(props: WidgetFrameProps) {
   const shouldShowCopyUrlButton = Boolean(props.onCopyUrlClick) && !props.error;
 
   const shouldShowActions = actions && actions.length > 0;
+  const hasDisabledActionsMessage = Boolean(
+    props.actionsDisabled && props.actionsMessage
+  );
 
   return (
     <Widget
@@ -140,6 +143,9 @@ export function WidgetFrame(props: WidgetFrameProps) {
                     variant: 'transparent',
                     showChevron: false,
                     icon: <IconEllipsis direction="down" size="sm" />,
+                    tooltipProps: {
+                      title: hasDisabledActionsMessage ? undefined : t('Widget actions'),
+                    },
                   }}
                   position="bottom-end"
                 />
@@ -166,6 +172,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
             <Button
               size="xs"
               aria-label={t('Open Full-Screen View')}
+              tooltipProps={{title: t('Open Full-Screen View')}}
               variant="transparent"
               icon={<IconExpand />}
               onClick={e => {


### PR DESCRIPTION
Dashboard widget overflow and full-screen icon buttons now expose their existing accessible labels as hover tooltips, making the actions discoverable without changing their labels or behavior.

The overflow tooltip yields to the existing disabled-action explanation so users continue to see why the menu is unavailable.

Looks like:

| More actions | Fullscreen |
| --- | --- |
|<img width="100%" alt="more" src="https://github.com/user-attachments/assets/48dd5eaa-0753-4178-b026-8503c7bcca9e" /> | <img width="100%" alt="fullscreen" src="https://github.com/user-attachments/assets/11741560-d0f4-4813-955d-6d71d1043e1e" /> |


