### PR TITLE
feat(project-keys): Turn DSN rate limit banner into a warning

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -135,15 +135,19 @@ export function KeyRateLimitsForm({
         return (
           <form.AppForm form={form}>
             <FieldGroup title={t('Rate Limits')}>
-              <Alert variant="info" system>
-                {t(
-                  `Rate limits provide a flexible way to manage your error
-                    volume. If you have a noisy project or environment you
-                    can configure a rate limit for this key to reduce the
-                    number of errors processed. To manage your transaction
-                    volume, we recommend adjusting your sample rate in your
-                    SDK configuration.`
-                )}
+              <Alert variant="warning" system>
+                <Stack gap="xs">
+                  <Text>
+                    {t(
+                      'Applying a rate limit to your DSN may cause you to miss critical but infrequent errors.'
+                    )}
+                  </Text>
+                  <Text>
+                    {t(
+                      'This limit also applies to all other telemetry types sent through this DSN, such as logs, metrics, and spans.'
+                    )}
+                  </Text>
+                </Stack>
               </Alert>
               {!hasFeature &&
                 typeof renderDisabled === 'function' &&


### PR DESCRIPTION
**Before**
<img width="1009" height="405" alt="Firefox 2026-07-23 02 57 21" src="https://github.com/user-attachments/assets/20230ffb-c3b8-4c87-9640-3dfe84eaf814" />

**After**
<img width="1003" height="388" alt="Firefox 2026-07-23 03 10 24" src="https://github.com/user-attachments/assets/344f27db-4e6f-49f4-a182-9559fa08e6cd" />
