### PR TITLE
feat(issues): Backport trigger autofix issue activity

### DIFF
--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -32,12 +32,13 @@ from sentry.apidocs.response_types import (
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import (
-    publish_action,
+    action_context_scope,
     resolve_action_actor,
     resolve_action_source,
 )
-from sentry.issues.action_log.types import TriggerAutofixAction
+from sentry.issues.action_log.types import GroupActorType
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
+from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix_agent import (
@@ -77,6 +78,7 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.endpoints.utils import get_seer_run, resolve_seer_run
 from sentry.seer.models import SeerPermissionError
 from sentry.tasks.seer.pr_iteration import consume_queued_autofix_feedback
+from sentry.types.activity import ActivityType
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.services.user.service import user_service
 from sentry.utils.http import is_mcp_request
@@ -431,13 +433,19 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                     raise PermissionDenied(SEER_PERMISSION_DENIED)
 
                 if is_autofix_kickoff:
-                    publish_action(
-                        TriggerAutofixAction(),
+                    actor = resolve_action_actor(request)
+                    with action_context_scope(
                         source=resolve_action_source(request),
-                        group_id=group.id,
-                        project=group.project,
-                        actor=resolve_action_actor(request),
-                    )
+                        actor=actor,
+                    ):
+                        Activity.objects.create_group_activity(
+                            group,
+                            ActivityType.TRIGGER_AUTOFIX,
+                            user_id=(
+                                actor.actor_id if actor.actor_type == GroupActorType.USER else None
+                            ),
+                            send_notification=False,
+                        )
                     run = get_seer_run(run_id, group.organization)
                     sentry_run_id = str(run.uuid) if run else None
                 else:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -444,6 +444,7 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                             user_id=(
                                 actor.actor_id if actor.actor_type == GroupActorType.USER else None
                             ),
+                            data={"referrer": referrer.value},
                             send_notification=False,
                         )
                     run = get_seer_run(run_id, group.organization)

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -2,7 +2,8 @@ import uuid
 from unittest.mock import ANY, Mock, patch
 
 from sentry.integrations.services.integration import RpcIntegration
-from sentry.issues.action_log.types import TriggerAutofixAction
+from sentry.issues.action_log.types import GroupActionActor, TriggerAutofixAction
+from sentry.models.activity import Activity
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -10,8 +11,10 @@ from sentry.seer.autofix.github_perms import MissingGithubPermissions
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.action_log import capture_action_log
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
+from sentry.types.activity import ActivityType
 
 # Note: Detailed tests for the implementation of functions in seer/autofix.py
 # have been moved to tests/sentry/seer/test_autofix.py
@@ -322,10 +325,29 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             enable_bash_tools=False,
         )
 
-    @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_kickoff_emits_trigger_autofix_action(self, mock_trigger, mock_publish):
+    def test_kickoff_emits_trigger_autofix_action(self, mock_trigger):
         # A kickoff (no run_id) records the action.
+        group = self.create_group()
+        mock_trigger.return_value = 123
+
+        self.login_as(user=self.user)
+        with capture_action_log() as action_log:
+            response = self.client.post(
+                self._get_url(group.id),
+                data={"step": "root_cause"},
+                format="json",
+            )
+
+        assert response.status_code == 202, response.data
+        action_log.assert_logged(
+            TriggerAutofixAction,
+            group_id=group.id,
+            actor=GroupActionActor.user(self.user.id),
+        )
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
+    def test_kickoff_creates_trigger_autofix_activity(self, mock_trigger):
         group = self.create_group()
         mock_trigger.return_value = 123
 
@@ -337,44 +359,42 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 202, response.data
-        mock_publish.assert_called_once()
-        assert isinstance(mock_publish.call_args.args[0], TriggerAutofixAction)
-        assert mock_publish.call_args.kwargs["group_id"] == group.id
-        assert mock_publish.call_args.kwargs["actor"].actor_id == self.user.id
+        activity = Activity.objects.get(group=group, type=ActivityType.TRIGGER_AUTOFIX.value)
+        assert activity.user_id == self.user.id
 
-    @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
-    def test_advancing_existing_run_skips_action(self, mock_trigger, mock_publish):
+    def test_advancing_existing_run_skips_action(self, mock_trigger):
         # Advancing an existing run (run_id provided) is steering, not a new trigger.
         group = self.create_group()
         mock_trigger.return_value = 42
 
         self.login_as(user=self.user)
-        response = self.client.post(
-            self._get_url(group.id),
-            data={"step": "solution", "run_id": 42},
-            format="json",
-        )
+        with capture_action_log() as action_log:
+            response = self.client.post(
+                self._get_url(group.id),
+                data={"step": "solution", "run_id": 42},
+                format="json",
+            )
 
         assert response.status_code == 202, response.data
-        mock_publish.assert_not_called()
+        action_log.assert_not_logged(TriggerAutofixAction, group_id=group.id)
 
-    @patch("sentry.seer.endpoints.group_ai_autofix.publish_action", autospec=True)
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_coding_agent_handoff")
-    def test_coding_agent_handoff_skips_action(self, mock_handoff, mock_publish):
+    def test_coding_agent_handoff_skips_action(self, mock_handoff):
         # The handoff path returns before the built-in-step branch, so it must not log.
         mock_handoff.return_value = {"successes": [], "failures": []}
         group = self.create_group()
 
         self.login_as(user=self.user)
-        response = self.client.post(
-            self._get_url(group.id),
-            data={"step": "coding_agent_handoff", "run_id": 123, "integration_id": 456},
-            format="json",
-        )
+        with capture_action_log() as action_log:
+            response = self.client.post(
+                self._get_url(group.id),
+                data={"step": "coding_agent_handoff", "run_id": 123, "integration_id": 456},
+                format="json",
+            )
 
         assert response.status_code == 202, response.data
-        mock_publish.assert_not_called()
+        action_log.assert_not_logged(TriggerAutofixAction, group_id=group.id)
 
     @with_feature("organizations:autofix-pr-iteration")
     @patch("sentry.seer.endpoints.group_ai_autofix.consume_queued_autofix_feedback")

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -344,6 +344,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             TriggerAutofixAction,
             group_id=group.id,
             actor=GroupActionActor.user(self.user.id),
+            referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value,
         )
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
@@ -354,13 +355,14 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         response = self.client.post(
             self._get_url(group.id),
-            data={"step": "root_cause"},
+            data={"step": "root_cause", "referrer": AutofixReferrer.WEB.value},
             format="json",
         )
 
         assert response.status_code == 202, response.data
         activity = Activity.objects.get(group=group, type=ActivityType.TRIGGER_AUTOFIX.value)
         assert activity.user_id == self.user.id
+        assert activity.data == {"referrer": AutofixReferrer.WEB.value}
 
     @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_agent")
     def test_advancing_existing_run_skips_action(self, mock_trigger):


### PR DESCRIPTION
Creates a legacy issue Activity when a user kicks off a new Autofix run, while preserving the existing mirrored action log entry and request attribution. Continuations and coding-agent handoffs remain unchanged.

Stacked on #120372, which adds the ActivityType mapping required for the backport.