### PR TITLE
fix(discover): put in reverse redirect and change page titles

### DIFF
--- a/static/app/views/discover/breadcrumb.tsx
+++ b/static/app/views/discover/breadcrumb.tsx
@@ -11,6 +11,7 @@ import type {EventView} from 'sentry/utils/discover/eventView';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {EventInputName} from 'sentry/views/discover/eventInputName';
 import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
+import {getDiscoverDeprecation} from 'sentry/views/discover/utils';
 
 type Props = {
   eventView: EventView;
@@ -47,7 +48,7 @@ export function DiscoverBreadcrumb({
       isHomepage && eventView
         ? eventView.getResultsViewUrlTarget(organization, isHomepage)
         : discoverTarget,
-    label: t('Discover'),
+    label: getDiscoverDeprecation(organization) ? t('Errors') : t('Discover'),
   });
 
   if (!isHomepage && eventView?.isValid()) {

--- a/static/app/views/discover/index.spec.tsx
+++ b/static/app/views/discover/index.spec.tsx
@@ -1,0 +1,92 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import DiscoverContainer from 'sentry/views/discover';
+
+describe('DiscoverContainer', () => {
+  const deprecatedOrg = OrganizationFixture({
+    slug: 'org-slug',
+    features: [
+      'discover-basic',
+      'deprecate-discover',
+      'discover-saved-queries-deprecation',
+    ],
+  });
+  const nonDeprecatedOrg = OrganizationFixture({
+    slug: 'org-slug',
+    features: ['discover-basic'],
+  });
+
+  it('redirects /explore/errors/ to /explore/discover/ when the org lacks the deprecation flag', async () => {
+    const {router} = render(<DiscoverContainer />, {
+      organization: nonDeprecatedOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/errors/queries/',
+          query: {foo: 'bar'},
+        },
+        route: '/organizations/:orgId/explore/errors/:tab/',
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/explore/discover/queries/'
+      );
+    });
+    expect(router.location.query).toEqual({foo: 'bar'});
+  });
+
+  it('does not redirect /explore/discover/ URLs when the org lacks the deprecation flag', () => {
+    render(<DiscoverContainer />, {
+      organization: nonDeprecatedOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/discover/queries/',
+        },
+        route: '/organizations/:orgId/explore/discover/:tab/',
+      },
+    });
+
+    expect(
+      screen.queryByText("You don't have access to this feature")
+    ).not.toBeInTheDocument();
+  });
+
+  it('redirects /explore/discover/ to /explore/errors/ when the org has the deprecation flag', async () => {
+    const {router} = render(<DiscoverContainer />, {
+      organization: deprecatedOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/discover/queries/',
+          query: {foo: 'bar'},
+        },
+        route: '/organizations/:orgId/explore/discover/:tab/',
+      },
+    });
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/explore/errors/queries/'
+      );
+    });
+    expect(router.location.query).toEqual({foo: 'bar'});
+  });
+
+  it('does not redirect /explore/errors/ URLs when the org has the deprecation flag', () => {
+    render(<DiscoverContainer />, {
+      organization: deprecatedOrg,
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/errors/queries/',
+        },
+        route: '/organizations/:orgId/explore/errors/:tab/',
+      },
+    });
+
+    expect(
+      screen.queryByText("You don't have access to this feature")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/discover/index.tsx
+++ b/static/app/views/discover/index.tsx
@@ -65,6 +65,24 @@ function DiscoverContainer() {
     return <Redirect to={normalizeUrl('/explore/traces/')} />;
   }
 
+  // Backwards compatibility: if the org doesn't (or no longer) has the
+  // deprecation enabled, /explore/errors/ links (e.g. shared before the flag
+  // was disabled, or sent to an org without it) should still work — send the
+  // user to the /explore/discover/ equivalent, which supports the full
+  // Discover experience.
+  if (
+    !discoverTransactionsDeprecation &&
+    location.pathname.includes('/explore/errors/')
+  ) {
+    const match = location.pathname.match(/\/explore\/errors\/([^/]+)\//);
+    const discoverPath = match?.[1] ?? 'homepage';
+    const targetPath = makeDiscoverPathname({
+      path: `/${discoverPath}/`,
+      organization,
+    });
+    return <Redirect to={targetPath + location.search} />;
+  }
+
   function renderNoAccess() {
     return (
       <Stack flex={1} padding="2xl 3xl">

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -186,13 +186,18 @@ function DiscoverLanding() {
       features="discover-query"
       renderDisabled={() => <NoAccess />}
     >
-      <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={getDiscoverDeprecation(organization) ? t('Errors') : t('Discover')}
+        orgSlug={organization.slug}
+      >
         <Stack flex={1}>
           <TopBar.Slot name="title">
             <Breadcrumbs
               crumbs={[
                 {
-                  label: t('Discover'),
+                  label: getDiscoverDeprecation(organization)
+                    ? t('Errors')
+                    : t('Discover'),
                   to: getDiscoverLandingUrl(organization),
                 },
                 {label: t('Saved Queries')},

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -261,14 +261,18 @@ function DiscoverLanding() {
                         )}
                       </Alert>
                     ) : (
-                      <Alert variant="info">
-                        {tct(
-                          'Your saved transactions queries are also available in the new Explore UI. Try them out in [exploreLink:Explore] instead.',
-                          {
-                            exploreLink: <Link to="/explore/saved-queries/" />,
-                          }
-                        )}
-                      </Alert>
+                      organization.features.includes(
+                        'expose-migrated-discover-queries'
+                      ) && (
+                        <Alert variant="info">
+                          {tct(
+                            'Your saved transactions queries are also available in the new Explore UI. Try them out in [exploreLink:Explore] instead.',
+                            {
+                              exploreLink: <Link to="/explore/saved-queries/" />,
+                            }
+                          )}
+                        </Alert>
+                      )
                     ))}
                   <QueryList
                     pageLinks={savedQueriesPageLinks ?? ''}

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -107,7 +107,6 @@ import Table from 'sentry/views/discover/table';
 import {
   generateTitle,
   getDiscoverDeprecation,
-  getTransactionsDeprecation,
   handleAddQueryToDashboard,
   SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
 } from 'sentry/views/discover/utils';
@@ -696,7 +695,7 @@ export class Results extends Component<Props, State> {
                   selection={selection}
                 />
                 {savedQueryDataset === SavedQueryDatasets.ERRORS &&
-                  getTransactionsDeprecation(organization) && (
+                  !getDiscoverDeprecation(organization) && (
                     <Alert.Container>
                       <Alert variant="info">
                         {t(

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -107,6 +107,8 @@ import Table from 'sentry/views/discover/table';
 import {
   generateTitle,
   getDiscoverDeprecation,
+  getDiscoverDeprecationEnabled,
+  getTransactionsDeprecation,
   handleAddQueryToDashboard,
   SAVED_QUERY_DATASET_TO_WIDGET_TYPE,
 } from 'sentry/views/discover/utils';
@@ -695,7 +697,8 @@ export class Results extends Component<Props, State> {
                   selection={selection}
                 />
                 {savedQueryDataset === SavedQueryDatasets.ERRORS &&
-                  !getDiscoverDeprecation(organization) && (
+                  !getDiscoverDeprecationEnabled(organization) &&
+                  getTransactionsDeprecation(organization) && (
                     <Alert.Container>
                       <Alert variant="info">
                         {t(

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -177,7 +177,10 @@ export function generateTitle({
 
 export function getPrebuiltQueries(organization: Organization) {
   const views = [...getAllViews(organization)];
-  if (organization.features.includes('performance-view')) {
+  if (
+    organization.features.includes('performance-view') &&
+    !getDiscoverDeprecation(organization)
+  ) {
     // insert transactions queries at index 2
     views.splice(2, 0, ...getTransactionViews(organization));
     views.push(...getWebVitalsViews(organization));

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -929,9 +929,13 @@ export function getTransactionsDeprecation(organization: Organization) {
   return organization.features.includes('discover-saved-queries-deprecation');
 }
 
+export function getDiscoverDeprecationEnabled(organization: Organization) {
+  return organization.features.includes('deprecate-discover');
+}
+
 export function getDiscoverDeprecation(organization: Organization) {
   return (
-    organization.features.includes('deprecate-discover') &&
+    getDiscoverDeprecationEnabled(organization) &&
     getTransactionsDeprecation(organization)
   );
 }


### PR DESCRIPTION
This is related to the discover deprecation. i put in a redirect so that all Discover urls get redirected to Errors but realized it should work both ways because there are users that will be on both versions. So i put the backwards compatible one in. I've also gone through with updating some of the page titles and breadcrumbs to say Errors instead. I'll have more PRs like this because i realized there are a lot of places that say Discover 😭 

Closes EXP-1114