### PR TITLE
feat(project-keys): Turn DSN rate limit banner into a warning

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -135,15 +135,19 @@ export function KeyRateLimitsForm({
         return (
           <form.AppForm form={form}>
             <FieldGroup title={t('Rate Limits')}>
-              <Alert variant="info" system>
-                {t(
-                  `Rate limits provide a flexible way to manage your error
-                    volume. If you have a noisy project or environment you
-                    can configure a rate limit for this key to reduce the
-                    number of errors processed. To manage your transaction
-                    volume, we recommend adjusting your sample rate in your
-                    SDK configuration.`
-                )}
+              <Alert variant="warning" system>
+                <Stack gap="xs">
+                  <Text>
+                    {t(
+                      'Applying a rate limit to your DSN may cause you to miss critical but infrequent errors.'
+                    )}
+                  </Text>
+                  <Text>
+                    {t(
+                      'This limit applies to errors and security reports sent through this DSN. Other telemetry types such as spans, metrics, and logs are not affected.'
+                    )}
+                  </Text>
+                </Stack>
               </Alert>
               {!hasFeature &&
                 typeof renderDisabled === 'function' &&


### PR DESCRIPTION
The rate limit section on the DSN key settings page now shows a warning alert
instead of an informational one. The copy warns that rate limiting a DSN may
cause missed critical errors, and clarifies that the limit applies only to
errors and security reports — not to spans, metrics, or logs.

The previous version of this change (#120416, reverted in 30e011689fe)
incorrectly stated the limit applied to all telemetry types. DSN rate limits
are scoped to `DataCategory.error_categories()` (DEFAULT, ERROR, SECURITY) in
`RedisQuota.get_quotas`, so the copy now reflects that.