### PR TITLE
fix(replays): use same thread pool for bulk deletes

### DIFF
--- a/src/sentry/replays/usecases/delete.py
+++ b/src/sentry/replays/usecases/delete.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+from collections.abc import Iterator
 from datetime import datetime
 from typing import TypedDict
 
@@ -60,8 +61,8 @@ def delete_matched_rows(project_id: int, rows: list[MatchedRow]) -> int | None:
     if not rows:
         return None
 
-    for row in rows:
-        delete_replay_recordings(project_id, row)
+    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
+        pool.map(_delete_if_exists, _make_recording_filenames(project_id, rows))
 
     delete_replays(project_id, [row["replay_id"] for row in rows])
     return None
@@ -73,11 +74,6 @@ def delete_replays(project_id: int, replay_ids: list[str]) -> None:
         publish_replay_event(archive_event(project_id, replay_id))
 
 
-def delete_replay_recordings(project_id: int, row: MatchedRow) -> None:
-    with ContextPropagatingThreadPoolExecutor(max_workers=100) as pool:
-        pool.map(_delete_if_exists, _make_recording_filenames(project_id, row))
-
-
 def _delete_if_exists(filename: str) -> None:
     """Delete the blob if it exists or silence the 404."""
     try:
@@ -86,24 +82,22 @@ def _delete_if_exists(filename: str) -> None:
         pass
 
 
-def _make_recording_filenames(project_id: int, row: MatchedRow) -> list[str]:
-    # Null segment_ids can cause this to fail. If no segments were ingested then we can skip
-    # deleting the segements.
-    if row["max_segment_id"] is None:
-        return []
+def _make_recording_filenames(project_id: int, rows: list[MatchedRow]) -> Iterator[str]:
+    for row in rows:
+        # Null segment_ids can cause this to fail. If no segments were ingested then we can skip
+        # deleting the segements.
+        if row["max_segment_id"] is None:
+            continue
 
-    # We assume every segment between 0 and the max_segment_id exists. Its a waste of time to
-    # delete a non-existent segment but its not so significant that we'd want to query ClickHouse
-    # to verify it exists.
-    replay_id = row["replay_id"]
-    retention_days = row["retention_days"]
+        # We assume every segment between 0 and the max_segment_id exists. Its a waste of time to
+        # delete a non-existent segment but its not so significant that we'd want to query ClickHouse
+        # to verify it exists.
+        replay_id = row["replay_id"]
+        retention_days = row["retention_days"]
 
-    filenames = []
-    for segment_id in range(row["max_segment_id"] + 1):
-        segment = RecordingSegmentStorageMeta(project_id, replay_id, segment_id, retention_days)
-        filenames.append(make_recording_filename(segment))
-
-    return filenames
+        for segment_id in range(row["max_segment_id"] + 1):
+            segment = RecordingSegmentStorageMeta(project_id, replay_id, segment_id, retention_days)
+            yield make_recording_filename(segment)
 
 
 class MatchedRow(TypedDict):


### PR DESCRIPTION
Slack thread context: https://sentry.slack.com/archives/C03USURCFBJ/p1784728151778839

Related to: `inc-2344`

this improves the pool behaviours so there's not an insane amount of thread pools running. This could have contributed to the incident but it's probably good to make this change anyways 