### PR TITLE
feat(seer): Add opt-in PR CI status to the seer runs serializer

### DIFF
--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict, cast
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.pullrequest import (
     PullRequestSerializer,
     PullRequestSerializerResponse,
 )
+from sentry.models.pullrequest import PullRequest
+from sentry.seer.autofix.pr_ci_status import PullRequestCiStatus, get_pr_ci_status
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunPullRequest
 
 
@@ -26,6 +28,24 @@ class RunQuestionOutput(TypedDict):
     question: NotRequired[str]
 
 
+# Seer-local extension so the shared response type (and other endpoints' schemas) stay untouched.
+class SeerRunPullRequestResponse(PullRequestSerializerResponse):
+    ciStatus: NotRequired[PullRequestCiStatus | None]
+
+
+class SeerRunPullRequestSerializer(PullRequestSerializer):
+    def __init__(self, include_ci_status: bool = False) -> None:
+        self.include_ci_status = include_ci_status
+
+    def serialize(
+        self, obj: PullRequest, attrs: Any, user: Any, **kwargs: Any
+    ) -> SeerRunPullRequestResponse:
+        result: SeerRunPullRequestResponse = {**super().serialize(obj, attrs, user, **kwargs)}
+        if self.include_ci_status:
+            result["ciStatus"] = get_pr_ci_status(obj)
+        return result
+
+
 class SeerRunResponse(TypedDict):
     id: str
     type: str
@@ -37,7 +57,7 @@ class SeerRunResponse(TypedDict):
     source: str | None
     projectId: str | None
     groupId: str | None
-    pullRequests: list[PullRequestSerializerResponse]
+    pullRequests: list[SeerRunPullRequestResponse]
     # One-shot outputs (question answers), injected by the endpoint when
     # ?expand=questions and/or ?question= is passed; the serializer itself never
     # populates them.
@@ -46,6 +66,9 @@ class SeerRunResponse(TypedDict):
 
 @register(SeerRun)
 class SeerRunSerializer(Serializer):
+    def __init__(self, include_ci_status: bool = False) -> None:
+        self.include_ci_status = include_ci_status
+
     def get_attrs(
         self, item_list: Sequence[SeerRun], user: Any, **kwargs: Any
     ) -> dict[SeerRun, dict[str, Any]]:
@@ -63,12 +86,12 @@ class SeerRunSerializer(Serializer):
             .order_by("date_added")
         )
         prs = [link.pull_request for link in pr_links]
-        serialized_pr_by_id = {
-            pr.id: serialized
-            for pr, serialized in zip(prs, serialize(prs, user, PullRequestSerializer()))
-        }
+        pr_serializer = SeerRunPullRequestSerializer(include_ci_status=self.include_ci_status)
+        # serialize()'s generic is bound by the base class, so re-narrow to the subclass response.
+        serialized_prs = cast(list[SeerRunPullRequestResponse], serialize(prs, user, pr_serializer))
+        serialized_pr_by_id = {pr.id: serialized for pr, serialized in zip(prs, serialized_prs)}
 
-        pull_requests_by_run_id: dict[int, list[PullRequestSerializerResponse]] = defaultdict(list)
+        pull_requests_by_run_id: dict[int, list[SeerRunPullRequestResponse]] = defaultdict(list)
         for link in pr_links:
             pull_requests_by_run_id[link.seer_run_id].append(
                 serialized_pr_by_id[link.pull_request_id]

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -127,6 +127,32 @@ class GitHubReaction(StrEnum):
     EYES = "eyes"
 
 
+class GitHubCheckRunStatus(StrEnum):
+    """
+    https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
+    """
+
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class GitHubCheckRunConclusion(StrEnum):
+    """
+    https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    NEUTRAL = "neutral"
+    CANCELLED = "cancelled"
+    TIMED_OUT = "timed_out"
+    ACTION_REQUIRED = "action_required"
+    SKIPPED = "skipped"
+    STALE = "stale"
+    STARTUP_FAILURE = "startup_failure"
+
+
 class GitHubApiRequestType(StrEnum):
     CHECK_FILE = "check_file"
     COMPARE_COMMITS = "compare_commits"
@@ -1243,6 +1269,14 @@ class GitHubBaseClient(
         """
         endpoint = f"/repos/{repo}/commits/{sha}/check-runs"
         return self.get(endpoint, api_request_type=GitHubApiRequestType.GET_CHECK_RUNS)
+
+    def get_all_check_runs(self, repo: str, sha: str) -> list[Any]:
+        """Like ``get_check_runs`` but follows pagination, returning the flat check-run list."""
+        return self._get_with_pagination(
+            f"/repos/{repo}/commits/{sha}/check-runs",
+            response_key="check_runs",
+            api_request_type=GitHubApiRequestType.GET_CHECK_RUNS,
+        )
 
 
 class _IntegrationIdParams(TypedDict, total=False):

--- a/src/sentry/seer/autofix/pr_ci_status.py
+++ b/src/sentry/seer/autofix/pr_ci_status.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from sentry.integrations.github.client import GitHubCheckRunConclusion, GitHubCheckRunStatus
+from sentry.integrations.services.integration import integration_service
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.repository import Repository
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+PullRequestCiStatus = Literal["passed", "running", "failed"]
+
+# Providers whose integration client exposes the GitHub checks API.
+SUPPORTED_PROVIDERS = ("integrations:github", "integrations:github_enterprise")
+
+# Mirrors check_suites.FAILURE_CONCLUSIONS plus startup_failure (we read raw conclusions; scm normalizes it to failure).
+FAILURE_CONCLUSIONS = (
+    GitHubCheckRunConclusion.FAILURE,
+    GitHubCheckRunConclusion.TIMED_OUT,
+    GitHubCheckRunConclusion.ACTION_REQUIRED,
+    GitHubCheckRunConclusion.STARTUP_FAILURE,
+)
+
+# States for which CI status is meaningless (the PR is no longer running checks).
+_SKIP_STATES = (PullRequestLifecycleState.MERGED, PullRequestLifecycleState.CLOSED)
+
+PR_CI_CACHE_TIMEOUT_SECONDS = 2 * 60  # 2 minutes
+PR_CI_NEGATIVE_CACHE_TIMEOUT_SECONDS = 30  # 30 seconds
+# Distinguishes a cached indeterminate result from a cache miss; never returned.
+_UNKNOWN = "unknown"
+
+
+def _get_pr_ci_cache_key(pull_request: PullRequest) -> str:
+    # The stored head sha invalidates the key on push; NULL-sha shell rows fall back to TTL expiry.
+    return f"seer:pr_ci:{pull_request.id}:{pull_request.head_commit_sha or ''}"
+
+
+def get_pr_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
+    """Aggregate CI status of a PR's head commit from GitHub check runs, cached; never raises."""
+    if pull_request.state in _SKIP_STATES:
+        return None
+
+    cache_key = _get_pr_ci_cache_key(pull_request)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return None if cached == _UNKNOWN else cached
+
+    try:
+        result = _compute_ci_status(pull_request)
+    except Exception:
+        logger.exception(
+            "seer.pr_ci_status.compute_failed",
+            extra={"pull_request_id": pull_request.id},
+        )
+        result = None
+
+    if result is None:
+        cache.set(cache_key, _UNKNOWN, timeout=PR_CI_NEGATIVE_CACHE_TIMEOUT_SECONDS)
+        return None
+
+    cache.set(cache_key, result, timeout=PR_CI_CACHE_TIMEOUT_SECONDS)
+    return result
+
+
+def _compute_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
+    repo = Repository.objects.filter(id=pull_request.repository_id).first()
+    if repo is None or repo.provider not in SUPPORTED_PROVIDERS:
+        return None
+
+    integration = integration_service.get_integration(integration_id=repo.integration_id)
+    if integration is None:
+        return None
+    client = integration.get_installation(organization_id=pull_request.organization_id).get_client()
+
+    sha = pull_request.head_commit_sha
+    if not sha:
+        sha = client.get_pull_request(repo.name, pull_request.key).get("head", {}).get("sha")
+    if not sha:
+        return None
+
+    check_runs = client.get_all_check_runs(repo.name, sha)
+    if not check_runs:
+        return None
+    if any(run.get("conclusion") in FAILURE_CONCLUSIONS for run in check_runs):
+        return "failed"
+    if any(run.get("status") != GitHubCheckRunStatus.COMPLETED for run in check_runs):
+        return "running"
+    return "passed"

--- a/src/sentry/seer/endpoints/organization_seer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_runs.py
@@ -131,6 +131,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             query=request.GET.get("query", "").strip(),
             expand=request.GET.getlist("expand"),
             questions=request.GET.getlist("question"),
+            include_ci_status=request.GET.get("includeCiStatus") == "1",
             start=start,
             end=end,
         )
@@ -151,6 +152,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             query=query.strip() if isinstance(query, str) else "",
             expand=_as_str_list(data.get("expand")),
             questions=_as_str_list(data.get("question")),
+            include_ci_status=False,
             start=start,
             end=end,
         )
@@ -163,6 +165,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
         query: str,
         expand: Sequence[str],
         questions: Sequence[str],
+        include_ci_status: bool,
         start: datetime | None,
         end: datetime | None,
     ) -> Response:
@@ -218,7 +221,9 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             return Response({"detail": str(e)}, status=400)
 
         def on_results(runs: Sequence[SeerRun]) -> list[SeerRunResponse]:
-            serialized: list[SeerRunResponse] = serialize(runs, request.user, SeerRunSerializer())
+            serialized: list[SeerRunResponse] = serialize(
+                runs, request.user, SeerRunSerializer(include_ci_status=include_ci_status)
+            )
             if include_outputs:
                 outputs_by_run_id = _fetch_run_outputs(
                     runs,
@@ -230,14 +235,14 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
                     data["outputs"] = outputs_by_run_id.get(run.id, [])
             return serialized
 
+        # Outputs run one one-shot per question per run; CI status can hit GitHub once per PR.
+        small_page = include_outputs or include_ci_status
         return self.paginate(
             request=request,
             queryset=queryset,
             order_by="-last_triggered_at",
             on_results=on_results,
             paginator_cls=OffsetPaginator,
-            # Computing outputs is expensive (one one-shot per question per run),
-            # so use a small default and cap the page size when they're requested.
-            default_per_page=10 if include_outputs else 100,
-            max_per_page=10 if include_outputs else 100,
+            default_per_page=10 if small_page else 100,
+            max_per_page=10 if small_page else 100,
         )

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1433,6 +1433,29 @@ class GitHubCommitContextClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_get_all_check_runs_follows_pagination(self, get_jwt) -> None:
+        repo_name = "getsentry/sentry"
+        sha = "abc123"
+        url = f"https://api.github.com/repos/{repo_name}/commits/{sha}/check-runs?per_page={self.github_client.page_size}"
+
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json={"total_count": 3, "check_runs": [{"id": 1}, {"id": 2}]},
+            headers={"link": f'<{url}&page=2>; rel="next"'},
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=2",
+            json={"total_count": 3, "check_runs": [{"id": 3}]},
+        )
+
+        result = self.github_client.get_all_check_runs(repo_name, sha)
+
+        assert [run["id"] for run in result] == [1, 2, 3]
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_create_check_run_error(self, get_jwt) -> None:
         repo_name = "getsentry/sentry"
         check_data = {"name": "sentry/ci", "head_sha": "abc123"}

--- a/tests/sentry/seer/autofix/test_pr_ci_status.py
+++ b/tests/sentry/seer/autofix/test_pr_ci_status.py
@@ -1,0 +1,273 @@
+from datetime import timedelta
+from unittest import mock
+
+import responses
+from django.utils import timezone
+
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.repository import Repository
+from sentry.seer.autofix.pr_ci_status import FAILURE_CONCLUSIONS, get_pr_ci_status
+from sentry.testutils.cases import TestCase
+from sentry.utils.cache import cache
+
+HEAD_SHA = "abc123"
+
+
+def test_failure_conclusions_match_raw_strings() -> None:
+    # The enum members must subclass str so raw API conclusions match the tuple.
+    for raw in ("failure", "timed_out", "action_required", "startup_failure"):
+        assert raw in FAILURE_CONCLUSIONS
+    assert "success" not in FAILURE_CONCLUSIONS
+
+
+class GetPrCiStatusTest(TestCase):
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def setUp(self, get_jwt: mock.MagicMock) -> None:
+        super().setUp()
+        cache.clear()
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+        self.pr = self._create_pr(head_commit_sha=HEAD_SHA)
+
+    def _create_pr(
+        self, *, key: str = "7", head_commit_sha: str | None = HEAD_SHA, state: str | None = None
+    ) -> PullRequest:
+        return PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key=key,
+            head_commit_sha=head_commit_sha,
+            state=state,
+        )
+
+    def _add_check_runs(self, check_runs: list[dict], sha: str = HEAD_SHA) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/commits/{sha}/check-runs",
+            json={"total_count": len(check_runs), "check_runs": check_runs},
+        )
+
+    @responses.activate
+    def test_failed_when_any_run_failed(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "completed", "conclusion": "success"},
+                {"status": "completed", "conclusion": "failure"},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_running_when_any_run_incomplete(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "completed", "conclusion": "success"},
+                {"status": "in_progress", "conclusion": None},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "running"
+
+    @responses.activate
+    def test_failed_when_startup_failure(self) -> None:
+        self._add_check_runs([{"status": "completed", "conclusion": "startup_failure"}])
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_failure_on_second_page_is_seen(self) -> None:
+        url = (
+            f"https://api.github.com/repos/{self.repo.name}/commits/{HEAD_SHA}"
+            f"/check-runs?per_page=100"
+        )
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json={"check_runs": [{"status": "completed", "conclusion": "success"}]},
+            headers={"link": f'<{url}&page=2>; rel="next"'},
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=2",
+            json={"check_runs": [{"status": "completed", "conclusion": "failure"}]},
+        )
+
+        assert get_pr_ci_status(self.pr) == "failed"
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_passed_when_all_runs_non_failing_and_complete(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "completed", "conclusion": "success"},
+                {"status": "completed", "conclusion": "neutral"},
+                {"status": "completed", "conclusion": "skipped"},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "passed"
+
+    @responses.activate
+    def test_none_when_no_check_runs(self) -> None:
+        self._add_check_runs([])
+        assert get_pr_ci_status(self.pr) is None
+
+    @responses.activate
+    def test_merged_and_closed_prs_skipped_without_github_call(self) -> None:
+        for key, state in (
+            ("8", PullRequestLifecycleState.MERGED),
+            ("9", PullRequestLifecycleState.CLOSED),
+        ):
+            pr = self._create_pr(key=key, state=state)
+            assert get_pr_ci_status(pr) is None
+            assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_non_github_provider_returns_none(self) -> None:
+        self.repo.update(provider="integrations:gitlab")
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_github_enterprise_provider_computes_status(self) -> None:
+        ten_days = timezone.now() + timedelta(days=10)
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="Github Enterprise Test Org",
+            external_id="github.example.org:1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+                "icon": "https://github.example.org/avatar.png",
+                "domain_name": "github.example.org/Test-Organization",
+                "account_type": "Organization",
+                "installation_id": "install_id_1",
+                "installation": {
+                    "client_id": "client_id",
+                    "client_secret": "client_secret",
+                    "id": "2",
+                    "name": "test-app",
+                    "private_key": "private_key",
+                    "url": "github.example.org",
+                    "webhook_secret": "webhook_secret",
+                    "verify_ssl": True,
+                },
+            },
+        )
+        ghe_repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/bar",
+            url="https://github.example.org/Test-Organization/bar",
+            provider="integrations:github_enterprise",
+            external_id="456",
+            integration_id=integration.id,
+        )
+        pr = PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=ghe_repo.id,
+            key="11",
+            head_commit_sha=HEAD_SHA,
+        )
+        responses.add(
+            method=responses.GET,
+            url=(
+                f"https://github.example.org/api/v3/repos/{ghe_repo.name}"
+                f"/commits/{HEAD_SHA}/check-runs"
+            ),
+            json={"check_runs": [{"status": "completed", "conclusion": "success"}]},
+        )
+
+        with mock.patch(
+            "sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1"
+        ):
+            assert get_pr_ci_status(pr) == "passed"
+
+    @responses.activate
+    def test_missing_head_sha_resolved_via_get_pull_request(self) -> None:
+        pr = self._create_pr(key="10", head_commit_sha=None)
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/pulls/{pr.key}",
+            json={"head": {"sha": HEAD_SHA}},
+        )
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+
+        assert get_pr_ci_status(pr) == "passed"
+        assert any("/pulls/" in call.request.url for call in responses.calls)
+
+    @responses.activate
+    def test_github_error_returns_none_and_negative_caches(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/commits/{HEAD_SHA}/check-runs",
+            status=500,
+        )
+
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 1
+
+        # Second call within the negative-cache TTL makes no HTTP request.
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_cache_hit_skips_github(self) -> None:
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_failure_takes_precedence_over_running(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "in_progress", "conclusion": None},
+                {"status": "completed", "conclusion": "failure"},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_cache_keys_are_isolated_per_pr(self) -> None:
+        other_pr = self._create_pr(key="12", head_commit_sha="def456")
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+        self._add_check_runs([{"status": "completed", "conclusion": "failure"}], sha="def456")
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+        # The second PR must not read the first PR's cached result.
+        assert get_pr_ci_status(other_pr) == "failed"
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_new_head_sha_invalidates_cache(self) -> None:
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+        self._add_check_runs([{"status": "completed", "conclusion": "failure"}], sha="def456")
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+        # A push updates the stored head sha; the old head's cached status must
+        # not be served, and the new head is fetched immediately.
+        self.pr.update(head_commit_sha="def456")
+        assert get_pr_ci_status(self.pr) == "failed"
+        assert len(responses.calls) == 2

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
+from sentry.models.pullrequest import PullRequest
 from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.seer.run_questions import QUESTIONS, question_hash
 from sentry.seer.runs_query import filtered_runs_queryset
@@ -410,6 +411,64 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         assert prs_by_key["124"]["mergedAt"] is None
 
         assert by_id[str(without_prs.uuid)]["pullRequests"] == []
+
+    def _run_with_pr(self) -> PullRequest:
+        run = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            last_triggered_at=before_now(minutes=1),
+        )
+        project = self.create_project(organization=self.organization)
+        repo = self.create_repo(project, name="getsentry/sentry")
+        pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="123"
+        )
+        SeerRunPullRequest.objects.create(seer_run=run, pull_request=pr)
+        return pr
+
+    @patch("sentry.api.serializers.models.seer_run.get_pr_ci_status", return_value="passed")
+    def test_ci_status_included_when_requested(self, mock_ci_status: Any) -> None:
+        pr = self._run_with_pr()
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"includeCiStatus": "1"}
+        )
+
+        prs = response.data[0]["pullRequests"]
+        assert prs[0]["ciStatus"] == "passed"
+        mock_ci_status.assert_called_once_with(pr)
+
+    @patch("sentry.api.serializers.models.seer_run.get_pr_ci_status", return_value="passed")
+    def test_ci_status_absent_without_param(self, mock_ci_status: Any) -> None:
+        self._run_with_pr()
+
+        response = self.get_success_response(self.organization.slug)
+
+        prs = response.data[0]["pullRequests"]
+        assert "ciStatus" not in prs[0]
+        assert not mock_ci_status.called
+
+    def test_ci_status_clamps_page_size(self) -> None:
+        for i in range(1, 12):
+            self.create_seer_run(
+                organization=self.organization,
+                user_id=self.user.id,
+                last_triggered_at=before_now(minutes=i),
+            )
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"includeCiStatus": "1"}
+        )
+
+        assert len(response.data) == 10
+        assert 'rel="next"; results="true"' in response.headers["Link"]
+
+        # Oversized pages are rejected outright, same as the outputs path.
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"includeCiStatus": "1", "per_page": "100"},
+            status_code=400,
+        )
 
     def test_outputs_absent_without_flag(self) -> None:
         self.create_seer_run(


### PR DESCRIPTION
The Autofix Overview page shows cards for issues whose autofix run opened a PR, but gives no signal about whether that PR's checks are green before the user clicks through to review it.

This adds an opt-in `includeCiStatus` param to the seer runs endpoint. When set, each entry in a run's `pullRequests` gains `ciStatus: "passed" | "running" | "failed" | null`, computed from GitHub check runs for the PR's head commit and cached (120s positive / 30s negative TTL) so repeat page views don't re-hit GitHub. Without the param the response is byte-identical to today.

Details:
- New `sentry.seer.autofix.pr_ci_status.get_pr_ci_status`: skips merged/closed PRs, GitHub-only (other providers report `null`), resolves the head SHA from `PullRequest.head_commit_sha` with a `get_pull_request` fallback for Seer-created shell rows, and aggregates check-run conclusions (any of `failure/timed_out/action_required` → failed, any incomplete → running, otherwise passed). Errors are negative-cached and never propagate into the endpoint.
- Page size is clamped to 10 when `includeCiStatus` is requested (same pattern as the existing outputs clamp) so a cold cache can't fan out ~100 synchronous GitHub calls in one request. The overview cards fetch `per_page=1`.

Frontend consumption (a status tag on the review cards) lands separately.