### PR TITLE
fix(releases): Sort numeric prerelease identifiers numerically

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -33,7 +33,7 @@ replays: 0001_squashed_0007_organizationmember_replay_access
 
 seer: 0029_add_agent_write_grant
 
-sentry: 1143_add_pipeline_hash_index_to_groupderiveddata
+sentry: 1144_backfill_semver_prerelease_sort_key
 
 social_auth: 0001_squashed_0003_social_auth_json_field
 

--- a/src/sentry/migrations/1144_backfill_semver_prerelease_sort_key.py
+++ b/src/sentry/migrations/1144_backfill_semver_prerelease_sort_key.py
@@ -1,0 +1,74 @@
+"""
+Backfill `Release.prerelease` into its normalized, sortable form.
+
+Numeric prerelease identifiers used to be stored raw, which made the
+lexicographic ordering Postgres applies to the column disagree with semver
+precedence (e.g. `rc.96` sorted higher than `rc.193`). New/updated releases
+now store numeric identifiers zero-padded via `normalize_semver_prerelease`;
+this migration rewrites existing rows to match.
+
+Safe to re-run: rows already in normalized form are left untouched.
+"""
+
+from typing import Any
+
+from django.db import migrations
+
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+
+# Keep in sync with
+# `sentry.models.releases.util.SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH`, inlined
+# here so the migration stays stable if the application code changes.
+SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH = 19
+
+
+def _normalize_semver_prerelease(prerelease: str) -> str:
+    return ".".join(
+        (
+            identifier.zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)
+            if identifier.isascii()
+            and identifier.isdigit()
+            and len(identifier) <= SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH
+            else identifier
+        )
+        for identifier in prerelease.split(".")
+    )
+
+
+def backfill_semver_prerelease_sort_key(apps: Any, schema_editor: Any) -> None:
+    Release = apps.get_model("sentry", "Release")
+
+    queryset = Release.objects.filter(prerelease__isnull=False).exclude(prerelease="")
+    for release in RangeQuerySetWrapperWithProgressBar(queryset):
+        normalized = _normalize_semver_prerelease(release.prerelease)
+        if normalized != release.prerelease:
+            Release.objects.filter(id=release.id).update(prerelease=normalized)
+
+
+class Migration(CheckedMigration):
+    # This flag is used to mark that a migration shouldn't be automatically run in production.
+    # This should only be used for operations where it's safe to run the migration after your
+    # code has deployed. So this should not be used for most operations that alter the schema
+    # of a table.
+    # Here are some things that make sense to mark as post deployment:
+    # - Large data migrations. Typically we want these to be run manually so that they can be
+    #   monitored and not block the deploy for a long period of time while they run.
+    # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
+    #   run this outside deployments so that we don't block them. Note that while adding an index
+    #   is a schema change, it's completely safe to run the operation after the code has deployed.
+    # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
+
+    is_post_deployment = True
+
+    dependencies = [
+        ("sentry", "1143_add_pipeline_hash_index_to_groupderiveddata"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_semver_prerelease_sort_key,
+            migrations.RunPython.noop,
+            hints={"tables": ["sentry_release"]},
+        ),
+    ]

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -256,6 +256,9 @@ class Release(Model):
     minor = models.BigIntegerField(null=True)
     patch = models.BigIntegerField(null=True)
     revision = models.BigIntegerField(null=True)
+    # Stored in the normalized form produced by `normalize_semver_prerelease`
+    # (numeric identifiers zero-padded) so that the text ordering Postgres uses
+    # matches semver precedence. Parse `version` to get the raw prerelease.
     prerelease = models.TextField(null=True)
     build_code = models.TextField(null=True)
     # If `build_code` can be parsed as a 64 bit int we'll store it here as well for

--- a/src/sentry/models/releases/util.py
+++ b/src/sentry/models/releases/util.py
@@ -37,6 +37,45 @@ class SemverFilter:
     negated: bool = False
 
 
+# Width that numeric prerelease identifiers are zero-padded to in
+# `normalize_semver_prerelease`. 19 digits covers the full range of a 64 bit
+# integer, which is far beyond any realistic prerelease counter.
+SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH = 19
+
+
+def normalize_semver_prerelease(prerelease: str) -> str:
+    """
+    Converts a raw semver prerelease string into the sortable form stored in
+    `Release.prerelease`.
+
+    The semver spec requires dot-separated prerelease identifiers that consist
+    solely of digits to be compared numerically (e.g. `rc.9` < `rc.10`), but we
+    store `prerelease` in a text column that Postgres compares
+    lexicographically (where `rc.9` > `rc.10`). To make the two orderings
+    agree, numeric identifiers are zero-padded to a fixed width before being
+    stored or compared against this column.
+
+    Note that the raw prerelease remains available by parsing
+    `Release.version`; this column only exists for sorting/filtering.
+
+    Known limitation (pre-existing): alphanumeric identifiers containing `-`
+    can still sort out of spec order relative to the `.` separator, because
+    `-` < `.` in ASCII (e.g. `alpha-1` vs `alpha.0`).
+    """
+    if not prerelease:
+        return prerelease
+    return ".".join(
+        (
+            identifier.zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)
+            if identifier.isascii()
+            and identifier.isdigit()
+            and len(identifier) <= SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH
+            else identifier
+        )
+        for identifier in prerelease.split(".")
+    )
+
+
 class ReleaseQuerySet(BaseQuerySet["Release"]):
     def annotate_prerelease_column(self) -> Self:
         """
@@ -265,7 +304,9 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
                             "minor": version_parsed.get("minor"),
                             "patch": version_parsed.get("patch"),
                             "revision": version_parsed.get("revision"),
-                            "prerelease": version_parsed.get("pre") or "",
+                            "prerelease": normalize_semver_prerelease(
+                                version_parsed.get("pre") or ""
+                            ),
                             "build_code": build_code,
                             "build_number": build_number,
                             "package": package,

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -21,7 +21,7 @@ from sentry.exceptions import InvalidSearchQuery
 from sentry.models.group import Group
 from sentry.models.project import Project
 from sentry.models.release import Release
-from sentry.models.releases.util import SemverFilter
+from sentry.models.releases.util import SemverFilter, normalize_semver_prerelease
 from sentry.search.events.constants import (
     ARRAY_FIELDS,
     EQUALITY_OPERATORS,
@@ -487,8 +487,11 @@ def parse_semver(version: str, operator: str) -> SemverFilter:
     parsed = parse_release_relay(version, json_loads=orjson.loads)
     parsed_version = parsed.get("version_parsed")
     if parsed_version:
-        # Convert `pre` to always be a string
-        prerelease = parsed_version["pre"] if parsed_version["pre"] else ""
+        # Convert `pre` to always be a string, normalized the same way as the
+        # `Release.prerelease` column it is compared against.
+        prerelease = normalize_semver_prerelease(
+            parsed_version["pre"] if parsed_version["pre"] else ""
+        )
         semver_filter = SemverFilter(
             operator,
             [

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -289,6 +289,23 @@ class OrganizationReleaseListTest(APITestCase, BaseMetricsTestCase):
         ]
         self.assert_expected_versions(response, expected_order)
 
+    def test_release_list_order_by_semver_numeric_prerelease(self) -> None:
+        # Numeric prerelease identifiers must sort numerically (96 < 193 < 195),
+        # not lexicographically ("193" < "195" < "96").
+        self.login_as(user=self.user)
+        release_96 = self.create_release(version="test@3.0.0-prerelease.96")
+        release_193 = self.create_release(version="test@3.0.0-prerelease.193")
+        release_195 = self.create_release(version="test@3.0.0-prerelease.195")
+        release_rc_9 = self.create_release(version="test@3.0.0-rc.9")
+        release_rc_10 = self.create_release(version="test@3.0.0-rc.10")
+        release_final = self.create_release(version="test@3.0.0")
+
+        response = self.get_success_response(self.organization.slug, sort="semver")
+        self.assert_expected_versions(
+            response,
+            [release_final, release_rc_10, release_rc_9, release_195, release_193, release_96],
+        )
+
     def test_query_filter(self) -> None:
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization

--- a/tests/sentry/migrations/test_1144_backfill_semver_prerelease_sort_key.py
+++ b/tests/sentry/migrations/test_1144_backfill_semver_prerelease_sort_key.py
@@ -1,0 +1,40 @@
+from sentry.models.release import Release
+from sentry.models.releases.util import SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH
+from sentry.testutils.cases import TestMigrations
+
+
+class BackfillSemverPrereleaseSortKeyTest(TestMigrations):
+    migrate_from = "1143_add_pipeline_hash_index_to_groupderiveddata"
+    migrate_to = "1144_backfill_semver_prerelease_sort_key"
+
+    def setup_before_migration(self, apps):
+        self.org = self.create_organization(name="Test org", slug="test-org")
+
+        def create_legacy_release(version, raw_prerelease):
+            # Simulate a pre-fix row: `update()` bypasses the pre_save signal
+            # that would normalize the prerelease.
+            release = Release.objects.create(organization=self.org, version=version)
+            Release.objects.filter(id=release.id).update(prerelease=raw_prerelease)
+            return release
+
+        self.release_numeric = create_legacy_release(
+            "test@3.0.0-prerelease.96", "prerelease.96"
+        )
+        self.release_alpha = create_legacy_release("test@3.0.0-alpha.beta", "alpha.beta")
+        self.release_no_prerelease = create_legacy_release("test@3.0.0", "")
+        self.release_non_semver = Release.objects.create(
+            organization=self.org, version="not a semver release"
+        )
+
+    def test(self):
+        self.release_numeric.refresh_from_db()
+        self.release_alpha.refresh_from_db()
+        self.release_no_prerelease.refresh_from_db()
+        self.release_non_semver.refresh_from_db()
+
+        padded_96 = "96".zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)
+        assert self.release_numeric.prerelease == f"prerelease.{padded_96}"
+        # Alphanumeric identifiers and empty prereleases are untouched.
+        assert self.release_alpha.prerelease == "alpha.beta"
+        assert self.release_no_prerelease.prerelease == ""
+        assert self.release_non_semver.prerelease is None

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -35,6 +35,10 @@ from sentry.models.releaseenvironment import ReleaseEnvironment
 from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
+from sentry.models.releases.util import (
+    SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH,
+    normalize_semver_prerelease,
+)
 from sentry.models.repository import Repository
 from sentry.search.events.filter import parse_semver
 from sentry.signals import receivers_raise_on_send
@@ -95,6 +99,56 @@ def test_version_is_semver_valid(release_version) -> None:
 )
 def test_version_is_semver_invalid(release_version) -> None:
     assert Release.is_semver_version(release_version) is False
+
+
+@pytest.mark.parametrize(
+    "prerelease,expected",
+    [
+        ("", ""),
+        ("alpha", "alpha"),
+        ("rc1", "rc1"),  # `rc1` is a single alphanumeric identifier, not numeric
+        ("rc.1", f"rc.{'1'.zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)}"),
+        ("alpha.beta", "alpha.beta"),
+        (
+            "0.3.7",
+            ".".join(part.zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH) for part in ("0", "3", "7")),
+        ),
+        # Identifiers longer than the pad width are left as-is.
+        ("rc.12345678901234567890", "rc.12345678901234567890"),
+        # Non-ascii digits are not numeric identifiers and must not be padded.
+        ("rc.١٢٣", "rc.١٢٣"),
+    ],
+)
+def test_normalize_semver_prerelease(prerelease, expected) -> None:
+    assert normalize_semver_prerelease(prerelease) == expected
+
+
+def test_normalize_semver_prerelease_ordering() -> None:
+    """
+    The normalized form must sort lexicographically in the same order that the
+    semver spec defines for the raw prereleases (spec item 11.4: numeric
+    identifiers compare numerically and sort below alphanumeric ones, fewer
+    identifiers sort first).
+    """
+    prereleases_in_semver_order = [
+        "1",
+        "2",
+        "9",
+        "10",
+        "96",
+        "193",
+        "alpha",
+        "alpha.1",
+        "alpha.beta",
+        "beta",
+        "beta.2",
+        "beta.11",
+        "prerelease.96",
+        "prerelease.193",
+        "rc.1",
+    ]
+    normalized = [normalize_semver_prerelease(p) for p in prereleases_in_semver_order]
+    assert normalized == sorted(normalized)
 
 
 class GetOrCreateNoCreateTest(TestCase):
@@ -1148,6 +1202,19 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.build_number is None
         assert release.package == "org.example.FooApp"
 
+    def test_parse_release_normalizes_numeric_prerelease(self) -> None:
+        """
+        Test that numeric prerelease identifiers are zero-padded when stored, so
+        that the lexicographic ordering Postgres applies to the `prerelease`
+        column matches semver precedence (`rc.9` < `rc.10`).
+        """
+        version = "org.example.FooApp@1.0.0-rc.9"
+        release = Release.objects.create(organization=self.org, version=version)
+        assert release.prerelease == f"rc.{'9'.zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)}"
+        # Alphanumeric identifiers are stored untouched.
+        assert release.prerelease > "rc"
+        assert release.prerelease < f"rc.{'10'.zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)}"
+
     def test_parse_non_semver_should_not_fail(self) -> None:
         """
         Test that ensures nothing breaks when sending a non semver compatible release
@@ -1269,6 +1336,22 @@ class ReleaseFilterBySemverTest(TestCase):
             [release_1, release_2, release_3, release_4],
         )
         self.run_test("<", "1.2.3", [release_1, release])
+
+    def test_prerelease_numeric_identifiers(self) -> None:
+        # Numeric prerelease identifiers must be compared numerically, not
+        # lexicographically (semver spec item 11.4.1): 9 < 10 < 96 < 193.
+        release_9 = self.create_release(version="test@3.0.0-prerelease.9")
+        release_10 = self.create_release(version="test@3.0.0-prerelease.10")
+        release_96 = self.create_release(version="test@3.0.0-prerelease.96")
+        release_193 = self.create_release(version="test@3.0.0-prerelease.193")
+        release_final = self.create_release(version="test@3.0.0")
+
+        self.run_test(">", "3.0.0-prerelease.9", [release_10, release_96, release_193, release_final])
+        self.run_test(">", "3.0.0-prerelease.96", [release_193, release_final])
+        self.run_test("<", "3.0.0-prerelease.96", [release_9, release_10])
+        self.run_test(">=", "3.0.0-prerelease.193", [release_193, release_final])
+        self.run_test("=", "3.0.0-prerelease.96", [release_96])
+        self.run_test("<", "3.0.0", [release_9, release_10, release_96, release_193])
 
     def test_granularity(self) -> None:
         self.create_release(version="test@1.0.0.0")

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -10,7 +10,10 @@ from snuba_sdk.function import Function
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.release_search import INVALID_SEMVER_MESSAGE
 from sentry.exceptions import InvalidSearchQuery
-from sentry.models.releases.util import SemverFilter
+from sentry.models.releases.util import (
+    SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH,
+    SemverFilter,
+)
 from sentry.search.events.builder.discover import UnresolvedQuery
 from sentry.search.events.constants import (
     SEMVER_ALIAS,
@@ -454,6 +457,15 @@ class ParseSemverTest(unittest.TestCase):
         self.run_test("1.2.3-hi", ">", SemverFilter("gt", [1, 2, 3, 0, 0, "hi"]))
         self.run_test("1.2.3-hi", "<", SemverFilter("lt", [1, 2, 3, 0, 0, "hi"]))
         self.run_test("sentry@1.2.3-hi", "<", SemverFilter("lt", [1, 2, 3, 0, 0, "hi"], "sentry"))
+
+    def test_numeric_prerelease(self) -> None:
+        # Numeric prerelease identifiers are normalized (zero-padded) to match
+        # the form stored in the `Release.prerelease` column.
+        padded_9 = "rc." + "9".zfill(SEMVER_PRERELEASE_NUMERIC_PAD_WIDTH)
+        self.run_test("1.2.3-rc.9", ">", SemverFilter("gt", [1, 2, 3, 0, 0, padded_9]))
+        self.run_test(
+            "sentry@1.2.3-rc.9", "=", SemverFilter("exact", [1, 2, 3, 0, 0, padded_9], "sentry")
+        )
 
     def test_wildcard(self) -> None:
         self.run_test("1.*", "=", SemverFilter("exact", [1]))


### PR DESCRIPTION
When I select the "Mark this crash fixed in the next release" option, I see this:

> Connor Clark marked this issue as resolved in versions greater than **3.0.0-prerelease.96 (2025-03-27)**.

However, the most recent release version in my project is `3.0.0-prerelease.202+2026-07-22`. The same wrong "latest" release shows up on the Releases page when sorted by semver.

What follows is an AI-generated root cause analysis (Fable). I validate the semver spec correctness part of it, but I don't have any knowledge of the Sentry code base so I can't speak to that part. Please consider the code in this PR as unvetted.

___ 

## Root cause

The denormalized `Release.prerelease` column is a text column, and every semver
ordering/filtering path (the `sentry_release_semver_idx` indexes, `SEMVER_COLS`
ordering, `filter_by_semver`'s ROW comparison, `get_latest_release`'s raw SQL)
compares it lexicographically. As text, `"prerelease.96" > "prerelease.193"`
because `'9' > '1'`.

That violates the semver spec, which requires numeric identifiers to be compared
numerically ([semver.org, spec item 11.4.1](https://semver.org/#spec-item-11)):

> Identifiers consisting of only digits are compared numerically.

So `prerelease.96 < prerelease.193 < prerelease.202`, and every release since
`.96` crossed into triple digits has been sorted below it.

Quick validation against the reference `semver` implementation (`npm i semver`):

```js
const semver = require('semver');

const versions = [
  '3.0.0-prerelease.96',
  '3.0.0-prerelease.193',
  '3.0.0-prerelease.202+2026-07-22',
];

versions.forEach((v) => console.log(v, 'valid:', semver.valid(v) !== null));
console.log('latest:', semver.rsort([...versions])[0]);
// latest: 3.0.0-prerelease.202+2026-07-22  — not prerelease.96
```

## Fix

Since nothing reads `prerelease` as a display value (serializers re-parse
`version`), the column is effectively a sort key — so store it as one:
`normalize_semver_prerelease()` zero-pads numeric identifiers to a fixed width
(`rc.9` → `rc.0000000000000000009`), making Postgres's text ordering agree with
numeric ordering. The same normalization is applied in `parse_semver()`, the
single choke point for `release.version:` filters, so query values keep matching
stored values. No schema or index changes needed.

A post-deployment migration (`1144`) backfills existing rows. Until it runs,
orgs with existing numeric-identifier prereleases may see mixed ordering between
old (raw) and new (padded) rows.

Known pre-existing limitation left unchanged (documented on the helper):
alphanumeric identifiers containing `-` can still sort out of spec order
relative to the `.` separator, because `'-' < '.'` in ASCII (e.g. `alpha-1` vs
`alpha.0`).

## Testing

- Property-checked the normalization against the Node `semver` library over
  1.6M prerelease pairs: spec-order mismatches drop from 259,094 to 5,200
  (all remaining are the pre-existing `-` vs `.` case), with zero new
  mismatches introduced.
- New tests: normalization unit tests + ordering property test,
  `filter_by_semver` with numeric identifiers, `parse_semver` normalization,
  Releases endpoint `sort=semver` ordering, and a backfill migration test.



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
