### PR TITLE
feat(seer): Polish autofix overview cards and fix run-activity timestamps

### DIFF
--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.spec.ts
@@ -1,16 +1,15 @@
 import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {
   buildAnalysis,
+  buildOverviewRow,
   deriveSectionKey,
   extractPatchInfo,
   extractPendingQuestion,
-  INLINE_DIFF_MAX_CHANGED_LINES,
-  INLINE_DIFF_MAX_FILES,
   mostRecentTimestamp,
   normalizeBulletList,
   parseRootCause,
 } from 'sentry/views/seerWorkflows/overview/buildOverviewRows';
-import type {SeerRun} from 'sentry/views/seerWorkflows/overview/types';
+import type {OverviewIssue, SeerRun} from 'sentry/views/seerWorkflows/overview/types';
 
 function makeBlock(step: string) {
   return {message: {role: 'assistant', content: step, metadata: {step}}};
@@ -21,10 +20,8 @@ function makePatch({
   path = 'src/cart.py',
   added = 1,
   removed = 0,
-  lines = 1,
 }: {
   added?: number;
-  lines?: number;
   path?: string;
   removed?: number;
   repo?: string;
@@ -39,22 +36,8 @@ function makePatch({
       type: 'M',
       added,
       removed,
-      hunks: [
-        {
-          section_header: '',
-          source_start: 1,
-          source_length: lines,
-          target_start: 1,
-          target_length: lines,
-          lines: Array.from({length: lines}, (_, index) => ({
-            value: `line ${index}`,
-            line_type: '+',
-            source_line_no: null,
-            target_line_no: index + 1,
-            diff_line_no: index + 1,
-          })),
-        },
-      ],
+      // extractPatchInfo only reads the counts; hunk content is irrelevant.
+      hunks: [],
     },
   };
 }
@@ -94,6 +77,43 @@ function makeRun(overrides: Partial<SeerRun> = {}): SeerRun {
     ...overrides,
   };
 }
+
+function makeIssue(overrides: Partial<OverviewIssue> = {}): OverviewIssue {
+  return {
+    count: '100',
+    id: '2',
+    lastSeen: '2026-07-20T12:00:00Z',
+    level: 'error',
+    project: {slug: 'proj'},
+    seerAutofixLastTriggered: null,
+    shortId: 'PROJ-1',
+    title: 'Boom',
+    userCount: 5,
+    ...overrides,
+  };
+}
+
+describe('buildOverviewRow', () => {
+  it('derives lastActivityAt from Seer-side timestamps, ignoring lastSeen', () => {
+    // The issue fired after every Seer signal — the activity time must still
+    // be the newest Seer timestamp, or it would duplicate the last-seen time
+    // on every actively-erroring issue.
+    const row = buildOverviewRow(
+      makeIssue({seerAutofixLastTriggered: '2026-07-14T08:00:00Z'}),
+      makeRun({lastTriggeredAt: '2026-07-14T09:00:00Z'}),
+      makeState({updated_at: '2026-07-14T10:00:00Z'}),
+      false,
+      '90d'
+    );
+    expect(row.lastActivityAt).toBe('2026-07-14T10:00:00Z');
+    expect(row.lastSeen).toBe('2026-07-20T12:00:00Z');
+  });
+
+  it('nulls lastActivityAt when the run has no Seer-side timestamp', () => {
+    const row = buildOverviewRow(makeIssue(), null, null, true, '90d');
+    expect(row.lastActivityAt).toBeNull();
+  });
+});
 
 describe('parseRootCause', () => {
   it('splits a headline from the root cause on the first pipe', () => {
@@ -207,55 +227,31 @@ describe('buildAnalysis', () => {
 });
 
 describe('extractPatchInfo', () => {
-  it('renders inline at exactly the changed-line limit', () => {
-    const {inlinePatches, patchStats} = extractPatchInfo(
+  it('aggregates counts across files and sorts the list by churn', () => {
+    const {patchStats} = extractPatchInfo(
       makeCodeChangesState([
-        makePatch({added: INLINE_DIFF_MAX_CHANGED_LINES, removed: 0, lines: 3}),
+        makePatch({path: 'src/small.py', added: 1, removed: 0}),
+        makePatch({path: 'src/big.py', added: 10, removed: 3}),
       ])
     );
-    expect(patchStats?.added).toBe(INLINE_DIFF_MAX_CHANGED_LINES);
-    expect(inlinePatches).toHaveLength(1);
-  });
-
-  it('falls back to a pill one line over the changed-line limit', () => {
-    const {inlinePatches, patchStats} = extractPatchInfo(
-      makeCodeChangesState([
-        makePatch({added: INLINE_DIFF_MAX_CHANGED_LINES + 1, removed: 0, lines: 3}),
-      ])
-    );
-    expect(patchStats?.added).toBe(INLINE_DIFF_MAX_CHANGED_LINES + 1);
-    expect(inlinePatches).toBeUndefined();
-  });
-
-  it('renders inline at exactly the file limit', () => {
-    const patches = Array.from({length: INLINE_DIFF_MAX_FILES}, (_, index) =>
-      makePatch({path: `src/file${index}.py`, added: 1, removed: 0, lines: 1})
-    );
-    const {inlinePatches} = extractPatchInfo(makeCodeChangesState(patches));
-    expect(inlinePatches).toHaveLength(INLINE_DIFF_MAX_FILES);
-  });
-
-  it('falls back to a pill one file over the file limit', () => {
-    const patches = Array.from({length: INLINE_DIFF_MAX_FILES + 1}, (_, index) =>
-      makePatch({path: `src/file${index}.py`, added: 1, removed: 0, lines: 1})
-    );
-    const {inlinePatches, patchStats} = extractPatchInfo(makeCodeChangesState(patches));
-    expect(inlinePatches).toBeUndefined();
-    expect(patchStats?.files).toBe(INLINE_DIFF_MAX_FILES + 1);
+    expect(patchStats).toMatchObject({files: 2, added: 11, removed: 3});
+    expect(patchStats?.fileList.map(file => file.path)).toEqual([
+      'src/big.py',
+      'src/small.py',
+    ]);
   });
 
   it('prefixes file paths with the repo when the diff spans repos', () => {
-    const {inlinePatches, patchStats} = extractPatchInfo(
+    const {patchStats} = extractPatchInfo(
       makeCodeChangesState([
-        makePatch({repo: 'getsentry/sentry', path: 'src/a.py', added: 1, lines: 1}),
-        makePatch({repo: 'getsentry/getsentry', path: 'src/b.py', added: 1, lines: 1}),
+        makePatch({repo: 'getsentry/sentry', path: 'src/a.py', added: 1}),
+        makePatch({repo: 'getsentry/getsentry', path: 'src/b.py', added: 1}),
       ])
     );
     expect(patchStats?.fileList.map(file => file.path).sort()).toEqual([
       'getsentry/getsentry:src/b.py',
       'getsentry/sentry:src/a.py',
     ]);
-    expect(inlinePatches?.every(patch => patch.repoName !== undefined)).toBe(true);
   });
 });
 

--- a/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
+++ b/static/app/views/seerWorkflows/overview/buildOverviewRows.ts
@@ -49,15 +49,7 @@ export function deriveSectionKey(
     .key;
 }
 
-// A diff qualifies for the on-card differ only when it is genuinely small:
-// few files, few changed lines, and bounded hunk context so a fix with huge
-// surrounding context can't blow the card up.
-export const INLINE_DIFF_MAX_FILES = 2;
-export const INLINE_DIFF_MAX_CHANGED_LINES = 25;
-const INLINE_DIFF_MAX_RENDERED_LINES = 60;
-
 export function extractPatchInfo(state: ExplorerAutofixState | null): {
-  inlinePatches?: OverviewRow['inlinePatches'];
   patchStats?: PatchStats;
 } {
   const section = getOrderedAutofixSections(state).find(isCodeChangesSection);
@@ -82,24 +74,8 @@ export function extractPatchInfo(state: ExplorerAutofixState | null): {
     .sort((a, b) => b.added + b.removed - (a.added + a.removed));
   const added = artifact.reduce((sum, filePatch) => sum + filePatch.patch.added, 0);
   const removed = artifact.reduce((sum, filePatch) => sum + filePatch.patch.removed, 0);
-  const renderedLines = artifact.reduce(
-    (sum, filePatch) =>
-      sum + filePatch.patch.hunks.reduce((lines, hunk) => lines + hunk.lines.length, 0),
-    0
-  );
-  const inlineEligible =
-    artifact.length <= INLINE_DIFF_MAX_FILES &&
-    added + removed <= INLINE_DIFF_MAX_CHANGED_LINES &&
-    renderedLines > 0 &&
-    renderedLines <= INLINE_DIFF_MAX_RENDERED_LINES;
   return {
     patchStats: {fileList, files: artifact.length, added, removed},
-    inlinePatches: inlineEligible
-      ? artifact.map(filePatch => ({
-          patch: filePatch.patch,
-          repoName: multiRepo ? filePatch.repo_name : undefined,
-        }))
-      : undefined,
   };
 }
 
@@ -254,12 +230,15 @@ export function buildOverviewRow(
     eventCount: Number.isFinite(eventCount) ? eventCount : 0,
     userCount: issue.userCount,
     statsPeriod,
-    lastActivityAt: mostRecentTimestamp(
-      state?.updated_at,
-      run?.lastTriggeredAt,
-      issue.seerAutofixLastTriggered,
-      issue.lastSeen
-    ),
+    lastSeen: issue.lastSeen,
+    // Seer-side timestamps only — folding in issue.lastSeen would make this
+    // collapse to lastSeen on any actively-erroring issue.
+    lastActivityAt:
+      mostRecentTimestamp(
+        state?.updated_at,
+        run?.lastTriggeredAt,
+        issue.seerAutofixLastTriggered
+      ) || null,
     runStatus: state?.status ?? null,
     statePending,
     trigger: mapRunSourceToTrigger(run?.source ?? null),

--- a/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.spec.tsx
@@ -17,6 +17,7 @@ function makeRow(overrides: Partial<OverviewRow> = {}): OverviewRow {
     eventCount: 1,
     id: '2',
     lastActivityAt: '2026-07-14T10:00:00Z',
+    lastSeen: '2026-07-14T09:00:00Z',
     level: 'error',
     project: {slug: 'proj'},
     runStatus: null,
@@ -88,7 +89,7 @@ describe('IssuePrimaryAction', () => {
       renderAction(action, makeRow({runStatus}));
 
       expect(screen.getByText(overlay)).toBeInTheDocument();
-      expect(screen.queryByRole('button', {name: 'Review PR'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: /Review PR/})).not.toBeInTheDocument();
     }
   );
 
@@ -100,7 +101,7 @@ describe('IssuePrimaryAction', () => {
     };
     renderAction(action, makeRow({runStatus: 'completed'}));
 
-    expect(screen.getByRole('button', {name: 'Review PR'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Review PR #9'})).toHaveAttribute(
       'href',
       'https://github.com/o/r/pull/9'
     );
@@ -108,9 +109,9 @@ describe('IssuePrimaryAction', () => {
 
   it.each([
     {type: 'merged', label: 'Merged'},
-    {type: 'code_changes_ready', label: 'Open PR'},
+    {type: 'code_changes_ready', label: 'Draft PR'},
     {type: 'solution_ready', label: 'Generate code'},
-    {type: 'needs_investigation', label: 'Investigate'},
+    {type: 'needs_investigation', label: 'Approve Root Cause'},
   ] as Array<{label: string; type: Exclude<CardAction['type'], 'review_pr'>}>)(
     'renders the $label action for a completed $type card',
     ({type, label}) => {

--- a/static/app/views/seerWorkflows/overview/cardAction.tsx
+++ b/static/app/views/seerWorkflows/overview/cardAction.tsx
@@ -1,8 +1,8 @@
-import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
 import {Tag} from '@sentry/scraps/badge';
 import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -10,6 +10,7 @@ import {
   IconCode,
   IconCommit,
   IconMerge,
+  IconOpen,
   IconPullRequest,
   IconRefresh,
   IconSearch,
@@ -44,12 +45,12 @@ const ACTION_META: Record<
   review_pr: {
     Icon: IconPullRequest,
     label: t('Review PR'),
-    variant: 'warning',
+    variant: 'primary',
     description: t('Autofix opened a pull request. Review and merge it.'),
   },
   code_changes_ready: {
     Icon: IconCommit,
-    label: t('Open PR'),
+    label: t('Draft PR'),
     variant: 'secondary',
     description: t('Autofix wrote a diff. Review it and open a pull request.'),
   },
@@ -63,10 +64,10 @@ const ACTION_META: Record<
   },
   needs_investigation: {
     Icon: IconSearch,
-    label: t('Investigate'),
+    label: t('Approve Root Cause'),
     variant: 'secondary',
     description: t(
-      'Seer stopped at a diagnosis. Open the run to investigate the root cause.'
+      'Seer stopped at a diagnosis. Review the root cause and approve it to continue.'
     ),
   },
   awaiting_input: {
@@ -95,30 +96,6 @@ export function deriveCardAction(
   return {type: sectionKey};
 }
 
-const AccentLinkButton = styled(LinkButton)`
-  background: ${p => p.theme.tokens.background.accent};
-  border-color: ${p => p.theme.tokens.border.accent};
-  color: ${p => p.theme.tokens.content.accent};
-  &:hover {
-    color: ${p => p.theme.tokens.content.accent};
-  }
-`;
-
-const SuccessLinkButton = styled(LinkButton)`
-  background: ${p => p.theme.tokens.background.success};
-  border-color: ${p => p.theme.tokens.border.success};
-  color: ${p => p.theme.tokens.content.success};
-  &:hover {
-    color: ${p => p.theme.tokens.content.success};
-  }
-`;
-
-const MutedLinkButton = styled(LinkButton)`
-  background: transparent;
-  border-color: ${p => p.theme.tokens.border.neutral};
-  color: ${p => p.theme.tokens.content.secondary};
-`;
-
 function ActionButton({
   actionKey,
   size,
@@ -129,33 +106,6 @@ function ActionButton({
   to: LocationDescriptor;
 }) {
   const meta = ACTION_META[actionKey];
-  if (actionKey === 'code_changes_ready') {
-    return (
-      <Tooltip title={meta.description} skipWrapper>
-        <AccentLinkButton size={size} icon={<meta.Icon />} to={to}>
-          {meta.label}
-        </AccentLinkButton>
-      </Tooltip>
-    );
-  }
-  if (actionKey === 'solution_ready') {
-    return (
-      <Tooltip title={meta.description} skipWrapper>
-        <SuccessLinkButton size={size} icon={<meta.Icon />} to={to}>
-          {meta.label}
-        </SuccessLinkButton>
-      </Tooltip>
-    );
-  }
-  if (actionKey === 'errored') {
-    return (
-      <Tooltip title={meta.description} skipWrapper>
-        <MutedLinkButton size={size} icon={<meta.Icon />} to={to}>
-          {meta.label}
-        </MutedLinkButton>
-      </Tooltip>
-    );
-  }
   return (
     <Tooltip title={meta.description} skipWrapper>
       <LinkButton size={size} variant={meta.variant} icon={<meta.Icon />} to={to}>
@@ -176,22 +126,22 @@ function ReviewPrButton({
 }) {
   const meta = ACTION_META.review_pr;
   return (
-    <Tooltip
-      title={
-        prNumber
-          ? t('Autofix opened pull request #%s. Review and merge it.', prNumber)
-          : meta.description
-      }
-      skipWrapper
-    >
+    <Tooltip title={meta.description} skipWrapper>
       <LinkButton
         size={size}
-        variant="warning"
-        icon={<IconPullRequest />}
+        variant={meta.variant}
+        icon={<meta.Icon />}
         href={prUrl}
         external
       >
-        {meta.label}
+        {/* The PR number breaks up a section of otherwise-identical buttons;
+            the trailing IconOpen marks the jump out to the code host. The
+            button only auto-spaces its leading icon slot, so the trailing
+            icon needs its own flex gap. */}
+        <Flex as="span" gap="xs" align="center">
+          {prNumber ? t('Review PR #%s', prNumber) : meta.label}
+          <IconOpen size="xs" />
+        </Flex>
       </LinkButton>
     </Tooltip>
   );

--- a/static/app/views/seerWorkflows/overview/focusedIssue.tsx
+++ b/static/app/views/seerWorkflows/overview/focusedIssue.tsx
@@ -68,7 +68,6 @@ export function FocusedIssue({id, period}: {id: string; period: string}) {
               orgSlug={organization.slug}
               view="cards"
               statsPeriod={period}
-              defaultExpanded
               lazy={false}
             />
           ))}

--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -279,9 +279,9 @@ describe('AutofixOverview', () => {
     // night_shift source maps to the Workflow trigger badge.
     expect(screen.getByText('Workflow')).toBeInTheDocument();
 
-    // An opened PR reads as needing review and links out to the PR; the PR
-    // number lives in the tooltip, not the label.
-    expect(screen.getByRole('button', {name: 'Review PR'})).toHaveAttribute(
+    // An opened PR reads as needing review, carries its number in the
+    // label, and links out to the PR.
+    expect(screen.getByRole('button', {name: 'Review PR #123'})).toHaveAttribute(
       'href',
       'https://github.com/getsentry/sentry/pull/123'
     );
@@ -291,9 +291,8 @@ describe('AutofixOverview', () => {
     expect(screen.getByText('+42')).toBeInTheDocument();
     expect(screen.getByText('−7')).toBeInTheDocument();
 
-    // This diff fails the inline-differ gates twice over (49 changed lines
-    // is past the cap, and its hunks are empty), so the file path lives only
-    // in the pill's hover tooltip — no diff header on the card.
+    // The card never renders the diff itself; the file path lives only in
+    // the pill's hover tooltip.
     expect(screen.queryByText('src/cart.py')).not.toBeInTheDocument();
 
     // Hovering the diff pill lists the changed files.
@@ -318,8 +317,12 @@ describe('AutofixOverview', () => {
       rootCause.compareDocumentPosition(proposedFix) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 
-    // The timestamp is labeled as run activity.
-    expect(screen.getByText(/^updated/)).toBeInTheDocument();
+    // Issue recency and Seer activity are two distinct timestamps: the
+    // issue's own lastSeen, then the newest Seer-side signal (here the
+    // state's updated_at) — never lastSeen again.
+    expect(
+      screen.getAllByRole('time').map(element => element.getAttribute('datetime'))
+    ).toEqual(['2019-04-11T01:08:59.000Z', '2026-07-14T10:00:00.000Z']);
 
     // Identity sits in the tail: short id + exactly one level marker.
     expect(screen.getByText('PROJ-1')).toBeVisible();
@@ -343,8 +346,9 @@ describe('AutofixOverview', () => {
     // The full analysis is card-only; the table row is the scannable summary.
     expect(screen.queryByText('Root cause')).not.toBeInTheDocument();
     expect(screen.getByText('PROJ-1')).toBeVisible();
-    expect(screen.getByText(/100 events · 5 users/)).toBeVisible();
-    expect(screen.getByRole('button', {name: 'Review PR'})).toHaveAttribute(
+    expect(screen.getByText('100 events')).toBeVisible();
+    expect(screen.getByText('5 users')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Review PR #123'})).toHaveAttribute(
       'href',
       'https://github.com/getsentry/sentry/pull/123'
     );
@@ -393,7 +397,7 @@ describe('AutofixOverview', () => {
     renderPage();
 
     // The review action wins, linking to the open PR from the run state.
-    expect(await screen.findByRole('button', {name: 'Review PR'})).toHaveAttribute(
+    expect(await screen.findByRole('button', {name: 'Review PR #123'})).toHaveAttribute(
       'href',
       'https://github.com/getsentry/sentry/pull/123'
     );
@@ -533,86 +537,7 @@ describe('AutofixOverview', () => {
     );
   });
 
-  it('renders an inline differ for small diffs, collapsed to a file header', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/2/autofix/`,
-      body: {
-        autofix: makeAutofixState({
-          blocks: [
-            makeBlock('code_changes', {
-              merged_file_patches: [
-                {
-                  repo_name: 'getsentry/sentry',
-                  diff: '--- a/src/cart.py\n+++ b/src/cart.py',
-                  patch: {
-                    path: 'src/cart.py',
-                    source_file: 'src/cart.py',
-                    target_file: 'src/cart.py',
-                    type: 'M',
-                    added: 2,
-                    removed: 1,
-                    hunks: [
-                      {
-                        section_header: 'def add_to_cart',
-                        source_start: 10,
-                        source_length: 3,
-                        target_start: 10,
-                        target_length: 4,
-                        lines: [
-                          {
-                            value: 'def add_to_cart(item):',
-                            line_type: ' ',
-                            source_line_no: 10,
-                            target_line_no: 10,
-                            diff_line_no: 1,
-                          },
-                          {
-                            value: '    total = None',
-                            line_type: '-',
-                            source_line_no: 11,
-                            target_line_no: null,
-                            diff_line_no: 2,
-                          },
-                          {
-                            value: '    total = 0',
-                            line_type: '+',
-                            source_line_no: null,
-                            target_line_no: 11,
-                            diff_line_no: 3,
-                          },
-                          {
-                            value: '    return total',
-                            line_type: '+',
-                            source_line_no: null,
-                            target_line_no: 12,
-                            diff_line_no: 4,
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                },
-              ],
-            }),
-          ],
-          repo_pr_states: {},
-        }),
-      },
-    });
-
-    renderPage();
-
-    // The differ's file header shows on the card without any interaction…
-    const fileHeader = await screen.findByText('src/cart.py');
-    // …but the diff body starts collapsed.
-    expect(screen.queryByText(/@@ -10,3 \+10,4 @@/)).not.toBeInTheDocument();
-
-    await userEvent.click(fileHeader);
-
-    expect(screen.getByText(/@@ -10,3 \+10,4 @@/)).toBeInTheDocument();
-  });
-
-  it('focuses a single fully-expanded card when id is present', async () => {
+  it('focuses a single card when id is present', async () => {
     // The focus fetch pins the exact group id (and the endpoint ignores the
     // section filters in that mode).
     const groupRequest = MockApiClient.addMockResponse({
@@ -666,11 +591,9 @@ describe('AutofixOverview', () => {
 
     renderPage({id: '2'});
 
-    // The full analysis renders expanded without any interaction…
+    // The full analysis renders without any interaction.
     expect(await screen.findByText('Root cause')).toBeVisible();
     expect(screen.getByText('PROJ-1')).toBeVisible();
-    // …and so does the inline diff.
-    expect(screen.getByText(/@@ -5,1 \+5,2 @@/)).toBeInTheDocument();
     expect(groupRequest).toHaveBeenCalled();
 
     // Focus mode hides the section list and offers the way back, keeping the

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -309,8 +309,11 @@ export function IssueCard({
         {/* align: start is vertical in row mode, but horizontal once the card
             stacks — there it must be stretch or the children shrink to
             content width and long code tokens push past the card edge. */}
+        {/* 3xl gutter: the narrative gives up width so the prose never
+            crowds the rail; xs keeps the tighter vertical gap when the
+            regions stack. */}
         <Flex
-          gap="xl"
+          gap={{xs: 'xl', sm: '3xl'}}
           align={{xs: 'stretch', sm: 'start'}}
           justify="between"
           direction={{xs: 'column-reverse', sm: 'row'}}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -1,8 +1,8 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {InfoText} from '@sentry/scraps/info';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -11,11 +11,19 @@ import {ErrorLevel} from 'sentry/components/events/errorLevel';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconArrow, IconCommit, IconFocus, IconPullRequest} from 'sentry/icons';
+import {
+  IconArrow,
+  IconClock,
+  IconCommit,
+  IconFocus,
+  IconGraph,
+  IconPullRequest,
+  IconSeer,
+  IconUser,
+} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
-import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
 import {deriveCardAction, IssuePrimaryAction} from './cardAction';
 import {periodWindowLabel} from './periods';
@@ -28,6 +36,13 @@ const TitleLink = styled(Link)`
     color: inherit;
     text-decoration: underline;
   }
+`;
+
+// ErrorLevel's colored line stretched from its 1em inline size into an accent
+// bar spanning the full title block (its grid cell stretches it).
+const LevelBar = styled(ErrorLevel)`
+  height: auto;
+  width: 4px;
 `;
 
 // The most-changed files shown on hover before collapsing into "+N more".
@@ -76,29 +91,135 @@ function PatchFilesTooltip({stats}: {stats: PatchStats}) {
   );
 }
 
-function issueCountLabels(row: OverviewRow) {
-  return {
-    eventCountLabel:
-      row.eventCount === 1
-        ? t('1 event')
-        : t('%s events', formatAbbreviatedNumber(row.eventCount)),
-    userCountLabel:
-      row.userCount === 1
-        ? t('1 user')
-        : t('%s users', formatAbbreviatedNumber(row.userCount)),
-  };
+// One icon-prefixed item in the metadata subline. The icon stands in for a
+// text label, so each item needs a tooltip carrying its meaning — TimeSince
+// children bring their own.
+function MetaItem({
+  children,
+  icon,
+  tooltip,
+}: {
+  children: React.ReactNode;
+  icon: React.ReactNode;
+  tooltip?: React.ReactNode;
+}) {
+  const item = (
+    <Flex gap="xs" align="center">
+      {icon}
+      <Text size="sm" variant="muted" wrap="nowrap">
+        {children}
+      </Text>
+    </Flex>
+  );
+  return tooltip ? (
+    <Tooltip title={tooltip} skipWrapper>
+      {item}
+    </Tooltip>
+  ) : (
+    item
+  );
 }
 
-function IssueTitleLink({row, to, size}: {row: OverviewRow; to: string; size?: 'lg'}) {
-  // The ellipsis Text is the shrinking flex item (overflow:hidden resolves its
-  // min-width to 0); the Link must nest inside it or the anchor refuses to
-  // shrink and the title overflows the card. When Seer produced a
-  // plain-language headline it replaces the raw issue title, which stays
-  // reachable via the tooltip and the expanded details.
+// The issue/run vitals shared by the card's rail and the table subline:
+// counts, then issue recency (when it last fired), then Seer recency (when
+// Seer last touched the run). Renders a Fragment, so the parent decides the
+// axis — stacked in the card rail, inline in the table row.
+function IssueVitals({row}: {row: OverviewRow}) {
+  const eventCountLabel =
+    row.eventCount === 1
+      ? t('1 event')
+      : t('%s events', formatAbbreviatedNumber(row.eventCount));
+  const userCountLabel =
+    row.userCount === 1
+      ? t('1 user')
+      : t('%s users', formatAbbreviatedNumber(row.userCount));
+  return (
+    <Fragment>
+      <MetaItem
+        icon={<IconGraph size="xs" variant="muted" aria-hidden />}
+        tooltip={t(
+          '%s events %s',
+          row.eventCount.toLocaleString(),
+          periodWindowLabel(row.statsPeriod)
+        )}
+      >
+        {eventCountLabel}
+      </MetaItem>
+      {row.userCount > 0 && (
+        <MetaItem
+          icon={<IconUser size="xs" variant="muted" aria-hidden />}
+          tooltip={t(
+            '%s affected users %s',
+            row.userCount.toLocaleString(),
+            periodWindowLabel(row.statsPeriod)
+          )}
+        >
+          {userCountLabel}
+        </MetaItem>
+      )}
+      <MetaItem icon={<IconClock size="xs" variant="muted" aria-hidden />}>
+        <TimeSince
+          date={row.lastSeen}
+          tooltipPrefix={t('The most recent event in this issue occurred')}
+        />
+      </MetaItem>
+      {row.lastActivityAt && (
+        <MetaItem icon={<IconSeer size="xs" variant="muted" aria-hidden />}>
+          <TimeSince
+            date={row.lastActivityAt}
+            tooltipPrefix={t('Last activity on this Seer run')}
+          />
+        </MetaItem>
+      )}
+    </Fragment>
+  );
+}
+
+function IssueTitleLink({
+  row,
+  to,
+  size,
+  ellipsis = true,
+}: {
+  row: OverviewRow;
+  to: string;
+  // Table rows truncate for density; cards pass false so titles always wrap
+  // instead of getting cut off.
+  ellipsis?: boolean;
+  size?: React.ComponentProps<typeof Text>['size'];
+}) {
+  // Card mode: the headline wraps freely (explicit block display — a
+  // non-ellipsis Text is otherwise a native inline span whose line boxes
+  // escape the title row's geometry), and the raw issue title reads as a
+  // quiet single-line subheader beneath it instead of hiding in a tooltip.
+  if (!ellipsis) {
+    return (
+      <Stack gap="2xs" minWidth="0">
+        <Text bold display="block" textWrap="pretty" size={size}>
+          <TitleLink to={to}>{row.headline ?? row.title}</TitleLink>
+        </Text>
+        {row.headline && (
+          // The raw title is provenance, not reading material: one muted
+          // truncated line — the full string lives on the issue page.
+          <Text size="sm" variant="muted" ellipsis title={row.title}>
+            {row.title}
+          </Text>
+        )}
+      </Stack>
+    );
+  }
+
+  // Table mode: one truncated line for density (overflow:hidden resolves the
+  // Text's flex min-width to 0; the Link must nest inside it or the anchor
+  // refuses to shrink and the title overflows the row). The raw title stays
+  // in a tooltip here — there's no room for a subheader. skipWrapper is
+  // load-bearing: the default tooltip wrapper is an inline-block, an atomic
+  // inline whose baseline anchors to its LAST line and breaks truncation.
   return (
     <Text bold ellipsis size={size}>
       {row.headline ? (
         <Tooltip
+          skipWrapper
           maxWidth={480}
           title={
             <Stack gap="2xs">
@@ -124,15 +245,11 @@ export function IssueCard({
   orgSlug,
   row,
   sectionKey,
-  defaultExpanded = false,
   minHeight,
 }: {
   orgSlug: string;
   row: OverviewRow;
   sectionKey: AutofixStateKey;
-  // Open the inline diffs on mount — the overview's ?id= focus mode wants
-  // the whole card readable at once.
-  defaultExpanded?: boolean;
   minHeight?: string;
 }) {
   const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
@@ -170,161 +287,162 @@ export function IssueCard({
       answer: nextSteps.answer,
     },
   ].filter(section => !!section);
-  const {eventCountLabel, userCountLabel} = issueCountLabels(row);
 
   return (
+    // inline-size makes the card a query container: the bare responsive keys
+    // below reflow on the CARD's width (sidebar, split windows), not the
+    // viewport's.
     <Container
       background="primary"
       border="primary"
       radius="md"
-      padding="lg"
+      padding="xl"
       minHeight={minHeight}
+      containerType="inline-size"
     >
       <Stack gap="lg">
-        {/* Header: title over metadata subline, diff size pinned right */}
-        <Flex justify="between" align="start" gap="md">
-          <Stack gap="2xs" minWidth="0" flex="1">
-            {/* lg matches the issues feed's row titles */}
-            <IssueTitleLink row={row} to={issueUrl} size="lg" />
-            {/* Only non-default triggers get a badge; "manual" is the default. */}
-            <Flex gap="sm" align="center" wrap="wrap">
-              <InfoText
-                title={
-                  row.userCount > 0
-                    ? t(
-                        '%s events and %s affected users %s',
-                        row.eventCount.toLocaleString(),
-                        row.userCount.toLocaleString(),
-                        periodWindowLabel(row.statsPeriod)
-                      )
-                    : t(
-                        '%s events %s',
-                        row.eventCount.toLocaleString(),
-                        periodWindowLabel(row.statsPeriod)
-                      )
-                }
-                size="sm"
-                variant="muted"
-              >
-                {eventCountLabel}
-                {row.userCount > 0 && ` · ${userCountLabel}`}
-              </InfoText>
-              <Text size="sm" variant="muted" aria-hidden>
-                {'·'}
+        {/* Two-column region: the narrative on the left, an identity + action
+            rail on the right. Narrow cards stack, rail first — it holds the
+            identity and the action, which lead on wide cards too. */}
+        {/* align: start is vertical in row mode, but horizontal once the card
+            stacks — there it must be stretch or the children shrink to
+            content width and long code tokens push past the card edge. */}
+        <Flex
+          gap="xl"
+          align={{xs: 'stretch', sm: 'start'}}
+          justify="between"
+          direction={{xs: 'column-reverse', sm: 'row'}}
+        >
+          {/* Left: what broke → what Seer changed → what the human does next.
+              The fixed rail pins the right edge; the grid below decides how
+              the prose uses the rest. */}
+          <Stack gap="lg" minWidth="0" flex="1">
+            {/* Grid, not flex: grid items stretch by default, so the level
+                bar spans every wrapped title line and the text cell can't
+                escape the row */}
+            <Grid columns="max-content minmax(0, 1fr)" gap="sm">
+              <LevelBar level={row.level} />
+              {/* lg matches the issues feed's row titles */}
+              <IssueTitleLink row={row} to={issueUrl} size="lg" ellipsis={false} />
+            </Grid>
+
+            {/* The question autofix is blocked on, surfaced right on the card */}
+            {row.pendingQuestion && (
+              <Text size="md" variant="accent">
+                {t('Seer asked: %s', row.pendingQuestion)}
               </Text>
-              <Text size="sm" variant="muted" wrap="nowrap">
-                <TimeSince
-                  date={row.lastActivityAt}
-                  prefix={t('updated')}
-                  tooltipPrefix={t('Last activity on this Seer run')}
-                />
-              </Text>
+            )}
+
+            {/* The analysis sections, one shared voice (eyebrow icon +
+                uppercase label + prose), in thought order — side by side when
+                the card is wide enough for two readable columns */}
+            <Grid
+              columns={
+                // Two-up only when the card is genuinely wide — two cramped
+                // columns read worse than one full-width stack.
+                sections.length > 1 ? {xs: '1fr', xl: 'repeat(2, minmax(0, 1fr))'} : '1fr'
+              }
+              gap="lg 2xl"
+              align="start"
+            >
+              {sections.map(section => (
+                <Stack key={section.key} gap="xs" maxWidth="70ch">
+                  <Flex gap="xs" align="center">
+                    {section.icon}
+                    <Text size="xs" bold uppercase variant={section.variant}>
+                      {section.label}
+                    </Text>
+                  </Flex>
+                  {/* break-word keeps unbreakable code tokens (long file
+                      paths) from forcing the column wider than the card */}
+                  <Text
+                    size={{xs: 'md', lg: 'lg'}}
+                    density="comfortable"
+                    wordBreak="break-word"
+                    as="div"
+                  >
+                    <SeerMarkdown raw={section.answer} />
+                  </Text>
+                </Stack>
+              ))}
+            </Grid>
+          </Stack>
+
+          {/* Right rail: issue identity and vitals, then the action column.
+              Fixed width so the rail (and everything in it) lines up across
+              cards; full-width band above the narrative on narrow cards. */}
+          {/* 3xl separates the vitals column from the action column — the
+              button shouldn't sit on top of the timestamps */}
+          <Flex
+            gap="3xl"
+            align="start"
+            justify="between"
+            flexShrink={0}
+            width={{xs: '100%', sm: '320px'}}
+          >
+            <Stack
+              gap={{xs: 'md', sm: 'xs'}}
+              direction={{xs: 'row', sm: 'column'}}
+              wrap="wrap"
+            >
+              <Flex gap="xs" align="center">
+                <Tooltip title={t('View project')} skipWrapper>
+                  <ProjectBadge project={row.project} avatarSize={14} hideName />
+                </Tooltip>
+                <Text size="sm" monospace variant="muted" wrap="nowrap">
+                  {row.shortId}
+                </Text>
+              </Flex>
+              <IssueVitals row={row} />
+              {/* Only non-default triggers get a badge; "manual" is the default. */}
               {row.trigger !== 'manual' && (
                 <TriggerBadge trigger={row.trigger} rawSource={row.rawSource} />
               )}
-            </Flex>
-          </Stack>
-          {/* Right cluster: just the diff-size fact — the action lives in
-              the card's tail, the pipeline story on the group header */}
-          <Flex gap="sm" align="center" flexShrink={0}>
-            {row.patchStats && (
-              <Tooltip
-                title={<PatchFilesTooltip stats={row.patchStats} />}
-                maxWidth={480}
-                skipWrapper
-              >
-                <Container
-                  tabIndex={0}
-                  aria-label={tn(
-                    '%s file changed',
-                    '%s files changed',
-                    row.patchStats.files
-                  )}
-                  border="muted"
-                  radius="sm"
-                  background="secondary"
-                  padding="2xs sm"
+            </Stack>
+            <Stack gap="xs" align="end">
+              <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} />
+              {row.patchStats && (
+                <Tooltip
+                  title={<PatchFilesTooltip stats={row.patchStats} />}
+                  maxWidth={480}
+                  skipWrapper
                 >
-                  <Text size="xs" variant="muted" monospace wrap="nowrap">
-                    {tn('%s file', '%s files', row.patchStats.files)}{' '}
-                    <Text size="xs" variant="success">
-                      +{row.patchStats.added}
-                    </Text>{' '}
-                    <Text size="xs" variant="danger">
-                      −{row.patchStats.removed}
+                  <Container
+                    tabIndex={0}
+                    aria-label={tn(
+                      '%s file changed',
+                      '%s files changed',
+                      row.patchStats.files
+                    )}
+                    border="muted"
+                    radius="sm"
+                    background="secondary"
+                    padding="2xs sm"
+                  >
+                    <Text size="xs" variant="muted" monospace wrap="nowrap">
+                      {tn('%s file', '%s files', row.patchStats.files)}{' '}
+                      <Text size="xs" variant="success">
+                        +{row.patchStats.added}
+                      </Text>{' '}
+                      <Text size="xs" variant="danger">
+                        −{row.patchStats.removed}
+                      </Text>
                     </Text>
-                  </Text>
-                </Container>
-              </Tooltip>
-            )}
-          </Flex>
-        </Flex>
-
-        {/* The question autofix is blocked on, surfaced right on the card */}
-        {row.pendingQuestion && (
-          <Text size="md" variant="accent">
-            {t('Seer asked: %s', row.pendingQuestion)}
-          </Text>
-        )}
-
-        {/* The analysis sections, one shared voice (eyebrow icon +
-            uppercase label + prose), in thought order */}
-        {sections.map(section => (
-          <Stack key={section.key} gap="xs">
-            <Flex gap="xs" align="center">
-              {section.icon}
-              <Text size="xs" bold uppercase variant={section.variant}>
-                {section.label}
-              </Text>
-            </Flex>
-            <Text size="md" density="comfortable" as="div">
-              <SeerMarkdown raw={section.answer} />
-            </Text>
-          </Stack>
-        ))}
-
-        {/* The drafted diff itself, but only when it's small enough to read
-            on a card (see the INLINE_DIFF_* limits): collapsed file headers
-            that expand in place, aligned with the body's text column */}
-        {row.inlinePatches && (
-          <Stack gap="xs">
-            {row.inlinePatches.map(({patch, repoName}) => (
-              <FileDiffViewer
-                key={`${repoName ?? ''}:${patch.path}`}
-                patch={patch}
-                repoName={repoName}
-                collapsible
-                defaultExpanded={defaultExpanded}
-                showBorder
-              />
-            ))}
-          </Stack>
-        )}
-
-        {/* Tail: primary action left, issue identity right */}
-        <Flex justify="between" align="center" gap="md">
-          <Flex gap="sm" align="center">
-            <IssuePrimaryAction action={cardAction} row={row} runUrl={runUrl} />
-            {row.prUrl && cardAction.type !== 'review_pr' && (
-              <LinkButton
-                size="sm"
-                variant="link"
-                icon={<IconPullRequest />}
-                href={row.prUrl}
-                external
-              >
-                {row.prNumber ? `#${row.prNumber}` : t('PR')}
-              </LinkButton>
-            )}
-          </Flex>
-          <Flex gap="sm" align="center" flexShrink={0}>
-            <ErrorLevel level={row.level} />
-            <Text size="xs" monospace variant="muted">
-              {row.shortId}
-            </Text>
-            <Tooltip title={t('View project')} skipWrapper>
-              <ProjectBadge project={row.project} avatarSize={14} />
-            </Tooltip>
+                  </Container>
+                </Tooltip>
+              )}
+              {row.prUrl && cardAction.type !== 'review_pr' && (
+                <LinkButton
+                  size="sm"
+                  variant="link"
+                  icon={<IconPullRequest />}
+                  href={row.prUrl}
+                  external
+                >
+                  {row.prNumber ? `#${row.prNumber}` : t('PR')}
+                </LinkButton>
+              )}
+            </Stack>
           </Flex>
         </Flex>
       </Stack>
@@ -351,7 +469,6 @@ export function IssueTableRow({
   const issueUrl = `/organizations/${orgSlug}/issues/${row.id}/`;
   const runUrl = {pathname: issueUrl, query: {seerDrawer: 'true'}};
   const cardAction = deriveCardAction(sectionKey, row);
-  const {eventCountLabel, userCountLabel} = issueCountLabels(row);
 
   return (
     <Flex
@@ -364,28 +481,14 @@ export function IssueTableRow({
     >
       <Stack gap="2xs" minWidth="0" flex="1">
         <IssueTitleLink row={row} to={issueUrl} />
-        <Flex gap="xs" align="center" wrap="wrap">
-          <ProjectBadge project={row.project} avatarSize={14} hideName />
-          <Text size="sm" variant="muted" monospace wrap="nowrap">
-            {row.shortId}
-          </Text>
-          <Text size="sm" variant="muted" aria-hidden>
-            {'·'}
-          </Text>
-          <Text size="sm" variant="muted" wrap="nowrap">
-            {eventCountLabel}
-            {row.userCount > 0 && ` · ${userCountLabel}`}
-          </Text>
-          <Text size="sm" variant="muted" aria-hidden>
-            {'·'}
-          </Text>
-          <Text size="sm" variant="muted" wrap="nowrap">
-            <TimeSince
-              date={row.lastActivityAt}
-              prefix={t('updated')}
-              tooltipPrefix={t('Last activity on this Seer run')}
-            />
-          </Text>
+        <Flex gap="md" align="center" wrap="wrap">
+          <Flex gap="xs" align="center">
+            <ProjectBadge project={row.project} avatarSize={14} hideName />
+            <Text size="sm" variant="muted" monospace wrap="nowrap">
+              {row.shortId}
+            </Text>
+          </Flex>
+          <IssueVitals row={row} />
         </Flex>
       </Stack>
       <Flex align="center" flexShrink={0}>

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -104,9 +104,11 @@ function MetaItem({
   tooltip?: React.ReactNode;
 }) {
   const item = (
-    <Flex gap="xs" align="center">
+    // minWidth 0 + ellipsis let the item truncate inside a tight rail column
+    // instead of pushing the layout wider.
+    <Flex gap="xs" align="center" minWidth="0">
       {icon}
-      <Text size="sm" variant="muted" wrap="nowrap">
+      <Text size="sm" variant="muted" ellipsis>
         {children}
       </Text>
     </Flex>
@@ -369,32 +371,31 @@ export function IssueCard({
           </Stack>
 
           {/* Right rail: issue identity and vitals, then the action column.
-              min-width (not a fixed width) keeps the rail lined up across
-              cards while letting a wide button (long PR number) GROW the
-              rail instead of overflowing the card — flex children can't
-              shrink below their content, so a hard width would push the
-              action past the card edge. Full-width band above the narrative
-              on narrow cards. */}
-          {/* 3xl separates the vitals column from the action column — the
-              button shouldn't sit on top of the timestamps */}
-          <Flex
-            gap="3xl"
+              The rail width is FIXED so every card's rail — and therefore
+              every card's narrative width and analysis columns — starts at
+              the same x. Inside, a grid gives the action column its natural
+              size and lets the vitals column shrink (minmax(0,1fr)) with
+              truncating text, so oversized content can never push past the
+              card edge. Full-width band above the narrative on narrow
+              cards. */}
+          <Grid
+            columns="minmax(0, 1fr) auto"
+            gap="xl"
             align="start"
-            justify="between"
             flexShrink={0}
-            width={{xs: '100%', sm: 'auto'}}
-            minWidth={{xs: '0', sm: '320px'}}
+            width={{xs: '100%', sm: '320px'}}
           >
             <Stack
               gap={{xs: 'md', sm: 'xs'}}
               direction={{xs: 'row', sm: 'column'}}
               wrap="wrap"
+              minWidth="0"
             >
-              <Flex gap="xs" align="center">
+              <Flex gap="xs" align="center" minWidth="0">
                 <Tooltip title={t('View project')} skipWrapper>
                   <ProjectBadge project={row.project} avatarSize={14} hideName />
                 </Tooltip>
-                <Text size="sm" monospace variant="muted" wrap="nowrap">
+                <Text size="sm" monospace variant="muted" ellipsis>
                   {row.shortId}
                 </Text>
               </Flex>
@@ -448,7 +449,7 @@ export function IssueCard({
                 </LinkButton>
               )}
             </Stack>
-          </Flex>
+          </Grid>
         </Flex>
       </Stack>
     </Container>

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -381,12 +381,15 @@ export function IssueCard({
               truncating text, so oversized content can never push past the
               card edge. Full-width band above the narrative on narrow
               cards. */}
+          {/* 380px: a full-width Review PR button (~210px) + gap still
+              leaves the vitals column ~130px, enough for the longest
+              shortIds before the ellipsis kicks in. */}
           <Grid
             columns="minmax(0, 1fr) auto"
             gap="xl"
             align="start"
             flexShrink={0}
-            width={{xs: '100%', sm: '320px'}}
+            width={{xs: '100%', sm: '380px'}}
           >
             <Stack
               gap={{xs: 'md', sm: 'xs'}}

--- a/static/app/views/seerWorkflows/overview/issueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/issueCard.tsx
@@ -369,8 +369,12 @@ export function IssueCard({
           </Stack>
 
           {/* Right rail: issue identity and vitals, then the action column.
-              Fixed width so the rail (and everything in it) lines up across
-              cards; full-width band above the narrative on narrow cards. */}
+              min-width (not a fixed width) keeps the rail lined up across
+              cards while letting a wide button (long PR number) GROW the
+              rail instead of overflowing the card — flex children can't
+              shrink below their content, so a hard width would push the
+              action past the card edge. Full-width band above the narrative
+              on narrow cards. */}
           {/* 3xl separates the vitals column from the action column — the
               button shouldn't sit on top of the timestamps */}
           <Flex
@@ -378,7 +382,8 @@ export function IssueCard({
             align="start"
             justify="between"
             flexShrink={0}
-            width={{xs: '100%', sm: '320px'}}
+            width={{xs: '100%', sm: 'auto'}}
+            minWidth={{xs: '0', sm: '320px'}}
           >
             <Stack
               gap={{xs: 'md', sm: 'xs'}}

--- a/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
+++ b/static/app/views/seerWorkflows/overview/sectionIssueCard.tsx
@@ -10,7 +10,6 @@ const TABLE_ROW_PLACEHOLDER_HEIGHT = 48;
 const LAZY_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
 
 function HydratedCard({
-  defaultExpanded,
   issue,
   orgSlug,
   sectionKey,
@@ -21,7 +20,6 @@ function HydratedCard({
   orgSlug: string;
   statsPeriod: string;
   view: 'cards' | 'table';
-  defaultExpanded?: boolean;
   // The server-bucketed section. Absent in focus mode, where the issues
   // endpoint omits issue.autofix_state, so we reconstruct it from enrichment.
   sectionKey?: AutofixStateKey;
@@ -41,7 +39,6 @@ function HydratedCard({
       row={row}
       orgSlug={orgSlug}
       sectionKey={resolvedSectionKey}
-      defaultExpanded={defaultExpanded}
       minHeight={minHeight}
     />
   ) : (
@@ -62,7 +59,6 @@ export function SectionIssueCard({
   orgSlug: string;
   statsPeriod: string;
   view: 'cards' | 'table';
-  defaultExpanded?: boolean;
   lazy?: boolean;
   sectionKey?: AutofixStateKey;
 }) {

--- a/static/app/views/seerWorkflows/overview/statusGroups.tsx
+++ b/static/app/views/seerWorkflows/overview/statusGroups.tsx
@@ -21,7 +21,7 @@ export const STATUS_GROUP_META: Record<StatusGroupKey, StatusGroupMeta> = {
   review_pr: {Icon: IconPullRequest, label: t('Awaiting your review')},
   code_changes_ready: {Icon: IconCommit, label: t('Code changes ready')},
   solution_ready: {Icon: IconCode, label: t('Ready to generate code')},
-  // Same magnifier as the card's Investigate action: these runs stopped at a
+  // Same magnifier as the card's Approve-Root-Cause action: these runs stopped at a
   // root cause, and their next steps are manual verify/decide work.
   needs_investigation: {Icon: IconSearch, label: t('Needs investigation')},
   merged: {Icon: IconMerge, label: t('Merged')},

--- a/static/app/views/seerWorkflows/overview/types.ts
+++ b/static/app/views/seerWorkflows/overview/types.ts
@@ -1,4 +1,3 @@
-import type {FilePatch} from 'sentry/components/events/autofix/types';
 import type {Level} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/platform';
 
@@ -143,9 +142,13 @@ export interface OverviewRow {
   analysis: RunAnalysisEntry[];
   eventCount: number;
   id: string;
-  // Most recent activity on the run (state update, trigger, or issue-level
-  // last-trigger timestamp); labels the card's "updated" TimeSince.
-  lastActivityAt: string;
+  // Most recent Seer activity on the run (state update, trigger, or
+  // issue-level last-trigger timestamp); null when the run has no Seer-side
+  // timestamp, which hides the card's Seer-activity TimeSince.
+  lastActivityAt: string | null;
+  // When the issue's most recent event occurred; labels the card's
+  // "last seen" TimeSince.
+  lastSeen: string;
   level: Level;
   project: {slug: string; platform?: PlatformKey};
   // Live run status, mirrored straight from the state payload; drives the
@@ -162,10 +165,6 @@ export interface OverviewRow {
   // Plain-language title from the run's root-cause answer (see runQuestions).
   // Falls back to the raw issue title.
   headline?: string;
-  // Structured patches for the on-card differ; present only when the diff is
-  // small enough to render inline (see the INLINE_DIFF_* limits in
-  // buildOverviewRows).
-  inlinePatches?: Array<{patch: FilePatch; repoName?: string}>;
   patchStats?: PatchStats;
   // The question autofix paused on, when status is NEED_MORE_INFORMATION and
   // the pending input payload carries readable text.


### PR DESCRIPTION
## What & why

Continued UX iteration on the Autofix Overview (`/issues/autofix/overview/`), plus one real data bug. All changes are frontend-only, inside `static/app/views/seerWorkflows/overview/`.

### Bug fix: the card's two timestamps were always identical

`buildOverviewRow` computed `lastActivityAt` as the max of the Seer timestamps **and** `issue.lastSeen` — on any actively-erroring issue, `lastSeen` is the newest signal, so the "Seer activity" time collapsed to the last-seen time on essentially every card. `lastActivityAt` now derives only from Seer-side signals (`state.updated_at`, the run's `lastTriggeredAt`, `seerAutofixLastTriggered`), typed `string | null`, and the Seer-time item hides when no signal exists (also prevents a `TimeSince date=""`). Pinned by new `buildOverviewRow` unit tests and a `role=time` datetime assertion at the page level.

### Card layout: responsive two-region cards via container queries

- The card root is a query container (`containerType="inline-size"`), so all breakpoints track the **card's** width (sidebar collapsed, split windows), not the viewport's.
- Narrative (title → root cause → proposed fix / next steps) on the left; a **fixed-width identity/action rail** (320px) on the right so vitals and buttons line up across cards.
- Analysis sections render **two-up on genuinely wide cards** (≥1440px card width) and stack below that; prose caps at 70ch with `break-word` so long file paths can't force column width.
- Below 800px card width the whole card stacks, rail first as a full-width band (`column-reverse` + `align: stretch` so children take card width).

### Layout escape bug found along the way

Wrapped headline titles were painting their first line *outside* the card, over the previous card's content. Root cause: the headline `Tooltip`'s default wrapper is an `inline-block` — an atomic inline whose baseline is its **last** line's baseline — so a wrapped title anchored its last line in the row and overflowed earlier lines upward. Fixed with `skipWrapper`; the title row is also now a grid (`max-content minmax(0,1fr)`) so the level accent bar spans every wrapped line, and non-ellipsis titles get an explicit block display (a non-ellipsis `Text` is otherwise a native inline span).

### Typography & metadata

- Card titles never truncate; the raw issue title moves from a hover tooltip to a muted single-line **subheader** under the Seer headline (native `title` attr keeps the full string on hover). Table rows keep the compact ellipsis + tooltip.
- The dot-separated metadata subline becomes **icon-prefixed vitals** shared by card rail and table row: events (IconGraph), users (IconUser), issue last-seen (IconClock, the issue-stream convention), Seer activity (IconSeer). Meaning lives in tooltips.

### Actions (per design feedback)

- **Review PR**: `warning` → `primary`, PR number in the label (`Review PR #119479`) to break up a wall of identical buttons, trailing `IconOpen` as the external-link indicator. The internal fallback (review section, no PR URL yet) keeps no external icon since it opens the in-app drawer.
- **Investigate → Approve Root Cause** for diagnosis-only runs.
- `code_changes_ready` label: **Open PR → Draft PR**; dropped the bespoke styled button variants in favor of stock `LinkButton` variants.

### Removed: the inline on-card differ

`inlinePatches` / `FileDiffViewer` rendering and the `INLINE_DIFF_*` gates are gone — the diff-stats pill (with its per-file tooltip breakdown) carries that job; the diff itself lives one click away in the run. `defaultExpanded` threading through `SectionIssueCard`/`FocusedIssue` went with it.

## Testing

- `pnpm test-ci static/app/views/seerWorkflows/overview/` — 79/79 pass (new coverage for the timestamp fix; inline-differ tests removed with the feature; dead test scaffolding pruned).
- Full `pnpm run typecheck`, `pnpm run lint:js` on all touched files, `prek` hooks, and `pnpm knip` all clean.
- Manually verified against prod data via `dev-ui` across card widths (full-screen → ~700px): wrapped titles stay inside their cards, rails align, sections reflow, no horizontal overflow.

## Notes for reviewers

- Known, intentionally out of scope: the server-side `issue.autofix_state:review_pr` bucketing can place issues whose *latest* run has no PR into "Awaiting your review" (milestone activity rows are never cleared and aren't scoped to the latest run — see `src/sentry/seer/autofix/issue_search.py`). That needs a separate backend PR; the frontend fallback for those cards links to the in-app run drawer.