### PR TITLE
feat(issue-workflow): Add notification platform support for deploy notifs

### DIFF
--- a/src/sentry/notifications/platform/strategies/deploy_release.py
+++ b/src/sentry/notifications/platform/strategies/deploy_release.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.notifications.platform.strategies.utils import get_targets_from_participant_map
+from sentry.notifications.platform.types import (
+    NotificationStrategy,
+    NotificationTarget,
+)
+from sentry.notifications.utils.participants import get_participants_for_release
+
+
+@dataclass(frozen=True)
+class DeployReleaseStrategy(NotificationStrategy):
+    projects: frozenset[Project]
+    organization: Organization
+    committer_user_ids: frozenset[int]
+
+    def get_targets(self) -> list[NotificationTarget]:
+        participant_map = get_participants_for_release(
+            projects=self.projects,
+            organization=self.organization,
+            commited_user_ids=set(self.committer_user_ids),
+        )
+        return get_targets_from_participant_map(
+            participant_map, organization_id=self.organization.id
+        )

--- a/src/sentry/notifications/platform/templates/deploy.py
+++ b/src/sentry/notifications/platform/templates/deploy.py
@@ -257,8 +257,9 @@ class DeployReleaseTemplate(NotificationTemplate[DeployReleaseData]):
 
 class DeployReleaseDataResult(TypedDict):
     data: DeployReleaseData
-    # We're attaching these here because they're also used in the strategy, saving a step
+    # These are attached here because they're also used in the strategy, saving duplicate queries
     committer_user_ids: set[int]
+    projects: set[Project]
 
 
 def build_deploy_release_data(deploy: Deploy, release: Release) -> DeployReleaseDataResult:
@@ -333,6 +334,7 @@ def build_deploy_release_data(deploy: Deploy, release: Release) -> DeployRelease
     return DeployReleaseDataResult(
         data=data,
         committer_user_ids={u.id for u in users},
+        projects=projects,
     )
 
 

--- a/src/sentry/notifications/platform/templates/deploy.py
+++ b/src/sentry/notifications/platform/templates/deploy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TypedDict
 from urllib.parse import urlencode
 
@@ -8,6 +10,9 @@ from sentry_relay.processing import parse_release
 from sentry.models.commit import Commit
 from sentry.models.commitfilechange import CommitFileChange
 from sentry.models.deploy import Deploy
+from sentry.models.organization import Organization
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.repository import Repository
 from sentry.notifications.platform.registry import template_registry
@@ -329,3 +334,25 @@ def build_deploy_release_data(deploy: Deploy, release: Release) -> DeployRelease
         data=data,
         committer_user_ids={u.id for u in users},
     )
+
+
+def filter_deploy_data(
+    *,
+    data: DeployReleaseData,
+    organization: Organization,
+    user_id: int | None,
+) -> DeployReleaseData:
+    if user_id is None or organization.flags.allow_joinleave:
+        return data
+
+    user_team_ids = OrganizationMember.objects.get_teams_by_user(organization).get(user_id, [])
+    user_project_slugs = (
+        set(Project.objects.get_for_team_ids(user_team_ids).values_list("slug", flat=True))
+        if user_team_ids
+        else set()
+    )
+    filtered_release_projects = [
+        rp for rp in data.release_projects if rp["project_slug"] in user_project_slugs
+    ]
+
+    return data.copy(update={"release_projects": filtered_release_projects})

--- a/src/sentry/notifications/platform/templates/deploy.py
+++ b/src/sentry/notifications/platform/templates/deploy.py
@@ -28,7 +28,6 @@ from sentry.notifications.platform.types import (
     ParagraphSection,
     PlainTextBlock,
 )
-from sentry.notifications.utils import get_environment_for_deploy, get_group_counts_by_project
 from sentry.users.services.user.service import user_service
 
 TEXT_DELIMITER = " · "
@@ -258,6 +257,8 @@ class DeployReleaseDataResult(TypedDict):
 
 
 def build_deploy_release_data(deploy: Deploy, release: Release) -> DeployReleaseDataResult:
+    from sentry.notifications.utils import get_environment_for_deploy, get_group_counts_by_project
+
     organization = release.organization
     projects = set(release.projects.all())
     commit_list = list(Commit.objects.get_for_release(release))
@@ -307,8 +308,8 @@ def build_deploy_release_data(deploy: Deploy, release: Release) -> DeployRelease
             DeployReleaseCommit(
                 author_name=author_name,
                 date=commit.date_added.isoformat() if commit.date_added else "",
-                sha=commit.key[:7],
-                message=commit.message or "",
+                sha=commit.short_id,
+                message=commit.title,
             )
         )
 

--- a/src/sentry/notifications/platform/templates/deploy.py
+++ b/src/sentry/notifications/platform/templates/deploy.py
@@ -1,9 +1,15 @@
 from typing import TypedDict
+from urllib.parse import urlencode
 
 import orjson
 from django.template.defaultfilters import pluralize
 from sentry_relay.processing import parse_release
 
+from sentry.models.commit import Commit
+from sentry.models.commitfilechange import CommitFileChange
+from sentry.models.deploy import Deploy
+from sentry.models.release import Release
+from sentry.models.repository import Repository
 from sentry.notifications.platform.registry import template_registry
 from sentry.notifications.platform.templates.utils import format_datetime
 from sentry.notifications.platform.types import (
@@ -22,6 +28,8 @@ from sentry.notifications.platform.types import (
     ParagraphSection,
     PlainTextBlock,
 )
+from sentry.notifications.utils import get_environment_for_deploy, get_group_counts_by_project
+from sentry.users.services.user.service import user_service
 
 TEXT_DELIMITER = " · "
 MAX_SUBJECT_PROJECTS = 2
@@ -42,7 +50,6 @@ class DeployReleaseProject(TypedDict):
 
 class DeployReleaseData(NotificationData):
     source: NotificationSource = NotificationSource.DEPLOY_RELEASE
-    notification_uuid: str
     # If this notification was triggered by an alert (Workflow)...
     alert_name: str | None = None
     alert_url: str | None = None
@@ -181,7 +188,6 @@ class DeployReleaseTemplate(NotificationTemplate[DeployReleaseData]):
     category = NotificationCategory.DEPLOY
     example_data = DeployReleaseData(
         source=NotificationSource.DEPLOY_RELEASE,
-        notification_uuid="1234567890",
         user_settings_url="https://sentry.io/settings/account/notifications/deploy/",
         alert_name="Notify #feed-deploys via Slack",
         alert_url="https://sentry.io/organizations/acme/monitors/alerts/1/",
@@ -243,3 +249,82 @@ class DeployReleaseTemplate(NotificationTemplate[DeployReleaseData]):
             actions=build_deploy_actions(data=data),
             footer=build_deploy_footer(data=data),
         )
+
+
+class DeployReleaseDataResult(TypedDict):
+    data: DeployReleaseData
+    # We're attaching these here because they're also used in the strategy, saving a step
+    committer_user_ids: set[int]
+
+
+def build_deploy_release_data(deploy: Deploy, release: Release) -> DeployReleaseDataResult:
+    organization = release.organization
+    projects = set(release.projects.all())
+    commit_list = list(Commit.objects.get_for_release(release))
+    email_list = {c.author.email for c in commit_list if c.author}
+    users = user_service.get_many_by_email(
+        emails=list(email_list),
+        organization_id=organization.id,
+        is_verified=True,
+    )
+    users_by_email = {u.email: u for u in users}
+
+    environment = get_environment_for_deploy(deploy)
+    group_counts_by_project = get_group_counts_by_project(release, projects)
+
+    release_projects: list[DeployReleaseProject] = []
+    for project in sorted(projects, key=lambda p: p.slug):
+        release_url = organization.absolute_url(
+            f"/organizations/{organization.slug}/releases/{release.version}/",
+            query=urlencode({"project": project.id}),
+        )
+        release_projects.append(
+            DeployReleaseProject(
+                project_slug=project.slug,
+                release_url=release_url,
+                resolved_issue_count=group_counts_by_project.get(project.id, 0),
+            )
+        )
+
+    repo_name_to_commits: dict[str, list[DeployReleaseCommit]] = {}
+
+    repositories_by_id = {
+        repo_id: repo_name
+        for repo_id, repo_name in Repository.objects.filter(
+            organization_id=organization.id,
+            id__in={c.repository_id for c in commit_list},
+        ).values_list("id", "name")
+    }
+    for commit in commit_list:
+        repo_name = repositories_by_id.get(commit.repository_id, "unknown")
+        author_name = ""
+        if commit.author:
+            user_option = users_by_email.get(commit.author.email)
+            author_name = (
+                user_option.get_display_name() if user_option else commit.author.name or ""
+            )
+        repo_name_to_commits.setdefault(repo_name, []).append(
+            DeployReleaseCommit(
+                author_name=author_name,
+                date=commit.date_added.isoformat() if commit.date_added else "",
+                sha=commit.key[:7],
+                message=commit.message or "",
+            )
+        )
+
+    data = DeployReleaseData(
+        date=deploy.date_finished.isoformat() if deploy.date_finished else "",
+        author_count=len(email_list),
+        commit_count=len(commit_list),
+        file_count=CommitFileChange.objects.get_count_for_commits(commit_list),
+        release_projects=release_projects,
+        repo_name_to_commits=repo_name_to_commits,
+        repo_setup_link=organization.absolute_url(f"/organizations/{organization.slug}/repos/"),
+        version=release.version,
+        environment_name=environment,
+    )
+
+    return DeployReleaseDataResult(
+        data=data,
+        committer_user_ids={u.id for u in users},
+    )

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -117,7 +117,10 @@ def get_repos(
 
 def get_environment_for_deploy(deploy: Deploy | None) -> str:
     if deploy:
-        environment = Environment.objects.get(id=deploy.environment_id)
+        try:
+            environment = Environment.objects.get(id=deploy.environment_id)
+        except Environment.DoesNotExist:
+            return "Default Environment"
         if environment and environment.name:
             return str(environment.name)
     return "Default Environment"

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -12,12 +12,44 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentry.models.activity import Activity
+    from sentry.models.organization import Organization
 
 
 def _send_legacy_activity_notification(activity: Activity) -> None:
     from sentry.mail import mail_adapter
 
     mail_adapter.notify_about_activity(activity)
+
+
+def _send_deploy_activity_notification(activity: Activity, organization: Organization) -> None:
+    from sentry.notifications.platform.service import NotificationService
+    from sentry.notifications.platform.strategies.deploy_release import DeployReleaseStrategy
+    from sentry.notifications.platform.templates.deploy import (
+        DeployReleaseData,
+        build_deploy_release_data,
+    )
+    from sentry.notifications.platform.types import NotificationSource
+    from sentry.notifications.utils import get_deploy, get_release
+
+    if not NotificationService.has_access(
+        organization=organization, source=NotificationSource.DEPLOY_RELEASE
+    ):
+        _send_legacy_activity_notification(activity=activity)
+        return
+
+    deploy = get_deploy(activity)
+    release = get_release(activity, organization)
+
+    if not deploy or not release:
+        return
+
+    result = build_deploy_release_data(deploy=deploy, release=release)
+    strategy = DeployReleaseStrategy(
+        projects=frozenset(release.projects.all()),
+        organization=organization,
+        committer_user_ids=frozenset(result["committer_user_ids"]),
+    )
+    NotificationService[DeployReleaseData](data=result["data"]).notify_sync(strategy=strategy)
 
 
 @instrumented_task(
@@ -38,6 +70,7 @@ def send_activity_notifications(activity_id: int) -> None:
         ActivityNotificationData,
         build_activity_notification_data,
     )
+    from sentry.types.activity import ActivityType
 
     try:
         activity = Activity.objects.get(pk=activity_id)
@@ -46,6 +79,10 @@ def send_activity_notifications(activity_id: int) -> None:
 
     organization = Organization.objects.get_from_cache(pk=activity.project.organization_id)
     bind_organization_context(organization)
+
+    if activity.type == ActivityType.DEPLOY.value:
+        _send_deploy_activity_notification(activity=activity, organization=organization)
+        return
 
     source = ACTIVITY_TYPE_TO_SOURCE.get(activity.type)
     if not source:

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -27,6 +27,7 @@ def _send_deploy_activity_notification(activity: Activity, organization: Organiz
     from sentry.notifications.platform.templates.deploy import (
         DeployReleaseData,
         build_deploy_release_data,
+        filter_deploy_data,
     )
     from sentry.notifications.platform.types import NotificationSource
     from sentry.notifications.utils import get_deploy, get_release
@@ -50,7 +51,12 @@ def _send_deploy_activity_notification(activity: Activity, organization: Organiz
         organization=organization,
         committer_user_ids=frozenset(result["committer_user_ids"]),
     )
-    NotificationService[DeployReleaseData](data=result["data"]).notify_sync(strategy=strategy)
+    targets = strategy.get_targets()
+
+    for target in targets:
+        user_id = target.specific_data.get("user_id") if target.specific_data else None
+        data = filter_deploy_data(data=result["data"], user_id=user_id, organization=organization)
+        NotificationService[DeployReleaseData](data=data).notify_target(target=target)
 
 
 @instrumented_task(

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -41,6 +41,7 @@ def _send_deploy_activity_notification(activity: Activity, organization: Organiz
     release = get_release(activity, organization)
 
     if not deploy or not release:
+        _send_legacy_activity_notification(activity=activity)
         return
 
     result = build_deploy_release_data(deploy=deploy, release=release)

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -47,7 +47,7 @@ def _send_deploy_activity_notification(activity: Activity, organization: Organiz
 
     result = build_deploy_release_data(deploy=deploy, release=release)
     strategy = DeployReleaseStrategy(
-        projects=frozenset(release.projects.all()),
+        projects=frozenset(result["projects"]),
         organization=organization,
         committer_user_ids=frozenset(result["committer_user_ids"]),
     )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -140,6 +140,7 @@ from sentry.notifications.models.notificationaction import (
     ActionTrigger,
     NotificationAction,
 )
+from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.models.notificationsettingprovider import NotificationSettingProvider
 from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.preprod.models import (
@@ -2222,6 +2223,11 @@ class Factories:
         action.save()
 
         return action
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CONTROL)
+    def create_notification_setting_option(*args, **kwargs) -> NotificationSettingOption:
+        return NotificationSettingOption.objects.create(*args, **kwargs)
 
     @staticmethod
     @assume_test_silo_mode(SiloMode.CONTROL)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -540,6 +540,9 @@ class Fixtures:
             organization=organization, projects=projects, **kwargs
         )
 
+    def create_notification_setting_option(self, *args, **kwargs):
+        return Factories.create_notification_setting_option(*args, **kwargs)
+
     def create_notification_settings_provider(self, *args, **kwargs):
         return Factories.create_notification_settings_provider(*args, **kwargs)
 

--- a/tests/sentry/notifications/platform/strategies/test_deploy_release.py
+++ b/tests/sentry/notifications/platform/strategies/test_deploy_release.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+from sentry.notifications.platform.strategies.deploy_release import DeployReleaseStrategy
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationTargetResourceType,
+)
+from sentry.notifications.types import (
+    NotificationSettingEnum,
+    NotificationSettingsOptionEnum,
+)
+from sentry.testutils.cases import TestCase
+
+
+class DeployReleaseStrategyTest(TestCase):
+    def _make_strategy(self, **overrides: Any) -> DeployReleaseStrategy:
+        defaults = dict(
+            projects=frozenset([self.project]),
+            organization=self.organization,
+            committer_user_ids=frozenset(),
+        )
+        defaults.update(overrides)
+        return DeployReleaseStrategy(**defaults)
+
+    def _set_deploy_setting(
+        self, option: NotificationSettingsOptionEnum, user_id: int | None = None
+    ) -> None:
+        self.create_notification_setting_option(
+            scope_type="user",
+            scope_identifier=user_id or self.user.id,
+            user_id=user_id or self.user.id,
+            type=NotificationSettingEnum.DEPLOY.value,
+            value=option.value,
+        )
+
+    def test_returns_empty_when_no_users_on_project_teams(self) -> None:
+        empty_project = self.create_project(organization=self.organization, teams=[])
+        strategy = self._make_strategy(projects=frozenset([empty_project]))
+        assert strategy.get_targets() == []
+
+    def test_returns_email_target_for_always_subscriber(self) -> None:
+        self._set_deploy_setting(NotificationSettingsOptionEnum.ALWAYS)
+
+        strategy = self._make_strategy()
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert len(email_targets) == 1
+        assert email_targets[0].resource_type == NotificationTargetResourceType.EMAIL
+        assert email_targets[0].resource_id == self.user.email
+        assert email_targets[0].specific_data == {"user_id": self.user.id}
+
+    def test_returns_email_target_for_committer_with_committed_only(self) -> None:
+        self._set_deploy_setting(NotificationSettingsOptionEnum.COMMITTED_ONLY)
+
+        strategy = self._make_strategy(committer_user_ids=frozenset([self.user.id]))
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert len(email_targets) == 1
+        assert email_targets[0].resource_id == self.user.email
+
+    def test_excludes_non_committer_with_committed_only(self) -> None:
+        self._set_deploy_setting(NotificationSettingsOptionEnum.COMMITTED_ONLY)
+
+        strategy = self._make_strategy(committer_user_ids=frozenset())
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert not any(t.resource_id == self.user.email for t in email_targets)
+
+    def test_excludes_user_with_never_setting(self) -> None:
+        self._set_deploy_setting(NotificationSettingsOptionEnum.NEVER)
+
+        strategy = self._make_strategy(committer_user_ids=frozenset([self.user.id]))
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        assert not any(t.resource_id == self.user.email for t in email_targets)
+
+    def test_multiple_users_across_projects(self) -> None:
+        user_b = self.create_user(email="b@example.com")
+        team_b = self.create_team(organization=self.organization)
+        self.create_member(organization=self.organization, user=user_b, teams=[team_b])
+        project_b = self.create_project(organization=self.organization, teams=[team_b])
+
+        for user_id in (self.user.id, user_b.id):
+            self._set_deploy_setting(NotificationSettingsOptionEnum.ALWAYS, user_id=user_id)
+
+        strategy = self._make_strategy(projects=frozenset([self.project, project_b]))
+        targets = strategy.get_targets()
+
+        email_targets = [t for t in targets if t.provider_key == NotificationProviderKey.EMAIL]
+        emails = {t.resource_id for t in email_targets}
+        assert self.user.email in emails
+        assert "b@example.com" in emails

--- a/tests/sentry/notifications/platform/templates/test_deploy.py
+++ b/tests/sentry/notifications/platform/templates/test_deploy.py
@@ -1,0 +1,95 @@
+from sentry.notifications.platform.templates.deploy import (
+    DeployReleaseData,
+    filter_deploy_data,
+)
+from sentry.notifications.platform.types import NotificationSource
+from sentry.testutils.cases import TestCase
+
+
+class FilterDeployDataTest(TestCase):
+    data = DeployReleaseData(
+        source=NotificationSource.DEPLOY_RELEASE,
+        date="2025-01-01T00:00:00+00:00",
+        author_count=1,
+        commit_count=1,
+        file_count=1,
+        release_projects=[
+            {
+                "project_slug": "proj-a",
+                "release_url": "https://example.com/proj-a",
+                "resolved_issue_count": 0,
+            },
+            {
+                "project_slug": "proj-b",
+                "release_url": "https://example.com/proj-b",
+                "resolved_issue_count": 2,
+            },
+        ],
+        repo_name_to_commits={},
+        version="1.0.0",
+        environment_name="production",
+    )
+
+    def test_returns_unfiltered_when_user_id_is_none(self) -> None:
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        result = filter_deploy_data(data=self.data, user_id=None, organization=self.organization)
+
+        assert result.release_projects == self.data.release_projects
+
+    def test_returns_unfiltered_when_allow_joinleave_is_true(self) -> None:
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        result = filter_deploy_data(
+            data=self.data, user_id=self.user.id, organization=self.organization
+        )
+
+        assert result.release_projects == self.data.release_projects
+
+    def test_filters_to_user_team_projects(self) -> None:
+        project_a = self.create_project(organization=self.organization, slug="proj-a")
+        project_a.add_team(self.team)
+
+        team_b = self.create_team(organization=self.organization)
+        other_user = self.create_user()
+        self.create_member(organization=self.organization, user=other_user, teams=[team_b])
+        self.create_project(organization=self.organization, slug="proj-b", teams=[team_b])
+
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        result = filter_deploy_data(
+            data=self.data, user_id=self.user.id, organization=self.organization
+        )
+
+        slugs = [rp["project_slug"] for rp in result.release_projects]
+        assert "proj-a" in slugs
+        assert "proj-b" not in slugs
+
+    def test_returns_empty_projects_when_user_has_no_teams(self) -> None:
+        other_user = self.create_user()
+        self.create_member(organization=self.organization, user=other_user)
+
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        result = filter_deploy_data(
+            data=self.data, user_id=other_user.id, organization=self.organization
+        )
+
+        assert result.release_projects == []
+
+    def test_does_not_mutate_original_data(self) -> None:
+        other_user = self.create_user()
+        self.create_member(organization=self.organization, user=other_user)
+
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        original_projects = list(self.data.release_projects)
+
+        filter_deploy_data(data=self.data, user_id=other_user.id, organization=self.organization)
+
+        assert self.data.release_projects == original_projects


### PR DESCRIPTION
Adds a new route specifically for deploy notifications. They are not like any other activity notification because the activity does not matter for them, they need a deploy/release (not group). 

The template already exists, this just adds a helper to build the data, and a strategy to notify committers + people who want to know about releases.

Ideally this wouldn't be tied to activity at all, but that was the trigger system for these notificiations before and we aren't changing that here

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>