### PR TITLE
chore(tracemetrics): Remove equation label const function call

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
@@ -7,7 +7,10 @@ import {Radio} from '@sentry/scraps/radio';
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
-import {RATE_AGGREGATES} from 'sentry/views/explore/metrics/constants';
+import {
+  DEFAULT_EQUATION_LABEL,
+  RATE_AGGREGATES,
+} from 'sentry/views/explore/metrics/constants';
 import {EquationBuilder} from 'sentry/views/explore/metrics/equationBuilder';
 import {extractReferenceLabels} from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {
@@ -21,7 +24,6 @@ import {DeleteMetricButton} from 'sentry/views/explore/metrics/metricToolbar/del
 import {Filter} from 'sentry/views/explore/metrics/metricToolbar/filter';
 import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 import {VisualizeLabel} from 'sentry/views/explore/metrics/metricToolbar/visualizeLabel';
-import {getEquationLabel} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {
   isVisualizeEquation,
   isVisualizeFunction,
@@ -84,7 +86,7 @@ export function MetricToolbar({
         <Radio
           name="metricAggregateRow"
           checked={isSelected}
-          onChange={() => onRowSelection(isEquation ? getEquationLabel() : label)}
+          onChange={() => onRowSelection(isEquation ? DEFAULT_EQUATION_LABEL : label)}
           aria-label={t('Use row %s as the widget aggregate', label)}
           disabled={isFunction && traceMetric.name === ''}
         />

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricToolbar.tsx
@@ -21,7 +21,7 @@ import {DeleteMetricButton} from 'sentry/views/explore/metrics/metricToolbar/del
 import {Filter} from 'sentry/views/explore/metrics/metricToolbar/filter';
 import {MetricSelector} from 'sentry/views/explore/metrics/metricToolbar/metricSelector/metricSelector';
 import {VisualizeLabel} from 'sentry/views/explore/metrics/metricToolbar/visualizeLabel';
-import {EQUATION_LABEL} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {getEquationLabel} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {
   isVisualizeEquation,
   isVisualizeFunction,
@@ -84,7 +84,7 @@ export function MetricToolbar({
         <Radio
           name="metricAggregateRow"
           checked={isSelected}
-          onChange={() => onRowSelection(isEquation ? EQUATION_LABEL : label)}
+          onChange={() => onRowSelection(isEquation ? getEquationLabel() : label)}
           aria-label={t('Use row %s as the widget aggregate', label)}
           disabled={isFunction && traceMetric.name === ''}
         />

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -37,10 +37,7 @@ import {
   useAddMetricQuery,
   useMultiMetricsQueryParams,
 } from 'sentry/views/explore/metrics/multiMetricsQueryParams';
-import {
-  EQUATION_LABEL,
-  parseAggregateExpression,
-} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {
   isVisualizeEquation,
   isVisualizeFunction,
@@ -388,7 +385,7 @@ function MetricToolbar({
         name="metricAggregateRow"
         checked={isSelected}
         onChange={() =>
-          onRowSelection(isVisualizeEquation(visualize) ? EQUATION_LABEL : queryLabel)
+          onRowSelection(isVisualizeEquation(visualize) ? getEquationLabel() : queryLabel)
         }
         aria-label={t('Use row %s as the alert aggregate', queryLabel)}
         disabled={isVisualizeFunction(visualize) && traceMetric.name === ''}

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -13,6 +13,7 @@ import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {METRIC_DETECTOR_FORM_FIELDS} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {ToolbarVisualizeAddChart} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
+import {DEFAULT_EQUATION_LABEL} from 'sentry/views/explore/metrics/constants';
 import {EquationBuilder} from 'sentry/views/explore/metrics/equationBuilder';
 import {
   extractReferenceLabels,
@@ -385,7 +386,9 @@ function MetricToolbar({
         name="metricAggregateRow"
         checked={isSelected}
         onChange={() =>
-          onRowSelection(isVisualizeEquation(visualize) ? getEquationLabel() : queryLabel)
+          onRowSelection(
+            isVisualizeEquation(visualize) ? DEFAULT_EQUATION_LABEL : queryLabel
+          )
         }
         aria-label={t('Use row %s as the alert aggregate', queryLabel)}
         disabled={isVisualizeFunction(visualize) && traceMetric.name === ''}

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -372,3 +372,6 @@ export const METRICS_DRAWER_QUERY_PARAM = 'metricsDrawer';
 // We do not support labels beyond Z yet, due to requiring single-character labels
 // for the arithmetic builder currently.
 export const MAX_METRIC_ALLOWED_LABEL_VALUE = 'Z';
+
+// The default starting label for equations in metrics.
+export const DEFAULT_EQUATION_LABEL = 'ƒ1';

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -18,7 +18,9 @@ import {
   getVisualizeLabel,
 } from 'sentry/views/explore/toolbar/toolbarVisualize';
 
-export const EQUATION_LABEL = getVisualizeLabel(1, true);
+export function getEquationLabel(): string {
+  return getVisualizeLabel(1, true);
+}
 
 interface ParsedAggregateExpression {
   /**
@@ -99,7 +101,7 @@ function makeEquationRow(prefixedEquation: string, query?: string): BaseMetricQu
       aggregateFields: [new VisualizeEquation(prefixedEquation)],
       query: query ?? '',
     }),
-    label: EQUATION_LABEL,
+    label: getEquationLabel(),
   };
 }
 

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -4,6 +4,7 @@ import {
 } from 'sentry/components/arithmeticBuilder/token';
 import {tokenizeExpression} from 'sentry/components/arithmeticBuilder/tokenizer';
 import {EQUATION_PREFIX, isEquation} from 'sentry/utils/discover/fields';
+import {DEFAULT_EQUATION_LABEL} from 'sentry/views/explore/metrics/constants';
 import {
   defaultMetricQuery,
   type BaseMetricQuery,
@@ -13,14 +14,7 @@ import {
   VisualizeEquation,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
-import {
-  getFunctionLabel,
-  getVisualizeLabel,
-} from 'sentry/views/explore/toolbar/toolbarVisualize';
-
-export function getEquationLabel(): string {
-  return getVisualizeLabel(1, true);
-}
+import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 
 interface ParsedAggregateExpression {
   /**
@@ -101,7 +95,7 @@ function makeEquationRow(prefixedEquation: string, query?: string): BaseMetricQu
       aggregateFields: [new VisualizeEquation(prefixedEquation)],
       query: query ?? '',
     }),
-    label: getEquationLabel(),
+    label: DEFAULT_EQUATION_LABEL,
   };
 }
 


### PR DESCRIPTION
Some downstream changes reveal that this causes a circular dependency error. Replacing it with a true const in this PR avoids the circular dependency from the function call