### PR TITLE
fix(nav): Keep collapsed settings section reachable

### DIFF
--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -421,7 +421,7 @@ function SecondaryNavigationSection(props: SecondaryNavigationSectionProps) {
         // Once the collapse animation settles, the scroll container may have shrunk
         // enough to leave this section's header below the scrollable area, with no
         // way to scroll back to it. Nudge it into view so it stays reachable.
-        onCollapsed={() => sectionRef.current?.scrollIntoView({block: 'nearest'})}
+        onCollapsed={() => sectionRef.current?.scrollIntoView?.({block: 'nearest'})}
       >
         {props.children}
       </Collapsible>

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -395,6 +395,7 @@ interface SecondaryNavigationSectionProps {
 function SecondaryNavigationSection(props: SecondaryNavigationSectionProps) {
   const collapsible = props.collapsible ?? true;
   const {layout} = usePrimaryNavigation();
+  const sectionRef = useRef<HTMLDivElement>(null);
   const [isCollapsedState, setIsCollapsedState] = useLocalStorageState(
     `secondary-nav-section-${props.id}-collapsed`,
     false
@@ -403,7 +404,7 @@ function SecondaryNavigationSection(props: SecondaryNavigationSectionProps) {
   const isCollapsed = canCollapse ? isCollapsedState : false;
 
   return (
-    <Container padding="md sm" data-nav-section>
+    <Container padding="md sm" data-nav-section ref={sectionRef}>
       {props.title ? (
         <SectionTitle
           trailingItems={props.trailingItems}
@@ -414,7 +415,14 @@ function SecondaryNavigationSection(props: SecondaryNavigationSectionProps) {
           {props.title}
         </SectionTitle>
       ) : null}
-      <Collapsible collapsed={isCollapsed} disabled={!canCollapse}>
+      <Collapsible
+        collapsed={isCollapsed}
+        disabled={!canCollapse}
+        // Once the collapse animation settles, the scroll container may have shrunk
+        // enough to leave this section's header below the scrollable area, with no
+        // way to scroll back to it. Nudge it into view so it stays reachable.
+        onCollapsed={() => sectionRef.current?.scrollIntoView({block: 'nearest'})}
+      >
         {props.children}
       </Collapsible>
     </Container>
@@ -523,6 +531,10 @@ interface CollapsibleProps {
   children: React.ReactNode;
   collapsed: boolean;
   disabled?: boolean;
+  /**
+   * Called once the collapse (exit) animation has fully completed.
+   */
+  onCollapsed?: () => void;
 }
 
 function Collapsible(props: CollapsibleProps) {
@@ -531,7 +543,7 @@ function Collapsible(props: CollapsibleProps) {
   }
 
   return (
-    <AnimatePresence mode="wait" initial={false}>
+    <AnimatePresence mode="wait" initial={false} onExitComplete={props.onCollapsed}>
       {!props.collapsed && (
         <MotionFlex
           // This column-reverse is what creates the "folder" animation effect, where children "fall out" of the header


### PR DESCRIPTION
Collapsing a secondary-nav section animates its content height to `0` over ~400ms (framer-motion spring). When a section near the bottom of the scroll area is collapsed — most visibly the last one, currently **Usage & Billing** — the scroll container can settle with the section's header below the new maximum scroll position, leaving it stranded off-screen. Because it's now past the scrollable range, there's nothing left to scroll to and no way to click it open again. The browser usually re-clamps `scrollTop` and self-heals, but a timing race between the shrink animation and the re-clamp makes it happen intermittently.

## Changes

- Scroll the section back into view once its collapse animation completes, hooking `AnimatePresence`'s `onExitComplete`. `scrollIntoView({block: 'nearest'})` is a no-op when the header is already visible and only nudges it back when it has drifted off-screen.
- The guard lives on the shared `SecondaryNavigationSection` component, so it protects whichever section is last — not just Usage & Billing — and any non-last section that a collapse could strand.

Fixes DE-1367.
