### PR TITLE
feat(pr-metrics): Re-check SeerRunPullRequest at deferred emission

### DIFF
--- a/src/sentry/pr_metrics/attribution.py
+++ b/src/sentry/pr_metrics/attribution.py
@@ -27,6 +27,7 @@ from sentry.models.pullrequest import (
     ResolvedPullRequest,
     parse_pull_request_number,
 )
+from sentry.seer.autofix.utils import CodingAgentProviderType
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,23 @@ DELEGATED_SIGNAL_TYPES = frozenset(
 JUDGE_ELIGIBLE_SIGNAL_TYPES = DELEGATED_SIGNAL_TYPES | frozenset(
     {PullRequestAttributionSignalType.SENTRY_APP}
 )
+
+# Maps a SeerRunCodingAgentHandoff.provider value to its SEER_DELEGATED_*
+# signal type. Falls back to SEER_DELEGATED_UNKNOWN for a provider we don't
+# recognize, so a new/renamed provider degrades to a weaker-confidence signal
+# rather than raising or silently attributing to the wrong agent.
+CODING_AGENT_PROVIDER_TO_SIGNAL_TYPE: dict[str, PullRequestAttributionSignalType] = {
+    CodingAgentProviderType.CURSOR_BACKGROUND_AGENT: PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR,
+    CodingAgentProviderType.GITHUB_COPILOT_AGENT: PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
+    CodingAgentProviderType.CLAUDE_CODE_AGENT: PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+}
+
+
+def signal_type_for_coding_agent_provider(provider: str) -> PullRequestAttributionSignalType:
+    """The SEER_DELEGATED_* signal type for a SeerRunCodingAgentHandoff.provider value."""
+    return CODING_AGENT_PROVIDER_TO_SIGNAL_TYPE.get(
+        provider, PullRequestAttributionSignalType.SEER_DELEGATED_UNKNOWN
+    )
 
 
 def is_seer_attribution(attribution: PullRequestAttribution) -> bool:

--- a/src/sentry/pr_metrics/utils.py
+++ b/src/sentry/pr_metrics/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 
@@ -254,22 +255,37 @@ def resolved_group_ids(pull_request: PullRequest) -> list[int]:
     return sorted(GroupLink.objects.filter(combined).values_list("group_id", flat=True).distinct())
 
 
-def seer_run_link_for_pull_request(pull_request: PullRequest) -> tuple[list[int], int | None]:
-    """Group id and run id for the Seer run that opened this PR, via the local
-    ``SeerRunPullRequest`` link.
+@dataclass(frozen=True)
+class SeerRunPullRequestLink:
+    """The Seer run (and, if applicable, delegated coding agent) that opened a PR,
+    resolved from the local ``SeerRunPullRequest`` link.
+    """
+
+    run_id: int | None
+    group_id: int | None
+    coding_agent_provider: str | None
+    coding_agent_id: str | None
+
+
+def seer_run_pull_request_link(pull_request: PullRequest) -> SeerRunPullRequestLink | None:
+    """The ``SeerRunPullRequest`` link for this PR, resolved to its run/group/agent
+    provider, or ``None`` if the PR has no such link.
 
     That link is written by the on_completion_hook-driven ``seer.pr_created`` flow
-    (``process_autofix_updates`` -> ``link_seer_run_pull_requests``). It may not
-    exist yet at the "opened" webhook if that flow hasn't landed; the "closed"
-    re-check in ``handle_attribution`` covers that case.
+    (``process_autofix_updates`` -> ``link_seer_run_pull_requests``) for Seer-native
+    PRs, and by ``sync_coding_agent_status`` for PRs opened by a delegated coding
+    agent (Cursor/GitHub Copilot/Claude Code) -- distinguished by a non-null
+    ``coding_agent_handoff``. It may not exist yet at the "opened" webhook if
+    neither flow has landed; the "closed" re-check in ``handle_attribution`` (and
+    the deferred-emission re-check in ``run_deferred_emission``) covers that case.
     """
     link = (
-        SeerRunPullRequest.objects.select_related("seer_run__agent")
+        SeerRunPullRequest.objects.select_related("seer_run__agent", "coding_agent_handoff")
         .filter(pull_request=pull_request)
         .first()
     )
     if link is None:
-        return [], None
+        return None
 
     run_id = link.seer_run.seer_run_state_id
     try:
@@ -277,4 +293,31 @@ def seer_run_link_for_pull_request(pull_request: PullRequest) -> tuple[list[int]
     except SeerAgentRun.DoesNotExist:
         group_id = None
 
-    return ([group_id] if group_id is not None else []), run_id
+    coding_agent_provider = (
+        link.coding_agent_handoff.provider if link.coding_agent_handoff is not None else None
+    )
+    coding_agent_id = (
+        link.coding_agent_handoff.agent_id if link.coding_agent_handoff is not None else None
+    )
+
+    return SeerRunPullRequestLink(
+        run_id=run_id,
+        group_id=group_id,
+        coding_agent_provider=coding_agent_provider,
+        coding_agent_id=coding_agent_id,
+    )
+
+
+def seer_run_link_for_pull_request(pull_request: PullRequest) -> tuple[list[int], int | None]:
+    """Group id and run id for the Seer run that opened this PR, via the local
+    ``SeerRunPullRequest`` link.
+
+    Thin wrapper around ``seer_run_pull_request_link`` for callers that only need
+    group ids/run id (e.g. the webhook-side ``SENTRY_APP`` author attribution) and
+    don't care whether the PR was opened by a delegated coding agent.
+    """
+    link = seer_run_pull_request_link(pull_request)
+    if link is None:
+        return [], None
+
+    return ([link.group_id] if link.group_id is not None else []), link.run_id

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -78,6 +78,7 @@ from sentry.pr_metrics.attribution import (
     DelegatedAgentSignalDetails,
     SentryAppSignalDetails,
     record_attribution_signal,
+    signal_type_for_coding_agent_provider,
 )
 from sentry.pr_metrics.emit import (
     VerdictDeferral,
@@ -95,6 +96,7 @@ from sentry.pr_metrics.utils import (
     org_has_coding_agent_for_provider,
     resolved_group_ids,
     seer_run_link_for_pull_request,
+    seer_run_pull_request_link,
 )
 from sentry.seer.autofix.utils import (
     DelegatedAgentMatch,
@@ -385,6 +387,80 @@ def _claim_cooldown(pr: PullRequest) -> bool:
     return bool(claimed)
 
 
+def _reconcile_seer_run_attribution(pr: PullRequest, organization: Organization) -> None:
+    """Sharpen a naive ``SENTRY_APP:webhook_data`` attribution using the local
+    ``SeerRunPullRequest`` link, if one has since landed.
+
+    The webhook-time author-id check (``_write_author_attribution``) can only
+    tell a PR was opened by one of our own GitHub apps -- it can't distinguish a
+    Seer-native PR from one opened by a Seer-delegated coding agent, since
+    Claude Code opens PRs under the Sentry app's own GitHub identity with no
+    distinct bot login. By the time this deferred-emission checkpoint runs (a
+    full cooldown window after close/merge), that distinction -- and a Seer
+    run's ``run_id``/``group_id`` -- may have landed via ``SeerRunPullRequest``,
+    written by either the Seer-native ``seer.pr_created`` flow or a delegated
+    coding-agent handoff. Backfilling it here closes races where the webhook's
+    "closed" re-check (``handle_attribution``) fired before that link existed.
+
+    Only runs for PRs that already carry a valid ``SENTRY_APP:webhook_data``
+    signal -- other attribution rows are left alone, and other signal types
+    (e.g. MCP) aren't naive webhook attributions this needs to correct.
+    ``record_attribution_signal`` is keyed on ``(pull_request, signal_type,
+    source)``, so writing a different signal_type/source here never clobbers
+    the existing row; it only adds to or refines the PR's attribution set.
+
+    Gated on ``pr-metrics-attribution``, matching every other attribution
+    writer.
+    """
+    if not features.has("organizations:pr-metrics-attribution", organization):
+        return
+
+    if not PullRequestAttribution.objects.filter(
+        pull_request=pr,
+        is_valid=True,
+        signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+        source=PullRequestAttributionSource.WEBHOOK_DATA,
+    ).exists():
+        return
+
+    link = seer_run_pull_request_link(pr)
+    if link is None:
+        return
+
+    pr_url = pr.get_external_url() or ""
+    group_ids = [link.group_id] if link.group_id is not None else []
+
+    if link.coding_agent_provider is not None:
+        # A delegated coding agent (Cursor/GitHub Copilot/Claude Code) produced
+        # this PR -- correct the naive SENTRY_APP bucketing to reflect that.
+        signal_type = signal_type_for_coding_agent_provider(link.coding_agent_provider)
+        record_attribution_signal(
+            pull_request=pr,
+            signal_type=signal_type,
+            source=PullRequestAttributionSource.SEER_DATA,
+            signal_details=DelegatedAgentSignalDetails(
+                agent_id=link.coding_agent_id,
+                pr_url=pr_url,
+                run_id=link.run_id,
+                group_ids=group_ids,
+            ).dict(),
+        )
+        metrics.incr("pr_metrics.attribution.reconciled", tags={"signal_type": str(signal_type)})
+        return
+
+    # A Seer-native run opened this PR -- record the run_id/group_id the
+    # webhook-time check may have missed.
+    record_attribution_signal(
+        pull_request=pr,
+        signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+        source=PullRequestAttributionSource.SEER_DATA,
+        signal_details=SentryAppSignalDetails(
+            pr_url=pr_url, group_ids=group_ids, run_id=link.run_id
+        ).dict(),
+    )
+    metrics.incr("pr_metrics.attribution.reconciled", tags={"signal_type": "sentry_app"})
+
+
 def handle_emission(
     *,
     github_event: GithubWebhookType,
@@ -469,9 +545,11 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
     final state.
 
     Reopen handling: if the PR is no longer terminal (reopened during the window),
-    release the sentinel and stop — a later re-close reschedules. Otherwise run the
-    standard verdict -> emit/forward path, whose own NULL-based guards settle the
-    row exactly once (a late redelivery that races the brief NULL window still
+    release the sentinel and stop — a later re-close reschedules. Otherwise
+    ``_reconcile_seer_run_attribution`` sharpens a naive ``SENTRY_APP:webhook_data``
+    signal against any ``SeerRunPullRequest`` link that has since landed, then the
+    standard verdict -> emit/forward path runs, whose own NULL-based guards settle
+    the row exactly once (a late redelivery that races the brief NULL window still
     emits once: whichever of the two claims the verdict wins, the other no-ops).
     """
     log_extra = {
@@ -490,6 +568,8 @@ def run_deferred_emission(pull_request: PullRequest, organization: Organization)
         metrics.incr("pr_metrics.cooldown.skipped", tags={"reason": "reopened"})
         logger.info("pr_metrics.cooldown.reopened", extra=log_extra)
         return
+
+    _reconcile_seer_run_attribution(pull_request, organization)
 
     verdict = select_verdict(pull_request, organization)
     if isinstance(verdict, VerdictDeferral):

--- a/src/sentry/pr_metrics/webhooks.py
+++ b/src/sentry/pr_metrics/webhooks.py
@@ -25,6 +25,7 @@ import orjson
 from django.conf import settings
 from django.core.cache import cache
 from django.db import IntegrityError, router, transaction
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from pydantic import ValidationError
@@ -387,6 +388,46 @@ def _claim_cooldown(pr: PullRequest) -> bool:
     return bool(claimed)
 
 
+def _needs_seer_run_reconciliation(pr: PullRequest) -> bool:
+    """Whether this PR's ``SENTRY_APP:webhook_data`` attribution is still missing
+    a ``run_id`` and hasn't already been backfilled by a prior reconciliation.
+
+    True when both hold:
+    1. A valid ``SENTRY_APP:webhook_data`` row exists without a ``run_id`` in its
+       ``signal_details`` (covers a JSON ``null`` value, a missing ``run_id`` key,
+       and a wholly-``None`` ``signal_details`` column).
+    2. No valid ``SENTRY_APP:seer_data`` row already carries a ``run_id`` -- once
+       one does, a prior reconciliation (or the Seer-native ``pr_created`` flow)
+       already backfilled it, so there's nothing left to salvage.
+    """
+    # A JSONField's ``run_id`` reads as missing under both a JSON `null` value
+    # and a genuinely absent key, and Django's ``isnull`` lookup only catches
+    # the latter -- OR both to cover a wholly-None ``signal_details`` column too.
+    missing_run_id = Q(signal_details__run_id__isnull=True) | Q(signal_details__run_id=None)
+
+    has_unresolved_webhook_signal = PullRequestAttribution.objects.filter(
+        missing_run_id,
+        pull_request=pr,
+        is_valid=True,
+        signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+        source=PullRequestAttributionSource.WEBHOOK_DATA,
+    ).exists()
+    if not has_unresolved_webhook_signal:
+        return False
+
+    has_resolved_seer_data_signal = (
+        PullRequestAttribution.objects.filter(
+            pull_request=pr,
+            is_valid=True,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+        )
+        .exclude(missing_run_id)
+        .exists()
+    )
+    return not has_resolved_seer_data_signal
+
+
 def _reconcile_seer_run_attribution(pr: PullRequest, organization: Organization) -> None:
     """Sharpen a naive ``SENTRY_APP:webhook_data`` attribution using the local
     ``SeerRunPullRequest`` link, if one has since landed.
@@ -402,12 +443,14 @@ def _reconcile_seer_run_attribution(pr: PullRequest, organization: Organization)
     coding-agent handoff. Backfilling it here closes races where the webhook's
     "closed" re-check (``handle_attribution``) fired before that link existed.
 
-    Only runs for PRs that already carry a valid ``SENTRY_APP:webhook_data``
-    signal -- other attribution rows are left alone, and other signal types
-    (e.g. MCP) aren't naive webhook attributions this needs to correct.
-    ``record_attribution_signal`` is keyed on ``(pull_request, signal_type,
-    source)``, so writing a different signal_type/source here never clobbers
-    the existing row; it only adds to or refines the PR's attribution set.
+    Only runs for PRs whose ``SENTRY_APP:webhook_data`` signal is still missing a
+    ``run_id`` and hasn't already been backfilled (see
+    ``_needs_seer_run_reconciliation``) -- other attribution rows are left
+    alone, and other signal types (e.g. MCP) aren't naive webhook attributions
+    this needs to correct. ``record_attribution_signal`` is keyed on
+    ``(pull_request, signal_type, source)``, so writing a different
+    signal_type/source here never clobbers the existing row; it only adds to or
+    refines the PR's attribution set.
 
     Gated on ``pr-metrics-attribution``, matching every other attribution
     writer.
@@ -415,12 +458,7 @@ def _reconcile_seer_run_attribution(pr: PullRequest, organization: Organization)
     if not features.has("organizations:pr-metrics-attribution", organization):
         return
 
-    if not PullRequestAttribution.objects.filter(
-        pull_request=pr,
-        is_valid=True,
-        signal_type=PullRequestAttributionSignalType.SENTRY_APP,
-        source=PullRequestAttributionSource.WEBHOOK_DATA,
-    ).exists():
+    if not _needs_seer_run_reconciliation(pr):
         return
 
     link = seer_run_pull_request_link(pr)

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -36,6 +36,7 @@ from sentry.pr_metrics.webhooks import (
     handle_review,
     handle_review_comment,
     handle_review_thread,
+    run_deferred_emission,
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
@@ -787,6 +788,228 @@ class HandleWebhookForPrMetricsCooldownTest(TestCase):
 
         assert get_event_count(mock_record, PrCloseMetricsEvent) == 0
         assert self._verdict() is None
+
+
+@with_feature("organizations:pr-metrics-emit")
+@with_feature("organizations:pr-metrics-attribution")
+@with_feature(["organizations:pr-metrics-activity", "organizations:gen-ai-features"])
+@cell_silo_test
+class DeferredEmissionReconcilesSeerRunAttributionTest(TestCase):
+    """The deferred-emission checkpoint (``run_deferred_emission`` via
+    ``emit_pr_metrics_cooldown_task``) sharpens a naive ``SENTRY_APP:webhook_data``
+    attribution against any ``SeerRunPullRequest`` link that has since landed.
+    """
+
+    def setUp(self) -> None:
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(
+            self.project,
+            provider="integrations:github",
+            external_id="99",
+            url="https://github.com/getsentry/sentry",
+        )
+        self.pull_request = self.create_pull_request(
+            repository_id=self.repo.id, organization_id=self.organization.id, key="42"
+        )
+        PullRequestAttribution.objects.create(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        PullRequestMetrics.objects.create(pull_request=self.pull_request, additions=1)
+        self.pull_request.update(
+            head_commit_sha=HEAD_SHA,
+            opened_at=OPENED_AT,
+            closed_at=CLOSED_AT,
+            merged_at=CLOSED_AT,
+            merge_commit_sha=MERGE_SHA,
+            draft=False,
+        )
+
+    def _run_deferred_emission(self) -> None:
+        with (
+            patch(f"{MODULE}.emit_pr_metrics_cooldown_task.apply_async"),
+            patch("sentry.analytics.record"),
+        ):
+            handle_emission(
+                github_event=GithubWebhookType.PULL_REQUEST,
+                event={"action": "closed", "pull_request": {"number": 42}},
+                organization=self.organization,
+                repo=self.repo,
+            )
+            emit_pr_metrics_cooldown_task(
+                pull_request_id=self.pull_request.id,
+                organization_id=self.organization.id,
+                repository_id=self.repo.id,
+            )
+
+    def test_seer_native_run_adds_sentry_app_seer_data_signal(self) -> None:
+        group = self.create_group(project=self.project)
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        self.create_seer_agent_run(run=run, group=group)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pull_request)
+
+        self._run_deferred_emission()
+
+        webhook_attr = PullRequestAttribution.objects.get(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+        )
+        assert webhook_attr.is_valid is True
+
+        seer_data_attr = PullRequestAttribution.objects.get(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+        )
+        assert seer_data_attr.signal_details == {
+            "pr_url": "https://github.com/getsentry/sentry/pull/42",
+            "group_ids": [group.id],
+            "run_id": 555,
+        }
+
+    def test_cursor_handoff_adds_delegated_signal(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=111)
+        handoff = self.create_seer_run_coding_agent_handoff(
+            seer_run=run, provider="cursor_background_agent", agent_id="cursor-agent-1"
+        )
+        self.create_seer_run_pull_request(
+            run=run, pull_request=self.pull_request, coding_agent_handoff=handoff
+        )
+
+        self._run_deferred_emission()
+
+        # The naive SENTRY_APP:webhook_data row is left untouched...
+        assert PullRequestAttribution.objects.filter(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        ).exists()
+        # ...and a delegated-agent signal is added alongside it.
+        delegated_attr = PullRequestAttribution.objects.get(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR,
+            source=PullRequestAttributionSource.SEER_DATA,
+        )
+        assert delegated_attr.signal_details == {
+            "agent_id": "cursor-agent-1",
+            "pr_url": "https://github.com/getsentry/sentry/pull/42",
+            "run_id": 111,
+            "group_ids": [],
+        }
+
+    def test_github_copilot_handoff_adds_delegated_signal(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=222)
+        handoff = self.create_seer_run_coding_agent_handoff(
+            seer_run=run, provider="github_copilot_agent", agent_id="copilot-agent-1"
+        )
+        self.create_seer_run_pull_request(
+            run=run, pull_request=self.pull_request, coding_agent_handoff=handoff
+        )
+
+        self._run_deferred_emission()
+
+        assert PullRequestAttribution.objects.filter(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_GITHUB_COPILOT,
+            source=PullRequestAttributionSource.SEER_DATA,
+        ).exists()
+
+    def test_claude_code_handoff_adds_delegated_signal(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=333)
+        handoff = self.create_seer_run_coding_agent_handoff(
+            seer_run=run, provider="claude_code_agent", agent_id="claude-agent-1"
+        )
+        self.create_seer_run_pull_request(
+            run=run, pull_request=self.pull_request, coding_agent_handoff=handoff
+        )
+
+        self._run_deferred_emission()
+
+        assert PullRequestAttribution.objects.filter(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CLAUDE_CODE,
+            source=PullRequestAttributionSource.SEER_DATA,
+        ).exists()
+
+    def test_unrecognized_provider_falls_back_to_unknown(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=444)
+        handoff = self.create_seer_run_coding_agent_handoff(
+            seer_run=run, provider="some_future_agent", agent_id="future-agent-1"
+        )
+        self.create_seer_run_pull_request(
+            run=run, pull_request=self.pull_request, coding_agent_handoff=handoff
+        )
+
+        self._run_deferred_emission()
+
+        assert PullRequestAttribution.objects.filter(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_UNKNOWN,
+            source=PullRequestAttributionSource.SEER_DATA,
+        ).exists()
+
+    def test_no_seer_run_link_leaves_attribution_unchanged(self) -> None:
+        self._run_deferred_emission()
+
+        assert PullRequestAttribution.objects.filter(pull_request=self.pull_request).count() == 1
+        assert PullRequestAttribution.objects.filter(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+        ).exists()
+
+    def test_non_sentry_app_webhook_attribution_is_not_reconciled(self) -> None:
+        # e.g. MCP attribution -- this reconciliation only corrects the naive
+        # SENTRY_APP:webhook_data signal, not other attribution types.
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).delete()
+        PullRequestAttribution.objects.create(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.MCP,
+            source=PullRequestAttributionSource.WEBHOOK_DATA,
+            is_valid=True,
+        )
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pull_request)
+
+        self._run_deferred_emission()
+
+        assert PullRequestAttribution.objects.filter(pull_request=self.pull_request).count() == 1
+
+    def test_invalid_sentry_app_webhook_attribution_is_not_reconciled(self) -> None:
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(is_valid=False)
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pull_request)
+
+        self._run_deferred_emission()
+
+        assert PullRequestAttribution.objects.filter(pull_request=self.pull_request).count() == 1
+
+    def test_idempotent_on_redelivery(self) -> None:
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        handoff = self.create_seer_run_coding_agent_handoff(
+            seer_run=run, provider="cursor_background_agent", agent_id="cursor-agent-1"
+        )
+        self.create_seer_run_pull_request(
+            run=run, pull_request=self.pull_request, coding_agent_handoff=handoff
+        )
+
+        self._run_deferred_emission()
+        # A redelivered cooldown task re-runs the reconciliation; it must not
+        # duplicate the delegated-agent attribution row.
+        with patch("sentry.analytics.record"):
+            run_deferred_emission(self.pull_request, self.organization)
+
+        assert (
+            PullRequestAttribution.objects.filter(
+                pull_request=self.pull_request,
+                signal_type=PullRequestAttributionSignalType.SEER_DELEGATED_CURSOR,
+            ).count()
+            == 1
+        )
 
 
 @with_feature("organizations:pr-metrics-emit")

--- a/tests/sentry/pr_metrics/test_webhooks.py
+++ b/tests/sentry/pr_metrics/test_webhooks.py
@@ -1011,6 +1011,55 @@ class DeferredEmissionReconcilesSeerRunAttributionTest(TestCase):
             == 1
         )
 
+    def test_webhook_signal_already_carrying_run_id_is_not_reconciled(self) -> None:
+        # The webhook-time check already resolved run_id/group_id (the common
+        # case, when SeerRunPullRequest landed before the close webhook) -- there
+        # is nothing to salvage, so the lookup shouldn't run at all.
+        PullRequestAttribution.objects.filter(pull_request=self.pull_request).update(
+            signal_details={
+                "pr_url": "https://github.com/getsentry/sentry/pull/42",
+                "group_ids": [],
+                "run_id": 999,
+            }
+        )
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pull_request)
+
+        self._run_deferred_emission()
+
+        # Only the original webhook_data row exists -- no seer_data row was added.
+        assert PullRequestAttribution.objects.filter(pull_request=self.pull_request).count() == 1
+
+    def test_already_reconciled_sentry_app_seer_data_is_not_re_reconciled(self) -> None:
+        # A prior reconciliation (or the Seer-native pr_created flow) already
+        # backfilled a SENTRY_APP:seer_data row with a run_id -- nothing left to
+        # salvage, even though the webhook_data row itself has no run_id.
+        PullRequestAttribution.objects.create(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+            is_valid=True,
+            signal_details={
+                "pr_url": "https://github.com/getsentry/sentry/pull/42",
+                "group_ids": [],
+                "run_id": 123,
+            },
+        )
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=555)
+        self.create_seer_run_pull_request(run=run, pull_request=self.pull_request)
+
+        self._run_deferred_emission()
+
+        seer_data_attr = PullRequestAttribution.objects.get(
+            pull_request=self.pull_request,
+            signal_type=PullRequestAttributionSignalType.SENTRY_APP,
+            source=PullRequestAttributionSource.SEER_DATA,
+        )
+        # Untouched -- still points at the originally-recorded run, not the
+        # (different) run linked above.
+        assert seer_data_attr.signal_details is not None
+        assert seer_data_attr.signal_details["run_id"] == 123
+
 
 @with_feature("organizations:pr-metrics-emit")
 @cell_silo_test


### PR DESCRIPTION
Adds a reconciliation step to the deferred-emission task that re-checks the
`SeerRunPullRequest` link for a PR once a valid `SENTRY_APP:webhook_data`
attribution already exists, to try to salvage two known gaps in attribution
completeness.

We were already using `SeerRun` rows to enhance SENTRY_APP:webhook_data attribution rows. And we are also using the `SeerRunCodingAgentHandoff` to enhance some data for Cursor.

Sadly it seems there are cases where:
1. The SENTRY_APP:webhook_data lookup is in race condition to the creation of the `SeerRunPullRequest` row that connects a `PullRequest` with `SeerRun`
2. The lookup _in Seer_ for delegated agents can be ambiguous. 

So I decided to add a new lookup after the cooldown period in the hopes of salvaging the sentry attribution rows (case 1) that we should reliably have in `SeerRun`. I suspect it won't help much for the delegated agents, but didn't hurt to add that in.