### PR TITLE
feat(notifications): Link regression notifications to the triggering event

### DIFF
--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -141,8 +141,10 @@ def get_title_link(
     elif issue_details and notification:
         referrer = notification.get_referrer(provider)
         notification_uuid = notification.notification_uuid
+        event_id = getattr(notification, "regression_event_id", None)
         url = group.get_absolute_url(
-            params={"referrer": referrer, "notification_uuid": notification_uuid, **other_params}
+            params={"referrer": referrer, "notification_uuid": notification_uuid, **other_params},
+            event_id=event_id,
         )
     elif notification_uuid:
         url = group.get_absolute_url(
@@ -192,8 +194,10 @@ def get_title_link_workflow_engine_ui(
     elif issue_details and notification:
         referrer = notification.get_referrer(provider)
         notification_uuid = notification.notification_uuid
+        event_id = getattr(notification, "regression_event_id", None)
         url = group.get_absolute_url(
-            params={"referrer": referrer, "notification_uuid": notification_uuid, **other_params}
+            params={"referrer": referrer, "notification_uuid": notification_uuid, **other_params},
+            event_id=event_id,
         )
     elif notification_uuid:
         url = group.get_absolute_url(

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -9,7 +9,6 @@ from sentry_relay.processing import parse_release
 
 from sentry.integrations.types import ExternalProviders
 from sentry.models.activity import Activity
-from sentry.types.actor import Actor
 
 from .base import GroupActivityNotification
 
@@ -22,6 +21,7 @@ class RegressionActivityNotification(GroupActivityNotification):
         super().__init__(activity)
         self.version = self.activity.data.get("version", "")
         self.version_parsed = parse_release(self.version, json_loads=orjson.loads)["description"]
+        self.regression_event_id: str | None = self.activity.data.get("event_id")
         self._apply_event_metadata()
 
     def _apply_event_metadata(self) -> None:
@@ -45,20 +45,11 @@ class RegressionActivityNotification(GroupActivityNotification):
 
     def get_group_link(self) -> str:
         referrer = self.get_referrer(ExternalProviders.EMAIL)
-        event_id = self.activity.data.get("event_id")
         return str(
             self.group.get_absolute_url(
                 params={"referrer": referrer, "notification_uuid": self.notification_uuid},
-                event_id=event_id,
+                event_id=self.regression_event_id,
             )
-        )
-
-    def get_title_link(self, recipient: Actor, provider: ExternalProviders) -> str | None:
-        referrer = self.get_referrer(provider)
-        event_id = self.activity.data.get("event_id")
-        return self.group.get_absolute_url(
-            params={"referrer": referrer, "notification_uuid": self.notification_uuid},
-            event_id=event_id,
         )
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -9,6 +9,7 @@ from sentry_relay.processing import parse_release
 
 from sentry.integrations.types import ExternalProviders
 from sentry.models.activity import Activity
+from sentry.types.actor import Actor
 
 from .base import GroupActivityNotification
 
@@ -41,6 +42,24 @@ class RegressionActivityNotification(GroupActivityNotification):
         if "event_type" in self.activity.data:
             group_data["type"] = self.activity.data["event_type"]
         self.group.data = group_data
+
+    def get_group_link(self) -> str:
+        referrer = self.get_referrer(ExternalProviders.EMAIL)
+        event_id = self.activity.data.get("event_id")
+        return str(
+            self.group.get_absolute_url(
+                params={"referrer": referrer, "notification_uuid": self.notification_uuid},
+                event_id=event_id,
+            )
+        )
+
+    def get_title_link(self, recipient: Actor, provider: ExternalProviders) -> str | None:
+        referrer = self.get_referrer(provider)
+        event_id = self.activity.data.get("event_id")
+        return self.group.get_absolute_url(
+            params={"referrer": referrer, "notification_uuid": self.notification_uuid},
+            event_id=event_id,
+        )
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
         text_message, html_message, params = "{author} marked {an issue} as a regression", None, {}

--- a/tests/sentry/integrations/msteams/notifications/test_regression.py
+++ b/tests/sentry/integrations/msteams/notifications/test_regression.py
@@ -50,3 +50,28 @@ class MSTeamsRegressionNotificationTest(MSTeamsActivityNotificationTest):
             f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=regression\\_activity-msteams-user&amp;notification\\_uuid={notification_uuid}&amp;organizationId={self.organization.id})"
             == body[3]["columns"][1]["items"][0]["text"]
         )
+
+    def test_regression_with_event_id(self, mock_send_card: MagicMock) -> None:
+        """
+        Test that the card links to the specific event when event_id is present.
+        """
+        event_id = "a" * 32
+        notification = RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=self.group,
+                user_id=self.user.id,
+                type=ActivityType.SET_REGRESSION,
+                data={"event_id": event_id},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        mock_send_card.assert_called_once()
+        args, kwargs = mock_send_card.call_args
+        body = args[1]["body"]
+        assert (
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression\\_activity-msteams&amp;notification\\_uuid="
+            in body[1]["text"]
+        )

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -67,6 +67,36 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
         )
 
+    def test_regression_with_event_id_block(self) -> None:
+        """
+        Test that the Slack notification URL links to the specific event that
+        caused the regression when event_id is present in activity data.
+        """
+        event_id = "a" * 32
+        with self.tasks():
+            self.create_notification(self.group, {"event_id": event_id}).send()
+
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+        assert blocks[1]["text"]["text"] == (
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+        )
+
+    def test_regression_with_event_id_and_release_block(self) -> None:
+        """
+        Test that the URL includes the event_id even when a release version is
+        also present.
+        """
+        event_id = "b" * 32
+        with self.tasks():
+            self.create_notification(self.group, {"event_id": event_id, "version": "1.0.0"}).send()
+
+        blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
+        notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
+        assert blocks[1]["text"]["text"] == (
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+        )
+
     @mock.patch(
         "sentry.services.eventstore.models.GroupEvent.occurrence",
         return_value=TEST_PERF_ISSUE_OCCURRENCE,


### PR DESCRIPTION
## Summary
- Add event id to the issue regression notification title link so instead of linking to issue we link to specific event.