### PR TITLE
feat(tracemetrics): Wrap seer combobox token for equation formatting

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/queryTokens.tsx
@@ -14,6 +14,7 @@ import {useSearchQueryBuilderConfig} from 'sentry/components/searchQueryBuilder/
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
 import {t} from 'sentry/locale';
+import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 
@@ -78,7 +79,9 @@ function NewQueryTokens({
         <Stack as="span" gap="xs" overflow="hidden">
           {visualizations.map((visualization, vIdx) =>
             visualization.yAxes.map(yAxis => (
-              <ExploreVisualizes key={`${vIdx}-${yAxis}`}>{yAxis}</ExploreVisualizes>
+              <ExploreVisualizes key={`${vIdx}-${yAxis}`}>
+                {isEquation(yAxis) ? stripEquationPrefix(yAxis) : yAxis}
+              </ExploreVisualizes>
             ))
           )}
         </Stack>
@@ -152,12 +155,15 @@ function NewQueryTokens({
   }
 
   if (sort && sort.length > 0) {
+    const descending = sort[0] === '-';
+    const rawSort = descending ? sort.slice(1) : sort;
+    const formattedSort = isEquation(rawSort) ? stripEquationPrefix(rawSort) : rawSort;
     tokens.push(
       <Stack key="sort">
         <ExploreParamTitle>{t('Sort')}</ExploreParamTitle>
         <Stack as="span" gap="xs" overflow="hidden">
           <ExploreGroupBys>
-            {sort[0] === '-' ? sort.slice(1) + ' Desc' : sort + ' Asc'}
+            {formattedSort + (descending ? ' Desc' : ' Asc')}
           </ExploreGroupBys>
         </Stack>
       </Stack>

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -19,6 +19,7 @@ import {
   WildcardOperators,
 } from 'sentry/components/searchSyntax/parser';
 import type {Project} from 'sentry/types/project';
+import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
@@ -605,7 +606,9 @@ export function generateQueryTokensString(
 
   if (args?.visualizations && args.visualizations.length > 0) {
     const vizParts = args.visualizations.flatMap(visualization =>
-      visualization.yAxes.map(yAxis => yAxis)
+      visualization.yAxes.map(yAxis =>
+        isEquation(yAxis) ? stripEquationPrefix(yAxis) : yAxis
+      )
     );
     if (vizParts.length > 0) {
       const vizText = vizParts.length === 1 ? vizParts[0] : vizParts.join(', ');

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -633,9 +633,12 @@ export function generateQueryTokensString(
   }
 
   if (args?.sort && args.sort.length > 0) {
-    const sortText =
-      args?.sort[0] === '-' ? `${args?.sort.slice(1)} Desc` : `${args?.sort} Asc`;
-    parts.push(`sort is '${sortText}'`);
+    const descending = args?.sort[0] === '-';
+    let rawSort = descending ? args?.sort.slice(1) : args?.sort;
+    rawSort = isEquation(rawSort) ? stripEquationPrefix(rawSort) : rawSort;
+    const formattedSort = descending ? `${rawSort} Desc` : `${rawSort} Asc`;
+
+    parts.push(`sort is '${formattedSort}'`);
   }
 
   if (projectIds && projectIds.length > 0) {


### PR DESCRIPTION
These are strings where equations can be rendered. If it's an equation (indicated by `equation|`), render it without the prefix.
