### PR TITLE
fix(agent-monitoring): Remove Truncated label from repaired JSON output

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.spec.tsx
@@ -18,11 +18,6 @@ describe('AIContentRenderer', () => {
     expect(screen.getByText('key')).toBeInTheDocument();
   });
 
-  it('renders fixed JSON with truncated indicator', () => {
-    render(<AIContentRenderer text='{"key": "value", "nested": {"inner": "trun' />);
-    expect(screen.getByText('Truncated')).toBeInTheDocument();
-  });
-
   it('renders Python dict as JSON', () => {
     render(<AIContentRenderer text="{'name': 'test', 'flag': True}" />);
     expect(screen.getByText('name')).toBeInTheDocument();

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -5,7 +5,6 @@ import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
-import {t} from 'sentry/locale';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {
   detectAIContentType,
@@ -123,6 +122,7 @@ export function AIContentRenderer({
 
   switch (detection.type) {
     case 'json':
+    case 'fixed-json':
     case 'python-dict':
       return (
         <TraceDrawerComponents.MultilineJSON
@@ -131,21 +131,6 @@ export function AIContentRenderer({
           autoCollapseLimit={autoCollapseLimit}
           clip={clipJson}
         />
-      );
-
-    case 'fixed-json':
-      return (
-        <Fragment>
-          <TraceDrawerComponents.MultilineJSON
-            value={detection.parsedData}
-            maxDefaultDepth={maxJsonDepth}
-            autoCollapseLimit={autoCollapseLimit}
-            clip={clipJson}
-          />
-          <Text size="xs" variant="muted">
-            {t('Truncated')}
-          </Text>
-        </Fragment>
       );
 
     case 'markdown-with-xml':


### PR DESCRIPTION
Repaired (truncated) JSON in AI span and conversation views rendered with a stray "Truncated" label below the payload, which looked out of place and confused users. Repaired JSON now renders exactly like regular JSON.

Fixes TET-2684
