### PR TITLE
feat(seer): Thread autofix_automation_tuning into night shift's triage payload

### DIFF
--- a/src/sentry/seer/night_shift/models.py
+++ b/src/sentry/seer/night_shift/models.py
@@ -28,6 +28,9 @@ class TriageCandidate(_Base):
     first_seen: str  # ISO 8601; Seer parses it back to a datetime.
     priority: str | None = None
     connected_repos: list[str] = Field(default_factory=list)
+    # The candidate's project-level `sentry:autofix_automation_tuning` value.
+    # Only ever set for legacy (non-seat-based) orgs.
+    automation_tuning: str | None = None
 
 
 class TriageTweaks(_Base):

--- a/src/sentry/seer/night_shift/models.py
+++ b/src/sentry/seer/night_shift/models.py
@@ -28,7 +28,6 @@ class TriageCandidate(_Base):
     first_seen: str  # ISO 8601; Seer parses it back to a datetime.
     priority: str | None = None
     connected_repos: list[str] = Field(default_factory=list)
-    # The candidate's project-level `sentry:autofix_automation_tuning` value.
     # Only ever set for legacy (non-seat-based) orgs.
     automation_tuning: str | None = None
 

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -459,6 +459,8 @@ class EligibleProject:
     tweaks: NightShiftTweaks
     stopping_point: AutofixStoppingPoint
     connected_repos: list[str]
+    # None for seat-based orgs, regardless of the project's own setting.
+    automation_tuning: AutofixAutomationTuningSettings | None
 
 
 def _get_eligible_projects(
@@ -486,8 +488,8 @@ def _get_eligible_projects(
 
     preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
-    # Rate limit only applies to legacy org plans
-    check_rate_limit = not is_seer_seat_based_tier_enabled(organization)
+    # The rate limit and automation_tuning both only apply to legacy org plans.
+    is_legacy_org = not is_seer_seat_based_tier_enabled(organization)
 
     eligible: list[EligibleProject] = []
     for pid, project in project_map.items():
@@ -506,7 +508,7 @@ def _get_eligible_projects(
             reasons.append("automation_tuning_off")
         if source == "cron" and not tweaks.enabled:
             reasons.append("tweaks_disabled")
-        if check_rate_limit and is_seer_autotriggered_autofix_rate_limited(project):
+        if is_legacy_org and is_seer_autotriggered_autofix_rate_limited(project):
             reasons.append("autofix_rate_limited")
         if stopping_point != AutofixStoppingPoint.OPEN_PR:
             # Night shift's only output is a PR, so a project that stops
@@ -533,6 +535,7 @@ def _get_eligible_projects(
                 tweaks=tweaks,
                 stopping_point=stopping_point,
                 connected_repos=[f"{repo.owner}/{repo.name}" for repo in pref.repositories],
+                automation_tuning=pref.autofix_automation_tuning if is_legacy_org else None,
             )
         )
 
@@ -552,6 +555,7 @@ def _build_triage_payload(
     candidates: Sequence[ScoredCandidate],
     resolved_options: SeerNightShiftRunOptions,
     repos_by_project: dict[int, list[str]],
+    tuning_by_project: dict[int, str],
 ) -> NightShiftPayload:
     return NightShiftPayload(
         candidates=[
@@ -564,6 +568,7 @@ def _build_triage_payload(
                 first_seen=c.group.first_seen.isoformat(),
                 priority=priority_label(c.group.priority),
                 connected_repos=repos_by_project.get(c.group.project_id, []),
+                automation_tuning=tuning_by_project.get(c.group.project_id),
             )
             for c in candidates
         ],
@@ -589,6 +594,11 @@ def _dispatch_to_seer_feature(
     deliver_feature_result."""
     eligible_projects = [ep.project for ep in eligible]
     repos_by_project = {ep.project.id: ep.connected_repos for ep in eligible}
+    tuning_by_project = {
+        ep.project.id: ep.automation_tuning.value
+        for ep in eligible
+        if ep.automation_tuning is not None
+    }
     per_project_quotas = _should_use_per_project_quotas(resolved_options["source"], organization.id)
     score_strategy = (
         fixability_score_strategy_per_project if per_project_quotas else fixability_score_strategy
@@ -613,7 +623,9 @@ def _dispatch_to_seer_feature(
     shards = list(chunked(scored, shard_size))
     dispatched = 0
     for shard_index, chunk in enumerate(shards):
-        payload = _build_triage_payload(chunk, resolved_options, repos_by_project)
+        payload = _build_triage_payload(
+            chunk, resolved_options, repos_by_project, tuning_by_project
+        )
         num_candidates = len(payload.candidates)
         title = ngettext(
             "Agentic triage (%(count)d candidate)",

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -488,7 +488,6 @@ def _get_eligible_projects(
 
     preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
-    # The rate limit and automation_tuning both only apply to legacy org plans.
     is_legacy_org = not is_seer_seat_based_tier_enabled(organization)
 
     eligible: list[EligibleProject] = []

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -359,6 +359,21 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
         assert repos_by_slug[a.slug] == ["owner/a"]
         assert repos_by_slug[b.slug] == ["owner/b", "owner/b-extra"]
 
+    def test_carries_each_projects_automation_tuning(self) -> None:
+        org = self.create_organization()
+        low = self._make_eligible(self.create_project(organization=org, slug="low"))
+        low.update_option("sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.LOW)
+        always = self._make_eligible(self.create_project(organization=org, slug="always"))
+        always.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.ALWAYS
+        )
+
+        result = _get_eligible_projects(org, "manual")
+
+        tuning_by_slug = {ep.project.slug: ep.automation_tuning for ep in result}
+        assert tuning_by_slug[low.slug] == AutofixAutomationTuningSettings.LOW
+        assert tuning_by_slug[always.slug] == AutofixAutomationTuningSettings.ALWAYS
+
     def test_filters_by_project_id(self) -> None:
         org = self.create_organization()
         target = self._make_eligible(self.create_project(organization=org))
@@ -478,6 +493,21 @@ class TestGetEligibleProjects(NightShiftFixtures, TestCase):
             result = _get_eligible_projects(org, "manual")
 
         assert [ep.project for ep in result] == [at_limit]
+
+    def test_seat_based_orgs_get_no_automation_tuning(self) -> None:
+        org = self.create_organization()
+        project = self._make_eligible(self.create_project(organization=org))
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.LOW
+        )
+
+        with patch(
+            "sentry.tasks.seer.night_shift.cron.is_seer_seat_based_tier_enabled",
+            return_value=True,
+        ):
+            result = _get_eligible_projects(org, "manual")
+
+        assert result[0].automation_tuning is None
 
 
 @django_db_all
@@ -766,6 +796,64 @@ class TestRunNightShiftFeatureDelivery(NightShiftFixtures, TestCase, SnubaTestCa
         assert run.extras.get("error_message") is None
         # Verdicts and autofix are Seer's responsibility now; no result rows here.
         assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
+
+    def test_payload_carries_automation_tuning_for_legacy_orgs(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH
+        )
+        self._store_event_and_update_group(project, "fixable", seer_fixability_score=0.9)
+
+        with self.feature("organizations:gen-ai-features"):
+            run_night_shift_for_org(org.id)
+
+        _, body = _dispatched_feature_body(org)
+        assert body["payload"]["candidates"][0]["automation_tuning"] == "high"
+
+    def test_payload_omits_automation_tuning_for_seat_based_orgs(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+        self._store_event_and_update_group(project, "fixable", seer_fixability_score=0.9)
+
+        with (
+            self.feature("organizations:gen-ai-features"),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.is_seer_seat_based_tier_enabled",
+                return_value=True,
+            ),
+        ):
+            run_night_shift_for_org(org.id)
+
+        _, body = _dispatched_feature_body(org)
+        assert body["payload"]["candidates"][0]["automation_tuning"] is None
+
+    def test_payload_carries_per_project_automation_tuning_within_one_org(self) -> None:
+        org = self.create_organization()
+        low = self._make_eligible(self.create_project(organization=org, slug="low"))
+        low.update_option("sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.LOW)
+        always = self._make_eligible(self.create_project(organization=org, slug="always"))
+        always.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.ALWAYS
+        )
+        low_group = self._store_event_and_update_group(
+            low, "low-fixable", seer_fixability_score=0.9
+        )
+        always_group = self._store_event_and_update_group(
+            always, "always-fixable", seer_fixability_score=0.9
+        )
+
+        with self.feature("organizations:gen-ai-features"):
+            run_night_shift_for_org(org.id)
+
+        _, body = _dispatched_feature_body(org)
+        tuning_by_group_id = {
+            c["group_id"]: c["automation_tuning"] for c in body["payload"]["candidates"]
+        }
+        assert tuning_by_group_id[low_group.id] == "low"
+        assert tuning_by_group_id[always_group.id] == "always"
 
     def test_allowed_project_slugs_gives_each_project_its_own_quota(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
Night shift never told Seer about a project's `sentry:autofix_automation_tuning` setting, so its triage prompt couldn't calibrate autofix selectivity per project — a project configured `super_low` (only autofix near-certain fixes) was triaged identically to one configured `always`.

Threads each eligible project's `automation_tuning` value through `EligibleProject` -> `_dispatch_to_seer_feature` -> `_build_triage_payload` onto `TriageCandidate`, gated to legacy (non-seat-based) orgs — seat-based orgs always send `None`, reusing the same `is_legacy_org` check already used for the autofix rate limit.

Pairs with getsentry/seer#7473, which adds the corresponding per-candidate field and prompt section on the Seer side (recommended to land first, since it's fully backward-compatible either way).