### PR TITLE
fix(issue-activity): Hide some duplicative pull request activity from the UI

### DIFF
--- a/static/app/views/issueDetails/activitySection/index.spec.tsx
+++ b/static/app/views/issueDetails/activitySection/index.spec.tsx
@@ -1452,6 +1452,159 @@ describe('ActivitySection', () => {
     );
   });
 
+  it('hides a referenced commit next to a merged activity', async () => {
+    const repository = RepositoryFixture({id: 'repository-1'});
+    const pullRequest = PullRequestFixture({id: '1234', repository});
+
+    const activityGroup = GroupFixture({
+      activity: [
+        {
+          type: GroupActivityType.PULL_REQUEST_MERGED,
+          id: 'pull-request-merged',
+          dateCreated: '2020-01-01T00:01:00',
+          data: {pullRequest},
+          user: null,
+        },
+        {
+          type: GroupActivityType.REFERENCED_IN_COMMIT,
+          id: 'referenced-in-commit',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {commit: CommitFixture({pullRequest, repository})},
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} />
+      </GroupDataContextProvider>
+    );
+
+    expect(await screen.findByTestId('activity-timeline')).toHaveTextContent('#1234');
+    expect(screen.queryByText('f7f395d')).not.toBeInTheDocument();
+  });
+
+  it('hides the duplicate when the referenced commit comes before the merged activity', async () => {
+    const repository = RepositoryFixture({id: 'repository-1'});
+    const pullRequest = PullRequestFixture({id: '1234', repository});
+
+    const activityGroup = GroupFixture({
+      activity: [
+        {
+          type: GroupActivityType.REFERENCED_IN_COMMIT,
+          id: 'referenced-in-commit',
+          dateCreated: '2020-01-01T00:01:00',
+          data: {commit: CommitFixture({pullRequest, repository})},
+          user,
+        },
+        {
+          type: GroupActivityType.PULL_REQUEST_MERGED,
+          id: 'pull-request-merged',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {pullRequest},
+          user: null,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} />
+      </GroupDataContextProvider>
+    );
+
+    expect(await screen.findByTestId('activity-timeline')).toHaveTextContent('#1234');
+    expect(screen.queryByText('f7f395d')).not.toBeInTheDocument();
+  });
+
+  it('keeps a referenced commit next to a merged activity for a different pull request', async () => {
+    const mergedPullRequest = PullRequestFixture({
+      id: '1234',
+      repository: RepositoryFixture({id: 'repository-1'}),
+    });
+    const referencedRepository = RepositoryFixture({id: 'repository-2'});
+    const referencedPullRequest = PullRequestFixture({
+      id: '1234',
+      repository: referencedRepository,
+    });
+
+    const activityGroup = GroupFixture({
+      activity: [
+        {
+          type: GroupActivityType.PULL_REQUEST_MERGED,
+          id: 'pull-request-merged',
+          dateCreated: '2020-01-01T00:01:00',
+          data: {pullRequest: mergedPullRequest},
+          user: null,
+        },
+        {
+          type: GroupActivityType.REFERENCED_IN_COMMIT,
+          id: 'referenced-in-commit',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            commit: CommitFixture({
+              pullRequest: referencedPullRequest,
+              repository: referencedRepository,
+            }),
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} />
+      </GroupDataContextProvider>
+    );
+
+    expect(await screen.findByText('f7f395d')).toBeInTheDocument();
+  });
+
+  it('keeps a referenced commit when the merged activity is not adjacent', async () => {
+    const repository = RepositoryFixture({id: 'repository-1'});
+    const pullRequest = PullRequestFixture({repository});
+
+    const activityGroup = GroupFixture({
+      activity: [
+        {
+          type: GroupActivityType.PULL_REQUEST_MERGED,
+          id: 'pull-request-merged',
+          dateCreated: '2020-01-01T00:02:00',
+          data: {pullRequest},
+          user: null,
+        },
+        {
+          type: GroupActivityType.NOTE,
+          id: 'note-between-pull-request-activities',
+          dateCreated: '2020-01-01T00:01:00',
+          data: {text: 'An activity between the pull request activities'},
+          user,
+        },
+        {
+          type: GroupActivityType.REFERENCED_IN_COMMIT,
+          id: 'referenced-in-commit',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {commit: CommitFixture({pullRequest, repository})},
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(
+      <GroupDataContextProvider group={activityGroup} project={activityGroup.project}>
+        <ActivitySection group={activityGroup} />
+      </GroupDataContextProvider>
+    );
+
+    expect(await screen.findByText('f7f395d')).toBeInTheDocument();
+  });
+
   it('prefers commit repository details for resolved commit activity line items', async () => {
     const commitRepository = RepositoryFixture({
       name: 'getsentry/sentry',

--- a/static/app/views/issueDetails/activitySection/index.tsx
+++ b/static/app/views/issueDetails/activitySection/index.tsx
@@ -216,6 +216,43 @@ interface ActivitySectionProps {
   variant?: 'sidebar' | 'standalone';
 }
 
+function isDuplicatePullRequestActivity(
+  activity: GroupActivity,
+  adjacentActivity: GroupActivity | undefined
+): boolean {
+  switch (activity.type) {
+    // REFERENCED_IN_COMMIT should be hidden if there is an adjacent PULL_REQUEST_MERGED activity with the same pull request
+    case GroupActivityType.REFERENCED_IN_COMMIT: {
+      if (adjacentActivity?.type !== GroupActivityType.PULL_REQUEST_MERGED) {
+        return false;
+      }
+
+      const pullRequest = activity.data.commit?.pullRequest;
+      const adjacentPullRequest = adjacentActivity.data.pullRequest;
+      if (!pullRequest || !adjacentPullRequest) {
+        return false;
+      }
+
+      return (
+        pullRequest.id === adjacentPullRequest.id &&
+        pullRequest.repository.id === adjacentPullRequest.repository.id
+      );
+    }
+    default:
+      return false;
+  }
+}
+
+function removeAdjacentDuplicatePullRequestActivities(
+  activities: GroupActivity[]
+): GroupActivity[] {
+  return activities.filter(
+    (activity, index) =>
+      !isDuplicatePullRequestActivity(activity, activities[index - 1]) &&
+      !isDuplicatePullRequestActivity(activity, activities[index + 1])
+  );
+}
+
 export function ActivitySection({
   group,
   filterComments,
@@ -277,9 +314,9 @@ export function ActivitySection({
       )
     : group.activity.filter(item => !SEER_ACTIVITY_TYPES.has(item.type));
 
-  const filteredActivities = visibleActivities.filter(
-    item => !filterComments || item.type === GroupActivityType.NOTE
-  );
+  const filteredActivities = removeAdjacentDuplicatePullRequestActivities(
+    visibleActivities
+  ).filter(item => !filterComments || item.type === GroupActivityType.NOTE);
   const inputVariant = variant === 'sidebar' ? 'compact' : 'full';
   const timestampUnitStyle = variant === 'sidebar' ? 'short' : undefined;
 


### PR DESCRIPTION
After adding the pull request merged activity, we are seeing many instances of "referenced in commit" next to "pr merged" which isn't very useful. This PR hides the commit reference activity if it is next to the pr merged activity with the same PR data.

This is a problem we are seeing in other activities as well, but I'm hoping that we can find a more long term solution when the action log takes over for Activity and we have better tools for deduplicating these kinds of things.

Before:

<img width="980" height="252" alt="CleanShot 2026-07-22 at 11 49 42@2x" src="https://github.com/user-attachments/assets/a832ea6b-661d-4c3c-bcee-72e7675da629" />

After:

<img width="984" height="198" alt="CleanShot 2026-07-22 at 11 49 49@2x" src="https://github.com/user-attachments/assets/f7455745-e52c-46c9-82a8-caccf3e37055" />
