### PR TITLE
fix(profiling): Use correct proguard uuid for android sample v2 chunks

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -1172,7 +1172,20 @@ def _deobfuscate_using_symbolicator(project: Project, profile: Profile, debug_fi
 
 
 def get_debug_file_id(profile: Profile) -> str | None:
-    debug_file_id = profile.get("build_id")
+    # Only the android trace formats (legacy transaction profiles and
+    # android-trace chunks) carry a top-level `build_id`. Sample v2 chunks
+    # reference their proguard mapping as a debug_meta image, like events do.
+    if is_android_trace_format(profile):
+        debug_file_id = profile.get("build_id")
+    else:
+        debug_file_id = next(
+            (
+                image.get("uuid")
+                for image in (profile.get("debug_meta") or {}).get("images") or ()
+                if image.get("type") == "proguard"
+            ),
+            None,
+        )
 
     if debug_file_id is None or debug_file_id == "":
         return None

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -6,6 +6,7 @@ from os.path import join
 from typing import Any
 from unittest import mock
 from unittest.mock import patch
+from uuid import UUID
 
 import msgpack
 import pytest
@@ -31,6 +32,7 @@ from sentry.profiles.task import (
     _set_frames_platform,
     _symbolicate_profile,
     determine_profile_type,
+    get_debug_file_id,
     process_profile_from_kafka,
     process_profile_task,
 )
@@ -536,6 +538,79 @@ def test_decode_signature(project, android_profile) -> None:
     assert frames[1]["signature"] == "(): boolean"
 
 
+def test_get_debug_file_id() -> None:
+    # android trace formats (legacy and android-trace chunks) carry a
+    # top-level build_id
+    assert (
+        get_debug_file_id(
+            {
+                "platform": "android",
+                "build_id": PROGUARD_UUID,
+                "profile": {"methods": []},
+            }
+        )
+        == UUID(PROGUARD_UUID).hex
+    )
+    assert (
+        get_debug_file_id({"platform": "android", "profile": {"methods": []}, "build_id": ""})
+        is None
+    )
+    assert (
+        get_debug_file_id(
+            {"platform": "android", "profile": {"methods": []}, "build_id": "not-a-uuid"}
+        )
+        is None
+    )
+
+    # sample v2 chunks reference the proguard mapping via debug_meta instead
+    sample_v2: dict[str, Any] = {
+        "version": "2",
+        "platform": "android",
+        "profile": {"frames": [], "stacks": [], "samples": []},
+        "debug_meta": {
+            "images": [
+                {"type": "jvm", "debug_id": "2bc44057-58ce-496b-a2fe-dd63254c921a"},
+                {"type": "proguard", "uuid": PROGUARD_UUID},
+            ]
+        },
+    }
+    assert get_debug_file_id(sample_v2) == UUID(PROGUARD_UUID).hex
+
+    # a top-level build_id is not part of the sample v2 schema and is ignored
+    assert (
+        get_debug_file_id(
+            {
+                "version": "2",
+                "platform": "android",
+                "profile": {"frames": [], "stacks": [], "samples": []},
+                "build_id": PROGUARD_UUID,
+            }
+        )
+        is None
+    )
+    assert (
+        get_debug_file_id(
+            {
+                "version": "2",
+                "platform": "android",
+                "profile": {"frames": [], "stacks": [], "samples": []},
+                "debug_meta": {"images": [{"type": "proguard"}]},
+            }
+        )
+        is None
+    )
+    assert (
+        get_debug_file_id(
+            {
+                "version": "2",
+                "platform": "android",
+                "profile": {"frames": [], "stacks": [], "samples": []},
+            }
+        )
+        is None
+    )
+
+
 def test_determine_profile_type() -> None:
     assert determine_profile_type({"version": "1"}) == EventType.PROFILE
     assert determine_profile_type({"version": "2"}) == EventType.PROFILE_CHUNK
@@ -907,7 +982,7 @@ class DeobfuscationViaSymbolicator(TransactionTestCase):
             "organization_id": self.project.organization_id,
             "project_id": self.project.id,
             "event_id": "a" * 32,
-            "build_id": PROGUARD_UUID,
+            "debug_meta": {"images": [{"type": "proguard", "uuid": PROGUARD_UUID}]},
             "client_sdk": {"name": "sentry.java.android", "version": "8.0.0"},
             "profile": {
                 "frames": [


### PR DESCRIPTION
For Android the proguard mapping uuid is either defined as `profile['build_id']` (legacy android profiles)
or within the `profile['debug_meta']['images']` for sample v2 chunks.

Existing tests only covered the `build_id` shape; the full-pipeline sample
v2 test now carries a correct proguard reference in `debug_meta` matching what
Relay actually emits, and a new `test_get_debug_file_id` covers both
formats plus the edge cases.