### PR TITLE
fix(autofix): Keep sticky headers above row actions

### DIFF
--- a/static/app/views/seerWorkflows/overview/sectionList.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionList.tsx
@@ -157,7 +157,7 @@ const StatusGroup = styled(Disclosure)`
 // Sticky group header; z-index isn't a layout-primitive prop so it lives here.
 // Opaque background so cards scroll under it.
 const GroupHeader = styled(Sticky)`
-  z-index: ${p => p.theme.zIndex.initial};
+  z-index: ${p => p.theme.zIndex.initial + 1};
   width: 100%;
   background: ${p => p.theme.tokens.background.secondary};
   border-radius: ${p => p.theme.radius.md};


### PR DESCRIPTION
Autofix overview sticky section headers now render one local stacking layer
above row button content. This prevents embossed action labels from bleeding
through the opaque header as rows scroll underneath, without raising the
header into global navigation or overlay layers.
