### PR TITLE
style(autofix): Refine overview section layout

### DIFF
--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -119,12 +119,20 @@ const MutedLinkButton = styled(LinkButton)`
   color: ${p => p.theme.tokens.content.secondary};
 `;
 
-function ActionButton({actionKey, to}: {actionKey: ActionKey; to: LocationDescriptor}) {
+function ActionButton({
+  actionKey,
+  size,
+  to,
+}: {
+  actionKey: ActionKey;
+  size: 'sm' | 'xs';
+  to: LocationDescriptor;
+}) {
   const meta = ACTION_META[actionKey];
   if (actionKey === 'code_changes_ready') {
     return (
       <Tooltip title={meta.description} skipWrapper>
-        <AccentLinkButton size="sm" icon={<meta.Icon />} to={to}>
+        <AccentLinkButton size={size} icon={<meta.Icon />} to={to}>
           {meta.label}
         </AccentLinkButton>
       </Tooltip>
@@ -133,7 +141,7 @@ function ActionButton({actionKey, to}: {actionKey: ActionKey; to: LocationDescri
   if (actionKey === 'solution_ready') {
     return (
       <Tooltip title={meta.description} skipWrapper>
-        <SuccessLinkButton size="sm" icon={<meta.Icon />} to={to}>
+        <SuccessLinkButton size={size} icon={<meta.Icon />} to={to}>
           {meta.label}
         </SuccessLinkButton>
       </Tooltip>
@@ -142,7 +150,7 @@ function ActionButton({actionKey, to}: {actionKey: ActionKey; to: LocationDescri
   if (actionKey === 'errored') {
     return (
       <Tooltip title={meta.description} skipWrapper>
-        <MutedLinkButton size="sm" icon={<meta.Icon />} to={to}>
+        <MutedLinkButton size={size} icon={<meta.Icon />} to={to}>
           {meta.label}
         </MutedLinkButton>
       </Tooltip>
@@ -150,7 +158,7 @@ function ActionButton({actionKey, to}: {actionKey: ActionKey; to: LocationDescri
   }
   return (
     <Tooltip title={meta.description} skipWrapper>
-      <LinkButton size="sm" variant={meta.variant} icon={<meta.Icon />} to={to}>
+      <LinkButton size={size} variant={meta.variant} icon={<meta.Icon />} to={to}>
         {meta.label}
       </LinkButton>
     </Tooltip>
@@ -160,9 +168,11 @@ function ActionButton({actionKey, to}: {actionKey: ActionKey; to: LocationDescri
 function ReviewPrButton({
   prUrl,
   prNumber,
+  size,
 }: {
   prNumber: number | undefined;
   prUrl: string;
+  size: 'sm' | 'xs';
 }) {
   const meta = ACTION_META.review_pr;
   return (
@@ -175,7 +185,7 @@ function ReviewPrButton({
       skipWrapper
     >
       <LinkButton
-        size="sm"
+        size={size}
         variant="warning"
         icon={<IconPullRequest />}
         href={prUrl}
@@ -197,10 +207,12 @@ export function IssuePrimaryAction({
   action,
   row,
   runUrl,
+  size = 'sm',
 }: {
   action: CardAction;
   row: OverviewRow;
   runUrl: LocationDescriptor;
+  size?: 'sm' | 'xs';
 }) {
   if (row.statePending) {
     return <Text variant="muted">{'…'}</Text>;
@@ -209,10 +221,10 @@ export function IssuePrimaryAction({
     return <Tag variant="info">{t('Running')}</Tag>;
   }
   if (row.runStatus === 'error') {
-    return <ActionButton actionKey="errored" to={runUrl} />;
+    return <ActionButton actionKey="errored" size={size} to={runUrl} />;
   }
   if (row.runStatus === 'awaiting_user_input') {
-    return <ActionButton actionKey="awaiting_input" to={runUrl} />;
+    return <ActionButton actionKey="awaiting_input" size={size} to={runUrl} />;
   }
 
   switch (action.type) {
@@ -226,11 +238,11 @@ export function IssuePrimaryAction({
       );
     case 'review_pr':
       return action.prUrl ? (
-        <ReviewPrButton prUrl={action.prUrl} prNumber={action.prNumber} />
+        <ReviewPrButton prUrl={action.prUrl} prNumber={action.prNumber} size={size} />
       ) : (
-        <ActionButton actionKey="review_pr" to={runUrl} />
+        <ActionButton actionKey="review_pr" size={size} to={runUrl} />
       );
     default:
-      return <ActionButton actionKey={action.type} to={runUrl} />;
+      return <ActionButton actionKey={action.type} size={size} to={runUrl} />;
   }
 }

--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -44,7 +44,7 @@ const ACTION_META: Record<
   review_pr: {
     Icon: IconPullRequest,
     label: t('Review PR'),
-    variant: 'warning',
+    variant: 'primary',
     description: t('Autofix opened a pull request. Review and merge it.'),
   },
   code_changes_ready: {
@@ -186,7 +186,7 @@ function ReviewPrButton({
     >
       <LinkButton
         size={size}
-        variant="warning"
+        variant={meta.variant}
         icon={<IconPullRequest />}
         href={prUrl}
         external

--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -44,7 +44,7 @@ const ACTION_META: Record<
   review_pr: {
     Icon: IconPullRequest,
     label: t('Review PR'),
-    variant: 'primary',
+    variant: 'warning',
     description: t('Autofix opened a pull request. Review and merge it.'),
   },
   code_changes_ready: {
@@ -186,7 +186,7 @@ function ReviewPrButton({
     >
       <LinkButton
         size={size}
-        variant={meta.variant}
+        variant="warning"
         icon={<IconPullRequest />}
         href={prUrl}
         external

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -389,7 +389,7 @@ export function IssueTableRow({
         </Flex>
       </Stack>
       <Flex align="center" flexShrink={0}>
-        <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} />
+        <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} size="xs" />
       </Flex>
     </Flex>
   );

--- a/static/app/views/seerWorkflows/overview/sectionList.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionList.tsx
@@ -81,14 +81,16 @@ export function SectionList({
     <Stack gap="lg">
       {sections.map(section => {
         const meta = STATUS_GROUP_META[section.key];
+        const expanded = !collapsedGroups.includes(section.key);
         return (
           <StatusGroup
             key={section.key}
             size="sm"
-            expanded={!collapsedGroups.includes(section.key)}
+            expanded={expanded}
             onExpandedChange={next => onToggleGroup(section.key, next)}
+            data-view={view}
           >
-            <GroupHeader>
+            <GroupHeader data-view={view} data-expanded={expanded}>
               <Disclosure.Title>
                 <Flex gap="sm" align="center">
                   <Tooltip
@@ -102,7 +104,7 @@ export function SectionList({
                 </Flex>
               </Disclosure.Title>
             </GroupHeader>
-            <Disclosure.Content>
+            <Disclosure.Content data-view={view}>
               {section.isError ? (
                 <LoadingError onRetry={section.refetch} />
               ) : section.isPending ? (
@@ -116,7 +118,7 @@ export function SectionList({
               ) : (
                 <SectionRows
                   gap={view === 'cards' ? 'md' : '0'}
-                  paddingTop="sm"
+                  paddingTop={view === 'cards' ? 'sm' : '0'}
                   data-view={view}
                 >
                   {section.issues.map(issue => (
@@ -145,12 +147,31 @@ const SectionRows = styled(Stack)`
   }
 `;
 
-// Disclosure.Content hardcodes a padding-left to indent its panel under the
-// title; the `> * + *` sibling selector drops it so the full-width cards line
-// up flush with their group header.
+// Disclosure.Content adds panel padding by default. Cards keep the vertical
+// spacing, but table rows should sit flush against the group border and header.
 const StatusGroup = styled(Disclosure)`
+  &[data-view='table'] {
+    position: relative;
+    border-radius: ${p => p.theme.radius.md};
+
+    &::after {
+      content: '';
+      position: absolute;
+      z-index: ${p => p.theme.zIndex.initial + 1};
+      inset: 0;
+      border: 1px solid ${p => p.theme.tokens.border.primary};
+      border-radius: inherit;
+      pointer-events: none;
+    }
+  }
+
   && > * + * {
     padding-left: 0;
+    padding-right: 0;
+  }
+
+  && > * + *[data-view='table'] {
+    padding: 0;
   }
 `;
 
@@ -158,9 +179,17 @@ const StatusGroup = styled(Disclosure)`
 // Opaque background so cards scroll under it.
 const GroupHeader = styled(Sticky)`
   z-index: ${p => p.theme.zIndex.initial + 1};
-  width: 100%;
+  align-self: stretch;
   background: ${p => p.theme.tokens.background.secondary};
   border-radius: ${p => p.theme.radius.md};
+
+  &[data-view='table'] {
+    border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
+  }
+
+  &[data-view='table'][data-expanded='false'] {
+    border-radius: ${p => p.theme.radius.md};
+  }
 
   &[data-stuck] {
     border-radius: 0;


### PR DESCRIPTION
Autofix Overview sections now read as a single framed table in list view: headers and rows share the same edges, disclosure padding no longer creates gaps, and row actions use the compact `xs` size. Card view keeps its existing `sm` actions and spacing between cards.

The table frame is drawn as an overlay so its border does not shrink or offset the content box. View-specific header radii and padding keep expanded, collapsed, list, and card layouts aligned without applying the table treatment to cards.
