### PR TITLE
feat(ai): Hook gen_ai title generation into ingestion pipeline

### DIFF
--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -124,24 +124,25 @@ def generate_ai_conversation_title(
 def spawn_conversation_title_generation(
     spans: Sequence[Mapping[str, Any]], project: Project
 ) -> None:
-    """
-    Entrypoint that spawns one title-generation task per conversation,
-    using the earliest span that has a user message.
-    """
+    """Spawn one title-generation task per conversation (earliest user message wins)."""
+    organization = project.organization
+    if not features.has(
+        "organizations:gen-ai-conversation-title-generation", organization
+    ) or organization.get_option("sentry:hide_ai_features"):
+        return
+
     earliest_by_conversation: dict[str, ConversationTitleSpanData] = {}
-    seen_conversation_ids: set[str] = set()
 
     for span in spans:
         conversation_id = conversation_id_from_span(span)
         if conversation_id is None:
             continue
-        seen_conversation_ids.add(conversation_id)
 
         source_timestamp = span_source_timestamp(span)
         if source_timestamp is None:
             continue
 
-        # A later-or-equal span can't win; skip the costly message extraction.
+        # Later/equal spans cannot win; skip costly message extraction.
         current = earliest_by_conversation.get(conversation_id)
         if current is not None and source_timestamp >= current.source_timestamp:
             continue
@@ -155,21 +156,6 @@ def spawn_conversation_title_generation(
             source_timestamp=source_timestamp,
             first_user_message=first_user_message,
         )
-
-    if seen_conversation_ids:
-        metrics.incr(
-            "spans.consumers.process_segments.gen_ai_conversation",
-            len(seen_conversation_ids),
-        )
-
-    if not earliest_by_conversation:
-        return
-
-    organization = project.organization
-    if not features.has("organizations:gen-ai-conversation-title-generation", organization):
-        return
-    if organization.get_option("sentry:hide_ai_features"):
-        return
 
     for data in earliest_by_conversation.values():
         generate_ai_conversation_title.delay(

--- a/src/sentry/ai_monitoring/tasks.py
+++ b/src/sentry/ai_monitoring/tasks.py
@@ -121,7 +121,9 @@ def generate_ai_conversation_title(
     metrics.incr("ai_monitoring.conversation_title.written", tags={"result": "created"})
 
 
-def spawn_conversation_title_generation(spans: Sequence[Mapping[str, Any]]) -> None:
+def spawn_conversation_title_generation(
+    spans: Sequence[Mapping[str, Any]], project: Project
+) -> None:
     """
     Entrypoint that spawns one title-generation task per conversation,
     using the earliest span that has a user message.
@@ -161,15 +163,6 @@ def spawn_conversation_title_generation(spans: Sequence[Mapping[str, Any]]) -> N
         )
 
     if not earliest_by_conversation:
-        return
-
-    # All spans in a segment share a project; the first one is enough.
-    project_id = spans[0].get("project_id")
-    if not isinstance(project_id, int):
-        return
-    try:
-        project = Project.objects.get_from_cache(id=project_id)
-    except Project.DoesNotExist:
         return
 
     organization = project.organization

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -102,6 +102,10 @@ def _process_segment(
             except (Project.DoesNotExist, Organization.DoesNotExist):
                 return []
 
+    if project is None:
+        # If the project does not exist then it might have been deleted during ingestion.
+        return []
+
     if project is not None and killswitch_matches_context(
         "spans.process-segments.drop-segments",
         {"org_id": str(project.organization_id)},
@@ -124,10 +128,6 @@ def _process_segment(
     segment_span, spans = _enrich_spans(unprocessed_spans)
     if segment_span is None:
         return spans
-
-    if project is None:
-        # If the project does not exist then it might have been deleted during ingestion.
-        return []
 
     _add_segment_name(segment_span, spans)
     _compute_breakdowns(segment_span, spans, project)

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -106,7 +106,7 @@ def _process_segment(
         # If the project does not exist then it might have been deleted during ingestion.
         return []
 
-    if project is not None and killswitch_matches_context(
+    if killswitch_matches_context(
         "spans.process-segments.drop-segments",
         {"org_id": str(project.organization_id)},
         emit_metrics=True,
@@ -114,8 +114,7 @@ def _process_segment(
         return []
 
     # Always attempt title generation, even when enrichment is skipped below.
-    if project is not None:
-        spawn_conversation_title_generation(unprocessed_spans, project)
+    spawn_conversation_title_generation(unprocessed_spans, project)
 
     if skip_enrichment:
         return [make_compatible(span) for span in unprocessed_spans]

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -12,6 +12,7 @@ from sentry_conventions.attributes import ATTRIBUTE_NAMES
 from sentry_kafka_schemas.schema_types.ingest_spans_v1 import SpanEvent
 
 from sentry import options
+from sentry.ai_monitoring.tasks import spawn_conversation_title_generation
 from sentry.constants import DataCategory
 from sentry.dynamic_sampling.rules.helpers.latest_releases import record_latest_release
 from sentry.event_manager import INSIGHT_MODULE_TO_PROJECT_FLAG_NAME
@@ -108,8 +109,9 @@ def _process_segment(
     ):
         return []
 
-    if any(attribute_value(s, ATTRIBUTE_NAMES.GEN_AI_CONVERSATION_ID) for s in unprocessed_spans):
-        metrics.incr("spans.consumers.process_segments.gen_ai_conversation")
+    # Always attempt title generation, even when enrichment is skipped below.
+    if project is not None:
+        spawn_conversation_title_generation(unprocessed_spans, project)
 
     if skip_enrichment:
         return [make_compatible(span) for span in unprocessed_spans]

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -464,6 +464,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
                     messages=_user_messages("middle"),
                 ),
             ],
+            self.project,
         )
 
         mock_delay.assert_called_once_with(
@@ -480,6 +481,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
                 make_gen_ai_span(project_id=self.project.id, conversation_id="a"),
                 make_gen_ai_span(project_id=self.project.id, conversation_id="b"),
             ],
+            self.project,
         )
 
         assert mock_delay.call_count == 2
@@ -493,6 +495,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
                 make_gen_ai_span(project_id=self.project.id, omit_messages=True),
                 make_gen_ai_span(project_id=self.project.id, messages="[Filtered]"),
             ],
+            self.project,
         )
         mock_delay.assert_not_called()
 
@@ -505,24 +508,16 @@ class SpawnConversationTitleGenerationTest(TestCase):
                     messages=_user_messages("a" * (MAX_USER_MESSAGE_CHARS + 100)),
                 )
             ],
+            self.project,
         )
         assert len(mock_delay.call_args.kwargs["first_user_message"]) == MAX_USER_MESSAGE_CHARS
 
     @patch(DELAY)
-    def test_resolves_project_from_span(self, mock_delay: MagicMock) -> None:
-        spawn_conversation_title_generation([make_gen_ai_span(project_id=self.project.id)])
-        mock_delay.assert_called_once()
-        assert mock_delay.call_args.kwargs["project_id"] == self.project.id
-
-    @patch(DELAY)
-    def test_no_enqueue_when_project_not_found(self, mock_delay: MagicMock) -> None:
-        spawn_conversation_title_generation([make_gen_ai_span(project_id=2**31 - 1)])
-        mock_delay.assert_not_called()
-
-    @patch(DELAY)
     def test_no_enqueue_when_hide_ai_features(self, mock_delay: MagicMock) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
-        spawn_conversation_title_generation([make_gen_ai_span(project_id=self.project.id)])
+        spawn_conversation_title_generation(
+            [make_gen_ai_span(project_id=self.project.id)], self.project
+        )
         mock_delay.assert_not_called()
 
     @patch(DELAY)
@@ -540,6 +535,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
                 ),
                 make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True),
             ],
+            self.project,
         )
         assert sum(1 for c in mock_incr.call_args_list if c == call(metric, 2)) == 1
         # Only the conversation with a message is enqueued.
@@ -554,6 +550,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
         metric = "spans.consumers.process_segments.gen_ai_conversation"
         spawn_conversation_title_generation(
             [make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True)],
+            self.project,
         )
         assert not any(c.args[:1] == (metric,) for c in mock_incr.call_args_list)
 
@@ -577,6 +574,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
                 make_gen_ai_span(project_id=self.project.id, start_timestamp=TS + 30),
                 make_gen_ai_span(project_id=self.project.id, start_timestamp=TS + 60),
             ],
+            self.project,
         )
         assert mock_extract.call_count == 1
         mock_delay.assert_called_once()
@@ -586,5 +584,5 @@ class SpawnConversationTitleGenerationFeatureDisabledTest(TestCase):
     @patch(DELAY)
     def test_no_enqueue_when_feature_disabled(self, mock_delay: MagicMock) -> None:
         project = self.create_project()
-        spawn_conversation_title_generation([make_gen_ai_span(project_id=project.id)])
+        spawn_conversation_title_generation([make_gen_ai_span(project_id=project.id)], project)
         mock_delay.assert_not_called()

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.db import IntegrityError, router, transaction
@@ -513,7 +513,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
         assert len(mock_delay.call_args.kwargs["first_user_message"]) == MAX_USER_MESSAGE_CHARS
 
     @patch(DELAY)
-    def test_no_enqueue_when_hide_ai_features(self, mock_delay: MagicMock) -> None:
+    def test_hide_ai_features_returns_early(self, mock_delay: MagicMock) -> None:
         self.organization.update_option("sentry:hide_ai_features", True)
         spawn_conversation_title_generation(
             [make_gen_ai_span(project_id=self.project.id)], self.project
@@ -521,15 +521,10 @@ class SpawnConversationTitleGenerationTest(TestCase):
         mock_delay.assert_not_called()
 
     @patch(DELAY)
-    @patch("sentry.ai_monitoring.tasks.metrics.incr")
-    def test_emits_conversation_count_metric(
-        self, mock_incr: MagicMock, mock_delay: MagicMock
-    ) -> None:
-        metric = "spans.consumers.process_segments.gen_ai_conversation"
+    def test_enqueues_only_conversations_with_user_message(self, mock_delay: MagicMock) -> None:
         spawn_conversation_title_generation(
             [
                 make_gen_ai_span(project_id=self.project.id, conversation_id="a"),
-                # A conversation without a usable message still counts as "seen".
                 make_gen_ai_span(
                     project_id=self.project.id, conversation_id="b", omit_messages=True
                 ),
@@ -537,22 +532,8 @@ class SpawnConversationTitleGenerationTest(TestCase):
             ],
             self.project,
         )
-        assert sum(1 for c in mock_incr.call_args_list if c == call(metric, 2)) == 1
-        # Only the conversation with a message is enqueued.
         mock_delay.assert_called_once()
         assert mock_delay.call_args.kwargs["conversation_id"] == "a"
-
-    @patch(DELAY)
-    @patch("sentry.ai_monitoring.tasks.metrics.incr")
-    def test_no_presence_metric_without_conversation_spans(
-        self, mock_incr: MagicMock, mock_delay: MagicMock
-    ) -> None:
-        metric = "spans.consumers.process_segments.gen_ai_conversation"
-        spawn_conversation_title_generation(
-            [make_gen_ai_span(project_id=self.project.id, omit_conversation_id=True)],
-            self.project,
-        )
-        assert not any(c.args[:1] == (metric,) for c in mock_incr.call_args_list)
 
     @patch(DELAY)
     @patch(
@@ -582,7 +563,7 @@ class SpawnConversationTitleGenerationTest(TestCase):
 
 class SpawnConversationTitleGenerationFeatureDisabledTest(TestCase):
     @patch(DELAY)
-    def test_no_enqueue_when_feature_disabled(self, mock_delay: MagicMock) -> None:
+    def test_feature_disabled_returns_early(self, mock_delay: MagicMock) -> None:
         project = self.create_project()
         spawn_conversation_title_generation([make_gen_ai_span(project_id=project.id)], project)
         mock_delay.assert_not_called()

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -332,50 +332,6 @@ class TestSpansTask(TestCase):
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_agent_monitoring"]
 
-    @mock.patch("sentry.ai_monitoring.tasks.metrics.incr")
-    def test_gen_ai_conversation_metric(self, mock_incr: mock.MagicMock) -> None:
-        """Count once per segment when any span has gen_ai.conversation.id."""
-        metric_name = "spans.consumers.process_segments.gen_ai_conversation"
-
-        def conversation_calls() -> int:
-            return sum(1 for c in mock_incr.call_args_list if c.args[:1] == (metric_name,))
-
-        child_span, segment_span = self.generate_basic_spans()
-        process_segment([child_span, segment_span])
-        assert conversation_calls() == 0
-
-        mock_incr.reset_mock()
-        child_span, segment_span = self.generate_basic_spans()
-        child_span["attributes"]["gen_ai.conversation.id"] = {
-            "type": "string",
-            "value": "conv-123",
-        }
-        process_segment([child_span, segment_span])
-        assert conversation_calls() == 1
-
-        mock_incr.reset_mock()
-        child_span, segment_span = self.generate_basic_spans()
-        child_span["attributes"]["gen_ai.conversation.id"] = {
-            "type": "string",
-            "value": "conv-123",
-        }
-        segment_span["attributes"]["gen_ai.conversation.id"] = {
-            "type": "string",
-            "value": "conv-123",
-        }
-        process_segment([child_span, segment_span])
-        assert conversation_calls() == 1
-
-        # Title generation (and the metric) run before enrichment is skipped.
-        mock_incr.reset_mock()
-        child_span, segment_span = self.generate_basic_spans()
-        child_span["attributes"]["gen_ai.conversation.id"] = {
-            "type": "string",
-            "value": "conv-123",
-        }
-        process_segment([child_span, segment_span], skip_enrichment=True)
-        assert conversation_calls() == 1
-
     def test_segment_name_propagation(self) -> None:
         child_span, segment_span = self.generate_basic_spans()
         assert (

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -332,13 +332,13 @@ class TestSpansTask(TestCase):
         signals = [args[0][1] for args in mock_track.call_args_list]
         assert signals == ["has_transactions", "has_insights_agent_monitoring"]
 
-    @mock.patch("sentry.spans.consumers.process_segments.message.metrics.incr")
+    @mock.patch("sentry.ai_monitoring.tasks.metrics.incr")
     def test_gen_ai_conversation_metric(self, mock_incr: mock.MagicMock) -> None:
         """Count once per segment when any span has gen_ai.conversation.id."""
         metric_name = "spans.consumers.process_segments.gen_ai_conversation"
 
         def conversation_calls() -> int:
-            return sum(1 for call in mock_incr.call_args_list if call == mock.call(metric_name))
+            return sum(1 for c in mock_incr.call_args_list if c.args[:1] == (metric_name,))
 
         child_span, segment_span = self.generate_basic_spans()
         process_segment([child_span, segment_span])
@@ -366,6 +366,7 @@ class TestSpansTask(TestCase):
         process_segment([child_span, segment_span])
         assert conversation_calls() == 1
 
+        # Title generation (and the metric) run before enrichment is skipped.
         mock_incr.reset_mock()
         child_span, segment_span = self.generate_basic_spans()
         child_span["attributes"]["gen_ai.conversation.id"] = {


### PR DESCRIPTION
Instead of looping over all spans just to emit a metric, now we also spawn a task (alongside emitting a metric) that will generate a title for the Gen AI conversation.

This is a small refactor since this logic of looping over spans is now part of `spawn_conversation_title_generation`, but keeps the same O(num_of_spans) complexity. 

Closes [TET-2726: Hook into ingestion pipeline](https://linear.app/getsentry/issue/TET-2726/hook-into-ingestion-pipeline)