### PR TITLE
feat(seer): Batch PR CI status via GitHub GraphQL statusCheckRollup

### DIFF
--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
-from typing import Any, NotRequired, TypedDict, cast
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, NotRequired, TypedDict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.pullrequest import (
@@ -10,7 +10,7 @@ from sentry.api.serializers.models.pullrequest import (
     PullRequestSerializerResponse,
 )
 from sentry.models.pullrequest import PullRequest
-from sentry.seer.autofix.pr_ci_status import PullRequestCiStatus, get_pr_ci_status
+from sentry.seer.autofix.pr_ci_status import PullRequestCiStatus, get_pr_ci_statuses
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunPullRequest
 
 
@@ -33,16 +33,32 @@ class SeerRunPullRequestResponse(PullRequestSerializerResponse):
     ciStatus: NotRequired[PullRequestCiStatus | None]
 
 
-class SeerRunPullRequestSerializer(PullRequestSerializer):
+# Wraps rather than subclasses PullRequestSerializer so ``Serializer[T]`` binds to the
+# seer-local response type and ``serialize(...)`` call sites typecheck without casts.
+class SeerRunPullRequestSerializer(Serializer[SeerRunPullRequestResponse]):
     def __init__(self, include_ci_status: bool = False) -> None:
+        self._pr_serializer = PullRequestSerializer()
         self.include_ci_status = include_ci_status
+
+    def get_attrs(
+        self, item_list: Sequence[Any], user: Any, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
+        # Batch every PR's CI status into one GraphQL round trip per integration here, once per page.
+        attrs = self._pr_serializer.get_attrs(item_list, user, **kwargs)
+        if self.include_ci_status:
+            statuses = get_pr_ci_statuses(item_list)
+            for pull_request in item_list:
+                attrs.setdefault(pull_request, {})["ci_status"] = statuses.get(pull_request.id)
+        return attrs
 
     def serialize(
         self, obj: PullRequest, attrs: Any, user: Any, **kwargs: Any
     ) -> SeerRunPullRequestResponse:
-        result: SeerRunPullRequestResponse = {**super().serialize(obj, attrs, user, **kwargs)}
+        result: SeerRunPullRequestResponse = {
+            **self._pr_serializer.serialize(obj, attrs, user, **kwargs)
+        }
         if self.include_ci_status:
-            result["ciStatus"] = get_pr_ci_status(obj)
+            result["ciStatus"] = attrs.get("ci_status")
         return result
 
 
@@ -87,9 +103,9 @@ class SeerRunSerializer(Serializer):
         )
         prs = [link.pull_request for link in pr_links]
         pr_serializer = SeerRunPullRequestSerializer(include_ci_status=self.include_ci_status)
-        # serialize()'s generic is bound by the base class, so re-narrow to the subclass response.
-        serialized_prs = cast(list[SeerRunPullRequestResponse], serialize(prs, user, pr_serializer))
-        serialized_pr_by_id = {pr.id: serialized for pr, serialized in zip(prs, serialized_prs)}
+        serialized_pr_by_id = {
+            pr.id: serialized for pr, serialized in zip(prs, serialize(prs, user, pr_serializer))
+        }
 
         pull_requests_by_run_id: dict[int, list[SeerRunPullRequestResponse]] = defaultdict(list)
         for link in pr_links:

--- a/src/sentry/api/serializers/models/seer_run.py
+++ b/src/sentry/api/serializers/models/seer_run.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
-from typing import Any, NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict, cast
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.pullrequest import (
     PullRequestSerializer,
     PullRequestSerializerResponse,
 )
+from sentry.models.pullrequest import PullRequest
+from sentry.seer.autofix.pr_ci_status import PullRequestCiStatus, get_pr_ci_status
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunPullRequest
 
 
@@ -26,6 +28,24 @@ class RunQuestionOutput(TypedDict):
     question: NotRequired[str]
 
 
+# Seer-local extension so the shared response type (and other endpoints' schemas) stay untouched.
+class SeerRunPullRequestResponse(PullRequestSerializerResponse):
+    ciStatus: NotRequired[PullRequestCiStatus | None]
+
+
+class SeerRunPullRequestSerializer(PullRequestSerializer):
+    def __init__(self, include_ci_status: bool = False) -> None:
+        self.include_ci_status = include_ci_status
+
+    def serialize(
+        self, obj: PullRequest, attrs: Any, user: Any, **kwargs: Any
+    ) -> SeerRunPullRequestResponse:
+        result: SeerRunPullRequestResponse = {**super().serialize(obj, attrs, user, **kwargs)}
+        if self.include_ci_status:
+            result["ciStatus"] = get_pr_ci_status(obj)
+        return result
+
+
 class SeerRunResponse(TypedDict):
     id: str
     type: str
@@ -37,7 +57,7 @@ class SeerRunResponse(TypedDict):
     source: str | None
     projectId: str | None
     groupId: str | None
-    pullRequests: list[PullRequestSerializerResponse]
+    pullRequests: list[SeerRunPullRequestResponse]
     # One-shot outputs (question answers), injected by the endpoint when
     # ?expand=questions and/or ?question= is passed; the serializer itself never
     # populates them.
@@ -46,6 +66,9 @@ class SeerRunResponse(TypedDict):
 
 @register(SeerRun)
 class SeerRunSerializer(Serializer):
+    def __init__(self, include_ci_status: bool = False) -> None:
+        self.include_ci_status = include_ci_status
+
     def get_attrs(
         self, item_list: Sequence[SeerRun], user: Any, **kwargs: Any
     ) -> dict[SeerRun, dict[str, Any]]:
@@ -63,12 +86,12 @@ class SeerRunSerializer(Serializer):
             .order_by("date_added")
         )
         prs = [link.pull_request for link in pr_links]
-        serialized_pr_by_id = {
-            pr.id: serialized
-            for pr, serialized in zip(prs, serialize(prs, user, PullRequestSerializer()))
-        }
+        pr_serializer = SeerRunPullRequestSerializer(include_ci_status=self.include_ci_status)
+        # serialize()'s generic is bound by the base class, so re-narrow to the subclass response.
+        serialized_prs = cast(list[SeerRunPullRequestResponse], serialize(prs, user, pr_serializer))
+        serialized_pr_by_id = {pr.id: serialized for pr, serialized in zip(prs, serialized_prs)}
 
-        pull_requests_by_run_id: dict[int, list[PullRequestSerializerResponse]] = defaultdict(list)
+        pull_requests_by_run_id: dict[int, list[SeerRunPullRequestResponse]] = defaultdict(list)
         for link in pr_links:
             pull_requests_by_run_id[link.seer_run_id].append(
                 serialized_pr_by_id[link.pull_request_id]

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -127,6 +127,32 @@ class GitHubReaction(StrEnum):
     EYES = "eyes"
 
 
+class GitHubCheckRunStatus(StrEnum):
+    """
+    https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
+    """
+
+    QUEUED = "queued"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class GitHubCheckRunConclusion(StrEnum):
+    """
+    https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    NEUTRAL = "neutral"
+    CANCELLED = "cancelled"
+    TIMED_OUT = "timed_out"
+    ACTION_REQUIRED = "action_required"
+    SKIPPED = "skipped"
+    STALE = "stale"
+    STARTUP_FAILURE = "startup_failure"
+
+
 class GitHubApiRequestType(StrEnum):
     CHECK_FILE = "check_file"
     COMPARE_COMMITS = "compare_commits"
@@ -1243,6 +1269,14 @@ class GitHubBaseClient(
         """
         endpoint = f"/repos/{repo}/commits/{sha}/check-runs"
         return self.get(endpoint, api_request_type=GitHubApiRequestType.GET_CHECK_RUNS)
+
+    def get_all_check_runs(self, repo: str, sha: str) -> list[Any]:
+        """Like ``get_check_runs`` but follows pagination, returning the flat check-run list."""
+        return self._get_with_pagination(
+            f"/repos/{repo}/commits/{sha}/check-runs",
+            response_key="check_runs",
+            api_request_type=GitHubApiRequestType.GET_CHECK_RUNS,
+        )
 
 
 class _IntegrationIdParams(TypedDict, total=False):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -127,32 +127,6 @@ class GitHubReaction(StrEnum):
     EYES = "eyes"
 
 
-class GitHubCheckRunStatus(StrEnum):
-    """
-    https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
-    """
-
-    QUEUED = "queued"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-
-
-class GitHubCheckRunConclusion(StrEnum):
-    """
-    https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
-    """
-
-    SUCCESS = "success"
-    FAILURE = "failure"
-    NEUTRAL = "neutral"
-    CANCELLED = "cancelled"
-    TIMED_OUT = "timed_out"
-    ACTION_REQUIRED = "action_required"
-    SKIPPED = "skipped"
-    STALE = "stale"
-    STARTUP_FAILURE = "startup_failure"
-
-
 class GitHubApiRequestType(StrEnum):
     CHECK_FILE = "check_file"
     COMPARE_COMMITS = "compare_commits"
@@ -178,6 +152,7 @@ class GitHubApiRequestType(StrEnum):
     GET_LANGUAGES = "get_languages"
     GET_LABELS = "get_labels"
     GET_ORGANIZATION_MEMBERSHIPS_FOR_USER = "get_organization_memberships_for_user"
+    GET_PR_CI_STATUSES = "get_pr_ci_statuses"
     GET_PULL_REQUEST = "get_pull_request"
     GET_PULL_REQUEST_COMMENTS = "get_pull_request_comments"
     GET_PULL_REQUEST_FILES = "get_pull_request_files"
@@ -196,6 +171,27 @@ class GitHubApiRequestType(StrEnum):
     UPDATE_COMMENT = "update_comment"
     UPDATE_ISSUE_ASSIGNEES = "update_issue_assignees"
     UPDATE_ISSUE_STATUS = "update_issue_status"
+
+
+def _make_pr_ci_status_query(index: int) -> str:
+    # One repository alias per PR: GraphQL allows only one pullRequest(number:) per repository field.
+    return f"""
+    repo{index}: repository(owner: $o{index}, name: $n{index}) {{
+        pr{index}: pullRequest(number: $p{index}) {{
+            commits(last: 1) {{ nodes {{ commit {{ statusCheckRollup {{ state }} }} }} }}
+        }}
+    }}"""
+
+
+def _extract_rollup_state(response: Mapping[str, Any], index: int) -> str | None:
+    # Read defensively: any level may be null on partial failures (deleted PR, no access, no checks).
+    repo = (response.get("data") or {}).get(f"repo{index}") or {}
+    pull_request = repo.get(f"pr{index}") or {}
+    nodes = (pull_request.get("commits") or {}).get("nodes") or []
+    if not nodes:
+        return None
+    rollup = ((nodes[0] or {}).get("commit") or {}).get("statusCheckRollup") or {}
+    return rollup.get("state")
 
 
 class GithubSetupApiClient(IntegrationProxyClient):
@@ -1241,6 +1237,55 @@ class GitHubBaseClient(
             },
         )
 
+    def get_pr_ci_statuses(self, pull_requests: Sequence[tuple[str, str, int]]) -> list[str | None]:
+        """Batch-fetch each PR head commit's statusCheckRollup state via one GraphQL query.
+
+        ``pull_requests`` is a list of ``(owner, name, number)`` triples; the returned list is
+        positional (one rollup ``state`` string, or ``None`` when the commit has no checks or the
+        alias could not be resolved). Never let one null alias poison the batch.
+        """
+        if not pull_requests:
+            return []
+
+        try:
+            rate_limit = self.get_rate_limit(specific_resource="graphql")
+        except ApiError:
+            # Some GitHub instances don't enforce rate limiting and will respond with a 404.
+            pass
+        else:
+            if rate_limit.remaining < MINIMUM_REQUESTS:
+                raise ApiRateLimitedError("Not enough requests remaining for GitHub")
+
+        variable_names: list[str] = []
+        variables: dict[str, str | int] = {}
+        pr_queries = ""
+        for index, (owner, name, number) in enumerate(pull_requests):
+            variable_names += [f"$o{index}: String!", f"$n{index}: String!", f"$p{index}: Int!"]
+            variables[f"o{index}"] = owner
+            variables[f"n{index}"] = name
+            variables[f"p{index}"] = number
+            pr_queries += _make_pr_ci_status_query(index)
+        query = f"""query ({", ".join(variable_names)}) {{{pr_queries}\n}}"""
+
+        response = self.post(
+            path="/graphql",
+            data={"query": query, "variables": variables},
+            allow_text=False,
+            api_request_type=GitHubApiRequestType.GET_PR_CI_STATUSES,
+        )
+        if not is_graphql_response(response):
+            raise ApiError("Response is not JSON")
+
+        errors = response.get("errors", [])
+        if errors:
+            if any(error.get("type") == "RATE_LIMITED" for error in errors):
+                raise ApiRateLimitedError("GitHub rate limit exceeded")
+            # data present means a partial success (missing/renamed repo); absent means a bad query.
+            if not response.get("data"):
+                raise ApiError("\n".join(error.get("message", "") for error in errors))
+
+        return [_extract_rollup_state(response, index) for index in range(len(pull_requests))]
+
     def create_check_run(self, repo: str, data: dict[str, Any]) -> Any:
         """
         https://docs.github.com/en/rest/checks/runs#create-a-check-run
@@ -1269,14 +1314,6 @@ class GitHubBaseClient(
         """
         endpoint = f"/repos/{repo}/commits/{sha}/check-runs"
         return self.get(endpoint, api_request_type=GitHubApiRequestType.GET_CHECK_RUNS)
-
-    def get_all_check_runs(self, repo: str, sha: str) -> list[Any]:
-        """Like ``get_check_runs`` but follows pagination, returning the flat check-run list."""
-        return self._get_with_pagination(
-            f"/repos/{repo}/commits/{sha}/check-runs",
-            response_key="check_runs",
-            api_request_type=GitHubApiRequestType.GET_CHECK_RUNS,
-        )
 
 
 class _IntegrationIdParams(TypedDict, total=False):

--- a/src/sentry/seer/autofix/pr_ci_status.py
+++ b/src/sentry/seer/autofix/pr_ci_status.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from sentry.integrations.github.client import GitHubCheckRunConclusion, GitHubCheckRunStatus
+from sentry.integrations.services.integration import integration_service
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.repository import Repository
+from sentry.utils.cache import cache
+
+logger = logging.getLogger(__name__)
+
+PullRequestCiStatus = Literal["passed", "running", "failed"]
+
+# Providers whose integration client exposes the GitHub checks API.
+SUPPORTED_PROVIDERS = ("integrations:github", "integrations:github_enterprise")
+
+# Mirrors check_suites.FAILURE_CONCLUSIONS plus startup_failure (we read raw conclusions; scm normalizes it to failure).
+FAILURE_CONCLUSIONS = (
+    GitHubCheckRunConclusion.FAILURE,
+    GitHubCheckRunConclusion.TIMED_OUT,
+    GitHubCheckRunConclusion.ACTION_REQUIRED,
+    GitHubCheckRunConclusion.STARTUP_FAILURE,
+)
+
+# States for which CI status is meaningless (the PR is no longer running checks).
+_SKIP_STATES = (PullRequestLifecycleState.MERGED, PullRequestLifecycleState.CLOSED)
+
+PR_CI_CACHE_TIMEOUT_SECONDS = 2 * 60  # 2 minutes
+PR_CI_NEGATIVE_CACHE_TIMEOUT_SECONDS = 30  # 30 seconds
+# Distinguishes a cached indeterminate result from a cache miss; never returned.
+_UNKNOWN = "unknown"
+
+
+def _get_pr_ci_cache_key(pull_request: PullRequest) -> str:
+    # The stored head sha invalidates the key on push; NULL-sha shell rows fall back to TTL expiry.
+    return f"seer:pr_ci:{pull_request.id}:{pull_request.head_commit_sha or ''}"
+
+
+def get_pr_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
+    """Aggregate CI status of a PR's head commit from GitHub check runs, cached; never raises."""
+    if pull_request.state in _SKIP_STATES:
+        return None
+
+    cache_key = _get_pr_ci_cache_key(pull_request)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return None if cached == _UNKNOWN else cached
+
+    try:
+        result = _compute_ci_status(pull_request)
+    except Exception:
+        logger.exception(
+            "seer.pr_ci_status.compute_failed",
+            extra={"pull_request_id": pull_request.id},
+        )
+        result = None
+
+    if result is None:
+        cache.set(cache_key, _UNKNOWN, timeout=PR_CI_NEGATIVE_CACHE_TIMEOUT_SECONDS)
+        return None
+
+    cache.set(cache_key, result, timeout=PR_CI_CACHE_TIMEOUT_SECONDS)
+    return result
+
+
+def _compute_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
+    repo = Repository.objects.filter(id=pull_request.repository_id).first()
+    if repo is None or repo.provider not in SUPPORTED_PROVIDERS:
+        return None
+
+    integration = integration_service.get_integration(integration_id=repo.integration_id)
+    if integration is None:
+        return None
+    client = integration.get_installation(organization_id=pull_request.organization_id).get_client()
+
+    sha = pull_request.head_commit_sha
+    if not sha:
+        sha = client.get_pull_request(repo.name, pull_request.key).get("head", {}).get("sha")
+    if not sha:
+        return None
+
+    check_runs = client.get_all_check_runs(repo.name, sha)
+    if not check_runs:
+        return None
+    if any(run.get("conclusion") in FAILURE_CONCLUSIONS for run in check_runs):
+        return "failed"
+    if any(run.get("status") != GitHubCheckRunStatus.COMPLETED for run in check_runs):
+        return "running"
+    return "passed"

--- a/src/sentry/seer/autofix/pr_ci_status.py
+++ b/src/sentry/seer/autofix/pr_ci_status.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
+from collections.abc import Sequence
 from typing import Literal
 
-from sentry.integrations.github.client import GitHubCheckRunConclusion, GitHubCheckRunStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.repository import Repository
@@ -13,16 +14,17 @@ logger = logging.getLogger(__name__)
 
 PullRequestCiStatus = Literal["passed", "running", "failed"]
 
-# Providers whose integration client exposes the GitHub checks API.
+# Providers whose integration client exposes the GraphQL statusCheckRollup query.
 SUPPORTED_PROVIDERS = ("integrations:github", "integrations:github_enterprise")
 
-# Mirrors check_suites.FAILURE_CONCLUSIONS plus startup_failure (we read raw conclusions; scm normalizes it to failure).
-FAILURE_CONCLUSIONS = (
-    GitHubCheckRunConclusion.FAILURE,
-    GitHubCheckRunConclusion.TIMED_OUT,
-    GitHubCheckRunConclusion.ACTION_REQUIRED,
-    GitHubCheckRunConclusion.STARTUP_FAILURE,
-)
+# GitHub statusCheckRollup StatusState -> our tri-state; a null rollup (no checks) maps to None.
+ROLLUP_STATE_MAP: dict[str, PullRequestCiStatus] = {
+    "SUCCESS": "passed",
+    "PENDING": "running",
+    "EXPECTED": "running",
+    "FAILURE": "failed",
+    "ERROR": "failed",
+}
 
 # States for which CI status is meaningless (the PR is no longer running checks).
 _SKIP_STATES = (PullRequestLifecycleState.MERGED, PullRequestLifecycleState.CLOSED)
@@ -38,54 +40,104 @@ def _get_pr_ci_cache_key(pull_request: PullRequest) -> str:
     return f"seer:pr_ci:{pull_request.id}:{pull_request.head_commit_sha or ''}"
 
 
-def get_pr_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
-    """Aggregate CI status of a PR's head commit from GitHub check runs, cached; never raises."""
-    if pull_request.state in _SKIP_STATES:
-        return None
-
-    cache_key = _get_pr_ci_cache_key(pull_request)
-    cached = cache.get(cache_key)
-    if cached is not None:
-        return None if cached == _UNKNOWN else cached
-
-    try:
-        result = _compute_ci_status(pull_request)
-    except Exception:
-        logger.exception(
-            "seer.pr_ci_status.compute_failed",
-            extra={"pull_request_id": pull_request.id},
+def _cache_status(pull_request: PullRequest, status: PullRequestCiStatus | None) -> None:
+    if status is None:
+        cache.set(
+            _get_pr_ci_cache_key(pull_request),
+            _UNKNOWN,
+            timeout=PR_CI_NEGATIVE_CACHE_TIMEOUT_SECONDS,
         )
-        result = None
+    else:
+        cache.set(_get_pr_ci_cache_key(pull_request), status, timeout=PR_CI_CACHE_TIMEOUT_SECONDS)
 
-    if result is None:
-        cache.set(cache_key, _UNKNOWN, timeout=PR_CI_NEGATIVE_CACHE_TIMEOUT_SECONDS)
-        return None
 
-    cache.set(cache_key, result, timeout=PR_CI_CACHE_TIMEOUT_SECONDS)
+def get_pr_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
+    """Resolve the CI status of a single PR's head commit; thin wrapper over the batch API."""
+    return get_pr_ci_statuses([pull_request]).get(pull_request.id)
+
+
+def get_pr_ci_statuses(
+    pull_requests: Sequence[PullRequest],
+) -> dict[int, PullRequestCiStatus | None]:
+    """Resolve CI status for many PRs with one GraphQL query per integration, cached; never raises."""
+    result: dict[int, PullRequestCiStatus | None] = {}
+    misses: list[PullRequest] = []
+    for pull_request in pull_requests:
+        if pull_request.state in _SKIP_STATES:
+            result[pull_request.id] = None
+            continue
+        cached = cache.get(_get_pr_ci_cache_key(pull_request))
+        if cached is not None:
+            result[pull_request.id] = None if cached == _UNKNOWN else cached
+        else:
+            misses.append(pull_request)
+
+    if not misses:
+        return result
+
+    repos_by_id = {
+        repo.id: repo
+        for repo in Repository.objects.filter(id__in={pr.repository_id for pr in misses})
+    }
+
+    # Group by (integration, org) so each group resolves one client and one GraphQL round trip.
+    groups: dict[tuple[int, int], list[PullRequest]] = defaultdict(list)
+    for pull_request in misses:
+        repo = repos_by_id.get(pull_request.repository_id)
+        if repo is None or repo.provider not in SUPPORTED_PROVIDERS or repo.integration_id is None:
+            result[pull_request.id] = None
+            _cache_status(pull_request, None)
+            continue
+        groups[(repo.integration_id, pull_request.organization_id)].append(pull_request)
+
+    for (integration_id, organization_id), group in groups.items():
+        result.update(
+            _resolve_group(integration_id, organization_id, group, repos_by_id),
+        )
     return result
 
 
-def _compute_ci_status(pull_request: PullRequest) -> PullRequestCiStatus | None:
-    repo = Repository.objects.filter(id=pull_request.repository_id).first()
-    if repo is None or repo.provider not in SUPPORTED_PROVIDERS:
-        return None
+def _resolve_group(
+    integration_id: int,
+    organization_id: int,
+    pull_requests: list[PullRequest],
+    repos_by_id: dict[int, Repository],
+) -> dict[int, PullRequestCiStatus | None]:
+    resolved: dict[int, PullRequestCiStatus | None] = {}
+    specs: list[tuple[str, str, int]] = []
+    queried: list[PullRequest] = []
+    for pull_request in pull_requests:
+        try:
+            owner, name = repos_by_id[pull_request.repository_id].name.split("/", maxsplit=1)
+            number = int(pull_request.key)
+        except (ValueError, TypeError):
+            resolved[pull_request.id] = None
+            _cache_status(pull_request, None)
+            continue
+        specs.append((owner, name, number))
+        queried.append(pull_request)
 
-    integration = integration_service.get_integration(integration_id=repo.integration_id)
-    if integration is None:
-        return None
-    client = integration.get_installation(organization_id=pull_request.organization_id).get_client()
+    if not specs:
+        return resolved
 
-    sha = pull_request.head_commit_sha
-    if not sha:
-        sha = client.get_pull_request(repo.name, pull_request.key).get("head", {}).get("sha")
-    if not sha:
-        return None
+    try:
+        integration = integration_service.get_integration(integration_id=integration_id)
+        if integration is None:
+            raise ValueError("integration not found")
+        client = integration.get_installation(organization_id=organization_id).get_client()
+        states = client.get_pr_ci_statuses(specs)
+    except Exception:
+        logger.exception(
+            "seer.pr_ci_status.batch_failed",
+            extra={"integration_id": integration_id, "organization_id": organization_id},
+        )
+        for pull_request in queried:
+            resolved[pull_request.id] = None
+            _cache_status(pull_request, None)
+        return resolved
 
-    check_runs = client.get_all_check_runs(repo.name, sha)
-    if not check_runs:
-        return None
-    if any(run.get("conclusion") in FAILURE_CONCLUSIONS for run in check_runs):
-        return "failed"
-    if any(run.get("status") != GitHubCheckRunStatus.COMPLETED for run in check_runs):
-        return "running"
-    return "passed"
+    for pull_request, state in zip(queried, states):
+        status = ROLLUP_STATE_MAP.get(state) if state is not None else None
+        resolved[pull_request.id] = status
+        _cache_status(pull_request, status)
+    return resolved

--- a/src/sentry/seer/endpoints/organization_seer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_runs.py
@@ -131,6 +131,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             query=request.GET.get("query", "").strip(),
             expand=request.GET.getlist("expand"),
             questions=request.GET.getlist("question"),
+            include_ci_status=request.GET.get("includeCiStatus") == "1",
             start=start,
             end=end,
         )
@@ -151,6 +152,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             query=query.strip() if isinstance(query, str) else "",
             expand=_as_str_list(data.get("expand")),
             questions=_as_str_list(data.get("question")),
+            include_ci_status=False,
             start=start,
             end=end,
         )
@@ -163,6 +165,7 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
         query: str,
         expand: Sequence[str],
         questions: Sequence[str],
+        include_ci_status: bool,
         start: datetime | None,
         end: datetime | None,
     ) -> Response:
@@ -218,7 +221,9 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
             return Response({"detail": str(e)}, status=400)
 
         def on_results(runs: Sequence[SeerRun]) -> list[SeerRunResponse]:
-            serialized: list[SeerRunResponse] = serialize(runs, request.user, SeerRunSerializer())
+            serialized: list[SeerRunResponse] = serialize(
+                runs, request.user, SeerRunSerializer(include_ci_status=include_ci_status)
+            )
             if include_outputs:
                 outputs_by_run_id = _fetch_run_outputs(
                     runs,
@@ -230,14 +235,14 @@ class OrganizationSeerRunsEndpoint(OrganizationEndpoint):
                     data["outputs"] = outputs_by_run_id.get(run.id, [])
             return serialized
 
+        # Outputs run one one-shot per question per run; CI status can hit GitHub once per PR.
+        small_page = include_outputs or include_ci_status
         return self.paginate(
             request=request,
             queryset=queryset,
             order_by="-last_triggered_at",
             on_results=on_results,
             paginator_cls=OffsetPaginator,
-            # Computing outputs is expensive (one one-shot per question per run),
-            # so use a small default and cap the page size when they're requested.
-            default_per_page=10 if include_outputs else 100,
-            max_per_page=10 if include_outputs else 100,
+            default_per_page=10 if small_page else 100,
+            max_per_page=10 if small_page else 100,
         )

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1433,6 +1433,29 @@ class GitHubCommitContextClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_get_all_check_runs_follows_pagination(self, get_jwt) -> None:
+        repo_name = "getsentry/sentry"
+        sha = "abc123"
+        url = f"https://api.github.com/repos/{repo_name}/commits/{sha}/check-runs?per_page={self.github_client.page_size}"
+
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json={"total_count": 3, "check_runs": [{"id": 1}, {"id": 2}]},
+            headers={"link": f'<{url}&page=2>; rel="next"'},
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=2",
+            json={"total_count": 3, "check_runs": [{"id": 3}]},
+        )
+
+        result = self.github_client.get_all_check_runs(repo_name, sha)
+
+        assert [run["id"] for run in result] == [1, 2, 3]
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_create_check_run_error(self, get_jwt) -> None:
         repo_name = "getsentry/sentry"
         check_data = {"name": "sentry/ci", "head_sha": "abc123"}

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1433,29 +1433,6 @@ class GitHubCommitContextClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_get_all_check_runs_follows_pagination(self, get_jwt) -> None:
-        repo_name = "getsentry/sentry"
-        sha = "abc123"
-        url = f"https://api.github.com/repos/{repo_name}/commits/{sha}/check-runs?per_page={self.github_client.page_size}"
-
-        responses.add(
-            method=responses.GET,
-            url=url,
-            json={"total_count": 3, "check_runs": [{"id": 1}, {"id": 2}]},
-            headers={"link": f'<{url}&page=2>; rel="next"'},
-        )
-        responses.add(
-            method=responses.GET,
-            url=f"{url}&page=2",
-            json={"total_count": 3, "check_runs": [{"id": 3}]},
-        )
-
-        result = self.github_client.get_all_check_runs(repo_name, sha)
-
-        assert [run["id"] for run in result] == [1, 2, 3]
-
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
-    @responses.activate
     def test_create_check_run_error(self, get_jwt) -> None:
         repo_name = "getsentry/sentry"
         check_data = {"name": "sentry/ci", "head_sha": "abc123"}
@@ -1469,6 +1446,134 @@ class GitHubCommitContextClientTest(TestCase):
 
         with pytest.raises(ApiError):
             self.github_client.create_check_run(repo_name, check_data)
+
+
+class GitHubGetPrCiStatusesTest(TestCase):
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def setUp(self, get_jwt):
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={"access_token": "12345token", "expires_at": ten_days.isoformat()},
+        )
+        install = get_installation_of_type(
+            GitHubIntegration, self.integration, self.organization.id
+        )
+        self.github_client = install.get_client()
+        # The graphql bucket check fires before the POST, so /graphql is always responses.calls[1].
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/rate_limit",
+            body=orjson.dumps(
+                {
+                    "resources": {
+                        "graphql": {
+                            "limit": 5000,
+                            "used": 1,
+                            "remaining": 4999,
+                            "reset": 1613064000,
+                        }
+                    }
+                }
+            ).decode(),
+            status=200,
+            content_type="application/json",
+        )
+
+    def _add_graphql(self, data, errors=None, status=200):
+        body: dict = {"data": data}
+        if errors is not None:
+            body["errors"] = errors
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json=body,
+            status=status,
+            content_type="application/json",
+        )
+
+    @staticmethod
+    def _rollup(state):
+        return {"commits": {"nodes": [{"commit": {"statusCheckRollup": {"state": state}}}]}}
+
+    @responses.activate
+    def test_builds_query_and_returns_states(self) -> None:
+        query = """query ($o0: String!, $n0: String!, $p0: Int!, $o1: String!, $n1: String!, $p1: Int!) {
+    repo0: repository(owner: $o0, name: $n0) {
+        pr0: pullRequest(number: $p0) {
+            commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
+        }
+    }
+    repo1: repository(owner: $o1, name: $n1) {
+        pr1: pullRequest(number: $p1) {
+            commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
+        }
+    }
+}"""
+        # Two PRs sharing a repo still get one repository alias each (repo0/repo1).
+        self._add_graphql(
+            {
+                "repo0": {"pr0": self._rollup("SUCCESS")},
+                "repo1": {"pr1": self._rollup("FAILURE")},
+            }
+        )
+
+        result = self.github_client.get_pr_ci_statuses(
+            [("getsentry", "sentry", 7), ("getsentry", "sentry", 9)]
+        )
+
+        assert result == ["SUCCESS", "FAILURE"]
+        assert orjson.loads(responses.calls[1].request.body)["query"] == query
+        assert orjson.loads(responses.calls[1].request.body)["variables"] == {
+            "o0": "getsentry",
+            "n0": "sentry",
+            "p0": 7,
+            "o1": "getsentry",
+            "n1": "sentry",
+            "p1": 9,
+        }
+
+    @responses.activate
+    def test_empty_input_makes_no_request(self) -> None:
+        assert self.github_client.get_pr_ci_statuses([]) == []
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_partial_null_alias_is_isolated(self) -> None:
+        self._add_graphql(
+            {
+                "repo0": None,
+                "repo1": {"pr1": self._rollup("PENDING")},
+            }
+        )
+        result = self.github_client.get_pr_ci_statuses([("o", "a", 1), ("o", "b", 2)])
+        assert result == [None, "PENDING"]
+
+    @responses.activate
+    def test_null_rollup_and_empty_nodes_are_none(self) -> None:
+        self._add_graphql(
+            {
+                "repo0": {"pr0": {"commits": {"nodes": [{"commit": {"statusCheckRollup": None}}]}}},
+                "repo1": {"pr1": {"commits": {"nodes": []}}},
+            }
+        )
+        result = self.github_client.get_pr_ci_statuses([("o", "a", 1), ("o", "b", 2)])
+        assert result == [None, None]
+
+    @responses.activate
+    def test_rate_limited_error_raises(self) -> None:
+        self._add_graphql({}, errors=[{"type": "RATE_LIMITED", "message": "over limit"}])
+        with pytest.raises(ApiRateLimitedError):
+            self.github_client.get_pr_ci_statuses([("o", "a", 1)])
+
+    @responses.activate
+    def test_error_without_data_raises_api_error(self) -> None:
+        self._add_graphql({}, errors=[{"message": "Bad query"}])
+        with pytest.raises(ApiError):
+            self.github_client.get_pr_ci_statuses([("o", "a", 1)])
 
 
 class GitHubClientFileBlameBase(TestCase):

--- a/tests/sentry/seer/autofix/test_pr_ci_status.py
+++ b/tests/sentry/seer/autofix/test_pr_ci_status.py
@@ -1,23 +1,28 @@
 from datetime import timedelta
 from unittest import mock
 
+import orjson
 import responses
 from django.utils import timezone
 
 from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.models.repository import Repository
-from sentry.seer.autofix.pr_ci_status import FAILURE_CONCLUSIONS, get_pr_ci_status
+from sentry.seer.autofix.pr_ci_status import get_pr_ci_status, get_pr_ci_statuses
 from sentry.testutils.cases import TestCase
 from sentry.utils.cache import cache
 
 HEAD_SHA = "abc123"
+GRAPHQL_URL = "https://api.github.com/graphql"
+RATE_LIMIT_URL = "https://api.github.com/rate_limit"
+
+# Sentinel for "commit has no checks/statuses" (statusCheckRollup is null).
+_NO_ROLLUP = object()
 
 
-def test_failure_conclusions_match_raw_strings() -> None:
-    # The enum members must subclass str so raw API conclusions match the tuple.
-    for raw in ("failure", "timed_out", "action_required", "startup_failure"):
-        assert raw in FAILURE_CONCLUSIONS
-    assert "success" not in FAILURE_CONCLUSIONS
+def _node(state):
+    if state is _NO_ROLLUP:
+        return {"commit": {"statusCheckRollup": None}}
+    return {"commit": {"statusCheckRollup": {"state": state}}}
 
 
 class GetPrCiStatusTest(TestCase):
@@ -44,7 +49,7 @@ class GetPrCiStatusTest(TestCase):
             external_id="123",
             integration_id=self.integration.id,
         )
-        self.pr = self._create_pr(head_commit_sha=HEAD_SHA)
+        self.pr = self._create_pr()
 
     def _create_pr(
         self, *, key: str = "7", head_commit_sha: str | None = HEAD_SHA, state: str | None = None
@@ -57,74 +62,81 @@ class GetPrCiStatusTest(TestCase):
             state=state,
         )
 
-    def _add_check_runs(self, check_runs: list[dict], sha: str = HEAD_SHA) -> None:
-        responses.add(
-            method=responses.GET,
-            url=f"https://api.github.com/repos/{self.repo.name}/commits/{sha}/check-runs",
-            json={"total_count": len(check_runs), "check_runs": check_runs},
-        )
-
-    @responses.activate
-    def test_failed_when_any_run_failed(self) -> None:
-        self._add_check_runs(
-            [
-                {"status": "completed", "conclusion": "success"},
-                {"status": "completed", "conclusion": "failure"},
-            ]
-        )
-        assert get_pr_ci_status(self.pr) == "failed"
-
-    @responses.activate
-    def test_running_when_any_run_incomplete(self) -> None:
-        self._add_check_runs(
-            [
-                {"status": "completed", "conclusion": "success"},
-                {"status": "in_progress", "conclusion": None},
-            ]
-        )
-        assert get_pr_ci_status(self.pr) == "running"
-
-    @responses.activate
-    def test_failed_when_startup_failure(self) -> None:
-        self._add_check_runs([{"status": "completed", "conclusion": "startup_failure"}])
-        assert get_pr_ci_status(self.pr) == "failed"
-
-    @responses.activate
-    def test_failure_on_second_page_is_seen(self) -> None:
-        url = (
-            f"https://api.github.com/repos/{self.repo.name}/commits/{HEAD_SHA}"
-            f"/check-runs?per_page=100"
-        )
+    def _mock_rate_limit(self, url: str = RATE_LIMIT_URL) -> None:
         responses.add(
             method=responses.GET,
             url=url,
-            json={"check_runs": [{"status": "completed", "conclusion": "success"}]},
-            headers={"link": f'<{url}&page=2>; rel="next"'},
-        )
-        responses.add(
-            method=responses.GET,
-            url=f"{url}&page=2",
-            json={"check_runs": [{"status": "completed", "conclusion": "failure"}]},
+            json={
+                "resources": {
+                    "graphql": {"limit": 5000, "used": 1, "remaining": 4999, "reset": 1613064000}
+                }
+            },
         )
 
-        assert get_pr_ci_status(self.pr) == "failed"
-        assert len(responses.calls) == 2
+    def _mock_graphql(self, *states, url: str = GRAPHQL_URL) -> None:
+        """Register one /graphql response whose repoN/prN aliases carry the given rollup states."""
+        self._mock_rate_limit()
+        data = {
+            f"repo{i}": {f"pr{i}": {"commits": {"nodes": [_node(state)]}}}
+            for i, state in enumerate(states)
+        }
+        responses.add(method=responses.POST, url=url, json={"data": data})
+
+    # --- rollup state -> status mapping ---------------------------------------------------------
 
     @responses.activate
-    def test_passed_when_all_runs_non_failing_and_complete(self) -> None:
-        self._add_check_runs(
-            [
-                {"status": "completed", "conclusion": "success"},
-                {"status": "completed", "conclusion": "neutral"},
-                {"status": "completed", "conclusion": "skipped"},
-            ]
-        )
+    def test_success_maps_to_passed(self) -> None:
+        self._mock_graphql("SUCCESS")
         assert get_pr_ci_status(self.pr) == "passed"
 
     @responses.activate
-    def test_none_when_no_check_runs(self) -> None:
-        self._add_check_runs([])
+    def test_pending_maps_to_running(self) -> None:
+        self._mock_graphql("PENDING")
+        assert get_pr_ci_status(self.pr) == "running"
+
+    @responses.activate
+    def test_expected_maps_to_running(self) -> None:
+        # A status context registered via the Status API but not yet reported is pending-like.
+        self._mock_graphql("EXPECTED")
+        assert get_pr_ci_status(self.pr) == "running"
+
+    @responses.activate
+    def test_failure_maps_to_failed(self) -> None:
+        self._mock_graphql("FAILURE")
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_error_maps_to_failed(self) -> None:
+        self._mock_graphql("ERROR")
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_null_rollup_maps_to_none(self) -> None:
+        self._mock_graphql(_NO_ROLLUP)
         assert get_pr_ci_status(self.pr) is None
+
+    @responses.activate
+    def test_unknown_state_maps_to_none(self) -> None:
+        self._mock_graphql("SOMETHING_NEW")
+        assert get_pr_ci_status(self.pr) is None
+
+    # --- semantic flips vs the old REST check-runs aggregation ----------------------------------
+
+    @responses.activate
+    def test_cancelled_build_now_maps_to_failed(self) -> None:
+        # GitHub's rollup folds a cancelled check into FAILURE; the old check-runs path folded
+        # cancelled into "passed". This is the single biggest observable divergence.
+        self._mock_graphql("FAILURE")
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_commit_status_only_pr_now_gets_status(self) -> None:
+        # The rollup counts legacy commit statuses (Status API); the old check-runs path ignored
+        # them, so such a PR returned None before and now returns a real status.
+        self._mock_graphql("SUCCESS")
+        assert get_pr_ci_status(self.pr) == "passed"
+
+    # --- skip / provider guards -----------------------------------------------------------------
 
     @responses.activate
     def test_merged_and_closed_prs_skipped_without_github_call(self) -> None:
@@ -140,6 +152,12 @@ class GetPrCiStatusTest(TestCase):
     def test_non_github_provider_returns_none(self) -> None:
         self.repo.update(provider="integrations:gitlab")
         assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_non_integer_pr_key_returns_none(self) -> None:
+        pr = self._create_pr(key="not-a-number")
+        assert get_pr_ci_status(pr) is None
         assert len(responses.calls) == 0
 
     @responses.activate
@@ -183,13 +201,11 @@ class GetPrCiStatusTest(TestCase):
             key="11",
             head_commit_sha=HEAD_SHA,
         )
+        self._mock_rate_limit(url="https://github.example.org/api/v3/rate_limit")
         responses.add(
-            method=responses.GET,
-            url=(
-                f"https://github.example.org/api/v3/repos/{ghe_repo.name}"
-                f"/commits/{HEAD_SHA}/check-runs"
-            ),
-            json={"check_runs": [{"status": "completed", "conclusion": "success"}]},
+            method=responses.POST,
+            url="https://github.example.org/api/graphql",
+            json={"data": {"repo0": {"pr0": {"commits": {"nodes": [_node("SUCCESS")]}}}}},
         )
 
         with mock.patch(
@@ -197,77 +213,101 @@ class GetPrCiStatusTest(TestCase):
         ):
             assert get_pr_ci_status(pr) == "passed"
 
-    @responses.activate
-    def test_missing_head_sha_resolved_via_get_pull_request(self) -> None:
-        pr = self._create_pr(key="10", head_commit_sha=None)
-        responses.add(
-            method=responses.GET,
-            url=f"https://api.github.com/repos/{self.repo.name}/pulls/{pr.key}",
-            json={"head": {"sha": HEAD_SHA}},
-        )
-        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
-
-        assert get_pr_ci_status(pr) == "passed"
-        assert any("/pulls/" in call.request.url for call in responses.calls)
-
-    @responses.activate
-    def test_github_error_returns_none_and_negative_caches(self) -> None:
-        responses.add(
-            method=responses.GET,
-            url=f"https://api.github.com/repos/{self.repo.name}/commits/{HEAD_SHA}/check-runs",
-            status=500,
-        )
-
-        assert get_pr_ci_status(self.pr) is None
-        assert len(responses.calls) == 1
-
-        # Second call within the negative-cache TTL makes no HTTP request.
-        assert get_pr_ci_status(self.pr) is None
-        assert len(responses.calls) == 1
+    # --- caching --------------------------------------------------------------------------------
 
     @responses.activate
     def test_cache_hit_skips_github(self) -> None:
-        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+        self._mock_graphql("SUCCESS")
 
         assert get_pr_ci_status(self.pr) == "passed"
-        assert len(responses.calls) == 1
+        calls_after_first = len(responses.calls)
 
         assert get_pr_ci_status(self.pr) == "passed"
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == calls_after_first
 
     @responses.activate
-    def test_failure_takes_precedence_over_running(self) -> None:
-        self._add_check_runs(
-            [
-                {"status": "in_progress", "conclusion": None},
-                {"status": "completed", "conclusion": "failure"},
-            ]
-        )
-        assert get_pr_ci_status(self.pr) == "failed"
+    def test_none_result_is_negative_cached(self) -> None:
+        self._mock_graphql(_NO_ROLLUP)
+
+        assert get_pr_ci_status(self.pr) is None
+        calls_after_first = len(responses.calls)
+
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == calls_after_first
+
+    @responses.activate
+    def test_transport_error_returns_none_and_negative_caches(self) -> None:
+        self._mock_rate_limit()
+        responses.add(method=responses.POST, url=GRAPHQL_URL, status=500)
+
+        assert get_pr_ci_status(self.pr) is None
+        calls_after_first = len(responses.calls)
+
+        # Second call within the negative-cache TTL makes no HTTP request.
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == calls_after_first
 
     @responses.activate
     def test_cache_keys_are_isolated_per_pr(self) -> None:
         other_pr = self._create_pr(key="12", head_commit_sha="def456")
-        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
-        self._add_check_runs([{"status": "completed", "conclusion": "failure"}], sha="def456")
+        self._mock_graphql("SUCCESS")
 
         assert get_pr_ci_status(self.pr) == "passed"
-        assert len(responses.calls) == 1
 
-        # The second PR must not read the first PR's cached result.
+        # The second PR must not read the first PR's cached result; it fetches fresh.
+        self._mock_graphql("FAILURE")
         assert get_pr_ci_status(other_pr) == "failed"
-        assert len(responses.calls) == 2
 
     @responses.activate
     def test_new_head_sha_invalidates_cache(self) -> None:
-        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
-        self._add_check_runs([{"status": "completed", "conclusion": "failure"}], sha="def456")
-
+        self._mock_graphql("SUCCESS")
         assert get_pr_ci_status(self.pr) == "passed"
-        assert len(responses.calls) == 1
 
-        # A push updates the stored head sha; the old head's cached status must
-        # not be served, and the new head is fetched immediately.
+        # A push updates the stored head sha -> new cache key -> forced refetch.
         self.pr.update(head_commit_sha="def456")
+        self._mock_graphql("FAILURE")
         assert get_pr_ci_status(self.pr) == "failed"
+
+    # --- batching -------------------------------------------------------------------------------
+
+    @responses.activate
+    def test_batch_one_query_for_many_prs(self) -> None:
+        pr2 = self._create_pr(key="8")
+        pr3 = self._create_pr(key="9")
+        self._mock_graphql("SUCCESS", "FAILURE", "PENDING")
+
+        result = get_pr_ci_statuses([self.pr, pr2, pr3])
+
+        assert result == {self.pr.id: "passed", pr2.id: "failed", pr3.id: "running"}
+        # One rate-limit GET + one graphql POST for the whole page.
         assert len(responses.calls) == 2
+        variables = orjson.loads(responses.calls[1].request.body)["variables"]
+        assert variables["p0"] == 7
+        assert variables["p1"] == 8
+        assert variables["p2"] == 9
+
+    @responses.activate
+    def test_batch_mixes_cache_hits_and_misses(self) -> None:
+        # Prime the cache for self.pr, then a batch only queries the uncached PR.
+        self._mock_graphql("SUCCESS")
+        assert get_pr_ci_status(self.pr) == "passed"
+
+        pr2 = self._create_pr(key="8")
+        self._mock_graphql("FAILURE")
+
+        result = get_pr_ci_statuses([self.pr, pr2])
+        assert result == {self.pr.id: "passed", pr2.id: "failed"}
+        variables = orjson.loads(responses.calls[-1].request.body)["variables"]
+        assert "p0" in variables
+        assert "p1" not in variables
+
+    @responses.activate
+    def test_skipped_prs_do_not_join_the_batch(self) -> None:
+        merged = self._create_pr(key="8", state=PullRequestLifecycleState.MERGED)
+        self._mock_graphql("SUCCESS")
+
+        result = get_pr_ci_statuses([self.pr, merged])
+
+        assert result == {self.pr.id: "passed", merged.id: None}
+        variables = orjson.loads(responses.calls[1].request.body)["variables"]
+        assert "p1" not in variables

--- a/tests/sentry/seer/autofix/test_pr_ci_status.py
+++ b/tests/sentry/seer/autofix/test_pr_ci_status.py
@@ -1,0 +1,273 @@
+from datetime import timedelta
+from unittest import mock
+
+import responses
+from django.utils import timezone
+
+from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
+from sentry.models.repository import Repository
+from sentry.seer.autofix.pr_ci_status import FAILURE_CONCLUSIONS, get_pr_ci_status
+from sentry.testutils.cases import TestCase
+from sentry.utils.cache import cache
+
+HEAD_SHA = "abc123"
+
+
+def test_failure_conclusions_match_raw_strings() -> None:
+    # The enum members must subclass str so raw API conclusions match the tuple.
+    for raw in ("failure", "timed_out", "action_required", "startup_failure"):
+        assert raw in FAILURE_CONCLUSIONS
+    assert "success" not in FAILURE_CONCLUSIONS
+
+
+class GetPrCiStatusTest(TestCase):
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def setUp(self, get_jwt: mock.MagicMock) -> None:
+        super().setUp()
+        cache.clear()
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+        self.pr = self._create_pr(head_commit_sha=HEAD_SHA)
+
+    def _create_pr(
+        self, *, key: str = "7", head_commit_sha: str | None = HEAD_SHA, state: str | None = None
+    ) -> PullRequest:
+        return PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=self.repo.id,
+            key=key,
+            head_commit_sha=head_commit_sha,
+            state=state,
+        )
+
+    def _add_check_runs(self, check_runs: list[dict], sha: str = HEAD_SHA) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/commits/{sha}/check-runs",
+            json={"total_count": len(check_runs), "check_runs": check_runs},
+        )
+
+    @responses.activate
+    def test_failed_when_any_run_failed(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "completed", "conclusion": "success"},
+                {"status": "completed", "conclusion": "failure"},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_running_when_any_run_incomplete(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "completed", "conclusion": "success"},
+                {"status": "in_progress", "conclusion": None},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "running"
+
+    @responses.activate
+    def test_failed_when_startup_failure(self) -> None:
+        self._add_check_runs([{"status": "completed", "conclusion": "startup_failure"}])
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_failure_on_second_page_is_seen(self) -> None:
+        url = (
+            f"https://api.github.com/repos/{self.repo.name}/commits/{HEAD_SHA}"
+            f"/check-runs?per_page=100"
+        )
+        responses.add(
+            method=responses.GET,
+            url=url,
+            json={"check_runs": [{"status": "completed", "conclusion": "success"}]},
+            headers={"link": f'<{url}&page=2>; rel="next"'},
+        )
+        responses.add(
+            method=responses.GET,
+            url=f"{url}&page=2",
+            json={"check_runs": [{"status": "completed", "conclusion": "failure"}]},
+        )
+
+        assert get_pr_ci_status(self.pr) == "failed"
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_passed_when_all_runs_non_failing_and_complete(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "completed", "conclusion": "success"},
+                {"status": "completed", "conclusion": "neutral"},
+                {"status": "completed", "conclusion": "skipped"},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "passed"
+
+    @responses.activate
+    def test_none_when_no_check_runs(self) -> None:
+        self._add_check_runs([])
+        assert get_pr_ci_status(self.pr) is None
+
+    @responses.activate
+    def test_merged_and_closed_prs_skipped_without_github_call(self) -> None:
+        for key, state in (
+            ("8", PullRequestLifecycleState.MERGED),
+            ("9", PullRequestLifecycleState.CLOSED),
+        ):
+            pr = self._create_pr(key=key, state=state)
+            assert get_pr_ci_status(pr) is None
+            assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_non_github_provider_returns_none(self) -> None:
+        self.repo.update(provider="integrations:gitlab")
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_github_enterprise_provider_computes_status(self) -> None:
+        ten_days = timezone.now() + timedelta(days=10)
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="Github Enterprise Test Org",
+            external_id="github.example.org:1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+                "icon": "https://github.example.org/avatar.png",
+                "domain_name": "github.example.org/Test-Organization",
+                "account_type": "Organization",
+                "installation_id": "install_id_1",
+                "installation": {
+                    "client_id": "client_id",
+                    "client_secret": "client_secret",
+                    "id": "2",
+                    "name": "test-app",
+                    "private_key": "private_key",
+                    "url": "github.example.org",
+                    "webhook_secret": "webhook_secret",
+                    "verify_ssl": True,
+                },
+            },
+        )
+        ghe_repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/bar",
+            url="https://github.example.org/Test-Organization/bar",
+            provider="integrations:github_enterprise",
+            external_id="456",
+            integration_id=integration.id,
+        )
+        pr = PullRequest.objects.create(
+            organization_id=self.organization.id,
+            repository_id=ghe_repo.id,
+            key="11",
+            head_commit_sha=HEAD_SHA,
+        )
+        responses.add(
+            method=responses.GET,
+            url=(
+                f"https://github.example.org/api/v3/repos/{ghe_repo.name}"
+                f"/commits/{HEAD_SHA}/check-runs"
+            ),
+            json={"check_runs": [{"status": "completed", "conclusion": "success"}]},
+        )
+
+        with mock.patch(
+            "sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1"
+        ):
+            assert get_pr_ci_status(pr) == "passed"
+
+    @responses.activate
+    def test_missing_head_sha_resolved_via_get_pull_request(self) -> None:
+        pr = self._create_pr(key="10", head_commit_sha=None)
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/pulls/{pr.key}",
+            json={"head": {"sha": HEAD_SHA}},
+        )
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+
+        assert get_pr_ci_status(pr) == "passed"
+        assert any("/pulls/" in call.request.url for call in responses.calls)
+
+    @responses.activate
+    def test_github_error_returns_none_and_negative_caches(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/commits/{HEAD_SHA}/check-runs",
+            status=500,
+        )
+
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 1
+
+        # Second call within the negative-cache TTL makes no HTTP request.
+        assert get_pr_ci_status(self.pr) is None
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_cache_hit_skips_github(self) -> None:
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_failure_takes_precedence_over_running(self) -> None:
+        self._add_check_runs(
+            [
+                {"status": "in_progress", "conclusion": None},
+                {"status": "completed", "conclusion": "failure"},
+            ]
+        )
+        assert get_pr_ci_status(self.pr) == "failed"
+
+    @responses.activate
+    def test_cache_keys_are_isolated_per_pr(self) -> None:
+        other_pr = self._create_pr(key="12", head_commit_sha="def456")
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+        self._add_check_runs([{"status": "completed", "conclusion": "failure"}], sha="def456")
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+        # The second PR must not read the first PR's cached result.
+        assert get_pr_ci_status(other_pr) == "failed"
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_new_head_sha_invalidates_cache(self) -> None:
+        self._add_check_runs([{"status": "completed", "conclusion": "success"}])
+        self._add_check_runs([{"status": "completed", "conclusion": "failure"}], sha="def456")
+
+        assert get_pr_ci_status(self.pr) == "passed"
+        assert len(responses.calls) == 1
+
+        # A push updates the stored head sha; the old head's cached status must
+        # not be served, and the new head is fetched immediately.
+        self.pr.update(head_commit_sha="def456")
+        assert get_pr_ci_status(self.pr) == "failed"
+        assert len(responses.calls) == 2

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
+from sentry.models.pullrequest import PullRequest
 from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.seer.run_questions import QUESTIONS, question_hash
 from sentry.seer.runs_query import filtered_runs_queryset
@@ -410,6 +411,64 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
         assert prs_by_key["124"]["mergedAt"] is None
 
         assert by_id[str(without_prs.uuid)]["pullRequests"] == []
+
+    def _run_with_pr(self) -> PullRequest:
+        run = self.create_seer_run(
+            organization=self.organization,
+            user_id=self.user.id,
+            last_triggered_at=before_now(minutes=1),
+        )
+        project = self.create_project(organization=self.organization)
+        repo = self.create_repo(project, name="getsentry/sentry")
+        pr = self.create_pull_request(
+            repository_id=repo.id, organization_id=self.organization.id, key="123"
+        )
+        SeerRunPullRequest.objects.create(seer_run=run, pull_request=pr)
+        return pr
+
+    @patch("sentry.api.serializers.models.seer_run.get_pr_ci_status", return_value="passed")
+    def test_ci_status_included_when_requested(self, mock_ci_status: Any) -> None:
+        pr = self._run_with_pr()
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"includeCiStatus": "1"}
+        )
+
+        prs = response.data[0]["pullRequests"]
+        assert prs[0]["ciStatus"] == "passed"
+        mock_ci_status.assert_called_once_with(pr)
+
+    @patch("sentry.api.serializers.models.seer_run.get_pr_ci_status", return_value="passed")
+    def test_ci_status_absent_without_param(self, mock_ci_status: Any) -> None:
+        self._run_with_pr()
+
+        response = self.get_success_response(self.organization.slug)
+
+        prs = response.data[0]["pullRequests"]
+        assert "ciStatus" not in prs[0]
+        assert not mock_ci_status.called
+
+    def test_ci_status_clamps_page_size(self) -> None:
+        for i in range(1, 12):
+            self.create_seer_run(
+                organization=self.organization,
+                user_id=self.user.id,
+                last_triggered_at=before_now(minutes=i),
+            )
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"includeCiStatus": "1"}
+        )
+
+        assert len(response.data) == 10
+        assert 'rel="next"; results="true"' in response.headers["Link"]
+
+        # Oversized pages are rejected outright, same as the outputs path.
+        self.get_error_response(
+            self.organization.slug,
+            qs_params={"includeCiStatus": "1", "per_page": "100"},
+            status_code=400,
+        )
 
     def test_outputs_absent_without_flag(self) -> None:
         self.create_seer_run(

--- a/tests/sentry/seer/endpoints/test_organization_seer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_runs.py
@@ -1,8 +1,14 @@
 from collections.abc import Mapping
+from datetime import timedelta
 from typing import Any
+from unittest import mock
 from unittest.mock import patch
 
+import responses
+from django.utils import timezone
+
 from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
 from sentry.seer.models.run import SeerRunPullRequest, SeerRunType
 from sentry.seer.run_questions import QUESTIONS, question_hash
 from sentry.seer.runs_query import filtered_runs_queryset
@@ -418,17 +424,62 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
             user_id=self.user.id,
             last_triggered_at=before_now(minutes=1),
         )
-        project = self.create_project(organization=self.organization)
-        repo = self.create_repo(project, name="getsentry/sentry")
+        ten_days = timezone.now() + timedelta(days=10)
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            url="https://github.com/getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=integration.id,
+        )
         pr = self.create_pull_request(
             repository_id=repo.id, organization_id=self.organization.id, key="123"
         )
         SeerRunPullRequest.objects.create(seer_run=run, pull_request=pr)
         return pr
 
-    @patch("sentry.api.serializers.models.seer_run.get_pr_ci_status", return_value="passed")
-    def test_ci_status_included_when_requested(self, mock_ci_status: Any) -> None:
-        pr = self._run_with_pr()
+    def _mock_ci_graphql(self, state: str) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/rate_limit",
+            json={
+                "resources": {
+                    "graphql": {"limit": 5000, "used": 1, "remaining": 4999, "reset": 1613064000}
+                }
+            },
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/graphql",
+            json={
+                "data": {
+                    "repo0": {
+                        "pr0": {
+                            "commits": {
+                                "nodes": [{"commit": {"statusCheckRollup": {"state": state}}}]
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def test_ci_status_included_when_requested(self, get_jwt: Any) -> None:
+        self._run_with_pr()
+        self._mock_ci_graphql("SUCCESS")
 
         response = self.get_success_response(
             self.organization.slug, qs_params={"includeCiStatus": "1"}
@@ -436,17 +487,19 @@ class OrganizationSeerRunsEndpointTest(APITestCase):
 
         prs = response.data[0]["pullRequests"]
         assert prs[0]["ciStatus"] == "passed"
-        mock_ci_status.assert_called_once_with(pr)
+        # The whole page resolves through exactly one graphql POST.
+        assert len([c for c in responses.calls if c.request.url.endswith("/graphql")]) == 1
 
-    @patch("sentry.api.serializers.models.seer_run.get_pr_ci_status", return_value="passed")
-    def test_ci_status_absent_without_param(self, mock_ci_status: Any) -> None:
+    @responses.activate
+    def test_ci_status_absent_without_param(self) -> None:
         self._run_with_pr()
 
         response = self.get_success_response(self.organization.slug)
 
         prs = response.data[0]["pullRequests"]
         assert "ciStatus" not in prs[0]
-        assert not mock_ci_status.called
+        # No CI request is made when the param is absent.
+        assert len(responses.calls) == 0
 
     def test_ci_status_clamps_page_size(self) -> None:
         for i in range(1, 12):


### PR DESCRIPTION
Experiment follow-up to #120384, prompted by review feedback there suggesting GitHub's GraphQL API for fetching multiple PR states in one query.

Structured as two commits for easy before/after review:
- **Commit 1** is #120384 as-is (the REST implementation: per-PR check-run fetch + hand-rolled aggregation).
- **Commit 2** is the GraphQL swap: one batched `statusCheckRollup` query per integration per page (modeled on the existing `get_blame_for_files` GraphQL pattern), replacing per-PR REST calls, the pagination loop, the head-SHA fallback, and the local aggregation logic — all deleted. Cache keys/TTLs unchanged; per-alias errors degrade that PR to no-badge without affecting the rest of the batch.

Runtime: ~10 REST round-trips per page collapse to ~1 GraphQL point.

Semantics change vs commit 1 (nothing is deployed yet, so this is choosing initial semantics, not flipping live behavior): the badge now matches GitHub's own rollup — `cancelled` check runs count as failed (previously passed), and legacy commit statuses are included (previously ignored). Both are encoded as explicit tests.

Caveat: commit 2 also carries a small `seer_run.py` typing cleanup that isn't strictly part of the GraphQL change; if this direction is chosen, the branch should be rebuilt clean on top of #120384's final state.