### PR TITLE
feat(seer): Show Seer trial CTA on autofix overview

### DIFF
--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -216,6 +216,7 @@ type ComponentOverrides = {
   'component:replay-onboarding-cta': () => React.ComponentType<ReplayOnboardingCTAProps>;
   'component:replay-settings-alert': () => React.ComponentType | null;
   'component:scm-github-multi-org-install': () => React.ComponentType<ScmGithubMultiOrgInstallProps>;
+  'component:seer-trial-cta': () => React.ComponentType | null;
   'component:superuser-access-category': React.ComponentType<SuperuserAccessCategoryProps>;
   'component:superuser-warning': React.ComponentType<any>;
   'component:superuser-warning-excluded': SuperuserWarningExcluded;

--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -214,6 +214,7 @@ type ComponentOverrides = {
   'component:replay-settings-alert': () => React.ComponentType | null;
   'component:scm-github-multi-org-install': () => React.ComponentType<ScmGithubMultiOrgInstallProps>;
   'component:seer-beta-closing-alert': () => React.ComponentType;
+  'component:seer-trial-cta': () => React.ComponentType | null;
   'component:superuser-access-category': React.ComponentType<any>;
   'component:superuser-warning': React.ComponentType<any>;
   'component:superuser-warning-excluded': SuperuserWarningExcluded;

--- a/static/app/utils/seer/orgNeedsSeerTrial.spec.ts
+++ b/static/app/utils/seer/orgNeedsSeerTrial.spec.ts
@@ -1,0 +1,38 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
+
+describe('orgNeedsSeerTrial', () => {
+  it('returns true when seer-user-billing-launch is present', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-user-billing-launch'],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(true);
+  });
+
+  it('returns false when hideAiFeatures is true', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-user-billing-launch'],
+      hideAiFeatures: true,
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+
+  it('returns false when seat-based-seer-enabled is present', () => {
+    const organization = OrganizationFixture({
+      features: ['seat-based-seer-enabled'],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+
+  it('returns false when no relevant features are present', () => {
+    const organization = OrganizationFixture({
+      features: [],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+});

--- a/static/app/utils/seer/orgNeedsSeerTrial.spec.ts
+++ b/static/app/utils/seer/orgNeedsSeerTrial.spec.ts
@@ -1,0 +1,54 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
+
+describe('orgNeedsSeerTrial', () => {
+  it('returns true when seer-user-billing-launch is present', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-user-billing-launch'],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(true);
+  });
+
+  it('returns false when hideAiFeatures is true', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-user-billing-launch'],
+      hideAiFeatures: true,
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+
+  it('returns false when seat-based-seer-enabled is present', () => {
+    const organization = OrganizationFixture({
+      features: ['seat-based-seer-enabled'],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+
+  it('returns false when seer-added is present', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-added'],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+
+  it('returns false when code-review-beta is present', () => {
+    const organization = OrganizationFixture({
+      features: ['code-review-beta'],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+
+  it('returns false when no relevant features are present', () => {
+    const organization = OrganizationFixture({
+      features: [],
+    });
+
+    expect(orgNeedsSeerTrial(organization)).toBe(false);
+  });
+});

--- a/static/app/utils/seer/orgNeedsSeerTrial.ts
+++ b/static/app/utils/seer/orgNeedsSeerTrial.ts
@@ -1,0 +1,10 @@
+import type {Organization} from 'sentry/types/organization';
+import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
+
+export function orgNeedsSeerTrial(organization: Organization) {
+  return (
+    showNewSeer(organization) &&
+    !organization.features.includes('seat-based-seer-enabled') &&
+    !organization.hideAiFeatures
+  );
+}

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -831,4 +831,58 @@ describe('AutofixOverview', () => {
       await screen.findByText('There was an error loading data.')
     ).toBeInTheDocument();
   });
+
+  it('replaces the overview content when the org is eligible for Seer but has not purchased it', () => {
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({
+        features: ['seer-night-shift-ui', 'seer-user-billing-launch'],
+      }),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(screen.getByText('Autofix Overview')).toBeInTheDocument();
+    expect(screen.queryByRole('radio', {name: 'Card view'})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /Awaiting your review/})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the overview normally when the org has seat-based Seer', async () => {
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({
+        features: ['seer-night-shift-ui', 'seat-based-seer-enabled'],
+      }),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Awaiting your review 3'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders the overview normally when the org hides AI features', async () => {
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({
+        features: ['seer-night-shift-ui', 'seer-user-billing-launch'],
+        hideAiFeatures: true,
+      }),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Awaiting your review 3'})
+    ).toBeInTheDocument();
+  });
+
+  it('prefers the trial CTA over the focused-issue view', () => {
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({
+        features: ['seer-night-shift-ui', 'seer-user-billing-launch'],
+      }),
+      initialRouterConfig: {location: {pathname: basePath, query: {id: '2'}}},
+    });
+
+    expect(screen.queryByRole('radio', {name: 'Card view'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'All issues'})).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -1017,4 +1017,38 @@ describe('AutofixOverview', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('replaces the overview content when the org is eligible for Seer but has not purchased it', () => {
+    const {baseRequest, enrichedRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({
+        features: ['seer-night-shift-ui', 'seer-user-billing-launch'],
+      }),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(screen.getByText('Autofix Overview')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Sort/})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Create Plan/})).not.toBeInTheDocument();
+    expect(baseRequest).not.toHaveBeenCalled();
+    expect(enrichedRequest).not.toHaveBeenCalled();
+  });
+
+  it('renders the overview normally when the org has seat-based Seer', async () => {
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+
+    render(<AutofixOverview />, {
+      organization: OrganizationFixture({
+        features: ['seer-night-shift-ui', 'seat-based-seer-enabled'],
+      }),
+      initialRouterConfig: {location: {pathname: basePath}},
+    });
+
+    expect(
+      await screen.findByRole('button', {name: 'Create Plan 1'})
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -12,7 +12,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
+import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -44,10 +44,7 @@ export default function AutofixOverview() {
   // the first fetch doesn't race it with an all-projects query.
   const {selection, isReady: pageFiltersReady} = usePageFilters();
 
-  const needsSeerSetup =
-    showNewSeer(organization) &&
-    !organization.features.includes('seat-based-seer-enabled') &&
-    !organization.hideAiFeatures;
+  const needsSeerSetup = orgNeedsSeerTrial(organization);
 
   const [collapsedGroups, setCollapsedGroups] = useLocalStorageState<StatusGroupKey[]>(
     'seer-autofix-overview:collapsed-groups',

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -6,11 +6,13 @@ import {Stack} from '@sentry/scraps/layout';
 
 import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -22,6 +24,10 @@ import {DEFAULT_STATS_PERIOD} from './periods';
 import {SectionList} from './sectionList';
 import type {StatusGroupKey} from './statusGroups';
 import {type OverviewView, SECTION_ORDER} from './types';
+
+const SeerTrialCTA = OverrideOrDefault({
+  overrideName: 'component:seer-trial-cta',
+});
 
 export default function AutofixOverview() {
   const organization = useOrganization();
@@ -37,6 +43,11 @@ export default function AutofixOverview() {
   // section requests are gated until the persisted selection is restored so
   // the first fetch doesn't race it with an all-projects query.
   const {selection, isReady: pageFiltersReady} = usePageFilters();
+
+  const needsSeerSetup =
+    showNewSeer(organization) &&
+    !organization.features.includes('seat-based-seer-enabled') &&
+    !organization.hideAiFeatures;
 
   const [collapsedGroups, setCollapsedGroups] = useLocalStorageState<StatusGroupKey[]>(
     'seer-autofix-overview:collapsed-groups',
@@ -81,7 +92,9 @@ export default function AutofixOverview() {
             />
           </Layout.Title>
           <Stack gap="lg" padding="lg xl">
-            {selectedId ? (
+            {needsSeerSetup ? (
+              <SeerTrialCTA />
+            ) : selectedId ? (
               <FocusedIssue id={selectedId} period={period} />
             ) : (
               <Fragment>

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -14,6 +14,7 @@ import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
@@ -24,6 +25,7 @@ import {Sticky} from 'sentry/components/sticky';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -33,6 +35,10 @@ import {OverviewCard} from './issueCard';
 import {STATUS_GROUP_META, type StatusGroupKey, StatusGroupTooltip} from './statusGroups';
 import {OVERVIEW_SECTIONS, type OverviewSort} from './types';
 import {useAutofixOverview} from './useAutofixOverview';
+
+const SeerTrialCTA = OverrideOrDefault({
+  overrideName: 'component:seer-trial-cta',
+});
 
 const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
   {value: 'seer', label: t('Recent Seer Activity')},
@@ -56,7 +62,13 @@ export default function AutofixOverview() {
       >
         <SentryDocumentTitle title={t('Autofix Overview')} orgSlug={organization.slug}>
           <Layout.Title>{t('Autofix Overview')}</Layout.Title>
-          <AutofixOverviewContent organization={organization} />
+          {orgNeedsSeerTrial(organization) ? (
+            <Stack gap="lg" padding="lg xl">
+              <SeerTrialCTA />
+            </Stack>
+          ) : (
+            <AutofixOverviewContent organization={organization} />
+          )}
         </SentryDocumentTitle>
       </PageFiltersContainer>
     </Feature>

--- a/static/gsApp/registerOverrides.tsx
+++ b/static/gsApp/registerOverrides.tsx
@@ -72,6 +72,7 @@ import {useReplayForCriticalFlow} from 'getsentry/overrides/useReplayForCritical
 import {useScmFeatureMeta} from 'getsentry/overrides/useScmFeatureMeta';
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
 import {trackMetric} from 'getsentry/utils/trackMetric';
+import SeerAutomationTrial from 'getsentry/views/seerAutomation/trial';
 
 import {GsBillingCommandPaletteActions} from './components/gsBillingCommandPaletteActions';
 import {PrimaryNavigationQuotaExceeded} from './components/navBillingStatus';
@@ -213,6 +214,7 @@ const GETSENTRY_OVERRIDES: Partial<Overrides> = {
 
   'component:ai-configure-seer-quota-sidebar': () => AiConfigureSeerQuotaSidebar,
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
+  'component:seer-trial-cta': () => SeerAutomationTrial,
   'component:continuous-profiling-billing-requirement-banner': () =>
     ContinuousProfilingBillingRequirementBanner,
   'component:header-date-page-filter-upsell-footer': () => DateRangeQueryLimitFooter,

--- a/static/gsApp/registerOverrides.tsx
+++ b/static/gsApp/registerOverrides.tsx
@@ -76,6 +76,7 @@ import {useReplayForCriticalFlow} from 'getsentry/overrides/useReplayForCritical
 import {useScmFeatureMeta} from 'getsentry/overrides/useScmFeatureMeta';
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
 import {trackMetric} from 'getsentry/utils/trackMetric';
+import SeerAutomationTrial from 'getsentry/views/seerAutomation/trial';
 
 import {GsBillingCommandPaletteActions} from './components/gsBillingCommandPaletteActions';
 import {PrimaryNavigationQuotaExceeded} from './components/navBillingStatus';
@@ -229,6 +230,7 @@ const GETSENTRY_OVERRIDES: Partial<Overrides> = {
   'component:insights-date-range-query-limit-footer': () =>
     InsightsDateRangeQueryLimitFooter,
   'component:ai-configure-seer-quota-sidebar': () => AiConfigureSeerQuotaSidebar,
+  'component:seer-trial-cta': () => SeerAutomationTrial,
   'component:ai-setup-data-consent': () => AiSetupDataConsent,
   'component:continuous-profiling-billing-requirement-banner': () =>
     ContinuousProfilingBillingRequirementBanner,

--- a/static/gsApp/views/seerAutomation/scmRequired.tsx
+++ b/static/gsApp/views/seerAutomation/scmRequired.tsx
@@ -18,6 +18,7 @@ import {IconOpen} from 'sentry/icons/iconOpen';
 import {t, tct} from 'sentry/locale';
 import type {Integration} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
 import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -58,7 +59,7 @@ export default function SeerAutomationSCMRequired() {
     return <Redirect to={normalizeUrl(`/settings/${organization.slug}/seer/`)} />;
   }
 
-  if (!hasSeatBasedSeer && !hasCodeReviewBeta) {
+  if (orgNeedsSeerTrial(organization)) {
     return <Redirect to={normalizeUrl(`/settings/${organization.slug}/seer/trial/`)} />;
   }
 

--- a/static/gsApp/views/seerAutomation/trial.tsx
+++ b/static/gsApp/views/seerAutomation/trial.tsx
@@ -19,6 +19,7 @@ import {AnalyticsArea, useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {IconUpgrade} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import {orgNeedsSeerTrial} from 'sentry/utils/seer/orgNeedsSeerTrial';
 import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -60,21 +61,10 @@ export default function SeerAutomationTrial() {
   );
 
   useEffect(() => {
-    // If the org is on the old-seer plan then they shouldn't be here on this new settings page
-    // they need to goto the old settings page, or get downgraded off old seer.
-    if (!showNewSeer(organization)) {
+    if (!orgNeedsSeerTrial(organization)) {
       navigate(normalizeUrl(`/settings/${organization.slug}/seer/`));
-      return;
     }
-
-    // If you've already got Seer, then go to settings and you should see the new ones.
-    if (organization.features.includes('seat-based-seer-enabled')) {
-      navigate(normalizeUrl(`/settings/${organization.slug}/seer/`));
-      return;
-    }
-
-    // Else you don't yet have the new seer plan, then stay here and click to start a trial.
-  }, [navigate, organization.features, organization.slug, organization]);
+  }, [navigate, organization]);
 
   useRouteAnalyticsParams({
     showNewSeer: showNewSeer(organization),


### PR DESCRIPTION
Users landing on `/issues/autofix/overview` without Seer previously saw an empty page; it now renders the "Say Hello to a Smarter Sentry" trial panel from Settings > Seer in place of the overview content. The panel lives in the getsentry bundle, so it's exposed via a new `component:seer-trial-cta` overrides entry (same pattern as `component:ai-setup-data-consent`) — self-hosted builds render nothing new. The audience check is extracted into a shared `orgNeedsSeerTrial` helper (`showNewSeer` && no `seat-based-seer-enabled` && not `hideAiFeatures`), now used by the overview gate, the settings trial page's redirect guard, and the SCM-required redirect so the surfaces can't drift. The gate keeps the panel's internal redirect inert on the overview, so the component is reused unmodified, and it replaces the content subtree that owns the overview queries, so trial-eligible orgs issue no overview requests.

Rebuilt on top of the promoted overview page (#122178/#122177): the gate now lives in the new `AutofixOverview` entry component, inside its existing `seer-night-shift-ui` feature gate, and the spec additions were rewritten against the new page.

Fixes [AIML-3328](https://linear.app/getsentry/issue/AIML-3328/empty-state-billing-empty-state)

Screenshot
<img width="1753" height="1049" alt="image" src="https://github.com/user-attachments/assets/bd8f044a-dbb8-4fca-9a2d-455a02f9a069" />
