### PR TITLE
feat(ai): Prepare task producer for gen_ai conversation title generator

### DIFF
--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -1,5 +1,5 @@
-from collections.abc import Mapping
-from datetime import datetime
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from typing import Any
 
 from django.db import IntegrityError, router, transaction
@@ -10,10 +10,14 @@ from taskbroker_client.retry import Retry
 from sentry import features
 from sentry.ai_monitoring.models import AIConversationMetadata
 from sentry.ai_monitoring.utils import (
+    ConversationTitleSpanData,
     clamp_conversation_id_for_storage,
+    clamp_user_message,
+    conversation_id_from_span,
     conversation_id_hash,
+    first_user_message_from_span,
     generate_conversation_title,
-    parse_conversation_title_span,
+    span_source_timestamp,
 )
 from sentry.models.project import Project
 from sentry.seer.signed_seer_api import SeerViewerContext
@@ -23,9 +27,9 @@ from sentry.taskworker.namespaces import ai_agent_monitoring_tasks
 from sentry.utils import metrics
 
 
-def _can_replace_title(source_timestamp: datetime) -> Q:
-    """Rows we are allowed to overwrite: no title yet, or a strictly later source."""
-    return Q(title_source_timestamp__isnull=True) | Q(title_source_timestamp__gt=source_timestamp)
+def _supersedable(source_ts: datetime) -> Q:
+    """Rows this source is allowed to overwrite: untitled, or titled from a later span."""
+    return Q(title_source_timestamp__isnull=True) | Q(title_source_timestamp__gt=source_ts)
 
 
 @instrumented_task(
@@ -33,23 +37,30 @@ def _can_replace_title(source_timestamp: datetime) -> Q:
     namespace=ai_agent_monitoring_tasks,
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=40,
-    compression_type=CompressionType.ZSTD,  # span payloads can get large
+    compression_type=CompressionType.ZSTD,  # first_user_message can be up to ~8KB of text
     retry=Retry(times=3, delay=5, on=(Exception,)),
 )
-def generate_ai_conversation_title(span: Mapping[str, Any]) -> None:
+def generate_ai_conversation_title(
+    project_id: int,
+    conversation_id: str,
+    first_user_message: str,
+    source_timestamp: float,
+) -> None:
     """
-    Generate and persist a conversation title from an ingested gen_ai span.
+    Generate and persist the title for a single gen_ai conversation.
 
-    Earliest source span wins. Equal timestamps keep the existing title (retry-stable).
-    Seer is never called under a DB lock: cheap precheck → generate → conditional write.
+    The caller (ingest) has already extracted and size-capped these fields from
+    the earliest span it saw, so this task never touches raw spans.
+
+    Concurrency: the earliest source span wins. Equal timestamps keep whatever
+    is stored (retry-stable). Seer is called between two short, lock-free
+    windows — a cheap precheck and a conditional write — never while we hold a
+    row, so we don't pin a connection across a network call.
     """
-    data = parse_conversation_title_span(span)
-    if data is None:
-        metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "invalid_span"})
-        return
+    source_ts = datetime.fromtimestamp(source_timestamp, tz=UTC)
 
     try:
-        project = Project.objects.get_from_cache(id=data.project_id)
+        project = Project.objects.get_from_cache(id=project_id)
     except Project.DoesNotExist:
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "project_not_found"})
         return
@@ -58,58 +69,55 @@ def generate_ai_conversation_title(span: Mapping[str, Any]) -> None:
     if not features.has("organizations:gen-ai-conversation-title-generation", organization):
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "feature_disabled"})
         return
-
     if organization.get_option("sentry:hide_ai_features"):
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "hide_ai_features"})
         return
 
-    # Hash the full id first; only the stored CharField is length-capped.
-    conv_hash = conversation_id_hash(data.conversation_id)
-    conversation_id = clamp_conversation_id_for_storage(data.conversation_id)
-    existing = AIConversationMetadata.objects.filter(
-        project_id=data.project_id,
+    conv_hash = conversation_id_hash(conversation_id)
+    rows = AIConversationMetadata.objects.filter(
+        project_id=project_id,
         conversation_id_hash=conv_hash,
-    ).first()
-    # Skip Seer when we already have an earlier-or-equal title source.
+    )
+
+    # Precheck: don't pay for Seer if an earlier-or-equal title already exists.
+    existing = rows.first()
     if (
         existing is not None
         and existing.title_source_timestamp is not None
-        and data.source_timestamp >= existing.title_source_timestamp
+        and source_ts >= existing.title_source_timestamp
     ):
         metrics.incr("ai_monitoring.conversation_title.skip", tags={"reason": "later_or_equal_ts"})
         return
 
-    viewer_context = SeerViewerContext(organization_id=organization.id)
-    title = generate_conversation_title(data.first_user_message, viewer_context=viewer_context)
-
-    qs = AIConversationMetadata.objects.filter(
-        project_id=data.project_id,
-        conversation_id_hash=conv_hash,
+    title = generate_conversation_title(
+        first_user_message, viewer_context=SeerViewerContext(organization_id=organization.id)
     )
-    # Atomic conditional update: only overwrite later (or missing) source timestamps.
-    if qs.filter(_can_replace_title(data.source_timestamp)).update(
+    stored_conversation_id = clamp_conversation_id_for_storage(conversation_id)
+
+    # Overwrite an existing row only while this source is still the earliest.
+    if rows.filter(_supersedable(source_ts)).update(
         title=title,
-        conversation_id=conversation_id,
-        title_source_timestamp=data.source_timestamp,
+        conversation_id=stored_conversation_id,
+        title_source_timestamp=source_ts,
     ):
         metrics.incr("ai_monitoring.conversation_title.written", tags={"result": "updated"})
         return
 
     try:
-        # Savepoint so IntegrityError doesn't abort an outer transaction.
+        # Savepoint so a lost insert race can't poison an enclosing transaction.
         with transaction.atomic(router.db_for_write(AIConversationMetadata)):
             AIConversationMetadata.objects.create(
-                project_id=data.project_id,
-                conversation_id=conversation_id,
+                project_id=project_id,
+                conversation_id=stored_conversation_id,
                 conversation_id_hash=conv_hash,
                 title=title,
-                title_source_timestamp=data.source_timestamp,
+                title_source_timestamp=source_ts,
             )
     except IntegrityError:
-        # Concurrent create won the insert; only keep our title if we're still earlier.
-        if qs.filter(_can_replace_title(data.source_timestamp)).update(
+        # A concurrent task created the row first; keep our title only if earlier.
+        if rows.filter(_supersedable(source_ts)).update(
             title=title,
-            title_source_timestamp=data.source_timestamp,
+            title_source_timestamp=source_ts,
         ):
             metrics.incr(
                 "ai_monitoring.conversation_title.written", tags={"result": "updated_after_race"}
@@ -121,3 +129,84 @@ def generate_ai_conversation_title(span: Mapping[str, Any]) -> None:
         return
 
     metrics.incr("ai_monitoring.conversation_title.written", tags={"result": "created"})
+
+
+def enqueue_conversation_titles(spans: Sequence[Mapping[str, Any]]) -> None:
+    """
+    Fan out title generation for the gen_ai conversations in a segment.
+
+    Runs early in the ingest path so titles are still generated for segments
+    that skip enrichment. It resolves the project itself (from the first span)
+    rather than depending on the enriched segment, which means the project may
+    be fetched again later in the pipeline — an acceptable cost for keeping the
+    ingest code untouched.
+
+    Single pass over the spans:
+      - Detect gen_ai conversation spans via the (cheap) conversation-id
+        attribute, tracking distinct ids so we can report how many gen_ai
+        conversations the segment carried.
+      - Keep only the earliest span per ``conversation_id``. The costly message
+        extraction runs only for a span that could still become the earliest,
+        so replayed later-turn spans (same conversation, same history) don't pay
+        for it. A conversation therefore costs at most one Seer call.
+    """
+    earliest_by_conversation: dict[str, ConversationTitleSpanData] = {}
+    seen_conversation_ids: set[str] = set()
+
+    for span in spans:
+        conversation_id = conversation_id_from_span(span)
+        if conversation_id is None:
+            continue
+        seen_conversation_ids.add(conversation_id)
+
+        source_timestamp = span_source_timestamp(span)
+        if source_timestamp is None:
+            continue
+
+        current = earliest_by_conversation.get(conversation_id)
+        if current is not None and source_timestamp >= current.source_timestamp:
+            # A later-or-equal span can never win; skip the costly message parse.
+            continue
+
+        first_user_message = first_user_message_from_span(span)
+        if first_user_message is None:
+            continue
+
+        earliest_by_conversation[conversation_id] = ConversationTitleSpanData(
+            conversation_id=conversation_id,
+            source_timestamp=source_timestamp,
+            first_user_message=first_user_message,
+        )
+
+    if seen_conversation_ids:
+        metrics.incr(
+            "spans.consumers.process_segments.gen_ai_conversation",
+            len(seen_conversation_ids),
+        )
+
+    if not earliest_by_conversation:
+        return
+
+    # All spans in a segment share a project; the first one is enough.
+    project_id = spans[0].get("project_id")
+    if not isinstance(project_id, int):
+        return
+    try:
+        project = Project.objects.get_from_cache(id=project_id)
+    except Project.DoesNotExist:
+        return
+
+    organization = project.organization
+    if not features.has("organizations:gen-ai-conversation-title-generation", organization):
+        return
+    if organization.get_option("sentry:hide_ai_features"):
+        return
+
+    for data in earliest_by_conversation.values():
+        generate_ai_conversation_title.delay(
+            project_id=project.id,
+            conversation_id=data.conversation_id,
+            first_user_message=clamp_user_message(data.first_user_message),
+            source_timestamp=data.source_timestamp.timestamp(),
+        )
+        metrics.incr("ai_monitoring.conversation_title.enqueued")

--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -121,10 +121,10 @@ def generate_ai_conversation_title(
     metrics.incr("ai_monitoring.conversation_title.written", tags={"result": "created"})
 
 
-def enqueue_conversation_titles(spans: Sequence[Mapping[str, Any]]) -> None:
+def spawn_conversation_title_generation(spans: Sequence[Mapping[str, Any]]) -> None:
     """
-    Enqueues one task per conversation, using the earliest spans
-    that has a user message.
+    Entrypoint that spawns one title-generation task per conversation,
+    using the earliest span that has a user message.
     """
     earliest_by_conversation: dict[str, ConversationTitleSpanData] = {}
     seen_conversation_ids: set[str] = set()

--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -27,7 +27,7 @@ from sentry.taskworker.namespaces import ai_agent_monitoring_tasks
 from sentry.utils import metrics
 
 
-def _supersedable(source_ts: datetime) -> Q:
+def _is_earliest(source_ts: datetime) -> Q:
     """Rows this source is allowed to overwrite: untitled, or titled from a later span."""
     return Q(title_source_timestamp__isnull=True) | Q(title_source_timestamp__gt=source_ts)
 
@@ -85,7 +85,7 @@ def generate_ai_conversation_title(
     stored_conversation_id = clamp_conversation_id_for_storage(conversation_id)
 
     # Update an existing row only if this span is still the earliest.
-    if qs.filter(_supersedable(source_ts)).update(
+    if qs.filter(_is_earliest(source_ts)).update(
         title=title,
         conversation_id=stored_conversation_id,
         title_source_timestamp=source_ts,
@@ -105,7 +105,7 @@ def generate_ai_conversation_title(
             )
     except IntegrityError:
         # Another task created the row first; keep our title only if it's earlier.
-        if qs.filter(_supersedable(source_ts)).update(
+        if qs.filter(_is_earliest(source_ts)).update(
             title=title,
             title_source_timestamp=source_ts,
         ):

--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -46,17 +46,7 @@ def generate_ai_conversation_title(
     first_user_message: str,
     source_timestamp: float,
 ) -> None:
-    """
-    Generate and persist the title for a single gen_ai conversation.
-
-    The caller (ingest) has already extracted and size-capped these fields from
-    the earliest span it saw, so this task never touches raw spans.
-
-    Concurrency: the earliest source span wins. Equal timestamps keep whatever
-    is stored (retry-stable). Seer is called between two short, lock-free
-    windows — a cheap precheck and a conditional write — never while we hold a
-    row, so we don't pin a connection across a network call.
-    """
+    """Generate and persist the title for a single gen_ai conversation (earliest span wins)."""
     source_ts = datetime.fromtimestamp(source_timestamp, tz=UTC)
 
     try:
@@ -79,7 +69,7 @@ def generate_ai_conversation_title(
         conversation_id_hash=conv_hash,
     )
 
-    # Precheck: don't pay for Seer if an earlier-or-equal title already exists.
+    # Skip Seer if we already have a title from an earlier-or-equal span.
     existing = rows.first()
     if (
         existing is not None
@@ -94,7 +84,7 @@ def generate_ai_conversation_title(
     )
     stored_conversation_id = clamp_conversation_id_for_storage(conversation_id)
 
-    # Overwrite an existing row only while this source is still the earliest.
+    # Update an existing row only if this span is still the earliest.
     if rows.filter(_supersedable(source_ts)).update(
         title=title,
         conversation_id=stored_conversation_id,
@@ -104,7 +94,7 @@ def generate_ai_conversation_title(
         return
 
     try:
-        # Savepoint so a lost insert race can't poison an enclosing transaction.
+        # Savepoint so a failed insert doesn't break an enclosing transaction.
         with transaction.atomic(router.db_for_write(AIConversationMetadata)):
             AIConversationMetadata.objects.create(
                 project_id=project_id,
@@ -114,7 +104,7 @@ def generate_ai_conversation_title(
                 title_source_timestamp=source_ts,
             )
     except IntegrityError:
-        # A concurrent task created the row first; keep our title only if earlier.
+        # Another task created the row first; keep our title only if it's earlier.
         if rows.filter(_supersedable(source_ts)).update(
             title=title,
             title_source_timestamp=source_ts,
@@ -133,22 +123,8 @@ def generate_ai_conversation_title(
 
 def enqueue_conversation_titles(spans: Sequence[Mapping[str, Any]]) -> None:
     """
-    Fan out title generation for the gen_ai conversations in a segment.
-
-    Runs early in the ingest path so titles are still generated for segments
-    that skip enrichment. It resolves the project itself (from the first span)
-    rather than depending on the enriched segment, which means the project may
-    be fetched again later in the pipeline — an acceptable cost for keeping the
-    ingest code untouched.
-
-    Single pass over the spans:
-      - Detect gen_ai conversation spans via the (cheap) conversation-id
-        attribute, tracking distinct ids so we can report how many gen_ai
-        conversations the segment carried.
-      - Keep only the earliest span per ``conversation_id``. The costly message
-        extraction runs only for a span that could still become the earliest,
-        so replayed later-turn spans (same conversation, same history) don't pay
-        for it. A conversation therefore costs at most one Seer call.
+    Enqueues one task per conversation, using the earliest spans
+    that has a user message.
     """
     earliest_by_conversation: dict[str, ConversationTitleSpanData] = {}
     seen_conversation_ids: set[str] = set()
@@ -163,9 +139,9 @@ def enqueue_conversation_titles(spans: Sequence[Mapping[str, Any]]) -> None:
         if source_timestamp is None:
             continue
 
+        # A later-or-equal span can't win; skip the costly message extraction.
         current = earliest_by_conversation.get(conversation_id)
         if current is not None and source_timestamp >= current.source_timestamp:
-            # A later-or-equal span can never win; skip the costly message parse.
             continue
 
         first_user_message = first_user_message_from_span(span)

--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -64,13 +64,13 @@ def generate_ai_conversation_title(
         return
 
     conv_hash = conversation_id_hash(conversation_id)
-    rows = AIConversationMetadata.objects.filter(
+    qs = AIConversationMetadata.objects.filter(
         project_id=project_id,
         conversation_id_hash=conv_hash,
     )
 
     # Skip Seer if we already have a title from an earlier-or-equal span.
-    existing = rows.first()
+    existing = qs.first()
     if (
         existing is not None
         and existing.title_source_timestamp is not None
@@ -85,7 +85,7 @@ def generate_ai_conversation_title(
     stored_conversation_id = clamp_conversation_id_for_storage(conversation_id)
 
     # Update an existing row only if this span is still the earliest.
-    if rows.filter(_supersedable(source_ts)).update(
+    if qs.filter(_supersedable(source_ts)).update(
         title=title,
         conversation_id=stored_conversation_id,
         title_source_timestamp=source_ts,
@@ -105,7 +105,7 @@ def generate_ai_conversation_title(
             )
     except IntegrityError:
         # Another task created the row first; keep our title only if it's earlier.
-        if rows.filter(_supersedable(source_ts)).update(
+        if qs.filter(_supersedable(source_ts)).update(
             title=title,
             title_source_timestamp=source_ts,
         ):

--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -66,7 +66,6 @@ _MESSAGE_ATTRS = (
 
 @dataclass(frozen=True, slots=True)
 class ConversationTitleSpanData:
-    project_id: int
     conversation_id: str
     source_timestamp: datetime
     first_user_message: str
@@ -98,7 +97,16 @@ def _extract_first_user_message(messages: Any) -> str | None:
     return None
 
 
-def _first_user_message(span: Mapping[str, Any]) -> str | None:
+def conversation_id_from_span(span: Mapping[str, Any]) -> str | None:
+    """Cheap check: the gen_ai conversation id, if this span carries one."""
+    raw = attribute_value(span, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID)
+    if raw is None:
+        return None
+    conversation_id = str(raw).strip()
+    return conversation_id or None
+
+
+def first_user_message_from_span(span: Mapping[str, Any]) -> str | None:
     for key in _MESSAGE_ATTRS:
         messages = attribute_value(span, key)
         if not messages:
@@ -130,41 +138,8 @@ def _parse_timestamp(raw: Any) -> datetime | None:
     return None
 
 
-def parse_conversation_title_span(
-    span: Mapping[str, Any],
-) -> ConversationTitleSpanData | None:
-    """
-    Pull everything needed for title generation out of a Kafka span.
-
-    Top-level fields (project_id, start_timestamp) live on the span root.
-    Gen-AI fields live under attributes[key].value — that's the wire format,
-    not two competing access styles at the call sites.
-    """
-    project_id = span.get("project_id")
-    if not isinstance(project_id, int):
-        return None
-
-    conversation_id_raw = attribute_value(span, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID)
-    if conversation_id_raw is None:
-        return None
-    conversation_id = str(conversation_id_raw).strip()
-    if not conversation_id:
-        return None
-
-    source_timestamp = _parse_timestamp(span.get("start_timestamp"))
-    if source_timestamp is None:
-        return None
-
-    first_user_message = _first_user_message(span)
-    if not first_user_message:
-        return None
-
-    return ConversationTitleSpanData(
-        project_id=project_id,
-        conversation_id=conversation_id,
-        source_timestamp=source_timestamp,
-        first_user_message=first_user_message,
-    )
+def span_source_timestamp(span: Mapping[str, Any]) -> datetime | None:
+    return _parse_timestamp(span.get("start_timestamp"))
 
 
 def clamp_user_message(message: str) -> str:

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -236,20 +236,15 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         super().setUp()
         self.project = self.create_project()
 
-    def _run(
-        self,
-        *,
-        conversation_id: str = "conv-1",
-        first_user_message: str = "How do I reset my password?",
-        start_timestamp: float = TS,
-        project_id: int | None = None,
-    ) -> None:
-        generate_ai_conversation_title(
-            project_id=self.project.id if project_id is None else project_id,
-            conversation_id=conversation_id,
-            first_user_message=first_user_message,
-            source_timestamp=start_timestamp,
-        )
+    def _task_kwargs(self, **kwargs: Any) -> dict[str, Any]:
+        """Defaults for generate_ai_conversation_title; override per test."""
+        return {
+            "project_id": self.project.id,
+            "conversation_id": "conv-1",
+            "first_user_message": "How do I reset my password?",
+            "source_timestamp": TS,
+            **kwargs,
+        }
 
     def _create_metadata(
         self,
@@ -274,7 +269,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="AI Title")
     def test_creates_metadata_row(self, mock_generate: MagicMock) -> None:
-        self._run(start_timestamp=TS)
+        generate_ai_conversation_title(**self._task_kwargs())
 
         row = self._row()
         assert row.conversation_id == "conv-1"
@@ -289,7 +284,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="AI Title")
     def test_stores_clamped_conversation_id_and_hashes_full(self, mock_generate: MagicMock) -> None:
         long_id = "c" * 3000
-        self._run(conversation_id=long_id, start_timestamp=TS)
+        generate_ai_conversation_title(**self._task_kwargs(conversation_id=long_id))
 
         row = self._row(long_id)
         assert row.conversation_id == "c" * 2040 + "..."
@@ -301,7 +296,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         earlier = _ts()
         self._create_metadata(title="Earlier Title", source_timestamp=earlier)
 
-        self._run(start_timestamp=TS + 60)
+        generate_ai_conversation_title(**self._task_kwargs(source_timestamp=TS + 60))
 
         row = self._row()
         assert row.title == "Earlier Title"
@@ -312,7 +307,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     def test_equal_timestamp_keeps_existing(self, mock_generate: MagicMock) -> None:
         self._create_metadata(title="Original", source_timestamp=_ts())
 
-        self._run(start_timestamp=TS)
+        generate_ai_conversation_title(**self._task_kwargs())
         assert self._row().title == "Original"
         mock_generate.assert_not_called()
 
@@ -320,7 +315,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     def test_supersedes_when_source_is_strictly_earlier(self, mock_generate: MagicMock) -> None:
         self._create_metadata(title="Later Turn Title", source_timestamp=_ts(60))
 
-        self._run(start_timestamp=TS)
+        generate_ai_conversation_title(**self._task_kwargs())
 
         row = self._row()
         assert row.title == "Earlier Title"
@@ -340,7 +335,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
             return "My Title"
 
         mock_generate.side_effect = seer_side_effect
-        self._run(start_timestamp=TS)
+        generate_ai_conversation_title(**self._task_kwargs())
 
         row = self._row()
         assert row.title == "Concurrent Earlier"
@@ -366,7 +361,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
             return real_update(self, **kwargs)
 
         with patch.object(QuerySet, "update", fake_update):
-            self._run(start_timestamp=TS)
+            generate_ai_conversation_title(**self._task_kwargs())
 
         row = self._row()
         assert row.title == "New Title"
@@ -375,31 +370,32 @@ class GenerateAIConversationTitleTaskTest(TestCase):
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_missing_project(self, mock_generate: MagicMock) -> None:
-        self._run(project_id=999999999)
+        generate_ai_conversation_title(**self._task_kwargs(project_id=999999999))
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_when_hide_ai_features(self, mock_generate: MagicMock) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
-        self._run()
+        generate_ai_conversation_title(**self._task_kwargs())
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_when_feature_disabled(self, mock_generate: MagicMock) -> None:
         with self.feature({"organizations:gen-ai-conversation-title-generation": False}):
-            self._run()
+            generate_ai_conversation_title(**self._task_kwargs())
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.utils.make_llm_generate_request")
     def test_end_to_end_with_mocked_seer(self, mock_request: MagicMock) -> None:
         mock_request.return_value = _mock_seer_success("Password Reset Guidance")
-        self._run(
-            conversation_id="e2e-conv",
-            first_user_message="How do I reset my password?",
-            start_timestamp=TS,
+        generate_ai_conversation_title(
+            **self._task_kwargs(
+                conversation_id="e2e-conv",
+                first_user_message="How do I reset my password?",
+            )
         )
 
         row = self._row("e2e-conv")
@@ -410,7 +406,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     @patch("sentry.ai_monitoring.utils.make_llm_generate_request")
     def test_end_to_end_seer_failure_uses_fallback(self, mock_request: MagicMock) -> None:
         mock_request.side_effect = Exception("network down")
-        self._run(first_user_message="Short question")
+        generate_ai_conversation_title(**self._task_kwargs(first_user_message="Short question"))
         assert self._row().title == "Short question"
 
     def test_unique_constraint_project_conversation_hash(self) -> None:

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -8,7 +8,10 @@ from django.db.models.query import QuerySet
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.ai_monitoring.models import AIConversationMetadata
-from sentry.ai_monitoring.tasks import enqueue_conversation_titles, generate_ai_conversation_title
+from sentry.ai_monitoring.tasks import (
+    generate_ai_conversation_title,
+    spawn_conversation_title_generation,
+)
 from sentry.ai_monitoring.utils import (
     MAX_USER_MESSAGE_CHARS,
     clamp_conversation_id_for_storage,
@@ -435,7 +438,7 @@ def _user_messages(content: str) -> str:
 
 
 @with_feature("organizations:gen-ai-conversation-title-generation")
-class EnqueueConversationTitlesTest(TestCase):
+class SpawnConversationTitleGenerationTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
@@ -443,7 +446,7 @@ class EnqueueConversationTitlesTest(TestCase):
     @patch(DELAY)
     def test_enqueues_earliest_span_per_conversation(self, mock_delay: MagicMock) -> None:
         # Many spans share one conversation in a segment; only the earliest is enqueued.
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [
                 make_gen_ai_span(
                     project_id=self.project.id,
@@ -472,7 +475,7 @@ class EnqueueConversationTitlesTest(TestCase):
 
     @patch(DELAY)
     def test_enqueues_once_per_conversation(self, mock_delay: MagicMock) -> None:
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [
                 make_gen_ai_span(project_id=self.project.id, conversation_id="a"),
                 make_gen_ai_span(project_id=self.project.id, conversation_id="b"),
@@ -484,7 +487,7 @@ class EnqueueConversationTitlesTest(TestCase):
 
     @patch(DELAY)
     def test_skips_spans_without_conversation_or_message(self, mock_delay: MagicMock) -> None:
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [
                 make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True),
                 make_gen_ai_span(project_id=self.project.id, omit_messages=True),
@@ -495,7 +498,7 @@ class EnqueueConversationTitlesTest(TestCase):
 
     @patch(DELAY)
     def test_clamps_user_message_before_enqueue(self, mock_delay: MagicMock) -> None:
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [
                 make_gen_ai_span(
                     project_id=self.project.id,
@@ -507,19 +510,19 @@ class EnqueueConversationTitlesTest(TestCase):
 
     @patch(DELAY)
     def test_resolves_project_from_span(self, mock_delay: MagicMock) -> None:
-        enqueue_conversation_titles([make_gen_ai_span(project_id=self.project.id)])
+        spawn_conversation_title_generation([make_gen_ai_span(project_id=self.project.id)])
         mock_delay.assert_called_once()
         assert mock_delay.call_args.kwargs["project_id"] == self.project.id
 
     @patch(DELAY)
     def test_no_enqueue_when_project_not_found(self, mock_delay: MagicMock) -> None:
-        enqueue_conversation_titles([make_gen_ai_span(project_id=2**31 - 1)])
+        spawn_conversation_title_generation([make_gen_ai_span(project_id=2**31 - 1)])
         mock_delay.assert_not_called()
 
     @patch(DELAY)
     def test_no_enqueue_when_hide_ai_features(self, mock_delay: MagicMock) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
-        enqueue_conversation_titles([make_gen_ai_span(project_id=self.project.id)])
+        spawn_conversation_title_generation([make_gen_ai_span(project_id=self.project.id)])
         mock_delay.assert_not_called()
 
     @patch(DELAY)
@@ -528,7 +531,7 @@ class EnqueueConversationTitlesTest(TestCase):
         self, mock_incr: MagicMock, mock_delay: MagicMock
     ) -> None:
         metric = "spans.consumers.process_segments.gen_ai_conversation"
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [
                 make_gen_ai_span(project_id=self.project.id, conversation_id="a"),
                 # A conversation without a usable message still counts as "seen".
@@ -549,7 +552,7 @@ class EnqueueConversationTitlesTest(TestCase):
         self, mock_incr: MagicMock, mock_delay: MagicMock
     ) -> None:
         metric = "spans.consumers.process_segments.gen_ai_conversation"
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True)],
         )
         assert not any(c.args[:1] == (metric,) for c in mock_incr.call_args_list)
@@ -564,7 +567,7 @@ class EnqueueConversationTitlesTest(TestCase):
     ) -> None:
         # Earliest span arrives first; later same-conversation spans must not pay
         # the message-extraction cost.
-        enqueue_conversation_titles(
+        spawn_conversation_title_generation(
             [
                 make_gen_ai_span(
                     project_id=self.project.id,
@@ -579,9 +582,9 @@ class EnqueueConversationTitlesTest(TestCase):
         mock_delay.assert_called_once()
 
 
-class EnqueueConversationTitlesFeatureDisabledTest(TestCase):
+class SpawnConversationTitleGenerationFeatureDisabledTest(TestCase):
     @patch(DELAY)
     def test_no_enqueue_when_feature_disabled(self, mock_delay: MagicMock) -> None:
         project = self.create_project()
-        enqueue_conversation_titles([make_gen_ai_span(project_id=project.id)])
+        spawn_conversation_title_generation([make_gen_ai_span(project_id=project.id)])
         mock_delay.assert_not_called()

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from django.db import IntegrityError, router, transaction
@@ -8,15 +8,18 @@ from django.db.models.query import QuerySet
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.ai_monitoring.models import AIConversationMetadata
-from sentry.ai_monitoring.tasks import generate_ai_conversation_title
+from sentry.ai_monitoring.tasks import enqueue_conversation_titles, generate_ai_conversation_title
 from sentry.ai_monitoring.utils import (
+    MAX_USER_MESSAGE_CHARS,
     clamp_conversation_id_for_storage,
     clamp_user_message,
+    conversation_id_from_span,
     conversation_id_hash,
     fallback_title_from_message,
+    first_user_message_from_span,
     generate_conversation_title,
     generate_title_with_seer,
-    parse_conversation_title_span,
+    span_source_timestamp,
 )
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.testutils.cases import TestCase
@@ -95,17 +98,25 @@ class TitleHelpersTest(TestCase):
         # Hash stays on the full id; storage clamp must not change the hash input.
         assert conversation_id_hash(long_id) != conversation_id_hash(clamped)
 
-    def test_parse_span_success(self) -> None:
-        data = parse_conversation_title_span(
-            make_gen_ai_span(project_id=1, conversation_id="  abc  ", start_timestamp=TS + 0.5)
+    def test_conversation_id_from_span(self) -> None:
+        assert (
+            conversation_id_from_span(make_gen_ai_span(project_id=1, conversation_id="  abc  "))
+            == "abc"
         )
-        assert data is not None
-        assert data.project_id == 1
-        assert data.conversation_id == "abc"
-        assert data.source_timestamp == _ts(0.5)
-        assert data.first_user_message == "How do I reset my password?"
+        assert (
+            conversation_id_from_span(make_gen_ai_span(project_id=1, omit_conversation_id=True))
+            is None
+        )
+        assert (
+            conversation_id_from_span(make_gen_ai_span(project_id=1, conversation_id="  ")) is None
+        )
 
-    def test_parse_span_prefers_input_messages(self) -> None:
+    def test_span_source_timestamp(self) -> None:
+        assert span_source_timestamp(
+            make_gen_ai_span(project_id=1, start_timestamp=TS + 0.5)
+        ) == _ts(0.5)
+
+    def test_first_user_message_prefers_input_messages(self) -> None:
         span = make_gen_ai_span(
             project_id=1,
             messages=json.dumps(
@@ -118,38 +129,32 @@ class TitleHelpersTest(TestCase):
         span["attributes"][ATTRIBUTE_NAMES.GEN_AI_REQUEST_MESSAGES] = _attr(
             json.dumps([{"role": "user", "content": "from request"}])
         )
-        data = parse_conversation_title_span(span)
-        assert data is not None
-        assert data.first_user_message == "from input"
+        assert first_user_message_from_span(span) == "from input"
 
-    def test_parse_span_falls_back_to_request_messages(self) -> None:
-        data = parse_conversation_title_span(
-            make_gen_ai_span(
-                project_id=1,
-                messages=json.dumps([{"role": "user", "content": "from request"}]),
-                use_request_messages=True,
+    def test_first_user_message_falls_back_to_request_messages(self) -> None:
+        assert (
+            first_user_message_from_span(
+                make_gen_ai_span(
+                    project_id=1,
+                    messages=json.dumps([{"role": "user", "content": "from request"}]),
+                    use_request_messages=True,
+                )
             )
-        )
-        assert data is not None
-        assert data.first_user_message == "from request"
-
-    def test_parse_span_missing_fields(self) -> None:
-        assert (
-            parse_conversation_title_span(make_gen_ai_span(project_id=1, omit_conversation_id=True))
-            is None
-        )
-        assert (
-            parse_conversation_title_span(make_gen_ai_span(project_id=1, omit_messages=True))
-            is None
+            == "from request"
         )
 
-    def test_parse_span_skips_privacy_filtered_messages(self) -> None:
+    def test_first_user_message_missing(self) -> None:
         assert (
-            parse_conversation_title_span(make_gen_ai_span(project_id=1, messages="[Filtered]"))
+            first_user_message_from_span(make_gen_ai_span(project_id=1, omit_messages=True)) is None
+        )
+
+    def test_first_user_message_skips_privacy_filtered(self) -> None:
+        assert (
+            first_user_message_from_span(make_gen_ai_span(project_id=1, messages="[Filtered]"))
             is None
         )
         assert (
-            parse_conversation_title_span(
+            first_user_message_from_span(
                 make_gen_ai_span(
                     project_id=1,
                     messages=json.dumps([{"role": "user", "content": "[Filtered]"}]),
@@ -231,9 +236,20 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         super().setUp()
         self.project = self.create_project()
 
-    def _span(self, **kwargs: Any) -> dict[str, Any]:
-        kwargs.setdefault("project_id", self.project.id)
-        return make_gen_ai_span(**kwargs)
+    def _run(
+        self,
+        *,
+        conversation_id: str = "conv-1",
+        first_user_message: str = "How do I reset my password?",
+        start_timestamp: float = TS,
+        project_id: int | None = None,
+    ) -> None:
+        generate_ai_conversation_title(
+            project_id=self.project.id if project_id is None else project_id,
+            conversation_id=conversation_id,
+            first_user_message=first_user_message,
+            source_timestamp=start_timestamp,
+        )
 
     def _create_metadata(
         self,
@@ -258,7 +274,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="AI Title")
     def test_creates_metadata_row(self, mock_generate: MagicMock) -> None:
-        generate_ai_conversation_title(self._span(start_timestamp=TS))
+        self._run(start_timestamp=TS)
 
         row = self._row()
         assert row.conversation_id == "conv-1"
@@ -273,7 +289,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="AI Title")
     def test_stores_clamped_conversation_id_and_hashes_full(self, mock_generate: MagicMock) -> None:
         long_id = "c" * 3000
-        generate_ai_conversation_title(self._span(conversation_id=long_id, start_timestamp=TS))
+        self._run(conversation_id=long_id, start_timestamp=TS)
 
         row = self._row(long_id)
         assert row.conversation_id == "c" * 2040 + "..."
@@ -285,7 +301,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         earlier = _ts()
         self._create_metadata(title="Earlier Title", source_timestamp=earlier)
 
-        generate_ai_conversation_title(self._span(start_timestamp=TS + 60))
+        self._run(start_timestamp=TS + 60)
 
         row = self._row()
         assert row.title == "Earlier Title"
@@ -296,7 +312,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     def test_equal_timestamp_keeps_existing(self, mock_generate: MagicMock) -> None:
         self._create_metadata(title="Original", source_timestamp=_ts())
 
-        generate_ai_conversation_title(self._span(start_timestamp=TS))
+        self._run(start_timestamp=TS)
         assert self._row().title == "Original"
         mock_generate.assert_not_called()
 
@@ -304,7 +320,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     def test_supersedes_when_source_is_strictly_earlier(self, mock_generate: MagicMock) -> None:
         self._create_metadata(title="Later Turn Title", source_timestamp=_ts(60))
 
-        generate_ai_conversation_title(self._span(start_timestamp=TS))
+        self._run(start_timestamp=TS)
 
         row = self._row()
         assert row.title == "Earlier Title"
@@ -324,7 +340,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
             return "My Title"
 
         mock_generate.side_effect = seer_side_effect
-        generate_ai_conversation_title(self._span(start_timestamp=TS))
+        self._run(start_timestamp=TS)
 
         row = self._row()
         assert row.title == "Concurrent Earlier"
@@ -350,7 +366,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
             return real_update(self, **kwargs)
 
         with patch.object(QuerySet, "update", fake_update):
-            generate_ai_conversation_title(self._span(start_timestamp=TS))
+            self._run(start_timestamp=TS)
 
         row = self._row()
         assert row.title == "New Title"
@@ -358,46 +374,32 @@ class GenerateAIConversationTitleTaskTest(TestCase):
         assert AIConversationMetadata.objects.filter(project=self.project).count() == 1
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
-    def test_skips_missing_conversation_id(self, mock_generate: MagicMock) -> None:
-        generate_ai_conversation_title(self._span(omit_conversation_id=True))
-        assert AIConversationMetadata.objects.count() == 0
-        mock_generate.assert_not_called()
-
-    @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
-    def test_skips_missing_user_message(self, mock_generate: MagicMock) -> None:
-        generate_ai_conversation_title(self._span(omit_messages=True))
-        assert AIConversationMetadata.objects.count() == 0
-        mock_generate.assert_not_called()
-
-    @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_missing_project(self, mock_generate: MagicMock) -> None:
-        generate_ai_conversation_title(self._span(project_id=999999999))
+        self._run(project_id=999999999)
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_when_hide_ai_features(self, mock_generate: MagicMock) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
-        generate_ai_conversation_title(self._span())
+        self._run()
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.tasks.generate_conversation_title", return_value="Unused")
     def test_skips_when_feature_disabled(self, mock_generate: MagicMock) -> None:
         with self.feature({"organizations:gen-ai-conversation-title-generation": False}):
-            generate_ai_conversation_title(self._span())
+            self._run()
         assert AIConversationMetadata.objects.count() == 0
         mock_generate.assert_not_called()
 
     @patch("sentry.ai_monitoring.utils.make_llm_generate_request")
     def test_end_to_end_with_mocked_seer(self, mock_request: MagicMock) -> None:
         mock_request.return_value = _mock_seer_success("Password Reset Guidance")
-        generate_ai_conversation_title(
-            self._span(
-                conversation_id="e2e-conv",
-                messages=json.dumps([{"role": "user", "content": "How do I reset my password?"}]),
-                start_timestamp=TS,
-            )
+        self._run(
+            conversation_id="e2e-conv",
+            first_user_message="How do I reset my password?",
+            start_timestamp=TS,
         )
 
         row = self._row("e2e-conv")
@@ -408,9 +410,7 @@ class GenerateAIConversationTitleTaskTest(TestCase):
     @patch("sentry.ai_monitoring.utils.make_llm_generate_request")
     def test_end_to_end_seer_failure_uses_fallback(self, mock_request: MagicMock) -> None:
         mock_request.side_effect = Exception("network down")
-        generate_ai_conversation_title(
-            self._span(messages=json.dumps([{"role": "user", "content": "Short question"}]))
-        )
+        self._run(first_user_message="Short question")
         assert self._row().title == "Short question"
 
     def test_unique_constraint_project_conversation_hash(self) -> None:
@@ -429,3 +429,163 @@ class GenerateAIConversationTitleTaskTest(TestCase):
                 title="Two",
                 title_source_timestamp=datetime.now(UTC) + timedelta(seconds=1),
             )
+
+
+DELAY = "sentry.ai_monitoring.tasks.generate_ai_conversation_title.delay"
+
+
+def _user_messages(content: str) -> str:
+    return json.dumps([{"role": "user", "content": content}])
+
+
+@with_feature("organizations:gen-ai-conversation-title-generation")
+class EnqueueConversationTitlesTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project()
+
+    @patch(DELAY)
+    def test_enqueues_earliest_span_per_conversation(self, mock_delay: MagicMock) -> None:
+        # Many spans share one conversation in a segment; only the earliest is enqueued.
+        enqueue_conversation_titles(
+            [
+                make_gen_ai_span(
+                    project_id=self.project.id,
+                    start_timestamp=TS + 60,
+                    messages=_user_messages("later"),
+                ),
+                make_gen_ai_span(
+                    project_id=self.project.id,
+                    start_timestamp=TS,
+                    messages=_user_messages("earliest"),
+                ),
+                make_gen_ai_span(
+                    project_id=self.project.id,
+                    start_timestamp=TS + 30,
+                    messages=_user_messages("middle"),
+                ),
+            ],
+        )
+
+        mock_delay.assert_called_once_with(
+            project_id=self.project.id,
+            conversation_id="conv-1",
+            first_user_message="earliest",
+            source_timestamp=TS,
+        )
+
+    @patch(DELAY)
+    def test_enqueues_once_per_conversation(self, mock_delay: MagicMock) -> None:
+        enqueue_conversation_titles(
+            [
+                make_gen_ai_span(project_id=self.project.id, conversation_id="a"),
+                make_gen_ai_span(project_id=self.project.id, conversation_id="b"),
+            ],
+        )
+
+        assert mock_delay.call_count == 2
+        assert {c.kwargs["conversation_id"] for c in mock_delay.call_args_list} == {"a", "b"}
+
+    @patch(DELAY)
+    def test_skips_spans_without_conversation_or_message(self, mock_delay: MagicMock) -> None:
+        enqueue_conversation_titles(
+            [
+                make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True),
+                make_gen_ai_span(project_id=self.project.id, omit_messages=True),
+                make_gen_ai_span(project_id=self.project.id, messages="[Filtered]"),
+            ],
+        )
+        mock_delay.assert_not_called()
+
+    @patch(DELAY)
+    def test_clamps_user_message_before_enqueue(self, mock_delay: MagicMock) -> None:
+        enqueue_conversation_titles(
+            [
+                make_gen_ai_span(
+                    project_id=self.project.id,
+                    messages=_user_messages("a" * (MAX_USER_MESSAGE_CHARS + 100)),
+                )
+            ],
+        )
+        assert len(mock_delay.call_args.kwargs["first_user_message"]) == MAX_USER_MESSAGE_CHARS
+
+    @patch(DELAY)
+    def test_resolves_project_from_span(self, mock_delay: MagicMock) -> None:
+        enqueue_conversation_titles([make_gen_ai_span(project_id=self.project.id)])
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args.kwargs["project_id"] == self.project.id
+
+    @patch(DELAY)
+    def test_no_enqueue_when_project_not_found(self, mock_delay: MagicMock) -> None:
+        enqueue_conversation_titles([make_gen_ai_span(project_id=2**31 - 1)])
+        mock_delay.assert_not_called()
+
+    @patch(DELAY)
+    def test_no_enqueue_when_hide_ai_features(self, mock_delay: MagicMock) -> None:
+        self.organization.update_option("sentry:hide_ai_features", True)
+        enqueue_conversation_titles([make_gen_ai_span(project_id=self.project.id)])
+        mock_delay.assert_not_called()
+
+    @patch(DELAY)
+    @patch("sentry.ai_monitoring.tasks.metrics.incr")
+    def test_emits_conversation_count_metric(
+        self, mock_incr: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        metric = "spans.consumers.process_segments.gen_ai_conversation"
+        enqueue_conversation_titles(
+            [
+                make_gen_ai_span(project_id=self.project.id, conversation_id="a"),
+                # A conversation without a usable message still counts as "seen".
+                make_gen_ai_span(
+                    project_id=self.project.id, conversation_id="b", omit_messages=True
+                ),
+                make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True),
+            ],
+        )
+        assert sum(1 for c in mock_incr.call_args_list if c == call(metric, 2)) == 1
+        # Only the conversation with a message is enqueued.
+        mock_delay.assert_called_once()
+        assert mock_delay.call_args.kwargs["conversation_id"] == "a"
+
+    @patch(DELAY)
+    @patch("sentry.ai_monitoring.tasks.metrics.incr")
+    def test_no_presence_metric_without_conversation_spans(
+        self, mock_incr: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        metric = "spans.consumers.process_segments.gen_ai_conversation"
+        enqueue_conversation_titles(
+            [make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True)],
+        )
+        assert not any(c.args[:1] == (metric,) for c in mock_incr.call_args_list)
+
+    @patch(DELAY)
+    @patch(
+        "sentry.ai_monitoring.tasks.first_user_message_from_span",
+        wraps=first_user_message_from_span,
+    )
+    def test_skips_message_extraction_for_later_spans(
+        self, mock_extract: MagicMock, mock_delay: MagicMock
+    ) -> None:
+        # Earliest span arrives first; later same-conversation spans must not pay
+        # the message-extraction cost.
+        enqueue_conversation_titles(
+            [
+                make_gen_ai_span(
+                    project_id=self.project.id,
+                    start_timestamp=TS,
+                    messages=_user_messages("earliest"),
+                ),
+                make_gen_ai_span(project_id=self.project.id, start_timestamp=TS + 30),
+                make_gen_ai_span(project_id=self.project.id, start_timestamp=TS + 60),
+            ],
+        )
+        assert mock_extract.call_count == 1
+        mock_delay.assert_called_once()
+
+
+class EnqueueConversationTitlesFeatureDisabledTest(TestCase):
+    @patch(DELAY)
+    def test_no_enqueue_when_feature_disabled(self, mock_delay: MagicMock) -> None:
+        project = self.create_project()
+        enqueue_conversation_titles([make_gen_ai_span(project_id=project.id)])
+        mock_delay.assert_not_called()


### PR DESCRIPTION
Prepares the producer of the task that will be used and hooked up in the ingestion pipeline. Also refactors task a bit and pushes a bit of logic to ingestion pipeline (segment enrichment) to transfer smaller payloads. 

It is safe to change task signature, because this task is not yet called from anywhere.

In this stack, there's a second PR in which we hook into the ingestion pipeline and call this task (will be deployed after this PR is deployed)