### PR TITLE
chore(tracemetrics): Stabilize effect on reference label change

### DIFF
--- a/static/app/views/explore/metrics/equationBuilder/index.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useTransition} from 'react';
+import {useCallback, useEffect, useEffectEvent, useMemo, useTransition} from 'react';
 
 import {ArithmeticBuilder} from 'sentry/components/arithmeticBuilder';
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
@@ -40,15 +40,19 @@ export function EquationBuilder({
   const internalExpression =
     storedInternalExpression ?? unresolveExpression(expression, referenceMap);
 
+  const onLabelsChange = useEffectEvent((labels: string[]) => {
+    onReferenceLabelsChange?.(labels);
+  });
+
   // Report which labels this equation references after unresolving.
   // Cleans up on unmount so deleted equations don't block metric deletion.
   useEffect(() => {
     const expr = new Expression(internalExpression, references);
-    onReferenceLabelsChange?.(extractReferenceLabels(expr));
+    onLabelsChange(extractReferenceLabels(expr));
     return () => {
-      onReferenceLabelsChange?.([]);
+      onLabelsChange([]);
     };
-  }, [internalExpression, references, onReferenceLabelsChange]);
+  }, [internalExpression, references]);
 
   const handleInternalExpressionChange = useCallback(
     (newExpression: Expression) => {


### PR DESCRIPTION
We only want to trigger the `onReferenceLabelChange` if we detect that the references or the internal expression changes. This ensures that upstream callers of the equation builder don't need to remember to memoize their functions, preventing infinite loops where updating the references updates the callback, which triggers the callback to update the reference object and so on.

This is not currently a bug but it is something that appears as a result of changes from updates to support equations with seer search assistant.