### PR TITLE
ref(chat): Adopt MessageRow primitive and add density in AI chat blocks

### DIFF
--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -23,7 +23,7 @@ interface UserMessageBlockProps {
 
 export function UserMessageBlock({children, className, expand}: UserMessageBlockProps) {
   return (
-    <MessageRow from="user" className={className}>
+    <MessageRow from="user" density="compact" className={className}>
       {/* Placeholder for spacing as we want to keep the right aligned look even on smaller screens */}
       <Container paddingLeft="3xl" flexShrink={0} />
       <UserMessage
@@ -81,7 +81,7 @@ export function AssistantMessageBlock({
   `;
 
   return (
-    <MessageRow from="assistant" className={className}>
+    <MessageRow from="assistant" density="compact" className={className}>
       <Flex justify="between" align="start" gap="md" width="100%">
         <Container
           maxWidth={AI_MESSAGE_MAX_WIDTH}

--- a/static/app/components/ai/chat/messageBlock.tsx
+++ b/static/app/components/ai/chat/messageBlock.tsx
@@ -1,41 +1,18 @@
 import type {ReactNode} from 'react';
 import {css, useTheme} from '@emotion/react';
 
-import {UserMessage} from '@sentry/scraps/chat';
+import {MessageRow, UserMessage} from '@sentry/scraps/chat';
 import {Container, Flex} from '@sentry/scraps/layout';
 
 /**
- * Presentational message shells shared across AI chat surfaces. They own
- * layout/alignment only; callers pass the rendered content as children. Mirrors
- * Seer Explorer: user bubbles right-aligned, assistant bubbles left-aligned.
+ * Presentational message bubbles shared across AI chat surfaces. Each wraps the
+ * scraps `MessageRow` primitive to own alignment; callers pass the rendered
+ * content as children. Mirrors Seer Explorer: user bubbles right-aligned,
+ * assistant bubbles left-aligned.
  */
 
 /** Max width shared by the user and assistant message bubbles. */
 const AI_MESSAGE_MAX_WIDTH = '800px';
-
-interface MessageBlockProps {
-  children: ReactNode;
-  className?: string;
-  justify?: 'start' | 'end';
-}
-
-export function MessageBlock({
-  children,
-  className,
-  justify = 'start',
-}: MessageBlockProps) {
-  return (
-    <Flex
-      align="start"
-      justify={justify}
-      width="100%"
-      padding="md xl"
-      className={className}
-    >
-      {children}
-    </Flex>
-  );
-}
 
 interface UserMessageBlockProps {
   children: ReactNode;
@@ -46,7 +23,7 @@ interface UserMessageBlockProps {
 
 export function UserMessageBlock({children, className, expand}: UserMessageBlockProps) {
   return (
-    <MessageBlock justify="end" className={className}>
+    <MessageRow from="user" className={className}>
       {/* Placeholder for spacing as we want to keep the right aligned look even on smaller screens */}
       <Container paddingLeft="3xl" flexShrink={0} />
       <UserMessage
@@ -55,7 +32,7 @@ export function UserMessageBlock({children, className, expand}: UserMessageBlock
       >
         {children}
       </UserMessage>
-    </MessageBlock>
+    </MessageRow>
   );
 }
 
@@ -104,7 +81,7 @@ export function AssistantMessageBlock({
   `;
 
   return (
-    <MessageBlock className={className}>
+    <MessageRow from="assistant" className={className}>
       <Flex justify="between" align="start" gap="md" width="100%">
         <Container
           maxWidth={AI_MESSAGE_MAX_WIDTH}
@@ -121,6 +98,6 @@ export function AssistantMessageBlock({
         </Container>
         {meta}
       </Flex>
-    </MessageBlock>
+    </MessageRow>
   );
 }

--- a/static/app/components/core/chat/messageRow.mdx
+++ b/static/app/components/core/chat/messageRow.mdx
@@ -41,3 +41,31 @@ role-to-side mapping — callers express whose turn it is, not the layout.
 </MessageRow>
 <MessageRow from="assistant">Here are the three escalating issues I found.</MessageRow>
 ```
+
+## Density
+
+`density` sets the row's vertical breathing room. It defaults to `default`, the
+spacing for a full message turn. Use `compact` for sub-turn connective content —
+tool calls, reasoning — or on a surface that stacks turns directly and reads too
+airy at the default spacing. The row owns the token-to-pixel mapping, so callers
+express intent, not spacing.
+
+<Storybook.Demo align="stretch">
+  <Container width="100%" background="secondary" radius="md">
+    <MessageRow from="user" density="compact">
+      <UserMessage>Which of my issues are getting worse?</UserMessage>
+    </MessageRow>
+    <MessageRow from="assistant" density="compact">
+      Here are the three escalating issues I found.
+    </MessageRow>
+  </Container>
+</Storybook.Demo>
+
+```jsx
+<MessageRow from="user" density="compact">
+  <UserMessage>Which of my issues are getting worse?</UserMessage>
+</MessageRow>
+<MessageRow from="assistant" density="compact">
+  Here are the three escalating issues I found.
+</MessageRow>
+```

--- a/static/app/components/core/chat/messageRow.tsx
+++ b/static/app/components/core/chat/messageRow.tsx
@@ -1,5 +1,14 @@
 import {Flex} from '@sentry/scraps/layout';
 
+/**
+ * How much vertical breathing room a row gets:
+ * - `default`: a full message turn (user/assistant bubble).
+ * - `compact`: sub-turn connective content (tool calls, reasoning) that sits
+ *   between bubbles, or a surface that stacks turns directly and would read too
+ *   airy at the default spacing.
+ */
+type MessageRowDensity = 'default' | 'compact';
+
 interface MessageRowProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   /**
@@ -7,7 +16,17 @@ interface MessageRowProps extends React.HTMLAttributes<HTMLDivElement> {
    * row owns the role-to-side mapping so callers express intent, not layout.
    */
   from: 'user' | 'assistant';
+  /**
+   * The row's vertical breathing room. The row owns the token-to-pixel mapping
+   * so callers express intent, not spacing. Defaults to `default`.
+   */
+  density?: MessageRowDensity;
 }
+
+const DENSITY_PADDING = {
+  default: 'xl',
+  compact: 'md xl',
+} as const;
 
 /**
  * The full-width row that positions a single message turn within a conversation.
@@ -16,13 +35,18 @@ interface MessageRowProps extends React.HTMLAttributes<HTMLDivElement> {
  * around a turn. The bubble or content is the caller's responsibility; lay out
  * multi-part content in your own wrapper.
  */
-export function MessageRow({children, from, ...props}: MessageRowProps) {
+export function MessageRow({
+  children,
+  from,
+  density = 'default',
+  ...props
+}: MessageRowProps) {
   return (
     <Flex
       align="start"
       justify={from === 'user' ? 'end' : 'start'}
       width="100%"
-      padding="xl"
+      padding={DENSITY_PADDING[density]}
       {...props}
     >
       {children}

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -405,7 +405,7 @@ export function MessagesPanelSkeleton() {
 
 function PanelContainer({children}: {children: React.ReactNode}) {
   return (
-    <Stack padding="xl 0" background="primary" minHeight="100%" width="100%">
+    <Stack background="primary" minHeight="100%" width="100%">
       {children}
     </Stack>
   );

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {MessageRow} from '@sentry/scraps/chat';
 import {Container, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
@@ -10,7 +11,6 @@ import {Text} from '@sentry/scraps/text';
 import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
 import {
   AssistantMessageBlock,
-  MessageBlock,
   UserMessageBlock,
 } from 'sentry/components/ai/chat/messageBlock';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -213,24 +213,24 @@ const AssistantTurn = memo(function AssistantTurn({
   return (
     <Fragment>
       {message.toolCalls && message.toolCalls.length > 0 && (
-        <MessageBlock>
+        <MessageRow from="assistant">
           <MessageToolCallsNew
             toolCalls={message.toolCalls}
             selectedToolCallId={selectedToolCallId}
             nodeMap={nodeMap}
             onSelectNode={onSelectNode}
           />
-        </MessageBlock>
+        </MessageRow>
       )}
       {message.reasoning && (
-        <MessageBlock>
+        <MessageRow from="assistant">
           <ReasoningSection reasoning={message.reasoning} />
           <Container width={TURN_META_WIDTH} flexShrink={0} />
-        </MessageBlock>
+        </MessageRow>
       )}
       {message.content === '' ? (
         // Tool/reasoning-only turn: still surface the turn's cost and duration.
-        hasMeta && <MessageBlock justify="end">{meta}</MessageBlock>
+        hasMeta && <MessageRow from="user">{meta}</MessageRow>
       ) : message.content === EMPTY_TEXT_CONTENT ? (
         <AssistantMessageBlock meta={meta} isSelected={isSelected} onClick={handleClick}>
           <MessageText align="left" variant="muted">

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {MessageRow} from '@sentry/scraps/chat';
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -229,8 +229,15 @@ const AssistantTurn = memo(function AssistantTurn({
         </MessageRow>
       )}
       {message.content === '' ? (
-        // Tool/reasoning-only turn: still surface the turn's cost and duration.
-        hasMeta && <MessageRow from="user">{meta}</MessageRow>
+        // Tool/reasoning-only turn: no bubble, but still surface the turn's cost
+        // and duration, right-aligned to the meta column like other assistant turns.
+        hasMeta && (
+          <MessageRow from="assistant">
+            <Flex justify="end" width="100%">
+              {meta}
+            </Flex>
+          </MessageRow>
+        )
       ) : message.content === EMPTY_TEXT_CONTENT ? (
         <AssistantMessageBlock meta={meta} isSelected={isSelected} onClick={handleClick}>
           <MessageText align="left" variant="muted">

--- a/static/app/views/explore/conversations/components/messagesPanelNew.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanelNew.tsx
@@ -213,7 +213,7 @@ const AssistantTurn = memo(function AssistantTurn({
   return (
     <Fragment>
       {message.toolCalls && message.toolCalls.length > 0 && (
-        <MessageRow from="assistant">
+        <MessageRow from="assistant" density="compact">
           <MessageToolCallsNew
             toolCalls={message.toolCalls}
             selectedToolCallId={selectedToolCallId}
@@ -223,7 +223,7 @@ const AssistantTurn = memo(function AssistantTurn({
         </MessageRow>
       )}
       {message.reasoning && (
-        <MessageRow from="assistant">
+        <MessageRow from="assistant" density="compact">
           <ReasoningSection reasoning={message.reasoning} />
           <Container width={TURN_META_WIDTH} flexShrink={0} />
         </MessageRow>
@@ -232,7 +232,7 @@ const AssistantTurn = memo(function AssistantTurn({
         // Tool/reasoning-only turn: no bubble, but still surface the turn's cost
         // and duration, right-aligned to the meta column like other assistant turns.
         hasMeta && (
-          <MessageRow from="assistant">
+          <MessageRow from="assistant" density="compact">
             <Flex justify="end" width="100%">
               {meta}
             </Flex>
@@ -412,7 +412,7 @@ export function MessagesPanelSkeleton() {
 
 function PanelContainer({children}: {children: React.ReactNode}) {
   return (
-    <Stack background="primary" minHeight="100%" width="100%">
+    <Stack padding="xl 0" background="primary" minHeight="100%" width="100%">
       {children}
     </Stack>
   );


### PR DESCRIPTION
This adopts the `MessageRow` primitive in the shared AI chat blocks, removing the bespoke `MessageBlock` shell, and adds a semantic `density` prop so conversations can use tighter (`compact`) turn spacing while Seer keeps the default.

**Before/After**
<img width="1709" height="914" alt="image" src="https://github.com/user-attachments/assets/96c40649-db18-47e8-93aa-4a0a4e87943b" />