### PR TITLE
fix(github): guard against null installation in webhook helpers

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -126,6 +126,8 @@ class WebhookProcessor(Protocol):
 
 def get_github_external_id(event: Mapping[str, Any], host: str | None = None) -> str | None:
     external_id: str | None = (event.get("installation") or {}).get("id")
+    if external_id is None:
+        return None
     return f"{host}:{external_id}" if host else external_id
 
 

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -125,7 +125,7 @@ class WebhookProcessor(Protocol):
 
 
 def get_github_external_id(event: Mapping[str, Any], host: str | None = None) -> str | None:
-    external_id: str | None = event.get("installation", {}).get("id")
+    external_id: str | None = (event.get("installation") or {}).get("id")
     return f"{host}:{external_id}" if host else external_id
 
 
@@ -135,8 +135,8 @@ def get_scm_stream_extra(
     """Identifiers an SCM-stream listener needs to resolve org/integration/repo context,
     surfaced so listeners don't have to re-parse the raw event body."""
     return {
-        "installation_id": event.get("installation", {}).get("id"),
-        "repository_id": event.get("repository", {}).get("id"),
+        "installation_id": (event.get("installation") or {}).get("id"),
+        "repository_id": (event.get("repository") or {}).get("id"),
     }
 
 

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -706,6 +706,32 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
     @patch(
         "sentry.integrations.github.tasks.sync_repos_on_install_change.sync_repos_on_install_change.apply_async"
     )
+    def test_handler_skips_when_installation_is_null(self, mock_apply_async: MagicMock) -> None:
+        """GitHub sends ``installation: null`` when repos are removed as part of a
+        deleted-account cleanup. The handler must return early cleanly rather than
+        raising AttributeError from ``event.get("installation", {}).get("id")``."""
+        handler = InstallationRepositoriesEventWebhook()
+        handler(
+            event=cast(
+                InstallationRepositoriesEvent,
+                {
+                    "installation": None,
+                    "action": "removed",
+                    "repositories_added": [],
+                    "repositories_removed": [
+                        {"id": 20, "full_name": "getsentry/old-repo", "private": False}
+                    ],
+                    "repository_selection": "selected",
+                    "sender": {"id": 1, "login": "octocat"},
+                },
+            )
+        )
+
+        mock_apply_async.assert_not_called()
+
+    @patch(
+        "sentry.integrations.github.tasks.sync_repos_on_install_change.sync_repos_on_install_change.apply_async"
+    )
     def test_handler_skips_when_integration_not_found(self, mock_apply_async: MagicMock) -> None:
         """Integration doesn't exist in Sentry — handler returns early."""
         handler = InstallationRepositoriesEventWebhook()

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -29,6 +29,7 @@ from sentry.integrations.github.webhook import (
     GitHubIntegrationsWebhookEndpoint,
     InstallationRepositoriesEventWebhook,
     _track_contributor_action_processor,
+    get_github_external_id,
 )
 from sentry.integrations.github.webhook_types import (
     GithubWebhookType,
@@ -725,6 +726,38 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
                     "sender": {"id": 1, "login": "octocat"},
                 },
             )
+        )
+
+        mock_apply_async.assert_not_called()
+
+    @patch(
+        "sentry.integrations.github.tasks.sync_repos_on_install_change.sync_repos_on_install_change.apply_async"
+    )
+    def test_handler_skips_when_installation_is_null_with_host(
+        self, mock_apply_async: MagicMock
+    ) -> None:
+        """GitHub Enterprise: ``installation: null`` with a host set must still return early.
+
+        Without the ``if external_id is None: return None`` guard in
+        ``get_github_external_id``, the function would return the truthy string
+        ``"ghe.example.com:None"`` instead of ``None``, causing the early-exit
+        check in the handler to be bypassed."""
+        handler = InstallationRepositoriesEventWebhook()
+        handler(
+            event=cast(
+                InstallationRepositoriesEvent,
+                {
+                    "installation": None,
+                    "action": "removed",
+                    "repositories_added": [],
+                    "repositories_removed": [
+                        {"id": 20, "full_name": "getsentry/old-repo", "private": False}
+                    ],
+                    "repository_selection": "selected",
+                    "sender": {"id": 1, "login": "octocat"},
+                },
+            ),
+            host="ghe.example.com",
         )
 
         mock_apply_async.assert_not_called()
@@ -2237,3 +2270,25 @@ class TrackContributorActionProcessorTest(TestCase):
         )
 
         mock_record.assert_not_called()
+
+
+class GetGithubExternalIdTest(TestCase):
+    """Unit tests for the get_github_external_id helper."""
+
+    def test_returns_id_when_installation_present(self) -> None:
+        assert get_github_external_id({"installation": {"id": 42}}) == 42
+
+    def test_returns_none_when_installation_is_null(self) -> None:
+        assert get_github_external_id({"installation": None}) is None
+
+    def test_returns_none_when_installation_is_null_with_host(self) -> None:
+        # GitHub Enterprise path: must not return the truthy string "ghe.example.com:None"
+        assert get_github_external_id({"installation": None}, host="ghe.example.com") is None
+
+    def test_returns_prefixed_id_for_ghe(self) -> None:
+        result = get_github_external_id({"installation": {"id": 7}}, host="ghe.example.com")
+        assert result == "ghe.example.com:7"
+
+    def test_returns_id_without_prefix_when_no_host(self) -> None:
+        result = get_github_external_id({"installation": {"id": 7}})
+        assert result == 7


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'NoneType' object has no attribute 'get'` raised while processing GitHub `installation_repositories` webhook events.

- Triage session: https://claude.ai/code/session_01CXoF7wjZpuFPscbkztDmqj
- Sentry issue: [SENTRY-5QXV](https://sentry.sentry.io/issues/SENTRY-5QXV) (6 occurrences, 6 users, substatus: regressed, first seen 2026-06-26)

## Root cause

Two helpers in `src/sentry/integrations/github/webhook.py` read the installation id like this:

```python
event.get("installation", {}).get("id")
```

When GitHub cleans up a **deleted account's** repositories, it delivers an `installation_repositories` payload whose body contains `"installation": null` (the account/installation no longer exists, but GitHub still sends the removal event). In Python, `dict.get(key, default)` only returns `default` when the key is **absent** — when the key is present with a value of `None`, it returns `None`. So `event.get("installation", {})` evaluates to `None`, and the chained `.get("id")` blows up with `AttributeError`.

The `{}` default is a false sense of safety here: it protects against a *missing* key, not against an *explicit null value*, which is exactly what GitHub sends.

## Fix

Change `event.get("installation", {})` to `(event.get("installation") or {})`. The `or {}` coerces a `None` value to an empty dict, so `.get("id")` returns `None` instead of raising. `get_github_external_id` then returns `None`, and `InstallationRepositoriesEventWebhook.__call__` already handles that with an early return:

```python
external_id = get_github_external_id(event=event, host=host)
if external_id is None:
    return
```

Applied to both affected helpers:

1. `get_github_external_id` — the `installation` lookup.
2. `get_scm_stream_extra` — the `installation` lookup, plus the identical `repository` lookup (same `None`-vs-absent footgun, guarded proactively so the SCM-stream path can't hit the same crash).

## What was ruled out

- **Guarding in the caller** (e.g. checking `event.get("installation")` inside `InstallationRepositoriesEventWebhook.__call__`): rejected. The unsafe pattern lives in the shared helper `get_github_external_id`, which is called from multiple webhook handlers; fixing it at the caller would leave the same latent crash for every other caller and for `get_scm_stream_extra`. Fixing the helper resolves it once for all call sites.
- **Broader refactor / normalizing the payload upstream**: out of scope. This is a minimal, targeted correctness fix for a single production regression.

## Testing

Added `test_handler_skips_when_installation_is_null` to `InstallationRepositoriesEventWebhookTest` in `tests/sentry/integrations/github/test_webhook.py`: it invokes the handler with a payload containing `"installation": null` and asserts the sync task is **not** dispatched (i.e. the handler returns early cleanly, no `AttributeError`).

> Note: the full Sentry backend test/venv/devservices environment is not provisioned in this session, so the suite could not be executed here — CI will run it. The fix logic was verified in isolation and `ruff check` / `ruff format --check` pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXoF7wjZpuFPscbkztDmqj

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXoF7wjZpuFPscbkztDmqj)_