### PR TITLE
feat(seer): Show PR CI status on autofix overview review cards

### DIFF
--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
@@ -4,6 +4,7 @@ import {
   deriveSectionKey,
   extractPatchInfo,
   extractPendingQuestion,
+  extractPrCiStatus,
   INLINE_DIFF_MAX_CHANGED_LINES,
   INLINE_DIFF_MAX_FILES,
   mostRecentTimestamp,
@@ -298,6 +299,38 @@ describe('extractPendingQuestion', () => {
 
     const noPayload = makeState({status: 'awaiting_user_input'});
     expect(extractPendingQuestion(noPayload)).toBeUndefined();
+  });
+});
+
+describe('extractPrCiStatus', () => {
+  it('prefers the pull request whose id matches the linked PR number', () => {
+    const run = makeRun({
+      pullRequests: [
+        {status: 'open', id: '9', ciStatus: 'failed'},
+        {status: 'open', id: '10', ciStatus: 'passed'},
+      ],
+    });
+    expect(extractPrCiStatus(run, 10)).toBe('passed');
+  });
+
+  it('falls back to the first non-merged pull request when no id matches', () => {
+    const run = makeRun({
+      pullRequests: [
+        {status: 'merged', id: '1', ciStatus: 'passed'},
+        {status: 'open', id: '2', ciStatus: 'running'},
+      ],
+    });
+    expect(extractPrCiStatus(run, 99)).toBe('running');
+  });
+
+  it('returns undefined when the matched pull request has no ci status', () => {
+    const run = makeRun({pullRequests: [{status: 'open', id: '9', ciStatus: null}]});
+    expect(extractPrCiStatus(run, 9)).toBeUndefined();
+  });
+
+  it('returns undefined when there are no pull requests', () => {
+    expect(extractPrCiStatus(makeRun(), undefined)).toBeUndefined();
+    expect(extractPrCiStatus(null, 9)).toBeUndefined();
   });
 });
 

--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
@@ -14,6 +14,7 @@ import {
   type OverviewRow,
   type PatchStats,
   PIPELINE,
+  type PrCiStatus,
   type RunAnalysisEntry,
   type RunQuestion,
   type SeerRun,
@@ -110,6 +111,23 @@ function extractPr(
     repoPr => repoPr.pr_creation_status === 'completed' && repoPr.pr_url
   );
   return pr ? {prUrl: pr.pr_url ?? undefined, prNumber: pr.pr_number ?? undefined} : {};
+}
+
+// The CI status of the linked PR: prefer the run's pullRequests entry whose id
+// matches the PR the card links to, else the first non-merged entry. Null or a
+// missing status (present only when the runs fetch requested includeCiStatus)
+// yields no value, so no badge renders.
+export function extractPrCiStatus(
+  run: SeerRun | null,
+  prNumber: number | undefined
+): PrCiStatus | undefined {
+  const pullRequests = run?.pullRequests ?? [];
+  const match =
+    (prNumber === undefined
+      ? undefined
+      : pullRequests.find(pr => pr.id === String(prNumber))) ??
+    pullRequests.find(pr => pr.status !== 'merged');
+  return match?.ciStatus ?? undefined;
 }
 
 // The pending-input payload is untyped (Record<string, unknown>). The canonical
@@ -243,6 +261,7 @@ export function buildOverviewRow(
 ): OverviewRow {
   const eventCount = Number(issue.count);
   const {entries: analysis, headline} = buildAnalysis(run?.outputs);
+  const pr = extractPr(state);
 
   return {
     headline,
@@ -267,6 +286,7 @@ export function buildOverviewRow(
     analysis,
     ...extractPatchInfo(state),
     pendingQuestion: extractPendingQuestion(state),
-    ...extractPr(state),
+    ...pr,
+    prCiStatus: extractPrCiStatus(run, pr.prNumber),
   };
 }

--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -8,6 +8,7 @@ import type {
   AutofixStateKey,
   CardAction,
   OverviewRow,
+  PrCiStatus,
   RunStatus,
 } from 'sentry/views/seerWorkflows/overview/types';
 
@@ -44,15 +45,20 @@ describe('deriveCardAction', () => {
     expect(deriveCardAction(sectionKey, makeRow())).toEqual({type: sectionKey});
   });
 
-  it('carries the linked PR on the review_pr action', () => {
+  it('carries the linked PR and CI status on the review_pr action', () => {
     const action = deriveCardAction(
       'review_pr',
-      makeRow({prUrl: 'https://github.com/o/r/pull/9', prNumber: 9})
+      makeRow({
+        prUrl: 'https://github.com/o/r/pull/9',
+        prNumber: 9,
+        prCiStatus: 'passed',
+      })
     );
     expect(action).toEqual({
       type: 'review_pr',
       prUrl: 'https://github.com/o/r/pull/9',
       prNumber: 9,
+      prCiStatus: 'passed',
     });
   });
 });
@@ -130,5 +136,42 @@ describe('IssuePrimaryAction', () => {
       'href',
       '/organizations/org-slug/issues/2/?seerDrawer=true'
     );
+  });
+
+  it.each([
+    {prCiStatus: 'passed', label: 'CI passed'},
+    {prCiStatus: 'running', label: 'CI running'},
+    {prCiStatus: 'failed', label: 'CI failed'},
+  ] as Array<{label: string; prCiStatus: PrCiStatus}>)(
+    'renders the $label tag beside Review PR when the linked PR CI is $prCiStatus',
+    ({prCiStatus, label}) => {
+      renderAction(
+        {
+          type: 'review_pr',
+          prUrl: 'https://github.com/o/r/pull/9',
+          prNumber: 9,
+          prCiStatus,
+        },
+        makeRow({runStatus: 'completed'})
+      );
+
+      expect(screen.getByRole('button', {name: 'Review PR'})).toBeInTheDocument();
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  );
+
+  it('renders no CI tag when the linked PR has no CI status', () => {
+    renderAction(
+      {
+        type: 'review_pr',
+        prUrl: 'https://github.com/o/r/pull/9',
+        prNumber: 9,
+        prCiStatus: undefined,
+      },
+      makeRow({runStatus: 'completed'})
+    );
+
+    expect(screen.getByRole('button', {name: 'Review PR'})).toBeInTheDocument();
+    expect(screen.queryByText(/^CI /)).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -3,6 +3,7 @@ import type {LocationDescriptor} from 'history';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -18,9 +19,10 @@ import {
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 
-import type {AutofixStateKey, CardAction, OverviewRow} from './types';
+import type {AutofixStateKey, CardAction, OverviewRow, PrCiStatus} from './types';
 
 type LinkButtonVariant = React.ComponentProps<typeof LinkButton>['variant'];
+type TagVariant = React.ComponentProps<typeof Tag>['variant'];
 
 // Stage actions are keyed by section; the two extras (awaiting_input, errored)
 // are the transient live-status overlays. Strings are translated product copy.
@@ -90,9 +92,28 @@ export function deriveCardAction(
   row: OverviewRow
 ): CardAction {
   if (sectionKey === 'review_pr') {
-    return {type: 'review_pr', prUrl: row.prUrl, prNumber: row.prNumber};
+    return {
+      type: 'review_pr',
+      prUrl: row.prUrl,
+      prNumber: row.prNumber,
+      prCiStatus: row.prCiStatus,
+    };
   }
   return {type: sectionKey};
+}
+
+const CI_STATUS_TAG: Record<PrCiStatus, {label: string; variant: TagVariant}> = {
+  passed: {variant: 'success', label: t('CI passed')},
+  running: {variant: 'info', label: t('CI running')},
+  failed: {variant: 'danger', label: t('CI failed')},
+};
+
+function PrCiStatusTag({status}: {status: PrCiStatus | undefined}) {
+  if (!status) {
+    return null;
+  }
+  const {variant, label} = CI_STATUS_TAG[status];
+  return <Tag variant={variant}>{label}</Tag>;
 }
 
 const AccentLinkButton = styled(LinkButton)`
@@ -225,10 +246,15 @@ export function IssuePrimaryAction({
         </Tooltip>
       );
     case 'review_pr':
-      return action.prUrl ? (
-        <ReviewPrButton prUrl={action.prUrl} prNumber={action.prNumber} />
-      ) : (
-        <ActionButton actionKey="review_pr" to={runUrl} />
+      return (
+        <Flex gap="sm" align="center">
+          {action.prUrl ? (
+            <ReviewPrButton prUrl={action.prUrl} prNumber={action.prNumber} />
+          ) : (
+            <ActionButton actionKey="review_pr" to={runUrl} />
+          )}
+          <PrCiStatusTag status={action.prCiStatus} />
+        </Flex>
       );
     default:
       return <ActionButton actionKey={action.type} to={runUrl} />;

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -350,6 +350,22 @@ describe('AutofixOverview', () => {
     );
   });
 
+  it('requests CI status with the per-card runs fetch', async () => {
+    const runsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/runs/`,
+      match: [MockApiClient.matchQuery({includeCiStatus: 1})],
+      body: [makeRun()],
+    });
+
+    renderPage();
+
+    await screen.findByRole('link', {
+      name: 'Proxy requests fail without Authorization header',
+    });
+
+    expect(runsRequest).toHaveBeenCalled();
+  });
+
   it('leads with the root cause and a single next step when no code was drafted', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/runs/`,

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -51,10 +51,19 @@ export type OverviewView = 'cards' | 'table';
 // section-driven primary action.
 export type RunStatus = 'processing' | 'completed' | 'error' | 'awaiting_user_input';
 
+// CI status of a linked PR, from the includeCiStatus runs param. null/absent
+// means unknown or not yet computable — no badge.
+export type PrCiStatus = 'passed' | 'running' | 'failed';
+
 // The primary action a card offers, derived from its section. review_pr carries
-// the linked PR so it can offer the external review button.
+// the linked PR so it can offer the external review button and CI status.
 export type CardAction =
-  | {prNumber: number | undefined; prUrl: string | undefined; type: 'review_pr'}
+  | {
+      prNumber: number | undefined;
+      prUrl: string | undefined;
+      type: 'review_pr';
+      prCiStatus?: PrCiStatus;
+    }
   | {type: 'code_changes_ready'}
   | {type: 'solution_ready'}
   | {type: 'needs_investigation'}
@@ -74,6 +83,10 @@ export interface RunQuestion {
 // `status` is 'open' | 'merged' | 'closed' | 'draft' | 'unknown'.
 interface RunPullRequest {
   status: string | null;
+  // Present only when the runs fetch requested includeCiStatus.
+  ciStatus?: PrCiStatus | null;
+  // The PR number, as a string.
+  id?: string;
   mergedAt?: string | null;
 }
 
@@ -170,6 +183,9 @@ export interface OverviewRow {
   // The question autofix paused on, when status is NEED_MORE_INFORMATION and
   // the pending input payload carries readable text.
   pendingQuestion?: string;
+  // CI status of the linked PR; present only when the runs fetch requested it
+  // and the server could compute it.
+  prCiStatus?: PrCiStatus;
   prNumber?: number;
   prUrl?: string;
   rawSource?: string | null;

--- a/static/app/views/seerWorkflows/overview/useIssueAutofixEnrichment.tsx
+++ b/static/app/views/seerWorkflows/overview/useIssueAutofixEnrichment.tsx
@@ -24,6 +24,7 @@ export function useIssueAutofixEnrichment(issueId: string): IssueAutofixEnrichme
         query: `${RUNS_QUERY} group:${issueId}`,
         question: RUN_QUESTION_PROMPTS,
         per_page: 1,
+        includeCiStatus: 1,
       },
       staleTime: QUERY_STALE_TIME,
     }),


### PR DESCRIPTION
The "Awaiting your review" cards on the Autofix Overview link to autofix-opened PRs but give no signal whether CI is green before clicking through.

This consumes the `includeCiStatus` param added to the seer runs endpoint in #120384: the per-card runs query now requests it, and each card renders a tag beside the Review PR button — "CI passed" (success), "CI running" (info), or "CI failed" (danger). No tag renders when the status is unknown, for non-GitHub repos, or until the backend change deploys, so this degrades gracefully.

Details:
- The linked PR is matched by PR number against the run's serialized `pullRequests` (falling back to the first non-merged entry), in a pure helper beside the existing `extractPr`.
- The tag renders through the shared primary-action component, so both card and table views get it.

Depends on #120384 (backend); safe to merge before it deploys.