### PR TITLE
feat(seer): Open autofix run drawer inline from overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
   deriveCardAction,
@@ -29,11 +29,6 @@ function makeRow(overrides: Partial<OverviewRow> = {}): OverviewRow {
   };
 }
 
-const runUrl = {
-  pathname: '/organizations/org-slug/issues/2/',
-  query: {seerDrawer: 'true'},
-};
-
 describe('deriveCardAction', () => {
   it.each([
     'code_changes_ready',
@@ -59,7 +54,11 @@ describe('deriveCardAction', () => {
 
 describe('IssuePrimaryAction', () => {
   function renderAction(action: CardAction, row: OverviewRow) {
-    return render(<IssuePrimaryAction action={action} row={row} runUrl={runUrl} />);
+    const onOpenRun = jest.fn();
+    const result = render(
+      <IssuePrimaryAction action={action} row={row} onOpenRun={onOpenRun} />
+    );
+    return {...result, onOpenRun};
   }
 
   it('renders a placeholder while the run state is pending', () => {
@@ -120,15 +119,29 @@ describe('IssuePrimaryAction', () => {
     }
   );
 
-  it('falls back to the internal review link when a review_pr card has no PR url', () => {
-    renderAction(
+  it.each([
+    {type: 'code_changes_ready', label: 'Open PR'},
+    {type: 'solution_ready', label: 'Generate code'},
+    {type: 'needs_investigation', label: 'Investigate'},
+  ] as Array<{label: string; type: Exclude<CardAction['type'], 'review_pr'>}>)(
+    'opens the run drawer when the $label action is clicked',
+    async ({type, label}) => {
+      const {onOpenRun} = renderAction({type}, makeRow({runStatus: 'completed'}));
+
+      await userEvent.click(screen.getByRole('button', {name: label}));
+
+      expect(onOpenRun).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('opens the run drawer when a review_pr card has no PR url', async () => {
+    const {onOpenRun} = renderAction(
       {type: 'review_pr', prUrl: undefined, prNumber: undefined},
       makeRow({runStatus: 'completed'})
     );
 
-    expect(screen.getByRole('button', {name: 'Review PR'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/issues/2/?seerDrawer=true'
-    );
+    await userEvent.click(screen.getByRole('button', {name: 'Review PR'}));
+
+    expect(onOpenRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
-import type {LocationDescriptor} from 'history';
 
 import {Tag} from '@sentry/scraps/badge';
-import {LinkButton} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -95,7 +94,7 @@ export function deriveCardAction(
   return {type: sectionKey};
 }
 
-const AccentLinkButton = styled(LinkButton)`
+const AccentButton = styled(Button)`
   background: ${p => p.theme.tokens.background.accent};
   border-color: ${p => p.theme.tokens.border.accent};
   color: ${p => p.theme.tokens.content.accent};
@@ -104,7 +103,7 @@ const AccentLinkButton = styled(LinkButton)`
   }
 `;
 
-const SuccessLinkButton = styled(LinkButton)`
+const SuccessButton = styled(Button)`
   background: ${p => p.theme.tokens.background.success};
   border-color: ${p => p.theme.tokens.border.success};
   color: ${p => p.theme.tokens.content.success};
@@ -113,46 +112,46 @@ const SuccessLinkButton = styled(LinkButton)`
   }
 `;
 
-const MutedLinkButton = styled(LinkButton)`
+const MutedButton = styled(Button)`
   background: transparent;
   border-color: ${p => p.theme.tokens.border.neutral};
   color: ${p => p.theme.tokens.content.secondary};
 `;
 
-function ActionButton({actionKey, to}: {actionKey: ActionKey; to: LocationDescriptor}) {
+function ActionButton({actionKey, onClick}: {actionKey: ActionKey; onClick: () => void}) {
   const meta = ACTION_META[actionKey];
   if (actionKey === 'code_changes_ready') {
     return (
       <Tooltip title={meta.description} skipWrapper>
-        <AccentLinkButton size="sm" icon={<meta.Icon />} to={to}>
+        <AccentButton size="sm" icon={<meta.Icon />} onClick={onClick}>
           {meta.label}
-        </AccentLinkButton>
+        </AccentButton>
       </Tooltip>
     );
   }
   if (actionKey === 'solution_ready') {
     return (
       <Tooltip title={meta.description} skipWrapper>
-        <SuccessLinkButton size="sm" icon={<meta.Icon />} to={to}>
+        <SuccessButton size="sm" icon={<meta.Icon />} onClick={onClick}>
           {meta.label}
-        </SuccessLinkButton>
+        </SuccessButton>
       </Tooltip>
     );
   }
   if (actionKey === 'errored') {
     return (
       <Tooltip title={meta.description} skipWrapper>
-        <MutedLinkButton size="sm" icon={<meta.Icon />} to={to}>
+        <MutedButton size="sm" icon={<meta.Icon />} onClick={onClick}>
           {meta.label}
-        </MutedLinkButton>
+        </MutedButton>
       </Tooltip>
     );
   }
   return (
     <Tooltip title={meta.description} skipWrapper>
-      <LinkButton size="sm" variant={meta.variant} icon={<meta.Icon />} to={to}>
+      <Button size="sm" variant={meta.variant} icon={<meta.Icon />} onClick={onClick}>
         {meta.label}
-      </LinkButton>
+      </Button>
     </Tooltip>
   );
 }
@@ -196,11 +195,11 @@ function ReviewPrButton({
 export function IssuePrimaryAction({
   action,
   row,
-  runUrl,
+  onOpenRun,
 }: {
   action: CardAction;
+  onOpenRun: () => void;
   row: OverviewRow;
-  runUrl: LocationDescriptor;
 }) {
   if (row.statePending) {
     return <Text variant="muted">{'…'}</Text>;
@@ -209,10 +208,10 @@ export function IssuePrimaryAction({
     return <Tag variant="info">{t('Running')}</Tag>;
   }
   if (row.runStatus === 'error') {
-    return <ActionButton actionKey="errored" to={runUrl} />;
+    return <ActionButton actionKey="errored" onClick={onOpenRun} />;
   }
   if (row.runStatus === 'awaiting_user_input') {
-    return <ActionButton actionKey="awaiting_input" to={runUrl} />;
+    return <ActionButton actionKey="awaiting_input" onClick={onOpenRun} />;
   }
 
   switch (action.type) {
@@ -228,9 +227,9 @@ export function IssuePrimaryAction({
       return action.prUrl ? (
         <ReviewPrButton prUrl={action.prUrl} prNumber={action.prNumber} />
       ) : (
-        <ActionButton actionKey="review_pr" to={runUrl} />
+        <ActionButton actionKey="review_pr" onClick={onOpenRun} />
       );
     default:
-      return <ActionButton actionKey={action.type} to={runUrl} />;
+      return <ActionButton actionKey={action.type} onClick={onOpenRun} />;
   }
 }

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -18,6 +18,7 @@ import {ellipsize} from 'sentry/utils/string/ellipsize';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
 import {deriveCardAction, IssuePrimaryAction} from './cardAction';
+import {useOpenOverviewSeerDrawer} from './overviewSeerDrawer';
 import {periodWindowLabel} from './periods';
 import {TriggerBadge} from './triggerBadge';
 import type {AutofixStateKey, OverviewRow, PatchStats} from './types';
@@ -136,9 +137,11 @@ export function IssueCard({
   minHeight?: string;
 }) {
   const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
-  // Deep-link into the issue page with the Seer drawer already open, so the
-  // run itself is one click away (matches the issue details ?seerDrawer param).
-  const runUrl = {pathname: issueUrl, query: {seerDrawer: 'true'}};
+  // The card's CTA opens the autofix run drawer in place; the title link still
+  // navigates to the issue page.
+  const openSeerDrawer = useOpenOverviewSeerDrawer();
+  const onOpenRun = () =>
+    openSeerDrawer({groupId: row.id, projectSlug: row.project.slug});
   const cardAction = deriveCardAction(sectionKey, row);
   const rootCause = row.analysis.find(entry => entry.key === 'root_cause');
   const proposedFix = row.analysis.find(entry => entry.key === 'fix_summary');
@@ -304,7 +307,7 @@ export function IssueCard({
         {/* Tail: primary action left, issue identity right */}
         <Flex justify="between" align="center" gap="md">
           <Flex gap="sm" align="center">
-            <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} />
+            <IssuePrimaryAction action={cardAction} row={row} onOpenRun={onOpenRun} />
             {row.prUrl && cardAction.type !== 'review_pr' && (
               <LinkButton
                 size="sm"
@@ -349,7 +352,9 @@ export function IssueTableRow({
   minHeight?: string;
 }) {
   const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
-  const runUrl = {pathname: issueUrl, query: {seerDrawer: 'true'}};
+  const openSeerDrawer = useOpenOverviewSeerDrawer();
+  const onOpenRun = () =>
+    openSeerDrawer({groupId: row.id, projectSlug: row.project.slug});
   const cardAction = deriveCardAction(sectionKey, row);
   const {eventCountLabel, userCountLabel} = issueCountLabels(row);
 
@@ -389,7 +394,7 @@ export function IssueTableRow({
         </Flex>
       </Stack>
       <Flex align="center" flexShrink={0}>
-        <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} />
+        <IssuePrimaryAction action={cardAction} row={row} onOpenRun={onOpenRun} />
       </Flex>
     </Flex>
   );

--- a/static/app/views/seerWorkflows/overview/overviewSeerDrawer.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewSeerDrawer.tsx
@@ -1,0 +1,59 @@
+import {useCallback} from 'react';
+
+import {useDrawer} from '@sentry/scraps/drawer';
+import {Stack} from '@sentry/scraps/layout';
+
+import {SeerDrawer} from 'sentry/components/events/autofix/v3/drawer';
+import {Placeholder} from 'sentry/components/placeholder';
+import {t} from 'sentry/locale';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
+
+interface OverviewSeerDrawerProps {
+  groupId: string;
+  projectSlug: string;
+}
+
+function OverviewSeerDrawer({groupId, projectSlug}: OverviewSeerDrawerProps) {
+  const organization = useOrganization();
+  const groupQuery = useGroup({groupId});
+  const projectQuery = useDetailedProject({orgSlug: organization.slug, projectSlug});
+
+  if (!groupQuery.data || !projectQuery.data) {
+    return (
+      <Stack gap="xl" padding="xl">
+        <Placeholder height="10rem" />
+        <Placeholder height="15rem" />
+        <Placeholder height="15rem" />
+      </Stack>
+    );
+  }
+
+  return <SeerDrawer group={groupQuery.data} project={projectQuery.data} />;
+}
+
+/**
+ * Opens the autofix run drawer (the same SeerDrawer the issue page shows) in
+ * place on the overview, fetching the full Group and Project the drawer needs
+ * from the lightweight overview row. Reuses the issue page's drawer key so both
+ * surfaces open the same drawer slot.
+ */
+export function useOpenOverviewSeerDrawer() {
+  const {openDrawer} = useDrawer();
+
+  return useCallback(
+    ({groupId, projectSlug}: OverviewSeerDrawerProps) => {
+      openDrawer(
+        () => <OverviewSeerDrawer groupId={groupId} projectSlug={projectSlug} />,
+        {
+          ariaLabel: t('Seer drawer'),
+          drawerKey: 'seer-autofix-drawer',
+          resizable: true,
+          mode: 'passive',
+        }
+      );
+    },
+    [openDrawer]
+  );
+}


### PR DESCRIPTION
Clicking a Seer overview CTA (card or table row) now opens the autofix run drawer in place instead of navigating to the issue page with `?seerDrawer=true`. The title link still goes to the issue page, so the run and the issue are each one click away without leaving the overview.

The overview only holds a lightweight row, while the `SeerDrawer` needs a full `Group` and `Project`. The new `useOpenOverviewSeerDrawer` hook opens the drawer and fetches both from the row's `groupId`/`projectSlug`, showing placeholders until they load. It reuses the issue page's `seer-autofix-drawer` key so both surfaces share the same drawer slot.

`IssuePrimaryAction` and its `ActionButton` now take an `onOpenRun` callback rather than a `runUrl`, so the CTAs render as `Button`s instead of `LinkButton`s. The external "Review PR" link is unchanged.
