### PR TITLE
feat(autofix): Refactor code-change feedback list into composable cells

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import type {
@@ -882,7 +882,8 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText('(unknown): Make the button blue')).toBeInTheDocument();
+      // The source is shown in the avatar tooltip, not prefixed on the comment.
+      expect(screen.getByText('Make the button blue')).toBeInTheDocument();
     });
 
     it('renders GitHub PR review comment feedback with attribution and a link', () => {
@@ -917,11 +918,10 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const feedbackLink = screen.getByRole('link', {
-        name: 'Please handle the null value.',
-      });
+      // The comment text is plain; a trailing "Open in GitHub" arrow links out.
+      expect(screen.getByText('Please handle the null value.')).toBeInTheDocument();
+      const feedbackLink = screen.getByRole('link', {name: 'Open in GitHub'});
       expect(feedbackLink).toHaveAttribute('href', commentUrl);
-      expect(screen.getByTestId('icon-github')).toBeInTheDocument();
     });
 
     it('renders GitHub PR review body feedback with a GitHub icon and link', () => {
@@ -1001,7 +1001,7 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      expect(screen.getByText('CI check suite failed')).toBeInTheDocument();
+      expect(screen.getByText('CI failure detected')).toBeInTheDocument();
       expect(screen.queryByText(/raw text/)).not.toBeInTheDocument();
     });
 
@@ -1040,7 +1040,9 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const link = screen.getByRole('link', {name: 'CI check suite failed'});
+      // The label is plain text; a trailing "Open in GitHub" arrow links to the run.
+      expect(screen.getByText('CI failure detected')).toBeInTheDocument();
+      const link = screen.getByRole('link', {name: 'Open in GitHub'});
       expect(link).toHaveAttribute(
         'href',
         'https://github.com/org/repo/commit/abc123/checks?check_suite_id=999'
@@ -1164,7 +1166,7 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('first pass')).toBeInTheDocument();
-      expect(screen.getByTestId('icon-check-mark')).toBeInTheDocument();
+      expect(screen.getByTestId('feedback-processed')).toBeInTheDocument();
     });
 
     it('marks the current iteration feedback as in progress while processing', () => {
@@ -1182,11 +1184,11 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const row =
-        screen.getByText('fix the CI failure').parentElement!.parentElement!
-          .parentElement!;
-      expect(within(row).getByTestId('loading-indicator')).toBeInTheDocument();
-      expect(within(row).queryByTestId('icon-check-mark')).not.toBeInTheDocument();
+      // While processing, the row shows a spinner (there is also the card body
+      // "Iterating on PR…" loader, hence getAllByTestId) and no processed check.
+      expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
+      expect(screen.getAllByTestId('loading-indicator').length).toBeGreaterThan(0);
+      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
     });
 
     it('marks queued feedback with a queued label and no timestamp', () => {
@@ -1214,7 +1216,7 @@ describe('ArtifactCard', () => {
 
       expect(screen.getByText('Make the button blue')).toBeInTheDocument();
       expect(screen.getByText('Queued')).toBeInTheDocument();
-      expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
     });
 
     it('keeps reset enabled with the feature flag even when PRs exist', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -924,7 +924,7 @@ describe('ArtifactCard', () => {
       expect(feedbackLink).toHaveAttribute('href', commentUrl);
     });
 
-    it('renders GitHub PR review body feedback with a GitHub icon and link', () => {
+    it('renders a GitHub PR review body as plain feedback text', () => {
       const reviewUrl = 'https://github.com/org/repo/pull/42#pullrequestreview-999';
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
@@ -958,11 +958,17 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const feedbackLink = screen.getByRole('link', {
-        name: 'Overall this looks good, please add a test.',
-      });
-      expect(feedbackLink).toHaveAttribute('href', reviewUrl);
-      expect(screen.getByTestId('icon-github')).toBeInTheDocument();
+      // Review bodies have no dedicated cell yet, so they fall through to the
+      // generic renderer: plain text with no external link. Grouping the body
+      // with its inline comments under a state header comes in a later change.
+      expect(
+        screen.getByText('Overall this looks good, please add a test.')
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', {
+          name: 'Overall this looks good, please add a test.',
+        })
+      ).not.toBeInTheDocument();
     });
 
     it('shows a formatted check-suite label instead of the raw feedback text', () => {

--- a/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.stories.tsx
@@ -1,0 +1,313 @@
+import type {ReactNode} from 'react';
+
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import type {
+  AutofixSection,
+  ExplorerAutofixState,
+  RawFeedback,
+  useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {CodeChangesCard} from 'sentry/components/events/autofix/v3/codeChangesCard';
+import * as Storybook from 'sentry/stories';
+import type {User} from 'sentry/types/user';
+import {OrganizationContext} from 'sentry/utils/organizationContext';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
+import type {ExplorerFilePatch} from 'sentry/views/seerExplorer/types';
+
+// The Feedback section is gated behind this feature flag; the wrapper below
+// injects it so every example renders it.
+const PR_ITERATION_FEATURE = 'autofix-pr-iteration';
+
+const noop = () => {};
+
+/**
+ * A minimal but realistic code-change artifact so the card renders its diff
+ * body — the Feedback section is drawn directly above it.
+ */
+function makePatch(repoName: string, path: string): ExplorerFilePatch {
+  return {
+    repo_name: repoName,
+    diff: '',
+    patch: {
+      path,
+      added: 1,
+      removed: 1,
+      source_file: path,
+      target_file: path,
+      type: 'M',
+      hunks: [
+        {
+          section_header: '',
+          source_start: 10,
+          source_length: 3,
+          target_start: 10,
+          target_length: 3,
+          lines: [
+            {
+              line_type: ' ',
+              value: 'def handler(request):',
+              source_line_no: 10,
+              target_line_no: 10,
+              diff_line_no: null,
+            },
+            {
+              line_type: '-',
+              value: '    return user.name',
+              source_line_no: 11,
+              target_line_no: null,
+              diff_line_no: null,
+            },
+            {
+              line_type: '+',
+              value: '    return user.name if user else None',
+              source_line_no: null,
+              target_line_no: 11,
+              diff_line_no: null,
+            },
+          ],
+        },
+      ],
+    },
+  } as ExplorerFilePatch;
+}
+
+/**
+ * A folded-in PR-iteration block. Its feedback drives one iteration and renders
+ * as a `processed` item once the section is no longer processing.
+ */
+function makeFeedbackBlock(
+  iterationIndex: number,
+  feedback: RawFeedback
+): AutofixSection['blocks'][number] {
+  return {
+    id: `block-pr-${iterationIndex}`,
+    timestamp: '2026-07-20T00:00:00Z',
+    message: {
+      role: 'user',
+      content: null,
+      metadata: {
+        step: 'pr_iteration',
+        iteration_index: String(iterationIndex),
+        feedback: JSON.stringify(feedback),
+      },
+    },
+  };
+}
+
+function makeSection(
+  status: AutofixSection['status'],
+  blocks: AutofixSection['blocks']
+): AutofixSection {
+  return {
+    step: 'code_changes',
+    status,
+    blocks,
+    artifacts: [[makePatch('org/repo', 'src/handlers/user.py')]],
+  };
+}
+
+function makeAutofix(
+  queuedFeedback: RawFeedback[] = []
+): ReturnType<typeof useExplorerAutofix> {
+  const runState: ExplorerAutofixState = {
+    run_id: 123,
+    blocks: [],
+    status: 'completed',
+    updated_at: '2026-07-20T00:00:00Z',
+    queued_feedback: queuedFeedback,
+  };
+
+  return {
+    runState,
+    isLoading: false,
+    isPolling: false,
+    // Async no-ops — none of these are invoked by the static examples below.
+    startStep: () => Promise.resolve(0),
+    createPR: () => Promise.resolve(),
+    reset: noop,
+    triggerCodingAgentHandoff: () => Promise.resolve(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: noop,
+    warnings: [],
+  };
+}
+
+// Feedback source builders — one per member of the RawFeedback discriminated
+// union, mirroring the wire shapes the backend serializes.
+function userUiFeedback(text: string, user: User): RawFeedback {
+  return {text, timestamp: '2026-07-20T00:00:00Z', source: {type: 'user-ui', user}};
+}
+
+function githubPrCommentFeedback(text: string): RawFeedback {
+  return {
+    text,
+    timestamp: '2026-07-20T00:00:00Z',
+    source: {
+      type: 'github-pr-comment',
+      comment: {
+        html_url: 'https://github.com/org/repo/pull/42#issuecomment-1',
+        user: {login: 'octocat'},
+      },
+    },
+  };
+}
+
+function githubPrReviewCommentFeedback(text: string): RawFeedback {
+  return {
+    text,
+    timestamp: '2026-07-20T00:00:00Z',
+    source: {
+      type: 'github-pr-review-comment',
+      comment: {
+        html_url: 'https://github.com/org/repo/pull/42#discussion_r1',
+        user: {login: 'octocat'},
+      },
+    },
+  };
+}
+
+function checkSuiteFeedback(): RawFeedback {
+  return {
+    // `text` is ignored for check-suite; the card derives its own label.
+    text: 'raw check-suite payload',
+    timestamp: '2026-07-20T00:00:00Z',
+    source: {
+      type: 'check-suite',
+      app_name: 'CI',
+      event: {
+        check_suite: {id: 999, head_sha: 'abc1234'},
+        repository: {html_url: 'https://github.com/org/repo'},
+      },
+    },
+  };
+}
+
+// Feedback with no recognized source renders as the `other` fallback; the
+// source is named in the avatar tooltip rather than prefixed on the comment.
+function unknownFeedback(text: string): RawFeedback {
+  return {text};
+}
+
+export default Storybook.story('CodeChangesCard Feedback', story => {
+  story('All feedback sources', () => {
+    const user = useUser();
+    return (
+      <FeatureWrapper>
+        <Text size="sm" variant="muted">
+          Every feedback source type, shown as <code>processed</code> block feedback (top
+          six) plus <code>queued</code> feedback (bottom two). Newest is listed first.
+          Note: multiline text is rendered inline (newlines collapse to spaces), so long
+          comments wrap rather than preserving hard breaks.
+        </Text>
+        <CodeChangesCard
+          groupId="1"
+          autofix={makeAutofix([
+            userUiFeedback('Also rename the variable for clarity', user),
+            unknownFeedback('Feedback from an unrecognized source'),
+          ])}
+          section={makeSection('completed', [
+            makeFeedbackBlock(0, userUiFeedback('Please add a null check', user)),
+            makeFeedbackBlock(1, githubPrCommentFeedback('Can you add a test for this?')),
+            makeFeedbackBlock(
+              2,
+              githubPrReviewCommentFeedback('This branch is never hit — remove it')
+            ),
+            makeFeedbackBlock(3, checkSuiteFeedback()),
+            // Multiline GitHub PR comment — several lines of reviewer prose.
+            makeFeedbackBlock(
+              4,
+              githubPrCommentFeedback(
+                'A few things on this change:\n' +
+                  '1. Guard against the null user before dereferencing.\n' +
+                  '2. Add a regression test covering the empty-session path.\n' +
+                  '3. The early return on line 42 looks unreachable — can we drop it?'
+              )
+            ),
+            // Multiline "local" comment — feedback typed directly in the Seer UI
+            // (the user-ui source), spanning multiple lines.
+            makeFeedbackBlock(
+              5,
+              userUiFeedback(
+                'Please also handle the case where the request has no authenticated user.\n\n' +
+                  'When that happens today we throw a 500 instead of returning a clean 401, ' +
+                  'so the whole flow should degrade gracefully rather than crash.',
+                user
+              )
+            ),
+          ])}
+        />
+      </FeatureWrapper>
+    );
+  });
+
+  story('Feedback statuses', () => {
+    const user = useUser();
+    return (
+      <Stack gap="xl">
+        <StatusExample label="Processed — the iteration it drove has finished and its changes are pushed (accent checkmark).">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('completed', [
+                makeFeedbackBlock(0, userUiFeedback('Please add a null check', user)),
+              ])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+
+        <StatusExample label="In progress — driving the iteration currently being processed (spinner). The card body shows the “Iterating on PR…” loader.">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix()}
+              section={makeSection('processing', [
+                makeFeedbackBlock(0, userUiFeedback('Fix the failing CI check', user)),
+              ])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+
+        <StatusExample label="Queued — submitted while a run was processing, not yet picked up (muted circle + “Queued” label).">
+          <FeatureWrapper>
+            <CodeChangesCard
+              groupId="1"
+              autofix={makeAutofix([userUiFeedback('Make the button blue', user)])}
+              section={makeSection('completed', [])}
+            />
+          </FeatureWrapper>
+        </StatusExample>
+      </Stack>
+    );
+  });
+});
+
+/**
+ * Injects the `autofix-pr-iteration` feature into the surrounding organization
+ * so the Feedback section renders. Mirrors the pattern used by
+ * activityLineItem.stories.tsx.
+ */
+function FeatureWrapper({children}: {children: ReactNode}) {
+  const organization = useOrganization();
+  const features = [...organization.features, PR_ITERATION_FEATURE];
+
+  return (
+    <OrganizationContext.Provider value={{...organization, features}}>
+      {children}
+    </OrganizationContext.Provider>
+  );
+}
+
+function StatusExample({children, label}: {children: ReactNode; label: string}) {
+  return (
+    <Stack gap="sm">
+      <Text size="sm" variant="muted">
+        {label}
+      </Text>
+      {children}
+    </Stack>
+  );
+}

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -1,15 +1,10 @@
-import {Fragment, useMemo} from 'react';
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
+import { Fragment, useMemo } from "react";
 
-import {UserAvatar} from '@sentry/scraps/avatar';
-import {Tag} from '@sentry/scraps/badge';
-import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
-import {Markdown} from '@sentry/scraps/markdown';
-import {Prose, Text} from '@sentry/scraps/text';
-import {Tooltip} from '@sentry/scraps/tooltip';
+import { Tag } from "@sentry/scraps/badge";
+import { Button } from "@sentry/scraps/button";
+import { Flex, Stack } from "@sentry/scraps/layout";
+import { Markdown } from "@sentry/scraps/markdown";
+import { Text } from "@sentry/scraps/text";
 
 import {
   collectPatches,
@@ -17,144 +12,31 @@ import {
   isCodeChangesArtifact,
   isPrIterationBlock,
   type AutofixSection,
-  type RawFeedback,
   type useExplorerAutofix,
-} from 'sentry/components/events/autofix/useExplorerAutofix';
-import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
-import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
-import {ArtifactLoadingDetails} from 'sentry/components/events/autofix/v3/artifactLoadingDetails';
-import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixResetPrompt';
-import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
-import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
-import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {TimeSince} from 'sentry/components/timeSince';
-import {IconCheckmark} from 'sentry/icons/iconCheckmark';
-import {IconClock} from 'sentry/icons/iconClock';
-import {IconCode} from 'sentry/icons/iconCode';
-import {IconGithub} from 'sentry/icons/iconGithub';
-import {IconRefresh} from 'sentry/icons/iconRefresh';
-import {t, tn} from 'sentry/locale';
-import type {User} from 'sentry/types/user';
-import {defined} from 'sentry/utils/defined';
-import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
+} from "sentry/components/events/autofix/useExplorerAutofix";
+import { ArtifactCard } from "sentry/components/events/autofix/v3/artifactCard";
+import { ArtifactDetails } from "sentry/components/events/autofix/v3/artifactDetails";
+import { ArtifactLoadingDetails } from "sentry/components/events/autofix/v3/artifactLoadingDetails";
+import { AutofixResetPrompt } from "sentry/components/events/autofix/v3/autofixResetPrompt";
+import {
+  FeedbackList,
+  usePrIterationFeedback,
+} from "sentry/components/events/autofix/v3/feedbackList";
+import { PrIterationFeedbackForm } from "sentry/components/events/autofix/v3/prIterationFeedbackForm";
+import { useResetAutofixStep } from "sentry/components/events/autofix/v3/useResetAutofixStep";
+import { artifactToMarkdown } from "sentry/components/events/autofix/v3/utils";
+import { IconCode } from "sentry/icons/iconCode";
+import { IconRefresh } from "sentry/icons/iconRefresh";
+import { t, tn } from "sentry/locale";
+import { defined } from "sentry/utils/defined";
+import { useCopyToClipboard } from "sentry/utils/useCopyToClipboard";
+import { useOrganization } from "sentry/utils/useOrganization";
+import { FileDiffViewer } from "sentry/views/seerExplorer/components/fileDiffViewer";
 
 interface CodeChangesCardProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
   groupId: string;
   section: AutofixSection;
-}
-
-/**
- * - `processed`: the iteration it drove has finished and its changes are pushed.
- * - `in_progress`: it's driving the iteration currently being processed.
- * - `queued`: submitted while a run was processing, not yet picked up.
- */
-type FeedbackStatus = 'processed' | 'in_progress' | 'queued';
-
-interface ParsedBaseFeedback {
-  text: string;
-  timestamp?: string;
-}
-
-interface UserUiFeedback extends ParsedBaseFeedback {
-  sourceType: 'user-ui';
-  user?: User | null;
-}
-
-interface GithubPrCommentFeedback extends ParsedBaseFeedback {
-  commentUrl: string;
-  sourceType: 'github-pr-comment' | 'github-pr-review-comment' | 'github-pr-review-body';
-  githubUsername?: string;
-}
-
-interface CheckSuiteFeedback extends ParsedBaseFeedback {
-  appName: string;
-  checkSuiteUrl: string;
-  sourceType: 'check-suite';
-}
-interface OtherFeedback extends ParsedBaseFeedback {
-  source: string;
-  sourceType: 'other';
-}
-
-// What `parseFeedback` can produce from the stored JSON alone.
-type ParsedFeedback =
-  | UserUiFeedback
-  | GithubPrCommentFeedback
-  | CheckSuiteFeedback
-  | OtherFeedback;
-
-// A parsed feedback enriched with the iteration context the caller supplies.
-type IterationFeedback = ParsedFeedback & {
-  iterationIndex: number;
-  status: FeedbackStatus;
-};
-
-function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
-  // `ui_text` is the short display label the backend derives per source; fall
-  // back to the raw prompt `text` for feedback serialized before it existed.
-  const base = {
-    text: parsed.ui_text ?? parsed.text,
-    timestamp: parsed.timestamp,
-  };
-  const source = parsed.source;
-  switch (source?.type) {
-    case 'user-ui':
-      return {...base, sourceType: 'user-ui', user: source.user};
-    case 'github-pr-comment':
-    case 'github-pr-review-comment': {
-      const commentUrl = source.comment?.html_url;
-      if (!commentUrl) {
-        return null;
-      }
-      return {
-        ...base,
-        sourceType: source.type,
-        githubUsername: source.comment?.user?.login,
-        commentUrl,
-      };
-    }
-    case 'github-pr-review-body': {
-      // Unlike a review comment, the review body carries its link directly on
-      // `html_url` and has no comment author login to attribute.
-      const commentUrl = source.html_url;
-      if (!commentUrl) {
-        return null;
-      }
-      return {
-        ...base,
-        sourceType: source.type,
-        commentUrl,
-      };
-    }
-    case 'check-suite': {
-      const appName = source.app_name;
-      const {head_sha: headSha, id: checkSuiteId} = source.event.check_suite;
-      const repoUrl = source.event.repository.html_url;
-      return {
-        ...base,
-        text: t('%s check suite failed', appName),
-        sourceType: 'check-suite',
-        appName,
-        checkSuiteUrl: `${repoUrl}/commit/${headSha}/checks?check_suite_id=${checkSuiteId}`,
-      };
-    }
-    default:
-      return {
-        ...base,
-        sourceType: 'other',
-        source: parsed.source?.type ?? 'unknown',
-      };
-  }
-}
-
-function parseFeedback(raw: string): ParsedFeedback[] {
-  const parsed: RawFeedback | RawFeedback[] = JSON.parse(raw);
-  const items = Array.isArray(parsed) ? parsed : [parsed];
-  return items.map(parseFeedbackItem).filter(defined);
 }
 
 function getFinalExplanation(section: AutofixSection): string | null {
@@ -164,103 +46,44 @@ function getFinalExplanation(section: AutofixSection): string | null {
       continue;
     }
     const message = block.message;
-    if (message.role === 'assistant' && message.content?.trim()) {
+    if (message.role === "assistant" && message.content?.trim()) {
       return message.content.trim();
     }
   }
   return null;
 }
 
-export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProps) {
+export function CodeChangesCard({
+  autofix,
+  groupId,
+  section,
+}: CodeChangesCardProps) {
   const organization = useOrganization();
-  const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
+  const hasPrIterationFeature = organization.features.includes(
+    "autofix-pr-iteration",
+  );
 
   const isIterating =
     hasPrIterationFeature &&
-    section.status === 'processing' &&
+    section.status === "processing" &&
     section.blocks.some(isPrIterationBlock);
 
   const currentStepStart = useMemo(
-    () => section.blocks.findLastIndex(block => defined(block.message.metadata?.step)),
-    [section.blocks]
-  );
-
-  // PR iterations are folded into this section's blocks. Surface the feedback
-  // that drove each one — the cumulative diff is already merged into the
-  // section's code-change artifact by getOrderedAutofixSections. Feedback on a
-  // block at/after the current step marker drives the iteration still running
-  // (when the section is processing); everything earlier is already pushed.
-  const blockFeedback = useMemo<IterationFeedback[]>(() => {
-    if (!hasPrIterationFeature) {
-      return [];
-    }
-
-    return section.blocks.flatMap((block, blockIndex) => {
-      if (!isPrIterationBlock(block)) {
-        return [];
-      }
-
-      const metadata = block.message.metadata;
-      const value = metadata?.feedback;
-      const iterationIndex = metadata?.iteration_index;
-
-      if (!value || iterationIndex === undefined) {
-        return [];
-      }
-
-      const status: FeedbackStatus =
-        section.status === 'processing' && blockIndex >= currentStepStart
-          ? 'in_progress'
-          : 'processed';
-
-      return parseFeedback(value).map(parsed => ({
-        ...parsed,
-        iterationIndex: Number(iterationIndex),
-        status,
-      }));
-    });
-  }, [section.blocks, section.status, currentStepStart, hasPrIterationFeature]);
-
-  const latestIterationIndex = useMemo(
     () =>
-      blockFeedback.reduce<number | null>(
-        (max, item) =>
-          max === null ? item.iterationIndex : Math.max(max, item.iterationIndex),
-        null
+      section.blocks.findLastIndex((block) =>
+        defined(block.message.metadata?.step),
       ),
-    [blockFeedback]
+    [section.blocks],
   );
 
-  // Feedback submitted while this run is processing that hasn't been picked up
-  // and folded into a block yet. It will become the next iteration.
-  const queuedFeedback = useMemo<IterationFeedback[]>(() => {
-    if (!hasPrIterationFeature) {
-      return [];
-    }
-
-    return (autofix.runState?.queued_feedback ?? []).flatMap(raw => {
-      const parsed = parseFeedbackItem(raw);
-      if (!parsed) {
-        return [];
-      }
-
-      return [
-        {
-          ...parsed,
-          iterationIndex: (latestIterationIndex ?? -1) + 1,
-          status: 'queued' as const,
-        },
-      ];
-    });
-  }, [autofix.runState?.queued_feedback, latestIterationIndex, hasPrIterationFeature]);
-
-  const feedback = useMemo(
-    () => [...blockFeedback, ...queuedFeedback].reverse(),
-    [blockFeedback, queuedFeedback]
+  const { feedback, latestIterationIndex } = usePrIterationFeedback(
+    section,
+    autofix,
+    hasPrIterationFeature,
   );
 
   const loadingBlocks = useMemo(() => {
-    if (section.status !== 'processing') {
+    if (section.status !== "processing") {
       return [];
     }
     if (currentStepStart === -1) {
@@ -274,10 +97,10 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     return isCodeChangesArtifact(sectionArtifact) ? sectionArtifact : null;
   }, [section]);
 
-  const {copy} = useCopyToClipboard();
+  const { copy } = useCopyToClipboard();
   const markdown = useMemo(
     () => (artifact ? artifactToMarkdown(artifact) : null),
-    [artifact]
+    [artifact],
   );
 
   const prIterationEnabled = hasPrIterationFeature;
@@ -286,17 +109,20 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
   const isResetEligible = prIterationEnabled
-    ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
-    : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
+    ? noCodingAgents && (hasPRs || autofix.runState?.status !== "processing")
+    : noCodingAgents && !hasPRs && autofix.runState?.status !== "processing";
 
-  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
+  const { canReset, shouldShowReset, setShouldShowReset, handleReset } =
     useResetAutofixStep({
       autofix,
       canReset: isResetEligible,
       section,
-      step: 'code_changes',
+      step: "code_changes",
     });
-  const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
+  const patchesByRepo = useMemo(
+    () => collectPatches(artifact ?? []),
+    [artifact],
+  );
 
   const explanation = useMemo(() => getFinalExplanation(section), [section]);
 
@@ -313,13 +139,13 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
 
     if (reposChanged === 1) {
       return tn(
-        '%s file changed in 1 repo',
-        '%s files changed in 1 repo',
-        filesChanged.size
+        "%s file changed in 1 repo",
+        "%s files changed in 1 repo",
+        filesChanged.size,
       );
     }
 
-    return t('%s files changed in %s repos', filesChanged.size, reposChanged);
+    return t("%s files changed in %s repos", filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
   const showPrIterationForm = hasPRs && prIterationEnabled;
@@ -333,19 +159,39 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
     />
   );
 
-  let title: React.ReactNode = t('Code Changes');
+  // The reset affordance shown inside a content branch when the user has opened
+  // it: the PR-iteration feedback form when PRs exist, otherwise a free-text
+  // reset prompt whose copy the branch supplies.
+  function resetPrompt(prompt: string, placeholder: string): React.ReactNode {
+    if (!shouldShowReset) {
+      return null;
+    }
+    if (showPrIterationForm) {
+      return prIterationForm;
+    }
+    return (
+      <AutofixResetPrompt
+        onClosePrompt={() => setShouldShowReset(false)}
+        onReset={handleReset}
+        placeholder={placeholder}
+        prompt={prompt}
+      />
+    );
+  }
+
+  let title: React.ReactNode = t("Code Changes");
   if (latestIterationIndex !== null) {
     title = (
       <Flex gap="md" align="center">
-        {t('Code Changes')}
+        {t("Code Changes")}
         {/* `iteration_index` is zero-based; display a one-based version number. */}
-        <Tag variant="muted">{t('v%s - Latest', latestIterationIndex + 1)}</Tag>
+        <Tag variant="muted">{t("v%s - Latest", latestIterationIndex + 1)}</Tag>
       </Flex>
     );
   }
 
   let content: React.ReactNode;
-  if (section.status === 'processing') {
+  if (section.status === "processing") {
     content = (
       <Fragment>
         {/* PR iteration feedback is queued while a run is in progress, so keep
@@ -354,38 +200,25 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
         <ArtifactLoadingDetails
           blocks={loadingBlocks}
           loadingMessage={
-            isIterating ? t('Iterating on PR…') : t('Implementing changes…')
+            isIterating ? t("Iterating on PR…") : t("Implementing changes…")
           }
         />
       </Fragment>
     );
-  } else if (section.status === 'completed' && artifact && patchesByRepo.size) {
-    let resetSection: React.ReactNode = null;
-    if (shouldShowReset) {
-      if (showPrIterationForm) {
-        resetSection = prIterationForm;
-      } else {
-        resetSection = (
-          <AutofixResetPrompt
-            onClosePrompt={() => setShouldShowReset(false)}
-            onReset={handleReset}
-            placeholder={t('Give seer additional context to improve this code change.')}
-            prompt={t('How can this code change be improved?')}
-          />
-        );
-      }
-    }
-
+  } else if (section.status === "completed" && artifact && patchesByRepo.size) {
     content = (
       <Fragment>
-        {resetSection}
+        {resetPrompt(
+          t("How can this code change be improved?"),
+          t("Give seer additional context to improve this code change."),
+        )}
         <ArtifactDetails>
           <Text>{summary}</Text>
         </ArtifactDetails>
         {[...patchesByRepo.entries()].map(([repo, patches]) => (
           <ArtifactDetails key={repo}>
             <Flex gap="lg">
-              <Text bold>{t('Repository:')}</Text>
+              <Text bold>{t("Repository:")}</Text>
               <Text>{repo}</Text>
             </Flex>
             {patches.map((patch, index) => (
@@ -402,42 +235,33 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       </Fragment>
     );
   } else if (explanation) {
-    let resetSection: React.ReactNode;
-    if (!shouldShowReset) {
-      resetSection = (
-        <Flex>
-          <Button
-            variant="primary"
-            icon={<IconRefresh />}
-            disabled={!canReset}
-            onClick={() => setShouldShowReset(true)}
-          >
-            {t('Add context & retry')}
-          </Button>
-        </Flex>
-      );
-    } else if (showPrIterationForm) {
-      resetSection = prIterationForm;
-    } else {
-      resetSection = (
-        <AutofixResetPrompt
-          onClosePrompt={() => setShouldShowReset(false)}
-          onReset={handleReset}
-          placeholder={t(
-            'Add context that could unblock the change, e.g. the repo or files to edit.'
-          )}
-          prompt={t('What additional context should Seer use?')}
-        />
-      );
-    }
-
     content = (
       <ArtifactDetails gap="lg">
         <Stack gap="md">
-          <Text bold>{t("Seer proposed a fix but couldn't apply it automatically")}</Text>
+          <Text bold>
+            {t("Seer proposed a fix but couldn't apply it automatically")}
+          </Text>
           <Markdown raw={explanation} />
         </Stack>
-        {resetSection}
+        {shouldShowReset ? (
+          resetPrompt(
+            t("What additional context should Seer use?"),
+            t(
+              "Add context that could unblock the change, e.g. the repo or files to edit.",
+            ),
+          )
+        ) : (
+          <Flex>
+            <Button
+              variant="primary"
+              icon={<IconRefresh />}
+              disabled={!canReset}
+              onClick={() => setShouldShowReset(true)}
+            >
+              {t("Add context & retry")}
+            </Button>
+          </Flex>
+        )}
       </ArtifactDetails>
     );
   } else {
@@ -445,12 +269,16 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       <ArtifactDetails>
         <Text>
           {t(
-            'Seer failed to generate a code change. This one is on us. Try running it again.'
+            "Seer failed to generate a code change. This one is on us. Try running it again.",
           )}
         </Text>
         <Flex>
-          <Button variant="primary" icon={<IconRefresh />} onClick={() => handleReset()}>
-            {t('Re-run')}
+          <Button
+            variant="primary"
+            icon={<IconRefresh />}
+            onClick={() => handleReset()}
+          >
+            {t("Re-run")}
           </Button>
         </Flex>
       </ArtifactDetails>
@@ -463,147 +291,14 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       title={title}
       onCopy={
         markdown
-          ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})
+          ? () => copy(markdown, { successMessage: t("Copied to clipboard.") })
           : undefined
       }
       allowReset
       onReset={canReset ? () => setShouldShowReset(true) : undefined}
     >
-      {feedback.length > 0 && (
-        <ArtifactDetails>
-          <Text bold>{t('Feedback')}</Text>
-          {feedback.map((item, index) => (
-            <FeedbackItem key={`${item.iterationIndex}-${index}`} item={item} />
-          ))}
-        </ArtifactDetails>
-      )}
+      <FeedbackList items={feedback} />
       {content}
     </ArtifactCard>
-  );
-}
-
-function feedbackLinkUrl(item: IterationFeedback): string | undefined {
-  switch (item.sourceType) {
-    case 'github-pr-comment':
-    case 'github-pr-review-comment':
-    case 'github-pr-review-body':
-      return item.commentUrl;
-    case 'check-suite':
-      return item.checkSuiteUrl;
-    default:
-      return undefined;
-  }
-}
-
-function FeedbackAttribution({item}: {item: IterationFeedback}) {
-  switch (item.sourceType) {
-    case 'github-pr-comment':
-    case 'github-pr-review-comment':
-    case 'github-pr-review-body': {
-      const fallbackTitle =
-        item.sourceType === 'github-pr-review-body'
-          ? t('GitHub PR review')
-          : t('GitHub PR comment');
-      return (
-        <Tooltip title={item.githubUsername ?? fallbackTitle} skipWrapper>
-          <ExternalLink href={item.commentUrl}>
-            <Flex align="center">
-              <IconGithub size="md" data-test-id="icon-github" />
-            </Flex>
-          </ExternalLink>
-        </Tooltip>
-      );
-    }
-    case 'check-suite': {
-      const icon = (
-        <Flex align="center">
-          <IconGithub size="md" />
-        </Flex>
-      );
-      return (
-        <Tooltip title={t('%s check suite', item.appName)} skipWrapper>
-          <ExternalLink href={item.checkSuiteUrl}>{icon}</ExternalLink>
-        </Tooltip>
-      );
-    }
-    case 'user-ui':
-      return item.user ? <UserAvatar size={16} user={item.user} hasTooltip /> : null;
-    default:
-      return null;
-  }
-}
-
-function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
-  switch (status) {
-    case 'processed':
-      return (
-        <Tooltip title={t('Changes from this feedback have been pushed')}>
-          <Tag variant="success" icon={<IconCheckmark />} />
-        </Tooltip>
-      );
-    case 'in_progress':
-      return (
-        <Tooltip title={t('This feedback is being processed')}>
-          <LoadingIndicator size={14} style={{margin: 0}} />
-        </Tooltip>
-      );
-    case 'queued':
-      return <Tag variant="muted" icon={<IconClock />} />;
-    default:
-      return null;
-  }
-}
-
-const FeedbackProse = styled(Prose)<{muted?: boolean}>`
-  ${p =>
-    p.muted
-      ? css`
-          color: ${p.theme.tokens.content.secondary};
-        `
-      : ''}
-`;
-
-function FeedbackItem({item}: {item: IterationFeedback}) {
-  const isQueued = item.status === 'queued';
-  const linkUrl = feedbackLinkUrl(item);
-  return (
-    <Flex gap="md" align="start" justify="between">
-      <Flex gap="md" align="start" flex="1" minWidth={0}>
-        <Flex align="center" gap="md" height="1lh">
-          <Flex align="center" justify="center" width="28px">
-            <FeedbackStatusIcon status={item.status} />
-          </Flex>
-          <FeedbackAttribution item={item} />
-        </Flex>
-        <Flex align="center" minWidth={0} minHeight="1lh">
-          {linkUrl ? (
-            <ExternalLink href={linkUrl}>{item.text}</ExternalLink>
-          ) : (
-            <FeedbackProse muted={isQueued}>
-              <p>
-                {item.sourceType === 'other'
-                  ? `(${item.source}): ${item.text}`
-                  : item.text}
-              </p>
-            </FeedbackProse>
-          )}
-        </Flex>
-      </Flex>
-      {isQueued ? (
-        <Flex flex="0 0 auto" align="center" height="1lh">
-          <Text variant="muted" size="sm" wrap="nowrap">
-            {t('Queued')}
-          </Text>
-        </Flex>
-      ) : (
-        item.timestamp && (
-          <Flex flex="0 0 auto" align="center" height="1lh">
-            <Text variant="muted" size="sm" wrap="nowrap">
-              <TimeSince date={item.timestamp} />
-            </Text>
-          </Flex>
-        )
-      )}
-    </Flex>
   );
 }

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -1,10 +1,10 @@
-import { Fragment, useMemo } from "react";
+import {Fragment, useMemo} from 'react';
 
-import { Tag } from "@sentry/scraps/badge";
-import { Button } from "@sentry/scraps/button";
-import { Flex, Stack } from "@sentry/scraps/layout";
-import { Markdown } from "@sentry/scraps/markdown";
-import { Text } from "@sentry/scraps/text";
+import {Tag} from '@sentry/scraps/badge';
+import {Button} from '@sentry/scraps/button';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
+import {Text} from '@sentry/scraps/text';
 
 import {
   collectPatches,
@@ -13,25 +13,25 @@ import {
   isPrIterationBlock,
   type AutofixSection,
   type useExplorerAutofix,
-} from "sentry/components/events/autofix/useExplorerAutofix";
-import { ArtifactCard } from "sentry/components/events/autofix/v3/artifactCard";
-import { ArtifactDetails } from "sentry/components/events/autofix/v3/artifactDetails";
-import { ArtifactLoadingDetails } from "sentry/components/events/autofix/v3/artifactLoadingDetails";
-import { AutofixResetPrompt } from "sentry/components/events/autofix/v3/autofixResetPrompt";
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
+import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
+import {ArtifactLoadingDetails} from 'sentry/components/events/autofix/v3/artifactLoadingDetails';
+import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixResetPrompt';
 import {
   FeedbackList,
   usePrIterationFeedback,
-} from "sentry/components/events/autofix/v3/feedbackList";
-import { PrIterationFeedbackForm } from "sentry/components/events/autofix/v3/prIterationFeedbackForm";
-import { useResetAutofixStep } from "sentry/components/events/autofix/v3/useResetAutofixStep";
-import { artifactToMarkdown } from "sentry/components/events/autofix/v3/utils";
-import { IconCode } from "sentry/icons/iconCode";
-import { IconRefresh } from "sentry/icons/iconRefresh";
-import { t, tn } from "sentry/locale";
-import { defined } from "sentry/utils/defined";
-import { useCopyToClipboard } from "sentry/utils/useCopyToClipboard";
-import { useOrganization } from "sentry/utils/useOrganization";
-import { FileDiffViewer } from "sentry/views/seerExplorer/components/fileDiffViewer";
+} from 'sentry/components/events/autofix/v3/feedbackList';
+import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
+import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
+import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
+import {IconCode} from 'sentry/icons/iconCode';
+import {IconRefresh} from 'sentry/icons/iconRefresh';
+import {t, tn} from 'sentry/locale';
+import {defined} from 'sentry/utils/defined';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
 interface CodeChangesCardProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -46,44 +46,35 @@ function getFinalExplanation(section: AutofixSection): string | null {
       continue;
     }
     const message = block.message;
-    if (message.role === "assistant" && message.content?.trim()) {
+    if (message.role === 'assistant' && message.content?.trim()) {
       return message.content.trim();
     }
   }
   return null;
 }
 
-export function CodeChangesCard({
-  autofix,
-  groupId,
-  section,
-}: CodeChangesCardProps) {
+export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProps) {
   const organization = useOrganization();
-  const hasPrIterationFeature = organization.features.includes(
-    "autofix-pr-iteration",
-  );
+  const hasPrIterationFeature = organization.features.includes('autofix-pr-iteration');
 
   const isIterating =
     hasPrIterationFeature &&
-    section.status === "processing" &&
+    section.status === 'processing' &&
     section.blocks.some(isPrIterationBlock);
 
   const currentStepStart = useMemo(
-    () =>
-      section.blocks.findLastIndex((block) =>
-        defined(block.message.metadata?.step),
-      ),
-    [section.blocks],
+    () => section.blocks.findLastIndex(block => defined(block.message.metadata?.step)),
+    [section.blocks]
   );
 
-  const { feedback, latestIterationIndex } = usePrIterationFeedback(
+  const {feedback, latestIterationIndex} = usePrIterationFeedback(
     section,
     autofix,
-    hasPrIterationFeature,
+    hasPrIterationFeature
   );
 
   const loadingBlocks = useMemo(() => {
-    if (section.status !== "processing") {
+    if (section.status !== 'processing') {
       return [];
     }
     if (currentStepStart === -1) {
@@ -97,10 +88,10 @@ export function CodeChangesCard({
     return isCodeChangesArtifact(sectionArtifact) ? sectionArtifact : null;
   }, [section]);
 
-  const { copy } = useCopyToClipboard();
+  const {copy} = useCopyToClipboard();
   const markdown = useMemo(
     () => (artifact ? artifactToMarkdown(artifact) : null),
-    [artifact],
+    [artifact]
   );
 
   const prIterationEnabled = hasPrIterationFeature;
@@ -109,20 +100,17 @@ export function CodeChangesCard({
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
   const isResetEligible = prIterationEnabled
-    ? noCodingAgents && (hasPRs || autofix.runState?.status !== "processing")
-    : noCodingAgents && !hasPRs && autofix.runState?.status !== "processing";
+    ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
+    : noCodingAgents && !hasPRs && autofix.runState?.status !== 'processing';
 
-  const { canReset, shouldShowReset, setShouldShowReset, handleReset } =
+  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
     useResetAutofixStep({
       autofix,
       canReset: isResetEligible,
       section,
-      step: "code_changes",
+      step: 'code_changes',
     });
-  const patchesByRepo = useMemo(
-    () => collectPatches(artifact ?? []),
-    [artifact],
-  );
+  const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
 
   const explanation = useMemo(() => getFinalExplanation(section), [section]);
 
@@ -139,13 +127,13 @@ export function CodeChangesCard({
 
     if (reposChanged === 1) {
       return tn(
-        "%s file changed in 1 repo",
-        "%s files changed in 1 repo",
-        filesChanged.size,
+        '%s file changed in 1 repo',
+        '%s files changed in 1 repo',
+        filesChanged.size
       );
     }
 
-    return t("%s files changed in %s repos", filesChanged.size, reposChanged);
+    return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
   const showPrIterationForm = hasPRs && prIterationEnabled;
@@ -179,19 +167,19 @@ export function CodeChangesCard({
     );
   }
 
-  let title: React.ReactNode = t("Code Changes");
+  let title: React.ReactNode = t('Code Changes');
   if (latestIterationIndex !== null) {
     title = (
       <Flex gap="md" align="center">
-        {t("Code Changes")}
+        {t('Code Changes')}
         {/* `iteration_index` is zero-based; display a one-based version number. */}
-        <Tag variant="muted">{t("v%s - Latest", latestIterationIndex + 1)}</Tag>
+        <Tag variant="muted">{t('v%s - Latest', latestIterationIndex + 1)}</Tag>
       </Flex>
     );
   }
 
   let content: React.ReactNode;
-  if (section.status === "processing") {
+  if (section.status === 'processing') {
     content = (
       <Fragment>
         {/* PR iteration feedback is queued while a run is in progress, so keep
@@ -200,17 +188,17 @@ export function CodeChangesCard({
         <ArtifactLoadingDetails
           blocks={loadingBlocks}
           loadingMessage={
-            isIterating ? t("Iterating on PR…") : t("Implementing changes…")
+            isIterating ? t('Iterating on PR…') : t('Implementing changes…')
           }
         />
       </Fragment>
     );
-  } else if (section.status === "completed" && artifact && patchesByRepo.size) {
+  } else if (section.status === 'completed' && artifact && patchesByRepo.size) {
     content = (
       <Fragment>
         {resetPrompt(
-          t("How can this code change be improved?"),
-          t("Give seer additional context to improve this code change."),
+          t('How can this code change be improved?'),
+          t('Give seer additional context to improve this code change.')
         )}
         <ArtifactDetails>
           <Text>{summary}</Text>
@@ -218,7 +206,7 @@ export function CodeChangesCard({
         {[...patchesByRepo.entries()].map(([repo, patches]) => (
           <ArtifactDetails key={repo}>
             <Flex gap="lg">
-              <Text bold>{t("Repository:")}</Text>
+              <Text bold>{t('Repository:')}</Text>
               <Text>{repo}</Text>
             </Flex>
             {patches.map((patch, index) => (
@@ -238,17 +226,15 @@ export function CodeChangesCard({
     content = (
       <ArtifactDetails gap="lg">
         <Stack gap="md">
-          <Text bold>
-            {t("Seer proposed a fix but couldn't apply it automatically")}
-          </Text>
+          <Text bold>{t("Seer proposed a fix but couldn't apply it automatically")}</Text>
           <Markdown raw={explanation} />
         </Stack>
         {shouldShowReset ? (
           resetPrompt(
-            t("What additional context should Seer use?"),
+            t('What additional context should Seer use?'),
             t(
-              "Add context that could unblock the change, e.g. the repo or files to edit.",
-            ),
+              'Add context that could unblock the change, e.g. the repo or files to edit.'
+            )
           )
         ) : (
           <Flex>
@@ -258,7 +244,7 @@ export function CodeChangesCard({
               disabled={!canReset}
               onClick={() => setShouldShowReset(true)}
             >
-              {t("Add context & retry")}
+              {t('Add context & retry')}
             </Button>
           </Flex>
         )}
@@ -269,16 +255,12 @@ export function CodeChangesCard({
       <ArtifactDetails>
         <Text>
           {t(
-            "Seer failed to generate a code change. This one is on us. Try running it again.",
+            'Seer failed to generate a code change. This one is on us. Try running it again.'
           )}
         </Text>
         <Flex>
-          <Button
-            variant="primary"
-            icon={<IconRefresh />}
-            onClick={() => handleReset()}
-          >
-            {t("Re-run")}
+          <Button variant="primary" icon={<IconRefresh />} onClick={() => handleReset()}>
+            {t('Re-run')}
           </Button>
         </Flex>
       </ArtifactDetails>
@@ -291,7 +273,7 @@ export function CodeChangesCard({
       title={title}
       onCopy={
         markdown
-          ? () => copy(markdown, { successMessage: t("Copied to clipboard.") })
+          ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})
           : undefined
       }
       allowReset

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -317,8 +317,22 @@ function GithubAvatar({item}: {item: IterationFeedback}) {
     item.sourceType === 'github-pr-review-comment'
       ? item.githubUsername
       : undefined;
-  // Synthetic avatar user: we only have the GitHub login, no Sentry user record.
-  const user = login ? ({username: login, name: login} as AvatarUser) : null;
+  // We only get the GitHub login on the wire (no Sentry user, no avatar URL), so
+  // point the avatar at GitHub's per-login image (`github.com/<login>.png`).
+  // UserAvatar falls back to a letter avatar from the login if it fails to load.
+  const user = login
+    ? ({
+        // GitHub's noreply email for the login. `email` must be present so
+        // UserAvatar's `isActor` check (`email === undefined`) treats this as an
+        // AvatarUser and honors the `avatar` field — an Actor is forced to a
+        // letter avatar. (The exact `ID+login@...` form needs the numeric GitHub
+        // user id, which isn't on the wire, so we use the id-less variant.)
+        email: `${login}@users.noreply.github.com`,
+        username: login,
+        name: login,
+        avatar: {avatarType: 'upload', avatarUrl: `https://github.com/${login}.png`},
+      } as AvatarUser)
+    : null;
   return (
     <AuthorAvatar
       user={user}

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -344,9 +344,7 @@ function GithubAvatar({item}: {item: IterationFeedback}) {
 
 function CheckSuiteAvatar() {
   // A system notice — no author, so the source icon is the primary glyph.
-  return (
-    <PrimaryIconAvatar Icon={IconGithub} tooltip={postedOnLabel(null, t('GitHub'))} />
-  );
+  return <PrimaryIconAvatar Icon={IconGithub} tooltip={t('GitHub Actions failed')} />;
 }
 
 // A comment whose author/source we can't identify. We render `LetterAvatar`
@@ -362,10 +360,12 @@ function UnknownAvatarCell({item}: {item: IterationFeedback}) {
     initials: '?',
   } as React.ComponentProps<typeof LetterAvatar>['configuration'];
 
-  const source = item.sourceType === 'other' ? item.source : 'unknown';
+  // Unknown source: show the raw source name alone (no "posted by" framing,
+  // since we can't attribute it to an author or a known origin).
+  const source = item.sourceType === 'other' ? item.source : t('unknown');
 
   return (
-    <Tooltip title={postedOnLabel(null, source)}>
+    <Tooltip title={source}>
       <AvatarFrame>
         <UnknownLetterAvatar round configuration={configuration} />
       </AvatarFrame>

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -1,0 +1,528 @@
+import {useMemo} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {LetterAvatar, UserAvatar} from '@sentry/scraps/avatar';
+import {Flex, Grid} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {
+  isPrIterationBlock,
+  type AutofixSection,
+  type RawFeedback,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconCircle} from 'sentry/icons/iconCircle';
+import {IconCircleCheckmark} from 'sentry/icons/iconCircleCheckmark';
+import {IconGithub} from 'sentry/icons/iconGithub';
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {IconSeer} from 'sentry/icons/iconSeer';
+import {t} from 'sentry/locale';
+import type {AvatarUser, User} from 'sentry/types/user';
+import {defined} from 'sentry/utils/defined';
+import {userDisplayName} from 'sentry/utils/formatters';
+
+const AVATAR_SIZE = 24;
+const SOURCE_BADGE_SIZE = 14;
+
+/**
+ * - `processed`: the iteration it drove has finished and its changes are pushed.
+ * - `in_progress`: it's driving the iteration currently being processed.
+ * - `queued`: submitted while a run was processing, not yet picked up.
+ */
+type FeedbackStatus = 'processed' | 'in_progress' | 'queued';
+
+interface ParsedBaseFeedback {
+  text: string;
+  timestamp?: string;
+}
+
+interface UserUiFeedback extends ParsedBaseFeedback {
+  sourceType: 'user-ui';
+  user?: User | null;
+}
+
+interface GithubPrCommentFeedback extends ParsedBaseFeedback {
+  commentUrl: string;
+  sourceType: 'github-pr-comment' | 'github-pr-review-comment';
+  githubUsername?: string;
+}
+
+interface CheckSuiteFeedback extends ParsedBaseFeedback {
+  checkSuiteUrl: string;
+  sourceType: 'check-suite';
+}
+interface OtherFeedback extends ParsedBaseFeedback {
+  source: string;
+  sourceType: 'other';
+}
+
+// What `parseFeedback` can produce from the stored JSON alone.
+type ParsedFeedback =
+  | UserUiFeedback
+  | GithubPrCommentFeedback
+  | CheckSuiteFeedback
+  | OtherFeedback;
+
+// A parsed feedback enriched with the iteration context the caller supplies.
+type IterationFeedback = ParsedFeedback & {
+  iterationIndex: number;
+  status: FeedbackStatus;
+};
+
+function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
+  // `ui_text` is the short display label the backend derives per source; fall
+  // back to the raw prompt `text` for feedback serialized before it existed.
+  const base = {
+    text: parsed.ui_text ?? parsed.text,
+    timestamp: parsed.timestamp,
+  };
+  const source = parsed.source;
+  switch (source?.type) {
+    case 'user-ui':
+      return {...base, sourceType: 'user-ui', user: source.user};
+    case 'github-pr-comment':
+    case 'github-pr-review-comment': {
+      const commentUrl = source.comment?.html_url;
+      if (!commentUrl) {
+        return null;
+      }
+      return {
+        ...base,
+        sourceType: source.type,
+        githubUsername: source.comment?.user?.login,
+        commentUrl,
+      };
+    }
+    case 'check-suite': {
+      const {head_sha: headSha, id: checkSuiteId} = source.event.check_suite;
+      const repoUrl = source.event.repository.html_url;
+      return {
+        ...base,
+        text: t('CI failure detected'),
+        sourceType: 'check-suite',
+        checkSuiteUrl: `${repoUrl}/commit/${headSha}/checks?check_suite_id=${checkSuiteId}`,
+      };
+    }
+    default:
+      return {
+        ...base,
+        sourceType: 'other',
+        source: parsed.source?.type ?? 'unknown',
+      };
+  }
+}
+
+function parseFeedback(raw: string): ParsedFeedback[] {
+  const parsed: RawFeedback | RawFeedback[] = JSON.parse(raw);
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  return items.map(parseFeedbackItem).filter(defined);
+}
+
+/**
+ * Collects the PR-iteration feedback to render in the Feedback section.
+ *
+ * PR iterations are folded into the section's blocks. Each drove one iteration;
+ * the cumulative diff is already merged into the section's code-change artifact
+ * by `getOrderedAutofixSections`, so here we only surface the feedback text.
+ * Feedback on a block at/after the current step marker drives the iteration
+ * still running (when the section is processing); everything earlier is pushed.
+ * Feedback submitted mid-run that hasn't been folded into a block yet is
+ * appended as `queued`. The list is returned newest-first.
+ */
+export function usePrIterationFeedback(
+  section: AutofixSection,
+  autofix: ReturnType<typeof useExplorerAutofix>,
+  enabled: boolean
+): {feedback: IterationFeedback[]; latestIterationIndex: number | null} {
+  const currentStepStart = useMemo(
+    () => section.blocks.findLastIndex(block => defined(block.message.metadata?.step)),
+    [section.blocks]
+  );
+
+  const blockFeedback = useMemo<IterationFeedback[]>(() => {
+    if (!enabled) {
+      return [];
+    }
+
+    return section.blocks.flatMap((block, blockIndex) => {
+      if (!isPrIterationBlock(block)) {
+        return [];
+      }
+
+      const metadata = block.message.metadata;
+      const value = metadata?.feedback;
+      const iterationIndex = metadata?.iteration_index;
+
+      if (!value || iterationIndex === undefined) {
+        return [];
+      }
+
+      const status: FeedbackStatus =
+        section.status === 'processing' && blockIndex >= currentStepStart
+          ? 'in_progress'
+          : 'processed';
+
+      return parseFeedback(value).map(parsed => ({
+        ...parsed,
+        iterationIndex: Number(iterationIndex),
+        status,
+      }));
+    });
+  }, [section.blocks, section.status, currentStepStart, enabled]);
+
+  const latestIterationIndex = useMemo(
+    () =>
+      blockFeedback.reduce<number | null>(
+        (max, item) =>
+          max === null ? item.iterationIndex : Math.max(max, item.iterationIndex),
+        null
+      ),
+    [blockFeedback]
+  );
+
+  const queuedFeedback = useMemo<IterationFeedback[]>(() => {
+    if (!enabled) {
+      return [];
+    }
+
+    return (autofix.runState?.queued_feedback ?? []).flatMap(raw => {
+      const parsed = parseFeedbackItem(raw);
+      if (!parsed) {
+        return [];
+      }
+
+      return [
+        {
+          ...parsed,
+          iterationIndex: (latestIterationIndex ?? -1) + 1,
+          status: 'queued' as const,
+        },
+      ];
+    });
+  }, [autofix.runState?.queued_feedback, latestIterationIndex, enabled]);
+
+  const feedback = useMemo(
+    () => [...blockFeedback, ...queuedFeedback].reverse(),
+    [blockFeedback, queuedFeedback]
+  );
+
+  return {feedback, latestIterationIndex};
+}
+
+export function FeedbackList({items}: {items: IterationFeedback[]}) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <ArtifactDetails>
+      <Text bold>{t('Feedback')}</Text>
+      {items.map((item, index) => (
+        <FeedbackItem key={`${item.iterationIndex}-${index}`} item={item} />
+      ))}
+    </ArtifactDetails>
+  );
+}
+
+// Each source type owns an `Avatar` and a `Comment` cell. `FeedbackItem` renders
+// the shared grid shell (avatar · comment · timestamp · status) and dispatches
+// the two varying cells through this table — the single place that switches on
+// `sourceType`. Adding a source means adding one entry plus its cell components.
+type FeedbackCell = React.ComponentType<{item: IterationFeedback}>;
+
+const SOURCE: Record<
+  IterationFeedback['sourceType'],
+  {Avatar: FeedbackCell; Comment: FeedbackCell}
+> = {
+  'user-ui': {Avatar: UserUiAvatar, Comment: UserUiComment},
+  'github-pr-comment': {Avatar: GithubAvatar, Comment: GithubComment},
+  'github-pr-review-comment': {Avatar: GithubAvatar, Comment: GithubComment},
+  'check-suite': {Avatar: CheckSuiteAvatar, Comment: CheckSuiteComment},
+  other: {Avatar: UnknownAvatarCell, Comment: OtherComment},
+};
+
+function FeedbackItem({item}: {item: IterationFeedback}) {
+  const {Avatar, Comment} = SOURCE[item.sourceType];
+
+  // Four columns: author avatar, comment, timestamp, status icon. `align="start"`
+  // keeps the avatar top-aligned against multiline comments; each non-avatar cell
+  // is at least one avatar tall (`minHeight`) so its content centers with the
+  // avatar on a single line, and grows top-aligned once the comment wraps.
+  return (
+    <Grid columns="auto 1fr auto auto" gap="md" align="start">
+      <Avatar item={item} />
+      <Cell>
+        <Comment item={item} />
+      </Cell>
+      <Cell>
+        <FeedbackTimestamp item={item} />
+      </Cell>
+      {/* Status icon sits at the far right, after the timestamp. */}
+      <Cell>
+        <FeedbackStatusIcon status={item.status} />
+      </Cell>
+    </Grid>
+  );
+}
+
+// A non-avatar grid cell: at least one avatar tall so its content centers with
+// the avatar on a single line, and top-aligned once the content wraps taller.
+function Cell({children}: {children: React.ReactNode}) {
+  return (
+    <Flex align="center" minWidth="0" minHeight={`${AVATAR_SIZE}px`}>
+      {children}
+    </Flex>
+  );
+}
+
+function FeedbackTimestamp({item}: {item: IterationFeedback}) {
+  return (
+    <Text variant="muted" size="sm" wrap="nowrap">
+      {item.status === 'queued' ? (
+        t('Queued')
+      ) : item.timestamp ? (
+        <TimeSince date={item.timestamp} />
+      ) : null}
+    </Text>
+  );
+}
+
+// Composes the single avatar tooltip: "<author> posted on <source>" when we
+// know who authored it, otherwise just "Posted by <source>".
+function postedOnLabel(author: string | null, source: string): string {
+  return author ? t('%s posted on %s', author, source) : t('Posted by %s', source);
+}
+
+function UserUiAvatar({item}: {item: IterationFeedback}) {
+  const user = item.sourceType === 'user-ui' ? (item.user ?? null) : null;
+  const author = user ? userDisplayName(user) : null;
+  return (
+    <AuthorAvatar
+      user={user}
+      Icon={IconSeer}
+      tooltip={postedOnLabel(author, t('Seer'))}
+    />
+  );
+}
+
+function GithubAvatar({item}: {item: IterationFeedback}) {
+  const login =
+    item.sourceType === 'github-pr-comment' ||
+    item.sourceType === 'github-pr-review-comment'
+      ? item.githubUsername
+      : undefined;
+  // Synthetic avatar user: we only have the GitHub login, no Sentry user record.
+  const user = login ? ({username: login, name: login} as AvatarUser) : null;
+  return (
+    <AuthorAvatar
+      user={user}
+      Icon={IconGithub}
+      tooltip={postedOnLabel(login ?? null, t('GitHub'))}
+    />
+  );
+}
+
+function CheckSuiteAvatar() {
+  // A system notice — no author, so the source icon is the primary glyph.
+  return (
+    <PrimaryIconAvatar Icon={IconGithub} tooltip={postedOnLabel(null, t('GitHub'))} />
+  );
+}
+
+// A comment whose author/source we can't identify. We render `LetterAvatar`
+// directly (rather than `UserAvatar`) so we can hand it an explicit gray
+// background: `UserAvatar` derives its color by hashing the identifier into a
+// categorical palette that has no neutral, so a nameless user comes out a
+// vivid color. `?` is the standard empty-name glyph (see `getInitials`).
+function UnknownAvatarCell({item}: {item: IterationFeedback}) {
+  const theme = useTheme();
+  const configuration = {
+    background: theme.tokens.background.secondary,
+    content: theme.tokens.content.secondary,
+    initials: '?',
+  } as React.ComponentProps<typeof LetterAvatar>['configuration'];
+
+  const source = item.sourceType === 'other' ? item.source : 'unknown';
+
+  return (
+    <Tooltip title={postedOnLabel(null, source)}>
+      <AvatarFrame>
+        <UnknownLetterAvatar round configuration={configuration} />
+      </AvatarFrame>
+    </Tooltip>
+  );
+}
+
+// `LetterAvatar` is `position: absolute` with no intrinsic size; fill the frame.
+const UnknownLetterAvatar = styled(LetterAvatar)`
+  position: relative;
+  width: ${AVATAR_SIZE}px;
+  height: ${AVATAR_SIZE}px;
+`;
+
+function UserUiComment({item}: {item: IterationFeedback}) {
+  return <CommentBody text={item.text} />;
+}
+
+function GithubComment({item}: {item: IterationFeedback}) {
+  const url =
+    item.sourceType === 'github-pr-comment' ||
+    item.sourceType === 'github-pr-review-comment'
+      ? item.commentUrl
+      : undefined;
+  // The comment text is plain; a trailing arrow links out to the PR comment.
+  return <CommentBody text={item.text} externalUrl={url} />;
+}
+
+function CheckSuiteComment({item}: {item: IterationFeedback}) {
+  const url = item.sourceType === 'check-suite' ? item.checkSuiteUrl : undefined;
+  // Automated failures read as system notices: muted, with a link to the run.
+  return <CommentBody text={item.text} externalUrl={url} muted />;
+}
+
+function OtherComment({item}: {item: IterationFeedback}) {
+  // The source is surfaced in the avatar tooltip (see `UnknownAvatarCell`), so
+  // the comment itself is just the plain text.
+  return <CommentBody text={item.text} />;
+}
+
+function CommentBody({
+  text,
+  externalUrl,
+  muted,
+}: {
+  text: string;
+  externalUrl?: string;
+  muted?: boolean;
+}) {
+  return (
+    <Text variant={muted ? 'muted' : undefined}>
+      {text}
+      {externalUrl && (
+        <ExternalLink href={externalUrl} aria-label={t('Open in GitHub')}>
+          <InlineOpenIcon size="xs" />
+        </ExternalLink>
+      )}
+    </Text>
+  );
+}
+
+// One-avatar-square frame that positions a corner badge against its avatar.
+function AvatarFrame({children}: {children: React.ReactNode}) {
+  return (
+    <Flex
+      position="relative"
+      align="center"
+      justify="center"
+      width={`${AVATAR_SIZE}px`}
+      height={`${AVATAR_SIZE}px`}
+      flex="0 0 auto"
+    >
+      {children}
+    </Flex>
+  );
+}
+
+// Author avatar when we know who authored the iteration; otherwise the source
+// icon as the primary glyph (sized `lg` === AVATAR_SIZE to fill the frame). A
+// single tooltip wraps the whole frame (avatar + badge) so hovering anywhere on
+// it shows one unified "<author> posted on <source>" label.
+function AuthorAvatar({
+  user,
+  Icon,
+  tooltip,
+}: {
+  Icon: typeof IconSeer;
+  tooltip: string;
+  user: AvatarUser | null;
+}) {
+  if (!user) {
+    return <PrimaryIconAvatar Icon={Icon} tooltip={tooltip} />;
+  }
+  return (
+    <Tooltip title={tooltip}>
+      <AvatarFrame>
+        <UserAvatar size={AVATAR_SIZE} user={user} />
+        {/* 14px badge with 1px padding → 12px icon (`xs`). */}
+        <SourceBadge>
+          <Icon size="xs" />
+        </SourceBadge>
+      </AvatarFrame>
+    </Tooltip>
+  );
+}
+
+// The source icon as the primary glyph, for iterations with no author identity.
+function PrimaryIconAvatar({Icon, tooltip}: {Icon: typeof IconSeer; tooltip: string}) {
+  return (
+    <Tooltip title={tooltip}>
+      <AvatarFrame>
+        <Icon size="lg" />
+      </AvatarFrame>
+    </Tooltip>
+  );
+}
+
+// Bottom-right corner badge: a filled circle in the card background color behind
+// the small source icon so it reads as separate from the avatar it overlaps.
+// Emotion edge case: the negative offsets and circular mask aren't expressible
+// through layout primitives.
+const SourceBadge = styled('div')`
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${SOURCE_BADGE_SIZE}px;
+  height: ${SOURCE_BADGE_SIZE}px;
+  padding: 1px;
+  border-radius: 50%;
+  background: ${p => p.theme.tokens.background.primary};
+`;
+
+// Source-agnostic: the same three status glyphs regardless of where the
+// iteration came from.
+function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
+  switch (status) {
+    case 'processed':
+      return (
+        <Tooltip title={t('Changes from this feedback have been pushed')} skipWrapper>
+          <Flex align="center" justify="center">
+            <IconCircleCheckmark variant="accent" data-test-id="feedback-processed" />
+          </Flex>
+        </Tooltip>
+      );
+    case 'in_progress':
+      return (
+        <Tooltip title={t('This feedback is being processed')} skipWrapper>
+          <LoadingIndicator size={16} style={{margin: 0}} />
+        </Tooltip>
+      );
+    case 'queued':
+      return (
+        <Tooltip title={t('Queued, not yet picked up')} skipWrapper>
+          <Flex align="center" justify="center">
+            <IconCircle variant="muted" />
+          </Flex>
+        </Tooltip>
+      );
+    default:
+      return null;
+  }
+}
+
+// The inline external-link arrow sits with the last line of the comment. A small
+// left margin separates it from the text. Emotion edge case: inline flow
+// (`vertical-align`) isn't expressible through layout primitives.
+const InlineOpenIcon = styled(IconOpen)`
+  margin-bottom: 3px; /* align icon to text */
+  margin-left: ${p => p.theme.space.xs};
+  vertical-align: middle;
+`;

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -463,10 +463,23 @@ function AuthorAvatar({
     <Tooltip title={tooltip}>
       <AvatarFrame>
         <UserAvatar size={AVATAR_SIZE} user={user} />
-        {/* 14px badge with 1px padding → 12px icon (`xs`). */}
-        <SourceBadge>
+        {/* Bottom-right corner badge: a filled circle in the card background
+            color behind the small source icon so it reads as separate from the
+            avatar it overlaps. Centering leaves ~1px of slack around the 12px
+            (`xs`) icon inside the 14px circle. */}
+        <Flex
+          position="absolute"
+          right="-3px"
+          bottom="-3px"
+          align="center"
+          justify="center"
+          radius="full"
+          background="primary"
+          width={`${SOURCE_BADGE_SIZE}px`}
+          height={`${SOURCE_BADGE_SIZE}px`}
+        >
           <Icon size="xs" />
-        </SourceBadge>
+        </Flex>
       </AvatarFrame>
     </Tooltip>
   );
@@ -482,24 +495,6 @@ function PrimaryIconAvatar({Icon, tooltip}: {Icon: typeof IconSeer; tooltip: str
     </Tooltip>
   );
 }
-
-// Bottom-right corner badge: a filled circle in the card background color behind
-// the small source icon so it reads as separate from the avatar it overlaps.
-// Emotion edge case: the negative offsets and circular mask aren't expressible
-// through layout primitives.
-const SourceBadge = styled('div')`
-  position: absolute;
-  right: -3px;
-  bottom: -3px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: ${SOURCE_BADGE_SIZE}px;
-  height: ${SOURCE_BADGE_SIZE}px;
-  padding: 1px;
-  border-radius: 50%;
-  background: ${p => p.theme.tokens.background.primary};
-`;
 
 // Source-agnostic: the same three status glyphs regardless of where the
 // iteration came from.


### PR DESCRIPTION
Extract the PR-iteration feedback list out of codeChangesCard into a
self-contained feedbackList module, and make each feedback source render
through its own avatar + comment cells dispatched by a single source
registry (rather than switching on sourceType in several helpers).

- Split presentation + the usePrIterationFeedback hook out of
  codeChangesCard; the card keeps only orchestration.
- Per-source Avatar/Comment cells behind a SOURCE registry; adding a
  source means one registry entry plus its cells.
- Author avatars use core UserAvatar with the source icon as a corner
  badge; unknown-source uses a gray LetterAvatar "?" placeholder.
- Single unified avatar tooltip ("<author> posted on <source>") instead
  of separate user/badge tooltips.
- Layout via scraps primitives (Flex/Grid) over hand-rolled styled divs.
- Add codeChangesCard stories covering every source type and status.

old
<img width="654" height="612" alt="image" src="https://github.com/user-attachments/assets/3d3ffd03-cb69-4b12-bfb7-8d547230b46e" />


new
<img width="805" height="745" alt="image" src="https://github.com/user-attachments/assets/5b98b5f9-4340-4696-914e-abcb6db74185" />