### PR TITLE
feat(issue-workflow): Add activity notification route via notification platform

### DIFF
--- a/src/sentry/notifications/platform/strategies/issue_subscribers.py
+++ b/src/sentry/notifications/platform/strategies/issue_subscribers.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+
+from sentry.models.activity import Activity
+from sentry.notifications.platform.strategies.utils import get_targets_from_participant_map
+from sentry.notifications.platform.types import (
+    NotificationStrategy,
+    NotificationTarget,
+)
+from sentry.notifications.utils.participants import get_participants_for_group
+
+
+@dataclass(frozen=True)
+class IssueSubscribersActivityStrategy(NotificationStrategy):
+    """
+    Strategy for issue workflow notifications.
+    Targets all the subscribers for a given issue attached to an activity.
+    If there is a user associated with the activity, skip their notification unless they've opted in for
+    notifications about their own activity.
+    """
+
+    activity: Activity
+
+    def get_targets(self) -> list[NotificationTarget]:
+        group = self.activity.group
+        if not group:
+            return []
+        participant_map = get_participants_for_group(group=group, user_id=self.activity.user_id)
+        return get_targets_from_participant_map(
+            participant_map, organization_id=group.organization.id
+        )

--- a/src/sentry/notifications/platform/strategies/issue_subscribers.py
+++ b/src/sentry/notifications/platform/strategies/issue_subscribers.py
@@ -26,5 +26,5 @@ class IssueSubscribersActivityStrategy(NotificationStrategy):
             return []
         participant_map = get_participants_for_group(group=group, user_id=self.activity.user_id)
         return get_targets_from_participant_map(
-            participant_map, organization_id=group.organization.id
+            participant_map, organization_id=group.project.organization_id
         )

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -7,11 +10,14 @@ from sentry.utils.sdk import bind_organization_context
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from sentry.models.activity import Activity
 
-def get_activity_notifiers(project):
+
+def _send_legacy_activity_notification(activity: Activity) -> None:
     from sentry.mail import mail_adapter
 
-    return [mail_adapter]
+    mail_adapter.notify_about_activity(activity)
 
 
 @instrumented_task(
@@ -23,6 +29,15 @@ def get_activity_notifiers(project):
 def send_activity_notifications(activity_id: int) -> None:
     from sentry.models.activity import Activity
     from sentry.models.organization import Organization
+    from sentry.notifications.platform.service import NotificationService
+    from sentry.notifications.platform.strategies.issue_subscribers import (
+        IssueSubscribersActivityStrategy,
+    )
+    from sentry.notifications.platform.templates.activity.base import (
+        ACTIVITY_TYPE_TO_SOURCE,
+        ActivityNotificationData,
+        build_activity_notification_data,
+    )
 
     try:
         activity = Activity.objects.get(pk=activity_id)
@@ -32,5 +47,15 @@ def send_activity_notifications(activity_id: int) -> None:
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
     bind_organization_context(organization)
 
-    for notifier in get_activity_notifiers(activity.project):
-        notifier.notify_about_activity(activity)
+    source = ACTIVITY_TYPE_TO_SOURCE.get(activity.type)
+    if not source:
+        _send_legacy_activity_notification(activity=activity)
+        return
+
+    if not NotificationService.has_access(organization=organization, source=source):
+        _send_legacy_activity_notification(activity=activity)
+        return
+
+    data = build_activity_notification_data(activity=activity)
+    strategy = IssueSubscribersActivityStrategy(activity=activity)
+    NotificationService[ActivityNotificationData](data=data).notify_sync(strategy=strategy)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -108,6 +108,7 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.grouprelease import GroupRelease
+from sentry.models.groupsubscription import GroupSubscription
 from sentry.models.organization import Organization
 from sentry.models.organizationcontributors import OrganizationContributors
 from sentry.models.organizationmapping import OrganizationMapping
@@ -1302,6 +1303,12 @@ class Factories:
     @assume_test_silo_mode(SiloMode.CELL)
     def create_group_activity(group, *args, **kwargs):
         return Activity.objects.create(group=group, project=group.project, *args, **kwargs)
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_group_subscription(group, **kwargs):
+        kwargs.setdefault("project", group.project)
+        return GroupSubscription.objects.create(group=group, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CELL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -372,6 +372,11 @@ class Fixtures:
             group = self.group
         return Factories.create_group_activity(group, *args, **kwargs)
 
+    def create_group_subscription(self, group=None, **kwargs):
+        if group is None:
+            group = self.group
+        return Factories.create_group_subscription(group, **kwargs)
+
     def create_group_owner(self, group=None, **kwargs):
         if group is None:
             group = self.group

--- a/tests/sentry/notifications/platform/strategies/test_issue_subscribers.py
+++ b/tests/sentry/notifications/platform/strategies/test_issue_subscribers.py
@@ -1,0 +1,130 @@
+from unittest.mock import patch
+
+from sentry.notifications.platform.strategies.issue_subscribers import (
+    IssueSubscribersActivityStrategy,
+)
+from sentry.notifications.platform.target import GenericNotificationTarget
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationTargetResourceType,
+)
+from sentry.testutils.cases import TestCase
+from sentry.types.activity import ActivityType
+
+
+class IssueSubscribersActivityStrategyTest(TestCase):
+    def test_returns_empty_when_no_group(self) -> None:
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+        )
+        activity.group = None
+        activity.save()
+
+        strategy = IssueSubscribersActivityStrategy(activity=activity)
+        assert strategy.get_targets() == []
+
+    def test_returns_subscriber_targets(self) -> None:
+        self.create_group_subscription(
+            group=self.group,
+            user_id=self.user.id,
+            is_active=True,
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+        )
+
+        strategy = IssueSubscribersActivityStrategy(activity=activity)
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert len(email_targets) >= 1
+        assert any(
+            isinstance(t, GenericNotificationTarget)
+            and t.resource_type == NotificationTargetResourceType.EMAIL
+            and t.resource_id == self.user.email
+            for t in email_targets
+        )
+
+    def test_excludes_activity_author_by_default(self) -> None:
+        self.create_group_subscription(
+            group=self.group,
+            user_id=self.user.id,
+            is_active=True,
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            user_id=self.user.id,
+        )
+
+        strategy = IssueSubscribersActivityStrategy(activity=activity)
+        targets = strategy.get_targets()
+
+        assert not any(
+            t.resource_id == self.user.email
+            for t in targets
+            if t.provider_key == NotificationProviderKey.EMAIL
+        )
+
+    def test_includes_activity_author_when_self_notifications_enabled(self) -> None:
+        self.create_group_subscription(
+            group=self.group,
+            user_id=self.user.id,
+            is_active=True,
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            user_id=self.user.id,
+        )
+
+        with patch(
+            "sentry.notifications.utils.participants.get_option_from_list",
+            return_value="1",
+        ):
+            strategy = IssueSubscribersActivityStrategy(activity=activity)
+            targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert any(t.resource_id == self.user.email for t in email_targets)
+
+    def test_multiple_subscribers(self) -> None:
+        user_b = self.create_user(email="b@example.com")
+        self.create_member(organization=self.organization, user=user_b, teams=[self.team])
+        for u in (self.user, user_b):
+            self.create_group_subscription(
+                group=self.group,
+                user_id=u.id,
+                is_active=True,
+            )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+        )
+
+        strategy = IssueSubscribersActivityStrategy(activity=activity)
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        emails = {t.resource_id for t in email_targets}
+        assert self.user.email in emails
+        assert "b@example.com" in emails
+
+    def test_unsubscribed_user_excluded(self) -> None:
+        self.create_group_subscription(
+            group=self.group,
+            user_id=self.user.id,
+            is_active=False,
+        )
+        activity = self.create_group_activity(
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+        )
+
+        strategy = IssueSubscribersActivityStrategy(activity=activity)
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert not any(t.resource_id == self.user.email for t in email_targets)


### PR DESCRIPTION
Add `IssueSubscribersActivityStrategy` and update `send_activity_notifications` to route supported activity types through the notification platform, falling back to legacy mail adapter.

This won't apply to deploy notifications though, that's handled in the next PR they are signaled by activity, but query completely different models

Depends on #120389.