### PR TITLE
fix(issues): Restore status banner progress markers

### DIFF
--- a/static/app/views/issueDetails/actions/statusBanner.spec.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.spec.tsx
@@ -12,7 +12,7 @@ const project = ProjectFixture();
 const actor = UserFixture({name: 'David Cramer'});
 
 describe('StatusBanner', () => {
-  it('renders the resolved progress indicator behind the progress flag', () => {
+  it('renders the activity resolved presentation behind the flag', () => {
     render(
       <StatusBanner
         group={GroupFixture({
@@ -22,9 +22,7 @@ describe('StatusBanner', () => {
         project={project}
       />,
       {
-        organization: OrganizationFixture({
-          features: ['issue-activity-feed-v2', 'issue-activity-progress'],
-        }),
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
       }
     );
 
@@ -44,9 +42,7 @@ describe('StatusBanner', () => {
         project={project}
       />,
       {
-        organization: OrganizationFixture({
-          features: ['issue-activity-feed-v2', 'issue-activity-progress'],
-        }),
+        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
       }
     );
 
@@ -55,26 +51,6 @@ describe('StatusBanner', () => {
       screen.getByText('David Cramer archived until 50 more events occur')
     ).toBeInTheDocument();
     expect(screen.getByRole('img', {name: 'Archived'})).toBeInTheDocument();
-    expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
-  });
-
-  it('hides other activity progress indicators without the progress flag', () => {
-    render(
-      <StatusBanner
-        group={GroupFixture({
-          status: GroupStatus.IGNORED,
-          substatus: GroupSubstatus.ARCHIVED_FOREVER,
-          statusDetails: {},
-        })}
-        project={project}
-      />,
-      {
-        organization: OrganizationFixture({features: ['issue-activity-feed-v2']}),
-      }
-    );
-
-    expect(screen.getByText('Archived')).toBeInTheDocument();
-    expect(screen.queryByRole('img', {name: 'Archived'})).not.toBeInTheDocument();
     expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
   });
 

--- a/static/app/views/issueDetails/actions/statusBanner.stories.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.stories.tsx
@@ -126,7 +126,6 @@ function Banner({
     <StatusBannerFrame
       markerLabel={isArchived ? 'Archived' : undefined}
       markerState={isArchived ? ProgressState.ASSIGNED : ProgressState.FIX_APPLIED}
-      showProgressIndicator
       title={isArchived ? 'Archived' : 'Resolved'}
     >
       {children}

--- a/static/app/views/issueDetails/actions/statusBanner.tsx
+++ b/static/app/views/issueDetails/actions/statusBanner.tsx
@@ -33,15 +33,9 @@ export function StatusBanner({group, project, resolvedCopy}: StatusBannerProps) 
   }
 
   const useActivityBanner = organization.features.includes('issue-activity-feed-v2');
-  const showProgressIndicator = organization.features.includes('issue-activity-progress');
 
   return useActivityBanner ? (
-    <ActivityStatusBanner
-      group={group}
-      project={project}
-      resolvedCopy={resolvedCopy}
-      showProgressIndicator={showProgressIndicator}
-    />
+    <ActivityStatusBanner group={group} project={project} resolvedCopy={resolvedCopy} />
   ) : (
     <DefaultStatusBanner group={group} project={project} resolvedCopy={resolvedCopy} />
   );
@@ -51,10 +45,8 @@ function ActivityStatusBanner({
   group,
   project,
   resolvedCopy,
-  showProgressIndicator,
 }: StatusBannerProps & {
   group: StatusGroup;
-  showProgressIndicator: boolean;
 }) {
   const isResolved = group.status === GroupStatus.RESOLVED;
 
@@ -62,7 +54,6 @@ function ActivityStatusBanner({
     <StatusBannerFrame
       markerLabel={isResolved ? undefined : t('Archived')}
       markerState={isResolved ? ProgressState.FIX_APPLIED : ProgressState.ASSIGNED}
-      showProgressIndicator={showProgressIndicator}
       title={isResolved ? resolvedCopy || t('Resolved') : t('Archived')}
     >
       {isResolved ? (
@@ -81,7 +72,6 @@ function ActivityStatusBanner({
 interface StatusBannerFrameProps {
   children: React.ReactNode;
   markerState: ProgressState;
-  showProgressIndicator: boolean;
   title: React.ReactNode;
   markerLabel?: string;
 }
@@ -90,14 +80,11 @@ export function StatusBannerFrame({
   children,
   markerLabel,
   markerState,
-  showProgressIndicator,
   title,
 }: StatusBannerFrameProps) {
   return (
     <Flex align="center" gap="sm">
-      {showProgressIndicator ? (
-        <ActivityProgressMarker label={markerLabel} state={markerState} />
-      ) : null}
+      <ActivityProgressMarker label={markerLabel} state={markerState} />
       <Stack gap="0">
         <Text as="div" bold density="compressed" size="lg">
           {title}


### PR DESCRIPTION
Reverts the extra progress flag check for status banners so activity feed v2 keeps showing its resolved and archived markers.