### PR TITLE
feat(seer): Add assignee filter and per-card assignee to Autofix Overview

### DIFF
--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
@@ -80,11 +80,12 @@ function makeRun(overrides: Partial<SeerRun> = {}): SeerRun {
 
 function makeIssue(overrides: Partial<OverviewIssue> = {}): OverviewIssue {
   return {
+    assignedTo: null,
     count: '100',
     id: '2',
     lastSeen: '2026-07-20T12:00:00Z',
     level: 'error',
-    project: {slug: 'proj'},
+    project: {id: '1', slug: 'proj'},
     seerAutofixLastTriggered: null,
     shortId: 'PROJ-1',
     title: 'Boom',

--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
@@ -227,6 +227,8 @@ export function buildOverviewRow(
     title: issue.title,
     level: issue.level,
     project: issue.project,
+    assignedTo: issue.assignedTo ?? null,
+    owners: issue.owners,
     eventCount: Number.isFinite(eventCount) ? eventCount : 0,
     userCount: issue.userCount,
     statsPeriod,

--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -14,12 +14,13 @@ import type {
 function makeRow(overrides: Partial<OverviewRow> = {}): OverviewRow {
   return {
     analysis: [],
+    assignedTo: null,
     eventCount: 1,
     id: '2',
     lastActivityAt: '2026-07-14T10:00:00Z',
     lastSeen: '2026-07-14T09:00:00Z',
     level: 'error',
-    project: {slug: 'proj'},
+    project: {id: '2', slug: 'proj'},
     runStatus: null,
     shortId: 'PROJ-1',
     statePending: false,

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -807,20 +807,20 @@ describe('AutofixOverview', () => {
       id: '42',
       name: 'Remote Member',
       email: 'remote.member@example.com',
-      username: 'remote-member',
+      username: 'Jane Doe',
     });
     const remoteRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/members/`,
-      match: [MockApiClient.matchQuery({query: 'remote-member'})],
+      match: [MockApiClient.matchQuery({query: remoteUser.username})],
       body: [MemberFixture({id: '42', user: remoteUser})],
     });
-    const reviewRequest = mockAssigneeSections(remoteUser.username);
+    const reviewRequest = mockAssigneeSections('"Jane Doe"');
     const {router} = renderPage();
 
     await userEvent.click(await screen.findByRole('button', {name: 'Assignee None'}));
     await userEvent.type(
       screen.getByPlaceholderText('Search assignees…'),
-      'remote-member'
+      remoteUser.username
     );
     await userEvent.click(await screen.findByRole('option', {name: remoteUser.name}));
 
@@ -831,7 +831,7 @@ describe('AutofixOverview', () => {
         `/organizations/${organization.slug}/issues/`,
         expect.objectContaining({
           query: expect.objectContaining({
-            query: `${SECTION_QUERIES.review_pr} assigned:${remoteUser.username}`,
+            query: `${SECTION_QUERIES.review_pr} assigned:"Jane Doe"`,
           }),
         })
       )
@@ -947,5 +947,69 @@ describe('AutofixOverview', () => {
 
     await waitFor(() => expect(assignRequest).toHaveBeenCalled());
     await waitFor(() => expect(reviewRequest).toHaveBeenCalledTimes(2));
+  });
+
+  it('invalidates cached filtered sections after reassignment in focus mode', async () => {
+    const nextAssignee = UserFixture({
+      id: '42',
+      name: 'Next Assignee',
+      email: 'next.assignee@example.com',
+    });
+    mockAssigneeSections('me');
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      match: [MockApiClient.matchQuery({group: [issue.id]})],
+      body: [issue],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [
+        MemberFixture({
+          id: nextAssignee.id,
+          projects: [issue.project.slug],
+          user: nextAssignee,
+        }),
+      ],
+    });
+    const assignRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${issue.id}/`,
+      method: 'PUT',
+      body: {
+        ...issue,
+        assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
+      },
+    });
+    const {router} = renderPage({assignee: 'me'});
+
+    expect(
+      await screen.findByRole('link', {
+        name: 'Proxy requests fail without Authorization header',
+      })
+    ).toBeInTheDocument();
+    router.navigate(`${basePath}?assignee=me&id=${issue.id}`);
+    expect(await screen.findByRole('button', {name: 'All issues'})).toBeInTheDocument();
+
+    mockAssigneeSections('me', []);
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      match: [MockApiClient.matchQuery({group: [issue.id]})],
+      body: [
+        {
+          ...issue,
+          assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
+        },
+      ],
+    });
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Modify issue assignee'})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: /Next Assignee/}));
+    await waitFor(() => expect(assignRequest).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByRole('button', {name: 'All issues'}));
+
+    expect(
+      await screen.findByText('No autofix runs match your filters.')
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1,12 +1,17 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
+import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
 import AutofixOverview from 'sentry/views/seerWorkflows/overview';
 import {RUN_QUESTIONS} from 'sentry/views/seerWorkflows/overview/runQuestions';
 
@@ -150,6 +155,21 @@ describe('AutofixOverview', () => {
     });
   }
 
+  function mockAssigneeSections(assignee: string, reviewIssues: unknown[] = [issue]) {
+    const reviewRequest = mockSection(
+      `${SECTION_QUERIES.review_pr} assigned:${assignee}`,
+      {
+        body: reviewIssues,
+        hits: String(reviewIssues.length),
+      }
+    );
+    mockSection(`${SECTION_QUERIES.code_changes_ready} assigned:${assignee}`);
+    mockSection(`${SECTION_QUERIES.solution_ready} assigned:${assignee}`);
+    mockSection(`${SECTION_QUERIES.needs_investigation} assigned:${assignee}`);
+    mockSection(`${SECTION_QUERIES.merged} assigned:${assignee}`);
+    return reviewRequest;
+  }
+
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     // Collapsed status groups persist to localStorage; keep tests isolated.
@@ -160,6 +180,8 @@ describe('AutofixOverview', () => {
     // gated off.
     PageFiltersStore.onInitializeUrlState(PageFiltersFixture());
     ProjectsStore.loadInitialData([ProjectFixture()]);
+    OrganizationStore.onUpdate(organization, {replace: true});
+    TeamStore.reset();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/`,
       body: [ProjectFixture()],
@@ -172,6 +194,22 @@ describe('AutofixOverview', () => {
     mockSection(SECTION_QUERIES.solution_ready);
     mockSection(SECTION_QUERIES.needs_investigation);
     mockSection(SECTION_QUERIES.merged);
+
+    // The assignee filter loads org members for its dropdown; teams come from
+    // the (empty here) TeamStore. Neither is needed for the default view.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
 
     // Per-card content: the IntersectionObserver override above reports every
     // card as in view, so these fire once per rendered card.
@@ -323,6 +361,10 @@ describe('AutofixOverview', () => {
     expect(
       screen.getAllByRole('time').map(element => element.getAttribute('datetime'))
     ).toEqual(['2019-04-11T01:08:59.000Z', '2026-07-14T10:00:00.000Z']);
+
+    expect(
+      screen.getByRole('button', {name: 'Modify issue assignee'})
+    ).toBeInTheDocument();
 
     // Identity sits in the tail: short id + exactly one level marker.
     expect(screen.getByText('PROJ-1')).toBeVisible();
@@ -511,30 +553,35 @@ describe('AutofixOverview', () => {
     ).toBeInTheDocument();
   });
 
-  it('scopes the section requests to the selected projects', async () => {
+  it('scopes section and member requests to the selected project', async () => {
     PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: [2]}));
     const reviewRequest = mockSection(SECTION_QUERIES.review_pr, {
       body: [issue],
       hits: '3',
     });
+    const membersRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
 
     renderPage();
 
     expect(
-      await screen.findByRole('link', {
-        name: 'Proxy requests fail without Authorization header',
-      })
+      await screen.findByRole('button', {name: 'Modify issue assignee'})
     ).toBeInTheDocument();
-    // The selector's trigger reflects the selection (the card's project badge
-    // is a link, so the button role isolates the filter)…
-    expect(screen.getByRole('button', {name: 'project-slug'})).toBeInTheDocument();
-    // …and the section request carries it.
     expect(reviewRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/issues/`,
       expect.objectContaining({
         query: expect.objectContaining({project: [2]}),
       })
     );
+    expect(membersRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/users/`,
+      expect.objectContaining({
+        query: expect.objectContaining({project: ['2']}),
+      })
+    );
+    expect(membersRequest).toHaveBeenCalledTimes(1);
   });
 
   it('focuses a single card when id is present', async () => {
@@ -753,5 +800,152 @@ describe('AutofixOverview', () => {
     expect(
       await screen.findByText('There was an error loading data.')
     ).toBeInTheDocument();
+  });
+
+  it('selects a remote member, writes it to the URL, and filters sections', async () => {
+    const remoteUser = UserFixture({
+      id: '42',
+      name: 'Remote Member',
+      email: 'remote.member@example.com',
+      username: 'remote-member',
+    });
+    const remoteRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/members/`,
+      match: [MockApiClient.matchQuery({query: 'remote-member'})],
+      body: [MemberFixture({id: '42', user: remoteUser})],
+    });
+    const reviewRequest = mockAssigneeSections(remoteUser.username);
+    const {router} = renderPage();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Assignee None'}));
+    await userEvent.type(
+      screen.getByPlaceholderText('Search assignees…'),
+      'remote-member'
+    );
+    await userEvent.click(await screen.findByRole('option', {name: remoteUser.name}));
+
+    expect(remoteRequest).toHaveBeenCalled();
+    expect(router.location.query.assignee).toBe(remoteUser.username);
+    await waitFor(() =>
+      expect(reviewRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/issues/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: `${SECTION_QUERIES.review_pr} assigned:${remoteUser.username}`,
+          }),
+        })
+      )
+    );
+  });
+
+  it('finds remote teams by slug and writes the selected team to the URL', async () => {
+    const remoteTeam = TeamFixture({
+      id: '42',
+      name: 'Remote Team',
+      slug: 'remote-team',
+    });
+    const remoteRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      match: [MockApiClient.matchQuery({query: 'remote-team'})],
+      body: [remoteTeam],
+    });
+    mockAssigneeSections(`#${remoteTeam.slug}`);
+    const {router} = renderPage();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Assignee None'}));
+    await userEvent.type(
+      screen.getByPlaceholderText('Search assignees…'),
+      `#${remoteTeam.slug}`
+    );
+    await userEvent.click(
+      await screen.findByRole('option', {name: `#${remoteTeam.slug}`})
+    );
+
+    expect(remoteRequest).toHaveBeenCalled();
+    expect(router.location.query.assignee).toBe(`#${remoteTeam.slug}`);
+  });
+
+  it('refetches filtered sections after reassignment', async () => {
+    const nextAssignee = UserFixture({
+      id: '42',
+      name: 'Next Assignee',
+      email: 'next.assignee@example.com',
+    });
+    mockAssigneeSections('me');
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [
+        MemberFixture({
+          id: '42',
+          projects: [issue.project.slug],
+          user: nextAssignee,
+        }),
+      ],
+    });
+    const assignRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${issue.id}/`,
+      method: 'PUT',
+      body: {
+        ...issue,
+        assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
+      },
+    });
+
+    renderPage({assignee: 'me'});
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Modify issue assignee'})
+    );
+
+    // The mutation's success callback immediately refetches all sections, so
+    // replace their responses before selecting the new assignee.
+    mockAssigneeSections('me', []);
+    await userEvent.click(await screen.findByRole('option', {name: /Next Assignee/}));
+
+    await waitFor(() => expect(assignRequest).toHaveBeenCalled());
+    expect(
+      await screen.findByText('No autofix runs match your filters.')
+    ).toBeInTheDocument();
+  });
+
+  it('refetches unfiltered sections after reassignment', async () => {
+    const nextAssignee = UserFixture({
+      id: '42',
+      name: 'Next Assignee',
+      email: 'next.assignee@example.com',
+    });
+    const reviewRequest = mockSection(SECTION_QUERIES.review_pr, {
+      body: [issue],
+      hits: '3',
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [
+        MemberFixture({
+          id: '42',
+          projects: [issue.project.slug],
+          user: nextAssignee,
+        }),
+      ],
+    });
+    const assignRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${issue.id}/`,
+      method: 'PUT',
+      body: {
+        ...issue,
+        assignedTo: {id: nextAssignee.id, name: nextAssignee.name, type: 'user'},
+      },
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(reviewRequest).toHaveBeenCalledTimes(1));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Modify issue assignee'})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: /Next Assignee/}));
+
+    await waitFor(() => expect(assignRequest).toHaveBeenCalled());
+    await waitFor(() => expect(reviewRequest).toHaveBeenCalledTimes(2));
   });
 });

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -32,6 +32,7 @@ export default function AutofixOverview() {
   const period = decodeScalar(location.query.period) ?? DEFAULT_STATS_PERIOD;
   // Unknown or legacy sort values fall back to the default.
   const sort = decodeScalar(location.query.sort) === 'events' ? 'events' : 'activity';
+  const assignee = decodeScalar(location.query.assignee);
 
   // Project scoping comes from the canonical page-filters selection; the
   // section requests are gated until the persisted selection is restored so
@@ -88,6 +89,7 @@ export default function AutofixOverview() {
                 <OverviewFilters
                   period={period}
                   sort={sort}
+                  assignee={assignee}
                   view={view}
                   allCollapsed={allGroupsCollapsed}
                   onUpdateQuery={updateQuery}
@@ -101,6 +103,7 @@ export default function AutofixOverview() {
                   projects={selection.projects}
                   sort={sort}
                   period={period}
+                  assignee={assignee}
                   view={view}
                   collapsedGroups={collapsedGroups}
                   onToggleGroup={toggleGroup}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -22,10 +22,12 @@ import {
   IconUser,
 } from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
+import type {User} from 'sentry/types/user';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
 
 import {deriveCardAction, IssuePrimaryAction} from './cardAction';
+import {OverviewIssueAssignee} from './overviewIssueAssignee';
 import {periodWindowLabel} from './periods';
 import {TriggerBadge} from './triggerBadge';
 import type {AutofixStateKey, OverviewRow, PatchStats} from './types';
@@ -247,12 +249,18 @@ export function IssueCard({
   orgSlug,
   row,
   sectionKey,
+  memberList,
+  memberListLoading,
   minHeight,
+  onAssigneeChange,
 }: {
   orgSlug: string;
   row: OverviewRow;
   sectionKey: AutofixStateKey;
+  memberList?: User[];
+  memberListLoading?: boolean;
   minHeight?: string;
+  onAssigneeChange?: () => void;
 }) {
   const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
   // Deep-link into the issue page with the Seer drawer already open, so the
@@ -413,36 +421,48 @@ export function IssueCard({
             </Stack>
             <Stack gap="xs" align="end">
               <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} />
-              {row.patchStats && (
-                <Tooltip
-                  title={<PatchFilesTooltip stats={row.patchStats} />}
-                  maxWidth={480}
-                  skipWrapper
-                >
-                  <Container
-                    tabIndex={0}
-                    aria-label={tn(
-                      '%s file changed',
-                      '%s files changed',
-                      row.patchStats.files
-                    )}
-                    border="muted"
-                    radius="sm"
-                    background="secondary"
-                    padding="2xs sm"
+              <Flex gap="xs" align="center">
+                {row.patchStats && (
+                  <Tooltip
+                    title={<PatchFilesTooltip stats={row.patchStats} />}
+                    maxWidth={480}
+                    skipWrapper
                   >
-                    <Text size="xs" variant="muted" monospace wrap="nowrap">
-                      {tn('%s file', '%s files', row.patchStats.files)}{' '}
-                      <Text size="xs" variant="success">
-                        +{row.patchStats.added}
-                      </Text>{' '}
-                      <Text size="xs" variant="danger">
-                        −{row.patchStats.removed}
+                    <Container
+                      tabIndex={0}
+                      aria-label={tn(
+                        '%s file changed',
+                        '%s files changed',
+                        row.patchStats.files
+                      )}
+                      border="muted"
+                      radius="sm"
+                      background="secondary"
+                      padding="2xs sm"
+                    >
+                      <Text size="xs" variant="muted" monospace wrap="nowrap">
+                        {tn('%s file', '%s files', row.patchStats.files)}{' '}
+                        <Text size="xs" variant="success">
+                          +{row.patchStats.added}
+                        </Text>{' '}
+                        <Text size="xs" variant="danger">
+                          −{row.patchStats.removed}
+                        </Text>
                       </Text>
-                    </Text>
-                  </Container>
-                </Tooltip>
-              )}
+                    </Container>
+                  </Tooltip>
+                )}
+                <OverviewIssueAssignee
+                  groupId={row.id}
+                  projectId={row.project.id}
+                  projectSlug={row.project.slug}
+                  assignedTo={row.assignedTo ?? undefined}
+                  memberList={memberList}
+                  memberListLoading={memberListLoading}
+                  onSuccess={onAssigneeChange}
+                  owners={row.owners ?? undefined}
+                />
+              </Flex>
               {row.prUrl && cardAction.type !== 'review_pr' && (
                 <LinkButton
                   size="sm"

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -252,7 +252,6 @@ export function IssueCard({
   memberList,
   memberListLoading,
   minHeight,
-  onAssigneeChange,
 }: {
   orgSlug: string;
   row: OverviewRow;
@@ -260,7 +259,6 @@ export function IssueCard({
   memberList?: User[];
   memberListLoading?: boolean;
   minHeight?: string;
-  onAssigneeChange?: () => void;
 }) {
   const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
   // Deep-link into the issue page with the Seer drawer already open, so the
@@ -459,7 +457,6 @@ export function IssueCard({
                   assignedTo={row.assignedTo ?? undefined}
                   memberList={memberList}
                   memberListLoading={memberListLoading}
-                  onSuccess={onAssigneeChange}
                   owners={row.owners ?? undefined}
                 />
               </Flex>

--- a/static/app/views/seerWorkflows/overview/overviewFilters.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewFilters.tsx
@@ -1,13 +1,28 @@
+import {useEffect, useMemo, useState} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import debounce from 'lodash/debounce';
+import uniqBy from 'lodash/uniqBy';
+
+import {TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
+import type {SelectOptionOrSection} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
-import {IconChevron, IconGrid, IconTable} from 'sentry/icons';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
+import {IconChevron, IconGrid, IconTable, IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {User} from 'sentry/types/user';
+import {memberUsersQueryOptions} from 'sentry/utils/members/shared';
+import {useMembers} from 'sentry/utils/members/useMembers';
+import {getUsername} from 'sentry/utils/membersAndTeams/userUtils';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useTeams} from 'sentry/utils/useTeams';
+import {useTeamsById} from 'sentry/utils/useTeamsById';
 
 import {DEFAULT_STATS_PERIOD, PERIOD_FILTER_OPTIONS} from './periods';
 import type {OverviewView, SortValue} from './types';
@@ -17,8 +32,159 @@ const SORT_OPTIONS: Array<{label: string; value: SortValue}> = [
   {value: 'events', label: t('Most events')},
 ];
 
+// The special "self"/"none" assignee tokens accepted by the issue-search
+// `assigned:` filter. Values map directly to the search token appended to the
+// query in `useAutofixSections`.
+const SPECIAL_ASSIGNEE_OPTIONS = [
+  {value: 'me', label: t('Assigned to me'), leadingItems: <IconUser size="sm" />},
+  {value: 'my_teams', label: t('My teams'), leadingItems: <IconUser size="sm" />},
+  {value: 'none', label: t('Unassigned'), leadingItems: <IconUser size="sm" />},
+];
+
+function isSpecialAssignee(value: string | undefined) {
+  return SPECIAL_ASSIGNEE_OPTIONS.some(option => option.value === value);
+}
+
+function makeMemberOption(member: User) {
+  const username = getUsername(member);
+  return {
+    value: username,
+    label: member.name || member.email,
+    textValue: [member.name, member.email, member.username, username]
+      .filter(Boolean)
+      .join(' '),
+    leadingItems: <UserAvatar user={member} size={16} />,
+  };
+}
+
+function useAssigneeOptions(assignee: string | undefined): {
+  isFetching: boolean;
+  onSearch: (value: string) => void;
+  options: Array<SelectOptionOrSection<string>>;
+} {
+  const organization = useOrganization();
+  const [memberSearchTerm, setMemberSearchTerm] = useState('');
+  const defaultMembersQuery = useMembers();
+  const searchedMembersQuery = useQuery({
+    ...memberUsersQueryOptions({
+      orgSlug: organization.slug,
+      search: memberSearchTerm,
+    }),
+    enabled: memberSearchTerm !== '',
+  });
+  const teamSearch = useTeams();
+  const searchTeams = teamSearch.onSearch;
+  const selectedTeamSlug = assignee?.startsWith('#') ? assignee.slice(1) : undefined;
+  const selectedMemberValue =
+    assignee && !selectedTeamSlug && !isSpecialAssignee(assignee) ? assignee : undefined;
+  const selectedTeamSlugs = useMemo(
+    () => (selectedTeamSlug ? [selectedTeamSlug] : undefined),
+    [selectedTeamSlug]
+  );
+  const selectedTeamQuery = useTeamsById({slugs: selectedTeamSlugs});
+  const selectedMemberQuery = useQuery({
+    ...memberUsersQueryOptions({
+      orgSlug: organization.slug,
+      search: selectedMemberValue,
+    }),
+    enabled: Boolean(selectedMemberValue),
+  });
+
+  const onSearch = useMemo(
+    () =>
+      debounce((value: string) => {
+        setMemberSearchTerm(value);
+        void searchTeams(value.replace(/^#/, ''));
+      }, DEFAULT_DEBOUNCE_DURATION),
+    [searchTeams]
+  );
+
+  useEffect(() => () => onSearch.cancel(), [onSearch]);
+
+  const options = useMemo<Array<SelectOptionOrSection<string>>>(() => {
+    const teams = teamSearch.teams.map(team => ({
+      value: `#${team.slug}`,
+      label: `#${team.slug}`,
+      textValue: `#${team.slug} ${team.slug}`,
+      leadingItems: <TeamAvatar team={team} size={16} />,
+    }));
+    const memberUsers = uniqBy(
+      [
+        ...(defaultMembersQuery.data ?? []),
+        ...(searchedMembersQuery.data ?? []),
+        ...(selectedMemberQuery.data ?? []),
+      ],
+      member => member.id
+    );
+    const resolvedSelectedMember = selectedMemberValue
+      ? selectedMemberQuery.data?.find(member =>
+          [getUsername(member), member.username, member.email].includes(
+            selectedMemberValue
+          )
+        )
+      : undefined;
+    const members = memberUsers.map(member => {
+      const option = makeMemberOption(member);
+      return resolvedSelectedMember?.id === member.id && assignee
+        ? {...option, value: assignee}
+        : option;
+    });
+
+    if (
+      assignee &&
+      selectedTeamSlug &&
+      !teams.some(option => option.value === assignee)
+    ) {
+      teams.unshift({
+        value: assignee,
+        label: assignee,
+        textValue: `${assignee} ${selectedTeamSlug}`,
+        leadingItems: <IconUser size="sm" />,
+      });
+    }
+    if (
+      assignee &&
+      selectedMemberValue &&
+      !members.some(option => option.value === assignee)
+    ) {
+      members.unshift({
+        value: assignee,
+        label: assignee,
+        textValue: assignee,
+        leadingItems: <IconUser size="sm" />,
+      });
+    }
+
+    return [
+      {label: t('Suggested'), options: SPECIAL_ASSIGNEE_OPTIONS},
+      {label: t('Teams'), options: teams},
+      {label: t('Members'), options: members},
+    ];
+  }, [
+    assignee,
+    defaultMembersQuery.data,
+    searchedMembersQuery.data,
+    selectedMemberQuery.data,
+    selectedMemberValue,
+    selectedTeamSlug,
+    teamSearch.teams,
+  ]);
+
+  return {
+    options,
+    onSearch,
+    isFetching:
+      defaultMembersQuery.isFetching ||
+      searchedMembersQuery.isFetching ||
+      teamSearch.fetching ||
+      selectedMemberQuery.isFetching ||
+      selectedTeamQuery.isLoading,
+  };
+}
+
 export function OverviewFilters({
   allCollapsed,
+  assignee,
   onToggleAll,
   onUpdateQuery,
   onViewChange,
@@ -27,6 +193,7 @@ export function OverviewFilters({
   view,
 }: {
   allCollapsed: boolean;
+  assignee: string | undefined;
   onToggleAll: () => void;
   onUpdateQuery: (patch: Record<string, string | string[] | undefined>) => void;
   onViewChange: (view: OverviewView) => void;
@@ -34,12 +201,34 @@ export function OverviewFilters({
   sort: SortValue;
   view: OverviewView;
 }) {
+  const {
+    isFetching: assigneesFetching,
+    onSearch: onAssigneeSearch,
+    options: assigneeOptions,
+  } = useAssigneeOptions(assignee);
+
   return (
     <Flex justify="between" align="center" gap="md" wrap="wrap">
       <Flex gap="md" align="center" wrap="wrap">
         <PageFilterBar condensed>
           <ProjectPageFilter />
         </PageFilterBar>
+        <CompactSelect
+          value={assignee}
+          options={assigneeOptions}
+          search={{
+            placeholder: t('Search assignees…'),
+            onChange: onAssigneeSearch,
+          }}
+          loading={assigneesFetching}
+          clearable
+          onChange={selected =>
+            onUpdateQuery({assignee: selected ? String(selected.value) : undefined})
+          }
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} size="sm" prefix={t('Assignee')} />
+          )}
+        />
         <CompactSelect
           value={period}
           options={PERIOD_FILTER_OPTIONS}

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -10,13 +10,12 @@ describe('OverviewIssueAssignee', () => {
   const organization = OrganizationFixture();
   const group = GroupFixture();
 
-  it('updates the local assignment and calls onSuccess after mutation', async () => {
+  it('updates the local assignment after mutation', async () => {
     const assignee = UserFixture({
       id: '42',
       name: 'Next Assignee',
       email: 'next.assignee@example.com',
     });
-    const onSuccess = jest.fn();
     const assignRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/`,
       method: 'PUT',
@@ -32,7 +31,6 @@ describe('OverviewIssueAssignee', () => {
         projectId={group.project.id}
         projectSlug={group.project.slug}
         memberList={[assignee]}
-        onSuccess={onSuccess}
       />,
       {organization}
     );
@@ -47,10 +45,5 @@ describe('OverviewIssueAssignee', () => {
       'title',
       assignee.name
     );
-    expect(onSuccess).toHaveBeenCalledWith({
-      id: assignee.id,
-      name: assignee.name,
-      type: 'user',
-    });
   });
 });

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.spec.tsx
@@ -1,0 +1,56 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {OverviewIssueAssignee} from './overviewIssueAssignee';
+
+describe('OverviewIssueAssignee', () => {
+  const organization = OrganizationFixture();
+  const group = GroupFixture();
+
+  it('updates the local assignment and calls onSuccess after mutation', async () => {
+    const assignee = UserFixture({
+      id: '42',
+      name: 'Next Assignee',
+      email: 'next.assignee@example.com',
+    });
+    const onSuccess = jest.fn();
+    const assignRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/`,
+      method: 'PUT',
+      body: {
+        ...group,
+        assignedTo: {id: assignee.id, name: assignee.name, type: 'user'},
+      },
+    });
+
+    render(
+      <OverviewIssueAssignee
+        groupId={group.id}
+        projectId={group.project.id}
+        projectSlug={group.project.slug}
+        memberList={[assignee]}
+        onSuccess={onSuccess}
+      />,
+      {organization}
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Modify issue assignee'}));
+    await userEvent.click(
+      await screen.findByRole('option', {name: new RegExp(assignee.name)})
+    );
+
+    await waitFor(() => expect(assignRequest).toHaveBeenCalled());
+    expect(await screen.findByTestId('assigned-avatar')).toHaveAttribute(
+      'title',
+      assignee.name
+    );
+    expect(onSuccess).toHaveBeenCalledWith({
+      id: assignee.id,
+      name: assignee.name,
+      type: 'user',
+    });
+  });
+});

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useMemo, useState} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
 
 import {
   AssigneeSelector,
@@ -7,6 +8,7 @@ import {
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {Group} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface OverviewIssueAssigneeProps {
@@ -16,7 +18,6 @@ interface OverviewIssueAssigneeProps {
   assignedTo?: Group['assignedTo'];
   memberList?: User[];
   memberListLoading?: boolean;
-  onSuccess?: (assignedTo: Group['assignedTo']) => void;
   owners?: Group['owners'];
 }
 
@@ -28,10 +29,13 @@ export function OverviewIssueAssignee({
   assignedTo,
   memberList,
   memberListLoading = false,
-  onSuccess,
   owners,
 }: OverviewIssueAssigneeProps) {
   const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const issueIndexUrl = getApiUrl('/organizations/$organizationIdOrSlug/issues/', {
+    path: {organizationIdOrSlug: organization.slug},
+  });
   const [assignedToOverride, setAssignedToOverride] = useState<{
     assignedTo: Group['assignedTo'];
     groupId: OverviewIssueAssigneeProps['groupId'];
@@ -58,9 +62,9 @@ export function OverviewIssueAssignee({
   const handleSuccess = useCallback(
     (nextAssignedTo: Group['assignedTo']) => {
       setAssignedToOverride({groupId, assignedTo: nextAssignedTo});
-      onSuccess?.(nextAssignedTo);
+      void queryClient.invalidateQueries({queryKey: [issueIndexUrl]});
     },
-    [groupId, onSuccess]
+    [groupId, issueIndexUrl, queryClient]
   );
 
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({

--- a/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewIssueAssignee.tsx
@@ -1,0 +1,84 @@
+import {useCallback, useMemo, useState} from 'react';
+
+import {
+  AssigneeSelector,
+  useHandleAssigneeChange,
+} from 'sentry/components/group/assigneeSelector';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import type {Group} from 'sentry/types/group';
+import type {User} from 'sentry/types/user';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+interface OverviewIssueAssigneeProps {
+  groupId: string;
+  projectId: string;
+  projectSlug: string;
+  assignedTo?: Group['assignedTo'];
+  memberList?: User[];
+  memberListLoading?: boolean;
+  onSuccess?: (assignedTo: Group['assignedTo']) => void;
+  owners?: Group['owners'];
+}
+
+// Intentionally duplicates static/app/utils/dashboards/issueAssignee.tsx for the Autofix Overview POC.
+export function OverviewIssueAssignee({
+  groupId,
+  projectId,
+  projectSlug,
+  assignedTo,
+  memberList,
+  memberListLoading = false,
+  onSuccess,
+  owners,
+}: OverviewIssueAssigneeProps) {
+  const organization = useOrganization();
+  const [assignedToOverride, setAssignedToOverride] = useState<{
+    assignedTo: Group['assignedTo'];
+    groupId: OverviewIssueAssigneeProps['groupId'];
+  } | null>(null);
+
+  const currentAssignedTo =
+    assignedToOverride?.groupId === groupId
+      ? assignedToOverride.assignedTo
+      : (assignedTo ?? null);
+
+  const group = useMemo(
+    () => ({
+      id: groupId,
+      assignedTo: currentAssignedTo,
+      owners,
+      project: {
+        id: projectId,
+        slug: projectSlug,
+      },
+    }),
+    [currentAssignedTo, groupId, owners, projectId, projectSlug]
+  );
+
+  const handleSuccess = useCallback(
+    (nextAssignedTo: Group['assignedTo']) => {
+      setAssignedToOverride({groupId, assignedTo: nextAssignedTo});
+      onSuccess?.(nextAssignedTo);
+    },
+    [groupId, onSuccess]
+  );
+
+  const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
+    group,
+    organization,
+    onSuccess: handleSuccess,
+  });
+
+  if (memberListLoading) {
+    return <LoadingIndicator mini relative size={24} />;
+  }
+
+  return (
+    <AssigneeSelector
+      group={group}
+      assigneeLoading={assigneeLoading}
+      handleAssigneeChange={handleAssigneeChange}
+      memberList={memberList}
+    />
+  );
+}

--- a/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
@@ -18,7 +18,6 @@ function HydratedCard({
   statsPeriod,
   memberList,
   memberListLoading,
-  onAssigneeChange,
 }: {
   issue: OverviewIssue;
   orgSlug: string;
@@ -26,7 +25,6 @@ function HydratedCard({
   view: 'cards' | 'table';
   memberList?: User[];
   memberListLoading?: boolean;
-  onAssigneeChange?: () => void;
   // The server-bucketed section. Absent in focus mode, where the issues
   // endpoint omits issue.autofix_state, so we reconstruct it from enrichment.
   sectionKey?: AutofixStateKey;
@@ -49,7 +47,6 @@ function HydratedCard({
       memberList={memberList}
       memberListLoading={memberListLoading}
       minHeight={minHeight}
-      onAssigneeChange={onAssigneeChange}
     />
   ) : (
     <IssueTableRow
@@ -72,7 +69,6 @@ export function SectionIssueCard({
   lazy?: boolean;
   memberList?: User[];
   memberListLoading?: boolean;
-  onAssigneeChange?: () => void;
   sectionKey?: AutofixStateKey;
 }) {
   return (

--- a/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
@@ -1,4 +1,5 @@
 import {LazyRender} from 'sentry/components/lazyRender';
+import type {User} from 'sentry/types/user';
 
 import {buildOverviewRow, deriveSectionKey} from './buildOverviewRows';
 import {IssueCard, IssueTableRow} from './issueCard';
@@ -15,11 +16,17 @@ function HydratedCard({
   sectionKey,
   view,
   statsPeriod,
+  memberList,
+  memberListLoading,
+  onAssigneeChange,
 }: {
   issue: OverviewIssue;
   orgSlug: string;
   statsPeriod: string;
   view: 'cards' | 'table';
+  memberList?: User[];
+  memberListLoading?: boolean;
+  onAssigneeChange?: () => void;
   // The server-bucketed section. Absent in focus mode, where the issues
   // endpoint omits issue.autofix_state, so we reconstruct it from enrichment.
   sectionKey?: AutofixStateKey;
@@ -39,7 +46,10 @@ function HydratedCard({
       row={row}
       orgSlug={orgSlug}
       sectionKey={resolvedSectionKey}
+      memberList={memberList}
+      memberListLoading={memberListLoading}
       minHeight={minHeight}
+      onAssigneeChange={onAssigneeChange}
     />
   ) : (
     <IssueTableRow
@@ -60,6 +70,9 @@ export function SectionIssueCard({
   statsPeriod: string;
   view: 'cards' | 'table';
   lazy?: boolean;
+  memberList?: User[];
+  memberListLoading?: boolean;
+  onAssigneeChange?: () => void;
   sectionKey?: AutofixStateKey;
 }) {
   return (

--- a/static/app/views/seerWorkflows/overview/sectionList.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionList.tsx
@@ -1,4 +1,6 @@
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
 
 import {Badge} from '@sentry/scraps/badge';
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -10,6 +12,8 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Sticky} from 'sentry/components/sticky';
 import {t} from 'sentry/locale';
+import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
+import {indexMembersByProject} from 'sentry/utils/members/shared';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 
@@ -27,6 +31,7 @@ function formatSectionCount(count: number | undefined) {
 }
 
 export function SectionList({
+  assignee,
   collapsedGroups,
   enabled,
   onToggleGroup,
@@ -42,6 +47,7 @@ export function SectionList({
   projects: number[];
   sort: SortValue;
   view: OverviewView;
+  assignee?: string;
 }) {
   const organization = useOrganization();
   const {projects: orgProjects} = useProjects();
@@ -50,6 +56,15 @@ export function SectionList({
     projects,
     sort: sort === 'events' ? 'freq' : 'date',
     statsPeriod: period,
+    assignee,
+  });
+  const memberProjectIds = useMemo(() => projects.map(String), [projects]);
+  const hasCardIssues =
+    view === 'cards' && sections.some(section => section.issues.length > 0);
+  const memberQuery = useQuery({
+    ...useProjectMembersQueryOptions(memberProjectIds),
+    select: response => indexMembersByProject(response.json),
+    enabled: enabled && hasCardIssues,
   });
 
   const firstLoad = isPending && sections.every(section => section.isPending);
@@ -57,7 +72,8 @@ export function SectionList({
     section => !section.isPending && !section.isError && section.issues.length === 0
   );
   const hasProjectFilter = projects.length > 0 && orgProjects.length > 1;
-  const hasNonDefaultFilters = hasProjectFilter || period !== DEFAULT_STATS_PERIOD;
+  const hasNonDefaultFilters =
+    hasProjectFilter || period !== DEFAULT_STATS_PERIOD || Boolean(assignee);
 
   if (isError) {
     return <LoadingError onRetry={refetch} />;
@@ -125,6 +141,13 @@ export function SectionList({
                     <SectionIssueCard
                       key={issue.id}
                       issue={issue}
+                      memberList={
+                        memberQuery.isError
+                          ? undefined
+                          : (memberQuery.data?.get(issue.project.slug) ?? [])
+                      }
+                      memberListLoading={memberQuery.isPending}
+                      onAssigneeChange={refetch}
                       orgSlug={organization.slug}
                       sectionKey={section.key}
                       view={view}

--- a/static/app/views/seerWorkflows/overview/sectionList.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionList.tsx
@@ -147,7 +147,6 @@ export function SectionList({
                           : (memberQuery.data?.get(issue.project.slug) ?? [])
                       }
                       memberListLoading={memberQuery.isPending}
-                      onAssigneeChange={refetch}
                       orgSlug={organization.slug}
                       sectionKey={section.key}
                       view={view}

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -1,4 +1,6 @@
+import type {Actor} from 'sentry/types/core';
 import type {Level} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
 import type {PlatformKey} from 'sentry/types/platform';
 
 // Shared staleTime for the overview's issue/run/state queries.
@@ -91,16 +93,18 @@ export interface SeerRun {
 
 // One issue from the issue stream, as the overview cards consume it.
 export interface OverviewIssue {
+  assignedTo: Actor | null;
   // Event count over the stats period; the endpoint returns it as a string.
   count: string;
   id: string;
   lastSeen: string;
   level: Level;
-  project: {slug: string; platform?: PlatformKey};
+  project: {id: string; slug: string; platform?: PlatformKey};
   seerAutofixLastTriggered: string | null;
   shortId: string;
   title: string;
   userCount: number;
+  owners?: Group['owners'];
 }
 
 // How the run was started. Sources without a mapping render a fallback
@@ -140,6 +144,7 @@ export interface PatchStats {
 // One issue + its latest autofix run, flattened for the overview cards.
 export interface OverviewRow {
   analysis: RunAnalysisEntry[];
+  assignedTo: Actor | null;
   eventCount: number;
   id: string;
   // Most recent Seer activity on the run (state update, trigger, or
@@ -150,7 +155,7 @@ export interface OverviewRow {
   // "last seen" TimeSince.
   lastSeen: string;
   level: Level;
-  project: {slug: string; platform?: PlatformKey};
+  project: {id: string; slug: string; platform?: PlatformKey};
   // Live run status, mirrored straight from the state payload; drives the
   // transient overlays only. Null until the state request resolves.
   runStatus: RunStatus | null;
@@ -165,6 +170,7 @@ export interface OverviewRow {
   // Plain-language title from the run's root-cause answer (see runQuestions).
   // Falls back to the raw issue title.
   headline?: string;
+  owners?: Group['owners'];
   patchStats?: PatchStats;
   // The question autofix paused on, when status is NEED_MORE_INFORMATION and
   // the pending input payload carries readable text.

--- a/static/app/views/seerWorkflows/overview/useAutofixSections.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixSections.tsx
@@ -28,11 +28,13 @@ export function useAutofixSections({
   projects,
   sort,
   statsPeriod,
+  assignee,
 }: {
   enabled: boolean;
   projects: number[];
   sort: 'date' | 'freq';
   statsPeriod: string;
+  assignee?: string;
 }) {
   const organization = useOrganization();
 
@@ -43,11 +45,14 @@ export function useAutofixSections({
         {
           path: {organizationIdOrSlug: organization.slug},
           query: {
-            query: `${REQUIRED_ISSUE_FILTER} issue.autofix_state:${key}`,
+            query: `${REQUIRED_ISSUE_FILTER} issue.autofix_state:${key}${
+              assignee ? ` assigned:${assignee}` : ''
+            }`,
             project: projects,
             statsPeriod,
             sort,
             limit: SECTION_LIMIT,
+            expand: ['owners'],
           },
           staleTime: QUERY_STALE_TIME,
         }

--- a/static/app/views/seerWorkflows/overview/useAutofixSections.tsx
+++ b/static/app/views/seerWorkflows/overview/useAutofixSections.tsx
@@ -1,5 +1,6 @@
 import {useQueries} from '@tanstack/react-query';
 
+import {escapeTagValue} from 'sentry/components/searchBar/utils';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -46,7 +47,7 @@ export function useAutofixSections({
           path: {organizationIdOrSlug: organization.slug},
           query: {
             query: `${REQUIRED_ISSUE_FILTER} issue.autofix_state:${key}${
-              assignee ? ` assigned:${assignee}` : ''
+              assignee ? ` assigned:${escapeTagValue(assignee)}` : ''
             }`,
             project: projects,
             statsPeriod,


### PR DESCRIPTION
Adds two assignee affordances to the Autofix Overview.

**Filter by assignee.** The toolbar gains an "Assignee" dropdown alongside the existing project, activity, and sort filters. It offers the standard issue-search assignee choices — assigned to me, my teams, unassigned, plus any team or member — and appends an `assigned:<value>` token to every section query. The selection lives in the `assignee` URL param so it's shareable and survives reloads, and an active assignee now counts as a non-default filter, so an empty result shows "No autofix runs match your filters." rather than the generic empty state.

**Assignee on each card.** Every card in the card view now shows the issue's assignee in the header's top-right, to the left of the files-changed pill. It reuses `IssueAssignee` — the same control the issue feed and issue-detail header use — so clicking it opens the familiar suggested/members/teams dropdown and reassigns through the normal mutation. To feed it, `OverviewIssue`/`OverviewRow` carry `assignedTo`, `owners`, and the project `id`, and the section requests add `expand=owners` for suggested-owner hints. Table view is unchanged.

This is frontend-only: the issues endpoint already returns `assignedTo` and the project fields, so no serializer changes were needed.

Reviewer note: the filter (which issues are listed) and the per-card control (who each issue is assigned to) are independent features that happen to share the same view; they can be reviewed separately.
