### PR TITLE
fix(seer): Correct overview action pending and empty-state checks

### DIFF
--- a/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
@@ -26,8 +26,11 @@ function HydratedCard({
   // endpoint omits issue.autofix_state, so we reconstruct it from enrichment.
   sectionKey?: AutofixStateKey;
 }) {
-  const {run, state, enrichmentPending} = useIssueAutofixEnrichment(issue.id);
-  const row = buildOverviewRow(issue, run, state, enrichmentPending, statsPeriod);
+  const {run, state, statePending, enrichmentPending} = useIssueAutofixEnrichment(
+    issue.id
+  );
+  const classificationPending = sectionKey ? statePending : enrichmentPending;
+  const row = buildOverviewRow(issue, run, state, classificationPending, statsPeriod);
   const resolvedSectionKey = sectionKey ?? deriveSectionKey(run, state);
   const minHeight = enrichmentPending
     ? `${view === 'cards' ? CARD_PLACEHOLDER_HEIGHT : TABLE_ROW_PLACEHOLDER_HEIGHT}px`

--- a/static/app/views/seerWorkflows/overview/sectionList.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionList.tsx
@@ -11,6 +11,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Sticky} from 'sentry/components/sticky';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 
 import {DEFAULT_STATS_PERIOD} from './periods';
 import {SectionIssueCard} from './sectionIssueCard';
@@ -43,6 +44,7 @@ export function SectionList({
   view: OverviewView;
 }) {
   const organization = useOrganization();
+  const {projects: orgProjects} = useProjects();
   const {sections, isPending, isError, refetch} = useAutofixSections({
     enabled,
     projects,
@@ -54,7 +56,8 @@ export function SectionList({
   const allSectionsEmpty = sections.every(
     section => !section.isPending && !section.isError && section.issues.length === 0
   );
-  const hasNonDefaultFilters = projects.length > 0 || period !== DEFAULT_STATS_PERIOD;
+  const hasProjectFilter = projects.length > 0 && orgProjects.length > 1;
+  const hasNonDefaultFilters = hasProjectFilter || period !== DEFAULT_STATS_PERIOD;
 
   if (isError) {
     return <LoadingError onRetry={refetch} />;


### PR DESCRIPTION
List cards now drop the action placeholder as soon as the autofix state request resolves, instead of also waiting on the runs request, which only feeds the analysis prose and trigger badge. Focus mode (`?id=`) still waits for both requests before classifying the card, since merge evidence comes from the run's pull requests and classifying early could briefly mislabel a merged issue as awaiting review.

The empty-state copy also stops counting a forced project selection as an active filter. Page filters auto-select the org's only project in single-project orgs, so a truly empty overview showed "No autofix runs match your filters." even with no filtering possible. A selection now counts as a filter only when the org has more than one project, mirroring the page-filters force-select rule.

Both address review findings surfaced on #120294 after it merged.