### PR TITLE
build(deps): Bump sentry-protos to 0.49.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.1.2",
-  "sentry-protos>=0.46.0",
+  "sentry-protos>=0.49.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
   "sentry-scm>=1.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2411,7 +2411,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.1.2" },
-    { name = "sentry-protos", specifier = ">=0.46.0" },
+    { name = "sentry-protos", specifier = ">=0.49.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
     { name = "sentry-scm", specifier = ">=1.2.0" },
@@ -2595,7 +2595,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.47.0"
+version = "0.49.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2603,7 +2603,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.47.0-py3-none-any.whl", hash = "sha256:4ec26ce7da25266f488987a42313c5c8ceff9252c7ffc5f59a84c4fd15941b99" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.49.0-py3-none-any.whl", hash = "sha256:20850cccbcc74f9856ea2518ee224f6bebd4580ece56fd9bb8770be7e2e55e82" },
 ]
 
 [[package]]


### PR DESCRIPTION
This updates the minimum `sentry-protos` requirement from `>=0.46.0` to `>=0.49.0`, and refreshes `uv.lock` to resolve the published 0.49.0 wheel instead of the previously locked 0.47.0 wheel. The new release makes the common retention policy types and `PackageConfig.retention_defaults` available to Sentry and GetSentry consumers.

The 0.49.0 wheel was regenerated and verified using the same `uv` version as CI (0.9.28). The lockfile contains only the expected `sentry-protos` version and hash changes. The 52 direct billing proto consumer tests pass with the published wheel installed.

Note that 0.49.0 includes #368 and #369 only. It does not include the later contract-retention override config or effective-retention endpoint work, so those APIs remain gated on the next release.
