### PR TITLE
ref(issue-workflow): Add ParticipantMap to NotificationTarget helper

### DIFF
--- a/src/sentry/notifications/platform/strategies/utils.py
+++ b/src/sentry/notifications/platform/strategies/utils.py
@@ -1,7 +1,11 @@
-from sentry.identity.services.identity import identity_service
+from sentry.constants import ObjectStatus
+from sentry.identity.services.identity import RpcIdentity, identity_service
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.services.integration.service import integration_service
-from sentry.integrations.types import ExternalProviders
+from sentry.integrations.types import (
+    ExternalProviderEnum,
+    ExternalProviders,
+)
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.notifications.platform.target import (
     GenericNotificationTarget,
@@ -22,14 +26,17 @@ def get_targets_from_participant_map(
 ) -> list[NotificationTarget]:
     """
     Converts legacy ParticipantMap types to the platform's new NotificationTarget list.
+    Note: For simplicity, we ignore SLACK_STAGING and MSTEAMS since they are not available in prod.
     """
     return [
-        *_get_email_targets(participant_map),
+        *_get_email_targets(participant_map, organization_id=organization_id),
         *_get_slack_targets(participant_map, organization_id=organization_id),
     ]
 
 
-def _get_email_targets(participant_map: ParticipantMap) -> list[NotificationTarget]:
+def _get_email_targets(
+    participant_map: ParticipantMap, organization_id: int
+) -> list[NotificationTarget]:
     user_ids: set[int] = set()
     team_ids: set[int] = set()
     for actor, _reason in participant_map.get_participants_by_provider(ExternalProviders.EMAIL):
@@ -39,9 +46,9 @@ def _get_email_targets(participant_map: ParticipantMap) -> list[NotificationTarg
             user_ids.add(actor.id)
 
     if team_ids:
-        members = OrganizationMemberTeam.objects.filter(team_id__in=team_ids).select_related(
-            "organizationmember"
-        )
+        members = OrganizationMemberTeam.objects.filter(
+            team_id__in=team_ids, team__organization_id=organization_id
+        ).select_related("organizationmember")
         for member in members:
             uid = member.organizationmember.user_id
             if uid is not None:
@@ -60,6 +67,7 @@ def _get_email_targets(participant_map: ParticipantMap) -> list[NotificationTarg
                 provider_key=NotificationProviderKey.EMAIL,
                 resource_type=NotificationTargetResourceType.EMAIL,
                 resource_id=user.email,
+                specific_data={"user_id": user.id},
             )
         )
     return targets
@@ -68,80 +76,88 @@ def _get_email_targets(participant_map: ParticipantMap) -> list[NotificationTarg
 def _get_slack_targets(
     participant_map: ParticipantMap, *, organization_id: int
 ) -> list[NotificationTarget]:
-    slack_user_ids: set[int] = set()
-    slack_team_ids: set[int] = set()
+    user_ids: set[int] = set()
+    team_ids: set[int] = set()
     for actor, _reason in participant_map.get_participants_by_provider(ExternalProviders.SLACK):
         if actor.actor_type == ActorType.TEAM:
-            slack_team_ids.add(actor.id)
+            team_ids.add(actor.id)
         else:
-            slack_user_ids.add(actor.id)
+            user_ids.add(actor.id)
 
-    if not slack_user_ids and not slack_team_ids:
+    if not user_ids and not team_ids:
         return []
 
-    org_integrations = integration_service.get_organization_integrations(
-        organization_id=organization_id,
-        providers=["slack"],
-        limit=1,
-    )
-    if not org_integrations:
-        return []
-
-    org_integration = org_integrations[0]
-    integration = integration_service.get_integration(integration_id=org_integration.integration_id)
-    if integration is None or integration.external_id is None:
-        return []
-
-    targets: list[NotificationTarget] = []
-    targets.extend(
-        _get_slack_user_targets(
-            user_ids=slack_user_ids,
-            integration_provider=integration.provider,
-            integration_external_id=integration.external_id,
-            integration_id=org_integration.integration_id,
-            organization_id=organization_id,
-        )
-    )
-    targets.extend(
-        _get_slack_team_targets(
-            team_ids=slack_team_ids,
-            integration_id=org_integration.integration_id,
-            organization_id=organization_id,
-        )
-    )
-    return targets
+    return [
+        *_get_slack_user_targets(user_ids=user_ids, organization_id=organization_id),
+        *_get_slack_team_targets(team_ids=team_ids, organization_id=organization_id),
+    ]
 
 
 def _get_slack_user_targets(
     *,
     user_ids: set[int],
-    integration_provider: str,
-    integration_external_id: str,
-    integration_id: int,
     organization_id: int,
 ) -> list[NotificationTarget]:
+    """
+    Checks the Identities available to a user, gets the IdentityProvider of those identities, and ensures
+    an Integration exists with IdentityProvider.external_id == Integration.external_id.
+
+    Note: This helper is extremely inefficient because of the limited RPC functions we have available on the
+    IdentityService and IntegrationService. This leads to N+1 calls, and lots of mappings. The proper fix
+    would be to implement a new RPC method or parameters to better fit this usecase, but I don't have time at the moment.
+    """
     if not user_ids:
         return []
 
-    idp = identity_service.get_provider(
-        provider_type=integration_provider,
-        provider_ext_id=integration_external_id,
-    )
-    if idp is None:
+    identities: list[RpcIdentity] = []
+    for user_id in user_ids:
+        user_identities = identity_service.get_user_identities_by_provider_type(
+            user_id=user_id,
+            provider_type=ExternalProviderEnum.SLACK.value,
+            exclude_matching_external_ids=True,
+        )
+        if user_identities:
+            identities.extend(user_identities)
+
+    if not identities:
         return []
 
+    identity_to_external_id: dict[int, str] = {}
+    for identity in identities:
+        idp = identity_service.get_provider(provider_id=identity.idp_id)
+        if not idp:
+            continue
+        if not idp.external_id:
+            continue
+        identity_to_external_id[identity.id] = idp.external_id
+
+    all_integrations = integration_service.get_integrations(
+        organization_id=organization_id,
+        status=ObjectStatus.ACTIVE,
+        org_integration_status=ObjectStatus.ACTIVE,
+        limit=None,
+        providers=[ExternalProviderEnum.SLACK.value],
+    )
+    external_id_to_integration_id = {
+        integration.external_id: integration.id for integration in all_integrations
+    }
+
     targets: list[NotificationTarget] = []
-    for user_id in user_ids:
-        identity = identity_service.get_identity(filter={"user_id": user_id, "provider_id": idp.id})
-        if identity is None:
+    for identity in identities:
+        external_id = identity_to_external_id.get(identity.id)
+        if not external_id:
+            continue
+        integration_id = external_id_to_integration_id.get(external_id)
+        if not integration_id:
             continue
         targets.append(
             IntegrationNotificationTarget(
                 provider_key=NotificationProviderKey.SLACK,
                 resource_type=NotificationTargetResourceType.DIRECT_MESSAGE,
-                resource_id=identity.external_id,
+                resource_id=external_id,
                 integration_id=integration_id,
                 organization_id=organization_id,
+                specific_data={"user_id": identity.user_id},
             )
         )
     return targets
@@ -150,9 +166,14 @@ def _get_slack_user_targets(
 def _get_slack_team_targets(
     *,
     team_ids: set[int],
-    integration_id: int,
     organization_id: int,
 ) -> list[NotificationTarget]:
+    org_integrations = integration_service.get_organization_integrations(
+        status=ObjectStatus.ACTIVE,
+        organization_id=organization_id,
+        providers=[ExternalProviderEnum.SLACK.value],
+    )
+
     if not team_ids:
         return []
 
@@ -160,7 +181,7 @@ def _get_slack_team_targets(
         provider=ExternalProviders.SLACK.value,
         team_id__in=team_ids,
         organization_id=organization_id,
-        integration_id=integration_id,
+        integration_id__in={oi.integration_id for oi in org_integrations},
     ).exclude(external_id__isnull=True)
 
     targets: list[NotificationTarget] = []
@@ -170,8 +191,9 @@ def _get_slack_team_targets(
                 provider_key=NotificationProviderKey.SLACK,
                 resource_type=NotificationTargetResourceType.CHANNEL,
                 resource_id=external_actor.external_id,
-                integration_id=integration_id,
+                integration_id=external_actor.integration_id,
                 organization_id=organization_id,
+                specific_data={"team_id": external_actor.team_id},
             )
         )
     return targets

--- a/src/sentry/notifications/platform/strategies/utils.py
+++ b/src/sentry/notifications/platform/strategies/utils.py
@@ -154,7 +154,7 @@ def _get_slack_user_targets(
             IntegrationNotificationTarget(
                 provider_key=NotificationProviderKey.SLACK,
                 resource_type=NotificationTargetResourceType.DIRECT_MESSAGE,
-                resource_id=external_id,
+                resource_id=identity.external_id,
                 integration_id=integration_id,
                 organization_id=organization_id,
                 specific_data={"user_id": identity.user_id},

--- a/src/sentry/notifications/platform/strategies/utils.py
+++ b/src/sentry/notifications/platform/strategies/utils.py
@@ -1,0 +1,177 @@
+from sentry.identity.services.identity import identity_service
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.types import ExternalProviders
+from sentry.models.organizationmemberteam import OrganizationMemberTeam
+from sentry.notifications.platform.target import (
+    GenericNotificationTarget,
+    IntegrationNotificationTarget,
+)
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationTarget,
+    NotificationTargetResourceType,
+)
+from sentry.notifications.utils.participants import ParticipantMap
+from sentry.types.actor import ActorType
+from sentry.users.services.user.service import user_service
+
+
+def get_targets_from_participant_map(
+    participant_map: ParticipantMap, *, organization_id: int
+) -> list[NotificationTarget]:
+    """
+    Converts legacy ParticipantMap types to the platform's new NotificationTarget list.
+    """
+    return [
+        *_get_email_targets(participant_map),
+        *_get_slack_targets(participant_map, organization_id=organization_id),
+    ]
+
+
+def _get_email_targets(participant_map: ParticipantMap) -> list[NotificationTarget]:
+    user_ids: set[int] = set()
+    team_ids: set[int] = set()
+    for actor, _reason in participant_map.get_participants_by_provider(ExternalProviders.EMAIL):
+        if actor.actor_type == ActorType.TEAM:
+            team_ids.add(actor.id)
+        else:
+            user_ids.add(actor.id)
+
+    if team_ids:
+        members = OrganizationMemberTeam.objects.filter(team_id__in=team_ids).select_related(
+            "organizationmember"
+        )
+        for member in members:
+            uid = member.organizationmember.user_id
+            if uid is not None:
+                user_ids.add(uid)
+
+    if not user_ids:
+        return []
+
+    users = user_service.get_many_by_id(ids=list(user_ids))
+    targets: list[NotificationTarget] = []
+    for user in users:
+        if not user.email:
+            continue
+        targets.append(
+            GenericNotificationTarget(
+                provider_key=NotificationProviderKey.EMAIL,
+                resource_type=NotificationTargetResourceType.EMAIL,
+                resource_id=user.email,
+            )
+        )
+    return targets
+
+
+def _get_slack_targets(
+    participant_map: ParticipantMap, *, organization_id: int
+) -> list[NotificationTarget]:
+    slack_user_ids: set[int] = set()
+    slack_team_ids: set[int] = set()
+    for actor, _reason in participant_map.get_participants_by_provider(ExternalProviders.SLACK):
+        if actor.actor_type == ActorType.TEAM:
+            slack_team_ids.add(actor.id)
+        else:
+            slack_user_ids.add(actor.id)
+
+    if not slack_user_ids and not slack_team_ids:
+        return []
+
+    org_integrations = integration_service.get_organization_integrations(
+        organization_id=organization_id,
+        providers=["slack"],
+        limit=1,
+    )
+    if not org_integrations:
+        return []
+
+    org_integration = org_integrations[0]
+    integration = integration_service.get_integration(integration_id=org_integration.integration_id)
+    if integration is None or integration.external_id is None:
+        return []
+
+    targets: list[NotificationTarget] = []
+    targets.extend(
+        _get_slack_user_targets(
+            user_ids=slack_user_ids,
+            integration_provider=integration.provider,
+            integration_external_id=integration.external_id,
+            integration_id=org_integration.integration_id,
+            organization_id=organization_id,
+        )
+    )
+    targets.extend(
+        _get_slack_team_targets(
+            team_ids=slack_team_ids,
+            integration_id=org_integration.integration_id,
+            organization_id=organization_id,
+        )
+    )
+    return targets
+
+
+def _get_slack_user_targets(
+    *,
+    user_ids: set[int],
+    integration_provider: str,
+    integration_external_id: str,
+    integration_id: int,
+    organization_id: int,
+) -> list[NotificationTarget]:
+    if not user_ids:
+        return []
+
+    idp = identity_service.get_provider(
+        provider_type=integration_provider,
+        provider_ext_id=integration_external_id,
+    )
+    if idp is None:
+        return []
+
+    targets: list[NotificationTarget] = []
+    for user_id in user_ids:
+        identity = identity_service.get_identity(filter={"user_id": user_id, "provider_id": idp.id})
+        if identity is None:
+            continue
+        targets.append(
+            IntegrationNotificationTarget(
+                provider_key=NotificationProviderKey.SLACK,
+                resource_type=NotificationTargetResourceType.DIRECT_MESSAGE,
+                resource_id=identity.external_id,
+                integration_id=integration_id,
+                organization_id=organization_id,
+            )
+        )
+    return targets
+
+
+def _get_slack_team_targets(
+    *,
+    team_ids: set[int],
+    integration_id: int,
+    organization_id: int,
+) -> list[NotificationTarget]:
+    if not team_ids:
+        return []
+
+    external_actors = ExternalActor.objects.filter(
+        provider=ExternalProviders.SLACK.value,
+        team_id__in=team_ids,
+        organization_id=organization_id,
+        integration_id=integration_id,
+    ).exclude(external_id__isnull=True)
+
+    targets: list[NotificationTarget] = []
+    for external_actor in external_actors:
+        targets.append(
+            IntegrationNotificationTarget(
+                provider_key=NotificationProviderKey.SLACK,
+                resource_type=NotificationTargetResourceType.CHANNEL,
+                resource_id=external_actor.external_id,
+                integration_id=integration_id,
+                organization_id=organization_id,
+            )
+        )
+    return targets

--- a/src/sentry/notifications/platform/strategies/utils.py
+++ b/src/sentry/notifications/platform/strategies/utils.py
@@ -168,14 +168,14 @@ def _get_slack_team_targets(
     team_ids: set[int],
     organization_id: int,
 ) -> list[NotificationTarget]:
+    if not team_ids:
+        return []
+
     org_integrations = integration_service.get_organization_integrations(
         status=ObjectStatus.ACTIVE,
         organization_id=organization_id,
         providers=[ExternalProviderEnum.SLACK.value],
     )
-
-    if not team_ids:
-        return []
 
     external_actors = ExternalActor.objects.filter(
         provider=ExternalProviders.SLACK.value,

--- a/tests/sentry/notifications/platform/strategies/test_utils.py
+++ b/tests/sentry/notifications/platform/strategies/test_utils.py
@@ -153,7 +153,7 @@ class GetTargetsSlackUserTest(TestCase):
         target = slack_targets[0]
         assert isinstance(target, IntegrationNotificationTarget)
         assert target.resource_type == NotificationTargetResourceType.DIRECT_MESSAGE
-        assert target.resource_id == self.integration.external_id
+        assert target.resource_id == "UXXXXXXX1"
         assert target.integration_id == self.integration.id
         assert target.organization_id == self.organization.id
         assert target.specific_data == {"user_id": self.user.id}

--- a/tests/sentry/notifications/platform/strategies/test_utils.py
+++ b/tests/sentry/notifications/platform/strategies/test_utils.py
@@ -1,0 +1,321 @@
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders, IntegrationProviderSlug
+from sentry.notifications.platform.strategies.utils import (
+    get_targets_from_participant_map,
+)
+from sentry.notifications.platform.target import (
+    GenericNotificationTarget,
+    IntegrationNotificationTarget,
+)
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationTargetResourceType,
+)
+from sentry.notifications.utils.participants import ParticipantMap
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.slack import add_identity, install_slack
+from sentry.types.actor import Actor, ActorType
+
+
+class GetTargetsFromParticipantMapTest(TestCase):
+    def test_empty_participant_map(self) -> None:
+        participant_map = ParticipantMap()
+        result = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+        assert result == []
+
+    def test_email_user_target(self) -> None:
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        assert len(targets) == 1
+        target = targets[0]
+        assert isinstance(target, GenericNotificationTarget)
+        assert target.provider_key == NotificationProviderKey.EMAIL
+        assert target.resource_type == NotificationTargetResourceType.EMAIL
+        assert target.resource_id == self.user.email
+        assert target.specific_data == {"user_id": self.user.id}
+
+    def test_email_multiple_users(self) -> None:
+        user_a = self.create_user(email="a@example.com")
+        user_b = self.create_user(email="b@example.com")
+        self.create_member(organization=self.organization, user=user_a)
+        self.create_member(organization=self.organization, user=user_b)
+
+        participant_map = ParticipantMap()
+        for u in (user_a, user_b):
+            participant_map.add(
+                ExternalProviders.EMAIL,
+                Actor(id=u.id, actor_type=ActorType.USER),
+                0,
+            )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        emails = {t.resource_id for t in targets}
+        assert "a@example.com" in emails
+        assert "b@example.com" in emails
+
+    def test_email_team_expands_to_members(self) -> None:
+        user_a = self.create_user(email="a@example.com")
+        user_b = self.create_user(email="b@example.com")
+        team = self.create_team(organization=self.organization)
+        self.create_team_membership(team=team, user=user_a)
+        self.create_team_membership(team=team, user=user_b)
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=team.id, actor_type=ActorType.TEAM),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        emails = {t.resource_id for t in targets}
+        assert "a@example.com" in emails
+        assert "b@example.com" in emails
+
+    def test_email_user_and_team_deduplicates(self) -> None:
+        team = self.create_team(organization=self.organization)
+        self.create_team_membership(team=team, user=self.user)
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=team.id, actor_type=ActorType.TEAM),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        emails = [t.resource_id for t in targets]
+        assert emails.count(self.user.email) == 1
+
+    def test_email_skips_users_without_email(self) -> None:
+        user_no_email = self.create_user(email="")
+        self.create_member(organization=self.organization, user=user_no_email)
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=user_no_email.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        assert targets == []
+
+
+class GetTargetsSlackUserTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = install_slack(self.organization)
+        self.idp = add_identity(self.integration, self.user, external_id="UXXXXXXX1")
+
+    def test_slack_user_target(self) -> None:
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.SLACK,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        slack_targets = [t for t in targets if t.provider_key == NotificationProviderKey.SLACK]
+        assert len(slack_targets) == 1
+        target = slack_targets[0]
+        assert isinstance(target, IntegrationNotificationTarget)
+        assert target.resource_type == NotificationTargetResourceType.DIRECT_MESSAGE
+        assert target.resource_id == self.integration.external_id
+        assert target.integration_id == self.integration.id
+        assert target.organization_id == self.organization.id
+        assert target.specific_data == {"user_id": self.user.id}
+
+    def test_slack_user_no_identity_returns_empty(self) -> None:
+        other_user = self.create_user(email="other@example.com")
+        self.create_member(organization=self.organization, user=other_user)
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.SLACK,
+            Actor(id=other_user.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        slack_targets = [t for t in targets if t.provider_key == NotificationProviderKey.SLACK]
+        assert slack_targets == []
+
+    def test_slack_empty_user_ids_returns_empty(self) -> None:
+        participant_map = ParticipantMap()
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+        assert targets == []
+
+
+class GetTargetsSlackTeamTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration, self.org_integration = self.create_provider_integration_for(
+            provider=IntegrationProviderSlug.SLACK,
+            organization=self.organization,
+            user=self.user,
+            name="test-slack",
+            metadata={"domain_name": "test-workspace.slack.com"},
+        )
+        self.team = self.create_team(organization=self.organization)
+
+    def test_slack_team_target(self) -> None:
+        ExternalActor.objects.create(
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.SLACK.value,
+            external_name="test-channel",
+            external_id="C1234567890",
+        )
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.SLACK,
+            Actor(id=self.team.id, actor_type=ActorType.TEAM),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        slack_targets = [t for t in targets if t.provider_key == NotificationProviderKey.SLACK]
+        assert len(slack_targets) == 1
+        target = slack_targets[0]
+        assert isinstance(target, IntegrationNotificationTarget)
+        assert target.resource_type == NotificationTargetResourceType.CHANNEL
+        assert target.resource_id == "C1234567890"
+        assert target.integration_id == self.integration.id
+        assert target.organization_id == self.organization.id
+        assert target.specific_data == {"team_id": self.team.id}
+
+    def test_slack_team_no_external_actor_returns_empty(self) -> None:
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.SLACK,
+            Actor(id=self.team.id, actor_type=ActorType.TEAM),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        slack_targets = [t for t in targets if t.provider_key == NotificationProviderKey.SLACK]
+        assert slack_targets == []
+
+    def test_slack_team_excludes_null_external_id(self) -> None:
+        ExternalActor.objects.create(
+            team_id=self.team.id,
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            provider=ExternalProviders.SLACK.value,
+            external_name="test-channel",
+            external_id=None,
+        )
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.SLACK,
+            Actor(id=self.team.id, actor_type=ActorType.TEAM),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        slack_targets = [t for t in targets if t.provider_key == NotificationProviderKey.SLACK]
+        assert slack_targets == []
+
+    def test_slack_team_multiple_external_actors(self) -> None:
+        team_b = self.create_team(organization=self.organization)
+        for team, chan_id in [(self.team, "C111"), (team_b, "C222")]:
+            ExternalActor.objects.create(
+                team_id=team.id,
+                organization_id=self.organization.id,
+                integration_id=self.integration.id,
+                provider=ExternalProviders.SLACK.value,
+                external_name="chan",
+                external_id=chan_id,
+            )
+
+        participant_map = ParticipantMap()
+        for t in (self.team, team_b):
+            participant_map.add(
+                ExternalProviders.SLACK,
+                Actor(id=t.id, actor_type=ActorType.TEAM),
+                0,
+            )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        slack_targets = [t for t in targets if t.provider_key == NotificationProviderKey.SLACK]
+        channel_ids = {t.resource_id for t in slack_targets}
+        assert channel_ids == {"C111", "C222"}
+
+
+class GetTargetsCombinedTest(TestCase):
+    def test_email_and_slack_combined(self) -> None:
+        integration = install_slack(self.organization)
+        add_identity(integration, self.user, external_id="UXXXXXXX1")
+
+        participant_map = ParticipantMap()
+        participant_map.add(
+            ExternalProviders.EMAIL,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+        participant_map.add(
+            ExternalProviders.SLACK,
+            Actor(id=self.user.id, actor_type=ActorType.USER),
+            0,
+        )
+
+        targets = get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )
+
+        provider_keys = {t.provider_key for t in targets}
+        assert NotificationProviderKey.EMAIL in provider_keys
+        assert NotificationProviderKey.SLACK in provider_keys


### PR DESCRIPTION
Add `strategies/utils.py` with `get_targets_from_participant_map` that converts a `ParticipantMap` into `NotificationTarget` objects, handling email (with team expansion) and Slack (user DMs + team channels).

The workflow notifications use participants, and instead of reading notif preferences ourselves for each notif type, an adapter works a little bit cleaner. This helper is used in the next two prs

Depends on #120388.