### PR TITLE
fix(seer): Skip page filter URL sync on autofix overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -68,7 +68,7 @@ export default function AutofixOverview() {
       features="seer-night-shift-ui"
       renderDisabled={() => <NoAccess />}
     >
-      <PageFiltersContainer>
+      <PageFiltersContainer skipInitializeUrlParams>
         <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
           <Layout.Title>
             {t('Autofix Overview')}


### PR DESCRIPTION
Loading `/issues/autofix/overview` immediately rewrote the URL to add `?project=-1&statsPeriod=30d` (the `statsPeriod` value coming from the user's pinned global datetime filter in localStorage). Nothing on this page reads `statsPeriod` — the Activity dropdown and all data fetching use the page-local `?period=` param — so the injected value was meaningless and confusing next to the visible time filter, which could show a different window.

This passes `skipInitializeUrlParams` to the page's `PageFiltersContainer`, the same pattern the issue stream uses, so the resolved selection is no longer echoed into the URL on load. The page filter store still initializes from URL params when present, so shared links with `?project=` keep working, and the project picker still writes `?project=` and persists to localStorage on change. The only behavior difference is that a bare URL stays bare until the user interacts with the project picker.