### PR TITLE
ref: Remove slack forced trial

### DIFF
--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -491,43 +491,6 @@ describe('GSBanner', () => {
     expect(openForcedTrialModal).not.toHaveBeenCalled();
   });
 
-  it('automatically starts forced trial for restricted integration', async () => {
-    const organization = OrganizationFixture({
-      access: ['org:billing'],
-    });
-
-    SubscriptionStore.set(
-      organization.slug,
-      SubscriptionFixture({
-        plan: 'am1_f',
-        organization,
-        totalLicenses: 1,
-        usedLicenses: 1,
-        hasRestrictedIntegration: true,
-      })
-    );
-
-    const mockForceTrial = MockApiClient.addMockResponse({
-      method: 'POST',
-      url: `/organizations/${organization.slug}/restricted-integration-trial/`,
-      body: {},
-    });
-
-    render(<GSBanner organization={organization} />, {
-      organization,
-    });
-
-    await waitFor(() => {
-      expect(mockForceTrial).toHaveBeenCalledWith(
-        `/organizations/${organization.slug}/restricted-integration-trial/`,
-        expect.objectContaining({
-          method: 'POST',
-        })
-      );
-    });
-    expect(openForcedTrialModal).toHaveBeenCalled();
-  });
-
   it('opens the forced trial modal', async () => {
     const now = moment();
     const organization = OrganizationFixture({

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -458,17 +458,11 @@ class GSBanner extends Component<Props, State> {
       return;
     }
 
-    // mutliple possible trial endpoints depending on the situation
-    let endpoint: string;
-    // check for restricted integration
-    if (subscription.hasRestrictedIntegration) {
-      endpoint = `/organizations/${organization.slug}/restricted-integration-trial/`;
-      // only trigger if member limit is 1 and we have multiple licenses used
-    } else if (subscription.totalLicenses === 1 && subscription.usedLicenses > 1) {
-      endpoint = `/organizations/${organization.slug}/over-member-limit-trial/`;
-    } else {
+    // only trigger if member limit is 1 and we have multiple licenses used
+    if (!(subscription.totalLicenses === 1 && subscription.usedLicenses > 1)) {
       return;
     }
+    const endpoint = `/organizations/${organization.slug}/over-member-limit-trial/`;
 
     try {
       await api.requestPromise(endpoint, {

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -310,7 +310,6 @@ export type Subscription = {
   hasDismissedForcedTrialNotice: boolean;
   hasDismissedTrialEndingNotice: boolean;
   hasMigratedToBillingPlatform: boolean;
-  hasRestrictedIntegration: boolean | null;
   id: string;
 
   // Added by SubscriptionStore to show/hide a UI element

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -78,7 +78,6 @@ export function SubscriptionFixture(props: Props): TSubscription {
     hasDismissedForcedTrialNotice: false,
     hasDismissedTrialEndingNotice: false,
     hasMigratedToBillingPlatform: false,
-    hasRestrictedIntegration: false,
     hadCustomDynamicSampling: false,
     id: '',
     isEnterpriseTrial,


### PR DESCRIPTION
There seems to be no way to trigger this "forced trial" anymore since orgs without slack access can't connect slack. Cleaning up this now dead code