### PR TITLE
ref(issue-workflow): Move build_activity_notification_data to template layer

### DIFF
--- a/src/sentry/notifications/notification_action/activity_registry/base.py
+++ b/src/sentry/notifications/notification_action/activity_registry/base.py
@@ -1,30 +1,16 @@
 import logging
-from urllib.parse import urlencode
 
-from sentry.integrations.messaging.message_builder import (
-    build_attachment_text,
-    build_attachment_title,
-)
 from sentry.models.activity import Activity
-from sentry.models.commit import Commit
-from sentry.models.group import Group
-from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.notifications.notification_action.registry import activity_handler_registry
-from sentry.notifications.notifications.activity.assigned import get_assignee_str
 from sentry.notifications.platform.service import NotificationService
-from sentry.notifications.platform.templates.activity import (
+from sentry.notifications.platform.templates.activity.base import (
     ACTIVITY_TYPE_TO_SOURCE,
     ActivityNotificationData,
-    AssignedNotificationData,
-    SetResolvedInCommitNotificationData,
-    SetResolvedInReleaseNotificationData,
+    build_activity_notification_data,
 )
 from sentry.notifications.platform.types import NotificationTarget
-from sentry.types.activity import SEER_ACTIVITY_TYPES, ActivityType
-from sentry.users.services.user.service import user_service
-from sentry.utils.http import absolute_uri
-from sentry.workflow_engine.models import Action, Workflow
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation
 
 logger = logging.getLogger(__name__)
@@ -47,115 +33,12 @@ def get_supported_action_types() -> frozenset[Action.Type]:
     )
 
 
-def extract_notification_models_by_activity(
-    activity: Activity,
-) -> tuple[Group, Project, Organization]:
-    try:
-        group = Group.objects.get_from_cache(id=activity.group_id)
-    except Group.DoesNotExist:
-        raise ValueError(f"Group not found: {activity.group_id}")
-    try:
-        project = Project.objects.get_from_cache(id=activity.project_id)
-    except Project.DoesNotExist:
-        raise ValueError(f"Project not found: {activity.project_id}")
-    try:
-        organization = Organization.objects.get_from_cache(id=project.organization_id)
-    except Organization.DoesNotExist:
-        raise ValueError(f"Organization not found: {project.organization_id}")
-
-    return group, project, organization
-
-
-def build_activity_notification_data(
-    invocation: ActionInvocation, activity: Activity
-) -> ActivityNotificationData:
-    source = ACTIVITY_TYPE_TO_SOURCE.get(activity.type)
-    if source is None:
-        raise ValueError(f"No notification source for activity type: {activity.type}")
-
-    group, project, organization = extract_notification_models_by_activity(activity)
-
-    try:
-        workflow = Workflow.objects.get(id=invocation.workflow_id, organization_id=organization.id)
-    except Workflow.DoesNotExist:
-        raise ValueError(f"Workflow not found: {invocation.workflow_id}")
-
-    issue_url_params: dict[str, str] = {}
-    if ActivityType(activity.type) in SEER_ACTIVITY_TYPES:
-        issue_url_params.update({"seerDrawer": "true"})
-
-    action_data = dict(
-        source=source,
-        activity_type=activity.type,
-        notification_uuid=invocation.notification_uuid,
-        issue_short_id=group.qualified_short_id,
-        issue_url=absolute_uri(group.get_absolute_url(params=issue_url_params)),
-        issue_title=build_attachment_title(group) or "",
-        issue_culprit=group.culprit,
-        issue_description=build_attachment_text(group),
-        project_slug=project.slug,
-        project_url=organization.absolute_url(
-            f"organizations/{organization.slug}/issues/",
-            query=urlencode({"project": project.id}),
-        ),
-        alert_url=organization.absolute_url(
-            f"organizations/{organization.slug}/monitors/alerts/{invocation.workflow_id}/"
-        ),
-        alert_name=workflow.name,
-        activity_data=activity.data,
-        activity_user_name=None,
-    )
-
-    if activity.user_id:
-        user = user_service.get_user(user_id=activity.user_id)
-        if user:
-            action_data["activity_user_name"] = user.get_display_name()
-
-    match activity.type:
-        case ActivityType.SET_RESOLVED_IN_COMMIT.value:
-            commit_sha = None
-            commit_message = None
-            if activity.data and "commit" in activity.data:
-                try:
-                    commit = Commit.objects.get(id=activity.data["commit"])
-                    commit_sha = commit.short_id
-                    commit_message = commit.message
-                except Commit.DoesNotExist:
-                    pass
-            return SetResolvedInCommitNotificationData(
-                **action_data, commit_sha=commit_sha, commit_message=commit_message
-            )
-        case ActivityType.SET_RESOLVED_IN_RELEASE.value:
-            release_url = None
-            # If version is missing, None or "" -> it was resolved in an upcoming release
-            if activity.data and activity.data.get("version"):
-                raw_version = activity.data["version"]
-                release_url = organization.absolute_url(
-                    f"organizations/{organization.slug}/releases/{raw_version}/",
-                    query=urlencode({"project": project.id}),
-                )
-            return SetResolvedInReleaseNotificationData(**action_data, release_url=release_url)
-
-        case ActivityType.ASSIGNED.value:
-            assignee_label = get_assignee_str(activity=activity, organization=organization)
-            assignee_email = activity.data.get("assigneeEmail")
-            assignee_url = None
-            # TODO(Leander): If a team is assigned, maybe link to the team page?
-            if assignee_email:
-                assignee_url = f"mailto:{assignee_email}"
-            return AssignedNotificationData(
-                **action_data, assignee_label=assignee_label, assignee_url=assignee_url
-            )
-        case _:
-            return ActivityNotificationData(**action_data)
-
-
 def send_activity_notification(
     invocation: ActionInvocation,
     activity: Activity,
     target: NotificationTarget,
 ) -> None:
-    data = build_activity_notification_data(invocation, activity)
+    data = build_activity_notification_data(activity, workflow_id=invocation.workflow_id)
     NotificationService[ActivityNotificationData](data=data).notify_sync(targets=[target])
 
 

--- a/src/sentry/notifications/notification_action/activity_registry/email.py
+++ b/src/sentry/notifications/notification_action/activity_registry/email.py
@@ -2,7 +2,6 @@ from sentry.models.activity import Activity
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.activity_registry.base import (
     NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
-    build_activity_notification_data,
     require_config,
     send_activity_notification,
 )
@@ -13,8 +12,9 @@ from sentry.notifications.platform.strategies.issue_owners import (
     IssueOwnersActivityAlertStrategy,
 )
 from sentry.notifications.platform.target import GenericNotificationTarget
-from sentry.notifications.platform.templates.activity import (
+from sentry.notifications.platform.templates.activity.base import (
     ActivityNotificationData,
+    build_activity_notification_data,
 )
 from sentry.notifications.platform.types import (
     NotificationProviderKey,
@@ -36,7 +36,7 @@ class EmailActivityHandler(ActivityHandler):
         if group is None:
             raise ValueError(f"Activity {activity.id} has no associated group")
         strategy = IssueOwnersActivityAlertStrategy(group=group)
-        data = build_activity_notification_data(invocation, activity)
+        data = build_activity_notification_data(activity, workflow_id=invocation.workflow_id)
         NotificationService[ActivityNotificationData](data=data).notify_sync(strategy=strategy)
 
     @classmethod

--- a/src/sentry/notifications/notification_action/activity_registry/sentry_app.py
+++ b/src/sentry/notifications/notification_action/activity_registry/sentry_app.py
@@ -5,12 +5,12 @@ from sentry.api.serializers import serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
-from sentry.notifications.notification_action.activity_registry.base import (
-    extract_notification_models_by_activity,
-    require_config,
-)
+from sentry.notifications.notification_action.activity_registry.base import require_config
 from sentry.notifications.notification_action.registry import activity_handler_registry
 from sentry.notifications.notification_action.types import ActivityHandler
+from sentry.notifications.platform.templates.activity.base import (
+    extract_notification_models_by_activity,
+)
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.metrics import (
     SentryAppInteractionEvent,

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -26,14 +26,14 @@ def _get_team_option(assignee_id: int | None, organization: Organization) -> Tea
 
 
 def is_team_assignee(activity: Activity) -> bool:
-    return activity.data.get("assigneeType") == "team"
+    return bool(activity.data) and activity.data.get("assigneeType") == "team"
 
 
 def get_assignee_str(activity: Activity, organization: Organization) -> str:
     """Get a human-readable version of the assignment's target."""
 
-    assignee_id = activity.data.get("assignee")
-    assignee_email: str | None = activity.data.get("assigneeEmail")
+    assignee_id = activity.data.get("assignee") if activity.data else None
+    assignee_email: str | None = activity.data.get("assigneeEmail") if activity.data else None
 
     if is_team_assignee(activity):
         assignee_team = _get_team_option(assignee_id, organization)

--- a/src/sentry/notifications/platform/templates/activity/__init__.py
+++ b/src/sentry/notifications/platform/templates/activity/__init__.py
@@ -1,11 +1,4 @@
 from .assigned import AssignedActivityTemplate
-from .base import (
-    ACTIVITY_TYPE_TO_SOURCE,
-    ActivityNotificationData,
-    AssignedNotificationData,
-    SetResolvedInCommitNotificationData,
-    SetResolvedInReleaseNotificationData,
-)
 from .note import NoteActivityTemplate
 from .seer.coding_completed import SeerCodingCompletedActivityTemplate
 from .seer.coding_started import SeerCodingStartedActivityTemplate
@@ -27,11 +20,6 @@ from .status_change.set_unresolved import SetUnresolvedActivityTemplate
 from .unassigned import UnassignedActivityTemplate
 
 __all__ = (
-    "ACTIVITY_TYPE_TO_SOURCE",
-    "ActivityNotificationData",
-    "SetResolvedInCommitNotificationData",
-    "SetResolvedInReleaseNotificationData",
-    "AssignedNotificationData",
     "SeerRcaStartedActivityTemplate",
     "SeerRcaCompletedActivityTemplate",
     "SeerSolutionStartedActivityTemplate",

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -1,10 +1,6 @@
 from typing import Any
 from urllib.parse import urlencode
 
-from sentry.integrations.messaging.message_builder import (
-    build_attachment_text,
-    build_attachment_title,
-)
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import Group
@@ -164,6 +160,10 @@ def extract_notification_models_by_activity(
 def build_activity_notification_data(
     activity: Activity, *, workflow_id: int | None = None
 ) -> ActivityNotificationData:
+    from sentry.integrations.messaging.message_builder import (
+        build_attachment_text,
+        build_attachment_title,
+    )
     from sentry.notifications.notifications.activity.assigned import get_assignee_str
 
     source = ACTIVITY_TYPE_TO_SOURCE.get(activity.type)

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -242,7 +242,7 @@ def build_activity_notification_data(
 
         case ActivityType.ASSIGNED.value:
             assignee_label = get_assignee_str(activity=activity, organization=organization)
-            assignee_email = activity.data.get("assigneeEmail")
+            assignee_email = activity.data.get("assigneeEmail") if activity.data else None
             assignee_url = None
             # TODO(Leander): If a team is assigned, maybe link to the team page?
             if assignee_email:

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -10,7 +10,6 @@ from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.notifications.notifications.activity.assigned import get_assignee_str
 from sentry.notifications.platform.types import (
     CodeSection,
     CodeTextBlock,
@@ -165,6 +164,8 @@ def extract_notification_models_by_activity(
 def build_activity_notification_data(
     activity: Activity, *, workflow_id: int | None = None
 ) -> ActivityNotificationData:
+    from sentry.notifications.notifications.activity.assigned import get_assignee_str
+
     source = ACTIVITY_TYPE_TO_SOURCE.get(activity.type)
     if source is None:
         raise ValueError(f"No notification source for activity type: {activity.type}")

--- a/src/sentry/notifications/platform/templates/activity/base.py
+++ b/src/sentry/notifications/platform/templates/activity/base.py
@@ -1,5 +1,16 @@
 from typing import Any
+from urllib.parse import urlencode
 
+from sentry.integrations.messaging.message_builder import (
+    build_attachment_text,
+    build_attachment_title,
+)
+from sentry.models.activity import Activity
+from sentry.models.commit import Commit
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.notifications.notifications.activity.assigned import get_assignee_str
 from sentry.notifications.platform.types import (
     CodeSection,
     CodeTextBlock,
@@ -11,7 +22,10 @@ from sentry.notifications.platform.types import (
     ParagraphSection,
     PlainTextBlock,
 )
-from sentry.types.activity import ActivityType
+from sentry.types.activity import SEER_ACTIVITY_TYPES, ActivityType
+from sentry.users.services.user.service import user_service
+from sentry.utils.http import absolute_uri
+from sentry.workflow_engine.models import Workflow
 
 ACTIVITY_TYPE_TO_SOURCE: dict[int, NotificationSource] = {
     ActivityType.SEER_RCA_STARTED.value: NotificationSource.ACTIVITY_SEER_RCA_STARTED,
@@ -45,7 +59,6 @@ FOOTER_DELIMITER = " · "
 
 class ActivityNotificationData(NotificationData):
     source: NotificationSource
-    notification_uuid: str
     activity_type: int
     activity_data: dict[str, Any] | None = None
     # The name of the user who is associated with an activity (Activity.user_id)
@@ -69,7 +82,6 @@ def create_activity_notification_example(
     activity_data: dict[str, Any] | None = None,
 ) -> ActivityNotificationData:
     return ActivityNotificationData(
-        notification_uuid="1234567890",
         activity_user_name="Jane Doe",
         issue_short_id="JAVASCRIPT-1",
         issue_url=EXAMPLE_ISSUE_URL,
@@ -129,3 +141,113 @@ def get_issue_description(data: ActivityNotificationData) -> list[NotificationSe
     if data.issue_description:
         sections.append(CodeSection(blocks=[PlainTextBlock(text=data.issue_description)]))
     return sections
+
+
+def extract_notification_models_by_activity(
+    activity: Activity,
+) -> tuple[Group, Project, Organization]:
+    try:
+        group = Group.objects.get_from_cache(id=activity.group_id)
+    except Group.DoesNotExist:
+        raise ValueError(f"Group not found: {activity.group_id}")
+    try:
+        project = Project.objects.get_from_cache(id=activity.project_id)
+    except Project.DoesNotExist:
+        raise ValueError(f"Project not found: {activity.project_id}")
+    try:
+        organization = Organization.objects.get_from_cache(id=project.organization_id)
+    except Organization.DoesNotExist:
+        raise ValueError(f"Organization not found: {project.organization_id}")
+
+    return group, project, organization
+
+
+def build_activity_notification_data(
+    activity: Activity, *, workflow_id: int | None = None
+) -> ActivityNotificationData:
+    source = ACTIVITY_TYPE_TO_SOURCE.get(activity.type)
+    if source is None:
+        raise ValueError(f"No notification source for activity type: {activity.type}")
+
+    group, project, organization = extract_notification_models_by_activity(activity)
+
+    workflow: Workflow | None = None
+    if workflow_id:
+        try:
+            workflow = Workflow.objects.get(id=workflow_id, organization_id=organization.id)
+        except Workflow.DoesNotExist:
+            raise ValueError(f"Workflow not found: {workflow_id}")
+
+    issue_url_params: dict[str, str] = {}
+    if ActivityType(activity.type) in SEER_ACTIVITY_TYPES:
+        issue_url_params.update({"seerDrawer": "true"})
+
+    action_data = dict(
+        source=source,
+        activity_type=activity.type,
+        issue_short_id=group.qualified_short_id,
+        issue_url=absolute_uri(group.get_absolute_url(params=issue_url_params)),
+        issue_title=build_attachment_title(group) or "",
+        issue_culprit=group.culprit,
+        issue_description=build_attachment_text(group),
+        project_slug=project.slug,
+        project_url=organization.absolute_url(
+            f"organizations/{organization.slug}/issues/",
+            query=urlencode({"project": project.id}),
+        ),
+        activity_data=activity.data,
+        activity_user_name=None,
+    )
+
+    if workflow:
+        action_data.update(
+            {
+                "alert_name": workflow.name,
+                "alert_url": organization.absolute_url(
+                    f"organizations/{organization.slug}/monitors/alerts/{workflow_id}/"
+                ),
+            }
+        )
+
+    if activity.user_id:
+        user = user_service.get_user(user_id=activity.user_id)
+        if user:
+            action_data["activity_user_name"] = user.get_display_name()
+
+    match activity.type:
+        case ActivityType.SET_RESOLVED_IN_COMMIT.value:
+            commit_sha = None
+            commit_message = None
+            if activity.data and "commit" in activity.data:
+                try:
+                    commit = Commit.objects.get(id=activity.data["commit"])
+                    commit_sha = commit.short_id
+                    commit_message = commit.message
+                except Commit.DoesNotExist:
+                    pass
+            return SetResolvedInCommitNotificationData(
+                **action_data, commit_sha=commit_sha, commit_message=commit_message
+            )
+        case ActivityType.SET_RESOLVED_IN_RELEASE.value:
+            release_url = None
+            # If version is missing, None or "" -> it was resolved in an upcoming release
+            if activity.data and activity.data.get("version"):
+                raw_version = activity.data["version"]
+                release_url = organization.absolute_url(
+                    f"organizations/{organization.slug}/releases/{raw_version}/",
+                    query=urlencode({"project": project.id}),
+                )
+            return SetResolvedInReleaseNotificationData(**action_data, release_url=release_url)
+
+        case ActivityType.ASSIGNED.value:
+            assignee_label = get_assignee_str(activity=activity, organization=organization)
+            assignee_email = activity.data.get("assigneeEmail")
+            assignee_url = None
+            # TODO(Leander): If a team is assigned, maybe link to the team page?
+            if assignee_email:
+                assignee_url = f"mailto:{assignee_email}"
+            return AssignedNotificationData(
+                **action_data, assignee_label=assignee_label, assignee_url=assignee_url
+            )
+        case _:
+            return ActivityNotificationData(**action_data)

--- a/tests/sentry/notifications/notification_action/activity_registry/test_base.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_base.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from sentry.notifications.notification_action.activity_registry.base import (
     NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES,
-    build_activity_notification_data,
     send_activity_notification,
 )
 from sentry.notifications.notification_action.activity_registry.discord import (
@@ -14,16 +13,14 @@ from sentry.notifications.notification_action.activity_registry.msteams import (
 )
 from sentry.notifications.notification_action.activity_registry.slack import SlackActivityHandler
 from sentry.notifications.platform.target import IntegrationNotificationTarget
-from sentry.notifications.platform.templates.activity import (
+from sentry.notifications.platform.templates.activity.base import (
     ActivityNotificationData,
 )
 from sentry.notifications.platform.types import (
     NotificationProviderKey,
-    NotificationSource,
     NotificationTargetResourceType,
 )
 from sentry.types.activity import ActivityType
-from sentry.utils.http import absolute_uri
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -37,40 +34,6 @@ class TestCompatibleActivityTypes:
         ]:
             for activity_type in NOTIFICATION_PLATFORM_COMPATIBLE_ACTIVITIES:
                 assert activity_type in handler.compatible_activity_types
-
-
-class TestBuildActivityData(BaseWorkflowTest):
-    def setUp(self) -> None:
-        super().setUp()
-        self.group = self.create_group()
-        self.workflow, self.detector, _, _ = self.create_detector_and_workflow()
-        self.action = self.create_action()
-
-    def test_build_activity_notification_data(self) -> None:
-        activity = self.create_group_activity(
-            group=self.group,
-            type=ActivityType.SEER_RCA_STARTED.value,
-        )
-        invocation = self.create_action_invocation(
-            event=activity,
-            group=self.group,
-            action=self.action,
-            detector=self.detector,
-            workflow_id=self.workflow.id,
-            notification_uuid="test-uuid",
-        )
-
-        data = build_activity_notification_data(invocation, activity)
-
-        assert isinstance(data, ActivityNotificationData)
-        assert data.source == NotificationSource.ACTIVITY_SEER_RCA_STARTED
-        assert data.activity_type == ActivityType.SEER_RCA_STARTED.value
-        assert data.notification_uuid == "test-uuid"
-        assert data.issue_short_id == self.group.qualified_short_id
-        assert absolute_uri(self.group.get_absolute_url()) in data.issue_url
-        assert data.issue_culprit == self.group.culprit
-        assert data.alert_url is not None
-        assert data.activity_data == activity.data
 
 
 class TestSendActivityNotification(BaseWorkflowTest):

--- a/tests/sentry/notifications/notification_action/activity_registry/test_email.py
+++ b/tests/sentry/notifications/notification_action/activity_registry/test_email.py
@@ -93,7 +93,7 @@ class TestEmailActivityHandler(BaseWorkflowTest):
 
         EmailActivityHandler.invoke_action(invocation=invocation, activity=activity)
 
-        mock_build_data.assert_called_once_with(invocation, activity)
+        mock_build_data.assert_called_once_with(activity, workflow_id=self.workflow.id)
         mock_service_instance = mock_notification_service.__getitem__.return_value.return_value
         mock_service_instance.notify_sync.assert_called_once()
         call_kwargs = mock_service_instance.notify_sync.call_args[1]

--- a/tests/sentry/notifications/platform/templates/test_activity.py
+++ b/tests/sentry/notifications/platform/templates/test_activity.py
@@ -1,11 +1,11 @@
-from sentry.notifications.platform.templates.activity import (
-    ACTIVITY_TYPE_TO_SOURCE,
-)
 from sentry.notifications.platform.templates.activity.base import (
+    ACTIVITY_TYPE_TO_SOURCE,
     EXAMPLE_ALERT_URL,
     EXAMPLE_ISSUE_URL,
     EXAMPLE_PROJECT_URL,
     EXAMPLE_USER_SETTINGS_URL,
+    ActivityNotificationData,
+    build_activity_notification_data,
     build_footer,
     build_issue_link,
     create_activity_notification_example,
@@ -19,10 +19,12 @@ from sentry.notifications.platform.templates.activity.status_change.base import 
 )
 from sentry.notifications.platform.types import (
     LinkTextBlock,
+    NotificationSource,
     NotificationTextBlockType,
 )
 from sentry.testutils.cases import TestCase
 from sentry.types.activity import ActivityType
+from sentry.utils.http import absolute_uri
 
 
 class ActivityAlertBaseTest(TestCase):
@@ -104,6 +106,27 @@ class ActivityAlertBaseTest(TestCase):
         sections = get_issue_description(data)
         blocks = sections[0].blocks
         assert not any(b.type == NotificationTextBlockType.CODE for b in blocks)
+
+    def test_build_activity_notification_data(self) -> None:
+        workflow = self.create_workflow(
+            name="my_workflow",
+            when_condition_group=self.create_data_condition_group(),
+        )
+
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SEER_RCA_STARTED.value,
+        )
+        data = build_activity_notification_data(activity, workflow_id=workflow.id)
+
+        assert isinstance(data, ActivityNotificationData)
+        assert data.source == NotificationSource.ACTIVITY_SEER_RCA_STARTED
+        assert data.activity_type == ActivityType.SEER_RCA_STARTED.value
+        assert data.issue_short_id == self.group.qualified_short_id
+        assert absolute_uri(self.group.get_absolute_url()) in data.issue_url
+        assert data.issue_culprit == self.group.culprit
+        assert data.alert_url is not None
+        assert data.activity_data == activity.data
 
 
 class ActivitySeerAlertBaseTest(TestCase):


### PR DESCRIPTION
Move `build_activity_notification_data` and `extract_notification_models_by_activity` from the action registry into `templates/activity/base.py`. Make `workflow_id` optional and remove `notification_uuid` from `ActivityNotificationData`.

This is to assist in migrating workflow notifications to use the notification platform, for those workflow_id is not requird (also notif_uuid wasnt used anyway, i hadnt noticed)